### PR TITLE
fix: confirmation modal onClose was not clickable

### DIFF
--- a/.changeset/rotten-dragons-buy.md
+++ b/.changeset/rotten-dragons-buy.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Close button on “Cancel adding account?” modal is difficult to click

--- a/apps/ledger-live-mobile/src/components/ConfirmationModal.tsx
+++ b/apps/ledger-live-mobile/src/components/ConfirmationModal.tsx
@@ -86,7 +86,15 @@ class ConfirmationModal extends PureComponent<Props> {
           </View>
         )}
         {confirmationTitle && (
-          <LText secondary semiBold style={[styles.confirmationTitle, customTitleStyle]}>
+          <LText
+            secondary
+            semiBold
+            style={[
+              styles.confirmationTitle,
+              !Icon && !image && styles.confirmationTitleWithCloseButton,
+              customTitleStyle,
+            ]}
+          >
             {confirmationTitle}
           </LText>
         )}
@@ -131,6 +139,9 @@ const styles = StyleSheet.create({
   confirmationTitle: {
     textAlign: "center",
     fontSize: 18,
+  },
+  confirmationTitleWithCloseButton: {
+    width: "90%",
   },
   confirmationDesc: {
     marginVertical: 24,

--- a/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
+++ b/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
@@ -11,9 +11,6 @@ import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/
 import { useNavigateToPostOnboardingHubCallback } from "~/logic/postOnboarding/useNavigateToPostOnboardingHubCallback";
 import { StyleProp, ViewStyle } from "react-native";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const emptyFunction = () => {};
-
 type Props = {
   /**
    * Function called when user presses on the close button.
@@ -110,7 +107,7 @@ export const NavigationHeaderCloseButtonAdvanced: React.FC<AdvancedProps> = Reac
     withConfirmation,
     confirmationTitle,
     confirmationDesc,
-    onClose = emptyFunction,
+    onClose,
     rounded = false,
     showButton = false,
     buttonText,
@@ -161,7 +158,7 @@ export const NavigationHeaderCloseButtonAdvanced: React.FC<AdvancedProps> = Reac
       if (navigation.canGoBack()) {
         navigation.goBack();
       }
-      onClose();
+      onClose?.();
     }, [
       navigateToPostOnboardingHub,
       navigation,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When no `Icon` or `image` props were provided, the `confirmationTitle` would take full width and potentially overlap with the close button, making it unclickable.


https://github.com/user-attachments/assets/c186c14d-57fe-4ee3-a8a0-5e63270fc8b8



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-21884

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
