### PR TITLE
fix(coin:sui): return positive amount for undelegate operations

### DIFF
--- a/.changeset/quick-oranges-beg.md
+++ b/.changeset/quick-oranges-beg.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": patch
+---
+
+coin:sui always returns positive operation amount

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -108,32 +108,31 @@ export const getAllBalancesCached = makeLRUCache(
   (owner: string) => owner,
   minutes(1),
 );
-function isStaking(block?: SuiTransactionBlockKind): block is {
+
+type ProgrammableTransaction = {
   inputs: SuiCallArg[];
   kind: "ProgrammableTransaction";
   transactions: SuiTransaction[];
-} {
+};
+
+function isMoveCallWithFunction(
+  functionName: string,
+  block?: SuiTransactionBlockKind,
+): block is ProgrammableTransaction {
   if (!block) return false;
   if (block.kind === "ProgrammableTransaction") {
     const move = block.transactions.find(item => "MoveCall" in item) as any;
-    return move?.MoveCall.function === "request_add_stake";
+    return move?.MoveCall.function === functionName;
   }
   return false;
 }
 
-function isUnstaking(block?: SuiTransactionBlockKind): block is {
-  inputs: SuiCallArg[];
-  kind: "ProgrammableTransaction";
-  transactions: SuiTransaction[];
-} {
-  if (!block) return false;
-  if (block.kind === "ProgrammableTransaction") {
-    const move = block.transactions.find(
-      item => "MoveCall" in item && item["MoveCall"].function === "request_withdraw_stake",
-    ) as any;
-    return Boolean(move);
-  }
-  return false;
+function isStaking(block?: SuiTransactionBlockKind): block is ProgrammableTransaction {
+  return isMoveCallWithFunction("request_add_stake", block);
+}
+
+function isUnstaking(block?: SuiTransactionBlockKind): block is ProgrammableTransaction {
+  return isMoveCallWithFunction("request_withdraw_stake", block);
 }
 
 /**
@@ -342,11 +341,48 @@ export function transactionToOperation(
   };
 }
 
+// This function is only used by alpaca code path
+// Logic is similar to getOperationAmount, but we guarantee to return a positive amount in any case
+// If there is need to display negative amount for staking or unstaking, the view can handle it based on the type of the operation
+export const alpacaGetOperationAmount = (
+  address: string,
+  transaction: SuiTransactionBlockResponse,
+  coinType: string,
+): BigNumber => {
+  const absoluteAmount = (balanceChange: BalanceChange | undefined) =>
+    new BigNumber(balanceChange?.amount || 0).abs();
+
+  const zero = BigNumber(0);
+
+  const tx = transaction.transaction?.data.transaction;
+
+  if (isStaking(tx) || isUnstaking(tx)) return absoluteAmount(transaction.balanceChanges?.[0]);
+  else {
+    return (
+      transaction.balanceChanges
+        ?.filter(
+          balanceChange =>
+            typeof balanceChange.owner !== "string" &&
+            "AddressOwner" in balanceChange.owner &&
+            balanceChange.owner.AddressOwner === address &&
+            balanceChange.coinType === coinType,
+        )
+        .map(absoluteAmount)
+        .reduce((acc, curr) => acc.plus(curr), zero) || zero
+    );
+  }
+};
+
 /**
+ * This function is only used by alpaca code path
+ *
  * @returns the operation converted. Note that if param `transaction` was retrieved as an "IN" operations, the type may be converted to "OUT".
  *    It happens for most "OUT" operations because the sender receive a new version of the coin objects.
  */
-export function transactionToOp(address: string, transaction: SuiTransactionBlockResponse): Op {
+export function alpacaTransactionToOp(
+  address: string,
+  transaction: SuiTransactionBlockResponse,
+): Op {
   const type = getOperationType(address, transaction);
   const coinType = getOperationCoinType(transaction);
   const hash = transaction.digest;
@@ -365,7 +401,7 @@ export function transactionToOp(address: string, transaction: SuiTransactionBloc
     recipients: getOperationRecipients(transaction.transaction?.data),
     senders: getOperationSenders(transaction.transaction?.data),
     type,
-    value: BigInt(getOperationAmount(address, transaction, coinType).toString()),
+    value: BigInt(alpacaGetOperationAmount(address, transaction, coinType).toString()),
   };
 }
 
@@ -576,7 +612,7 @@ export const getListOperations = async (
 
     const operations = ops.operations
       .sort((a, b) => Number(b.timestampMs) - Number(a.timestampMs))
-      .map(t => transactionToOp(addr, t));
+      .map(t => alpacaTransactionToOp(addr, t));
 
     return {
       items: operations,

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -119,12 +119,12 @@ function isMoveCallWithFunction(
   functionName: string,
   block?: SuiTransactionBlockKind,
 ): block is ProgrammableTransaction {
-  if (!block) return false;
-  if (block.kind === "ProgrammableTransaction") {
+  if (block?.kind === "ProgrammableTransaction") {
     const move = block.transactions.find(item => "MoveCall" in item) as any;
     return move?.MoveCall.function === functionName;
+  } else {
+    return false;
   }
-  return false;
 }
 
 function isStaking(block?: SuiTransactionBlockKind): block is ProgrammableTransaction {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - alpaca api for coin:sui returns positive amounts, even for staking
  - no impact for bridge (different code path)

### 📝 Description

IN or OUT operations always return positive amounts
but UNSTAKING was returning a negative

we believe this is inconsistent API. It's UI to job to negate the amount if that makes sense for user.


### ❓ Context

https://ledgerhq.atlassian.net/browse/BACK-9784

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
