### PR TITLE
🐛 (IOS) disable liquid glass

### DIFF
--- a/.changeset/wise-ligers-float.md
+++ b/.changeset/wise-ligers-float.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+IOS - add UIDesignRequiresCompatibility to avoid any issue with liquid glass

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile/Info.plist
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile/Info.plist
@@ -17,6 +17,8 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>UIDesignRequiresCompatibility</key>
+	<true />
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>

--- a/apps/ledger-live-mobile/ios/ledgerlivemobileTests/Info.plist
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobileTests/Info.plist
@@ -10,6 +10,8 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>UIDesignRequiresCompatibility</key>
+	<true />
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - IOS
  
### 📝 Description

As RN is not fully compatible with liquid glass, we can deactivate it using UIDesignRequiresCompatibility (as reco by Apple)

Apple doc: 

https://developer.apple.com/documentation/BundleResources/Information-Property-List/UIDesignRequiresCompatibility




| Before        | After         |
| ------------- | ------------- |
|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/27aa46f4-69bb-4499-ae1e-26bf78775d85" />| https://github.com/user-attachments/assets/d322c4cc-5929-46c4-a51f-7a919c988aa1| 

### ❓ Context

- **JIRA or GitHub link**: [LIVE-21865](https://ledgerhq.atlassian.net/browse/LIVE-21865)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21865]: https://ledgerhq.atlassian.net/browse/LIVE-21865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ