### PR TITLE
fix(coin-solana) do not reject unknown SPL 2022 extensions

### DIFF
--- a/.changeset/tasty-knives-design.md
+++ b/.changeset/tasty-knives-design.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": minor
+---
+
+fix(coin-solana) do not reject unknown SPL 2022 extensions

--- a/libs/coin-modules/coin-solana/src/network/chain/account/tokenExtensions.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/account/tokenExtensions.ts
@@ -368,6 +368,7 @@ export const MintExtensions = array(
     GroupMemberPointerExt,
     TokenGroupExt,
     TokenGroupMemberExt,
+    UnknownExt,
   ]),
 );
 

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
@@ -59,6 +59,42 @@ describe("testing prepareTransaction", () => {
     );
   });
 
+  it("does not fail on unknown SPL 2022 extensions", async () => {
+    const preparedTransaction = prepareTransaction(
+      {
+        currency: { units: [{ magnitude: 2 }] },
+        subAccounts: [
+          {
+            id: "subAccountId",
+            type: "TokenAccount",
+            token: { contractAddress: "mintAddress", units: [{ magnitude: 2 }] },
+          },
+        ],
+      } as unknown as SolanaAccount,
+      transaction({ kind: "token.transfer", subAccountId: "subAccountId" }),
+      {
+        getAccountInfo: () => ({
+          data: {
+            parsed: {
+              type: "mint",
+              info: {
+                extensions: [{ extension: "defaultAccountState" }],
+                mintAuthority: null,
+                supply: "",
+                decimals: 2,
+                isInitialized: true,
+                freezeAuthority: null,
+              },
+            },
+            program: "spl-token-2022",
+          },
+        }),
+      } as unknown as ChainAPI,
+    );
+
+    await expect(() => preparedTransaction).not.toThrow();
+  });
+
   it("should return a new transaction from the raw transaction when user provide it", async () => {
     // Given
     const estimatedFees = 0.00005;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Solana users should be able to send SPL 2022 that have unknown extensions

### 📝 Description

Solana users are not able to send SPL 2022 that have unknown extensions. It is the case in the screenshot below, with the `defaultAccountState` extension.

Note this is very similar to https://github.com/LedgerHQ/ledger-live/pull/11013, at the account level.

| Before        | After         |
| ------------- | ------------- |
| <img width="513" height="738" alt="image" src="https://github.com/user-attachments/assets/70a97a78-88ab-4a14-adef-e3457534b0fc" /> | <img width="513" height="738" alt="image" src="https://github.com/user-attachments/assets/5edd45af-36f8-4c45-a58b-72c97e14cdc5" /> |

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
