### PR TITLE
fix: canton allow alphanumeric

### DIFF
--- a/.changeset/fuzzy-maps-love.md
+++ b/.changeset/fuzzy-maps-love.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-canton": patch
+---
+
+allow alphanumeric after ::

--- a/libs/coin-modules/coin-canton/src/common-logic/utils.test.ts
+++ b/libs/coin-modules/coin-canton/src/common-logic/utils.test.ts
@@ -13,6 +13,10 @@ describe("utils", () => {
         "user123::42",
         "canton_1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t1u2v3w4x5y6z::123",
         "test::123456789",
+        "abc::abc", // letters after ::
+        "test::ABC123", // mixed case letters and numbers
+        "user::a1b2c3", // alphanumeric after ::
+        "contract::XyZ789", // mixed case with numbers
       ];
 
       validAddresses.forEach(address => {
@@ -24,20 +28,23 @@ describe("utils", () => {
       const invalidAddresses = [
         "", // empty string
         "::123", // no characters before ::
-        "abc::", // no numbers after ::
+        "abc::", // no characters after ::
         "abc:123", // single colon instead of double
-        "abc::abc", // letters instead of numbers after ::
         "abc::", // empty after ::
         "::", // only colons
         "abc", // no colons
         "123", // no colons
-        "abc::123abc", // mixed letters and numbers after ::
         "abc::123.456", // decimal numbers
         "abc::-123", // negative numbers
         "abc::+123", // positive sign
-        "abc:: 123", // space before number
-        "abc::123 ", // space after number
+        "abc:: 123", // space before alphanumeric
+        "abc::123 ", // space after alphanumeric
         "abc:: 123", // space after ::
+        "abc::123-abc", // dash in alphanumeric part
+        "abc::123_abc", // underscore in alphanumeric part
+        "abc::123.abc", // dot in alphanumeric part
+        "abc::123 abc", // space in alphanumeric part
+        "abc::", // empty after ::
       ];
 
       invalidAddresses.forEach(address => {
@@ -46,18 +53,26 @@ describe("utils", () => {
     });
 
     it("should handle edge cases", () => {
-      expect(isRecipientValid("a::1")).toBe(true); // minimum valid case
+      expect(isRecipientValid("a::1")).toBe(true); // minimum valid case with number
+      expect(isRecipientValid("a::a")).toBe(true); // minimum valid case with letter
       expect(isRecipientValid("1::1")).toBe(true); // number before ::
+      expect(isRecipientValid("1::a")).toBe(true); // number before ::, letter after
       expect(isRecipientValid("_::1")).toBe(true); // underscore before ::
+      expect(isRecipientValid("_::a")).toBe(true); // underscore before ::, letter after
       expect(isRecipientValid("-::1")).toBe(true); // dash before ::
+      expect(isRecipientValid("-::a")).toBe(true); // dash before ::, letter after
       expect(isRecipientValid(".::1")).toBe(true); // dot before ::
+      expect(isRecipientValid(".::a")).toBe(true); // dot before ::, letter after
     });
 
     it("should handle addresses with spaces and multiple colons", () => {
       // These are valid according to our regex but might not be ideal Canton addresses
       expect(isRecipientValid(" abc::123")).toBe(true); // space before address
+      expect(isRecipientValid(" abc::abc")).toBe(true); // space before address with letters
       expect(isRecipientValid("abc ::123")).toBe(true); // space before ::
+      expect(isRecipientValid("abc ::abc")).toBe(true); // space before :: with letters
       expect(isRecipientValid("abc::123::456")).toBe(true); // multiple ::
+      expect(isRecipientValid("abc::abc::def")).toBe(true); // multiple :: with letters
     });
   });
 

--- a/libs/coin-modules/coin-canton/src/common-logic/utils.ts
+++ b/libs/coin-modules/coin-canton/src/common-logic/utils.ts
@@ -8,9 +8,9 @@ export const validateTag = (tag: BigNumber) => {
   );
 };
 
-const CANTON_ADDRESS_REGEX = /^.+::\d+$/;
+const CANTON_ADDRESS_REGEX = /^.+::[a-zA-Z0-9]+$/;
 
 export function isRecipientValid(recipient: string): boolean {
-  // Canton address format: at least 1 character :: at least 1 number
+  // Canton address format: at least 1 character :: at least 1 alphanumeric character
   return CANTON_ADDRESS_REGEX.test(recipient);
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

allow alphanumeric after ::  for example abc::zxc123

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
