### PR TITLE
Fix/live 21925 reaply sui e2e tests

### DIFF
--- a/.changeset/popular-coins-brush.md
+++ b/.changeset/popular-coins-brush.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+"ledger-live-desktop-e2e-tests": minor
+---
+
+adding sui native and token e2e tests

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -496,7 +496,7 @@ const OperationD = (props: Props) => {
           horizontal
           flow={1}
         >
-          <Box>
+          <Box data-testid="status-drawer">
             {hasFailed
               ? t("operationDetails.failed")
               : isConfirmed
@@ -642,7 +642,7 @@ const OperationD = (props: Props) => {
         </OpDetailsData>
       </OpDetailsSection>
       {uniqueSenders.length ? (
-        <OpDetailsSection>
+        <OpDetailsSection data-testid="operation-from">
           <OpDetailsTitle>{t("operationDetails.from")}</OpDetailsTitle>
           <DataList lines={uniqueSenders} t={t} />
         </OpDetailsSection>
@@ -650,7 +650,7 @@ const OperationD = (props: Props) => {
       {recipients.length ? (
         <OpDetailsSection>
           <OpDetailsTitle>{t("operationDetails.to")}</OpDetailsTitle>
-          <Box alignItems="flex-end" flex="1">
+          <Box data-testid="operation-to" alignItems="flex-end" flex="1">
             {recipients.length > 1 ? (
               <Link>
                 <FakeLink

--- a/e2e/desktop/tests/page/account.page.ts
+++ b/e2e/desktop/tests/page/account.page.ts
@@ -32,6 +32,9 @@ export class AccountPage extends AppPage {
   private editName = this.page.locator("#input-edit-name");
   private applyButton = this.page.getByTestId("account-settings-apply-button");
   private accountHeaderName = this.page.locator("#account-header-name");
+  private accountChart = this.page.getByTestId("chart-container");
+  private selectSpecificOperation = (operationType: string) =>
+    this.page.locator("[data-testid^='operation-row-']").filter({ hasText: operationType });
 
   @step("Navigate to token")
   async navigateToToken(account: AccountType) {
@@ -169,5 +172,15 @@ export class AccountPage extends AppPage {
   @step("Verify account with header name $0 is visible")
   async verifyAccountHeaderNameIsVisible(headerName: string) {
     await expect(this.accountHeaderName).toHaveValue(headerName);
+  }
+
+  @step("Check account chart is visible")
+  async checkAccountChart() {
+    await this.accountChart.waitFor({ state: "visible" });
+  }
+
+  @step("Click on selected ($0) last operation")
+  async selectAndClickOnLastOperation(operation: string) {
+    await this.selectSpecificOperation(operation).first().click();
   }
 }

--- a/e2e/desktop/tests/page/drawer/send.drawer.ts
+++ b/e2e/desktop/tests/page/drawer/send.drawer.ts
@@ -1,13 +1,70 @@
 import { step } from "../../misc/reporters/step";
 import { Drawer } from "../../component/drawer.component";
 import { expect } from "@playwright/test";
+import { getAccountAddress } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Transaction } from "@ledgerhq/live-common/e2e/models/Transaction";
 
 export class SendDrawer extends Drawer {
   private sendDrawer = this.page.getByTestId("drawer-content");
   private addressValue = (address: string) => this.sendDrawer.filter({ hasText: address });
+  private transactionTitle = this.page.getByTestId("modal-title").first();
+  private transactionMessageStatus = this.page.getByTestId("success-message-label");
+  private amountValue = this.page.getByTestId("amountReceived-drawer").first();
+  private transactionStatus = this.page.getByTestId("status-drawer");
+  private drawerOperationtype = this.page.getByTestId("operation-type");
+  private operationFromAccount = this.page.getByTestId("operation-from");
+  private operationToAccount = this.page.getByTestId("operation-to");
 
   @step("Verify address is visible")
   async addressValueIsVisible(address: string) {
     await expect(this.addressValue(address)).toBeVisible();
+  }
+
+  @step("Verify transaction title")
+  async expectTransactionTitle(transactionTitle: string) {
+    const displayedTransactionTitle = await this.transactionTitle.innerText();
+    expect(displayedTransactionTitle).toEqual(transactionTitle);
+  }
+
+  @step("Verify transaction message status")
+  async expectTransactionMessageStatus(transactionMessage: string) {
+    const displayedTransactionMessageStatus = await this.transactionMessageStatus.innerText();
+    expect(displayedTransactionMessageStatus).toEqual(transactionMessage);
+  }
+
+  @step("Verify that the information of the transaction is visible")
+  async expectReceiverInfos(tx: Transaction) {
+    await this.amountValue.waitFor();
+    await expect(this.addressValue(getAccountAddress(tx.accountToCredit))).toBeVisible();
+    await expect(this.amountValue).toBeVisible();
+    const displayedAmount = await this.amountValue.innerText();
+    expect(displayedAmount).toEqual(expect.stringContaining(tx.amount));
+    expect(displayedAmount).toEqual(expect.stringContaining(tx.accountToDebit.currency.ticker));
+  }
+
+  @step("Verify transaction status")
+  async expectTransactionStatus(transactionStatus: string) {
+    const displayedTransactionStatus = await this.transactionStatus.innerText();
+    expect(displayedTransactionStatus).toEqual(transactionStatus);
+  }
+
+  @step("Verify drawer operation type")
+  async expectDrawerOperationType(operationType: string) {
+    const displayedOperationType = await this.drawerOperationtype.innerText();
+    expect(displayedOperationType).toEqual(operationType);
+  }
+
+  @step("Verify drawer accounts")
+  async expectDrawerAccounts(tx: Transaction) {
+    await expect(this.operationToAccount).toContainText(tx.accountToCredit.address);
+    await expect(this.operationFromAccount).toContainText(tx.accountToDebit.address);
+  }
+
+  @step("Verify that the information of the token transaction is visible")
+  async expectTokenReceiverInfos(tx: Transaction) {
+    await expect(this.amountValue).toBeVisible();
+    const displayedAmount = await this.amountValue.innerText();
+    expect(displayedAmount).toEqual(expect.stringContaining(tx.amount));
+    expect(displayedAmount).toEqual(expect.stringContaining(tx.accountToDebit.currency.ticker));
   }
 }

--- a/e2e/desktop/tests/page/drawer/send.drawer.ts
+++ b/e2e/desktop/tests/page/drawer/send.drawer.ts
@@ -11,7 +11,7 @@ export class SendDrawer extends Drawer {
   private transactionMessageStatus = this.page.getByTestId("success-message-label");
   private amountValue = this.page.getByTestId("amountReceived-drawer").first();
   private transactionStatus = this.page.getByTestId("status-drawer");
-  private drawerOperationtype = this.page.getByTestId("operation-type");
+  private drawerOperationType = this.page.getByTestId("operation-type");
   private operationFromAccount = this.page.getByTestId("operation-from");
   private operationToAccount = this.page.getByTestId("operation-to");
 
@@ -50,7 +50,7 @@ export class SendDrawer extends Drawer {
 
   @step("Verify drawer operation type")
   async expectDrawerOperationType(operationType: string) {
-    const displayedOperationType = await this.drawerOperationtype.innerText();
+    const displayedOperationType = await this.drawerOperationType.innerText();
     expect(displayedOperationType).toEqual(operationType);
   }
 

--- a/e2e/desktop/tests/page/speculos.page.ts
+++ b/e2e/desktop/tests/page/speculos.page.ts
@@ -12,6 +12,7 @@ import {
   activateExpertMode,
   activateContractData,
   removeMemberLedgerSync,
+  providePublicKey,
 } from "@ledgerhq/live-common/e2e/speculos";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { NFTTransaction, Transaction } from "@ledgerhq/live-common/e2e/models/Transaction";
@@ -72,5 +73,10 @@ export class SpeculosPage extends AppPage {
   @step("Activate contract data")
   async activateContractData() {
     await activateContractData();
+  }
+
+  @step("Provide Public Key")
+  async providePublicKey() {
+    await providePublicKey();
   }
 }

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -208,7 +208,7 @@ const transactionE2E = [
     xrayTicket: "B2CQA-3840",
   },
   {
-    transaction: new Transaction(Account.SUI_1, Account.SUI_2, "0.0001", undefined, "noTag"),
+    transaction: new Transaction(Account.SUI_1, Account.SUI_2, "0.0001", undefined),
     xrayTicket: "B2CQA-3802",
   },
 ];

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -207,6 +207,10 @@ const transactionE2E = [
     transaction: new Transaction(Account.KASPA_1, Account.KASPA_2, "1"),
     xrayTicket: "B2CQA-3840",
   },
+  {
+    transaction: new Transaction(Account.SUI_1, Account.SUI_2, "0.0001", undefined, "noTag"),
+    xrayTicket: "B2CQA-3802",
+  },
 ];
 
 test.describe("Send flows", () => {

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -10,6 +10,7 @@ import {
 import { Transaction } from "@ledgerhq/live-common/e2e/models/Transaction";
 import { Fee } from "@ledgerhq/live-common/e2e/enum/Fee";
 import invariant from "invariant";
+import { TransactionStatus } from "@ledgerhq/live-common/e2e/enum/TransactionStatus";
 
 const subAccounts = [
   {
@@ -22,6 +23,7 @@ const subAccounts = [
   { account: Account.TRX_USDT, xrayTicket1: "B2CQA-2580", xrayTicket2: "B2CQA-2586" },
   { account: Account.BSC_BUSD_1, xrayTicket1: "B2CQA-2576", xrayTicket2: "B2CQA-2582" },
   { account: Account.POL_DAI_1, xrayTicket1: "B2CQA-2578", xrayTicket2: "B2CQA-2584" },
+  { account: TokenAccount.SUI_USDC_1, xrayTicket1: "B2CQA-3904", xrayTicket2: "B2CQA-3905" },
 ];
 
 const subAccountReceive = [
@@ -32,6 +34,7 @@ const subAccountReceive = [
   { account: Account.BSC_SHIBA, xrayTicket: "B2CQA-2490" },
   { account: Account.POL_DAI_1, xrayTicket: "B2CQA-2493" },
   { account: Account.POL_UNI, xrayTicket: "B2CQA-2494" },
+  { account: TokenAccount.SUI_USDC_1, xrayTicket: "B2CQA-3906" },
 ];
 
 for (const token of subAccounts) {
@@ -476,6 +479,79 @@ test.describe("Send token (subAccount) - valid address & amount input", () => {
       await app.send.expectTxSent();
       await app.account.navigateToViewDetails();
       await app.sendDrawer.addressValueIsVisible(tokenTransactionValid.accountToCredit.address);
+    },
+  );
+});
+
+test.describe("Send token (subAccount) - e2e ", () => {
+  const tokenValidSend = {
+    tx: new Transaction(TokenAccount.SUI_USDC_1, TokenAccount.SUI_USDC_2, "0.01", Fee.MEDIUM),
+    xrayTicket: "B2CQA-3908",
+  };
+  test.use({
+    userdata: "skip-onboarding",
+    speculosApp: tokenValidSend.tx.accountToDebit.currency.speculosApp,
+    cliCommands: [
+      (appjsonPath: string) => {
+        return CLI.liveData({
+          currency: tokenValidSend.tx.accountToDebit.currency.speculosApp.name,
+          index: tokenValidSend.tx.accountToDebit.index,
+          add: true,
+          appjson: appjsonPath,
+        });
+      },
+      (appjsonPath: string) => {
+        return CLI.liveData({
+          currency: tokenValidSend.tx.accountToCredit.currency.speculosApp.name,
+          index: tokenValidSend.tx.accountToCredit.index,
+          add: true,
+          appjson: appjsonPath,
+        });
+      },
+    ],
+  });
+  test(
+    `Send from ${tokenValidSend.tx.accountToDebit.accountName} to ${tokenValidSend.tx.accountToCredit.accountName} - e2e`,
+    {
+      tag: ["@NanoSP", "@LNS", "@NanoX"],
+      annotation: { type: "TMS", description: tokenValidSend.xrayTicket },
+    },
+    async ({ app }) => {
+      const tx = tokenValidSend.tx;
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.layout.goToAccounts();
+      await app.accounts.navigateToAccountByName(getParentAccountName(tx.accountToDebit));
+      await app.account.navigateToTokenInAccount(tx.accountToDebit);
+      await app.account.clickSend();
+      await app.send.fillRecipient(tx.accountToCredit.address);
+      await app.send.checkContinueButtonEnable();
+      await app.send.checkInputErrorVisibility("hidden");
+      await app.send.continue();
+      await app.send.fillAmount(tx.amount);
+      await app.send.continue();
+      await app.send.expectTxInfoValidity(tx);
+      await app.send.clickContinueToDevice();
+      await app.speculos.signSendTransaction(tx);
+      await app.send.expectTxSent();
+      await app.sendDrawer.expectTransactionTitle(TransactionStatus.SEND);
+      await app.sendDrawer.expectTransactionMessageStatus(TransactionStatus.TRANSACTION_SENT);
+      await app.account.navigateToViewDetails();
+      await app.sendDrawer.addressValueIsVisible(tx.accountToCredit.address);
+      await app.sendDrawer.expectReceiverInfos(tx);
+      await app.drawer.closeDrawer();
+      if (process.env.DISABLE_TRANSACTION_BROADCAST !== "1") {
+        await app.layout.goToAccounts();
+        await app.accounts.clickSyncBtnForAccount(getParentAccountName(tx.accountToCredit));
+        await app.accounts.navigateToAccountByName(getParentAccountName(tx.accountToCredit));
+        await app.account.navigateToTokenInAccount(tx.accountToDebit);
+        await app.account.expectAccountBalance();
+        await app.account.checkAccountChart();
+        await app.account.selectAndClickOnLastOperation(TransactionStatus.RECEIVED);
+        await app.sendDrawer.expectTransactionStatus(TransactionStatus.CONFIRMED);
+        await app.sendDrawer.expectDrawerOperationType(TransactionStatus.RECEIVED);
+        await app.sendDrawer.expectDrawerAccounts(tx);
+        await app.sendDrawer.expectTokenReceiverInfos(tx);
+      }
     },
   );
 });

--- a/e2e/desktop/tests/specs/swap.send.spec.ts
+++ b/e2e/desktop/tests/specs/swap.send.spec.ts
@@ -88,6 +88,12 @@ const swaps = [
   //  xrayTicket: "B2CQA-3753",
   //  tag: ["@NanoSP", "@NanoX"],
   //},
+  {
+    fromAccount: TokenAccount.SUI_USDC_1,
+    toAccount: Account.SOL_1,
+    xrayTicket: "B2CQA-3907",
+    tag: ["@NanoSP", "@NanoX"],
+  },
 ];
 
 for (const { fromAccount, toAccount, xrayTicket, tag } of swaps) {

--- a/e2e/desktop/tests/userdata/speculos-subAccount.json
+++ b/e2e/desktop/tests/userdata/speculos-subAccount.json
@@ -20851,7 +20851,48 @@
           "starred": false
         },
         "version": 1
-      }
+      },
+        {
+            "data": {
+                "id": "js:2:sui:0xc6169bcce8718609e43d179b087e6c1e2ac28e5325660af34d22fb5ce284031e:sui",
+                "seedIdentifier": "f90d60d74022f1ba8a5ec81a43d8b3905f94bdb4057f1593e7339a8d211138d1",
+                "used": true,
+                "derivationMode": "sui",
+                "index": 0,
+                "freshAddress": "0xc6169bcce8718609e43d179b087e6c1e2ac28e5325660af34d22fb5ce284031e",
+                "freshAddressPath": "44'/784'/0'/0'/0'",
+                "blockHeight": 5,
+                "syncHash": "H5WfMj6L9rT9yqa67qxDqqTDUopYSSdcC6c1exoVqGUd",
+                "creationDate": "2025-09-08T15:06:19.635Z",
+                "operationsCount": 0,
+                "operations": [],
+                "pendingOperations": [],
+                "currencyId": "sui",
+                "lastSyncDate": "2025-09-08T15:06:19.635Z",
+                "balance": "3048628000",
+                "spendableBalance": "3048628000",
+                "balanceHistoryCache": {
+                    "HOUR": {
+                        "balances": [],
+                        "latestDate": 1757343600000
+                    },
+                    "DAY": {
+                        "balances": [],
+                        "latestDate": 1757282400000
+                    },
+                    "WEEK": {
+                        "balances": [],
+                        "latestDate": 1757196000000
+                    }
+                },
+                "subAccounts": [],
+                "suiResources": {},
+                "swapHistory": [],
+                "name": "Sui 1",
+                "starred": false
+            },
+            "version": 1
+        }
     ],
     "postOnboarding": {
       "deviceModelId": "nanoX",

--- a/libs/ledger-live-common/src/e2e/enum/Account.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Account.ts
@@ -526,6 +526,19 @@ export class Account {
     1,
   );
 
+  static readonly SUI_1 = new Account(
+    Currency.SUI,
+    "Sui 1",
+    "0xc6169bcce8718609e43d179b087e6c1e2ac28e5325660af34d22fb5ce284031e",
+    0,
+  );
+  static readonly SUI_2 = new Account(
+    Currency.SUI,
+    "Sui 2",
+    "0x6644c1ce77c5e5ef8d8bd3ae2a4e18239e5d418a5e0800ed5037818399e3a7f6",
+    1,
+  );
+
   static readonly EMPTY = new Account(Currency.BTC, "Empty", "", 0);
 }
 
@@ -639,6 +652,24 @@ export class TokenAccount extends Account {
     0,
     TokenType.TRC20,
     Account.TRX_1,
+  );
+
+  static readonly SUI_USDC_1 = new TokenAccount(
+    Currency.SUI_USDC,
+    "SUI USDC 1",
+    Account.SUI_1.address,
+    0,
+    TokenType.ERC20,
+    Account.SUI_1,
+  );
+
+  static readonly SUI_USDC_2 = new TokenAccount(
+    Currency.SUI_USDC,
+    "SUI USDC 2",
+    Account.SUI_2.address,
+    1,
+    TokenType.ERC20,
+    Account.SUI_2,
   );
 }
 

--- a/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
+++ b/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
@@ -64,4 +64,6 @@ export class AppInfos {
   static readonly KASPA = new AppInfos("Kaspa");
 
   static readonly HEDERA = new AppInfos("Hedera");
+
+  static readonly SUI = new AppInfos("Sui");
 }

--- a/libs/ledger-live-common/src/e2e/enum/Currency.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Currency.ts
@@ -207,4 +207,15 @@ export class Currency {
   static readonly OP = new Currency("OP Mainnet", "OP", "optimism", AppInfos.ETHEREUM, [
     Network.OPTIMISM,
   ]);
+
+  static readonly SUI = new Currency("Sui", "SUI", "sui", AppInfos.SUI, [Network.SUI]);
+
+  static readonly SUI_USDC = new Currency(
+    "USDC",
+    "USDC",
+    "sui/coin/usdc_0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::usdc",
+    AppInfos.SUI,
+    [Network.SUI],
+    "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7",
+  );
 }

--- a/libs/ledger-live-common/src/e2e/enum/Network.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Network.ts
@@ -33,4 +33,5 @@ export enum Network {
   LITECOIN = "Litecoin",
   KASPA = "Kaspa",
   HEDERA = "Hedera",
+  SUI = "Sui",
 }

--- a/libs/ledger-live-common/src/e2e/enum/TokenType.ts
+++ b/libs/ledger-live-common/src/e2e/enum/TokenType.ts
@@ -2,4 +2,5 @@ export enum TokenType {
   ERC20 = "erc20",
   TRC20 = "trc20",
   SPL = "spl",
+  SUI = "sui",
 }

--- a/libs/ledger-live-common/src/e2e/enum/TransactionStatus.ts
+++ b/libs/ledger-live-common/src/e2e/enum/TransactionStatus.ts
@@ -3,7 +3,10 @@ export enum TransactionStatus {
   DELEGATED = "Delegated",
   NFT_RECEIVED = "NFT Received",
   SENT = "Sent",
+  SEND = "Send",
   FEES = "Fees",
   STAKED = "Staked",
   SENDING = "Sending",
+  TRANSACTION_SENT = "Transaction sent",
+  CONFIRMED = "Confirmed",
 }

--- a/libs/ledger-live-common/src/e2e/families/sui.ts
+++ b/libs/ledger-live-common/src/e2e/families/sui.ts
@@ -1,0 +1,7 @@
+import { pressBoth, pressUntilTextFound } from "../speculos";
+import { DeviceLabels } from "../enum/DeviceLabels";
+
+export async function sendSui() {
+  await pressUntilTextFound(DeviceLabels.ACCEPT);
+  await pressBoth();
+}

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -42,6 +42,7 @@ import { Swap } from "./models/Swap";
 import { delegateOsmosis } from "./families/osmosis";
 import { AppInfos } from "./enum/AppInfos";
 import { DEVICE_LABELS_CONFIG } from "./data/deviceLabelsData";
+import { sendSui } from "./families/sui";
 
 const isSpeculosRemote = process.env.REMOTE_SPECULOS === "true";
 
@@ -344,6 +345,14 @@ export const specs: Specs = {
     },
     dependency: "",
   },
+  Sui: {
+    currency: getCryptoCurrencyById("sui"),
+    appQuery: {
+      model: getSpeculosModel(),
+      appName: "Sui",
+    },
+    dependency: "",
+  },
 };
 
 export async function startSpeculos(
@@ -632,6 +641,10 @@ export async function goToSettings() {
   await pressBoth();
 }
 
+export async function providePublicKey() {
+  await pressRightButton();
+}
+
 type DeviceLabelsReturn = {
   delegateConfirmLabel: string;
   delegateVerifyLabel: string;
@@ -660,6 +673,10 @@ export function getDeviceLabels(appInfo: AppInfos): DeviceLabelsReturn {
 }
 
 export async function expectValidAddressDevice(account: Account, addressDisplayed: string) {
+  if (account.currency === Currency.SUI_USDC) {
+    providePublicKey();
+  }
+
   const { receiveVerifyLabel, receiveConfirmLabel } = getDeviceLabels(account.currency.speculosApp);
 
   await waitFor(receiveVerifyLabel);
@@ -720,6 +737,12 @@ export async function signSendTransaction(tx: Transaction) {
       break;
     case Currency.HBAR:
       await sendHedera();
+      break;
+    case Currency.SUI:
+      await sendSui();
+      break;
+    case Currency.SUI_USDC:
+      await sendSui();
       break;
     default:
       throw new Error(`Unsupported currency: ${currencyName.ticker}`);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Adding test coverage to SUI native and tokens. 
  - Adding data-tetestId to operation details index
  - Adding more assertions to send.drawer and account.page

### 📝 Description

Adding back the SUI native and token E2E tests


### ❓ Context

- [Fixing SUI E2E tests](https://ledgerhq.atlassian.net/browse/LIVE-21925)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
