### PR TITLE
feat: LIVE-21389 add noah loading screen

### DIFF
--- a/.changeset/metal-mayflies-check.md
+++ b/.changeset/metal-mayflies-check.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Added loading screen for noah

--- a/apps/ledger-live-desktop/src/newArch/components/ProviderInterstitial/ProviderInterstitial.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/components/ProviderInterstitial/ProviderInterstitial.test.tsx
@@ -3,11 +3,11 @@ import React from "react";
 import { BUY_SELL_UI_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { useShowProviderLoadingTransition } from "@ledgerhq/live-common/hooks/useShowProviderLoadingTransition";
-import { screen } from "@testing-library/react-native";
-import { render } from "@tests/test-renderer";
 
-import { ProviderInterstitial } from "./ProviderInterstitial";
+import { render, screen } from "tests/testSetup";
+import { ProviderInterstitial } from ".";
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const mockManifest = {
   id: BUY_SELL_UI_APP_ID,
   name: "Moonpay",
@@ -19,16 +19,18 @@ jest.mock("@ledgerhq/live-common/hooks/useShowProviderLoadingTransition", () => 
 
 describe("ProviderInterstitial", () => {
   it("renders nothing if transition hook returns false", () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     (useShowProviderLoadingTransition as jest.Mock).mockReturnValue(false);
     render(<ProviderInterstitial manifest={mockManifest} isLoading={false} />);
     expect(screen.queryByTestId("custom-buy-sell-loader")).toBeNull();
   });
 
   it("renders loader when transition hook returns true", () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     (useShowProviderLoadingTransition as jest.Mock).mockReturnValue(true);
     render(<ProviderInterstitial manifest={mockManifest} isLoading={true} />);
 
-    expect(screen.getByTestId("custom-buy-sell-loader")).toBeTruthy();
+    expect(screen.queryByTestId("custom-buy-sell-loader")).toBeInTheDocument();
     expect(screen.getByText("Connecting you to Moonpay", { exact: false })).toBeTruthy(); // or mock t()
   });
 });

--- a/apps/ledger-live-desktop/src/newArch/components/ProviderInterstitial/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/components/ProviderInterstitial/index.tsx
@@ -78,8 +78,8 @@ const EllipsisLoader = () => (
   </Ellipsis>
 );
 
-/** Custom loader for transition between Buy/Sell and providers */
-export const ProviderInterstitial: WebviewLoader = ({ manifest, isLoading }) => {
+/** Custom loader for transition between LL and providers */
+export const ProviderInterstitial: WebviewLoader = ({ manifest, isLoading, description }) => {
   const { t } = useTranslation();
   const showProviderLoadingTransition = useShowProviderLoadingTransition({ manifest, isLoading });
 
@@ -99,7 +99,7 @@ export const ProviderInterstitial: WebviewLoader = ({ manifest, isLoading }) => 
         </IconContainer>
       </VisualWrapper>
       <Text variant="body" color="palette.opacityDefault.c60" textAlign="center">
-        {t("exchange.connectingTo", { provider: manifest.name })}
+        {description ?? t("exchange.connectingTo", { provider: manifest.name })}
       </Text>
     </Loader>
   );

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/types.ts
@@ -10,6 +10,7 @@ export interface WebviewTag extends Electron.WebviewTag {
 export type WebviewLoader = React.ComponentType<{
   manifest: LiveAppManifest;
   isLoading: boolean;
+  description?: string;
 }>;
 
 export type WebviewProps = {

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.tsx
@@ -46,7 +46,14 @@ export const WebViewWrapper = styled.div<WebViewWrapperProps>`
     mobileView.display ? `width: ${mobileView.width ?? 355}px;` : "width: 100%;"}
 `;
 
-export default function WebPlatformPlayer({ manifest, inputs, onClose, config, ...props }: Props) {
+export default function WebPlatformPlayer({
+  manifest,
+  inputs,
+  onClose,
+  config,
+  Loader,
+  ...props
+}: Props) {
   const webviewAPIRef = useRef<WebviewAPI>(null);
   const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
 
@@ -92,6 +99,7 @@ export default function WebPlatformPlayer({ manifest, inputs, onClose, config, .
             ref={webviewAPIRef}
             customHandlers={customHandlers}
             currentAccountHistDb={currentAccountHistDb}
+            Loader={Loader}
           />
         </WebViewWrapper>
       </Wrapper>

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -30,8 +30,8 @@ import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalL
 import { useProviderInterstitalEnabled } from "@ledgerhq/live-common/hooks/useShowProviderLoadingTransition";
 import { walletSelector } from "~/renderer/reducers/wallet";
 import { useDiscreetMode } from "~/renderer/components/Discreet";
-import { ProviderInterstitial } from "./BuySell/ProviderInterstitial";
 import { NetworkErrorScreen } from "~/renderer/components/Web3AppWebview/NetworkError";
+import { ProviderInterstitial } from "LLD/components/ProviderInterstitial";
 
 type ExchangeState = { account?: string } | undefined;
 

--- a/apps/ledger-live-desktop/src/renderer/screens/receive/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/receive/index.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next";
+import { useProviderInterstitalEnabled } from "@ledgerhq/live-common/hooks/useShowProviderLoadingTransition";
 import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import React from "react";
@@ -7,6 +9,8 @@ import Card from "~/renderer/components/Box/Card";
 import WebPlatformPlayer from "~/renderer/components/WebPlatformPlayer";
 import useTheme from "~/renderer/hooks/useTheme";
 import { languageSelector } from "~/renderer/reducers/settings";
+import { WebviewLoader } from "~/renderer/components/Web3AppWebview/types";
+import { ProviderInterstitial } from "LLD/components/ProviderInterstitial";
 
 const PROVIDER_MANIFEST_ID = "noah";
 
@@ -18,6 +22,9 @@ const Receive = () => {
   const manifest = localManifest || remoteManifest;
   const themeType = useTheme().colors.palette.type;
   const params = location.state || {};
+  const providerInterstitialEnabled = useProviderInterstitalEnabled({
+    manifest,
+  });
 
   return (
     <Card grow style={{ overflow: "hidden" }} data-testid="reveive-app-container">
@@ -37,10 +44,16 @@ const Receive = () => {
             lang: locale,
             ...params,
           }}
+          Loader={providerInterstitialEnabled ? CustomProviderInterstitial : undefined}
         />
       ) : null}
     </Card>
   );
+};
+
+const CustomProviderInterstitial: WebviewLoader = props => {
+  const { t } = useTranslation();
+  return <ProviderInterstitial {...props} description={t("receive.connectToNoah")} />;
 };
 
 export default Receive;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2250,6 +2250,7 @@
   "receive": {
     "title": "Receive",
     "successTitle": "Address shared securely",
+    "connectToNoah": "Re-directing you to Noah, our partner, to create your cash-to-stable account",
     "steps": {
       "options": {
         "fromBank": {

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
@@ -114,6 +114,7 @@ function HeaderRight({ softExit }: { softExit: boolean }) {
 export type InterstitialType = React.ComponentType<{
   manifest: LiveAppManifest;
   isLoading: boolean;
+  description?: string;
 }>;
 
 type Props = {

--- a/apps/ledger-live-mobile/src/components/WebReceivePlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebReceivePlayer/index.tsx
@@ -1,16 +1,16 @@
-import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
-import React, { useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { StyleSheet, SafeAreaView, BackHandler, Platform } from "react-native";
 import { ScopeProvider } from "jotai-scope";
-
 import { useNavigation } from "@react-navigation/native";
 import { currentAccountAtom } from "@ledgerhq/live-common/wallet-api/useDappLogic";
-import { WebviewAPI } from "../Web3AppWebview/types";
-
+import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { Web3AppWebview } from "../Web3AppWebview";
+import { WebviewAPI, WebviewState } from "../Web3AppWebview/types";
+import { initialWebviewState } from "../Web3AppWebview/helpers";
 import { RootNavigationComposite, StackNavigatorNavigation } from "../RootNavigator/types/helpers";
 import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigator";
-
+import { ProviderInterstitial } from "LLM/components/ProviderInterstitial";
 import { NavigatorName } from "~/const";
 
 type Props = {
@@ -20,6 +20,8 @@ type Props = {
 
 const WebReceivePlayer = ({ manifest, inputs }: Props) => {
   const webviewAPIRef = useRef<WebviewAPI>(null);
+  const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
+  const { t } = useTranslation();
 
   const navigation =
     useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();
@@ -63,6 +65,12 @@ const WebReceivePlayer = ({ manifest, inputs }: Props) => {
               });
             },
           }}
+          onStateChange={setWebviewState}
+        />
+        <ProviderInterstitial
+          manifest={manifest}
+          isLoading={webviewState.loading}
+          description={t("transfer.receive.connectToNoah")}
         />
       </SafeAreaView>
     </ScopeProvider>

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3433,6 +3433,7 @@
       "shareAddress": "Share address",
       "addressCopied": "Address copied in clipboard",
       "taprootWarning": "Make sure the sender supports taproot",
+      "connectToNoah": "Re-directing you to Noah, our partner, to create your cash-to-stable account",
       "menu": {
         "crypto": {
           "title": "From a crypto address",

--- a/apps/ledger-live-mobile/src/newArch/components/ProviderInterstitial/ProviderInterstitial.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/ProviderInterstitial/ProviderInterstitial.test.tsx
@@ -3,11 +3,11 @@ import React from "react";
 import { BUY_SELL_UI_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { useShowProviderLoadingTransition } from "@ledgerhq/live-common/hooks/useShowProviderLoadingTransition";
+import { screen } from "@testing-library/react-native";
+import { render } from "@tests/test-renderer";
 
-import { render, screen } from "tests/testSetup";
-import { ProviderInterstitial } from "./ProviderInterstitial";
+import { ProviderInterstitial } from ".";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const mockManifest = {
   id: BUY_SELL_UI_APP_ID,
   name: "Moonpay",
@@ -19,18 +19,16 @@ jest.mock("@ledgerhq/live-common/hooks/useShowProviderLoadingTransition", () => 
 
 describe("ProviderInterstitial", () => {
   it("renders nothing if transition hook returns false", () => {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     (useShowProviderLoadingTransition as jest.Mock).mockReturnValue(false);
     render(<ProviderInterstitial manifest={mockManifest} isLoading={false} />);
     expect(screen.queryByTestId("custom-buy-sell-loader")).toBeNull();
   });
 
   it("renders loader when transition hook returns true", () => {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     (useShowProviderLoadingTransition as jest.Mock).mockReturnValue(true);
     render(<ProviderInterstitial manifest={mockManifest} isLoading={true} />);
 
-    expect(screen.queryByTestId("custom-buy-sell-loader")).toBeInTheDocument();
+    expect(screen.getByTestId("custom-buy-sell-loader")).toBeTruthy();
     expect(screen.getByText("Connecting you to Moonpay", { exact: false })).toBeTruthy(); // or mock t()
   });
 });

--- a/apps/ledger-live-mobile/src/newArch/components/ProviderInterstitial/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/ProviderInterstitial/index.tsx
@@ -86,7 +86,7 @@ const AnimatedCircle = ({ delay }: { delay: number }) => {
 };
 
 /** Custom loader for transition between Buy/Sell and providers */
-export const ProviderInterstitial: InterstitialType = ({ manifest, isLoading }) => {
+export const ProviderInterstitial: InterstitialType = ({ manifest, isLoading, description }) => {
   const { t } = useTranslation();
   const showProviderLoadingTransition = useShowProviderLoadingTransition({ manifest, isLoading });
 
@@ -119,8 +119,8 @@ export const ProviderInterstitial: InterstitialType = ({ manifest, isLoading }) 
           />
         </IconContainer>
       </VisualWrapper>
-      <Text variant="body" color="opacityDefault.c60" textAlign="center">
-        {t("transfer.exchange.connectingTo", { provider: manifest.name })}
+      <Text variant="body" color="opacityDefault.c60" textAlign="center" style={{ padding: 16 }}>
+        {description ?? t("transfer.exchange.connectingTo", { provider: manifest.name })}
       </Text>
     </Loader>
   );

--- a/apps/ledger-live-mobile/src/screens/PTX/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 
 import { accountToWalletAPIAccount } from "@ledgerhq/live-common/wallet-api/converters";
+import { useProviderInterstitalEnabled } from "@ledgerhq/live-common/hooks/useShowProviderLoadingTransition";
 import { useTheme } from "styled-components/native";
 import { Flex, InfiniteLoader } from "@ledgerhq/native-ui";
 import TrackScreen from "~/analytics/TrackScreen";
@@ -25,8 +26,7 @@ import { walletSelector } from "~/reducers/wallet";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
 import { useSettings } from "~/hooks";
-import { ProviderInterstitial } from "./BuySell/ProviderInterstitial";
-import { useProviderInterstitalEnabled } from "@ledgerhq/live-common/hooks/useShowProviderLoadingTransition";
+import { ProviderInterstitial } from "LLM/components/ProviderInterstitial";
 
 export type Props = StackNavigatorProps<
   PtxNavigatorParamList,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Added the provider interstitial to the noah flow. Hopefully moved the existing components into more logical places now it is shared across screens.

Mobile:
<img width="518" height="984" alt="Screenshot 2025-10-02 at 09 05 45" src="https://github.com/user-attachments/assets/cd4bbf77-12fd-4922-8159-3d952386c7dd" />

Desktop:
<img width="1624" height="1004" alt="Screenshot 2025-10-02 at 10 50 59" src="https://github.com/user-attachments/assets/ed2189ce-2bef-4c95-a4a8-2c1d4b795deb" />

### ❓ Context

 https://ledgerhq.atlassian.net/browse/LIVE-21389


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
