### PR TITLE
chore(lld): Analytics to know if Receive is done on Add Tokens

### DIFF
--- a/.changeset/chatty-teachers-invite.md
+++ b/.changeset/chatty-teachers-invite.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add a way to know if Receive is done through Add Tokens in analytics

--- a/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/analytics/addAccount.types.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/analytics/addAccount.types.ts
@@ -29,6 +29,7 @@ export type AddAccountEventParams = {
   [ADD_ACCOUNT_EVENTS_NAME.ACCOUNT_ADDED]: {
     currency: string;
     amount: number;
+    isTokenAdd?: boolean;
   };
   [ADD_ACCOUNT_EVENTS_NAME.LOOKING_FOR_ACCOUNTS]: {
     source: string;

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepAccount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepAccount.tsx
@@ -108,7 +108,11 @@ export default function StepAccount(props: Readonly<StepProps>) {
 
   return (
     <Box flow={1}>
-      <TrackPage category={`Receive Flow${eventType ? ` (${eventType})` : ""}`} name="Step 1" />
+      <TrackPage
+        category={`Receive Flow${eventType ? ` (${eventType})` : ""}`}
+        name="Step 1"
+        isTokenAdd={receiveTokenMode || account?.type === "TokenAccount"}
+      />
       {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
       {accountError ? <ErrorBanner error={accountError} /> : null}
 


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD: account > Receive
  - analytics only

### 📝 Description

Add a way to know when user is using Add Tokens on an account that don't have tokens yet.

### ❓ Context

- **JIRA or GitHub link**: LIVE-21967


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
