### PR TITLE
fix(LLD): mad networks incorrect for only balance component

### DIFF
--- a/.changeset/nervous-peas-chew.md
+++ b/.changeset/nervous-peas-chew.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Display correct information on networks when only balance used for right component

--- a/libs/ledger-live-common/src/modularDrawer/hooks/useRightBalanceNetwork.tsx
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/useRightBalanceNetwork.tsx
@@ -26,8 +26,9 @@ export function createUseRightBalanceNetwork({ useBalanceDeps, balanceItem }: Ne
 
     return networks.map(network => {
       const balanceData = balanceMap.get(network.id) || {};
+      const details = network.type === "TokenCurrency" ? network.parentCurrency : network;
       return {
-        ...network,
+        ...details,
         rightElement: balanceItem(balanceData),
         balanceData: balanceData,
       };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD network drawer configured as balance on right component only

### 📝 Description

When selecting a network with MAD configured with only the balance right component, the networks should be displayed correctly


| Before        | After         |
| ------------- | ------------- |
|  <img width="1306" height="927" alt="image" src="https://github.com/user-attachments/assets/7523a910-5fa3-44cb-a61d-8d3125f8ecf8" />  | <img width="1306" height="927" alt="image" src="https://github.com/user-attachments/assets/efb8a431-18fd-433f-b803-bd5ea14a0741" />  |


### ❓ Context

- **JIRA or GitHub link**: [LIVE-21971](https://ledgerhq.atlassian.net/browse/LIVE-21971)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
