### PR TITLE
Live 20813 earn feature flag for asset drawer parameters

### DIFF
--- a/.changeset/lazy-bottles-breathe.md
+++ b/.changeset/lazy-bottles-breathe.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+add new feature flag(to display apy in the drawer) to the earn app

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
@@ -32,6 +32,7 @@ const Earn = () => {
   const locale = useSelector(localeSelector);
   const fiatCurrency = useSelector(counterValueCurrencySelector);
   const earnFlag = useFeature("ptxEarnLiveApp");
+  const earnDrawerApyFlag = useFeature("ptxEarnDrawerApy");
   const earnManifestId = earnFlag?.enabled ? earnFlag.params?.manifest_id : DEFAULT_MANIFEST_ID;
   const localManifest = useLocalLiveAppManifest(earnManifestId);
   const remoteManifest = useRemoteLiveAppManifest(earnManifestId);
@@ -78,6 +79,7 @@ const Earn = () => {
           stakeCurrenciesParam: stakeCurrenciesParam
             ? JSON.stringify(stakeCurrenciesParam)
             : undefined,
+          earnDrawerApyFlag: earnDrawerApyFlag ? JSON.stringify(earnDrawerApyFlag) : undefined,
         }}
       />
     </Card>

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -49,6 +49,7 @@ function Earn({ route }: Props) {
   );
 
   const earnFlag = useFeature("ptxEarnLiveApp");
+  const earnDrawerApyFlag = useFeature("ptxEarnDrawerApy");
   const earnManifestId = earnFlag?.enabled ? earnFlag.params?.manifest_id : DEFAULT_MANIFEST_ID;
   const localManifest: LiveAppManifest | undefined = useLocalLiveAppManifest(earnManifestId);
   const remoteManifest: LiveAppManifest | undefined = useRemoteLiveAppManifest(earnManifestId);
@@ -88,6 +89,7 @@ function Earn({ route }: Props) {
             ? JSON.stringify(stakeCurrenciesParam)
             : undefined,
           OS: Platform.OS,
+          earnDrawerApyFlag: earnDrawerApyFlag ? JSON.stringify(earnDrawerApyFlag) : undefined,
           ...params,
           ...Object.fromEntries(searchParams.entries()),
         }}


### PR DESCRIPTION

Flag data
id: `feature_ptx_earn_drawer_apy`
value: `{"enabled": false,"params": {}}`

This flag will be used accrosed LL and earn webapp to enable/disable the apy in the drawer
 
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-20813](https://ledgerhq.atlassian.net/browse/LIVE-20813)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
