### PR TITLE
feat: LIVE-21973 add provider session id to noah

### DIFF
--- a/.changeset/flat-actors-protect.md
+++ b/.changeset/flat-actors-protect.md
@@ -1,0 +1,8 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-env": minor
+---
+
+Add providerSessionId to noah manifest url

--- a/apps/ledger-live-desktop/src/renderer/screens/receive/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/receive/index.tsx
@@ -1,16 +1,17 @@
-import { useTranslation } from "react-i18next";
-import { useProviderInterstitalEnabled } from "@ledgerhq/live-common/hooks/useShowProviderLoadingTransition";
-import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
-import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import React from "react";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useProviderInterstitalEnabled } from "@ledgerhq/live-common/hooks/useShowProviderLoadingTransition";
+import { useManifestWithSessionId } from "@ledgerhq/live-common/hooks/useManifestWithSessionId";
+import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
+import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import Card from "~/renderer/components/Box/Card";
 import WebPlatformPlayer from "~/renderer/components/WebPlatformPlayer";
-import useTheme from "~/renderer/hooks/useTheme";
-import { languageSelector } from "~/renderer/reducers/settings";
 import { WebviewLoader } from "~/renderer/components/Web3AppWebview/types";
 import { ProviderInterstitial } from "LLD/components/ProviderInterstitial";
+import useTheme from "~/renderer/hooks/useTheme";
+import { languageSelector, shareAnalyticsSelector } from "~/renderer/reducers/settings";
 
 const PROVIDER_MANIFEST_ID = "noah";
 
@@ -19,7 +20,12 @@ const Receive = () => {
   const locale = useSelector(languageSelector);
   const localManifest = useLocalLiveAppManifest(PROVIDER_MANIFEST_ID);
   const remoteManifest = useRemoteLiveAppManifest(PROVIDER_MANIFEST_ID);
+  const shareAnalytics = useSelector(shareAnalyticsSelector);
   const manifest = localManifest || remoteManifest;
+  const { manifest: manifestWithSessionId } = useManifestWithSessionId({
+    manifest,
+    shareAnalytics,
+  });
   const themeType = useTheme().colors.palette.type;
   const params = location.state || {};
   const providerInterstitialEnabled = useProviderInterstitalEnabled({
@@ -28,7 +34,7 @@ const Receive = () => {
 
   return (
     <Card grow style={{ overflow: "hidden" }} data-testid="reveive-app-container">
-      {manifest ? (
+      {manifestWithSessionId ? (
         <WebPlatformPlayer
           config={{
             topBarConfig: {
@@ -38,7 +44,7 @@ const Receive = () => {
               shouldDisplayNavigation: false,
             },
           }}
-          manifest={manifest}
+          manifest={manifestWithSessionId}
           inputs={{
             theme: themeType,
             lang: locale,

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/01b-ReceiveProvider..tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/01b-ReceiveProvider..tsx
@@ -5,6 +5,7 @@ import { ScreenName } from "~/const";
 import { ReceiveFundsStackParamList } from "~/components/RootNavigator/types/ReceiveFundsNavigator";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
+import { useManifestWithSessionId } from "@ledgerhq/live-common/hooks/useManifestWithSessionId";
 import {
   useRemoteLiveAppContext,
   useRemoteLiveAppManifest,
@@ -12,6 +13,8 @@ import {
 import WebRecievePlayer from "~/components/WebReceivePlayer";
 import GenericErrorView from "~/components/GenericErrorView";
 import { Flex, InfiniteLoader } from "@ledgerhq/native-ui";
+import { useSelector } from "react-redux";
+import { analyticsEnabledSelector } from "~/reducers/settings";
 
 export default function ReceiveProvider(
   props: StackNavigatorProps<ReceiveFundsStackParamList, ScreenName.ReceiveProvider>,
@@ -24,14 +27,20 @@ export default function ReceiveProvider(
   const remoteManifest = useRemoteLiveAppManifest(manifestId);
   const manifest = localManifest || remoteManifest;
 
+  const shareAnalytics = useSelector(analyticsEnabledSelector);
+  const { manifest: manifestWithSessionId, loading: sessionIdLoading } = useManifestWithSessionId({
+    manifest,
+    shareAnalytics,
+  });
+
   // Below can be used for loading
   const { state: remoteLiveAppState } = useRemoteLiveAppContext();
 
-  return manifest ? (
-    <WebRecievePlayer manifest={manifest} />
+  return manifestWithSessionId ? (
+    <WebRecievePlayer manifest={manifestWithSessionId} />
   ) : (
     <Flex flex={1} p={10} justifyContent="center" alignItems="center">
-      {remoteLiveAppState.isLoading ? (
+      {remoteLiveAppState.isLoading || sessionIdLoading ? (
         <InfiniteLoader />
       ) : (
         <GenericErrorView error={new Error("App not found")} />

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -651,6 +651,11 @@ const envDefinitions = {
     parser: stringParser,
     desc: "(dev feature) seed to be used by speculos (device simulator)",
   },
+  PROVIDER_SESSION_ID_ENDPOINT: {
+    def: "https://buy.api.live.ledger.com/session",
+    parser: stringParser,
+    desc: "Request provider session id",
+  },
   SHOW_LEGACY_NEW_ACCOUNT: {
     def: false,
     parser: boolParser,

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -173,6 +173,7 @@
     "src/hooks/useLatestFirmware.ts",
     "src/hooks/useLdmkFeatureFlagInitiallyEnabled.ts",
     "src/hooks/useLocalizedUrl.ts",
+    "src/hooks/useManifestWithSessionId.ts",
     "src/hooks/useSearch.ts",
     "src/hooks/useTimer.ts",
     "src/hooks/useOFACGeoBlockCheck.ts",

--- a/libs/ledger-live-common/src/hooks/useManifestWithSessionId.test.ts
+++ b/libs/ledger-live-common/src/hooks/useManifestWithSessionId.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { useManifestWithSessionId } from "./useManifestWithSessionId";
+import { LiveAppManifest } from "../platform/types";
+
+const mockFetch = jest.fn();
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+global.fetch = mockFetch as any;
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const baseManifest = {
+  id: "test-app",
+  name: "Test App",
+  url: "https://example.com",
+} as LiveAppManifest;
+
+describe("useManifestWithSessionId", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null manifest during loading", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ providerSessionId: "abc123" }),
+    });
+
+    const { result } = renderHook(() =>
+      useManifestWithSessionId({ manifest: baseManifest, shareAnalytics: true }),
+    );
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.manifest).toBeNull();
+  });
+
+  it("returns manifest with externalID after success", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ providerSessionId: "abc123" }),
+    });
+
+    const { result } = renderHook(() =>
+      useManifestWithSessionId({ manifest: baseManifest, shareAnalytics: true }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.manifest).toEqual({
+        ...baseManifest,
+        url: "https://example.com/?externalID=abc123",
+      }),
+    );
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("falls back to original manifest if fetch rejects", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+
+    const { result } = renderHook(() =>
+      useManifestWithSessionId({ manifest: baseManifest, shareAnalytics: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.manifest).toEqual(baseManifest);
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("falls back to original manifest if response is not ok", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+
+    const { result } = renderHook(() =>
+      useManifestWithSessionId({ manifest: baseManifest, shareAnalytics: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.manifest).toEqual(baseManifest);
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("returns null if manifest is not provided", async () => {
+    const { result } = renderHook(() =>
+      useManifestWithSessionId({ manifest: null, shareAnalytics: true }),
+    );
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.manifest).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("skips fetch if shareAnalytics is false and just returns manifest", () => {
+    const { result } = renderHook(() =>
+      useManifestWithSessionId({ manifest: baseManifest, shareAnalytics: false }),
+    );
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.manifest).toEqual(baseManifest);
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/libs/ledger-live-common/src/hooks/useManifestWithSessionId.ts
+++ b/libs/ledger-live-common/src/hooks/useManifestWithSessionId.ts
@@ -1,0 +1,83 @@
+import React from "react";
+import { appendQueryParamsToManifestURL } from "../wallet-api/utils/appendQueryParamsToManifestURL";
+import { LiveAppManifest } from "../platform/types";
+import { getEnv } from "@ledgerhq/live-env";
+
+type Options = {
+  manifest: LiveAppManifest | null | undefined;
+  shareAnalytics: boolean;
+};
+
+type HookResult = {
+  manifest?: LiveAppManifest | null;
+  loading: boolean;
+};
+
+export function useManifestWithSessionId({ manifest, shareAnalytics }: Options): HookResult {
+  const [id, setId] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    async function fetchId() {
+      if (!shareAnalytics || !manifest) {
+        setId(null);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+
+      try {
+        const response = await fetch(getEnv("PROVIDER_SESSION_ID_ENDPOINT"), {
+          method: "GET",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+        });
+
+        if (!response.ok) throw new Error("Failed to fetch session ID");
+
+        const { providerSessionId } = await response.json();
+
+        if (!cancelled) {
+          setId(providerSessionId);
+          setLoading(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setId(null);
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchId();
+
+    return () => {
+      cancelled = true; // avoid setting state after unmount
+    };
+  }, [shareAnalytics]);
+
+  const customizedManifest = React.useMemo(() => {
+    if (!manifest) return null;
+
+    if (loading) {
+      return null;
+    }
+
+    if (id) {
+      const url = appendQueryParamsToManifestURL(manifest, {
+        externalID: id,
+      });
+
+      return url ? { ...manifest, url: url.toString() } : manifest;
+    }
+
+    return manifest;
+  }, [manifest, id, loading]);
+
+  return { manifest: customizedManifest, loading };
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

In order for tracking to be correctly sent from the Noah live app we need to supply them with the providerSessionId. For Noah this is sent as `externalId`.

Below a test live app that is outputting the url params. Mobile doesn't have locale or theme - I'm looking at that separately:

<img width="1624" height="1004" alt="Screenshot 2025-10-03 at 10 06 53" src="https://github.com/user-attachments/assets/69c59a2e-7eb7-4c19-9fa5-73c3fddb8476" />

<img width="518" height="984" alt="Screenshot 2025-10-03 at 10 42 19" src="https://github.com/user-attachments/assets/a1eb90f8-fa03-4f7f-a495-f0600a1ef64c" />


### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-21973

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
