### PR TITLE
:bug: (LLD) fix opt in prompt double scroll

### DIFF
--- a/.changeset/rare-radios-relax.md
+++ b/.changeset/rare-radios-relax.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Optin Prompt LLD fix double scroll

--- a/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/VariantA/Main/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/VariantA/Main/index.tsx
@@ -19,14 +19,7 @@ const Main = ({ shouldWeTrack, handleOpenPrivacyPolicy }: MainProps) => {
   return (
     <>
       <Track onMount mandatory={shouldWeTrack} event={page} page={page} />
-      <Flex
-        flexDirection={"column"}
-        rowGap={"32px"}
-        mx={"40px"}
-        height={"100%"}
-        pt={paddingTop}
-        overflowY="scroll"
-      >
+      <Flex flexDirection={"column"} rowGap={"32px"} mx={"40px"} flex={1} pt={paddingTop}>
         <HeaderTitle title={"analyticsOptInPrompt.common.title"} />
         <MainBody handleOpenPrivacyPolicy={() => handleOpenPrivacyPolicy(page)} />
       </Flex>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - optin prompt

### 📝 Description

The opt-in prompt had a double scroll layout

No issue with the other variant

| Before        | After         |
| ------------- | ------------- |
|https://github.com/user-attachments/assets/6d45e597-dd5e-47a6-9d0a-b1b2ba82f646|https://github.com/user-attachments/assets/02978a6b-1448-47ed-bcf3-60705ae4fdb6|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-21998](https://ledgerhq.atlassian.net/browse/LIVE-21998)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21998]: https://ledgerhq.atlassian.net/browse/LIVE-21998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ