### PR TITLE
chore(lld): fix flaky tests of useAddMember

### DIFF
--- a/.changeset/hot-ligers-cross.md
+++ b/.changeset/hot-ligers-cross.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix flaky tests of useAddMember

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/useAddMember.test.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/useAddMember.test.ts
@@ -117,7 +117,8 @@ describe("useAddMember", () => {
     Mocks.memberCredentialsSelector.mockReturnValue(null);
     const { result } = renderHook(() => useAddMember({ device }));
 
-    expect(result.current.error).toBeInstanceOf(Error);
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error)); // Wait for the setError
+
     expect(Mocks.sdk.getOrCreateTrustchain).not.toHaveBeenCalled();
     expect(Mocks.setTrustchain).not.toHaveBeenCalledWith(trustchain);
     expect(Mocks.setFlow).not.toHaveBeenCalled();
@@ -129,8 +130,8 @@ describe("useAddMember", () => {
     const { result } = renderHook(() => useAddMember({ device }));
 
     await waitFor(() => expect(Mocks.sdk.getOrCreateTrustchain).toHaveBeenCalled());
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error)); // Wait for the setError
 
-    expect(result.current.error).toBeInstanceOf(Error);
     expect(result.current.error?.message).toBe("Random error");
     expect(Mocks.setTrustchain).not.toHaveBeenCalled();
     expect(Mocks.setFlow).not.toHaveBeenCalled();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Address this CI failure: https://github.com/LedgerHQ/ledger-live/actions/runs/18227122083/job/51901275949?pr=12015
It seems that the hook result was looked at after the `getOrCreateTrustchain` add been called but before the hook was re-rendered with the error.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
