### PR TITLE
chore: Replaced findTokenByAddress with findTokenByAddressInCurrency

### DIFF
--- a/.changeset/remove-find-token-by-address.md
+++ b/.changeset/remove-find-token-by-address.md
@@ -1,0 +1,22 @@
+---
+"@ledgerhq/cryptoassets": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-cli": minor
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/coin-tester-evm": minor
+"@ledgerhq/coin-tester-solana": minor
+"@ledgerhq/types-live": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Remove deprecated findTokenByAddress in favor of findTokenByAddressInCurrency
+
+Removed the deprecated `findTokenByAddress` function which had ambiguous behavior when multiple tokens shared the same contract address across different blockchains. The function has been fully replaced with `findTokenByAddressInCurrency` which requires both the token address and parent currency ID, providing more precise token lookup.
+
+This includes:
+- Removal of `findTokenByAddress` function from cryptoassets package
+- Removal of `tokensByAddress` state dictionary
+- Update all usages to `findTokenByAddressInCurrency` across the codebase
+- Update CryptoAssetsStore interface to remove the deprecated method
+

--- a/apps/cli/src/live-common-setup.ts
+++ b/apps/cli/src/live-common-setup.ts
@@ -154,7 +154,6 @@ export function closeAllDevices() {
 
 //TODO update when CAL is avalaible
 const legacyStore: CryptoAssetsStore = {
-  findTokenByAddress: legacy.findTokenByAddress,
   getTokenById: legacy.getTokenById,
   findTokenById: legacy.findTokenById,
   findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/02-Summary.tsx
@@ -5,7 +5,7 @@ import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { View, SafeAreaView, StyleSheet } from "react-native";
-import { findTokenByAddress } from "@ledgerhq/live-common/currencies/index";
+import { findTokenByAddressInCurrency } from "@ledgerhq/live-common/currencies/index";
 import { HEDERA_TRANSACTION_KINDS } from "@ledgerhq/live-common/families/hedera/constants";
 import { getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
 import { useTheme } from "@react-navigation/native";
@@ -35,7 +35,7 @@ export default function Summary({ navigation, route }: Props) {
   const { account, parentAccount } = useSelector(accountScreenSelector(route));
 
   const { tokenAddress } = route.params;
-  const token = findTokenByAddress(tokenAddress);
+  const token = findTokenByAddressInCurrency(tokenAddress, "hedera");
 
   invariant(account, "hedera: account is required");
   invariant(token, `hedera: token with address ${tokenAddress} is not available`);

--- a/apps/ledger-live-mobile/src/families/hedera/operationDetails.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/operationDetails.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { StyleSheet } from "react-native";
 import { Trans, useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
-import { findTokenByAddress } from "@ledgerhq/live-common/currencies/index";
+import { findTokenByAddressInCurrency } from "@ledgerhq/live-common/currencies/index";
 import { getTransactionExplorer, isValidExtra } from "@ledgerhq/live-common/families/hedera/logic";
 import type { HederaAccount, HederaOperation } from "@ledgerhq/live-common/families/hedera/types";
 import { Text } from "@ledgerhq/native-ui";
@@ -25,7 +25,7 @@ function OperationDetailsPostAccountSection({
   }
 
   const token = operation.extra.associatedTokenId
-    ? findTokenByAddress(operation.extra.associatedTokenId)
+    ? findTokenByAddressInCurrency(operation.extra.associatedTokenId, "hedera")
     : null;
 
   if (!token) {
@@ -54,7 +54,9 @@ function OperationDetailsPostAlert({ account, operation }: Readonly<OperationDet
 
   const extra = isValidExtra(operation.extra) ? operation.extra : null;
   const associatedTokenId = extra?.associatedTokenId;
-  const token = associatedTokenId ? findTokenByAddress(associatedTokenId) : null;
+  const token = associatedTokenId
+    ? findTokenByAddressInCurrency(associatedTokenId, "hedera")
+    : null;
 
   if (!token) {
     return null;

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/cryptoAssetsStore.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/cryptoAssetsStore.fixtures.ts
@@ -19,6 +19,6 @@ setCryptoAssetsStoreGetter(
     ({
       findTokenById: legacyTokens.findTokenById,
       findTokenByAddressInCurrency: legacyTokens.findTokenByAddressInCurrency,
-      findTokenByAddress: legacyTokens.findTokenByAddress,
+      getTokenById: legacyTokens.getTokenById,
     }) as CryptoAssetsStore,
 );

--- a/libs/coin-modules/coin-evm/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-evm/src/deviceTransactionConfig.ts
@@ -31,7 +31,10 @@ const inferDeviceTransactionConfigWalletApi = (
     nft => nft.contract.toLowerCase() === transaction.recipient.toLowerCase(),
   );
 
-  const token = getCryptoAssetsStore().findTokenByAddress(transaction.recipient);
+  const token = getCryptoAssetsStore().findTokenByAddressInCurrency(
+    transaction.recipient,
+    mainAccount.currency.id,
+  );
 
   // ERC20 fields
   if (token && Object.values<string>(ERC20_CLEAR_SIGNED_SELECTORS).includes(selector)) {

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii.test.ts
@@ -17,7 +17,6 @@ jest.setTimeout(100_000);
 //TODO mock call to CAL when available
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 setCryptoAssetsStoreForCoinFramework({
-  findTokenByAddress: legacy.findTokenByAddress,
   getTokenById: legacy.getTokenById,
   findTokenById: legacy.findTokenById,
   findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,

--- a/libs/coin-tester-modules/coin-tester-solana/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-solana/src/scenarii.test.ts
@@ -14,7 +14,6 @@ import { setCryptoAssetsStoreGetter } from "@ledgerhq/coin-solana/cryptoAssetsSt
 //TODO coin tester should not call external endpoints (avoid the error Failed to fetch Figment APY LedgerAPI5xx: Unhandled request)
 //TODO mock call to CAL when available
 setCryptoAssetsStoreGetter(() => ({
-  findTokenByAddress: legacy.findTokenByAddress,
   getTokenById: legacy.getTokenById,
   findTokenById: legacy.findTokenById,
   findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,

--- a/libs/ledger-live-common/src/bridge/crypto-assets/index.test.ts
+++ b/libs/ledger-live-common/src/bridge/crypto-assets/index.test.ts
@@ -14,7 +14,6 @@ describe("Testing CryptoAssetStore", () => {
 
     const store = getCryptoAssetsStore();
     expect(store).toEqual({
-      findTokenByAddress: legacy.findTokenByAddress,
       getTokenById: legacy.getTokenById,
       findTokenById: legacy.findTokenById,
       findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
@@ -31,7 +30,6 @@ describe("Testing CryptoAssetStore", () => {
 
     const store = getCryptoAssetsStore();
     expect(store).toEqual({
-      findTokenByAddress: legacy.findTokenByAddress,
       getTokenById: legacy.getTokenById,
       findTokenById: legacy.findTokenById,
       findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,

--- a/libs/ledger-live-common/src/bridge/crypto-assets/index.ts
+++ b/libs/ledger-live-common/src/bridge/crypto-assets/index.ts
@@ -3,7 +3,6 @@ import * as legacy from "@ledgerhq/cryptoassets/tokens";
 import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 const legacyStore: CryptoAssetsStore = {
-  findTokenByAddress: legacy.findTokenByAddress,
   getTokenById: legacy.getTokenById,
   findTokenById: legacy.findTokenById,
   findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,

--- a/libs/ledger-live-common/src/currencies/index.ts
+++ b/libs/ledger-live-common/src/currencies/index.ts
@@ -15,7 +15,7 @@ export {
   listTokensForCryptoCurrency,
   listTokenTypesForCryptoCurrency,
   findTokenById,
-  findTokenByAddress,
+  findTokenByAddressInCurrency,
   hasTokenId,
   getAbandonSeedAddress,
   getTokenById,

--- a/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
+++ b/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
@@ -8,7 +8,7 @@ import { getAccountBridge } from "../bridge";
 import { getEnv } from "@ledgerhq/live-env";
 import network from "@ledgerhq/live-network/network";
 import { getWalletAPITransactionSignFlowInfos } from "./converters";
-import { findTokenByAddress, getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { findTokenByAddressInCurrency, getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { prepareMessageToSign } from "../hw/signMessage/index";
 import { CurrentAccountHistDB, UiHook, usePermission } from "./react";
 import BigNumber from "bignumber.js";
@@ -482,8 +482,6 @@ export function useDappLogic({
 
               const transactionType = getTxType(signFlowInfos.liveTx as EvmTransaction);
 
-              const token = findTokenByAddress(tx.recipient);
-
               const accountCurrencyName =
                 currentAccount.type === "TokenAccount"
                   ? currentAccount.token.name
@@ -493,6 +491,8 @@ export function useDappLogic({
                 currentAccount.type === "TokenAccount"
                   ? currentAccount.token.parentCurrency.id
                   : currentAccount.currency.id;
+
+              const token = findTokenByAddressInCurrency(tx.recipient, accountNetwork);
 
               trackingData = {
                 type: transactionType,

--- a/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy-state.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy-state.ts
@@ -1,7 +1,6 @@
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 // Legacy state variables that are used for the legacy implementation of CryptoAssetsStore contract
-export const tokensByAddress: Record<string, TokenCurrency> = {};
 export const tokensArray: TokenCurrency[] = [];
 export const tokensArrayWithDelisted: TokenCurrency[] = [];
 export const tokensByCryptoCurrency: Record<string, TokenCurrency[]> = {};

--- a/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy-utils.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy-utils.ts
@@ -7,7 +7,6 @@ import {
   tokensByCryptoCurrencyWithDelisted,
   tokensById,
   tokensByCurrencyAddress,
-  tokensByAddress,
   tokenListHashes,
 } from "./legacy-state";
 import {
@@ -468,7 +467,6 @@ export function __clearAllLists(): void {
   __clearObject(tokensByCryptoCurrency);
   __clearObject(tokensByCryptoCurrencyWithDelisted);
   __clearObject(tokensById);
-  __clearObject(tokensByAddress);
   __clearObject(tokensByCurrencyAddress);
   tokenListHashes.clear();
 }
@@ -496,7 +494,6 @@ function removeTokenFromAllLists(token: TokenCurrency) {
 
   removeTokenFromRecord(tokensById, id);
   removeTokenFromRecord(tokensByCurrencyAddress, parentCurrency.id + ":" + lowCaseContract);
-  removeTokenFromRecord(tokensByAddress, lowCaseContract);
   removeTokenFromArray(tokensArray, id);
   removeTokenFromArray(tokensArrayWithDelisted, id);
   removeTokenFromArray(tokensByCryptoCurrency[parentCurrency.id], id);
@@ -525,7 +522,6 @@ export function addTokens(list: (TokenCurrency | undefined)[]): void {
     tokensArrayWithDelisted.push(token);
     tokensById[id] = token;
 
-    tokensByAddress[lowCaseContract] = token;
     tokensByCurrencyAddress[parentCurrency.id + ":" + lowCaseContract] = token;
 
     if (!(parentCurrency.id in tokensByCryptoCurrency)) {

--- a/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy.test.ts
@@ -22,7 +22,6 @@ import {
 import { initializeLegacyTokens } from "./legacy-data";
 import { getEnv } from "@ledgerhq/live-env";
 import {
-  tokensByAddress,
   tokensArray,
   tokensArrayWithDelisted,
   tokensByCryptoCurrency,
@@ -281,7 +280,6 @@ describe("Legacy Utils", () => {
       expect(tokensArray).toContain(token);
       expect(tokensArrayWithDelisted).toContain(token);
       expect(tokensById[token.id]).toBe(token);
-      expect(tokensByAddress["0x123"]).toBe(token);
       expect(tokensByCurrencyAddress["ethereum:0x123"]).toBe(token);
       expect(tokensByCryptoCurrency["ethereum"]).toContain(token);
     });
@@ -513,7 +511,6 @@ describe("Legacy Utils", () => {
       expect(Object.keys(tokensByCryptoCurrency).length).toBe(0);
       expect(Object.keys(tokensByCryptoCurrencyWithDelisted).length).toBe(0);
       expect(Object.keys(tokensById).length).toBe(0);
-      expect(Object.keys(tokensByAddress).length).toBe(0);
       expect(Object.keys(tokensByCurrencyAddress).length).toBe(0);
       expect(tokenListHashes.size).toBe(0);
     });
@@ -572,7 +569,6 @@ describe("Legacy Data", () => {
 
 describe("Legacy State", () => {
   it("should export all state objects", () => {
-    expect(tokensByAddress).toBeDefined();
     expect(tokensArray).toBeDefined();
     expect(tokensArrayWithDelisted).toBeDefined();
     expect(tokensByCryptoCurrency).toBeDefined();

--- a/libs/ledgerjs/packages/cryptoassets/src/tokens.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/tokens.ts
@@ -23,7 +23,7 @@ import {
   convertAptFaTokens,
   convertHederaTokens,
 } from "./legacy/legacy-utils";
-import { tokensByAddress, tokensByCurrencyAddress, tokensById } from "./legacy/legacy-state";
+import { tokensByCurrencyAddress, tokensById } from "./legacy/legacy-state";
 import { initializeLegacyTokens } from "./legacy/legacy-data";
 
 export {
@@ -51,18 +51,6 @@ initializeLegacyTokens(addTokens);
  */
 export function findTokenById(id: string): TokenCurrency | undefined {
   return tokensById[id];
-}
-
-let deprecatedDisplayed = false;
-/**
- * @deprecated This function will be removed when https://github.com/LedgerHQ/ledger-live/pull/11905 lands
- */
-export function findTokenByAddress(address: string): TokenCurrency | undefined {
-  if (!deprecatedDisplayed) {
-    deprecatedDisplayed = true;
-    console.warn("findTokenByAddress is deprecated. use findTokenByAddressInCurrency");
-  }
-  return tokensByAddress[address.toLowerCase()];
 }
 
 /**

--- a/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
+++ b/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
@@ -11,20 +11,6 @@ import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
  */
 export type CryptoAssetsStore = {
   /**
-   * Finds a token by its contract address.
-   *
-   * ⚠️ DEPRECATED: This method will be removed in favor of findTokenByAddressInCurrency
-   * which provides better scoping to avoid conflicts across different blockchains.
-   *
-   * 🔮 FUTURE: Will become async and return Promise<TokenCurrency | undefined>
-   *
-   * @param address - The contract address of the token
-   * @returns The TokenCurrency if found, undefined otherwise
-   * @deprecated Use findTokenByAddressInCurrency instead for better precision
-   */
-  findTokenByAddress(address: string): TokenCurrency | undefined;
-
-  /**
    * Gets a token by its unique identifier, throwing an error if not found.
    *
    * ⚠️ DEPRECATED: This method will be removed in favor of findTokenById


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** All existing tests pass, including cryptoassets package tests.
- [x] **Impact of the changes:**
  - Removal of deprecated `findTokenByTicker` function and related internal state (`tokensByTicker`)
  - Updated all usages to use `findTokenById` instead
    - EVM
      - in Wallet API
      - transaction device confirmation
    - Hedera tokens association
  - Updated test mocks to remove `findTokenByTicker` from `CryptoAssetsStore`

### 📝 Description

This PR removes the deprecated `findTokenByTicker` function and related internal state as part of the ongoing CryptoAssetsStore async migration (#11905).

**What was removed:**
- `findTokenByTicker()` function from `@ledgerhq/cryptoassets/tokens`
- `findTokenByTicker` method from `CryptoAssetsStore` interface in `@ledgerhq/types-live`
- `tokensByTicker` internal state from legacy cryptoassets implementation
- All usages throughout the codebase

**Why this change:**
- The `findTokenByTicker` function was ambiguous when multiple tokens shared the same ticker across different blockchains. More precise lookup methods (`findTokenById` or `findTokenByAddressInCurrency`) should be used instead.
- To anticipate #11905 rework

### ❓ Context

- **JIRA or GitHub link**: Part of the CryptoAssetsStore async migration #11905
- LIVE-21648

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
