### PR TITLE
chore: drop unused `indTokenByTicker function

### DIFF
--- a/.changeset/drop-find-token-by-ticker.md
+++ b/.changeset/drop-find-token-by-ticker.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/types-live": patch
+"@ledgerhq/cryptoassets": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/live-countervalues": patch
+"@ledgerhq/coin-solana": patch
+"@ledgerhq/coin-tester-evm": patch
+"@ledgerhq/coin-tester-solana": patch
+"@ledgerhq/live-cli": patch
+---
+
+Remove deprecated `findTokenByTicker` function and related internal state. This function was ambiguous when multiple tokens shared the same ticker across different blockchains. Use `findTokenById` or `findTokenByAddressInCurrency` instead for more precise token lookup.
+

--- a/apps/cli/src/live-common-setup.ts
+++ b/apps/cli/src/live-common-setup.ts
@@ -158,7 +158,6 @@ const legacyStore: CryptoAssetsStore = {
   getTokenById: legacy.getTokenById,
   findTokenById: legacy.findTokenById,
   findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-  findTokenByTicker: legacy.findTokenByTicker,
 };
 
 setCryptoAssetsStore(legacyStore);

--- a/libs/coin-modules/coin-solana/src/cli-transaction.ts
+++ b/libs/coin-modules/coin-solana/src/cli-transaction.ts
@@ -94,9 +94,7 @@ function inferTransactions(
           throw new Error("expected main account");
         }
 
-        const tokenCurrency =
-          getCryptoAssetsStore().findTokenByTicker(token) ??
-          getCryptoAssetsStore().findTokenById(token);
+        const tokenCurrency = getCryptoAssetsStore().findTokenById(token);
 
         if (!tokenCurrency) {
           throw new Error(`token <${token}> not found`);

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii.test.ts
@@ -21,7 +21,6 @@ setCryptoAssetsStoreForCoinFramework({
   getTokenById: legacy.getTokenById,
   findTokenById: legacy.findTokenById,
   findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-  findTokenByTicker: legacy.findTokenByTicker,
 } as CryptoAssetsStore);
 
 // Note this config runs with NanoX

--- a/libs/coin-tester-modules/coin-tester-solana/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-solana/src/scenarii.test.ts
@@ -18,7 +18,6 @@ setCryptoAssetsStoreGetter(() => ({
   getTokenById: legacy.getTokenById,
   findTokenById: legacy.findTokenById,
   findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-  findTokenByTicker: legacy.findTokenByTicker,
 }));
 
 describe("Solana Deterministic Tester", () => {

--- a/libs/ledger-live-common/src/bridge/crypto-assets/index.test.ts
+++ b/libs/ledger-live-common/src/bridge/crypto-assets/index.test.ts
@@ -18,7 +18,6 @@ describe("Testing CryptoAssetStore", () => {
       getTokenById: legacy.getTokenById,
       findTokenById: legacy.findTokenById,
       findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-      findTokenByTicker: legacy.findTokenByTicker,
     });
   });
 
@@ -36,7 +35,6 @@ describe("Testing CryptoAssetStore", () => {
       getTokenById: legacy.getTokenById,
       findTokenById: legacy.findTokenById,
       findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-      findTokenByTicker: legacy.findTokenByTicker,
     });
   });
 

--- a/libs/ledger-live-common/src/bridge/crypto-assets/index.ts
+++ b/libs/ledger-live-common/src/bridge/crypto-assets/index.ts
@@ -7,7 +7,6 @@ const legacyStore: CryptoAssetsStore = {
   getTokenById: legacy.getTokenById,
   findTokenById: legacy.findTokenById,
   findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-  findTokenByTicker: legacy.findTokenByTicker,
 };
 
 let cryptoAssetsStore: CryptoAssetsStore | undefined = undefined;

--- a/libs/ledger-live-common/src/currencies/index.ts
+++ b/libs/ledger-live-common/src/currencies/index.ts
@@ -14,7 +14,6 @@ export {
   listTokens,
   listTokensForCryptoCurrency,
   listTokenTypesForCryptoCurrency,
-  findTokenByTicker,
   findTokenById,
   findTokenByAddress,
   hasTokenId,

--- a/libs/ledger-live-common/src/currencies/sortByMarketcap.test.ts
+++ b/libs/ledger-live-common/src/currencies/sortByMarketcap.test.ts
@@ -7,9 +7,7 @@ import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { findCurrencyByTicker } from "@ledgerhq/live-countervalues/findCurrencyByTicker";
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-setCryptoAssetsStoreForCoinFramework({
-  findTokenByTicker: (_: string) => undefined,
-} as CryptoAssetsStore);
+setCryptoAssetsStoreForCoinFramework({} as CryptoAssetsStore);
 
 test("sortCurrenciesByIds snapshot", () => {
   const list = [...listCryptoCurrencies(), ...listTokens()];

--- a/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy-state.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy-state.ts
@@ -1,7 +1,6 @@
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 // Legacy state variables that are used for the legacy implementation of CryptoAssetsStore contract
-export const tokensByTicker: Record<string, TokenCurrency> = {};
 export const tokensByAddress: Record<string, TokenCurrency> = {};
 export const tokensArray: TokenCurrency[] = [];
 export const tokensArrayWithDelisted: TokenCurrency[] = [];

--- a/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy-utils.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy-utils.ts
@@ -7,7 +7,6 @@ import {
   tokensByCryptoCurrencyWithDelisted,
   tokensById,
   tokensByCurrencyAddress,
-  tokensByTicker,
   tokensByAddress,
   tokenListHashes,
 } from "./legacy-state";
@@ -469,7 +468,6 @@ export function __clearAllLists(): void {
   __clearObject(tokensByCryptoCurrency);
   __clearObject(tokensByCryptoCurrencyWithDelisted);
   __clearObject(tokensById);
-  __clearObject(tokensByTicker);
   __clearObject(tokensByAddress);
   __clearObject(tokensByCurrencyAddress);
   tokenListHashes.clear();
@@ -493,13 +491,12 @@ function removeTokenFromRecord(record: Record<string, TokenCurrency>, key: strin
  * @param token
  */
 function removeTokenFromAllLists(token: TokenCurrency) {
-  const { id, contractAddress, parentCurrency, ticker } = token;
+  const { id, contractAddress, parentCurrency } = token;
   const lowCaseContract = contractAddress.toLowerCase();
 
   removeTokenFromRecord(tokensById, id);
   removeTokenFromRecord(tokensByCurrencyAddress, parentCurrency.id + ":" + lowCaseContract);
   removeTokenFromRecord(tokensByAddress, lowCaseContract);
-  removeTokenFromRecord(tokensByTicker, ticker);
   removeTokenFromArray(tokensArray, id);
   removeTokenFromArray(tokensArrayWithDelisted, id);
   removeTokenFromArray(tokensByCryptoCurrency[parentCurrency.id], id);
@@ -520,17 +517,13 @@ export function addTokens(list: (TokenCurrency | undefined)[]): void {
      * Like this we can update any change from a already added token coming from Dynamic CAL
      * and maintain it up to date without having to release a new version of LLD or LLM
      */
-    const { id, contractAddress, parentCurrency, delisted, ticker } = token;
+    const { id, contractAddress, parentCurrency, delisted } = token;
     if (tokensById[id]) removeTokenFromAllLists(token);
     const lowCaseContract = contractAddress.toLowerCase();
 
     if (!delisted) tokensArray.push(token);
     tokensArrayWithDelisted.push(token);
     tokensById[id] = token;
-
-    if (!tokensByTicker[ticker]) {
-      tokensByTicker[ticker] = token;
-    }
 
     tokensByAddress[lowCaseContract] = token;
     tokensByCurrencyAddress[parentCurrency.id + ":" + lowCaseContract] = token;

--- a/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy.test.ts
@@ -22,7 +22,6 @@ import {
 import { initializeLegacyTokens } from "./legacy-data";
 import { getEnv } from "@ledgerhq/live-env";
 import {
-  tokensByTicker,
   tokensByAddress,
   tokensArray,
   tokensArrayWithDelisted,
@@ -282,7 +281,6 @@ describe("Legacy Utils", () => {
       expect(tokensArray).toContain(token);
       expect(tokensArrayWithDelisted).toContain(token);
       expect(tokensById[token.id]).toBe(token);
-      expect(tokensByTicker["TEST"]).toBe(token);
       expect(tokensByAddress["0x123"]).toBe(token);
       expect(tokensByCurrencyAddress["ethereum:0x123"]).toBe(token);
       expect(tokensByCryptoCurrency["ethereum"]).toContain(token);
@@ -352,7 +350,9 @@ describe("Legacy Utils", () => {
 
       addTokens([token1, token2]);
 
-      expect(tokensByTicker["TEST"]).toBe(token1); // First one wins
+      // Both tokens should be added successfully
+      expect(tokensById[token1.id]).toBe(token1);
+      expect(tokensById[token2.id]).toBe(token2);
     });
 
     it("should handle undefined tokens", () => {
@@ -513,7 +513,6 @@ describe("Legacy Utils", () => {
       expect(Object.keys(tokensByCryptoCurrency).length).toBe(0);
       expect(Object.keys(tokensByCryptoCurrencyWithDelisted).length).toBe(0);
       expect(Object.keys(tokensById).length).toBe(0);
-      expect(Object.keys(tokensByTicker).length).toBe(0);
       expect(Object.keys(tokensByAddress).length).toBe(0);
       expect(Object.keys(tokensByCurrencyAddress).length).toBe(0);
       expect(tokenListHashes.size).toBe(0);
@@ -573,7 +572,6 @@ describe("Legacy Data", () => {
 
 describe("Legacy State", () => {
   it("should export all state objects", () => {
-    expect(tokensByTicker).toBeDefined();
     expect(tokensByAddress).toBeDefined();
     expect(tokensArray).toBeDefined();
     expect(tokensArrayWithDelisted).toBeDefined();

--- a/libs/ledgerjs/packages/cryptoassets/src/tokens.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/tokens.ts
@@ -23,12 +23,7 @@ import {
   convertAptFaTokens,
   convertHederaTokens,
 } from "./legacy/legacy-utils";
-import {
-  tokensByAddress,
-  tokensByCurrencyAddress,
-  tokensById,
-  tokensByTicker,
-} from "./legacy/legacy-state";
+import { tokensByAddress, tokensByCurrencyAddress, tokensById } from "./legacy/legacy-state";
 import { initializeLegacyTokens } from "./legacy/legacy-data";
 
 export {
@@ -50,13 +45,6 @@ export {
 };
 
 initializeLegacyTokens(addTokens);
-
-/**
- * @deprecated this function must not be used and will be replaced by `getCryptoAssetsStore().findTokenById(id)` in https://github.com/LedgerHQ/ledger-live/pull/11905
- */
-export function findTokenByTicker(ticker: string): TokenCurrency | undefined {
-  return tokensByTicker[ticker];
-}
 
 /**
  * @deprecated Please do `await getCryptoAssetsStore().findTokenById(id)` instead to anticipate https://github.com/LedgerHQ/ledger-live/pull/11905

--- a/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
+++ b/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
@@ -86,20 +86,6 @@ export type CryptoAssetsStore = {
    * ```
    */
   findTokenByAddressInCurrency(address: string, currencyId: string): TokenCurrency | undefined;
-
-  /**
-   * Finds a token by its ticker symbol.
-   *
-   * ⚠️ DEPRECATED: This method will be removed as ticker-based lookup can be ambiguous
-   * when multiple tokens share the same ticker across different blockchains.
-   *
-   * 🔮 FUTURE: Will be removed - use findTokenById or findTokenByAddressInCurrency instead
-   *
-   * @param ticker - The ticker symbol of the token (e.g., "USDC")
-   * @returns The TokenCurrency if found, undefined otherwise
-   * @deprecated Use findTokenById or findTokenByAddressInCurrency for more precise lookup
-   */
-  findTokenByTicker(ticker: string): TokenCurrency | undefined;
 };
 
 export type CryptoAssetsStoreGetter = () => CryptoAssetsStore;

--- a/libs/live-countervalues/src/findCurrencyByTicker.ts
+++ b/libs/live-countervalues/src/findCurrencyByTicker.ts
@@ -1,8 +1,5 @@
 import type { Currency } from "@ledgerhq/types-cryptoassets";
 import { findCryptoCurrencyByTicker, findFiatCurrencyByTicker } from "@ledgerhq/cryptoassets/index";
-import { getCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
 
 export const findCurrencyByTicker = (ticker: string): Currency | null | undefined =>
-  findCryptoCurrencyByTicker(ticker) ||
-  findFiatCurrencyByTicker(ticker) ||
-  getCryptoAssetsStore().findTokenByTicker(ticker);
+  findCryptoCurrencyByTicker(ticker) || findFiatCurrencyByTicker(ticker);

--- a/libs/live-countervalues/src/mock.test.ts
+++ b/libs/live-countervalues/src/mock.test.ts
@@ -41,9 +41,7 @@ test("mock load with nothing to track", async () => {
 });
 test("mock fetchIdsSortedByMarketcap", async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  jest.spyOn(cryptoAssets, "getCryptoAssetsStore").mockReturnValue({
-    findTokenByTicker: (_: string) => undefined,
-  } as CryptoAssetsStore);
+  jest.spyOn(cryptoAssets, "getCryptoAssetsStore").mockReturnValue({} as CryptoAssetsStore);
 
   expect(await CountervaluesAPI.fetchIdsSortedByMarketcap()).toBeDefined();
 });
@@ -250,9 +248,9 @@ test("missing rate in mock is filled by autofillGaps", async () => {
 
 test("fetchIdsSortedByMarketcap", async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  jest.spyOn(cryptoAssets, "getCryptoAssetsStore").mockReturnValue({
-    findTokenByTicker: (_: string) => undefined,
-  } as unknown as CryptoAssetsStore);
+  jest
+    .spyOn(cryptoAssets, "getCryptoAssetsStore")
+    .mockReturnValue({} as unknown as CryptoAssetsStore);
 
   const ids = await api.fetchIdsSortedByMarketcap();
   expect(ids).toContain("bitcoin");


### PR DESCRIPTION

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** All existing tests pass, including cryptoassets package tests.
- [x] **Impact of the changes:**
  - Removal of deprecated `findTokenByTicker` function and related internal state (`tokensByTicker`)
  - Updated all usages to use `findTokenById` instead
    - there were no usages for the user!
    - only one usage what on the solana CLI where you could pass ticker to describe a token, now you will need to use the ID.

### 📝 Description

This PR removes the deprecated `findTokenByTicker` function and related internal state as part of the ongoing CryptoAssetsStore async migration strategy.

The `findTokenByTicker` function was problematic because it was ambiguous when multiple tokens shared the same ticker across different blockchains (e.g., USDC exists on Ethereum, Polygon, Solana, etc.). This removal encourages using more precise lookup methods:
- `findTokenById(id)` for exact token identification
- `findTokenByAddressInCurrency(address, currencyId)` for scoped token lookup

**NB: this function actually wasn't used anymore.**


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
