### PR TITLE
chore: drop hasToken and replace getTokenById by findTokenById

### DIFF
--- a/.changeset/remove-getTokenById-hasTokenId.md
+++ b/.changeset/remove-getTokenById-hasTokenId.md
@@ -1,0 +1,16 @@
+---
+"@ledgerhq/cryptoassets": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/coin-solana": minor
+"@ledgerhq/coin-vechain": minor
+"@ledgerhq/coin-ton": minor
+"@ledgerhq/coin-tester-evm": minor
+"@ledgerhq/coin-tester-solana": minor
+"@ledgerhq/live-countervalues": minor
+"live-mobile": minor
+---
+
+Remove deprecated getTokenById and hasTokenId functions
+
+

--- a/apps/cli/src/live-common-setup.ts
+++ b/apps/cli/src/live-common-setup.ts
@@ -17,8 +17,7 @@ import { liveConfig } from "@ledgerhq/live-common/config/sharedConfig";
 import SpeculosHttpTransport, {
   SpeculosHttpTransportOpts,
 } from "@ledgerhq/hw-transport-node-speculos-http";
-import * as legacy from "@ledgerhq/cryptoassets/tokens";
-import type { CryptoAssetsStore } from "@ledgerhq/types-live";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
 import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
 
 let idCounter = 0;
@@ -153,10 +152,4 @@ export function closeAllDevices() {
 }
 
 //TODO update when CAL is avalaible
-const legacyStore: CryptoAssetsStore = {
-  getTokenById: legacy.getTokenById,
-  findTokenById: legacy.findTokenById,
-  findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-};
-
-setCryptoAssetsStore(legacyStore);
+setCryptoAssetsStore(legacyCryptoAssetsStore);

--- a/apps/ledger-live-mobile/src/components/MarketQuickActions/MarketQuickActions.test.tsx
+++ b/apps/ledger-live-mobile/src/components/MarketQuickActions/MarketQuickActions.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { renderWithReactQuery } from "@tests/test-renderer";
 import { MarketQuickActions } from "./";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/live-common/currencies/index";
 import { ScreenName } from "~/const";
 import { createStackNavigator } from "@react-navigation/stack";
 import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
@@ -9,7 +9,8 @@ import { State } from "~/reducers/types";
 
 const Stack = createStackNavigator();
 
-const usdcCurrency = getTokenById("ethereum/erc20/usd__coin");
+const usdcCurrency = findTokenById("ethereum/erc20/usd__coin");
+if (!usdcCurrency) throw new Error("USDC token not found");
 const moneroCurrency = getCryptoCurrencyById("monero");
 const kaspaCurrency = getCryptoCurrencyById("kaspa");
 const bitcoinCurrency = getCryptoCurrencyById("bitcoin");

--- a/apps/ledger-live-mobile/src/helpers/useCurrency.tsx
+++ b/apps/ledger-live-mobile/src/helpers/useCurrency.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useRoute } from "@react-navigation/native";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/live-common/currencies/index";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 
 type NavigationProps = StackNavigatorProps<{
@@ -10,13 +10,16 @@ type NavigationProps = StackNavigatorProps<{
 const useCurrency = () => {
   const route = useRoute<NavigationProps["route"]>();
   const { currencyId, currencyType } = route.params;
-  return useMemo(
-    () =>
-      currencyType === "CryptoCurrency"
-        ? getCryptoCurrencyById(currencyId)
-        : getTokenById(currencyId),
-    [currencyId, currencyType],
-  );
+  return useMemo(() => {
+    if (currencyType === "CryptoCurrency") {
+      return getCryptoCurrencyById(currencyId);
+    }
+    const token = findTokenById(currencyId);
+    if (!token) {
+      throw new Error(`token with id "${currencyId}" not found`);
+    }
+    return token;
+  }, [currencyId, currencyType]);
 };
 
 export default useCurrency;

--- a/apps/ledger-live-mobile/src/screens/Account/ReadOnly/ReadOnlyAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ReadOnly/ReadOnlyAccount.tsx
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import { Trans, useTranslation } from "react-i18next";
 import { Box, Flex, Text } from "@ledgerhq/native-ui";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/live-common/currencies/index";
 import { Currency } from "@ledgerhq/types-cryptoassets";
 import { useFocusEffect } from "@react-navigation/native";
 import ReadOnlyGraphCard from "~/components/ReadOnlyGraphCard";
@@ -29,15 +29,17 @@ type Props = StackNavigatorProps<AccountsNavigatorParamList, ScreenName.Account>
 function ReadOnlyAccount({ route }: Props) {
   const { currencyId, currencyType } = route.params;
 
-  const currency: Currency | null = useMemo(
-    () =>
-      currencyId
-        ? currencyType === "CryptoCurrency"
-          ? getCryptoCurrencyById(currencyId)
-          : getTokenById(currencyId)
-        : null,
-    [currencyType, currencyId],
-  );
+  const currency: Currency | null = useMemo(() => {
+    if (!currencyId) return null;
+    if (currencyType === "CryptoCurrency") {
+      return getCryptoCurrencyById(currencyId);
+    }
+    const token = findTokenById(currencyId);
+    if (!token) {
+      throw new Error(`token with id "${currencyId}" not found`);
+    }
+    return token;
+  }, [currencyType, currencyId]);
   const { t } = useTranslation();
 
   const counterValueCurrency: Currency = useSelector(counterValueCurrencySelector);

--- a/libs/coin-modules-monitoring/src/run.ts
+++ b/libs/coin-modules-monitoring/src/run.ts
@@ -1,5 +1,5 @@
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import * as store from "@ledgerhq/cryptoassets/tokens";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
 import type { Account } from "@ledgerhq/types-live";
 import { getAccountBridgeByFamily, setup } from "@ledgerhq/live-common/bridge/impl";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
@@ -116,7 +116,7 @@ function getSync(currency: CryptoCurrency) {
 
 export default async function (currencyIds: string[], accountTypes: AccountType[]) {
   LiveConfig.setConfig(liveConfig);
-  setup(store);
+  setup(legacyCryptoAssetsStore);
   const result: RunResult = {
     entries: [],
     failed: false,

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/cryptoAssetsStore.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/cryptoAssetsStore.fixtures.ts
@@ -1,5 +1,4 @@
-import * as legacyTokens from "@ledgerhq/cryptoassets/tokens";
-import type { CryptoAssetsStore } from "@ledgerhq/types-live";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
 import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
 import { setCryptoAssetsStoreGetter } from "../../cryptoAssetsStore";
 
@@ -7,18 +6,5 @@ import { setCryptoAssetsStoreGetter } from "../../cryptoAssetsStore";
  * TODO change implementation when new CryptoAssesStore implemented with DADA
  */
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-setCryptoAssetsStoreForCoinFramework({
-  findTokenById: legacyTokens.findTokenById,
-  findTokenByAddressInCurrency: legacyTokens.findTokenByAddressInCurrency,
-} as CryptoAssetsStore);
-
-setCryptoAssetsStoreGetter(
-  () =>
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    ({
-      findTokenById: legacyTokens.findTokenById,
-      findTokenByAddressInCurrency: legacyTokens.findTokenByAddressInCurrency,
-      getTokenById: legacyTokens.getTokenById,
-    }) as CryptoAssetsStore,
-);
+setCryptoAssetsStoreForCoinFramework(legacyCryptoAssetsStore);
+setCryptoAssetsStoreGetter(() => legacyCryptoAssetsStore);

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/deviceTransactionConfig.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/deviceTransactionConfig.unit.test.ts
@@ -2,7 +2,7 @@ import eip55 from "eip55";
 import BigNumber from "bignumber.js";
 import { encodeNftId } from "@ledgerhq/coin-framework/nft/nftId";
 import { Account, ProtoNFT } from "@ledgerhq/types-live";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/cryptoassets";
 import { makeAccount, makeTokenAccount } from "../fixtures/common.fixtures";
 import getDeviceTransactionConfig from "../../deviceTransactionConfig";
 import getTransactionStatus from "../../bridge/getTransactionStatus";
@@ -15,7 +15,8 @@ enum NFT_CONTRACTS {
 }
 
 const currency = getCryptoCurrencyById("ethereum");
-const tokenCurrency = getTokenById("ethereum/erc20/usd__coin");
+const tokenCurrency = findTokenById("ethereum/erc20/usd__coin");
+if (!tokenCurrency) throw new Error("USDC token not found");
 const tokenAccount = makeTokenAccount("0xkvn", tokenCurrency);
 const account = makeAccount("0xkvn", currency, [tokenAccount]);
 const accountWithNfts: Account = Object.freeze({

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
@@ -6,7 +6,7 @@ import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { decodeAccountId, encodeTokenAccountId } from "@ledgerhq/coin-framework/account/accountId";
 import { AccountShapeInfo } from "@ledgerhq/coin-framework/bridge/jsHelpers";
 import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
-import * as legacy from "@ledgerhq/cryptoassets/tokens";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
 import { makeTokenAccount } from "../fixtures/common.fixtures";
 import * as etherscanAPI from "../../network/explorer/etherscan";
 import { UnknownExplorer, UnknownNode } from "../../errors";
@@ -50,7 +50,7 @@ const getAccountShapeParameters: AccountShapeInfo = {
 
 describe("EVM Family", () => {
   beforeAll(() => {
-    setCryptoAssetsStoreGetter(() => legacy);
+    setCryptoAssetsStoreGetter(() => legacyCryptoAssetsStore);
   });
 
   beforeEach(() => {
@@ -683,7 +683,10 @@ describe("EVM Family", () => {
       });
 
       it("should return the right subAccounts, excluding tokens unknown by the CAL and recomputing operations `id` and `accountId`", async () => {
-        const findTokenByAddressInCurrency = jest.spyOn(legacy, "findTokenByAddressInCurrency");
+        const findTokenByAddressInCurrency = jest.spyOn(
+          legacyCryptoAssetsStore,
+          "findTokenByAddressInCurrency",
+        );
         const swapHistoryMap = createSwapHistoryMap(account);
         const tokenAccounts = await synchronization.getSubAccounts(
           {

--- a/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
@@ -6,7 +6,7 @@ import {
   StakingTransactionIntent,
 } from "@ledgerhq/coin-framework/api/types";
 import { ethers } from "ethers";
-import * as legacy from "@ledgerhq/cryptoassets/tokens";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
 import { EvmConfig } from "../config";
 import { setCryptoAssetsStoreGetter } from "../cryptoAssetsStore";
 import { createApi } from "./index";
@@ -36,7 +36,7 @@ describe.each([
   let module: Api<MemoNotSupported, BufferTxData>;
 
   beforeAll(() => {
-    setCryptoAssetsStoreGetter(() => legacy);
+    setCryptoAssetsStoreGetter(() => legacyCryptoAssetsStore);
     module = createApi(config as EvmConfig, "ethereum");
   });
 
@@ -263,7 +263,7 @@ describe("EVM Api (SEI Network)", () => {
   let module: Api<MemoNotSupported, BufferTxData>;
 
   beforeAll(() => {
-    setCryptoAssetsStoreGetter(() => legacy);
+    setCryptoAssetsStoreGetter(() => legacyCryptoAssetsStore);
     const config = {
       node: {
         type: "external",

--- a/libs/coin-modules/coin-evm/src/logic/getTokenFromAsset.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getTokenFromAsset.test.ts
@@ -1,12 +1,11 @@
-import * as tokenModule from "@ledgerhq/cryptoassets/tokens";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import * as legacy from "@ledgerhq/cryptoassets/tokens";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
 import { setCryptoAssetsStoreGetter } from "../cryptoAssetsStore";
 import { getAssetFromToken, getTokenFromAsset } from "./getTokenFromAsset";
 
 describe("getTokenFromAsset", () => {
   beforeAll(() => {
-    setCryptoAssetsStoreGetter(() => legacy);
+    setCryptoAssetsStoreGetter(() => legacyCryptoAssetsStore);
   });
 
   afterEach(() => {
@@ -14,7 +13,10 @@ describe("getTokenFromAsset", () => {
   });
 
   it("computes the token of the USDC asset, trusting the CAL", async () => {
-    const findTokenByAddressInCurrency = jest.spyOn(tokenModule, "findTokenByAddressInCurrency");
+    const findTokenByAddressInCurrency = jest.spyOn(
+      legacyCryptoAssetsStore,
+      "findTokenByAddressInCurrency",
+    );
 
     expect(
       await getTokenFromAsset({ id: "ethereum" } as CryptoCurrency, {
@@ -47,7 +49,10 @@ describe("getTokenFromAsset", () => {
   });
 
   it("does not compute the token of an unknown asset, trusting the CAL", async () => {
-    const findTokenByAddressInCurrency = jest.spyOn(tokenModule, "findTokenByAddressInCurrency");
+    const findTokenByAddressInCurrency = jest.spyOn(
+      legacyCryptoAssetsStore,
+      "findTokenByAddressInCurrency",
+    );
 
     expect(
       await getTokenFromAsset({ id: "ethereum" } as CryptoCurrency, {

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.ts
@@ -374,7 +374,10 @@ async function deriveCreateAssociatedTokenAccountCommandDescriptor(
 ): Promise<CommandDescriptor> {
   const errors: Record<string, Error> = {};
 
-  const token = getCryptoAssetsStore().getTokenById(model.uiState.tokenId);
+  const token = getCryptoAssetsStore().findTokenById(model.uiState.tokenId);
+  if (!token) {
+    throw new Error(`token with id "${model.uiState.tokenId}" not found`);
+  }
   const mint = token.contractAddress;
   const tokenProgram = await getMaybeTokenMintProgram(mint, api);
 

--- a/libs/coin-modules/coin-ton/src/__tests__/unit/logic.unit.test.ts
+++ b/libs/coin-modules/coin-ton/src/__tests__/unit/logic.unit.test.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/cryptoassets";
 import { getSyncHash } from "../../logic";
 
 describe("getSyncHash", () => {
@@ -10,7 +10,8 @@ describe("getSyncHash", () => {
   });
 
   it("should provide a new hash if a token is added to the blacklistedTokenIds", () => {
-    const token = getTokenById("ton/jetton/eqcxe6mutqjkfngfarotkot1lzbdiix1kcixrv7nw2id_sds");
+    const token = findTokenById("ton/jetton/eqcxe6mutqjkfngfarotkot1lzbdiix1kcixrv7nw2id_sds");
+    if (!token) throw new Error("TON jetton token not found");
     expect(getSyncHash(currency, [])).not.toEqual(getSyncHash(currency, [token.id]));
   });
 });

--- a/libs/coin-modules/coin-vechain/src/bridge/synchronisation.test.ts
+++ b/libs/coin-modules/coin-vechain/src/bridge/synchronisation.test.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { createEmptyHistoryCache } from "@ledgerhq/coin-framework/account";
 import { makeScanAccounts } from "@ledgerhq/coin-framework/bridge/jsHelpers";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/cryptoassets";
 import BigNumber from "bignumber.js";
 import { setupServer } from "msw/node";
 import { firstValueFrom } from "rxjs";
@@ -102,13 +102,13 @@ describe("scanAccounts", () => {
         swapHistory: [],
         type: "Account",
         used: false,
-        feesCurrency: getTokenById("vechain/vip180/vtho"),
+        feesCurrency: findTokenById("vechain/vip180/vtho"),
         subAccounts: [
           {
             type: "TokenAccount",
             id: "js:2:vechain:0x5066118c66793ED86bd379b50b20E32B0FC1aBf5:vechain+vechain%2Fvip180%2Fvtho",
             parentId: "js:2:vechain:0x5066118c66793ED86bd379b50b20E32B0FC1aBf5:vechain",
-            token: getTokenById("vechain/vip180/vtho"),
+            token: findTokenById("vechain/vip180/vtho"),
             balance: new BigNumber("0"),
             spendableBalance: new BigNumber("0"),
             creationDate: expect.any(Date),

--- a/libs/coin-modules/coin-vechain/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-vechain/src/bridge/synchronisation.ts
@@ -8,7 +8,7 @@ import {
 } from "@ledgerhq/coin-framework/account/index";
 
 import { getAccount, getLastBlockHeight, getOperations, getTokenOperations } from "../network";
-import { findTokenById, getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { findTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { GetAccountShape, mergeOps } from "@ledgerhq/coin-framework/bridge/jsHelpers";
 import { Account } from "@ledgerhq/types-live";
 import { isAccountEmpty } from "./helpers";
@@ -52,6 +52,11 @@ export const getAccountShape: GetAccountShape<Account> = async info => {
     minDate = Math.min(...operationsDates);
   }
 
+  const vthoToken = findTokenById("vechain/vip180/vtho");
+  if (!vthoToken) {
+    throw new Error('token with id "vechain/vip180/vtho" not found');
+  }
+
   const shape = {
     id: accountId,
     balance: new BigNumber(balance),
@@ -60,13 +65,13 @@ export const getAccountShape: GetAccountShape<Account> = async info => {
     operationsCount: operations.length,
     operations,
     blockHeight,
-    feesCurrency: getTokenById("vechain/vip180/vtho"),
+    feesCurrency: vthoToken,
     subAccounts: [
       {
         type: "TokenAccount" as const,
         id: vthoAccountId,
         parentId: accountId,
-        token: getTokenById("vechain/vip180/vtho"),
+        token: vthoToken,
         balance: new BigNumber(energy),
         spendableBalance: new BigNumber(energy),
         creationDate: minDate !== -1 ? new Date(minDate) : new Date(),

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii.test.ts
@@ -8,19 +8,13 @@ import { scenarioBlast } from "./scenarii/blast";
 import { scenarioSonic } from "./scenarii/sonic";
 import { scenarioCore } from "./scenarii/core";
 import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
-import type { CryptoAssetsStore } from "@ledgerhq/types-live";
-import * as legacy from "@ledgerhq/cryptoassets/tokens";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
 
 global.console = require("console");
 jest.setTimeout(100_000);
 
 //TODO mock call to CAL when available
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-setCryptoAssetsStoreForCoinFramework({
-  getTokenById: legacy.getTokenById,
-  findTokenById: legacy.findTokenById,
-  findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-} as CryptoAssetsStore);
+setCryptoAssetsStoreForCoinFramework(legacyCryptoAssetsStore);
 
 // Note this config runs with NanoX
 // https://github.com/LedgerHQ/ledger-live/blob/develop/libs/coin-tester/docker-compose.yml

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/blast.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/blast.ts
@@ -2,7 +2,7 @@ import { LegacySignerEth } from "@ledgerhq/live-signer-evm";
 import { BigNumber } from "bignumber.js";
 import { ethers } from "ethers";
 import { Account } from "@ledgerhq/types-live";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { findTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
 import { encodeTokenAccountId } from "@ledgerhq/coin-framework/account/index";
 import { killSpeculos, spawnSpeculos } from "@ledgerhq/coin-tester/signers/speculos";
@@ -39,7 +39,8 @@ const makeScenarioTransactions = ({ address }: { address: string }): BlastScenar
     },
   };
 
-  const MIM_ON_BLAST = getTokenById(TOKEN_ID);
+  const MIM_ON_BLAST = findTokenById(TOKEN_ID);
+  if (!MIM_ON_BLAST) throw new Error("MIM on Blast token not found");
   const scenarioSendMIMTransaction: BlastScenarioTransaction = {
     name: "Send 80 MIM",
     amount: new BigNumber(ethers.parseUnits("80", MIM_ON_BLAST.units[0].magnitude).toString()),
@@ -109,7 +110,8 @@ export const scenarioBlast: Scenario<EvmTransaction, Account> = {
 
     const scenarioAccount = makeAccount(address, blast);
 
-    const MIM_ON_BLAST = getTokenById(TOKEN_ID);
+    const MIM_ON_BLAST = findTokenById(TOKEN_ID);
+    if (!MIM_ON_BLAST) throw new Error("MIM on Blast token not found");
     await callMyDealer({
       provider,
       drug: MIM_ON_BLAST,
@@ -130,7 +132,8 @@ export const scenarioBlast: Scenario<EvmTransaction, Account> = {
     await indexBlocks();
   },
   beforeAll: account => {
-    const MIM_ON_BLAST = getTokenById(TOKEN_ID);
+    const MIM_ON_BLAST = findTokenById(TOKEN_ID);
+    if (!MIM_ON_BLAST) throw new Error("MIM on Blast token not found");
     expect(account.balance.toFixed()).toBe(ethers.parseEther("10000").toString());
     expect(account.subAccounts?.[0]?.type).toBe("TokenAccount");
     expect(account.subAccounts?.[0]?.balance?.toFixed()).toBe(
@@ -138,7 +141,8 @@ export const scenarioBlast: Scenario<EvmTransaction, Account> = {
     );
   },
   afterAll: account => {
-    const MIM_ON_BLAST = getTokenById(TOKEN_ID);
+    const MIM_ON_BLAST = findTokenById(TOKEN_ID);
+    if (!MIM_ON_BLAST) throw new Error("MIM on Blast token not found");
     expect(account.subAccounts?.length).toBe(1);
     expect(account.subAccounts?.[0].balance.toFixed()).toBe(
       ethers.parseUnits("20", MIM_ON_BLAST.units[0].magnitude).toString(),

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/core.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/core.ts
@@ -8,7 +8,7 @@ import { encodeTokenAccountId } from "@ledgerhq/coin-framework/account/index";
 import { SignerContext } from "@ledgerhq/coin-framework/signer";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
 import { killSpeculos, spawnSpeculos } from "@ledgerhq/coin-tester/signers/speculos";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { findTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { LegacySignerEth } from "@ledgerhq/live-signer-evm";
 import { Account } from "@ledgerhq/types-live";
@@ -21,9 +21,11 @@ import { defaultNanoApp } from "../scenarii.test";
 
 type CoreScenarioTransaction = ScenarioTransaction<EvmTransaction, Account>;
 
-const STCORE_ON_CORE = getTokenById(
+const stcoreOnCore = findTokenById(
   "core/erc20/liquid_staked_core_0xb3a8f0f0da9ffc65318aa39e55079796093029ad",
 );
+if (!stcoreOnCore) throw new Error("stCORE on Core token not found");
+const STCORE_ON_CORE = stcoreOnCore;
 
 const makeScenarioTransactions = ({ address }: { address: string }): CoreScenarioTransaction[] => {
   const scenarioSendSTransaction: CoreScenarioTransaction = {

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/ethereum.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/ethereum.ts
@@ -1,7 +1,7 @@
 import { encodeTokenAccountId } from "@ledgerhq/coin-framework/account/index";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
 import { killSpeculos, spawnSpeculos } from "@ledgerhq/coin-tester/signers/speculos";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { findTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { Account } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { ethers } from "ethers";
@@ -20,7 +20,9 @@ import { BridgeStrategy } from "@ledgerhq/coin-tester/types";
 
 type EthereumScenarioTransaction = ScenarioTransaction<EvmTransaction, Account>;
 
-const USDC_ON_ETHEREUM = getTokenById("ethereum/erc20/usd__coin");
+const usdcOnEthereum = findTokenById("ethereum/erc20/usd__coin");
+if (!usdcOnEthereum) throw new Error("USDC on Ethereum token not found");
+const USDC_ON_ETHEREUM = usdcOnEthereum;
 const boredApeContract = "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D";
 const boredApeTokenId = "3368";
 const cloneXContract = "0x348FC118bcC65a92dC033A951aF153d14D945312";

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/polygon.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/polygon.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "bignumber.js";
 import { ethers } from "ethers";
 import { Account } from "@ledgerhq/types-live";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { findTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
 import { encodeTokenAccountId } from "@ledgerhq/coin-framework/account/index";
 import { killSpeculos, spawnSpeculos } from "@ledgerhq/coin-tester/signers/speculos";
@@ -17,7 +17,9 @@ import { BridgeStrategy } from "@ledgerhq/coin-tester/types";
 
 type PolygonScenarioTransaction = ScenarioTransaction<EvmTransaction, Account>;
 
-const USDC_ON_POLYGON = getTokenById("polygon/erc20/usd_coin_(pos)");
+const usdcOnPolygon = findTokenById("polygon/erc20/usd_coin_(pos)");
+if (!usdcOnPolygon) throw new Error("USDC on Polygon token not found");
+const USDC_ON_POLYGON = usdcOnPolygon;
 const yootContract = "0x670fd103b1a08628e9557cD66B87DeD841115190";
 const yootTokenId = "1988";
 const emberContract = "0xa5511E9941E303101b50675926Fd4d9c1A8a8805";

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/scroll.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/scroll.ts
@@ -2,7 +2,7 @@ import { LegacySignerEth } from "@ledgerhq/live-signer-evm";
 import { BigNumber } from "bignumber.js";
 import { ethers } from "ethers";
 import { Account } from "@ledgerhq/types-live";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { findTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
 import { encodeTokenAccountId } from "@ledgerhq/coin-framework/account/index";
 import { killSpeculos, spawnSpeculos } from "@ledgerhq/coin-tester/signers/speculos";
@@ -43,7 +43,8 @@ const makeScenarioTransactions = ({
     },
   };
 
-  const USDC_ON_SCROLL = getTokenById("scroll/erc20/usd_coin");
+  const USDC_ON_SCROLL = findTokenById("scroll/erc20/usd_coin");
+  if (!USDC_ON_SCROLL) throw new Error("USDC on Scroll token not found");
   const scenarioSendUSDCTransaction: ScrollScenarioTransaction = {
     name: "Send USDC",
     amount: new BigNumber(ethers.parseUnits("80", USDC_ON_SCROLL.units[0].magnitude).toString()),
@@ -113,7 +114,8 @@ export const scenarioScroll: Scenario<EvmTransaction, Account> = {
 
     const scenarioAccount = makeAccount(address, scroll);
 
-    const USDC_ON_SCROLL = getTokenById(TOKEN_ID);
+    const USDC_ON_SCROLL = findTokenById(TOKEN_ID);
+    if (!USDC_ON_SCROLL) throw new Error("USDC on Scroll token not found");
     await callMyDealer({
       provider,
       drug: USDC_ON_SCROLL,
@@ -134,7 +136,8 @@ export const scenarioScroll: Scenario<EvmTransaction, Account> = {
     await indexBlocks();
   },
   beforeAll: account => {
-    const USDC_ON_SCROLL = getTokenById(TOKEN_ID);
+    const USDC_ON_SCROLL = findTokenById(TOKEN_ID);
+    if (!USDC_ON_SCROLL) throw new Error("USDC on Scroll token not found");
     expect(account.balance.toFixed()).toBe(ethers.parseEther("10000").toString());
     expect(account.subAccounts?.[0]?.type).toBe("TokenAccount");
     expect(account.subAccounts?.[0]?.balance?.toFixed()).toBe(
@@ -142,7 +145,8 @@ export const scenarioScroll: Scenario<EvmTransaction, Account> = {
     );
   },
   afterAll: account => {
-    const USDC_ON_SCROLL = getTokenById(TOKEN_ID);
+    const USDC_ON_SCROLL = findTokenById(TOKEN_ID);
+    if (!USDC_ON_SCROLL) throw new Error("USDC on Scroll token not found");
     expect(account.subAccounts?.length).toBe(1);
     expect(account.subAccounts?.[0].balance.toFixed()).toBe(
       ethers.parseUnits("20", USDC_ON_SCROLL.units[0].magnitude).toString(),

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/sonic.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/sonic.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "bignumber.js";
 import { ethers } from "ethers";
 import { Account } from "@ledgerhq/types-live";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { findTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { encodeTokenAccountId } from "@ledgerhq/coin-framework/account/index";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
 import { killSpeculos, spawnSpeculos } from "@ledgerhq/coin-tester/signers/speculos";
@@ -16,9 +16,11 @@ import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 
 type SonicScenarioTransaction = ScenarioTransaction<EvmTransaction, Account>;
 
-const USDC_ON_SONIC = getTokenById(
+const usdcOnSonic = findTokenById(
   "sonic/erc20/bridged_usdc_sonic_labs_0x29219dd400f2bf60e5a23d13be72b486d4038894",
 );
+if (!usdcOnSonic) throw new Error("USDC on Sonic token not found");
+const USDC_ON_SONIC = usdcOnSonic;
 
 const makeScenarioTransactions = ({ address }: { address: string }): SonicScenarioTransaction[] => {
   const scenarioSendSTransaction: SonicScenarioTransaction = {

--- a/libs/coin-tester-modules/coin-tester-solana/src/fixtures.ts
+++ b/libs/coin-tester-modules/coin-tester-solana/src/fixtures.ts
@@ -5,14 +5,18 @@ import { TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { SolanaAccount } from "@ledgerhq/coin-solana/types";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { findTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 
 export const RECIPIENT = "Hj69wRzkrFuf1Nby4yzPEFHdsmQdMoVYjvDKZSLjZFEp";
 export const SOLANA = getCryptoCurrencyById("solana");
-export const SOLANA_USDC = getTokenById("solana/spl/epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v");
-export const SOLANA_CWIF = getTokenById("solana/spl/7atgf8kqo4wjrd5atgx7t1v2zvvykpjbffnevf1icfv1");
+const solanaUsdc = findTokenById("solana/spl/epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v");
+if (!solanaUsdc) throw new Error("Solana USDC token not found");
+export const SOLANA_USDC = solanaUsdc;
+const solanaCwif = findTokenById("solana/spl/7atgf8kqo4wjrd5atgx7t1v2zvvykpjbffnevf1icfv1");
+if (!solanaCwif) throw new Error("Solana CWIF token not found");
+export const SOLANA_CWIF = solanaCwif;
 export const SOLANA_VIRTUAL: TokenCurrency = {
   type: "TokenCurrency",
   id: "solana/spl/3iql8bfs2ve7mww4ehaqqhasbmrncrpxizwat2zfyr9y",

--- a/libs/coin-tester-modules/coin-tester-solana/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-solana/src/scenarii.test.ts
@@ -2,7 +2,7 @@ import { executeScenario } from "@ledgerhq/coin-tester/main";
 import { killSpeculos } from "@ledgerhq/coin-tester/signers/speculos";
 import { scenarioSolana } from "./scenarii/solana";
 import { killAgave } from "./agave";
-import * as legacy from "@ledgerhq/cryptoassets/tokens";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
 import { setCryptoAssetsStoreGetter } from "@ledgerhq/coin-solana/cryptoAssetsStore";
 
 ["exit", "SIGINT", "SIGQUIT", "SIGTERM", "SIGUSR1", "SIGUSR2", "uncaughtException"].map(e =>
@@ -13,11 +13,7 @@ import { setCryptoAssetsStoreGetter } from "@ledgerhq/coin-solana/cryptoAssetsSt
 
 //TODO coin tester should not call external endpoints (avoid the error Failed to fetch Figment APY LedgerAPI5xx: Unhandled request)
 //TODO mock call to CAL when available
-setCryptoAssetsStoreGetter(() => ({
-  getTokenById: legacy.getTokenById,
-  findTokenById: legacy.findTokenById,
-  findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-}));
+setCryptoAssetsStoreGetter(() => legacyCryptoAssetsStore);
 
 describe("Solana Deterministic Tester", () => {
   it("scenario Solana", async () => {

--- a/libs/ledger-live-common/src/bridge/crypto-assets/index.test.ts
+++ b/libs/ledger-live-common/src/bridge/crypto-assets/index.test.ts
@@ -1,6 +1,6 @@
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { getCryptoAssetsStore, setCryptoAssetsStore } from ".";
-import * as legacy from "@ledgerhq/cryptoassets/tokens";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
 import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 describe("Testing CryptoAssetStore", () => {
@@ -13,11 +13,10 @@ describe("Testing CryptoAssetStore", () => {
     });
 
     const store = getCryptoAssetsStore();
-    expect(store).toEqual({
-      getTokenById: legacy.getTokenById,
-      findTokenById: legacy.findTokenById,
-      findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-    });
+    expect(store.findTokenById).toBe(legacyCryptoAssetsStore.findTokenById);
+    expect(store.findTokenByAddressInCurrency).toBe(
+      legacyCryptoAssetsStore.findTokenByAddressInCurrency,
+    );
   });
 
   it("should return the default methods from cryptoassets libs when feature flag is disabled", () => {
@@ -29,11 +28,10 @@ describe("Testing CryptoAssetStore", () => {
     });
 
     const store = getCryptoAssetsStore();
-    expect(store).toEqual({
-      getTokenById: legacy.getTokenById,
-      findTokenById: legacy.findTokenById,
-      findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-    });
+    expect(store.findTokenById).toBe(legacyCryptoAssetsStore.findTokenById);
+    expect(store.findTokenByAddressInCurrency).toBe(
+      legacyCryptoAssetsStore.findTokenByAddressInCurrency,
+    );
   });
 
   it("should throw an error when no store is set and feature flag is enabled", () => {

--- a/libs/ledger-live-common/src/bridge/crypto-assets/index.ts
+++ b/libs/ledger-live-common/src/bridge/crypto-assets/index.ts
@@ -1,12 +1,6 @@
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
-import * as legacy from "@ledgerhq/cryptoassets/tokens";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
 import type { CryptoAssetsStore } from "@ledgerhq/types-live";
-
-const legacyStore: CryptoAssetsStore = {
-  getTokenById: legacy.getTokenById,
-  findTokenById: legacy.findTokenById,
-  findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
-};
 
 let cryptoAssetsStore: CryptoAssetsStore | undefined = undefined;
 
@@ -18,7 +12,7 @@ export function getCryptoAssetsStore(): CryptoAssetsStore {
   const featureEnabled =
     LiveConfig.isConfigSet() && LiveConfig.getValueByKey("feature_cal_lazy_loading");
   if (!featureEnabled) {
-    return legacyStore;
+    return legacyCryptoAssetsStore;
   }
 
   if (!cryptoAssetsStore) {

--- a/libs/ledger-live-common/src/currencies/cryptoIcons.test.ts
+++ b/libs/ledger-live-common/src/currencies/cryptoIcons.test.ts
@@ -1,6 +1,6 @@
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { inferCryptoCurrencyIcon } from "./cryptoIcons";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { findTokenById } from "@ledgerhq/cryptoassets/tokens";
 
 describe("inferCryptoCurrencyIcon", () => {
   const registryMock = {
@@ -23,8 +23,8 @@ describe("inferCryptoCurrencyIcon", () => {
   });
 
   test("USDT is inferred properly", () => {
-    expect(
-      inferCryptoCurrencyIcon(registryMock, getTokenById("ethereum/erc20/usd_tether__erc20_")),
-    ).toBe(4);
+    const usdt = findTokenById("ethereum/erc20/usd_tether__erc20_");
+    if (!usdt) throw new Error("USDT token not found");
+    expect(inferCryptoCurrencyIcon(registryMock, usdt)).toBe(4);
   });
 });

--- a/libs/ledger-live-common/src/currencies/index.ts
+++ b/libs/ledger-live-common/src/currencies/index.ts
@@ -16,9 +16,7 @@ export {
   listTokenTypesForCryptoCurrency,
   findTokenById,
   findTokenByAddressInCurrency,
-  hasTokenId,
   getAbandonSeedAddress,
-  getTokenById,
   addTokens,
 } from "@ledgerhq/cryptoassets";
 export {

--- a/libs/ledger-live-common/src/deposit/helper.ts
+++ b/libs/ledger-live-common/src/deposit/helper.ts
@@ -3,7 +3,7 @@ import { MappedAsset, CurrenciesByProviderId, GroupedCurrencies } from "./type";
 import {
   currenciesByMarketcap,
   getCryptoCurrencyById,
-  getTokenById,
+  findTokenById,
   hasCryptoCurrencyId,
 } from "../currencies";
 import { getMappedAssets } from "./api";
@@ -75,5 +75,9 @@ export const getTokenOrCryptoCurrencyById = (id: string): CryptoOrTokenCurrency 
   if (hasCryptoCurrencyId(id)) {
     return getCryptoCurrencyById(id);
   }
-  return getTokenById(id);
+  const token = findTokenById(id);
+  if (!token) {
+    throw new Error(`token with id "${id}" not found`);
+  }
+  return token;
 };

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useFromState.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useFromState.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import "../../../__tests__/test-helpers/dom-polyfill";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/cryptoassets";
 import { Account } from "@ledgerhq/types-live";
 import { renderHook, act } from "@testing-library/react";
 import BigNumber from "bignumber.js";
@@ -14,7 +14,9 @@ import { useFromState } from "./useFromState";
 
 const BTC = getCryptoCurrencyById("bitcoin");
 const ETH = getCryptoCurrencyById("ethereum");
-const USDT = getTokenById("ethereum/erc20/usd_tether__erc20_");
+const usdtToken = findTokenById("ethereum/erc20/usd_tether__erc20_");
+if (!usdtToken) throw new Error("USDT token not found");
+const USDT = usdtToken;
 
 jest.useFakeTimers();
 

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useReverseAccounts.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useReverseAccounts.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import "../../../__tests__/test-helpers/dom-polyfill";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
 import { renderHook, act } from "@testing-library/react";
 import { genTokenAccount } from "@ledgerhq/coin-framework/mocks/account";
@@ -11,7 +11,9 @@ import { useReverseAccounts } from "./useReverseAccounts";
 
 const BTC = getCryptoCurrencyById("bitcoin");
 const ETH = getCryptoCurrencyById("ethereum");
-const USDT = getTokenById("ethereum/erc20/usd_tether__erc20_");
+const usdtToken = findTokenById("ethereum/erc20/usd_tether__erc20_");
+if (!usdtToken) throw new Error("USDT token not found");
+const USDT = usdtToken;
 
 const fromParentAccount = genAccount("mocked-account-2", {
   currency: ETH,

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useToState.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useToState.test.ts
@@ -3,7 +3,7 @@
  */
 import "../../../__tests__/test-helpers/dom-polyfill";
 import { renderHook, act } from "@testing-library/react";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/cryptoassets";
 import { selectorStateDefaultValues, useToState } from ".";
 import { genTokenAccount } from "@ledgerhq/coin-framework/mocks/account";
 import { genAccount } from "../../../mock/account";
@@ -12,7 +12,9 @@ import type { Account } from "@ledgerhq/types-live";
 
 const BTC = getCryptoCurrencyById("bitcoin");
 const ETH = getCryptoCurrencyById("ethereum");
-const USDT = getTokenById("ethereum/erc20/usd_tether__erc20_");
+const usdtToken = findTokenById("ethereum/erc20/usd_tether__erc20_");
+if (!usdtToken) throw new Error("USDT token not found");
+const USDT = usdtToken;
 
 const selectedAccount = genAccount("mocked-account-selected", { currency: ETH });
 

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useUpdateMaxAmount.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useUpdateMaxAmount.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import "../../../__tests__/test-helpers/dom-polyfill";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/cryptoassets";
 import { act, renderHook } from "@testing-library/react";
 import BigNumber from "bignumber.js";
 import { checkAccountSupported } from "../../../account/index";
@@ -19,7 +19,9 @@ jest.mock("../../../families/evm/bridge/mock");
 const mockedEstimateMaxSpendable = jest.mocked(ethBridge.accountBridge.estimateMaxSpendable);
 
 const ETH = getCryptoCurrencyById("ethereum");
-const USDT = getTokenById("ethereum/erc20/usd_tether__erc20_");
+const usdtToken = findTokenById("ethereum/erc20/usd_tether__erc20_");
+if (!usdtToken) throw new Error("USDT token not found");
+const USDT = usdtToken;
 
 const parentAccount = genAccount("parent-account", {
   currency: ETH,

--- a/libs/ledger-live-common/src/exchange/swap/utils/index.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { getTokenById } from "@ledgerhq/cryptoassets";
+import { findTokenById } from "@ledgerhq/cryptoassets";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
@@ -87,7 +87,9 @@ describe("swap/utils/getAccountTuplesForCurrency", () => {
   });
 
   describe("TokenCurrency", () => {
-    const aaveToken = Object.freeze(getTokenById("ethereum/erc20/aave"));
+    const token = findTokenById("ethereum/erc20/aave");
+    if (!token) throw new Error("AAVE token not found");
+    const aaveToken = Object.freeze(token);
 
     test("returns correct parent accounts including a new subAccount when a TokenCurrency is provided", () => {
       const ethAccounts = [

--- a/libs/ledger-live-common/src/utils/__tests__/getAccountTuplesForCurrency.test.ts
+++ b/libs/ledger-live-common/src/utils/__tests__/getAccountTuplesForCurrency.test.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/cryptoassets";
 import { genAccount } from "../../mock/account";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
@@ -66,7 +66,9 @@ describe("getAccountTuplesForCurrency", () => {
   });
 
   describe("TokenCurrency", () => {
-    const aaveToken = getTokenById("ethereum/erc20/aave");
+    const token = findTokenById("ethereum/erc20/aave");
+    if (!token) throw new Error("AAVE token not found");
+    const aaveToken = token;
 
     test("returns correct parent accounts including a new subAccount when a TokenCurrency is provided", () => {
       const ethAccounts = [

--- a/libs/ledgerjs/packages/cryptoassets/package.json
+++ b/libs/ledgerjs/packages/cryptoassets/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@ledgerhq/live-env": "workspace:^",
+    "@ledgerhq/types-live": "workspace:^",
     "axios": "1.11.0",
     "bs58check": "^2.1.2",
     "invariant": "2"

--- a/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy-store.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/legacy/legacy-store.ts
@@ -1,0 +1,23 @@
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
+import { tokensById, tokensByCurrencyAddress } from "./legacy-state";
+
+function findTokenById(id: string): TokenCurrency | undefined {
+  return tokensById[id];
+}
+
+function findTokenByAddressInCurrency(
+  address: string,
+  currencyId: string,
+): TokenCurrency | undefined {
+  return tokensByCurrencyAddress[currencyId + ":" + address.toLowerCase()];
+}
+
+/**
+ * Legacy CryptoAssetsStore adapter that wraps the legacy token lookup functions
+ * and provides the CryptoAssetsStore interface expected by the rest of the codebase.
+ */
+export const legacyCryptoAssetsStore: CryptoAssetsStore = {
+  findTokenById,
+  findTokenByAddressInCurrency,
+};

--- a/libs/ledgerjs/packages/cryptoassets/src/tokens.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/tokens.ts
@@ -25,6 +25,7 @@ import {
 } from "./legacy/legacy-utils";
 import { tokensByCurrencyAddress, tokensById } from "./legacy/legacy-state";
 import { initializeLegacyTokens } from "./legacy/legacy-data";
+import { legacyCryptoAssetsStore } from "./legacy/legacy-store";
 
 export {
   addTokens,
@@ -42,6 +43,7 @@ export {
   convertAptFaTokens,
   convertHederaTokens,
   __clearAllLists,
+  legacyCryptoAssetsStore,
 };
 
 initializeLegacyTokens(addTokens);
@@ -61,24 +63,6 @@ export function findTokenByAddressInCurrency(
   currencyId: string,
 ): TokenCurrency | undefined {
   return tokensByCurrencyAddress[currencyId + ":" + address.toLowerCase()];
-}
-
-/**
- * @deprecated This function will be removed when https://github.com/LedgerHQ/ledger-live/pull/11905 lands
- */
-export const hasTokenId = (id: string): boolean => id in tokensById;
-
-/**
- * @deprecated Please use `await getCryptoAssetsStore().findTokenById(id)` instead to anticipate https://github.com/LedgerHQ/ledger-live/pull/11905
- */
-export function getTokenById(id: string): TokenCurrency {
-  const currency = findTokenById(id);
-
-  if (!currency) {
-    throw new Error(`token with id "${id}" not found`);
-  }
-
-  return currency;
 }
 
 /**

--- a/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
+++ b/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
@@ -11,21 +11,6 @@ import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
  */
 export type CryptoAssetsStore = {
   /**
-   * Gets a token by its unique identifier, throwing an error if not found.
-   *
-   * ⚠️ DEPRECATED: This method will be removed in favor of findTokenById
-   * which gracefully handles missing tokens without throwing.
-   *
-   * 🔮 FUTURE: Will be removed - use findTokenById instead
-   *
-   * @param id - The unique identifier of the token (e.g., "ethereum/erc20/usd_coin")
-   * @returns The TokenCurrency
-   * @throws Error if the token is not found
-   * @deprecated Use findTokenById instead for graceful error handling
-   */
-  getTokenById(id: string): TokenCurrency;
-
-  /**
    * Finds a token by its unique identifier.
    * This is the preferred method for token lookup as it gracefully handles missing tokens.
    *

--- a/libs/live-countervalues/src/logic.integ.test.ts
+++ b/libs/live-countervalues/src/logic.integ.test.ts
@@ -9,7 +9,7 @@ import { findCurrencyByTicker } from "./findCurrencyByTicker";
 import {
   getFiatCurrencyByTicker,
   getCryptoCurrencyById,
-  getTokenById,
+  findTokenById,
 } from "@ledgerhq/cryptoassets";
 import { getBTCValues } from "./mock";
 import { Currency } from "@ledgerhq/types-cryptoassets";
@@ -160,7 +160,8 @@ describe("extreme cases", () => {
 describe("WETH rules", () => {
   // this test is created to confirm the recent removal of weth/eth specific management is still functional in v3 context
   test("ethereum WETH have countervalues", async () => {
-    const weth = getTokenById("ethereum/erc20/weth");
+    const weth = findTokenById("ethereum/erc20/weth");
+    if (!weth) throw new Error("WETH token not found");
     const state = await loadCountervalues(initialState, {
       trackingPairs: [
         {
@@ -188,7 +189,8 @@ describe("HTTP 422 management of unsupported rates", () => {
   // context of this test: https://ledgerhq.atlassian.net/browse/LIVE-11339
   test("a cache that was accumulated needs to be cleared when a coin becomes disabled", async () => {
     // for this test, we start with weth
-    const weth = getTokenById("ethereum/erc20/weth");
+    const weth = findTokenById("ethereum/erc20/weth");
+    if (!weth) throw new Error("WETH token not found");
     let state = await loadCountervalues(initialState, {
       trackingPairs: [
         {
@@ -209,7 +211,8 @@ describe("HTTP 422 management of unsupported rates", () => {
     });
     expect(value).toBeGreaterThan(0);
     // we will now alter the state to replace the weth token to sether that we know has been disabled by the api
-    const sether = getTokenById("ethereum/erc20/sether");
+    const sether = findTokenById("ethereum/erc20/sether");
+    if (!sether) throw new Error("sETHER token not found");
     const prevKey = pairId({ from: weth, to: usd });
     const nextKey = pairId({ from: sether, to: usd });
     function mutateVisit(o: any) {

--- a/libs/live-countervalues/src/mock.test.ts
+++ b/libs/live-countervalues/src/mock.test.ts
@@ -4,7 +4,7 @@ import CountervaluesAPI from "./api";
 import { setEnv } from "@ledgerhq/live-env";
 import {
   getFiatCurrencyByTicker,
-  getTokenById,
+  findTokenById,
   getCryptoCurrencyById,
 } from "@ledgerhq/cryptoassets";
 import { formatCounterValueDay, formatCounterValueHour, parseFormattedDate } from "./helpers";
@@ -141,10 +141,12 @@ test("mock load with btc-eth to track", async () => {
   ).toBe(1.4890024626718706e21);
 });
 test("DAI EUR latest price", async () => {
+  const dai = findTokenById("ethereum/erc20/dai_stablecoin_v2_0");
+  if (!dai) throw new Error("DAI token not found");
   const state = await loadCountervalues(initialState, {
     trackingPairs: [
       {
-        from: getTokenById("ethereum/erc20/dai_stablecoin_v2_0"),
+        from: dai,
         to: getFiatCurrencyByTicker("EUR"),
         startDate: new Date(),
       },
@@ -157,16 +159,18 @@ test("DAI EUR latest price", async () => {
   expect(
     calculate(state, {
       value: 100000000,
-      from: getTokenById("ethereum/erc20/dai_stablecoin_v2_0"),
+      from: dai,
       to: getFiatCurrencyByTicker("EUR"),
     }),
   ).toBeUndefined();
 });
 test("calculate(now()) is calculate(null)", async () => {
+  const dai = findTokenById("ethereum/erc20/dai_stablecoin_v2_0");
+  if (!dai) throw new Error("DAI token not found");
   const state = await loadCountervalues(initialState, {
     trackingPairs: [
       {
-        from: getTokenById("ethereum/erc20/dai_stablecoin_v2_0"),
+        from: dai,
         to: getFiatCurrencyByTicker("EUR"),
         startDate: new Date(),
       },
@@ -179,13 +183,13 @@ test("calculate(now()) is calculate(null)", async () => {
   expect(
     calculate(state, {
       value: 100000000,
-      from: getTokenById("ethereum/erc20/dai_stablecoin_v2_0"),
+      from: dai,
       to: getFiatCurrencyByTicker("EUR"),
     }),
   ).toEqual(
     calculate(state, {
       value: 100000000,
-      from: getTokenById("ethereum/erc20/dai_stablecoin_v2_0"),
+      from: dai,
       to: getFiatCurrencyByTicker("EUR"),
       date: new Date(),
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5883,6 +5883,9 @@ importers:
       '@ledgerhq/live-env':
         specifier: workspace:^
         version: link:../../../env
+      '@ledgerhq/types-live':
+        specifier: workspace:^
+        version: link:../types-live
       axios:
         specifier: 1.11.0
         version: 1.11.0


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** All existing tests pass, including cryptoassets package tests.
- [x] **Impact of the changes:**
  - LLD and LLM are touched but no impact for users.
  - it's mostly tests that are actually altered here.

### 📝 Description

- `hasToken` is an unused function that was dropped.
- `getTokenById` usages has been inlined to use `findTokenById`. hopefully there weren't a lot of remaining usages (mostly in tests)
  - throwing an untyped exception wasn't a good pattern and it's never really safe to expect a token to be available by id
  - so it's up to dev to manage that possibly it can be undefined. the falsy case is to be handled on the usage side.
  - this simplifies the CryptoAssetStore interface which should only focus implementing the canonical need
  - in a very near future (#11905), `store.findTokenById` is becoming asynchronous, it will only "fail/throw exception" if the networking fails, so it's a better paradigm to differentiate between "unavailable token" and "temporarily impossible to retrieve it" cases.
- we take this opportunity to introduce `import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";` in order to reduce the previous repetitive pattern we had everywhere.

**The CryptoAssetsStore interface finally have its final shape (minus the async future changes):**

```ts
export type CryptoAssetsStore = {
  findTokenById(id: string): TokenCurrency | undefined;
  findTokenByAddressInCurrency(address: string, currencyId: string): TokenCurrency | undefined;
};
```

### ❓ Context

- **JIRA or GitHub link**:  facilitator of #11905 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
