### PR TITLE
fix: canton add account with wrong index

### DIFF
--- a/.changeset/popular-turkeys-trade.md
+++ b/.changeset/popular-turkeys-trade.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix canton add account with wrong index

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
@@ -407,7 +407,7 @@ export const StepImportFooter = ({
   const isHandledError = err && err.name === "SatStackDescriptorNotImported";
 
   const hasCantonCreatableAccounts = scannedAccounts.some(
-    a => checkedAccountsIds.includes(a.id) && isAccountEmpty(a) && a.currency?.family === "canton",
+    a => checkedAccountsIds.includes(a.id) && !a.used && a.currency?.family === "canton",
   );
 
   const goCantonOnboard = () => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - coin-canton

### 📝 Description

fixing problem when canton account could be added with wrong index

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: 
- [LIVE-22040](https://ledgerhq.atlassian.net/browse/LIVE-22040)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22040]: https://ledgerhq.atlassian.net/browse/LIVE-22040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ