### PR TITLE
feat: LIVE-22111 close noah desktop

### DIFF
--- a/.changeset/tame-drinks-raise.md
+++ b/.changeset/tame-drinks-raise.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add close button to receive provider screen

--- a/apps/ledger-live-desktop/src/renderer/screens/receive/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/receive/index.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
+import { useHistory, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useProviderInterstitalEnabled } from "@ledgerhq/live-common/hooks/useShowProviderLoadingTransition";
 import { useManifestWithSessionId } from "@ledgerhq/live-common/hooks/useManifestWithSessionId";
 import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
+import { openModal } from "~/renderer/actions/modals";
 import Card from "~/renderer/components/Box/Card";
 import WebPlatformPlayer from "~/renderer/components/WebPlatformPlayer";
 import { WebviewLoader } from "~/renderer/components/Web3AppWebview/types";
@@ -18,6 +19,7 @@ const PROVIDER_MANIFEST_ID = "noah";
 const Receive = () => {
   const location = useLocation();
   const locale = useSelector(languageSelector);
+  const dispatch = useDispatch();
   const localManifest = useLocalLiveAppManifest(PROVIDER_MANIFEST_ID);
   const remoteManifest = useRemoteLiveAppManifest(PROVIDER_MANIFEST_ID);
   const shareAnalytics = useSelector(shareAnalyticsSelector);
@@ -26,11 +28,17 @@ const Receive = () => {
     manifest,
     shareAnalytics,
   });
+  const history = useHistory();
   const themeType = useTheme().colors.palette.type;
   const params = location.state || {};
   const providerInterstitialEnabled = useProviderInterstitalEnabled({
     manifest,
   });
+
+  function handleClose() {
+    history.goBack();
+    dispatch(openModal("MODAL_RECEIVE", undefined));
+  }
 
   return (
     <Card grow style={{ overflow: "hidden" }} data-testid="reveive-app-container">
@@ -40,7 +48,7 @@ const Receive = () => {
             topBarConfig: {
               shouldDisplayName: false,
               shouldDisplayInfo: false,
-              shouldDisplayClose: false,
+              shouldDisplayClose: true,
               shouldDisplayNavigation: false,
             },
           }}
@@ -50,6 +58,7 @@ const Receive = () => {
             lang: locale,
             ...params,
           }}
+          onClose={handleClose}
           Loader={providerInterstitialEnabled ? CustomProviderInterstitial : undefined}
         />
       ) : null}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add the close button on the receive provider screen. It returns from the previous screen the user was on and re-opens the menu.

Before:
<img width="1624" height="1004" alt="Screenshot 2025-10-07 at 10 30 11" src="https://github.com/user-attachments/assets/9040a656-e24e-4930-bf14-968ffa391c18" />

After:

https://github.com/user-attachments/assets/52ff2032-c7c2-4a8c-ba60-4777482310bd





### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-22111


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
