### PR TITLE
remove dependency on getTokenOrCryptoCurrencyById in getProviderCurrency

### DIFF
--- a/.changeset/refactor-provider-currency-lookup.md
+++ b/.changeset/refactor-provider-currency-lookup.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+refactor: remove dependency on getTokenOrCryptoCurrencyById in getProviderCurrency

--- a/libs/ledger-live-common/src/modularDrawer/utils/__tests__/currencyUtils.test.ts
+++ b/libs/ledger-live-common/src/modularDrawer/utils/__tests__/currencyUtils.test.ts
@@ -1,58 +1,12 @@
 import { useGroupedCurrenciesByProvider } from "../../__mocks__/useGroupedCurrenciesByProvider.mock";
-import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 import {
   buildProviderCoverageMap,
   extractProviderCurrencies,
   filterProvidersByIds,
   getProviderCurrency,
-  isProviderToken,
-  safeCurrencyLookup,
 } from "../currencyUtils";
-import {
-  mockBaseCryptoCurrency,
-  mockBtcCryptoCurrency,
-  mockEthCryptoCurrency,
-  usdcToken,
-} from "../../__mocks__/currencies.mock";
-
-describe("safeCurrencyLookup", () => {
-  it("should return the currency if it is found", () => {
-    const currency = safeCurrencyLookup("ethereum");
-    expect(currency).toBeDefined();
-  });
-  it("should return null if the currency is not found", () => {
-    const currency = safeCurrencyLookup("not-a-currency");
-    expect(currency).toBeNull();
-  });
-});
-
-describe("isProviderToken", () => {
-  it("should return true if the currency is a provider token", () => {
-    const baseToken: TokenCurrency = {
-      type: "TokenCurrency",
-      id: "base/erc20/base",
-      contractAddress: "0x0000000000000000000000000000000000000000",
-      parentCurrency: mockBaseCryptoCurrency,
-      tokenType: "erc20",
-      name: "Base",
-      ticker: "BASE",
-      units: [
-        {
-          name: "Base",
-          code: "BASE",
-          magnitude: 18,
-        },
-      ],
-    };
-    const currency = isProviderToken(baseToken, "base");
-    expect(currency).toBe(true);
-  });
-  it("should return false if the currency is not a provider token", () => {
-    const currency = isProviderToken(mockEthCryptoCurrency, "ethereum");
-    expect(currency).toBe(false);
-  });
-});
+import { mockBtcCryptoCurrency, usdcToken } from "../../__mocks__/currencies.mock";
 
 describe("getProviderCurrency", () => {
   it("should return the currency if it is a provider currency", () => {


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - MAD

### 📝 Description

- This removes the last dependency that MAD has on the CAL tokens
- this remove the previous mechanism that was mapping the extracted currencies into the hardcoded tokens from the bundle.
  - note that it means, we will always have a new ref of a `token` object. so we must not assume `tokenA.id === tokenB.id` means `tokenA === tokenB`. this is the main impact this could have here, but i didn't experience issue so far. that said, the problem could have exist if the backend would return token unknown from the client, as the fallback case was to use [0], in any case we now converge to the same approach.
- I can't find a valid reason that we needed to `toLowerCase` on ids. it's generally a bad practice and that usually need a fix backend side.
- by testing many search term on my end, i never have cases of seeing the console.warn that I've introduced so I think this rework is functional.

### ❓ Context

- **JIRA or GitHub link**: LIVE-21847


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
