### PR TITLE
fix: [LIVE-21723] check validators length

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/fields/ValidatorField.tsx
@@ -41,11 +41,20 @@ const ValidatorField = ({ account, onChangeValidator, chosenVoteAccAddr }: Props
     (evt: React.ChangeEvent<HTMLInputElement>) => setSearch(evt.target.value),
     [setSearch],
   );
-  if (!chosenVoteAccAddr && validators[0].validatorAddress === FIGMENT_NEAR_VALIDATOR_ADDRESS) {
+  if (
+    !chosenVoteAccAddr &&
+    validators.length &&
+    validators[0].validatorAddress === FIGMENT_NEAR_VALIDATOR_ADDRESS
+  ) {
     onChangeValidator({
       address: FIGMENT_NEAR_VALIDATOR_ADDRESS,
     });
   }
+
+  if (!validators.length) {
+    return null;
+  }
+
   return (
     <>
       {showAll && <ValidatorSearchInput noMargin={true} search={search} onSearch={onSearch} />}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71568,7 +71568,7 @@ snapshots:
 
   terser-webpack-plugin@5.3.10(@swc/core@1.4.11)(metro@0.81.5)(webpack@5.94.0(metro@0.81.5)):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1(metro@0.81.5)
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
@@ -71581,7 +71581,7 @@ snapshots:
 
   terser-webpack-plugin@5.3.10(@swc/core@1.4.11)(webpack@5.94.0(@swc/core@1.4.11)):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
@@ -71594,7 +71594,7 @@ snapshots:
 
   terser-webpack-plugin@5.3.10(esbuild@0.19.12)(webpack@5.94.0(esbuild@0.19.12)):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
@@ -71607,7 +71607,7 @@ snapshots:
 
   terser-webpack-plugin@5.3.10(metro@0.81.5)(webpack@5.94.0(metro@0.81.5)):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1(metro@0.81.5)
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
@@ -71618,7 +71618,7 @@ snapshots:
 
   terser-webpack-plugin@5.3.10(webpack@5.94.0):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E tests failed due to actions to delegate before list of validators is available

### 📝 Description
To avoid the runtime error accessing a property, added a flag to check if the validators list is bigger then 0 on the react components
This follows the same pattern applied on here https://github.com/LedgerHQ/ledger-live/pull/11890/files


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> https://ledgerhq.atlassian.net/browse/LIVE-21723


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
