### PR TITLE
fix(live-22119,coin:sui): identify all unstaking operations

### DIFF
--- a/.changeset/kind-tools-reflect.md
+++ b/.changeset/kind-tools-reflect.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": patch
+---
+
+fix(live-22119,coin:sui): identify all unstaking operations

--- a/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
@@ -93,14 +93,17 @@ describe("Sui Api", () => {
     });
   });
 
-  describe.only("listOperations (staking)", () => {
+  describe("listOperations (staking)", () => {
     let txs: Operation[];
 
     beforeAll(async () => {
-      [txs] = await module.listOperations("0x13d73cab19d2cf14e39289b122ed93fb0f9edd00e4c829e0cefb1f0611c54a8f", { minHeight: 0, order: "asc" });
+      [txs] = await module.listOperations(
+        "0x13d73cab19d2cf14e39289b122ed93fb0f9edd00e4c829e0cefb1f0611c54a8f",
+        { minHeight: 0, order: "asc" },
+      );
     });
 
-    it("should map undelegate operations", async () => {
+    it("should map undelegate operations when it's not the first move call", async () => {
       const tx1 = txs.find(t => t.id === "4UtCqCH3oNEdaprZR9UjaMGg6HgLn3V3q3FEcvs5vieM");
       expect(tx1?.type).toBe("UNDELEGATE");
       const tx2 = txs.find(t => t.id === "JEGnHCx2mtpDin216kbUBXm7V5rdMSPSUmgYbP3yxTEf");

--- a/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
@@ -93,6 +93,21 @@ describe("Sui Api", () => {
     });
   });
 
+  describe.only("listOperations (staking)", () => {
+    let txs: Operation[];
+
+    beforeAll(async () => {
+      [txs] = await module.listOperations("0x13d73cab19d2cf14e39289b122ed93fb0f9edd00e4c829e0cefb1f0611c54a8f", { minHeight: 0, order: "asc" });
+    });
+
+    it("should map undelegate operations", async () => {
+      const tx1 = txs.find(t => t.id === "4UtCqCH3oNEdaprZR9UjaMGg6HgLn3V3q3FEcvs5vieM");
+      expect(tx1?.type).toBe("UNDELEGATE");
+      const tx2 = txs.find(t => t.id === "JEGnHCx2mtpDin216kbUBXm7V5rdMSPSUmgYbP3yxTEf");
+      expect(tx2?.type).toBe("UNDELEGATE");
+    });
+  });
+
   describe("listOperations", () => {
     let txs: Operation[];
 

--- a/libs/coin-modules/coin-sui/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.test.ts
@@ -6,9 +6,7 @@ import { SuiClient } from "@mysten/sui/client";
 import type {
   TransactionBlockData,
   SuiTransactionBlockResponse,
-  SuiTransaction,
   SuiTransactionBlockKind,
-  SuiCallArg,
 } from "@mysten/sui/client";
 import assert, { fail } from "assert";
 

--- a/libs/coin-modules/coin-sui/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.test.ts
@@ -3,8 +3,14 @@ import coinConfig from "../config";
 
 import { BigNumber } from "bignumber.js";
 import { SuiClient } from "@mysten/sui/client";
-import type { TransactionBlockData, SuiTransactionBlockResponse } from "@mysten/sui/client";
-import assert from "assert";
+import type {
+  TransactionBlockData,
+  SuiTransactionBlockResponse,
+  SuiTransaction,
+  SuiTransactionBlockKind,
+  SuiCallArg,
+} from "@mysten/sui/client";
+import assert, { fail } from "assert";
 
 // Mock SUI client for tests
 jest.mock("@mysten/sui/client", () => {
@@ -609,16 +615,47 @@ describe("SDK Functions", () => {
 
 describe("Staking Operations", () => {
   describe("Operation Type Detection", () => {
+    const address = "0x65449f57946938c84c512732f1d69405d1fce417d9c9894696ddf4522f479e24";
     test("getOperationType should return DELEGATE for staking transaction", () => {
-      const address = "0x65449f57946938c84c512732f1d69405d1fce417d9c9894696ddf4522f479e24";
       expect(sdk.getOperationType(address, mockStakingTx(address, "-1000000000"))).toBe("DELEGATE");
     });
 
     test("getOperationType should return UNDELEGATE for unstaking transaction", () => {
-      const address = "0x65449f57946938c84c512732f1d69405d1fce417d9c9894696ddf4522f479e24";
       expect(sdk.getOperationType(address, mockUnstakingTx(address, "1000000000"))).toBe(
         "UNDELEGATE",
       );
+    });
+
+    function prependOtherMoveCall(block: SuiTransactionBlockKind) {
+      if (block?.kind === "ProgrammableTransaction") {
+        block.transactions.unshift({
+          MoveCall: {
+            function: "other_function",
+            module: "module",
+            package: "package",
+          },
+        });
+      }
+    }
+
+    test("getOperationType should return UNDELEGATE when it's not the first MoveCall ", () => {
+      const tx = mockUnstakingTx(address, "1000");
+      if (tx.transaction) {
+        prependOtherMoveCall(tx.transaction.data.transaction);
+        expect(sdk.getOperationType(address, tx)).toBe("UNDELEGATE");
+      } else {
+        fail("can't prepare fixture");
+      }
+    });
+
+    test("getOperationType should return DELEGATE when it's not the first MoveCall ", () => {
+      const tx = mockStakingTx(address, "-1000");
+      if (tx.transaction) {
+        prependOtherMoveCall(tx.transaction.data.transaction);
+        expect(sdk.getOperationType(address, tx)).toBe("DELEGATE");
+      } else {
+        fail("can't prepare fixture");
+      }
     });
   });
 

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -115,24 +115,26 @@ type ProgrammableTransaction = {
   transactions: SuiTransaction[];
 };
 
-function isMoveCallWithFunction(
+function hasMoveCallWithFunction(
   functionName: string,
   block?: SuiTransactionBlockKind,
 ): block is ProgrammableTransaction {
   if (block?.kind === "ProgrammableTransaction") {
-    const move = block.transactions.find(item => "MoveCall" in item) as any;
-    return move?.MoveCall.function === functionName;
+    const move = block.transactions.find(
+      item => "MoveCall" in item && item["MoveCall"].function === functionName,
+    ) as any;
+    return Boolean(move);
   } else {
     return false;
   }
 }
 
 function isStaking(block?: SuiTransactionBlockKind): block is ProgrammableTransaction {
-  return isMoveCallWithFunction("request_add_stake", block);
+  return hasMoveCallWithFunction("request_add_stake", block);
 }
 
 function isUnstaking(block?: SuiTransactionBlockKind): block is ProgrammableTransaction {
-  return isMoveCallWithFunction("request_withdraw_stake", block);
+  return hasMoveCallWithFunction("request_withdraw_stake", block);
 }
 
 /**


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - coin module identifies staking/unstaking operations even if they are not the first move call of the transaction

### 📝 Description

- There was a regression identifying unstaking operations (see ticket) when the move call (ie: the function of the contract that proceeds to the unstaking) is not the first one of the list in the tx (a tx can call many functions)
- I think there was also an historical bug on staking operations (with same conditions) that is also fixed in this PR

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-22119


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

