### PR TITLE
test(e2e): Update test to validate token account in speculos

### DIFF
--- a/e2e/mobile/specs/send/sendXRP.spec.ts
+++ b/e2e/mobile/specs/send/sendXRP.spec.ts
@@ -1,4 +1,5 @@
 import { runSendTest } from "./send";
 
+// Existing issue LIVE-22207
 const transaction = new Transaction(Account.XRP_1, Account.XRP_2, "0.0001", undefined, "noTag");
 runSendTest(transaction, ["B2CQA-2816"]);

--- a/libs/ledger-live-common/src/e2e/families/solana.ts
+++ b/libs/ledger-live-common/src/e2e/families/solana.ts
@@ -5,12 +5,10 @@ import {
   containsSubstringInEvent,
   getDelegateEvents,
 } from "../speculos";
-import { getSpeculosModel } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { Device } from "../enum/Device";
 import { Transaction } from "../models/Transaction";
 import { Delegate } from "../models/Delegate";
-import { DeviceModelId } from "@ledgerhq/types-devices";
 
 export async function delegateSolana(delegatingAccount: Delegate) {
   await getDelegateEvents(delegatingAccount);
@@ -18,10 +16,7 @@ export async function delegateSolana(delegatingAccount: Delegate) {
 }
 
 export async function sendSolana(tx: Transaction) {
-  const events =
-    getSpeculosModel() !== DeviceModelId.nanoS
-      ? await pressUntilTextFound(DeviceLabels.SIGN_TRANSACTION)
-      : await pressUntilTextFound(DeviceLabels.APPROVE);
+  const events = await pressUntilTextFound(DeviceLabels.APPROVE);
   const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
   expect(isAmountCorrect).toBeTruthy();
   if (process.env.SPECULOS_DEVICE !== Device.LNS.name) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Speculos device screen is showing the token account address and not the parent account as previously_
_[CI run](https://github.com/LedgerHQ/ledger-live/actions/runs/18412609922/job/52473177321)_
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA**:  [QAA-841](https://ledgerhq.atlassian.net/browse/QAA-841)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-841]: https://ledgerhq.atlassian.net/browse/QAA-841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ