### PR TITLE
chore(hedera): migrate to new hooks

### DIFF
--- a/.changeset/great-hairs-exist.md
+++ b/.changeset/great-hairs-exist.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Migrate Hedera UI flow to new react hooks (useTokenBy*).

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/OperationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/OperationDetails.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import type { OperationType } from "@ledgerhq/types-live";
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets";
 import { isValidExtra } from "@ledgerhq/live-common/families/hedera/logic";
 import type { HederaAccount, HederaOperation } from "@ledgerhq/live-common/families/hedera/types";
 import { Link } from "@ledgerhq/react-ui";
@@ -22,6 +21,7 @@ import {
   OpDetailsTitle,
   TextEllipsis,
 } from "~/renderer/drawers/OperationDetails/styledComponents";
+import { cryptoAssetsHooks } from "~/config/bridge-setup";
 
 const OperationDetailsPostAccountSection = ({
   operation,
@@ -32,9 +32,10 @@ const OperationDetailsPostAccountSection = ({
     return null;
   }
 
-  const token = operation.extra.associatedTokenId
-    ? findTokenByAddressInCurrency(operation.extra.associatedTokenId, "hedera")
-    : null;
+  const { token } = cryptoAssetsHooks.useTokenByAddressInCurrency(
+    operation.extra.associatedTokenId || "",
+    "hedera",
+  );
 
   if (!token) {
     return null;
@@ -64,9 +65,11 @@ const OperationDetailsPostAlert = ({
 
   const extra = isValidExtra(operation.extra) ? operation.extra : null;
   const associatedTokenId = extra?.associatedTokenId;
-  const token = associatedTokenId
-    ? findTokenByAddressInCurrency(associatedTokenId, "hedera")
-    : null;
+
+  const { token } = cryptoAssetsHooks.useTokenByAddressInCurrency(
+    associatedTokenId || "",
+    "hedera",
+  );
 
   if (!token) {
     return null;
@@ -99,9 +102,10 @@ const OperationDetailsPostAlert = ({
 };
 
 const AddressCell = ({ operation }: AddressCellProps<HederaOperation>) => {
-  const token = operation.extra.associatedTokenId
-    ? findTokenByAddressInCurrency(operation.extra.associatedTokenId, "hedera")
-    : null;
+  const { token } = cryptoAssetsHooks.useTokenByAddressInCurrency(
+    operation.extra.associatedTokenId || "",
+    "hedera",
+  );
 
   if (!token) {
     return <Box flex="1" />;

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/02-Summary.tsx
@@ -5,7 +5,7 @@ import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { View, SafeAreaView, StyleSheet } from "react-native";
-import { findTokenByAddressInCurrency } from "@ledgerhq/live-common/currencies/index";
+import { cryptoAssetsHooks } from "~/config/bridge-setup";
 import { HEDERA_TRANSACTION_KINDS } from "@ledgerhq/live-common/families/hedera/constants";
 import { getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
 import { useTheme } from "@react-navigation/native";
@@ -35,10 +35,10 @@ export default function Summary({ navigation, route }: Props) {
   const { account, parentAccount } = useSelector(accountScreenSelector(route));
 
   const { tokenAddress } = route.params;
-  const token = findTokenByAddressInCurrency(tokenAddress, "hedera");
+  const { token } = cryptoAssetsHooks.useTokenByAddressInCurrency(tokenAddress || "", "hedera");
 
   invariant(account, "hedera: account is required");
-  invariant(token, `hedera: token with address ${tokenAddress} is not available`);
+  invariant(token, "hedera: token is not available");
 
   const { transaction, status, bridgeError, bridgePending } = useBridgeTransaction(() => {
     const bridge = getAccountBridge(account, parentAccount);

--- a/apps/ledger-live-mobile/src/families/hedera/operationDetails.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/operationDetails.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { StyleSheet } from "react-native";
 import { Trans, useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
-import { findTokenByAddressInCurrency } from "@ledgerhq/live-common/currencies/index";
+import { cryptoAssetsHooks } from "~/config/bridge-setup";
 import { getTransactionExplorer, isValidExtra } from "@ledgerhq/live-common/families/hedera/logic";
 import type { HederaAccount, HederaOperation } from "@ledgerhq/live-common/families/hedera/types";
 import { Text } from "@ledgerhq/native-ui";
@@ -24,9 +24,10 @@ function OperationDetailsPostAccountSection({
     return null;
   }
 
-  const token = operation.extra.associatedTokenId
-    ? findTokenByAddressInCurrency(operation.extra.associatedTokenId, "hedera")
-    : null;
+  const { token } = cryptoAssetsHooks.useTokenByAddressInCurrency(
+    operation.extra.associatedTokenId || "",
+    "hedera",
+  );
 
   if (!token) {
     return null;
@@ -54,9 +55,11 @@ function OperationDetailsPostAlert({ account, operation }: Readonly<OperationDet
 
   const extra = isValidExtra(operation.extra) ? operation.extra : null;
   const associatedTokenId = extra?.associatedTokenId;
-  const token = associatedTokenId
-    ? findTokenByAddressInCurrency(associatedTokenId, "hedera")
-    : null;
+
+  const { token } = cryptoAssetsHooks.useTokenByAddressInCurrency(
+    associatedTokenId || "",
+    "hedera",
+  );
 
   if (!token) {
     return null;


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Hedera flows
    - LLD and LLM: open the OperationDetails on a token operation
    - LLM: Associate Token Flow

### 📝 Description

with https://github.com/LedgerHQ/ledger-live/pull/12257 and to prepare async rework of https://github.com/LedgerHQ/ledger-live/pull/11905 this will lighten the amount of work and we can ship things bit by bit.

- feature is still functional on LLD

<img width="1020" height="494" alt="Screenshot 2025-10-14 at 13 35 29" src="https://github.com/user-attachments/assets/9d70513d-8b15-462b-a11d-54e7cae1e23d" />

- on LLM I can see the operation

<img width="300" src="https://github.com/user-attachments/assets/c82ef1c4-818d-447d-aeff-f109cee5db84" />

- however, like on develop, i can't currently access the Hedera token associate token flow. but the changes of this PR are the same as operation details.


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
