### PR TITLE
[QAA][LLM] Set iOS Remote speculos image tag version with env

### DIFF
--- a/libs/ledger-live-common/src/e2e/speculosCI.ts
+++ b/libs/ledger-live-common/src/e2e/speculosCI.ts
@@ -7,7 +7,7 @@ import {
 import { SpeculosDevice } from "./speculos";
 import https from "https";
 
-const { SEED, GITHUB_TOKEN, AWS_ROLE, CLUSTER } = process.env;
+const { SEED, GITHUB_TOKEN, AWS_ROLE, CLUSTER, SPECULOS_IMAGE_TAG } = process.env;
 const GIT_API_URL = "https://api.github.com/repos/LedgerHQ/actions/actions/";
 const START_WORKFLOW_ID = "workflows/161487603/dispatches";
 const STOP_WORKFLOW_ID = "workflows/161487604/dispatches";
@@ -147,6 +147,7 @@ function createStartPayload(deviceParams: DeviceParams, runId: string) {
   return {
     ref: GITHUB_REF,
     inputs: {
+      speculos_version: SPECULOS_IMAGE_TAG?.split(":")[1] || "master",
       coin_app: appName,
       coin_app_version: appVersion,
       device: reverseModelMap[model],


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Detox iOS tests

### 📝 Description

_Recent Speculos image tag doesn't contain nanoS so we need to be able to set version via env var_

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [CI run](https://github.com/LedgerHQ/ledger-live/actions/runs/18458843722)
- [Speculos CI start](https://github.com/LedgerHQ/actions/actions/runs/18459440864)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
