### PR TITLE
fix(MAD): introduce useAcceptedCurrency to filter out unsupported coins

### DIFF
--- a/.changeset/refactor-accepted-currency-hook.md
+++ b/.changeset/refactor-accepted-currency-hook.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Fix a bug where you could select unsupported coins (like NEO) in the Add Accounts flow of Modular Assets Drawer.
+Refactor currency acceptance logic by introducing useAcceptedCurrency hook. This new hook encapsulates the logic for determining if a currency or token is accepted based on platform support and feature flags, replacing direct access to deactivatedCurrencyIds.
+

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/__tests__/modules.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/__tests__/modules.test.tsx
@@ -22,13 +22,11 @@ import {
 import { mockDomMeasurements, mockOnAssetSelected } from "../../__tests__/shared";
 import ModularDrawerFlowManager from "../ModularDrawerFlowManager";
 
-jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag", () => ({
-  useCurrenciesUnderFeatureFlag: () => mockUseCurrenciesUnderFeatureFlag(),
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: () => mockUseAcceptedCurrency(),
 }));
 
-const mockUseCurrenciesUnderFeatureFlag = jest.fn(() => ({
-  deactivatedCurrencyIds: new Set(),
-}));
+const mockUseAcceptedCurrency = jest.fn(() => () => true);
 
 beforeEach(async () => {
   mockDomMeasurements();

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/__tests__/selectAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/__tests__/selectAccountFlow.test.tsx
@@ -28,13 +28,11 @@ import {
 } from "../../__tests__/shared";
 import ModularDrawerFlowManager from "../ModularDrawerFlowManager";
 
-jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag", () => ({
-  useCurrenciesUnderFeatureFlag: () => mockUseCurrenciesUnderFeatureFlag(),
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: () => mockUseAcceptedCurrency(),
 }));
 
-const mockUseCurrenciesUnderFeatureFlag = jest.fn(() => ({
-  deactivatedCurrencyIds: new Set(),
-}));
+const mockUseAcceptedCurrency = jest.fn(() => () => true);
 
 const MAD_BACK_BUTTON_TEST_ID = "mad-back-button";
 

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/__tests__/selectNetworkFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/__tests__/selectNetworkFlow.test.tsx
@@ -10,13 +10,11 @@ import {
 import { currencies, mockDomMeasurements, mockOnAssetSelected } from "../../__tests__/shared";
 import ModularDrawerFlowManager from "../ModularDrawerFlowManager";
 
-jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag", () => ({
-  useCurrenciesUnderFeatureFlag: () => mockUseCurrenciesUnderFeatureFlag(),
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: () => mockUseAcceptedCurrency(),
 }));
 
-const mockUseCurrenciesUnderFeatureFlag = jest.fn(() => ({
-  deactivatedCurrencyIds: new Set(),
-}));
+const mockUseAcceptedCurrency = jest.fn(() => () => true);
 
 beforeEach(() => {
   mockDomMeasurements();

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/__tests__/useAssetSelection.test.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/__tests__/useAssetSelection.test.ts
@@ -1,24 +1,59 @@
 import { renderHook } from "tests/testSetup";
 import { useAssetSelection } from "../useAssetSelection";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { setSupportedCurrencies } from "@ledgerhq/coin-framework/lib-es/currencies/support";
+
+setSupportedCurrencies(["cardano", "bitcoin", "ethereum", "neo"]);
+
+// Mock useAcceptedCurrency to return a function that checks if currency is in supported list
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: jest.fn(() => {
+    const supported = new Set(["cardano", "bitcoin", "ethereum", "neo"]);
+    return (currency: CryptoOrTokenCurrency) => supported.has(currency.id);
+  }),
+}));
 
 describe("useAssetSelection", () => {
-  const mockCurrencyIds = ["ada", "btc", "eth"];
-  const mockSorted = [
-    { id: "eth", name: "Ethereum", type: "CryptoCurrency" },
-    { id: "btc", name: "Bitcoin", type: "CryptoCurrency" },
-    { id: "ada", name: "Cardano", type: "CryptoCurrency" },
-  ] as CryptoOrTokenCurrency[];
+  const mockCurrencyIds = ["cardano", "bitcoin", "ethereum"];
+  const mockEthereum = {
+    id: "ethereum",
+    name: "Ethereum",
+    type: "CryptoCurrency",
+  } as CryptoOrTokenCurrency;
+  const mockBitcoin = {
+    id: "bitcoin",
+    name: "Bitcoin",
+    type: "CryptoCurrency",
+  } as CryptoOrTokenCurrency;
+  const mockCardano = {
+    id: "cardano",
+    name: "Cardano",
+    type: "CryptoCurrency",
+  } as CryptoOrTokenCurrency;
+  const mockNeo = { id: "neo", name: "NEO", type: "CryptoCurrency" } as CryptoOrTokenCurrency;
 
-  it("returns filtered currencies by default", () => {
-    const { result } = renderHook(() => useAssetSelection(mockCurrencyIds, mockSorted));
-    expect(result.current.assetsToDisplay).toEqual(mockSorted);
-    expect(result.current.currencyIdsSet).toEqual(new Set(["ada", "btc", "eth"]));
+  beforeEach(() => {
+    // Ensure currencies are marked as supported before each test
+    setSupportedCurrencies(["cardano", "bitcoin", "ethereum", "neo"]);
   });
 
-  it("returns all the assets in assetsToDisplay if no matching currencies", () => {
+  it("returns all currencies when all are supported", () => {
+    const mockSorted = [mockEthereum, mockBitcoin, mockCardano, mockNeo];
+    const { result } = renderHook(() => useAssetSelection(mockCurrencyIds, mockSorted));
+    // All currencies are supported
+    expect(result.current.assetsToDisplay).toEqual([
+      mockEthereum,
+      mockBitcoin,
+      mockCardano,
+      mockNeo,
+    ]);
+    expect(result.current.currencyIdsSet).toEqual(new Set(["cardano", "bitcoin", "ethereum"]));
+  });
+
+  it("returns all supported assets even if currencyIds is empty", () => {
+    const mockSorted = [mockEthereum, mockBitcoin, mockCardano];
     const { result } = renderHook(() => useAssetSelection([], mockSorted));
-    expect(result.current.assetsToDisplay).toEqual(mockSorted);
+    expect(result.current.assetsToDisplay).toEqual([mockEthereum, mockBitcoin, mockCardano]);
     expect(result.current.currencyIdsSet).toEqual(new Set());
   });
 });

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useAssetSelection.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useAssetSelection.ts
@@ -1,20 +1,17 @@
 import { useMemo } from "react";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
+import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
 
 export function useAssetSelection(
   currencyIds: string[],
   sortedCryptoCurrencies: CryptoOrTokenCurrency[],
 ) {
-  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+  const isAcceptedCurrency = useAcceptedCurrency();
 
-  const assetsToDisplay = useMemo(() => {
-    return sortedCryptoCurrencies.filter(
-      c =>
-        (c.type === "CryptoCurrency" && !deactivatedCurrencyIds.has(c.id)) ||
-        (c.type === "TokenCurrency" && !deactivatedCurrencyIds.has(c.parentCurrency.id)),
-    );
-  }, [sortedCryptoCurrencies, deactivatedCurrencyIds]);
+  const assetsToDisplay = useMemo(
+    () => sortedCryptoCurrencies.filter(isAcceptedCurrency),
+    [sortedCryptoCurrencies, isAcceptedCurrency],
+  );
 
   const currencyIdsSet = useMemo(() => new Set(currencyIds), [currencyIds]);
 

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useModularDrawerFlowState.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useModularDrawerFlowState.ts
@@ -10,7 +10,7 @@ import { isCorrespondingCurrency } from "@ledgerhq/live-common/modularDrawer/uti
 import { useSelector } from "react-redux";
 import { modularDrawerSearchedSelector } from "~/renderer/reducers/modularDrawer";
 import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
-import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
+import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
 
 type Props = {
   assets: AssetData[] | undefined;
@@ -31,7 +31,7 @@ export function useModularDrawerFlowState({
   isSelectAccountFlow,
   onAssetSelected,
 }: Props) {
-  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+  const isAcceptedCurrency = useAcceptedCurrency();
   const { trackModularDrawerEvent } = useModularDrawerAnalytics();
   const searchedValue = useSelector(modularDrawerSearchedSelector);
 
@@ -91,15 +91,12 @@ export function useModularDrawerFlowState({
   const getNetworksFromProvider = useCallback(
     (provider: AssetData) => {
       return provider.networks.filter(elem => {
-        const currencyId = elem.type === "CryptoCurrency" ? elem.id : elem.parentCurrency.id;
-
-        const isDeactivated = deactivatedCurrencyIds.has(currencyId);
         const isAllowedByFilter = currencyIds.length === 0 || currencyIds.includes(elem.id);
 
-        return !isDeactivated && isAllowedByFilter;
+        return isAcceptedCurrency(elem) && isAllowedByFilter;
       });
     },
-    [deactivatedCurrencyIds, currencyIds],
+    [isAcceptedCurrency, currencyIds],
   );
 
   const handleNoProvider = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.tsx
@@ -27,25 +27,21 @@ import { NetworkDown } from "@ledgerhq/errors";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 
-import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
+import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
 
 const listSupportedTokens = () =>
   listTokens().filter(token => isCurrencySupported(token.parentCurrency));
 
 const StepChooseCurrency = ({ currency, setCurrency }: StepProps) => {
-  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+  const isAcceptedCurrency = useAcceptedCurrency();
 
   const currencies = useMemo(() => {
     const supportedCurrenciesAndTokens =
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       (listSupportedCurrencies() as CryptoOrTokenCurrency[]).concat(listSupportedTokens());
 
-    return supportedCurrenciesAndTokens.filter(
-      c =>
-        (c.type === "CryptoCurrency" && !deactivatedCurrencyIds.has(c.id)) ||
-        (c.type === "TokenCurrency" && !deactivatedCurrencyIds.has(c.parentCurrency.id)),
-    );
-  }, [deactivatedCurrencyIds]);
+    return supportedCurrenciesAndTokens.filter(isAcceptedCurrency);
+  }, [isAcceptedCurrency]);
 
   const url =
     currency && currency.type === "TokenCurrency"

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -187,3 +187,12 @@ console.log = (...args) => {
   }
   originalLog.call(console, ...args);
 };
+
+// Mock isCurrencySupported globally for tests
+jest.mock("@ledgerhq/coin-framework/currencies/support", () => {
+  const actual = jest.requireActual("@ledgerhq/coin-framework/currencies/support");
+  return {
+    ...actual,
+    isCurrencySupported: jest.fn(() => true),
+  };
+});

--- a/apps/ledger-live-mobile/src/components/MarketQuickActions/MarketQuickActions.test.tsx
+++ b/apps/ledger-live-mobile/src/components/MarketQuickActions/MarketQuickActions.test.tsx
@@ -6,6 +6,7 @@ import { ScreenName } from "~/const";
 import { createStackNavigator } from "@react-navigation/stack";
 import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
 import { State } from "~/reducers/types";
+import { isCurrencySupported } from "@ledgerhq/coin-framework/currencies/support";
 
 const Stack = createStackNavigator();
 
@@ -20,14 +21,14 @@ const bitcoinAccount = genAccount("bitcoin-account", { currency: bitcoinCurrency
 const kaspaAccount = genAccount("kaspa-account", { currency: kaspaCurrency });
 const ethereumAccount = genAccount("ethereum-account", { currency: ethereumCurrency });
 
-jest.mock("@ledgerhq/coin-framework/currencies/support", () => ({
-  listSupportedCurrencies: jest.fn(() => [
-    usdcCurrency,
-    kaspaCurrency,
-    bitcoinCurrency,
-    ethereumCurrency,
-  ]),
-}));
+// Mock the support module
+jest.mock("@ledgerhq/coin-framework/currencies/support");
+
+// Set up the mock implementation
+(isCurrencySupported as jest.Mock).mockImplementation(currency => {
+  const supportedIds = new Set(["ethereum", "kaspa", "bitcoin"]);
+  return supportedIds.has(currency.id);
+});
 
 jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog", () => ({
   useRampCatalog: jest.fn(() => ({

--- a/apps/ledger-live-mobile/src/components/MarketQuickActions/index.tsx
+++ b/apps/ledger-live-mobile/src/components/MarketQuickActions/index.tsx
@@ -7,8 +7,7 @@ import { track } from "~/analytics";
 import useQuickActions, { QuickActionProps } from "../../hooks/useQuickActions";
 import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigator";
 import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
-import { listSupportedCurrencies } from "@ledgerhq/coin-framework/currencies/support";
-import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
+import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
 
 const stakeLabel = getStakeLabelLocaleBased();
 export const MarketQuickActions = (quickActionsProps: Required<QuickActionProps>) => {
@@ -16,16 +15,9 @@ export const MarketQuickActions = (quickActionsProps: Required<QuickActionProps>
   const navigation = useNavigation<StackNavigationProp<BaseNavigatorStackParamList>>();
   const router = useRoute();
   const { quickActionsList } = useQuickActions(quickActionsProps);
-  const supportedCurrencies = listSupportedCurrencies();
-  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+  const isAcceptedCurrency = useAcceptedCurrency();
 
-  const baseCurrencyId =
-    quickActionsProps.currency.type === "TokenCurrency"
-      ? quickActionsProps.currency.parentCurrency.id
-      : quickActionsProps.currency.id;
-  const isCurrencySupported =
-    !deactivatedCurrencyIds.has(baseCurrencyId) &&
-    supportedCurrencies.some(currency => currency.id === baseCurrencyId);
+  const isCurrencySupported = isAcceptedCurrency(quickActionsProps.currency);
   const hideQuickActions = !isCurrencySupported;
 
   const quickActionsData: QuickActionButtonProps[] = useMemo(

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
@@ -15,13 +15,11 @@ import { http, HttpResponse } from "msw";
 import { server } from "@tests/server";
 import { NetInfoStateType, useNetInfo } from "@react-native-community/netinfo";
 
-jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag", () => ({
-  useCurrenciesUnderFeatureFlag: () => mockUseCurrenciesUnderFeatureFlag(),
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: () => mockUseAcceptedCurrency(),
 }));
 
-const mockUseCurrenciesUnderFeatureFlag = jest.fn(() => ({
-  deactivatedCurrencyIds: new Set(),
-}));
+const mockUseAcceptedCurrency = jest.fn(() => () => true);
 
 jest.mock("@react-native-community/netinfo", () => {
   const mockUseNetInfo = jest.fn(() => ({

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/modules.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/modules.test.tsx
@@ -9,13 +9,11 @@ import {
 import { INITIAL_STATE } from "~/reducers/settings";
 import { State } from "~/reducers/types";
 
-jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag", () => ({
-  useCurrenciesUnderFeatureFlag: () => mockUseCurrenciesUnderFeatureFlag(),
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: () => mockUseAcceptedCurrency(),
 }));
 
-const mockUseCurrenciesUnderFeatureFlag = jest.fn(() => ({
-  deactivatedCurrencyIds: new Set(),
-}));
+const mockUseAcceptedCurrency = jest.fn(() => () => true);
 
 const advanceTimers = () => {
   act(() => {

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/__tests__/useAssets.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/__tests__/useAssets.test.ts
@@ -3,6 +3,10 @@ import { useAssets } from "../useAssets";
 import { expectedAssetsSorted as expectedAssetsSortedFromMock } from "@ledgerhq/live-common/modularDrawer/__mocks__/dada.mock";
 import { LoadingStatus } from "@ledgerhq/live-common/deposit/type";
 
+jest.mock("@ledgerhq/coin-framework/currencies/support", () => ({
+  isCurrencySupported: jest.fn(() => true),
+}));
+
 describe("useAssets", () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/__tests__/useModularDrawerState.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/__tests__/useModularDrawerState.test.ts
@@ -12,13 +12,11 @@ import { NavigationProp } from "@react-navigation/native";
 import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
 import { State } from "~/reducers/types";
 
-jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag", () => ({
-  useCurrenciesUnderFeatureFlag: () => mockUseCurrenciesUnderFeatureFlag(),
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: () => mockUseAcceptedCurrency(),
 }));
 
-const mockUseCurrenciesUnderFeatureFlag = jest.fn(() => ({
-  deactivatedCurrencyIds: new Set(),
-}));
+const mockUseAcceptedCurrency = jest.fn(() => () => true);
 
 const assetsSorted: AssetData[] = [
   {

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/useAssets.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/useAssets.ts
@@ -5,8 +5,7 @@ import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssets
 import VersionNumber from "react-native-version-number";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
-import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
-import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
 
 interface AssetsProps {
   currencyIds?: string[];
@@ -21,7 +20,7 @@ export function useAssets({
   useCase,
   areCurrenciesFiltered,
 }: AssetsProps) {
-  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+  const isAcceptedCurrency = useAcceptedCurrency();
   const modularDrawerFeature = useFeature("llmModularDrawer");
 
   const isStaging = useMemo(
@@ -65,19 +64,10 @@ export function useAssets({
   const assetsToDisplay = useMemo(() => {
     if (!assetsSorted || !data) return [];
 
-    return assetsSorted.reduce<CryptoOrTokenCurrency[]>((acc, { asset }) => {
-      const currency = data.cryptoOrTokenCurrencies[asset.id];
-      if (!currency) return acc;
-
-      const isActive =
-        (currency.type === "CryptoCurrency" && !deactivatedCurrencyIds.has(currency.id)) ||
-        (currency.type === "TokenCurrency" &&
-          !deactivatedCurrencyIds.has(currency.parentCurrency?.id));
-
-      if (isActive) acc.push(currency);
-      return acc;
-    }, []);
-  }, [assetsSorted, data, deactivatedCurrencyIds]);
+    return assetsSorted
+      .map(({ asset }) => data.cryptoOrTokenCurrencies[asset.id])
+      .filter(currency => currency && isAcceptedCurrency(currency));
+  }, [assetsSorted, data, isAcceptedCurrency]);
 
   return {
     data,

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/useModularDrawerState.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/useModularDrawerState.ts
@@ -10,7 +10,7 @@ import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
 import { getNetworksForAsset, resolveCurrency } from "../utils/helpers";
 import { useDispatch, useSelector } from "react-redux";
 import { modularDrawerEnableAccountSelectionSelector, setStep } from "~/reducers/modularDrawer";
-import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
+import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
 
 type ModularDrawerStateProps = {
   assetsSorted?: AssetData[];
@@ -30,7 +30,7 @@ export function useModularDrawerState({
   hasSearchedValue,
   onAccountSelected,
 }: ModularDrawerStateProps) {
-  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+  const isAcceptedCurrency = useAcceptedCurrency();
   const enableAccountSelection = useSelector(modularDrawerEnableAccountSelectionSelector);
   const dispatch = useDispatch();
 
@@ -83,7 +83,7 @@ export function useModularDrawerState({
       const availableNetworksList = getNetworksForAsset(
         assetsSorted,
         selected.id,
-        deactivatedCurrencyIds,
+        isAcceptedCurrency,
       );
 
       if (availableNetworksList.length > 1) {
@@ -93,7 +93,7 @@ export function useModularDrawerState({
         const singleNetwork = availableNetworksList[0];
         const resolvedCurrency = resolveCurrency(
           assetsSorted,
-          deactivatedCurrencyIds,
+          isAcceptedCurrency,
           selected,
           singleNetwork,
         );
@@ -110,7 +110,7 @@ export function useModularDrawerState({
       dispatch,
       navigateToDeviceWithCurrency,
       proceedToNextStep,
-      deactivatedCurrencyIds,
+      isAcceptedCurrency,
     ],
   );
 
@@ -120,13 +120,13 @@ export function useModularDrawerState({
       if (!asset) return;
       const correspondingCurrency = resolveCurrency(
         assetsSorted,
-        deactivatedCurrencyIds,
+        isAcceptedCurrency,
         asset,
         selectedNetwork,
       );
       if (correspondingCurrency) proceedToNextStep(correspondingCurrency, selectedNetwork);
     },
-    [asset, assetsSorted, proceedToNextStep, deactivatedCurrencyIds],
+    [asset, assetsSorted, proceedToNextStep, isAcceptedCurrency],
   );
 
   const { handleBackButton, handleCloseButton } = useDrawerLifecycle({
@@ -154,8 +154,8 @@ export function useModularDrawerState({
   }, [isDrawerOpen, reset]);
 
   const accountCurrency = useMemo(
-    () => resolveCurrency(assetsSorted, deactivatedCurrencyIds, asset, network),
-    [asset, network, assetsSorted, deactivatedCurrencyIds],
+    () => resolveCurrency(assetsSorted, isAcceptedCurrency, asset, network),
+    [asset, network, assetsSorted, isAcceptedCurrency],
   );
 
   const onAddNewAccount = () => {

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/utils/__tests__/helpers.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/utils/__tests__/helpers.test.ts
@@ -7,8 +7,12 @@ import {
   usdcToken,
   mockScrollCryptoCurrency,
 } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 describe("helpers", () => {
+  const acceptAll = () => true;
+  const rejectScroll = (currency: CryptoOrTokenCurrency) => currency.id !== "scroll";
+
   describe("getNetworksForAsset", () => {
     it("should return an empty array if the asset id does not exist", () => {
       const assets: AssetData[] = [
@@ -17,7 +21,7 @@ describe("helpers", () => {
           networks: [mockEthCryptoCurrency],
         },
       ];
-      expect(getNetworksForAsset(assets, "unknown", new Set())).toEqual([]);
+      expect(getNetworksForAsset(assets, "unknown", acceptAll)).toEqual([]);
     });
 
     it("should return the networks for a matching asset id", () => {
@@ -28,7 +32,7 @@ describe("helpers", () => {
           networks,
         },
       ];
-      expect(getNetworksForAsset(assets, "btc", new Set())).toEqual(networks);
+      expect(getNetworksForAsset(assets, "btc", acceptAll)).toEqual(networks);
     });
     it("should not return scroll network (when deactivated) for asset", () => {
       const networks = [mockEthCryptoCurrency];
@@ -38,7 +42,7 @@ describe("helpers", () => {
           networks: [mockEthCryptoCurrency, mockScrollCryptoCurrency],
         },
       ];
-      expect(getNetworksForAsset(assets, "eth", new Set(["scroll"]))).toEqual(networks);
+      expect(getNetworksForAsset(assets, "eth", rejectScroll)).toEqual(networks);
     });
   });
 
@@ -59,23 +63,23 @@ describe("helpers", () => {
     ];
 
     it("should return undefined if no asset is selected", () => {
-      expect(resolveCurrency(assets, new Set(), undefined, undefined)).toBeUndefined();
+      expect(resolveCurrency(assets, acceptAll, undefined, undefined)).toBeUndefined();
     });
 
     it("should return the selected asset if no network is selected", () => {
-      expect(resolveCurrency(assets, new Set(), eth, undefined)).toBe(eth);
+      expect(resolveCurrency(assets, acceptAll, eth, undefined)).toBe(eth);
     });
 
     it("should return the selected asset when the selected network is the same currency", () => {
-      expect(resolveCurrency(assets, new Set(), eth, eth)).toBe(eth);
+      expect(resolveCurrency(assets, acceptAll, eth, eth)).toBe(eth);
     });
 
     it("should return the token correctly for both parent and other networks", () => {
       // Token selected with its parent network
-      expect(resolveCurrency(assets, new Set(), usdc, eth)).toBe(usdc);
+      expect(resolveCurrency(assets, acceptAll, usdc, eth)).toBe(usdc);
 
       // Token selected with a different network
-      expect(resolveCurrency(assets, new Set(), usdc, base)).toBe(usdc);
+      expect(resolveCurrency(assets, acceptAll, usdc, base)).toBe(usdc);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/utils/helpers.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/utils/helpers.ts
@@ -4,28 +4,23 @@ import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
 function getNetworksForAsset(
   assetsSorted: AssetData[] | undefined,
   assetId: string,
-  deactivatedAssets: Set<string>,
+  isAcceptedCurrency: (currency: CryptoOrTokenCurrency) => boolean,
 ) {
   return (
-    assetsSorted
-      ?.find(elem => elem.asset.id === assetId)
-      ?.networks.filter(
-        elem =>
-          !deactivatedAssets.has(elem.type === "CryptoCurrency" ? elem.id : elem.parentCurrency.id),
-      ) ?? []
+    assetsSorted?.find(elem => elem.asset.id === assetId)?.networks.filter(isAcceptedCurrency) ?? []
   );
 }
 
 function resolveCurrency(
   assetsSorted: AssetData[] | undefined,
-  deactivatedAssets: Set<string>,
+  isAcceptedCurrency: (currency: CryptoOrTokenCurrency) => boolean,
   selectedAsset?: CryptoOrTokenCurrency,
   selectedNetwork?: CryptoOrTokenCurrency,
 ): CryptoOrTokenCurrency | undefined {
   if (!selectedAsset) return undefined;
   if (!selectedNetwork) return selectedAsset;
 
-  const networksForAsset = getNetworksForAsset(assetsSorted, selectedAsset.id, deactivatedAssets);
+  const networksForAsset = getNetworksForAsset(assetsSorted, selectedAsset.id, isAcceptedCurrency);
   const correspondingCurrency = networksForAsset.find(n =>
     n.type === "CryptoCurrency"
       ? n.id === selectedNetwork.id

--- a/libs/ledger-live-common/src/deposit/useGroupedCurrenciesByProvider.hook.ts
+++ b/libs/ledger-live-common/src/deposit/useGroupedCurrenciesByProvider.hook.ts
@@ -3,7 +3,7 @@ import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { useEffect, useMemo, useState } from "react";
 import { isCurrencySupported, listSupportedCurrencies, listTokens } from "../currencies";
 import { loadCurrenciesByProvider } from "./helper";
-import { useCurrenciesUnderFeatureFlag } from "../modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
+import { useAcceptedCurrency } from "../modularDrawer/hooks/useAcceptedCurrency";
 
 // FIXME(LIVE-10505): bad performane & shared utility to move to coin-framework
 const listSupportedTokens = () => listTokens().filter(t => isCurrencySupported(t.parentCurrency));
@@ -17,16 +17,15 @@ export const useGroupedCurrenciesByProvider = (
   withLoading?: boolean,
 ): GroupedCurrencies | LoadingBasedGroupedCurrencies => {
   const [result, setResult] = useState(initialResult);
-  // the import is from MAD but as this hook will be removed, it's fine to keep it here
-  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+  const isAcceptedCurrency = useAcceptedCurrency();
 
   const [loadingStatus, setLoadingStatus] = useState<LoadingStatus>(LoadingStatus.Idle);
   const coinsAndTokensSupported = useMemo(
     () =>
       (listSupportedCurrencies() as CryptoOrTokenCurrency[])
         .concat(listSupportedTokens())
-        .filter(c => !deactivatedCurrencyIds.has(c.id)),
-    [deactivatedCurrencyIds],
+        .filter(isAcceptedCurrency),
+    [isAcceptedCurrency],
   );
 
   // Get mapped assets filtered by supported & sorted currencies, grouped by provider id

--- a/libs/ledger-live-common/src/modularDrawer/hooks/__tests__/useAcceptedCurrency.test.ts
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/__tests__/useAcceptedCurrency.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { useAcceptedCurrency } from "../useAcceptedCurrency";
+import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { useCurrenciesUnderFeatureFlag } from "../useCurrenciesUnderFeatureFlag";
+import { isCurrencySupported } from "@ledgerhq/coin-framework/currencies/support";
+
+// Mock dependencies
+jest.mock("../useCurrenciesUnderFeatureFlag");
+jest.mock("@ledgerhq/coin-framework/currencies/support");
+
+const mockUseCurrenciesUnderFeatureFlag = useCurrenciesUnderFeatureFlag as jest.MockedFunction<
+  typeof useCurrenciesUnderFeatureFlag
+>;
+const mockIsCurrencySupported = isCurrencySupported as jest.MockedFunction<
+  typeof isCurrencySupported
+>;
+
+describe("useAcceptedCurrency", () => {
+  const mockCryptoCurrency: CryptoCurrency = {
+    id: "bitcoin",
+    name: "Bitcoin",
+    ticker: "BTC",
+    type: "CryptoCurrency",
+  } as CryptoCurrency;
+
+  const mockDeactivatedCurrency: CryptoCurrency = {
+    id: "ethereum",
+    name: "Ethereum",
+    ticker: "ETH",
+    type: "CryptoCurrency",
+  } as CryptoCurrency;
+
+  const mockTokenCurrency: TokenCurrency = {
+    id: "usdc",
+    name: "USD Coin",
+    ticker: "USDC",
+    type: "TokenCurrency",
+    parentCurrency: mockCryptoCurrency,
+  } as TokenCurrency;
+
+  const mockTokenWithDeactivatedParent: TokenCurrency = {
+    id: "weth",
+    name: "Wrapped Ethereum",
+    ticker: "WETH",
+    type: "TokenCurrency",
+    parentCurrency: mockDeactivatedCurrency,
+  } as TokenCurrency;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return true for a supported and non-deactivated currency", () => {
+    mockUseCurrenciesUnderFeatureFlag.mockReturnValue({
+      deactivatedCurrencyIds: new Set<string>(),
+      featureFlaggedCurrencies: {},
+    } as any);
+    mockIsCurrencySupported.mockReturnValue(true);
+
+    const { result } = renderHook(() => useAcceptedCurrency());
+    const isAccepted = result.current(mockCryptoCurrency);
+
+    expect(isAccepted).toBe(true);
+    expect(mockIsCurrencySupported).toHaveBeenCalledWith(mockCryptoCurrency);
+  });
+
+  it("should return false for a deactivated currency", () => {
+    mockUseCurrenciesUnderFeatureFlag.mockReturnValue({
+      deactivatedCurrencyIds: new Set(["ethereum"]),
+      featureFlaggedCurrencies: {},
+    } as any);
+    mockIsCurrencySupported.mockReturnValue(true);
+
+    const { result } = renderHook(() => useAcceptedCurrency());
+    const isAccepted = result.current(mockDeactivatedCurrency);
+
+    expect(isAccepted).toBe(false);
+    expect(mockIsCurrencySupported).toHaveBeenCalledWith(mockDeactivatedCurrency);
+  });
+
+  it("should return false for an unsupported currency", () => {
+    mockUseCurrenciesUnderFeatureFlag.mockReturnValue({
+      deactivatedCurrencyIds: new Set<string>(),
+      featureFlaggedCurrencies: {},
+    } as any);
+    mockIsCurrencySupported.mockReturnValue(false);
+
+    const { result } = renderHook(() => useAcceptedCurrency());
+    const isAccepted = result.current(mockCryptoCurrency);
+
+    expect(isAccepted).toBe(false);
+    expect(mockIsCurrencySupported).toHaveBeenCalledWith(mockCryptoCurrency);
+  });
+
+  it("should return true for a token with an accepted parent currency", () => {
+    mockUseCurrenciesUnderFeatureFlag.mockReturnValue({
+      deactivatedCurrencyIds: new Set<string>(),
+      featureFlaggedCurrencies: {},
+    } as any);
+    mockIsCurrencySupported.mockReturnValue(true);
+
+    const { result } = renderHook(() => useAcceptedCurrency());
+    const isAccepted = result.current(mockTokenCurrency);
+
+    expect(isAccepted).toBe(true);
+    expect(mockIsCurrencySupported).toHaveBeenCalledWith(mockCryptoCurrency);
+  });
+
+  it("should return false for a token with a deactivated parent currency", () => {
+    mockUseCurrenciesUnderFeatureFlag.mockReturnValue({
+      deactivatedCurrencyIds: new Set(["ethereum"]),
+      featureFlaggedCurrencies: {},
+    } as any);
+    mockIsCurrencySupported.mockReturnValue(true);
+
+    const { result } = renderHook(() => useAcceptedCurrency());
+    const isAccepted = result.current(mockTokenWithDeactivatedParent);
+
+    expect(isAccepted).toBe(false);
+    expect(mockIsCurrencySupported).toHaveBeenCalledWith(mockDeactivatedCurrency);
+  });
+
+  it("should return false for a token with an unsupported parent currency", () => {
+    mockUseCurrenciesUnderFeatureFlag.mockReturnValue({
+      deactivatedCurrencyIds: new Set<string>(),
+      featureFlaggedCurrencies: {},
+    } as any);
+    mockIsCurrencySupported.mockReturnValue(false);
+
+    const { result } = renderHook(() => useAcceptedCurrency());
+    const isAccepted = result.current(mockTokenCurrency);
+
+    expect(isAccepted).toBe(false);
+    expect(mockIsCurrencySupported).toHaveBeenCalledWith(mockCryptoCurrency);
+  });
+
+  it("should update when deactivatedCurrencyIds changes", () => {
+    const { result, rerender } = renderHook(() => useAcceptedCurrency());
+
+    // First render - currency is accepted
+    mockUseCurrenciesUnderFeatureFlag.mockReturnValue({
+      deactivatedCurrencyIds: new Set<string>(),
+      featureFlaggedCurrencies: {},
+    } as any);
+    mockIsCurrencySupported.mockReturnValue(true);
+    rerender();
+    expect(result.current(mockCryptoCurrency)).toBe(true);
+
+    // Second render - currency is deactivated
+    mockUseCurrenciesUnderFeatureFlag.mockReturnValue({
+      deactivatedCurrencyIds: new Set(["bitcoin"]),
+      featureFlaggedCurrencies: {},
+    } as any);
+    rerender();
+    expect(result.current(mockCryptoCurrency)).toBe(false);
+  });
+
+  it("should handle multiple currencies in deactivated set", () => {
+    mockUseCurrenciesUnderFeatureFlag.mockReturnValue({
+      deactivatedCurrencyIds: new Set(["ethereum", "cardano", "polkadot"]),
+      featureFlaggedCurrencies: {},
+    } as any);
+    mockIsCurrencySupported.mockReturnValue(true);
+
+    const { result } = renderHook(() => useAcceptedCurrency());
+
+    // Bitcoin should be accepted (not in deactivated set)
+    expect(result.current(mockCryptoCurrency)).toBe(true);
+
+    // Ethereum should be rejected (in deactivated set)
+    expect(result.current(mockDeactivatedCurrency)).toBe(false);
+  });
+});

--- a/libs/ledger-live-common/src/modularDrawer/hooks/index.ts
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useDetailedAccountsCore } from "./useDetailedAccountsCore";
+export { useAcceptedCurrency } from "./useAcceptedCurrency";

--- a/libs/ledger-live-common/src/modularDrawer/hooks/useAcceptedCurrency.ts
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/useAcceptedCurrency.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { CryptoCurrency, CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { isCurrencySupported } from "@ledgerhq/coin-framework/currencies/support";
+import { useCurrenciesUnderFeatureFlag } from "./useCurrenciesUnderFeatureFlag";
+
+/**
+ * Hook that returns a predicate function to check if a currency or token is accepted.
+ * A currency is accepted if:
+ * - It is supported by the platform (via isCurrencySupported)
+ * - It is not deactivated by a feature flag
+ *
+ * For tokens, the parent currency is checked instead.
+ */
+export function useAcceptedCurrency() {
+  const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+
+  const isAcceptedCurrency = useCallback(
+    (currencyOrToken: CryptoOrTokenCurrency): boolean => {
+      const currency: CryptoCurrency =
+        currencyOrToken.type === "TokenCurrency" ? currencyOrToken.parentCurrency : currencyOrToken;
+
+      return isCurrencySupported(currency) && !deactivatedCurrencyIds.has(currency.id);
+    },
+    [deactivatedCurrencyIds],
+  );
+
+  return isAcceptedCurrency;
+}


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD & LLM
  - MAD flows

### 📝 Description

coins like NEO are now properly filtered out from being listed in the Add Accounts flow (modular assets drawer)

we also took the opportunity to factorise the feature flags checks logic.

```diff
- const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
- deactivatedCurrencyIds.includes(c.type==="CryptoCurrency" ? c.id : c.parentCurrency.id)
+ const isAcceptedCurrency = useAcceptedCurrency();
+ isAcceptedCurrency(c)
```

### ❓ Context

- **JIRA or GitHub link**: LIVE-22240


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
