### PR TITLE
fix(LIVE-21181): hide fee selection in approval flow of sponsored tra…

### DIFF
--- a/.changeset/pretty-apes-repair.md
+++ b/.changeset/pretty-apes-repair.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+hide the fee selection option in approval flow of sponsored transactions on mobile

--- a/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.test.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.test.tsx
@@ -1,0 +1,141 @@
+import BigNumber from "bignumber.js";
+import React from "react";
+import { screen } from "@testing-library/react-native";
+import { render } from "@tests/test-renderer";
+import { Text } from "react-native";
+import EvmFeesStrategy from "./EvmFeesStrategy";
+import type { Transaction } from "@ledgerhq/coin-evm/lib/types/transaction";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { useGasOptions } from "@ledgerhq/live-common/families/evm/react";
+
+jest.mock("@ledgerhq/live-common/families/evm/react", () => ({
+  useGasOptions: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  getAccountBridge: jest.fn().mockReturnValue({
+    updateTransaction: jest.fn((tx, patch) => ({ ...tx, ...patch })),
+  }),
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useRoute: jest.fn().mockReturnValue({ params: {} }),
+  useNavigation: jest.fn().mockReturnValue({ navigate: jest.fn() }),
+}));
+
+jest.mock("./EvmNetworkFeesInfo", () => ({
+  EvmNetworkFeeInfo: jest.fn(() => null),
+}));
+
+jest.mock("./SelectFeesStrategy", () => {
+  return jest.fn(() => <Text testID="select-fees-strategy">SelectFeesStrategy</Text>);
+});
+
+const mockUseGasOptions = useGasOptions as jest.MockedFunction<typeof useGasOptions>;
+
+const mockAccount = {
+  type: "Account",
+  id: "mock-account-id",
+  currency: {
+    id: "ethereum",
+    name: "Ethereum",
+    ticker: "ETH",
+    units: [{ name: "eth", code: "ETH", magnitude: 18 }],
+    blockAvgTime: 15,
+  },
+} as AccountLike;
+
+const mockGasOptions = {
+  slow: {
+    maxPriorityFeePerGas: null,
+    maxFeePerGas: null,
+    gasPrice: BigNumber(2000000000000),
+    nextBaseFee: null,
+  },
+  medium: {
+    maxPriorityFeePerGas: null,
+    maxFeePerGas: null,
+    gasPrice: BigNumber(3000000000000),
+    nextBaseFee: null,
+  },
+  fast: {
+    maxPriorityFeePerGas: null,
+    maxFeePerGas: null,
+    gasPrice: BigNumber(4000000000000),
+    nextBaseFee: null,
+  },
+};
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  setOptions: jest.fn(),
+};
+
+const mockRoute = {
+  params: {},
+  key: "test-route",
+  name: "SendSummary",
+};
+
+describe("EvmFeesStrategy", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders SelectFeesStrategy component when transaction is not sponsored", () => {
+    const mockTransaction: Partial<Transaction> = {
+      amount: BigNumber(1000000000000000000),
+      recipient: "0x1234567890123456789012345678901234567890",
+      gasLimit: BigNumber(21000),
+      type: 0,
+      sponsored: false,
+      feesStrategy: "medium",
+    };
+
+    mockUseGasOptions.mockReturnValue([mockGasOptions, null, false]);
+
+    render(
+      <EvmFeesStrategy
+        account={mockAccount}
+        transaction={mockTransaction as Transaction}
+        setTransaction={jest.fn()}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        navigation={mockNavigation as any}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        route={mockRoute as any}
+      />,
+    );
+
+    expect(screen.getByTestId("select-fees-strategy")).toBeTruthy();
+  });
+
+  it("returns null when transaction is sponsored", () => {
+    const mockTransaction: Partial<Transaction> = {
+      amount: BigNumber(1000000000000000000),
+      recipient: "0x1234567890123456789012345678901234567890",
+      gasLimit: BigNumber(21000),
+      type: 0,
+      sponsored: true,
+      feesStrategy: "medium",
+    };
+
+    mockUseGasOptions.mockReturnValue([mockGasOptions, null, false]);
+
+    render(
+      <EvmFeesStrategy
+        account={mockAccount}
+        transaction={mockTransaction as Transaction}
+        setTransaction={jest.fn()}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        navigation={mockNavigation as any}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        route={mockRoute as any}
+      />,
+    );
+
+    // When sponsored is true, the component returns null, so SelectFeesStrategy should not be rendered
+    expect(screen.queryByTestId("select-fees-strategy")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.tsx
@@ -212,6 +212,10 @@ export default function EvmFeesStrategy({
     return <InfiniteLoader size={32} />;
   }
 
+  if (transaction.sponsored) {
+    return null;
+  }
+
   /**
    * If no gasOptions available, this means this currency does not have a
    * gasTracker. Hence, we do not display the fee fields.


### PR DESCRIPTION
…nsaction

hide the fee selection option in approval flow of sponsored transaction

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
