### PR TITLE
test(e2e): Fix app freeze problem on swap other spec

### DIFF
--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -117,4 +117,8 @@ export default class CommonPage {
   async disableSynchronizationForiOS() {
     if (isIos()) await device.disableSynchronization();
   }
+
+  async enableSynchronization() {
+    await device.enableSynchronization();
+  }
 }

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -1,7 +1,6 @@
 import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { getMinimumSwapAmount } from "@ledgerhq/live-common/e2e/swap";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { addDelayBeforeInteractingWithDevice } from "../../helpers/commonHelpers";
 
 export default class SwapLiveAppPage {
   fromSelector = "from-account-coin-selector";
@@ -139,7 +138,6 @@ export default class SwapLiveAppPage {
 
   @Step("Check error message: $0")
   async checkErrorMessage(errorMessage: string) {
-    await addDelayBeforeInteractingWithDevice();
     const error = await getTextOfElement(this.deviceActionErrorDescriptionId);
     jestExpect(error).toContain(errorMessage);
   }

--- a/e2e/mobile/specs/earn/earn.ts
+++ b/e2e/mobile/specs/earn/earn.ts
@@ -109,6 +109,7 @@ export async function runCorrectEarnPageIsLoadedDependingOnUserStakingSituationT
       await app.portfolio.openEarnTab();
       await earnReady;
       if (staking) {
+        await app.earnDashboard.goToTab("My Rewards");
         await app.earnDashboard.verifyTotalDeposited();
         await app.earnDashboard.verifyTotalRewardsEarned();
         await app.earnDashboard.verifyDepositedAssets(account);

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -133,9 +133,9 @@ export function runSwapWithDifferentSeedTest(
       await app.common.disableSynchronizationForiOS();
       await app.common.selectKnownDevice();
       if (errorMessage) {
+        await app.common.enableSynchronization();
         await app.swapLiveApp.checkErrorMessage(errorMessage);
       } else {
-        await app.common.selectKnownDevice();
         await app.swap.verifyAmountsAndAcceptSwapForDifferentSeed(swap, minAmount);
         await app.swap.verifyDeviceActionLoadingNotVisible();
         await app.swap.waitForSuccessAndContinue();

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -801,7 +801,7 @@ export async function getDelegateEvents(delegatingAccount: Delegate): Promise<st
 
 export async function verifyAmountsAndAcceptSwap(swap: Swap, amount: string) {
   await waitFor(DeviceLabels.REVIEW_TRANSACTION);
-  const events = await pressUntilTextFound(DeviceLabels.ACCEPT_AND_SEND);
+  const events = await pressUntilTextFound(DeviceLabels.SIGN_TRANSACTION);
   verifySwapData(swap, events, amount);
   await pressBoth();
 }


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* _`disableSynchronizationForiOS` was causing test flakiness by freezing swap on ios_
* _The timeout is not needed on `checkErrorMessage` as sync was enabled_
* _Update speculos to SIGN_TRANSACTION text_
* _Extra fix: Earn screen now opens on "Earn Opportunities" Tab, so I added a step to open "My Rewards" tab_
* [Swap tests CI run](https://github.com/LedgerHQ/ledger-live/actions/runs/18487986285)
* [Earn tests CI run](https://github.com/LedgerHQ/ledger-live/actions/runs/18489153999)
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA**: [QAA-847](https://ledgerhq.atlassian.net/browse/QAA-847)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-847]: https://ledgerhq.atlassian.net/browse/QAA-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ