### PR TITLE
ci: fix incorrect failure on screenshot updates

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -52,11 +52,13 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
+
       - uses: actions/checkout@v4
         if: ${{ !inputs.ref }}
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
+
       - name: Checkout PR
         if: ${{ inputs.number != null }}
         run: gh pr checkout ${{ inputs.number }}
@@ -65,6 +67,7 @@ jobs:
 
       - name: Setup git user
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
+
       - name: Setup the toolchain
         id: caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
@@ -74,12 +77,14 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
           turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+
       - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-test-desktop@develop
         id: setup-test-desktop
         with:
           skip_ruby: true
           install_playwright: true
           turborepo-server-port: ${{ steps.caches.outputs.port }}
+
       - uses: LedgerHQ/ledger-live/tools/actions/composites/update-snapshots-desktop@develop
         id: update-snapshots
         with:

--- a/tools/actions/composites/update-snapshots-desktop/action.yml
+++ b/tools/actions/composites/update-snapshots-desktop/action.yml
@@ -46,6 +46,7 @@ runs:
       shell: bash
 
     - name: Add changed files
+      if: ${{ steps.status.outputs.status != '0' || steps.status-windows.outputs.status != '0' }}
       run: |
         git stash -u
         git pull --rebase
@@ -60,7 +61,7 @@ runs:
 
     - name: Commit snapshots
       uses: planetscale/ghcommit-action@v0.2.9
-      if: ${{ steps.status.outputs.status != 0 || steps.status-windows.outputs.status != 0 }}
+      if: ${{ steps.status.outputs.status != '0' || steps.status-windows.outputs.status != '0' }}
       with:
         commit_message: "test(lld): update screenshots (${{ inputs.os }}) ${{ steps.changes.outputs.changes }} lld, test, screenshot"
         repo: ${{ github.repository }}


### PR DESCRIPTION
Update screenshots incorrectly reports no updates (i.e. no change) as a failure. For reporting purposes this should be reported as a success.

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-20519

No screenshots updated: https://github.com/LedgerHQ/ledger-live/actions/runs/18501492516/attempts/2
Screenshots updated: https://github.com/LedgerHQ/ledger-live/actions/runs/18501492516/job/52725842594