### PR TITLE
chore: introduce useCurrencyById in cryptoassets to prepare async rework

### DIFF
--- a/.changeset/twenty-icons-burn.md
+++ b/.changeset/twenty-icons-burn.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/cryptoassets": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add useCurrencyById hook to cryptoassets package that finds a currency by ID (crypto or token) with async loading state. Updates mobile and desktop apps to use the new hook for currency/token lookups.

--- a/apps/ledger-live-mobile/src/helpers/useCurrency.tsx
+++ b/apps/ledger-live-mobile/src/helpers/useCurrency.tsx
@@ -1,25 +1,21 @@
-import { useMemo } from "react";
 import { useRoute } from "@react-navigation/native";
-import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/live-common/currencies/index";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { cryptoAssetsHooks } from "~/config/bridge-setup";
 
 type NavigationProps = StackNavigatorProps<{
-  [key: string]: { currencyId: string; currencyType: string };
+  [key: string]: { currencyId: string };
 }>;
 
 const useCurrency = () => {
   const route = useRoute<NavigationProps["route"]>();
-  const { currencyId, currencyType } = route.params;
-  return useMemo(() => {
-    if (currencyType === "CryptoCurrency") {
-      return getCryptoCurrencyById(currencyId);
-    }
-    const token = findTokenById(currencyId);
-    if (!token) {
-      throw new Error(`token with id "${currencyId}" not found`);
-    }
-    return token;
-  }, [currencyId, currencyType]);
+  const { currencyId } = route.params;
+  const { currency } = cryptoAssetsHooks.useCurrencyById(currencyId || "");
+
+  if (!currency) {
+    throw new Error(`currency with id "${currencyId}" not found`);
+  }
+
+  return currency;
 };
 
 export default useCurrency;

--- a/apps/ledger-live-mobile/src/screens/Account/ReadOnly/ReadOnlyAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ReadOnly/ReadOnlyAccount.tsx
@@ -1,10 +1,9 @@
-import React, { useCallback, useMemo, useContext } from "react";
+import React, { useCallback, useContext } from "react";
 import { FlatList, ListRenderItemInfo } from "react-native";
 import { useSelector } from "react-redux";
 import { Trans, useTranslation } from "react-i18next";
 import { Box, Flex, Text } from "@ledgerhq/native-ui";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/live-common/currencies/index";
 import { Currency } from "@ledgerhq/types-cryptoassets";
 import { useFocusEffect } from "@react-navigation/native";
 import ReadOnlyGraphCard from "~/components/ReadOnlyGraphCard";
@@ -23,23 +22,14 @@ import { AnalyticsContext } from "~/analytics/AnalyticsContext";
 import type { AccountsNavigatorParamList } from "~/components/RootNavigator/types/AccountsNavigator";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { ScreenName } from "~/const";
+import { cryptoAssetsHooks } from "~/config/bridge-setup";
 
 type Props = StackNavigatorProps<AccountsNavigatorParamList, ScreenName.Account>;
 
 function ReadOnlyAccount({ route }: Props) {
-  const { currencyId, currencyType } = route.params;
+  const { currencyId } = route.params;
 
-  const currency: Currency | null = useMemo(() => {
-    if (!currencyId) return null;
-    if (currencyType === "CryptoCurrency") {
-      return getCryptoCurrencyById(currencyId);
-    }
-    const token = findTokenById(currencyId);
-    if (!token) {
-      throw new Error(`token with id "${currencyId}" not found`);
-    }
-    return token;
-  }, [currencyType, currencyId]);
+  const { currency } = cryptoAssetsHooks.useCurrencyById(currencyId || "");
   const { t } = useTranslation();
 
   const counterValueCurrency: Currency = useSelector(counterValueCurrencySelector);

--- a/apps/ledger-live-mobile/src/screens/Accounts/AddAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/Accounts/AddAccount.tsx
@@ -1,15 +1,13 @@
 import React, { memo, useState } from "react";
 import { Flex } from "@ledgerhq/native-ui";
 import { PlusMedium } from "@ledgerhq/native-ui/assets/icons";
-import { findCryptoCurrencyById, findTokenById } from "@ledgerhq/live-common/currencies/index";
 import Touchable from "~/components/Touchable";
 import { track } from "~/analytics";
 import AddAccountDrawer from "LLM/features/Accounts/screens/AddAccount";
+import { cryptoAssetsHooks } from "~/config/bridge-setup";
 
 function AddAccount({ currencyId }: { currencyId?: string }) {
-  const currency = currencyId
-    ? findCryptoCurrencyById(currencyId) || findTokenById(currencyId)
-    : undefined;
+  const { currency } = cryptoAssetsHooks.useCurrencyById(currencyId || "");
   const [isAddModalOpened, setIsAddModalOpened] = useState(false);
 
   function openAddModal() {


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLM currency/token related screens

### 📝 Description

in order to prepare some other screens that were using getCurrencyById which essentially become async (due to getTokenById becoming soon through the CryptoAssetsStore) we introduce a `useCurrencyById` utility in cryptoassets the same way we did for tokens.

### ❓ Context

- **JIRA or GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/11905 for the big picture


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
