### PR TITLE
fix(sui): correctly pass extra parameters for undelegate tx fee estimation

### DIFF
--- a/.changeset/nervous-worms-cry.md
+++ b/.changeset/nervous-worms-cry.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": patch
+---
+
+fix: correctly pass extra parameters for undelegate tx fee estimation

--- a/libs/coin-modules/coin-sui/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-sui/src/logic/estimateFees.test.ts
@@ -33,14 +33,17 @@ describe("estimateFees", () => {
 
     const result = await estimateFees(transactionIntent);
 
-    expect(suiAPI.paymentInfo).toHaveBeenCalledWith(transactionIntent.sender, {
-      recipient: transactionIntent.recipient,
-      amount: BigNumber(transactionIntent.amount.toString()),
-      coinType: "0x2::sui::SUI",
-      errors: {},
-      family: "sui",
-      mode: "send",
-    });
+    expect(suiAPI.paymentInfo).toHaveBeenCalledWith(
+      transactionIntent.sender,
+      expect.objectContaining({
+        recipient: transactionIntent.recipient,
+        amount: BigNumber(transactionIntent.amount.toString()),
+        coinType: "0x2::sui::SUI",
+        errors: {},
+        family: "sui",
+        mode: "send",
+      }),
+    );
     expect(result).toBe(BigInt(mockGasBudget));
   });
 
@@ -61,14 +64,17 @@ describe("estimateFees", () => {
 
     const result = await estimateFees(transactionIntent);
 
-    expect(suiAPI.paymentInfo).toHaveBeenCalledWith(transactionIntent.sender, {
-      recipient: transactionIntent.recipient,
-      amount: BigNumber("0"),
-      coinType: "0x2::sui::SUI",
-      errors: {},
-      family: "sui",
-      mode: "send",
-    });
+    expect(suiAPI.paymentInfo).toHaveBeenCalledWith(
+      transactionIntent.sender,
+      expect.objectContaining({
+        recipient: transactionIntent.recipient,
+        amount: BigNumber("0"),
+        coinType: "0x2::sui::SUI",
+        errors: {},
+        family: "sui",
+        mode: "send",
+      }),
+    );
     expect(result).toBe(BigInt(mockGasBudget));
   });
 });

--- a/libs/coin-modules/coin-sui/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-sui/src/logic/estimateFees.ts
@@ -9,7 +9,11 @@ export async function estimateFees({
   sender,
   asset,
   type,
-}: TransactionIntent): Promise<bigint> {
+  ...extra
+}: TransactionIntent & {
+  useAllAmount?: boolean;
+  stakedSuiId?: string;
+}): Promise<bigint> {
   let coinType = DEFAULT_COIN_TYPE;
   if (asset.type === "token" && asset.assetReference) {
     coinType = asset.assetReference;
@@ -35,6 +39,7 @@ export async function estimateFees({
     amount: BigNumber(amount.toString()),
     errors: {},
     coinType,
+    ...extra,
   });
   return BigInt(gasBudget);
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** See below for test strategy
- [x] **Impact of the changes:** Fixing a bug for alpaca integration, no impact on the rest
  - ...

### 📝 Description

Fee estimation for `undelegate` sui transaction is currently broken from alpaca ([see related PR](https://github.com/LedgerHQ/alpaca-coin-module/pull/170)).

I've written the tests in alpaca repo, then copied the coin-sui lib in the node modules there to run the testsuite.
If needed I'll add unit tests in the coin module itself


### ❓ Context

https://ledgerhq.atlassian.net/browse/BACK-9862

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
