### PR TITLE
feat: adding stax to our e2e mobile tests

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -31,6 +31,7 @@ on:
           - nanoS
           - nanoSP
           - nanoX
+          - stax
         default: nanoX
       production_firebase:
         description: "Target Firebase Production env"

--- a/e2e/mobile/specs/account/accountRename.spec.ts
+++ b/e2e/mobile/specs/account/accountRename.spec.ts
@@ -2,7 +2,7 @@ import { launchApp } from "../../helpers/commonHelpers";
 import { device } from "detox";
 
 $TmsLink("B2CQA-2996");
-const tags: string[] = ["@NanoSP", "@LNS", "@NanoX"];
+const tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"];
 tags.forEach(tag => $Tag(tag));
 describe.skip("Account name change", () => {
   const account = Account.BTC_NATIVE_SEGWIT_1;

--- a/e2e/mobile/specs/addAccount/addAccount.ts
+++ b/e2e/mobile/specs/addAccount/addAccount.ts
@@ -3,7 +3,7 @@ import { CurrencyType } from "@ledgerhq/live-common/e2e/enum/Currency";
 export function runAddAccountTest(
   currency: CurrencyType,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@LNS", "@NanoX"],
+  tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 ) {
   describe("Add accounts - Network Based", () => {
     beforeAll(async () => {

--- a/e2e/mobile/specs/buySell/buyQueryParameters_BTC.spec.ts
+++ b/e2e/mobile/specs/buySell/buyQueryParameters_BTC.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3521"],
   provider: Provider.MOONPAY,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runQueryParametersTest(

--- a/e2e/mobile/specs/buySell/buyQueryParameters_ETH.spec.ts
+++ b/e2e/mobile/specs/buySell/buyQueryParameters_ETH.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3522"],
   provider: Provider.MOONPAY,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runQueryParametersTest(

--- a/e2e/mobile/specs/buySell/buyQueryParameters_USDT.spec.ts
+++ b/e2e/mobile/specs/buySell/buyQueryParameters_USDT.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3523"],
   provider: Provider.COINBASE,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runQueryParametersTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromAccountPage_BTC.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromAccountPage_BTC.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3467"],
   provider: Provider.MOONPAY,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromAccountPageTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromAccountPage_ETH.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromAccountPage_ETH.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3466"],
   provider: Provider.MOONPAY,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromAccountPageTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromAccountPage_USDT.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromAccountPage_USDT.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3468"],
   provider: Provider.COINBASE,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromAccountPageTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromAssetPage_BTC.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromAssetPage_BTC.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3391"],
   provider: Provider.MOONPAY,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromAssetPageTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromAssetPage_ETH.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromAssetPage_ETH.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3392"],
   provider: Provider.MOONPAY,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromAssetPageTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromAssetPage_USDT.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromAssetPage_USDT.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3393"],
   provider: Provider.COINBASE,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromAssetPageTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromMarketPage_BTC.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromMarketPage_BTC.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3412"],
   provider: Provider.MOONPAY,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromMarketPageTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromMarketPage_ETH.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromMarketPage_ETH.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3413"],
   provider: Provider.MOONPAY,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromMarketPageTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromMarketPage_USDT.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromMarketPage_USDT.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3414"],
   provider: Provider.COINBASE,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromMarketPageTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromPortfolioPage_BTC.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromPortfolioPage_BTC.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3520"],
   provider: Provider.MOONPAY,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromPortfolioPageTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromPortfolioPage_ETH.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromPortfolioPage_ETH.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3519"],
   provider: Provider.MOONPAY,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromPortfolioPageTest(

--- a/e2e/mobile/specs/buySell/navigateToBuyFromPortfolioPage_USDT.spec.ts
+++ b/e2e/mobile/specs/buySell/navigateToBuyFromPortfolioPage_USDT.spec.ts
@@ -12,7 +12,7 @@ const testConfig = {
   tmsLinks: ["B2CQA-3518"],
   provider: Provider.COINBASE,
   paymentMethod: "card",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runNavigateToBuyFromPortfolioPageTest(

--- a/e2e/mobile/specs/deeplinks.spec.ts
+++ b/e2e/mobile/specs/deeplinks.spec.ts
@@ -1,5 +1,5 @@
 $TmsLink("B2CQA-1837");
-const tags: string[] = ["@NanoSP", "@LNS", "@NanoX"];
+const tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"];
 tags.forEach(tag => $Tag(tag));
 describe("DeepLinks Tests", () => {
   const nanoApp = AppInfos.ETHEREUM;

--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -7,7 +7,7 @@ import { getCurrencyManagerApp } from "../../models/currencies";
 export function runDelegateTest(
   delegation: DelegateType,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@LNS", "@NanoX"],
+  tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 ) {
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));

--- a/e2e/mobile/specs/deleteAccount/deleteAccount.ts
+++ b/e2e/mobile/specs/deleteAccount/deleteAccount.ts
@@ -3,7 +3,7 @@ import { AccountType } from "@ledgerhq/live-common/e2e/enum/Account";
 export function runDeleteAccountTest(
   account: AccountType,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@LNS", "@NanoX"],
+  tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 ) {
   describe("Delete account", () => {
     beforeAll(async () => {

--- a/e2e/mobile/specs/deposit/createNewAccountAndDeposit_XRP_1.spec.ts
+++ b/e2e/mobile/specs/deposit/createNewAccountAndDeposit_XRP_1.spec.ts
@@ -5,7 +5,7 @@ const testConfig = {
   currentAccount: Account.XRP_1,
   newAccount: Account.XRP_2,
   tmsLinks: ["B2CQA-1861"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runCreateNewAccountAndDepositTest(

--- a/e2e/mobile/specs/deposit/depositInExistingAccount_ETH_1.spec.ts
+++ b/e2e/mobile/specs/deposit/depositInExistingAccount_ETH_1.spec.ts
@@ -5,7 +5,7 @@ const testConfig = {
   account: Account.ETH_1,
   networkName: "ethereum",
   tmsLinks: ["B2CQA-1898"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runDepositInExistingAccountTest(

--- a/e2e/mobile/specs/deposit/selectCryptoNetworkWithAccount_ETH_1.spec.ts
+++ b/e2e/mobile/specs/deposit/selectCryptoNetworkWithAccount_ETH_1.spec.ts
@@ -5,7 +5,7 @@ const testConfig = {
   account: Account.ETH_1,
   withAccount: true,
   tmsLinks: ["B2CQA-1857"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSelectCryptoNetworkTest(

--- a/e2e/mobile/specs/deposit/selectCryptoNetworkWithoutAccount_ETH_1.spec.ts
+++ b/e2e/mobile/specs/deposit/selectCryptoNetworkWithoutAccount_ETH_1.spec.ts
@@ -5,7 +5,7 @@ const testConfig = {
   account: Account.ETH_1,
   withAccount: false,
   tmsLinks: ["B2CQA-1855"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSelectCryptoNetworkTest(

--- a/e2e/mobile/specs/deposit/selectCryptoWithoutNetworkAndAccount_BTC_LEGACY_1.spec.ts
+++ b/e2e/mobile/specs/deposit/selectCryptoWithoutNetworkAndAccount_BTC_LEGACY_1.spec.ts
@@ -4,7 +4,7 @@ import { runSelectCryptoWithoutNetworkAndAccountTest } from "./deposit";
 const testConfig = {
   account: Account.BTC_LEGACY_1,
   tmsLinks: ["B2CQA-1854"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSelectCryptoWithoutNetworkAndAccountTest(

--- a/e2e/mobile/specs/earn/correctEarnPage_ATOM_1_withStaking.spec.ts
+++ b/e2e/mobile/specs/earn/correctEarnPage_ATOM_1_withStaking.spec.ts
@@ -5,7 +5,7 @@ const testConfig = {
   account: Account.ATOM_1,
   staking: true,
   tmsLinks: ["B2CQA-3685"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest(

--- a/e2e/mobile/specs/earn/correctEarnPage_ATOM_2_noStaking.spec.ts
+++ b/e2e/mobile/specs/earn/correctEarnPage_ATOM_2_noStaking.spec.ts
@@ -5,7 +5,7 @@ const testConfig = {
   account: Account.ATOM_2,
   staking: false,
   tmsLinks: ["B2CQA-3681"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest(

--- a/e2e/mobile/specs/earn/correctEarnPage_ETH_1_noStaking.spec.ts
+++ b/e2e/mobile/specs/earn/correctEarnPage_ETH_1_noStaking.spec.ts
@@ -6,7 +6,7 @@ const testConfig = {
   earnButtonId: "3bd9fab1-fb6c-5fc2-a8b6-a1d810365b1e",
   staking: false,
   tmsLinks: ["B2CQA-3679"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest(

--- a/e2e/mobile/specs/earn/correctEarnPage_NEAR_1_withStaking.spec.ts
+++ b/e2e/mobile/specs/earn/correctEarnPage_NEAR_1_withStaking.spec.ts
@@ -5,7 +5,7 @@ const testConfig = {
   account: Account.NEAR_1,
   staking: true,
   tmsLinks: ["B2CQA-3683"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest(

--- a/e2e/mobile/specs/earn/correctEarnPage_NEAR_2_noStaking.spec.ts
+++ b/e2e/mobile/specs/earn/correctEarnPage_NEAR_2_noStaking.spec.ts
@@ -6,7 +6,7 @@ const testConfig = {
   earnButtonId: "4969e17f-213a-5180-809b-ee16abe3f400",
   staking: false,
   tmsLinks: ["B2CQA-3682"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest(

--- a/e2e/mobile/specs/earn/correctEarnPage_SOL_1_withStaking.spec.ts
+++ b/e2e/mobile/specs/earn/correctEarnPage_SOL_1_withStaking.spec.ts
@@ -5,7 +5,7 @@ const testConfig = {
   account: Account.SOL_2,
   staking: true,
   tmsLinks: ["B2CQA-3684"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest(

--- a/e2e/mobile/specs/earn/correctEarnPage_SOL_2_noStaking.spec.ts
+++ b/e2e/mobile/specs/earn/correctEarnPage_SOL_2_noStaking.spec.ts
@@ -6,7 +6,7 @@ const testConfig = {
   earnButtonId: "7db7743d-3e2f-592b-b3f8-db5916290ec0",
   staking: false,
   tmsLinks: ["B2CQA-3680"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest(

--- a/e2e/mobile/specs/earn/earnInlineAddAccount.spec.ts
+++ b/e2e/mobile/specs/earn/earnInlineAddAccount.spec.ts
@@ -3,7 +3,7 @@ import { runInlineAddAccountTest } from "./earn";
 const testConfig = {
   account: Account.ETH_1,
   tmsLinks: ["B2CQA-3001"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runInlineAddAccountTest(testConfig.account, testConfig.tmsLinks, testConfig.tags);

--- a/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_KILN.spec.ts
+++ b/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_KILN.spec.ts
@@ -6,7 +6,7 @@ const testConfig = {
   earnButtonId: "3bd9fab1-fb6c-5fc2-a8b6-a1d810365b1e",
   provider: Provider.KILN,
   tmsLinks: ["B2CQA-3678"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runStartETHStakingFromEarnDashboardTest(

--- a/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_LIDO.spec.ts
+++ b/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_LIDO.spec.ts
@@ -6,7 +6,7 @@ const testConfig = {
   earnButtonId: "3bd9fab1-fb6c-5fc2-a8b6-a1d810365b1e",
   provider: Provider.LIDO,
   tmsLinks: ["B2CQA-3676, B2CQA-1713"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runStartETHStakingFromEarnDashboardTest(

--- a/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_STADER_LABS.spec.ts
+++ b/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_STADER_LABS.spec.ts
@@ -6,7 +6,7 @@ const testConfig = {
   earnButtonId: "3bd9fab1-fb6c-5fc2-a8b6-a1d810365b1e",
   provider: Provider.STADER_LABS,
   tmsLinks: ["B2CQA-3677"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runStartETHStakingFromEarnDashboardTest(

--- a/e2e/mobile/specs/languageChange.spec.ts
+++ b/e2e/mobile/specs/languageChange.spec.ts
@@ -1,5 +1,5 @@
 $TmsLink("B2CQA-2344");
-const tags: string[] = ["@NanoSP", "@LNS", "@NanoX"];
+const tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"];
 tags.forEach(tag => $Tag(tag));
 describe("Change Language", () => {
   const langButtonText = [

--- a/e2e/mobile/specs/ledgerSync/ledgerSync.spec.ts
+++ b/e2e/mobile/specs/ledgerSync/ledgerSync.spec.ts
@@ -4,7 +4,7 @@ import { getFlags } from "../../bridge/server";
 import { describeIfNotNanoS } from "../../helpers/commonHelpers";
 
 const tmsLinks = ["B2CQA-2292", "B2CQA-2293", "B2CQA-2296"];
-const tags = ["@NanoSP", "@NanoX"];
+const tags = ["@NanoSP", "@NanoX", "@Stax"];
 
 const ledgerKeyRingProtocolArgs = {
   apiBaseUrl: "",

--- a/e2e/mobile/specs/market.spec.ts
+++ b/e2e/mobile/specs/market.spec.ts
@@ -1,4 +1,4 @@
-const tags: string[] = ["@NanoSP", "@LNS", "@NanoX"];
+const tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"];
 describe("Market page for user with no device", () => {
   const nanoApp = AppInfos.ETHEREUM;
   const ticker = "ETH";

--- a/e2e/mobile/specs/onboardingReadOnly.spec.ts
+++ b/e2e/mobile/specs/onboardingReadOnly.spec.ts
@@ -2,7 +2,7 @@ describe("Onboarding - Read Only", () => {
   $TmsLink("B2CQA-370");
   $TmsLink("B2CQA-1753");
   $TmsLink("B2CQA-1806");
-  const tags: string[] = ["@NanoSP", "@LNS", "@NanoX"];
+  const tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"];
   tags.forEach(tag => $Tag(tag));
   it("goes through discover app and should see an empty portfolio page", async () => {
     await app.onboarding.startOnboarding();

--- a/e2e/mobile/specs/password.spec.ts
+++ b/e2e/mobile/specs/password.spec.ts
@@ -1,6 +1,6 @@
 import { device } from "detox";
 
-const tags: string[] = ["@NanoSP", "@LNS", "@NanoX"];
+const tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"];
 describe("Password Lock Screen", () => {
   const nanoApp = AppInfos.ETHEREUM;
   const CORRECT_PASSWORD = "passWORD$123!";

--- a/e2e/mobile/specs/portfolio/portfolio.ts
+++ b/e2e/mobile/specs/portfolio/portfolio.ts
@@ -8,7 +8,11 @@ async function beforeAllFunction(options: ApplicationOptions) {
   });
   await app.portfolio.waitForPortfolioPageToLoad();
 }
-export function runPortfolioTransactionsHistoryTest(currency: CurrencyType, tmsLinks: string[]) {
+export function runPortfolioTransactionsHistoryTest(
+  currency: CurrencyType,
+  tmsLinks: string[],
+  tags: string[],
+) {
   describe("Portfolio transaction history", () => {
     beforeAll(async () => {
       await beforeAllFunction({
@@ -18,6 +22,7 @@ export function runPortfolioTransactionsHistoryTest(currency: CurrencyType, tmsL
     });
 
     tmsLinks.forEach(link => $TmsLink(link));
+    tags.forEach(tag => $Tag(tag));
     it("Transaction history displayed when user added his accounts", async () => {
       await app.portfolio.openViaDeeplink();
       await app.portfolio.checkTransactionAllocationSection();
@@ -27,7 +32,7 @@ export function runPortfolioTransactionsHistoryTest(currency: CurrencyType, tmsL
   });
 }
 
-export function runPortfolioChartsAndAssetsTest(tmsLinks: string[]) {
+export function runPortfolioChartsAndAssetsTest(tmsLinks: string[], tags: string[]) {
   describe("Portfolio charts and assets", () => {
     beforeAll(async () => {
       await beforeAllFunction({
@@ -36,6 +41,7 @@ export function runPortfolioChartsAndAssetsTest(tmsLinks: string[]) {
     });
 
     tmsLinks.forEach(link => $TmsLink(link));
+    tags.forEach(tag => $Tag(tag));
     it("Charts and assets section are displayed when user added his accounts", async () => {
       await app.portfolio.openViaDeeplink();
       await app.portfolio.checkQuickActionButtonsVisibility();

--- a/e2e/mobile/specs/portfolio/portfolioAccountsTab.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioAccountsTab.spec.ts
@@ -1,6 +1,6 @@
 const testConfig = {
   tmsLinks: ["B2CQA-2871", "B2CQA-2873", "B2CQA-3060", "B2CQA-2873"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 describe("Wallet Page", () => {

--- a/e2e/mobile/specs/portfolio/portfolioAddAccount.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioAddAccount.spec.ts
@@ -1,6 +1,6 @@
 const testConfig = {
   tmsLinks: ["B2CQA-2874"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 describe("Wallet Page", () => {

--- a/e2e/mobile/specs/portfolio/portfolioAssetsTab.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioAssetsTab.spec.ts
@@ -1,6 +1,6 @@
 const testConfig = {
   tmsLinks: ["B2CQA-2869", "B2CQA-2870"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 describe("Wallet Page", () => {

--- a/e2e/mobile/specs/portfolio/portfolioChartAndAssets.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioChartAndAssets.spec.ts
@@ -1,3 +1,3 @@
 import { runPortfolioChartsAndAssetsTest } from "./portfolio";
 
-runPortfolioChartsAndAssetsTest(["B2CQA-927", "B2CQA-928"]);
+runPortfolioChartsAndAssetsTest(["B2CQA-927", "B2CQA-928"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/portfolio/portfolioTransactionsHistory_BTC.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioTransactionsHistory_BTC.spec.ts
@@ -1,3 +1,7 @@
 import { runPortfolioTransactionsHistoryTest } from "./portfolio";
 
-runPortfolioTransactionsHistoryTest(Currency.BTC, ["B2CQA-2073"]);
+runPortfolioTransactionsHistoryTest(
+  Currency.BTC,
+  ["B2CQA-2073"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
+);

--- a/e2e/mobile/specs/portfolio/portfolioTransactionsHistory_ETH.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioTransactionsHistory_ETH.spec.ts
@@ -1,3 +1,7 @@
 import { runPortfolioTransactionsHistoryTest } from "./portfolio";
 
-runPortfolioTransactionsHistoryTest(Currency.ETH, ["B2CQA-929"]);
+runPortfolioTransactionsHistoryTest(
+  Currency.ETH,
+  ["B2CQA-929"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
+);

--- a/e2e/mobile/specs/send/send.ts
+++ b/e2e/mobile/specs/send/send.ts
@@ -35,7 +35,7 @@ const beforeAllFunction = async (transaction: TransactionType) => {
 export function runSendTest(
   transaction: TransactionType,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@LNS", "@NanoX"],
+  tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 ) {
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
@@ -76,7 +76,7 @@ export function runSendInvalidAddressTest(
   transaction: TransactionType,
   expectedErrorMessage: string,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@LNS", "@NanoX"],
+  tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   accountName?: string,
 ) {
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
@@ -98,7 +98,7 @@ export function runSendValidAddressTest(
   transaction: TransactionType,
   tmsLinks: string[],
   testName: string,
-  tags: string[] = ["@NanoSP", "@LNS", "@NanoX"],
+  tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   accountName?: string,
   expectedWarningMessage?: string,
 ) {
@@ -129,7 +129,7 @@ export function runSendInvalidAmountTest(
   transaction: TransactionType,
   expectedErrorMessage: string,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@LNS", "@NanoX"],
+  tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 ) {
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
@@ -154,7 +154,7 @@ export function runSendInvalidTokenAmountTest(
   transaction: TransactionType,
   expectedErrorMessage: RegExp | string,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@LNS", "@NanoX"],
+  tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 ) {
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
@@ -188,7 +188,7 @@ export function runSendInvalidTokenAmountTest(
 export function runSendMaxTest(
   transaction: TransactionType,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@LNS", "@NanoX"],
+  tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 ) {
   setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
@@ -217,7 +217,7 @@ export function runSendMaxTest(
 export function runSendENSTest(
   transaction: TransactionType,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@LNS", "@NanoX"],
+  tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 ) {
   setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 

--- a/e2e/mobile/specs/send/sendInvalid/sendInvalidAddressALGO_USDT.spec.ts
+++ b/e2e/mobile/specs/send/sendInvalid/sendInvalidAddressALGO_USDT.spec.ts
@@ -5,6 +5,6 @@ runSendInvalidAddressTest(
   transaction,
   "Recipient account has not opted in the selected ASA.",
   ["B2CQA-2702"],
-  ["@NanoSP", "@LNS", "@NanoX"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   transaction.accountToDebit.currency.name,
 );

--- a/e2e/mobile/specs/send/sendValidAddress/sendValidAddressETH_USDT.spec.ts
+++ b/e2e/mobile/specs/send/sendValidAddress/sendValidAddressETH_USDT.spec.ts
@@ -10,6 +10,6 @@ runSendValidAddressTest(
   transaction,
   ["B2CQA-2703", "B2CQA-475"],
   "Recipient and Amount",
-  ["@NanoSP", "@LNS", "@NanoX"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   transaction.accountToDebit.currency.name,
 );

--- a/e2e/mobile/specs/settings/userCanAccessLedgerSupport.spec.ts
+++ b/e2e/mobile/specs/settings/userCanAccessLedgerSupport.spec.ts
@@ -2,7 +2,7 @@ import { runUserCanAccessLedgerSupportTest } from "./settings";
 
 const testConfig = {
   tmsLinks: ["B2CQA-820"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runUserCanAccessLedgerSupportTest(testConfig.tmsLinks, testConfig.tags);

--- a/e2e/mobile/specs/settings/userCanExportLogs.spec.ts
+++ b/e2e/mobile/specs/settings/userCanExportLogs.spec.ts
@@ -2,7 +2,7 @@ import { runUserCanExportLogsTest } from "./settings";
 
 const testConfig = {
   tmsLinks: ["B2CQA-2074"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runUserCanExportLogsTest(testConfig.tmsLinks, testConfig.tags);

--- a/e2e/mobile/specs/settings/userCanSelectCounterValueToDisplayAmountInLedgerLive.spec.ts
+++ b/e2e/mobile/specs/settings/userCanSelectCounterValueToDisplayAmountInLedgerLive.spec.ts
@@ -3,7 +3,7 @@ import { runUserCanSelectCounterValueToDisplayAmountInLedgerLive } from "./setti
 const testConfig = {
   account: Account.BTC_NATIVE_SEGWIT_1,
   tmsLinks: ["B2CQA-804"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runUserCanSelectCounterValueToDisplayAmountInLedgerLive(

--- a/e2e/mobile/specs/settings/userClearApplicationCache.spec.ts
+++ b/e2e/mobile/specs/settings/userClearApplicationCache.spec.ts
@@ -3,7 +3,7 @@ import { runUserClearApplicationCacheTest } from "./settings";
 const testConfig = {
   account: Account.ETH_1,
   tmsLinks: ["B2CQA-826"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runUserClearApplicationCacheTest(testConfig.account, testConfig.tmsLinks, testConfig.tags);

--- a/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountBSC_BUSD.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountBSC_BUSD.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   account: Account.BSC_BUSD_1,
   tmslinks: ["B2CQA-2489"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: true,
 };
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountBSC_SHIBA.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountBSC_SHIBA.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   account: Account.BSC_SHIBA,
   tmslinks: ["B2CQA-2490"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: true,
 };
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountETH_LIDO.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountETH_LIDO.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   account: TokenAccount.ETH_LIDO,
   tmslinks: ["B2CQA-2491"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: true,
 };
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountETH_USDT.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountETH_USDT.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   account: TokenAccount.ETH_USDT_1,
   tmslinks: ["B2CQA-2492"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: true,
 };
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountPOL_DAI.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountPOL_DAI.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   account: Account.POL_DAI_1,
   tmslinks: ["B2CQA-2493"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: true,
 };
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountPOL_UNI.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountPOL_UNI.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   account: Account.POL_UNI,
   tmslinks: ["B2CQA-2494"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: true,
 };
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountTRX_USDT.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithParent/addSubAccountTRX_USDT.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   account: Account.TRX_USDT,
   tmslinks: ["B2CQA-2496"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: true,
 };
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountALGO_USDT.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountALGO_USDT.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   asset: Account.ALGO_USDT_1,
   tmslinks: ["B2CQA-2575"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: false,
 };
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountBSC_BUSD.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountBSC_BUSD.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   asset: Account.BSC_BUSD_1,
   tmslinks: ["B2CQA-2576"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: false,
 };
 runAddSubAccountTest(

--- a/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountETH_USDT.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountETH_USDT.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   asset: TokenAccount.ETH_USDT_1,
   tmslinks: ["B2CQA-2577", "B2CQA-1079"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: false,
 };
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountPOL_DAI.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountPOL_DAI.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   asset: Account.POL_DAI_1,
   tmslinks: ["B2CQA-2578"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: false,
 };
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountTRX_USDT.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountTRX_USDT.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   asset: Account.TRX_USDT,
   tmslinks: ["B2CQA-2580"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: false,
 };
 

--- a/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountXLM_USCD.spec.ts
+++ b/e2e/mobile/specs/subAccount/addSubAccountWithoutParent/addSubAccountXLM_USCD.spec.ts
@@ -3,7 +3,7 @@ import { runAddSubAccountTest } from "../subAccount";
 const testConfig = {
   asset: Account.XLM_USCD,
   tmslinks: ["B2CQA-2579"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
   withParentAccount: false,
 };
 

--- a/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressInvalid_GIGAtoWIF.spec.ts
+++ b/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressInvalid_GIGAtoWIF.spec.ts
@@ -5,6 +5,7 @@ const transactionE2E = {
   recipient: TokenAccount.SOL_WIF_2.address,
   expectedErrorMessage: "This associated token account holds another token",
   xrayTicket: ["B2CQA-3083"],
+  tag: ["@NanoSP", "@NanoX", "@Stax"],
 };
 
 runSendSPLAddressInvalid(
@@ -12,4 +13,5 @@ runSendSPLAddressInvalid(
   transactionE2E.recipient,
   transactionE2E.expectedErrorMessage,
   transactionE2E.xrayTicket,
+  transactionE2E.tag,
 );

--- a/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressInvalid_SOLtoGIGA.spec.ts
+++ b/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressInvalid_SOLtoGIGA.spec.ts
@@ -5,6 +5,7 @@ const transactionE2E = {
   recipient: TokenAccount.SOL_GIGA_2.address,
   expectedErrorMessage: "This is a token account. Input a regular wallet address",
   xrayTicket: ["B2CQA-3084"],
+  tag: ["@NanoSP", "@NanoX", "@Stax"],
 };
 
 runSendSPLAddressInvalid(
@@ -12,4 +13,5 @@ runSendSPLAddressInvalid(
   transactionE2E.recipient,
   transactionE2E.expectedErrorMessage,
   transactionE2E.xrayTicket,
+  transactionE2E.tag,
 );

--- a/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressInvalid_SOLtoWIF.spec.ts
+++ b/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressInvalid_SOLtoWIF.spec.ts
@@ -5,6 +5,7 @@ const transactionE2E = {
   recipient: TokenAccount.SOL_WIF_2.currency.contractAddress,
   expectedErrorMessage: "This is a token address. Input a regular wallet address",
   xrayTicket: ["B2CQA-3087"],
+  tag: ["@NanoSP", "@NanoX", "@Stax"],
 };
 
 runSendSPLAddressInvalid(
@@ -12,4 +13,5 @@ runSendSPLAddressInvalid(
   transactionE2E.recipient,
   transactionE2E.expectedErrorMessage,
   transactionE2E.xrayTicket,
+  transactionE2E.tag,
 );

--- a/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressInvalid_WIFtoGIGA.spec.ts
+++ b/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressInvalid_WIFtoGIGA.spec.ts
@@ -5,6 +5,7 @@ const transactionE2E = {
   recipient: TokenAccount.SOL_GIGA_2.currency.contractAddress,
   expectedErrorMessage: "This is a token address. Input a regular wallet address",
   xrayTicket: ["B2CQA-3086"],
+  tag: ["@NanoSP", "@NanoX", "@Stax"],
 };
 
 runSendSPLAddressInvalid(
@@ -12,4 +13,5 @@ runSendSPLAddressInvalid(
   transactionE2E.recipient,
   transactionE2E.expectedErrorMessage,
   transactionE2E.xrayTicket,
+  transactionE2E.tag,
 );

--- a/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressInvalid_WIFtoWIF.spec.ts
+++ b/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressInvalid_WIFtoWIF.spec.ts
@@ -5,6 +5,7 @@ const transactionE2E = {
   recipient: TokenAccount.SOL_WIF_2.currency.contractAddress,
   expectedErrorMessage: "This is a token address. Input a regular wallet address",
   xrayTicket: ["B2CQA-3085"],
+  tag: ["@NanoSP", "@NanoX", "@Stax"],
 };
 
 runSendSPLAddressInvalid(
@@ -12,4 +13,5 @@ runSendSPLAddressInvalid(
   transactionE2E.recipient,
   transactionE2E.expectedErrorMessage,
   transactionE2E.xrayTicket,
+  transactionE2E.tag,
 );

--- a/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressValid.spec.ts
+++ b/e2e/mobile/specs/subAccount/splTokensErrorMessages/transactionsAddressValid.spec.ts
@@ -4,9 +4,11 @@ const transactionE2E = {
   expectedWarningMessage:
     "This is not a regular wallet address but an associated token account. Continue only if you know what you are doing",
   xrayTicket: ["B2CQA-3082"],
+  tag: ["@NanoSP", "@NanoX", "@Stax"],
 };
 runSendSPLAddressValid(
   transactionE2E.tx,
   transactionE2E.expectedWarningMessage,
   transactionE2E.xrayTicket,
+  transactionE2E.tag,
 );

--- a/e2e/mobile/specs/subAccount/subAccount.ts
+++ b/e2e/mobile/specs/subAccount/subAccount.ts
@@ -53,8 +53,9 @@ const beforeAllFunction = async (transaction: TransactionType, setAccountToCredi
   await app.portfolio.waitForPortfolioPageToLoad();
 };
 
-export function runSendSPL(transaction: TransactionType, tmsLinks: string[]) {
+export function runSendSPL(transaction: TransactionType, tmsLinks: string[], tags: string[]) {
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+  tags.forEach(tag => $Tag(tag));
   describe("Send SPL tokens from 1 account to another", () => {
     beforeAll(async () => {
       await beforeAllFunction(transaction, true);
@@ -99,8 +100,10 @@ export function runSendSPLAddressValid(
   transaction: TransactionType,
   expectedWarningMessage: string,
   tmsLinks: string[],
+  tags: string[],
 ) {
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+  tags.forEach(tag => $Tag(tag));
   describe("Send token - valid address input", () => {
     beforeAll(async () => {
       await beforeAllFunction(transaction, false);
@@ -122,8 +125,10 @@ export function runSendSPLAddressInvalid(
   recipientContractAddress: string | undefined,
   expectedErrorMessage: string,
   tmsLinks: string[],
+  tags: string[],
 ) {
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+  tags.forEach(tag => $Tag(tag));
   describe("Send token - invalid address input", () => {
     beforeAll(async () => {
       await beforeAllFunction(transaction, false);

--- a/e2e/mobile/specs/subAccount/subAccountGIGA.spec.ts
+++ b/e2e/mobile/specs/subAccount/subAccountGIGA.spec.ts
@@ -10,9 +10,10 @@ const transactionE2E = [
       "noTag",
     ),
     xrayTicket: ["B2CQA-3055", "B2CQA-3057"],
+    tag: ["@NanoSP", "@NanoX", "@Stax"],
   },
 ];
 
 for (const transaction of transactionE2E) {
-  runSendSPL(transaction.tx, transaction.xrayTicket);
+  runSendSPL(transaction.tx, transaction.xrayTicket, transaction.tag);
 }

--- a/e2e/mobile/specs/swap/otherTestCases/swapCheckProviderOneInch.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapCheckProviderOneInch.spec.ts
@@ -6,7 +6,7 @@ const swapCheckProviderTestConfig = {
   toAccount: TokenAccount.ETH_USDT_1,
   provider: Provider.ONE_INCH,
   tmsLinks: ["B2CQA-3120"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapCheckProvider(

--- a/e2e/mobile/specs/swap/otherTestCases/swapCheckProviderVelora.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapCheckProviderVelora.spec.ts
@@ -6,7 +6,7 @@ const swapCheckProviderTestConfig = {
   toAccount: TokenAccount.ETH_USDT_1,
   provider: Provider.VELORA,
   tmsLinks: ["B2CQA-3119"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapCheckProvider(

--- a/e2e/mobile/specs/swap/otherTestCases/swapEntryPoints.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapEntryPoints.spec.ts
@@ -3,7 +3,7 @@ import { runSwapEntryPoints } from "./swap.other";
 const swapEntryPointsConfig = {
   account: Account.BTC_NATIVE_SEGWIT_1,
   tmsLinks: ["B2CQA-2784"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapEntryPoints(

--- a/e2e/mobile/specs/swap/otherTestCases/swapExportHistoryOperations.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapExportHistoryOperations.spec.ts
@@ -6,7 +6,7 @@ const swapHistoryTestConfig = {
   provider: Provider.EXODUS,
   swapId: "wQ90NrWdvJz5dA4",
   tmsLinks: ["B2CQA-604"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runExportSwapHistoryOperationsTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swapLandingPage.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapLandingPage.spec.ts
@@ -4,7 +4,7 @@ const swapTestConfig = {
   fromAccount: Account.ETH_1,
   toAccount: TokenAccount.ETH_USDC_1,
   tmsLinks: ["B2CQA-2918"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapLandingPageTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swapNetworkFeesAboveAccountBalance.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapNetworkFeesAboveAccountBalance.spec.ts
@@ -4,7 +4,7 @@ const testConfig = {
   swap: new Swap(TokenAccount.ETH_USDT_2, Account.BTC_NATIVE_SEGWIT_1, "USE_MIN_AMOUNT"),
   errorMessage: new RegExp(/\d+(\.\d{1,10})? ETH needed for network fees\.[\s\S]*Learn More/),
   tmsLinks: ["B2CQA-2363"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapNetworkFeesAboveAccountBalanceTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swapSeeHistoryOperations.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapSeeHistoryOperations.spec.ts
@@ -6,7 +6,7 @@ const swapHistoryTestConfig = {
   provider: Provider.EXODUS,
   swapId: "wQ90NrWdvJz5dA4",
   tmsLinks: ["B2CQA-602"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapHistoryOperationsTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swapSwitchSendAndReceiveCurrencies.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapSwitchSendAndReceiveCurrencies.spec.ts
@@ -3,7 +3,7 @@ import { runSwapSwitchSendAndReceiveCurrenciesTest } from "./swap.other";
 const swapSwitchSendAndReceiveCurrenciesTestConfig = {
   swap: new Swap(Account.BTC_NATIVE_SEGWIT_1, Account.ETH_1, "0.03"),
   tmsLinks: ["B2CQA-602"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapSwitchSendAndReceiveCurrenciesTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swapUserRefusesTransaction.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapUserRefusesTransaction.spec.ts
@@ -4,7 +4,7 @@ const userRefusesTransactionSwapTestConfig = {
   fromAccount: Account.ETH_1,
   toAccount: Account.SOL_1,
   tmsLinks: ["B2CQA-2212"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runUserRefusesTransactionTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swapWithDifferentSeed_AAB.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapWithDifferentSeed_AAB.spec.ts
@@ -6,7 +6,7 @@ const swapTestConfig = {
   userData: "speculos-x-other-account",
   errorMessage:
     "This sending account does not belong to the connected device. Please change and retry.",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapWithDifferentSeedTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swapWithDifferentSeed_ABA.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapWithDifferentSeed_ABA.spec.ts
@@ -5,7 +5,7 @@ const swapTestConfig = {
   tmsLinks: ["B2CQA-3090"],
   userData: "speculos-x-other-account",
   errorMessage: null,
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapWithDifferentSeedTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swapWithDifferentSeed_BAA.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapWithDifferentSeed_BAA.spec.ts
@@ -6,7 +6,7 @@ const swapTestConfig = {
   userData: "speculos-x-other-account",
   errorMessage:
     "This sending account does not belong to the connected device. Please change and retry.",
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapWithDifferentSeedTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swapWithSendMaxETHtoBTC.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapWithSendMaxETHtoBTC.spec.ts
@@ -4,7 +4,7 @@ const swapWithSendMaxConfig = {
   fromAccount: Account.ETH_1,
   toAccount: Account.BTC_NATIVE_SEGWIT_1,
   tmsLinks: ["B2CQA-3365"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapWithSendMaxTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swapWithSendMaxUSDTtoBTC.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapWithSendMaxUSDTtoBTC.spec.ts
@@ -4,7 +4,7 @@ const swapWithSendMaxConfig = {
   fromAccount: TokenAccount.ETH_USDT_1,
   toAccount: Account.BTC_NATIVE_SEGWIT_1,
   tmsLinks: ["B2CQA-3366"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapWithSendMaxTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swap_noAccountFrom.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap_noAccountFrom.spec.ts
@@ -5,7 +5,7 @@ const noAccountFromTestConfig = {
   account2: Account.ETH_1,
   testTitle: "from Account not present to Account present",
   tmsLinks: ["B2CQA-3353"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapWithoutAccountTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swap_noAccountFromAndTo.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap_noAccountFromAndTo.spec.ts
@@ -5,7 +5,7 @@ const noAccountFromAndToTestConfig = {
   account2: Account.BSC_1,
   testTitle: "from Account not present to Account not present",
   tmsLinks: ["B2CQA-3355"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapWithoutAccountTest(

--- a/e2e/mobile/specs/swap/otherTestCases/swap_noAccountTo.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap_noAccountTo.spec.ts
@@ -5,7 +5,7 @@ const noAccountToTestConfig = {
   account2: Account.BTC_NATIVE_SEGWIT_1,
   testTitle: "from Account present to Account not present",
   tmsLinks: ["B2CQA-3354"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runSwapWithoutAccountTest(

--- a/e2e/mobile/specs/swap/otherTestCases/tooLowAmountForQuoteSwaps/swapETH_BTC_NATIVE_SEGWIT_10000NotEnoughFee.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/tooLowAmountForQuoteSwaps/swapETH_BTC_NATIVE_SEGWIT_10000NotEnoughFee.spec.ts
@@ -6,7 +6,7 @@ const transactionE2E = {
   errorMessage: "Not enough balance, including network fee",
   ctaBanner: true,
   quotesVisible: false,
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runTooLowAmountForQuoteSwapsTest(

--- a/e2e/mobile/specs/swap/otherTestCases/tooLowAmountForQuoteSwaps/swapETH_USDC_BTC_NATIVE_SEGWIT_NotEnoughFee.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/tooLowAmountForQuoteSwaps/swapETH_USDC_BTC_NATIVE_SEGWIT_NotEnoughFee.spec.ts
@@ -6,7 +6,7 @@ const transactionE2E = {
   errorMessage: "Not enough balance, including network fee",
   ctaBanner: true,
   quotesVisible: false,
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runTooLowAmountForQuoteSwapsTest(

--- a/e2e/mobile/specs/swap/otherTestCases/tooLowAmountForQuoteSwaps/swapETH_USDT_BTC_NATIVE_SEGWIT_200NotEnough.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/tooLowAmountForQuoteSwaps/swapETH_USDT_BTC_NATIVE_SEGWIT_200NotEnough.spec.ts
@@ -6,7 +6,7 @@ const transactionE2E = {
   errorMessage: "Not enough balance",
   ctaBanner: false,
   quotesVisible: false,
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runTooLowAmountForQuoteSwapsTest(

--- a/e2e/mobile/specs/swap/otherTestCases/tooLowAmountForQuoteSwaps/swapETH_USDT_BTC_NATIVE_SEGWIT_24EthFee.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/tooLowAmountForQuoteSwaps/swapETH_USDT_BTC_NATIVE_SEGWIT_24EthFee.spec.ts
@@ -6,7 +6,7 @@ const transactionE2E = {
   errorMessage: new RegExp(/\d+(\.\d{1,10})? ETH needed for network fees\.[\s\S]*Learn More/),
   ctaBanner: true,
   quotesVisible: true,
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runTooLowAmountForQuoteSwapsTest(

--- a/e2e/mobile/specs/swap/otherTestCases/tooLowAmountForQuoteSwaps/swapETH_USDT_BTC_NATIVE_SEGWIT_MinQuote.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/tooLowAmountForQuoteSwaps/swapETH_USDT_BTC_NATIVE_SEGWIT_MinQuote.spec.ts
@@ -6,7 +6,7 @@ const transactionE2E = {
   errorMessage: new RegExp(/Minimum \d+(\.\d{1,10})? USDT needed for quotes\.[\s\S]*Learn More/),
   ctaBanner: false,
   quotesVisible: false,
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 runTooLowAmountForQuoteSwapsTest(

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH.spec.ts
@@ -1,4 +1,8 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(Account.BTC_NATIVE_SEGWIT_1, Account.ETH_1, "0.00067", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2744", "B2CQA-2432", "B2CQA-620"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(
+  swap,
+  ["B2CQA-2744", "B2CQA-2432", "B2CQA-620"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
+);

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH_USDT.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH_USDT.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(Account.BTC_NATIVE_SEGWIT_1, TokenAccount.ETH_USDT_1, "0.0006", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2746"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2746"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_LTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_LTC.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(Account.BTC_NATIVE_SEGWIT_1, Account.LTC_1, "0.0006", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-3078"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-3078"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_SOL.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_SOL.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(Account.BTC_NATIVE_SEGWIT_1, Account.SOL_1, "0.0006", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2747"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2747"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapETH_BTC_NATIVE_SEGWIT.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_BTC_NATIVE_SEGWIT.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(Account.ETH_1, Account.BTC_NATIVE_SEGWIT_1, "0.02", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2750", "B2CQA-3135"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2750", "B2CQA-3135"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapETH_DOT.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_DOT.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(Account.ETH_1, Account.DOT_1, "0.02", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-3017"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-3017"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapETH_ETH_USDT.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_ETH_USDT.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(Account.ETH_1, TokenAccount.ETH_USDT_1, "0.02", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2749"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2749"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapETH_SOL.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_SOL.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(Account.ETH_1, Account.SOL_1, "0.018", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2748"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2748"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapETH_USDC_BTC_NATIVE_SEGWIT.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDC_BTC_NATIVE_SEGWIT.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(TokenAccount.ETH_USDC_1, Account.BTC_NATIVE_SEGWIT_1, "65", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2832"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2832"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapETH_USDC_ETH.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDC_ETH.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(TokenAccount.ETH_USDC_1, Account.ETH_1, "65", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2830"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2830"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapETH_USDC_SOL.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDC_SOL.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(TokenAccount.ETH_USDC_1, Account.SOL_1, "45", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2831"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2831"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapETH_USDT_BTC_NATIVE_SEGWIT.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDT_BTC_NATIVE_SEGWIT.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(TokenAccount.ETH_USDT_1, Account.BTC_NATIVE_SEGWIT_1, "40", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2753"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2753"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapETH_USDT_ETH.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDT_ETH.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(TokenAccount.ETH_USDT_1, Account.ETH_1, "40", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2752", "B2CQA-2048"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2752", "B2CQA-2048"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapETH_USDT_SOL.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDT_SOL.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(TokenAccount.ETH_USDT_1, Account.SOL_1, "60", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2751"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2751"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapXRP_BTC_NATIVE_SEGWIT.spec.ts
+++ b/e2e/mobile/specs/swap/swapXRP_BTC_NATIVE_SEGWIT.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(Account.XRP_1, Account.BTC_NATIVE_SEGWIT_1, "15", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-3077"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-3077"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/swap/swapXRP_ETH_USDC.spec.ts
+++ b/e2e/mobile/specs/swap/swapXRP_ETH_USDC.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(Account.XRP_1, TokenAccount.ETH_USDC_1, "15", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-3075"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-3075"], ["@NanoSP", "@LNS", "@NanoX", "@Stax"]);

--- a/e2e/mobile/specs/userOpensApplication.spec.ts
+++ b/e2e/mobile/specs/userOpensApplication.spec.ts
@@ -1,6 +1,6 @@
 const testConfig = {
   tmsLinks: ["B2CQA-734"],
-  tags: ["@NanoSP", "@LNS", "@NanoX"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 };
 
 describe("User opens application", () => {

--- a/e2e/mobile/specs/verifyAddress/verifyAddress.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddress.ts
@@ -3,7 +3,7 @@ import { AccountType } from "@ledgerhq/live-common/e2e/enum/Account";
 export function runVerifyAddressTest(
   account: AccountType,
   tmsLinks: string[],
-  tags: string[] = ["@NanoSP", "@LNS", "@NanoX"],
+  tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
 ) {
   describe("Verify Address", () => {
     beforeAll(async () => {

--- a/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
+++ b/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
@@ -106,47 +106,6 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
     sendConfirm: {
       default: DeviceLabels.HOLD_TO_SIGN,
     },
-    sendVerify: {
-      default: DeviceLabels.REVIEW_OPERATION,
-    },
-    sendConfirm: {
-      [AppInfos.SOLANA.name]: DeviceLabels.SIGN_TRANSACTION,
-      [AppInfos.TRON.name]: DeviceLabels.SIGN,
-      [AppInfos.STELLAR.name]: DeviceLabels.SIGN,
-      [AppInfos.RIPPLE.name]: DeviceLabels.SIGN,
-      [AppInfos.APTOS.name]: DeviceLabels.APPROVE,
-      [AppInfos.SUI.name]: DeviceLabels.ACCEPT,
-      [AppInfos.BITCOIN.name]: DeviceLabels.CONTINUE,
-      default: DeviceLabels.CAPS_APPROVE,
-    },
-  },
-  [DeviceModelId.stax]: {
-    receiveVerify: {
-      [AppInfos.BNB_CHAIN.name]: DeviceLabels.VERIFY_BSC,
-      [AppInfos.COSMOS.name]: DeviceLabels.PLEASE_REVIEW,
-      [AppInfos.ETHEREUM.name]: DeviceLabels.VERIFY_ETHEREUM,
-      [AppInfos.POLKADOT.name]: DeviceLabels.PLEASE_REVIEW,
-      [AppInfos.POLYGON.name]: DeviceLabels.VERIFY_POLYGON,
-      [AppInfos.SOLANA.name]: DeviceLabels.VERIFY_SOLANA_ADDRESS,
-      default: DeviceLabels.ADDRESS,
-    },
-    receiveConfirm: {
-      default: DeviceLabels.CONFIRM,
-    },
-    delegateVerify: {
-      [AppInfos.NEAR.name]: DeviceLabels.VIEW_HEADER,
-      default: DeviceLabels.REVIEW_OPERATION,
-    },
-    delegateConfirm: {
-      [AppInfos.NEAR.name]: DeviceLabels.CONTINUE_TO_ACTION,
-      default: DeviceLabels.HOLD_TO_SIGN,
-    },
-    sendVerify: {
-      default: DeviceLabels.REVIEW_OPERATION,
-    },
-    sendConfirm: {
-      default: DeviceLabels.HOLD_TO_SIGN,
-    },
   },
   default: {
     receiveVerify: {

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -654,7 +654,12 @@ export async function activateLedgerSync() {
 export async function activateExpertMode() {
   if (isTouchDevice()) {
     await goToSettings();
-    await pressAndRelease(DeviceLabels.SETTINGS_TOGGLE_1);
+    const SettingsToggle1Coordinates = { x: 344, y: 136 };
+    await pressAndRelease(
+      DeviceLabels.SETTINGS_TOGGLE_1,
+      SettingsToggle1Coordinates.x,
+      SettingsToggle1Coordinates.y,
+    );
   } else {
     await pressUntilTextFound(DeviceLabels.EXPERT_MODE);
     await pressBoth();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Adding Stax to mobile e2e pipeline
- Updating LLM Workflow
- Fixing `activateExpertMode` function on Stax

Uploading Screen Recording 2025-10-15 at 17.33.53.mov…


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [QAA-829](https://ledgerhq.atlassian.net/browse/QAA-829)

### 🤖 CI

- **CI run**: [Stax x LLM](https://github.com/LedgerHQ/ledger-live/actions/runs/18534434550)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-829]: https://ledgerhq.atlassian.net/browse/QAA-829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ