### PR TITLE
ci: add tsconfig base to global deps for caching purposes

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,8 @@
   "$schema": "https://turborepo.org/schema.json",
   "daemon": false,
   "globalDependencies": [
-    "turbo.json"
+    "turbo.json",
+    "tsconfig.base.json"
   ],
   "globalEnv": [
     "ANDROID_HOME",


### PR DESCRIPTION
An updated base typescript file caused packages to pass tests as the caching checksum didn't include the global dependency.

Requires the merge of this [PR](https://github.com/LedgerHQ/ledger-live/pull/12321) to fix the issue prior to merge 

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-22338