### PR TITLE
fix: MAD  -  incorrect display of non-stakable assets in Market staking flow

### DIFF
--- a/.changeset/two-icons-drum.md
+++ b/.changeset/two-icons-drum.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+MAD - fix Extra step and incorrect display of non-stakable assets in Market staking flow

--- a/apps/ledger-live-desktop/src/renderer/screens/stake/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/stake/index.tsx
@@ -156,6 +156,7 @@ const useStakeFlow = () => {
           useCase: "earn",
           onSuccess,
           onCancel: handleRequestClose,
+          areCurrenciesFiltered: cryptoCurrencies.length > 0,
         });
       } else {
         setDrawer(


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

In the Market, assets where all displayed even those who are not-stackable in the MAD (for `earn` flow)
- Extra Step was displayed also

Now pre-select right asset on the MAD

https://github.com/user-attachments/assets/e8cb34e0-7be2-4b52-bcb0-e46cb9d68431


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-22339


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
