### PR TITLE
ci: enable mobile meta reporting on push flow

### DIFF
--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -35,7 +35,6 @@ jobs:
     secrets: inherit
     with:
       macos-specificity-runner-label: "performance-pool"
-      skip-bundle-size-reporting: true
       max-shards: 1
       skip-pod-checks: "true"
 


### PR DESCRIPTION
Bundle size reporting is needed on push flows in order to enable bundle size analysis on PR flows