### PR TITLE
chore: migrate getDeviceTransactionConfig to async

### DIFF
--- a/.changeset/gentle-mirrors-beg.md
+++ b/.changeset/gentle-mirrors-beg.md
@@ -1,0 +1,33 @@
+---
+"@ledgerhq/coin-module-boilerplate": minor
+"@ledgerhq/coin-internet_computer": minor
+"@ledgerhq/coin-multiversx": minor
+"@ledgerhq/coin-algorand": minor
+"@ledgerhq/coin-filecoin": minor
+"@ledgerhq/coin-polkadot": minor
+"@ledgerhq/coin-bitcoin": minor
+"@ledgerhq/coin-cardano": minor
+"@ledgerhq/coin-stellar": minor
+"@ledgerhq/coin-canton": minor
+"@ledgerhq/coin-casper": minor
+"@ledgerhq/coin-cosmos": minor
+"@ledgerhq/coin-hedera": minor
+"@ledgerhq/coin-solana": minor
+"@ledgerhq/coin-stacks": minor
+"@ledgerhq/coin-aptos": minor
+"@ledgerhq/coin-kaspa": minor
+"@ledgerhq/coin-tezos": minor
+"@ledgerhq/coin-celo": minor
+"@ledgerhq/coin-icon": minor
+"@ledgerhq/coin-mina": minor
+"@ledgerhq/coin-near": minor
+"@ledgerhq/coin-tron": minor
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/coin-ton": minor
+"@ledgerhq/coin-xrp": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+migrate getDeviceTransactionConfig to async

--- a/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/index.test.tsx
@@ -1,0 +1,291 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import TransactionConfirm from "./index";
+import { useDeviceTransactionConfig } from "@ledgerhq/live-common/hooks/useDeviceTransactionConfig";
+import { getLLDCoinFamily } from "~/renderer/families";
+import useTheme from "~/renderer/hooks/useTheme";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { DeviceTransactionField } from "@ledgerhq/live-common/transaction/deviceTransactionConfig";
+import { Account } from "@ledgerhq/types-live";
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import { BigNumber } from "bignumber.js";
+import { getDeviceAnimation } from "../DeviceAction/animations";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+
+jest.mock("@ledgerhq/live-common/hooks/useDeviceTransactionConfig");
+jest.mock("~/renderer/families");
+jest.mock("~/renderer/hooks/useTheme");
+jest.mock("~/renderer/hooks/useAccountUnit");
+jest.mock("@ledgerhq/live-common/account/index");
+jest.mock("../DeviceAction/animations");
+jest.mock("~/renderer/animations", () => ({ __esModule: true, default: () => null }));
+
+const mockDevice: Device = {
+  deviceId: "test-device",
+  modelId: DeviceModelId.nanoX,
+  wired: true,
+};
+
+const mockCurrency = getCryptoCurrencyById("bitcoin");
+
+const mockAccount: Account = {
+  id: "account-1",
+  type: "Account",
+  currency: mockCurrency,
+  balance: new BigNumber(1000000),
+  spendableBalance: new BigNumber(1000000),
+  blockHeight: 1,
+  freshAddress: "test-address",
+  seedIdentifier: "seed-id",
+  derivationMode: "" as const,
+  index: 0,
+  freshAddressPath: "44'/0'/0'/0/0",
+  operations: [],
+  pendingOperations: [],
+  lastSyncDate: new Date(),
+  creationDate: new Date(),
+  operationsCount: 0,
+  balanceHistoryCache: {
+    HOUR: { latestDate: null, balances: [] },
+    DAY: { latestDate: null, balances: [] },
+    WEEK: { latestDate: null, balances: [] },
+  },
+  swapHistory: [],
+  used: false,
+};
+
+const mockTransaction = { family: "bitcoin" } as Transaction;
+const mockStatus = {
+  amount: new BigNumber(50000),
+  estimatedFees: new BigNumber(1000),
+  errors: {},
+  warnings: {},
+} as TransactionStatus;
+
+const mockUnit = { code: "BTC", magnitude: 8, name: "Bitcoin" };
+
+describe("TransactionConfirm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useTheme as jest.Mock).mockReturnValue({ colors: { palette: { type: "dark" } } });
+    (useAccountUnit as jest.Mock).mockReturnValue(mockUnit);
+    (getMainAccount as jest.Mock).mockReturnValue(mockAccount);
+    (getLLDCoinFamily as jest.Mock).mockReturnValue(undefined);
+    (getDeviceAnimation as jest.Mock).mockReturnValue({ name: "test-animation", loop: true });
+  });
+
+  it("returns null when device is not provided", () => {
+    (useDeviceTransactionConfig as jest.Mock).mockReturnValue({ fields: [], loading: false });
+    const { container } = render(
+      <TransactionConfirm
+        device={null as unknown as Device}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders loading state without fields", () => {
+    (useDeviceTransactionConfig as jest.Mock).mockReturnValue({ fields: [], loading: true });
+    const { container } = render(
+      <TransactionConfirm
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+    expect(container).toBeInTheDocument();
+  });
+
+  it("renders amount field correctly", () => {
+    const amountField: DeviceTransactionField = {
+      type: "amount",
+      label: "Amount",
+    };
+    (useDeviceTransactionConfig as jest.Mock).mockReturnValue({
+      fields: [amountField],
+      loading: false,
+    });
+    render(
+      <TransactionConfirm
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+    expect(screen.getByText("Amount")).toBeInTheDocument();
+  });
+
+  it("renders fees field correctly", () => {
+    const feesField: DeviceTransactionField = {
+      type: "fees",
+      label: "Fees",
+    };
+    (useDeviceTransactionConfig as jest.Mock).mockReturnValue({
+      fields: [feesField],
+      loading: false,
+    });
+    render(
+      <TransactionConfirm
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+    expect(screen.getByText("Fees")).toBeInTheDocument();
+  });
+
+  it("renders address field correctly", () => {
+    const addressField: DeviceTransactionField = {
+      type: "address",
+      label: "Recipient",
+      address: "test-address-123",
+    };
+    (useDeviceTransactionConfig as jest.Mock).mockReturnValue({
+      fields: [addressField],
+      loading: false,
+    });
+    render(
+      <TransactionConfirm
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+    expect(screen.getByText("Recipient")).toBeInTheDocument();
+    expect(screen.getByText("test-address-123")).toBeInTheDocument();
+  });
+
+  it("renders text field correctly", () => {
+    const textField: DeviceTransactionField = {
+      type: "text",
+      label: "Memo",
+      value: "test-memo",
+    };
+    (useDeviceTransactionConfig as jest.Mock).mockReturnValue({
+      fields: [textField],
+      loading: false,
+    });
+    render(
+      <TransactionConfirm
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+    expect(screen.getByText("Memo")).toBeInTheDocument();
+    expect(screen.getByText("test-memo")).toBeInTheDocument();
+  });
+
+  it("filters out Address label field", () => {
+    const fields: DeviceTransactionField[] = [
+      { type: "text", label: "Amount", value: "1 BTC" },
+      { type: "text", label: "Address", value: "should-be-filtered" },
+    ];
+    (useDeviceTransactionConfig as jest.Mock).mockReturnValue({ fields, loading: false });
+    render(
+      <TransactionConfirm
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+    expect(screen.getByText("Amount")).toBeInTheDocument();
+    expect(screen.queryByText("should-be-filtered")).not.toBeInTheDocument();
+  });
+
+  it("extracts transaction type from fields", () => {
+    const fields: DeviceTransactionField[] = [{ type: "text", label: "Type", value: "DELEGATE" }];
+    (useDeviceTransactionConfig as jest.Mock).mockReturnValue({ fields, loading: false });
+    render(
+      <TransactionConfirm
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+    expect(screen.getByText("Type")).toBeInTheDocument();
+  });
+
+  it("warns for unknown field type", () => {
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
+    const unknownField = {
+      type: "unknown",
+      label: "Unknown",
+    } as unknown as DeviceTransactionField;
+    (useDeviceTransactionConfig as jest.Mock).mockReturnValue({
+      fields: [unknownField],
+      loading: false,
+    });
+    render(
+      <TransactionConfirm
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("field unknown is not implemented"),
+    );
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("renders with manifestId and manifestName", () => {
+    (useDeviceTransactionConfig as jest.Mock).mockReturnValue({ fields: [], loading: false });
+    const { container } = render(
+      <TransactionConfirm
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+        manifestId="test-manifest-id"
+        manifestName="Test Manifest"
+      />,
+    );
+    expect(container).toBeInTheDocument();
+  });
+
+  it("renders custom family title", () => {
+    const CustomTitle = () => <div>Custom Title</div>;
+    (getLLDCoinFamily as jest.Mock).mockReturnValue({
+      transactionConfirmFields: {
+        title: CustomTitle,
+        fieldComponents: {},
+      },
+    });
+    (useDeviceTransactionConfig as jest.Mock).mockReturnValue({ fields: [], loading: false });
+    render(
+      <TransactionConfirm
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+    expect(screen.getByText("Custom Title")).toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/index.tsx
@@ -5,7 +5,7 @@ import { Account, AccountLike, TransactionCommon } from "@ledgerhq/types-live";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { getDeviceTransactionConfig } from "@ledgerhq/live-common/transaction/index";
+import { useDeviceTransactionConfig } from "@ledgerhq/live-common/hooks/useDeviceTransactionConfig";
 import Animation from "~/renderer/animations";
 import Box from "~/renderer/components/Box";
 import FormattedVal from "~/renderer/components/FormattedVal";
@@ -127,7 +127,7 @@ const TransactionConfirm = ({
   const mainAccount = getMainAccount(account, parentAccount);
   const type = useTheme().colors.palette.type;
 
-  const fields = getDeviceTransactionConfig({
+  const { fields, loading } = useDeviceTransactionConfig({
     account,
     parentAccount,
     transaction,
@@ -186,25 +186,27 @@ const TransactionConfirm = ({
           }}
           mb={20}
         >
-          {displayedFields.map((field, i) => {
-            const MaybeComponent = fieldComponents[field.type];
-            if (!MaybeComponent) {
-              console.warn(
-                `TransactionConfirm field ${field.type} is not implemented! add a generic implementation in components/TransactionConfirm.js or inside families/*/TransactionConfirmFields.js`,
-              );
-              return null;
-            }
-            return (
-              <MaybeComponent
-                key={i}
-                field={field}
-                account={account}
-                parentAccount={parentAccount}
-                transaction={transaction}
-                status={status}
-              />
-            );
-          })}
+          {loading
+            ? null
+            : displayedFields.map((field, i) => {
+                const MaybeComponent = fieldComponents[field.type];
+                if (!MaybeComponent) {
+                  console.warn(
+                    `TransactionConfirm field ${field.type} is not implemented! add a generic implementation in components/TransactionConfirm.js or inside families/*/TransactionConfirmFields.js`,
+                  );
+                  return null;
+                }
+                return (
+                  <MaybeComponent
+                    key={i}
+                    field={field}
+                    account={account}
+                    parentAccount={parentAccount}
+                    transaction={transaction}
+                    status={status}
+                  />
+                );
+              })}
         </Box>
       </Container>
       <ConfirmFooter

--- a/apps/ledger-live-desktop/src/renderer/families/solana/TransactionConfirmFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/TransactionConfirmFields.tsx
@@ -1,6 +1,6 @@
 import invariant from "invariant";
 import React, { useMemo } from "react";
-import { getDeviceTransactionConfig } from "@ledgerhq/live-common/transaction/index";
+import { useDeviceTransactionConfig } from "@ledgerhq/live-common/hooks/useDeviceTransactionConfig";
 import Alert from "~/renderer/components/Alert";
 import { Trans } from "react-i18next";
 import ConfirmTitle from "~/renderer/components/TransactionConfirm/ConfirmTitle";
@@ -22,7 +22,7 @@ const Title: TitleComponent = props => {
   const { transaction, account, parentAccount, status, device } = props;
   const transferTokenHelpUrl = useLocalizedUrl(urls.solana.splTokenInfo);
 
-  const fields = getDeviceTransactionConfig({
+  const { fields } = useDeviceTransactionConfig({
     account,
     parentAccount,
     transaction,

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
@@ -21,10 +21,8 @@ import logger from "~/renderer/logger";
 import Text from "~/renderer/components/Text";
 import { TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { ModalData } from "../types";
-import {
-  DeviceTransactionField,
-  getDeviceTransactionConfig,
-} from "@ledgerhq/live-common/transaction/index";
+import { DeviceTransactionField } from "@ledgerhq/live-common/transaction/index";
+import { useDeviceTransactionConfig } from "@ledgerhq/live-common/hooks/useDeviceTransactionConfig";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 
 export type Params = {
@@ -190,7 +188,7 @@ export default function Body({ onChangeStepId, onClose, setError, stepId, params
   );
   const errorSteps = [];
 
-  const fields = getDeviceTransactionConfig({
+  const { fields } = useDeviceTransactionConfig({
     account: params.account,
     parentAccount,
     transaction,

--- a/apps/ledger-live-mobile/src/components/ValidateOnDevice.test.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateOnDevice.test.tsx
@@ -1,0 +1,161 @@
+/* eslint-disable i18next/no-literal-string */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from "react";
+import { render } from "@tests/test-renderer";
+import ValidateOnDevice from "./ValidateOnDevice";
+import BigNumber from "bignumber.js";
+
+// Mocks
+jest.mock("@ledgerhq/live-common/hooks/useDeviceTransactionConfig");
+jest.mock("~/hooks/useAccountUnit");
+
+const mockUseDeviceTransactionConfig =
+  require("@ledgerhq/live-common/hooks/useDeviceTransactionConfig")
+    .useDeviceTransactionConfig as jest.Mock;
+const mockUseAccountUnit = require("~/hooks/useAccountUnit").useAccountUnit as jest.Mock;
+
+const mockAccount = {
+  type: "Account",
+  id: "test-account",
+  currency: { family: "bitcoin", units: [{ code: "BTC", magnitude: 8 }] },
+  freshAddress: "test-address",
+  balance: new BigNumber(10000),
+  spendableBalance: new BigNumber(10000),
+} as any;
+
+const mockDevice = { modelId: "nanoX" } as any;
+const mockTransaction = { family: "bitcoin", amount: new BigNumber(1000) } as any;
+const mockStatus = {
+  amount: new BigNumber(1000),
+  estimatedFees: new BigNumber(100),
+} as any;
+
+describe("ValidateOnDevice", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAccountUnit.mockReturnValue({ code: "BTC", magnitude: 8 });
+  });
+
+  it("renders loading state", () => {
+    mockUseDeviceTransactionConfig.mockReturnValue({ fields: [], loading: true });
+
+    const { getByTestId } = render(
+      <ValidateOnDevice
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+
+    expect(getByTestId("device-validation-scroll-view")).toBeTruthy();
+  });
+
+  it("calls useDeviceTransactionConfig with correct params", () => {
+    mockUseDeviceTransactionConfig.mockReturnValue({ fields: [], loading: false });
+
+    render(
+      <ValidateOnDevice
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+
+    expect(mockUseDeviceTransactionConfig).toHaveBeenCalledWith({
+      account: mockAccount,
+      parentAccount: null,
+      transaction: mockTransaction,
+      status: mockStatus,
+    });
+  });
+
+  it("renders fields when not loading", () => {
+    mockUseDeviceTransactionConfig.mockReturnValue({
+      fields: [
+        { type: "amount", label: "Amount" },
+        { type: "address", label: "Address", address: "test-addr" },
+      ],
+      loading: false,
+    });
+
+    const { getByTestId } = render(
+      <ValidateOnDevice
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+
+    expect(getByTestId("device-validation-scroll-view")).toBeTruthy();
+    expect(mockUseAccountUnit).toHaveBeenCalledWith(mockAccount);
+  });
+
+  it("warns on unsupported field type", () => {
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
+    mockUseDeviceTransactionConfig.mockReturnValue({
+      fields: [{ type: "unknown", label: "Unknown" }],
+      loading: false,
+    });
+
+    render(
+      <ValidateOnDevice
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("field unknown is not implemented"),
+    );
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("renders scroll view container", () => {
+    mockUseDeviceTransactionConfig.mockReturnValue({ fields: [], loading: false });
+
+    const { getByTestId } = render(
+      <ValidateOnDevice
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+
+    expect(getByTestId("device-validation-scroll-view")).toBeTruthy();
+  });
+
+  it("renders multiple fields correctly", () => {
+    mockUseDeviceTransactionConfig.mockReturnValue({
+      fields: [
+        { type: "amount", label: "Amount" },
+        { type: "fees", label: "Fees" },
+        { type: "text", label: "Network", value: "Bitcoin" },
+      ],
+      loading: false,
+    });
+
+    const { getByTestId } = render(
+      <ValidateOnDevice
+        device={mockDevice}
+        account={mockAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+
+    expect(getByTestId("device-validation-scroll-view")).toBeTruthy();
+  });
+});

--- a/apps/ledger-live-mobile/src/components/ValidateOnDevice.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateOnDevice.tsx
@@ -7,10 +7,8 @@ import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/
 import { getMainAccount, getFeesCurrency, getFeesUnit } from "@ledgerhq/live-common/account/index";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 
-import {
-  getDeviceTransactionConfig,
-  DeviceTransactionField,
-} from "@ledgerhq/live-common/transaction/index";
+import { DeviceTransactionField } from "@ledgerhq/live-common/transaction/index";
+import { useDeviceTransactionConfig } from "@ledgerhq/live-common/hooks/useDeviceTransactionConfig";
 import { getDeviceModel } from "@ledgerhq/devices";
 
 import { useTheme } from "@react-navigation/native";
@@ -150,7 +148,7 @@ export default function ValidateOnDevice({
       }
     ).footer;
 
-  const fields = getDeviceTransactionConfig({
+  const { fields, loading } = useDeviceTransactionConfig({
     account,
     parentAccount,
     transaction,
@@ -204,27 +202,29 @@ export default function ValidateOnDevice({
           )}
 
           <DataRowsContainer>
-            {fields.map((field, i) => {
-              const MaybeComponent = fieldComponents[field.type as keyof typeof fieldComponents] as
-                | React.ComponentType<FieldComponentProps>
-                | undefined;
-              if (!MaybeComponent) {
-                console.warn(
-                  `TransactionConfirm field ${field.type} is not implemented! add a generic implementation in components/TransactionConfirm.js or inside families/*/TransactionConfirmFields.js`,
-                );
-                return null;
-              }
-              return (
-                <MaybeComponent
-                  key={i}
-                  field={field}
-                  account={account}
-                  parentAccount={parentAccount}
-                  transaction={transaction}
-                  status={status}
-                />
-              );
-            })}
+            {loading
+              ? null
+              : fields.map((field, i) => {
+                  const MaybeComponent = fieldComponents[
+                    field.type as keyof typeof fieldComponents
+                  ] as React.ComponentType<FieldComponentProps> | undefined;
+                  if (!MaybeComponent) {
+                    console.warn(
+                      `TransactionConfirm field ${field.type} is not implemented! add a generic implementation in components/TransactionConfirm.js or inside families/*/TransactionConfirmFields.js`,
+                    );
+                    return null;
+                  }
+                  return (
+                    <MaybeComponent
+                      key={i}
+                      field={field}
+                      account={account}
+                      parentAccount={parentAccount}
+                      transaction={transaction}
+                      status={status}
+                    />
+                  );
+                })}
 
             {Warning ? (
               <Warning

--- a/libs/coin-modules/coin-algorand/src/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-algorand/src/deviceTransactionConfig.test.ts
@@ -1,0 +1,29 @@
+import getDeviceTransactionConfig from "./deviceTransactionConfig";
+import BigNumber from "bignumber.js";
+import { AccountLike } from "@ledgerhq/types-live";
+
+describe("getDeviceTransactionConfig", () => {
+  const mockAccount: AccountLike = {
+    type: "Account",
+    currency: {
+      units: [{ code: "ALGO", magnitude: 6 }],
+    },
+  } as any;
+
+  it("should return fields for send transaction", async () => {
+    const result = await getDeviceTransactionConfig({
+      account: mockAccount,
+      transaction: {
+        mode: "send",
+        recipient: "test-address",
+      } as any,
+      status: {
+        amount: new BigNumber(1000000),
+        estimatedFees: new BigNumber(1000),
+      } as any,
+    });
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]).toEqual({ type: "text", label: "Type", value: "Payment" });
+  });
+});

--- a/libs/coin-modules/coin-algorand/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-algorand/src/deviceTransactionConfig.ts
@@ -20,14 +20,9 @@ const getSendFields = (
   status: TransactionStatus,
   account: AccountLike,
   addRecipient: boolean,
-) => {
+): Array<DeviceTransactionField> => {
   const { estimatedFees, amount } = status;
-  const fields: {
-    type: string;
-    label: string;
-    value?: string;
-    address?: string;
-  }[] = [];
+  const fields: Array<DeviceTransactionField> = [];
   fields.push({
     type: "text",
     label: "Type",
@@ -71,7 +66,7 @@ const getSendFields = (
   return fields;
 };
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   account,
   transaction,
   status,
@@ -79,15 +74,10 @@ function getDeviceTransactionConfig({
   account: AccountLike;
   transaction: AlgorandTransaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const { mode, assetId } = transaction;
   const { estimatedFees } = status;
-  let fields: {
-    type: string;
-    label: string;
-    value?: string;
-    address?: string;
-  }[] = [];
+  let fields: Array<DeviceTransactionField> = [];
 
   switch (mode) {
     case "send":
@@ -132,7 +122,7 @@ function getDeviceTransactionConfig({
       break;
   }
 
-  return fields as Array<DeviceTransactionField>;
+  return fields;
 }
 
 export default getDeviceTransactionConfig;

--- a/libs/coin-modules/coin-aptos/src/__tests__/bridge/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/bridge/deviceTransactionConfig.test.ts
@@ -6,14 +6,14 @@ import { APTOS_PRECISION } from "../../constants";
 const nonBreakableSpace = " ";
 
 describe("deviceTransactionConfig", () => {
-  test("coin transfer", () => {
+  test("coin transfer", async () => {
     const account = createFixtureAccount();
     const parentAccount = null;
     const transaction = createFixtureTransaction({
       amount: BigNumber(123).shiftedBy(APTOS_PRECISION),
       fees: BigNumber(456),
     });
-    const fields = getDeviceTransactionConfig({
+    const fields = await getDeviceTransactionConfig({
       account,
       parentAccount,
       transaction,
@@ -33,7 +33,7 @@ describe("deviceTransactionConfig", () => {
     ]);
   });
 
-  test("stake", () => {
+  test("stake", async () => {
     const account = createFixtureAccount();
     const parentAccount = null;
     const transaction = createFixtureTransaction({
@@ -42,7 +42,7 @@ describe("deviceTransactionConfig", () => {
       recipient: "delegator id",
       mode: "stake",
     });
-    const fields = getDeviceTransactionConfig({
+    const fields = await getDeviceTransactionConfig({
       account,
       parentAccount,
       transaction,
@@ -67,7 +67,7 @@ describe("deviceTransactionConfig", () => {
     ]);
   });
 
-  test("unstake", () => {
+  test("unstake", async () => {
     const account = createFixtureAccount();
     const parentAccount = null;
     const transaction = createFixtureTransaction({
@@ -76,7 +76,7 @@ describe("deviceTransactionConfig", () => {
       recipient: "delegator id",
       mode: "unstake",
     });
-    const fields = getDeviceTransactionConfig({
+    const fields = await getDeviceTransactionConfig({
       account,
       parentAccount,
       transaction,
@@ -101,7 +101,7 @@ describe("deviceTransactionConfig", () => {
     ]);
   });
 
-  test("unstake", () => {
+  test("unstake", async () => {
     const account = createFixtureAccount();
     const parentAccount = null;
     const transaction = createFixtureTransaction({
@@ -109,7 +109,7 @@ describe("deviceTransactionConfig", () => {
       fees: BigNumber(456),
       mode: "withdraw",
     });
-    const fields = getDeviceTransactionConfig({
+    const fields = await getDeviceTransactionConfig({
       account,
       parentAccount,
       transaction,

--- a/libs/coin-modules/coin-aptos/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-aptos/src/bridge/deviceTransactionConfig.ts
@@ -4,7 +4,7 @@ import { Transaction } from "../types";
 import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/formatCurrencyUnit";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   account,
   parentAccount,
   transaction,
@@ -12,7 +12,7 @@ function getDeviceTransactionConfig({
   account: AccountLike;
   parentAccount: Account | null | undefined;
   transaction: Transaction;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const { mode } = transaction;
   const fields: DeviceTransactionField[] = [];
   const mainAccount = getMainAccount(account, parentAccount);

--- a/libs/coin-modules/coin-bitcoin/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-bitcoin/src/deviceTransactionConfig.ts
@@ -2,14 +2,14 @@ import type { Transaction, TransactionStatus } from "./types";
 import type { CommonDeviceTransactionField as DeviceTransactionField } from "@ledgerhq/coin-framework/transaction/common";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   status: { amount, estimatedFees, opReturnData },
 }: {
   account: AccountLike;
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const fields: Array<{ label: string; type: string }> = [];
 
   if (!amount.isZero()) {

--- a/libs/coin-modules/coin-canton/src/bridge/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/deviceTransactionConfig.test.ts
@@ -2,21 +2,25 @@ import getDeviceTransactionConfig from "./deviceTransactionConfig";
 import BigNumber from "bignumber.js";
 
 describe("getDeviceTransactionConfig", () => {
-  it("should return amount field when it's more than 0", () => {
+  it("should return amount field when it's more than 0", async () => {
     expect(
-      getDeviceTransactionConfig({
-        transaction: {},
-        status: { amount: new BigNumber(1), estimatedFees: new BigNumber(0) },
-      } as any)[0],
+      (
+        await getDeviceTransactionConfig({
+          transaction: {},
+          status: { amount: new BigNumber(1), estimatedFees: new BigNumber(0) },
+        } as any)
+      )[0],
     ).toEqual({ type: "amount", label: "Amount" });
   });
 
-  it("should return fee field when it's more than 0", () => {
+  it("should return fee field when it's more than 0", async () => {
     expect(
-      getDeviceTransactionConfig({
-        transaction: {},
-        status: { amount: new BigNumber(0), estimatedFees: new BigNumber(1) },
-      } as any)[0],
+      (
+        await getDeviceTransactionConfig({
+          transaction: {},
+          status: { amount: new BigNumber(0), estimatedFees: new BigNumber(1) },
+        } as any)
+      )[0],
     ).toEqual({ type: "fees", label: "Fees" });
   });
 });

--- a/libs/coin-modules/coin-canton/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/deviceTransactionConfig.ts
@@ -3,7 +3,7 @@ import type { Transaction, TransactionStatus } from "../types";
 import type { CommonDeviceTransactionField } from "@ledgerhq/coin-framework/transaction/common";
 
 // This method adds additional fields that need to be reviewed when signing a transaction on the device.
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   transaction: {},
   status: { amount, estimatedFees },
 }: {
@@ -11,7 +11,7 @@ function getDeviceTransactionConfig({
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<CommonDeviceTransactionField> {
+}): Promise<Array<CommonDeviceTransactionField>> {
   const fields: Array<CommonDeviceTransactionField> = [];
 
   if (!amount.isZero()) {

--- a/libs/coin-modules/coin-cardano/src/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-cardano/src/deviceTransactionConfig.test.ts
@@ -1,0 +1,38 @@
+import getDeviceTransactionConfig from "./deviceTransactionConfig";
+import BigNumber from "bignumber.js";
+import { Account } from "@ledgerhq/types-live";
+
+describe("getDeviceTransactionConfig", () => {
+  const mockAccount: Account = {
+    type: "Account",
+    currency: {
+      id: "cardano",
+      family: "cardano",
+      units: [{ code: "ADA", magnitude: 6 }],
+    },
+    cardanoResources: {
+      protocolParams: {
+        utxoCostPerByte: "4310",
+      },
+    },
+  } as any;
+
+  it("should return fields for send transaction with fees", async () => {
+    const result = await getDeviceTransactionConfig({
+      account: mockAccount,
+      parentAccount: null,
+      transaction: {
+        mode: "send",
+        amount: new BigNumber(1000000),
+        fees: new BigNumber(170000),
+        recipient: "addr_test1qz",
+      } as any,
+      status: {} as any,
+    });
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "text", label: "Transaction Fee" })]),
+    );
+  });
+});

--- a/libs/coin-modules/coin-cardano/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-cardano/src/deviceTransactionConfig.ts
@@ -14,7 +14,7 @@ import {
 } from "./logic";
 import { CARDANO_MAX_SUPPLY } from "./constants";
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   account,
   transaction,
   parentAccount,
@@ -23,7 +23,7 @@ function getDeviceTransactionConfig({
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const { mode } = transaction;
   const fields: DeviceTransactionField[] = [];
   const mainAccount = getMainAccount(account, parentAccount);

--- a/libs/coin-modules/coin-casper/src/bridge/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/deviceTransactionConfig.test.ts
@@ -35,8 +35,8 @@ describe("getDeviceTransactionConfig", () => {
   /**
    * Helper to get config fields
    */
-  const getConfigFields = (transaction: Transaction, account = createMockAccount()) =>
-    getDeviceTransactionConfig({
+  const getConfigFields = async (transaction: Transaction, account = createMockAccount()) =>
+    await getDeviceTransactionConfig({
       account,
       parentAccount: null,
       transaction,
@@ -47,14 +47,14 @@ describe("getDeviceTransactionConfig", () => {
     jest.clearAllMocks();
   });
 
-  test("should display chain ID, transaction type and amount fields for standard transactions", () => {
+  test("should display chain ID, transaction type and amount fields for standard transactions", async () => {
     // Create mock transaction
     const mockTransaction = createMockTransaction({
       amount: MOCK_AMOUNT,
     });
 
     // Get display fields
-    const fields = getConfigFields(mockTransaction);
+    const fields = await getConfigFields(mockTransaction);
 
     // Verify the results
     expect(fields).toHaveLength(4);
@@ -90,7 +90,7 @@ describe("getDeviceTransactionConfig", () => {
     expect(log).toHaveBeenCalledWith("debug", expect.stringContaining("Transaction config"));
   });
 
-  test("should include transferId field when provided in transaction", () => {
+  test("should include transferId field when provided in transaction", async () => {
     // Create mock transaction with transferId
     const mockTransaction = createMockTransaction({
       amount: MOCK_AMOUNT,
@@ -98,7 +98,7 @@ describe("getDeviceTransactionConfig", () => {
     });
 
     // Get display fields
-    const fields = getConfigFields(mockTransaction);
+    const fields = await getConfigFields(mockTransaction);
 
     // Verify the results
     expect(fields).toHaveLength(5); // Chain ID, Type, Amount, Transfer ID fields
@@ -115,7 +115,7 @@ describe("getDeviceTransactionConfig", () => {
     });
   });
 
-  test("should not include transferId field when undefined in transaction", () => {
+  test("should not include transferId field when undefined in transaction", async () => {
     // Create mock transaction with explicitly undefined transferId
     const mockTransaction = createMockTransaction({
       amount: MOCK_AMOUNT,
@@ -123,21 +123,21 @@ describe("getDeviceTransactionConfig", () => {
     });
 
     // Get display fields
-    const fields = getConfigFields(mockTransaction);
+    const fields = await getConfigFields(mockTransaction);
 
     // Verify no transferId field is present
     expect(fields).toHaveLength(4);
     expect(fields.map(field => field.label)).not.toContain("Transfer ID");
   });
 
-  test("should handle zero amount transactions correctly", () => {
+  test("should handle zero amount transactions correctly", async () => {
     // Create mock transaction with zero amount
     const mockTransaction = createMockTransaction({
       amount: new BigNumber(0),
     });
 
     // Get display fields
-    const fields = getConfigFields(mockTransaction);
+    const fields = await getConfigFields(mockTransaction);
 
     // Verify amount field has zero value
     const amountField = fields.find(field => field.label === "Amount");
@@ -149,7 +149,7 @@ describe("getDeviceTransactionConfig", () => {
     });
   });
 
-  test("should maintain consistent order of fields regardless of transaction properties", () => {
+  test("should maintain consistent order of fields regardless of transaction properties", async () => {
     // Create two transactions - one with transferId, one without
     const txWithTransferId = createMockTransaction({
       amount: MOCK_AMOUNT,
@@ -160,8 +160,8 @@ describe("getDeviceTransactionConfig", () => {
       amount: MOCK_AMOUNT,
     });
 
-    const fieldsWithId = getConfigFields(txWithTransferId);
-    const fieldsWithoutId = getConfigFields(txWithoutTransferId);
+    const fieldsWithId = await getConfigFields(txWithTransferId);
+    const fieldsWithoutId = await getConfigFields(txWithoutTransferId);
 
     // Verify field order consistency for common fields
     for (let i = 0; i < fieldsWithoutId.length; i++) {

--- a/libs/coin-modules/coin-casper/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/deviceTransactionConfig.ts
@@ -14,14 +14,14 @@ export type ExtraDeviceTransactionField = {
 
 type DeviceTransactionField = CommonDeviceTransactionField | ExtraDeviceTransactionField;
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   transaction,
 }: {
   account: AccountLike;
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const fields: Array<DeviceTransactionField> = [];
   fields.push({
     type: "text",

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/deviceTransactionConfig.test.ts
@@ -1,8 +1,9 @@
 import getDeviceTransactionConfig from "../../bridge/deviceTransactionConfig";
 
 describe("deviceTransactionConfig", () => {
-  it("returns the expected config", () => {
-    expect(getDeviceTransactionConfig()).toEqual([
+  it("returns the expected config", async () => {
+    const result = await getDeviceTransactionConfig();
+    expect(result).toEqual([
       {
         type: "amount",
         label: "Amount",

--- a/libs/coin-modules/coin-celo/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/deviceTransactionConfig.ts
@@ -1,6 +1,6 @@
 import type { CommonDeviceTransactionField as DeviceTransactionField } from "@ledgerhq/coin-framework/transaction/common";
 
-function getDeviceTransactionConfig(): Array<DeviceTransactionField> {
+async function getDeviceTransactionConfig(): Promise<Array<DeviceTransactionField>> {
   const fields: Array<DeviceTransactionField> = [];
 
   fields.push({

--- a/libs/coin-modules/coin-cosmos/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-cosmos/src/deviceTransactionConfig.ts
@@ -64,7 +64,7 @@ const getSendFields = ({
   return fields;
 };
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   account,
   parentAccount,
   transaction,
@@ -74,7 +74,7 @@ function getDeviceTransactionConfig({
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<CosmosTransactionFieldType> {
+}): Promise<Array<CosmosTransactionFieldType>> {
   const { mode, memo, validators } = transaction;
   const { estimatedFees } = status;
   const mainAccount = getMainAccount(account, parentAccount);

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/deviceTransactionConfig.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/deviceTransactionConfig.unit.test.ts
@@ -71,7 +71,7 @@ describe("EVM Family", () => {
     describe("getDeviceTransactionConfig", () => {
       describe("From Live", () => {
         describe("Coin", () => {
-          it("should return the fields for a normal transaction without domain", () => {
+          it("should return the fields for a normal transaction without domain", async () => {
             const transaction: EvmTransaction = {
               ...baseTransaction,
               amount: new BigNumber(100),
@@ -79,7 +79,7 @@ describe("EVM Family", () => {
             };
 
             expect(
-              getDeviceTransactionConfig({
+              await getDeviceTransactionConfig({
                 account: account,
                 parentAccount: undefined,
                 transaction,
@@ -100,7 +100,7 @@ describe("EVM Family", () => {
             ]);
           });
 
-          it("should return the fields for a normal transaction with domain", () => {
+          it("should return the fields for a normal transaction with domain", async () => {
             const transaction: EvmTransaction = {
               ...baseTransaction,
               amount: new BigNumber(100),
@@ -114,7 +114,7 @@ describe("EVM Family", () => {
             };
 
             expect(
-              getDeviceTransactionConfig({
+              await getDeviceTransactionConfig({
                 account: account,
                 parentAccount: undefined,
                 transaction,
@@ -137,7 +137,7 @@ describe("EVM Family", () => {
         });
 
         describe("Tokens", () => {
-          it("should return the fields for a token transfer transaction without domain", () => {
+          it("should return the fields for a token transfer transaction without domain", async () => {
             const transaction: EvmTransaction = {
               ...baseTransaction,
               amount: new BigNumber(100),
@@ -145,7 +145,7 @@ describe("EVM Family", () => {
             };
 
             expect(
-              getDeviceTransactionConfig({
+              await getDeviceTransactionConfig({
                 account: tokenAccount,
                 parentAccount: account,
                 transaction,
@@ -166,7 +166,7 @@ describe("EVM Family", () => {
             ]);
           });
 
-          it("should return the fields for a token transfer transaction with domain", () => {
+          it("should return the fields for a token transfer transaction with domain", async () => {
             const transaction: EvmTransaction = {
               ...baseTransaction,
               amount: new BigNumber(100),
@@ -180,7 +180,7 @@ describe("EVM Family", () => {
             };
 
             expect(
-              getDeviceTransactionConfig({
+              await getDeviceTransactionConfig({
                 account: account,
                 parentAccount: undefined,
                 transaction,
@@ -218,7 +218,7 @@ describe("EVM Family", () => {
             const status = await getTransactionStatus(account, nftTransaction);
 
             expect(
-              getDeviceTransactionConfig({
+              await getDeviceTransactionConfig({
                 account: tokenAccount,
                 parentAccount: account,
                 transaction: nftTransaction,
@@ -270,7 +270,7 @@ describe("EVM Family", () => {
             const status = await getTransactionStatus(account, nftTransaction);
 
             expect(
-              getDeviceTransactionConfig({
+              await getDeviceTransactionConfig({
                 account: tokenAccount,
                 parentAccount: account,
                 transaction: nftTransaction,
@@ -316,7 +316,7 @@ describe("EVM Family", () => {
 
       describe("From Wallet API", () => {
         describe("Coin", () => {
-          it("should return the fields for a normal transaction", () => {
+          it("should return the fields for a normal transaction", async () => {
             const transaction = {
               ...baseTransaction,
               amount: new BigNumber(100),
@@ -324,7 +324,7 @@ describe("EVM Family", () => {
             };
 
             expect(
-              getDeviceTransactionConfig({
+              await getDeviceTransactionConfig({
                 account: account,
                 parentAccount: undefined,
                 transaction,
@@ -347,7 +347,7 @@ describe("EVM Family", () => {
         });
 
         describe("Tokens", () => {
-          it("should return the fields for a token transfer transaction", () => {
+          it("should return the fields for a token transfer transaction", async () => {
             const transaction = {
               ...baseTransaction,
               amount: new BigNumber(0),
@@ -359,7 +359,7 @@ describe("EVM Family", () => {
             };
 
             expect(
-              getDeviceTransactionConfig({
+              await getDeviceTransactionConfig({
                 account: account,
                 parentAccount: undefined,
                 transaction,
@@ -381,7 +381,7 @@ describe("EVM Family", () => {
             ]);
           });
 
-          it("should return the fields for a token allowance transaction", () => {
+          it("should return the fields for a token allowance transaction", async () => {
             const transaction = {
               ...baseTransaction,
               amount: new BigNumber(0),
@@ -393,7 +393,7 @@ describe("EVM Family", () => {
             };
 
             expect(
-              getDeviceTransactionConfig({
+              await getDeviceTransactionConfig({
                 account: account,
                 parentAccount: undefined,
                 transaction,
@@ -416,7 +416,7 @@ describe("EVM Family", () => {
             ]);
           });
 
-          it("should return the fields for an unlimited token allowance transaction", () => {
+          it("should return the fields for an unlimited token allowance transaction", async () => {
             const transaction = {
               ...baseTransaction,
               amount: new BigNumber(0),
@@ -428,7 +428,7 @@ describe("EVM Family", () => {
             };
 
             expect(
-              getDeviceTransactionConfig({
+              await getDeviceTransactionConfig({
                 account: account,
                 parentAccount: undefined,
                 transaction,
@@ -454,7 +454,7 @@ describe("EVM Family", () => {
 
         describe("NFTs", () => {
           describe("ERC721", () => {
-            it("should return the fields for an ERC721 transferFrom transaction", () => {
+            it("should return the fields for an ERC721 transferFrom transaction", async () => {
               const transaction = {
                 ...baseTransaction,
                 amount: new BigNumber(0),
@@ -466,7 +466,7 @@ describe("EVM Family", () => {
               };
 
               expect(
-                getDeviceTransactionConfig({
+                await getDeviceTransactionConfig({
                   account: accountWithNfts,
                   parentAccount: undefined,
                   transaction,
@@ -503,7 +503,7 @@ describe("EVM Family", () => {
               ]);
             });
 
-            it("should return the fields for an ERC721 safeTransferFrom transaction", () => {
+            it("should return the fields for an ERC721 safeTransferFrom transaction", async () => {
               const transaction = {
                 ...baseTransaction,
                 amount: new BigNumber(0),
@@ -515,7 +515,7 @@ describe("EVM Family", () => {
               };
 
               expect(
-                getDeviceTransactionConfig({
+                await getDeviceTransactionConfig({
                   account: accountWithNfts,
                   parentAccount: undefined,
                   transaction,
@@ -552,7 +552,7 @@ describe("EVM Family", () => {
               ]);
             });
 
-            it("should return the fields for an ERC721 safeTransferFromWithData transaction", () => {
+            it("should return the fields for an ERC721 safeTransferFromWithData transaction", async () => {
               const transaction = {
                 ...baseTransaction,
                 amount: new BigNumber(0),
@@ -564,7 +564,7 @@ describe("EVM Family", () => {
               };
 
               expect(
-                getDeviceTransactionConfig({
+                await getDeviceTransactionConfig({
                   account: accountWithNfts,
                   parentAccount: undefined,
                   transaction,
@@ -601,7 +601,7 @@ describe("EVM Family", () => {
               ]);
             });
 
-            it("should return the fields for an ERC721 approve transaction", () => {
+            it("should return the fields for an ERC721 approve transaction", async () => {
               const transaction = {
                 ...baseTransaction,
                 amount: new BigNumber(0),
@@ -613,7 +613,7 @@ describe("EVM Family", () => {
               };
 
               expect(
-                getDeviceTransactionConfig({
+                await getDeviceTransactionConfig({
                   account: accountWithNfts,
                   parentAccount: undefined,
                   transaction,
@@ -650,7 +650,7 @@ describe("EVM Family", () => {
               ]);
             });
 
-            it("should return the fields for an ERC721 setApprovalForAll true transaction", () => {
+            it("should return the fields for an ERC721 setApprovalForAll true transaction", async () => {
               const transaction = {
                 ...baseTransaction,
                 amount: new BigNumber(0),
@@ -662,7 +662,7 @@ describe("EVM Family", () => {
               };
 
               expect(
-                getDeviceTransactionConfig({
+                await getDeviceTransactionConfig({
                   account: accountWithNfts,
                   parentAccount: undefined,
                   transaction,
@@ -694,7 +694,7 @@ describe("EVM Family", () => {
               ]);
             });
 
-            it("should return the fields for an ERC721 setApprovalForAll false transaction", () => {
+            it("should return the fields for an ERC721 setApprovalForAll false transaction", async () => {
               const transaction = {
                 ...baseTransaction,
                 amount: new BigNumber(0),
@@ -706,7 +706,7 @@ describe("EVM Family", () => {
               };
 
               expect(
-                getDeviceTransactionConfig({
+                await getDeviceTransactionConfig({
                   account: accountWithNfts,
                   parentAccount: undefined,
                   transaction,
@@ -740,7 +740,7 @@ describe("EVM Family", () => {
           });
 
           describe("ERC1155", () => {
-            it("should return the fields for an ERC1155 safeTransferFrom transaction", () => {
+            it("should return the fields for an ERC1155 safeTransferFrom transaction", async () => {
               const transaction = {
                 ...baseTransaction,
                 amount: new BigNumber(0),
@@ -752,7 +752,7 @@ describe("EVM Family", () => {
               };
 
               expect(
-                getDeviceTransactionConfig({
+                await getDeviceTransactionConfig({
                   account: accountWithNfts,
                   parentAccount: undefined,
                   transaction,
@@ -794,7 +794,7 @@ describe("EVM Family", () => {
               ]);
             });
 
-            it("should return the fields for an ERC1155 safeBatchTransferFrom transaction", () => {
+            it("should return the fields for an ERC1155 safeBatchTransferFrom transaction", async () => {
               const transaction = {
                 ...baseTransaction,
                 amount: new BigNumber(0),
@@ -806,7 +806,7 @@ describe("EVM Family", () => {
               };
 
               expect(
-                getDeviceTransactionConfig({
+                await getDeviceTransactionConfig({
                   account: accountWithNfts,
                   parentAccount: undefined,
                   transaction,
@@ -843,7 +843,7 @@ describe("EVM Family", () => {
               ]);
             });
 
-            it("should return the fields for an ERC1155 setApprovalForAll true transaction", () => {
+            it("should return the fields for an ERC1155 setApprovalForAll true transaction", async () => {
               const transaction = {
                 ...baseTransaction,
                 amount: new BigNumber(0),
@@ -855,7 +855,7 @@ describe("EVM Family", () => {
               };
 
               expect(
-                getDeviceTransactionConfig({
+                await getDeviceTransactionConfig({
                   account: accountWithNfts,
                   parentAccount: undefined,
                   transaction,
@@ -887,7 +887,7 @@ describe("EVM Family", () => {
               ]);
             });
 
-            it("should return the fields for an ERC1155 setApprovalForAll false transaction", () => {
+            it("should return the fields for an ERC1155 setApprovalForAll false transaction", async () => {
               const transaction = {
                 ...baseTransaction,
                 amount: new BigNumber(0),
@@ -899,7 +899,7 @@ describe("EVM Family", () => {
               };
 
               expect(
-                getDeviceTransactionConfig({
+                await getDeviceTransactionConfig({
                   account: accountWithNfts,
                   parentAccount: undefined,
                   transaction,
@@ -933,7 +933,7 @@ describe("EVM Family", () => {
           });
         });
 
-        it("should fallback on other cases without amount", () => {
+        it("should fallback on other cases without amount", async () => {
           const transaction = {
             ...baseTransaction,
             amount: new BigNumber(0),
@@ -942,7 +942,7 @@ describe("EVM Family", () => {
           };
 
           expect(
-            getDeviceTransactionConfig({
+            await getDeviceTransactionConfig({
               account: account,
               parentAccount: undefined,
               transaction,
@@ -968,7 +968,7 @@ describe("EVM Family", () => {
           ]);
         });
 
-        it("should fallback on other cases with amount", () => {
+        it("should fallback on other cases with amount", async () => {
           const transaction = {
             ...baseTransaction,
             amount: new BigNumber(1),
@@ -977,7 +977,7 @@ describe("EVM Family", () => {
           };
 
           expect(
-            getDeviceTransactionConfig({
+            await getDeviceTransactionConfig({
               account: account,
               parentAccount: undefined,
               transaction,
@@ -1014,7 +1014,7 @@ describe("EVM Family", () => {
         const status = await getTransactionStatus(account, coinTransaction);
 
         expect(
-          getDeviceTransactionConfig({
+          await getDeviceTransactionConfig({
             account,
             parentAccount: undefined,
             transaction: coinTransaction,

--- a/libs/coin-modules/coin-evm/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-evm/src/deviceTransactionConfig.ts
@@ -15,10 +15,10 @@ import { getCryptoAssetsStore } from "./cryptoAssetsStore";
 
 type DeviceTransactionField = CommonDeviceTransactionField;
 
-const inferDeviceTransactionConfigWalletApi = (
+const inferDeviceTransactionConfigWalletApi = async (
   transaction: EvmTransaction,
   mainAccount: Account,
-): Array<DeviceTransactionField> => {
+): Promise<Array<DeviceTransactionField>> => {
   if (!transaction.data) throw new Error();
   const abiCoder = ethers.AbiCoder.defaultAbiCoder();
   const fields: Array<DeviceTransactionField> = [];
@@ -371,7 +371,7 @@ const inferDeviceTransactionConfigWalletApi = (
 /**
  * Method responsible for creating the summary of the screens visible on the nano
  */
-const getDeviceTransactionConfig = ({
+const getDeviceTransactionConfig = async ({
   account,
   parentAccount,
   transaction,
@@ -380,7 +380,7 @@ const getDeviceTransactionConfig = ({
   parentAccount: Account | null | undefined;
   transaction: EvmTransaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> => {
+}): Promise<Array<DeviceTransactionField>> => {
   const mainAccount = getMainAccount(account, parentAccount);
   const { mode } = transaction;
   const fields: Array<DeviceTransactionField> = [];
@@ -392,7 +392,7 @@ const getDeviceTransactionConfig = ({
       // For contract interactions
       if (transaction.data) {
         try {
-          fields.push(...inferDeviceTransactionConfigWalletApi(transaction, mainAccount));
+          fields.push(...(await inferDeviceTransactionConfigWalletApi(transaction, mainAccount)));
         } catch (e) {
           fields.push(
             {

--- a/libs/coin-modules/coin-filecoin/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/deviceTransactionConfig.ts
@@ -40,12 +40,12 @@ export type ExtraDeviceTransactionField =
 
 export type DeviceTransactionField = CommonDeviceTransactionField | ExtraDeviceTransactionField;
 
-function getDeviceTransactionConfig(input: {
+async function getDeviceTransactionConfig(input: {
   account: AccountLike;
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const tokenTransfer = input.account.type === AccountType.TokenAccount;
   const subAccount = tokenTransfer ? (input.account as TokenAccount) : null;
 

--- a/libs/coin-modules/coin-hedera/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-hedera/src/deviceTransactionConfig.ts
@@ -3,7 +3,7 @@ import type { Transaction, TransactionStatus } from "./types";
 import type { CommonDeviceTransactionField as DeviceTransactionField } from "@ledgerhq/coin-framework/transaction/common";
 import { isTokenAssociateTransaction } from "./logic";
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   transaction,
   status: { estimatedFees },
 }: {
@@ -11,7 +11,7 @@ function getDeviceTransactionConfig({
   parentAccount?: Account;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const fields: Array<DeviceTransactionField> = [];
 
   const method = (() => {

--- a/libs/coin-modules/coin-icon/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-icon/src/deviceTransactionConfig.ts
@@ -8,7 +8,7 @@ export type ExtraDeviceTransactionField = {
   label: string;
 };
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   transaction,
   account,
   parentAccount,
@@ -18,7 +18,7 @@ function getDeviceTransactionConfig({
   parentAccount?: Account;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const fields: Array<DeviceTransactionField> = [];
   const mainAccount = getMainAccount(account, parentAccount);
   const { mode } = transaction;

--- a/libs/coin-modules/coin-internet_computer/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-internet_computer/src/bridge/deviceTransactionConfig.ts
@@ -9,14 +9,14 @@ import { methodToString } from "../common-logic/utils";
 
 const currency = getCryptoCurrencyById("internet_computer");
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   transaction,
 }: {
   account: AccountLike;
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<CommonDeviceTransactionField> {
+}): Promise<Array<CommonDeviceTransactionField>> {
   const fields: Array<CommonDeviceTransactionField> = [];
   fields.push({
     type: "text",

--- a/libs/coin-modules/coin-kaspa/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-kaspa/src/deviceTransactionConfig.ts
@@ -2,7 +2,7 @@ import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus } from "./types";
 import type { CommonDeviceTransactionField as DeviceTransactionField } from "@ledgerhq/coin-framework/transaction/common";
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   transaction,
   status: { estimatedFees },
 }: {
@@ -10,7 +10,7 @@ function getDeviceTransactionConfig({
   parentAccount?: Account;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const fields: Array<DeviceTransactionField> = [];
 
   if (transaction.useAllAmount) {

--- a/libs/coin-modules/coin-mina/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/deviceTransactionConfig.ts
@@ -2,12 +2,12 @@ import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus } from "../types/common";
 import type { CommonDeviceTransactionField as DeviceTransactionField } from "@ledgerhq/coin-framework/transaction/common";
 
-function getDeviceTransactionConfig(_input: {
+async function getDeviceTransactionConfig(_input: {
   account: AccountLike;
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const fields: Array<DeviceTransactionField> = [];
   return fields;
 }

--- a/libs/coin-modules/coin-module-boilerplate/src/bridge/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/bridge/deviceTransactionConfig.test.ts
@@ -2,21 +2,19 @@ import getDeviceTransactionConfig from "./deviceTransactionConfig";
 import BigNumber from "bignumber.js";
 
 describe("getDeviceTransactionConfig", () => {
-  it("should return amount field when it's more than 0", () => {
-    expect(
-      getDeviceTransactionConfig({
-        transaction: {},
-        status: { amount: new BigNumber(1), estimatedFees: new BigNumber(0) },
-      } as any)[0],
-    ).toEqual({ type: "amount", label: "Amount" });
+  it("should return amount field when it's more than 0", async () => {
+    const result = await getDeviceTransactionConfig({
+      transaction: {},
+      status: { amount: new BigNumber(1), estimatedFees: new BigNumber(0) },
+    } as any);
+    expect(result[0]).toEqual({ type: "amount", label: "Amount" });
   });
 
-  it("should return fee field when it's more than 0", () => {
-    expect(
-      getDeviceTransactionConfig({
-        transaction: {},
-        status: { amount: new BigNumber(0), estimatedFees: new BigNumber(1) },
-      } as any)[0],
-    ).toEqual({ type: "fees", label: "Fees" });
+  it("should return fee field when it's more than 0", async () => {
+    const result = await getDeviceTransactionConfig({
+      transaction: {},
+      status: { amount: new BigNumber(0), estimatedFees: new BigNumber(1) },
+    } as any);
+    expect(result[0]).toEqual({ type: "fees", label: "Fees" });
   });
 });

--- a/libs/coin-modules/coin-module-boilerplate/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/bridge/deviceTransactionConfig.ts
@@ -3,7 +3,7 @@ import type { Transaction, TransactionStatus } from "../types";
 import type { CommonDeviceTransactionField } from "@ledgerhq/coin-framework/transaction/common";
 
 // This method adds additional fields that need to be reviewed when signing a transaction on the device.
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   transaction: {},
   status: { amount, estimatedFees },
 }: {
@@ -11,7 +11,7 @@ function getDeviceTransactionConfig({
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<CommonDeviceTransactionField> {
+}): Promise<Array<CommonDeviceTransactionField>> {
   const fields: Array<CommonDeviceTransactionField> = [];
 
   if (!amount.isZero()) {

--- a/libs/coin-modules/coin-multiversx/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-multiversx/src/deviceTransactionConfig.ts
@@ -6,7 +6,7 @@ import { decodeTokenAccountId, getAccountCurrency } from "@ledgerhq/coin-framewo
 import { Account } from "@ledgerhq/types-live";
 import { isAmountSpentFromBalance } from "./logic";
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   account,
   transaction,
   status: { estimatedFees },
@@ -14,7 +14,7 @@ function getDeviceTransactionConfig({
   account: Account;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const fields: Array<DeviceTransactionField> = [];
 
   const { subAccountId } = transaction;

--- a/libs/coin-modules/coin-near/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-near/src/deviceTransactionConfig.ts
@@ -1,11 +1,11 @@
 import type { CommonDeviceTransactionField as DeviceTransactionField } from "@ledgerhq/coin-framework/transaction/common";
 import type { Transaction } from "./types";
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   transaction,
 }: {
   transaction: Transaction;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const fields: Array<DeviceTransactionField> = [];
 
   const confirmField = {

--- a/libs/coin-modules/coin-polkadot/src/bridge/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/deviceTransactionConfig.test.ts
@@ -1,0 +1,27 @@
+import getDeviceTransactionConfig from "./deviceTransactionConfig";
+import BigNumber from "bignumber.js";
+import { AccountLike } from "@ledgerhq/types-live";
+
+describe("getDeviceTransactionConfig", () => {
+  const mockAccount: AccountLike = {
+    type: "Account",
+    currency: { id: "polkadot", family: "polkadot" },
+  } as any;
+
+  it("should return fields for send transaction", async () => {
+    const result = await getDeviceTransactionConfig({
+      account: mockAccount,
+      parentAccount: null,
+      transaction: {
+        mode: "send",
+        useAllAmount: false,
+      } as any,
+      status: {
+        amount: new BigNumber(1000000),
+      } as any,
+    });
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toEqual(expect.arrayContaining([expect.objectContaining({ type: "fees" })]));
+  });
+});

--- a/libs/coin-modules/coin-polkadot/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/deviceTransactionConfig.ts
@@ -18,12 +18,12 @@ const getSendFields = ({
 }: {
   transaction: Transaction;
   status: TransactionStatus;
-}) => {
-  const fields: { type: string; label: string; value: string }[] = [];
+}): Array<DeviceTransactionField> => {
+  const fields: Array<DeviceTransactionField> = [];
   fields.push({
     type: "text",
     label: "Balances",
-    value: transaction && transaction.useAllAmount ? "Transfer" : "Transfer keep alive",
+    value: transaction?.useAllAmount ? "Transfer" : "Transfer keep alive",
   });
   fields.push({
     type: "amount",
@@ -36,7 +36,7 @@ const getSendFields = ({
   return fields;
 };
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   account,
   parentAccount,
   transaction,
@@ -46,7 +46,7 @@ function getDeviceTransactionConfig({
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const { mode, rewardDestination } = transaction;
   const { amount } = status;
   const mainAccount = getMainAccount(account, parentAccount) as PolkadotAccount;

--- a/libs/coin-modules/coin-solana/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-solana/src/deviceTransactionConfig.ts
@@ -24,14 +24,14 @@ type DeviceTransactionField = CommonDeviceTransactionField | SolanaExtraDeviceTr
 
 export type SolanaExtraDeviceFields = SolanaExtraDeviceTransactionField["type"];
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   account,
   transaction,
 }: {
   account: AccountLike;
   parentAccount: Account | null | undefined;
   transaction: Transaction;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const { commandDescriptor } = transaction.model;
 
   return commandDescriptor ? fieldsForCommand(commandDescriptor, account) : [];
@@ -39,10 +39,10 @@ function getDeviceTransactionConfig({
 
 export default getDeviceTransactionConfig;
 
-function fieldsForCommand(
+async function fieldsForCommand(
   commandDescriptor: CommandDescriptor,
   account: AccountLike,
-): DeviceTransactionField[] {
+): Promise<DeviceTransactionField[]> {
   const { command } = commandDescriptor;
   switch (command.kind) {
     case "transfer":
@@ -70,7 +70,7 @@ function fieldsForCommand(
   }
 }
 
-function fieldsForTransfer(_command: TransferCommand): DeviceTransactionField[] {
+async function fieldsForTransfer(_command: TransferCommand): Promise<DeviceTransactionField[]> {
   const fields: Array<DeviceTransactionField> = [];
 
   fields.push({
@@ -81,7 +81,9 @@ function fieldsForTransfer(_command: TransferCommand): DeviceTransactionField[] 
   return fields;
 }
 
-function fieldsForTokenTransfer(command: TokenTransferCommand): DeviceTransactionField[] {
+async function fieldsForTokenTransfer(
+  command: TokenTransferCommand,
+): Promise<DeviceTransactionField[]> {
   const fields: Array<DeviceTransactionField> = [];
 
   fields.push({
@@ -110,7 +112,9 @@ function fieldsForTokenTransfer(command: TokenTransferCommand): DeviceTransactio
   return fields;
 }
 
-function fieldsForCreateATA(command: TokenCreateATACommand): DeviceTransactionField[] {
+async function fieldsForCreateATA(
+  command: TokenCreateATACommand,
+): Promise<DeviceTransactionField[]> {
   const fields: Array<DeviceTransactionField> = [];
 
   fields.push({
@@ -146,7 +150,9 @@ function fieldsForCreateATA(command: TokenCreateATACommand): DeviceTransactionFi
   return fields;
 }
 
-function fieldsForCreateApprove(command: TokenCreateApproveCommand): DeviceTransactionField[] {
+async function fieldsForCreateApprove(
+  command: TokenCreateApproveCommand,
+): Promise<DeviceTransactionField[]> {
   const fields: Array<DeviceTransactionField> = [];
 
   fields.push({
@@ -175,7 +181,9 @@ function fieldsForCreateApprove(command: TokenCreateApproveCommand): DeviceTrans
   return fields;
 }
 
-function fieldsForCreateRevoke(command: TokenCreateRevokeCommand): DeviceTransactionField[] {
+async function fieldsForCreateRevoke(
+  command: TokenCreateRevokeCommand,
+): Promise<DeviceTransactionField[]> {
   const fields: Array<DeviceTransactionField> = [];
 
   fields.push({
@@ -193,10 +201,10 @@ function fieldsForCreateRevoke(command: TokenCreateRevokeCommand): DeviceTransac
   return fields;
 }
 
-function fieldsForStakeCreateAccount(
+async function fieldsForStakeCreateAccount(
   command: StakeCreateAccountCommand,
   account: AccountLike,
-): DeviceTransactionField[] {
+): Promise<DeviceTransactionField[]> {
   if (account.type !== "Account") {
     throw new Error("unsupported account type");
   }
@@ -241,7 +249,9 @@ function fieldsForStakeCreateAccount(
   return fields;
 }
 
-function fieldsForStakeDelegate(command: StakeDelegateCommand): DeviceTransactionField[] {
+async function fieldsForStakeDelegate(
+  command: StakeDelegateCommand,
+): Promise<DeviceTransactionField[]> {
   const fields: Array<DeviceTransactionField> = [];
 
   fields.push({
@@ -259,7 +269,9 @@ function fieldsForStakeDelegate(command: StakeDelegateCommand): DeviceTransactio
   return fields;
 }
 
-function fieldsForStakeUndelegate(command: StakeUndelegateCommand): DeviceTransactionField[] {
+async function fieldsForStakeUndelegate(
+  command: StakeUndelegateCommand,
+): Promise<DeviceTransactionField[]> {
   const fields: Array<DeviceTransactionField> = [];
 
   fields.push({
@@ -271,7 +283,9 @@ function fieldsForStakeUndelegate(command: StakeUndelegateCommand): DeviceTransa
   return fields;
 }
 
-function fieldsForStakeWithdraw(command: StakeWithdrawCommand): DeviceTransactionField[] {
+async function fieldsForStakeWithdraw(
+  command: StakeWithdrawCommand,
+): Promise<DeviceTransactionField[]> {
   const fields: Array<DeviceTransactionField> = [];
 
   fields.push({
@@ -288,7 +302,7 @@ function fieldsForStakeWithdraw(command: StakeWithdrawCommand): DeviceTransactio
   return fields;
 }
 
-function fieldsForStakeSplit(command: StakeSplitCommand): DeviceTransactionField[] {
+async function fieldsForStakeSplit(command: StakeSplitCommand): Promise<DeviceTransactionField[]> {
   const fields: Array<DeviceTransactionField> = [];
 
   fields.push({

--- a/libs/coin-modules/coin-stacks/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-stacks/src/bridge/deviceTransactionConfig.ts
@@ -17,12 +17,12 @@ export type ExtraDeviceTransactionField =
 
 export type DeviceTransactionField = CommonDeviceTransactionField | ExtraDeviceTransactionField;
 
-function getDeviceTransactionConfig(input: {
+async function getDeviceTransactionConfig(input: {
   account: AccountLike;
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const fields: Array<DeviceTransactionField> = [];
 
   fields.push({

--- a/libs/coin-modules/coin-stellar/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-stellar/src/bridge/deviceTransactionConfig.ts
@@ -20,7 +20,7 @@ export type ExtraDeviceTransactionField =
       label: string;
     };
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   status: { amount, estimatedFees },
   transaction,
 }: {
@@ -28,7 +28,7 @@ function getDeviceTransactionConfig({
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField | ExtraDeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField | ExtraDeviceTransactionField>> {
   const { assetReference, assetOwner } = transaction;
 
   const fields: Array<DeviceTransactionField | ExtraDeviceTransactionField> = [

--- a/libs/coin-modules/coin-tezos/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-tezos/src/bridge/deviceTransactionConfig.ts
@@ -14,7 +14,7 @@ export type ExtraDeviceTransactionField =
     };
 type DeviceTransactionField = CommonDeviceTransactionField | ExtraDeviceTransactionField;
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   account,
   parentAccount,
   transaction: { mode, recipient },
@@ -24,7 +24,7 @@ function getDeviceTransactionConfig({
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const mainAccount = getMainAccount(account, parentAccount);
   const source = mainAccount.freshAddress;
   const isDelegateOperation = mode === "delegate";

--- a/libs/coin-modules/coin-ton/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-ton/src/deviceTransactionConfig.ts
@@ -7,12 +7,12 @@ import { BigNumber } from "bignumber.js";
 import { TOKEN_TRANSFER_MAX_FEE } from "./constants";
 import type { Transaction, TransactionStatus } from "./types";
 
-function getDeviceTransactionConfig(input: {
+async function getDeviceTransactionConfig(input: {
   account: AccountLike;
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const fields: Array<DeviceTransactionField> = [];
   const tokenTransfer = Boolean(input.account && isTokenAccount(input.account));
 

--- a/libs/coin-modules/coin-tron/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/deviceTransactionConfig.ts
@@ -16,7 +16,7 @@ export type ExtraDeviceTransactionField =
 
 type DeviceTransactionField = CommonDeviceTransactionField | ExtraDeviceTransactionField;
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   transaction: { votes, resource, mode, recipient },
   account,
   parentAccount,
@@ -26,7 +26,7 @@ function getDeviceTransactionConfig({
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const mainAccount = getMainAccount(account, parentAccount);
   const fields: Array<DeviceTransactionField> = [];
 

--- a/libs/coin-modules/coin-xrp/src/bridge/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-xrp/src/bridge/deviceTransactionConfig.ts
@@ -2,7 +2,7 @@ import type { AccountLike, Account } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus } from "../types";
 import type { CommonDeviceTransactionField } from "@ledgerhq/coin-framework/transaction/common";
 
-function getDeviceTransactionConfig({
+async function getDeviceTransactionConfig({
   transaction: { tag },
   status: { amount, estimatedFees },
 }: {
@@ -10,7 +10,7 @@ function getDeviceTransactionConfig({
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<CommonDeviceTransactionField> {
+}): Promise<Array<CommonDeviceTransactionField>> {
   const fields: Array<CommonDeviceTransactionField> = [];
 
   if (!amount.isZero()) {

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -179,6 +179,7 @@
     "src/hooks/useTimer.ts",
     "src/hooks/useOFACGeoBlockCheck.ts",
     "src/hooks/useShowProviderLoadingTransition.ts",
+    "src/hooks/useDeviceTransactionConfig.ts",
     "src/hw/actions/app.ts",
     "src/hw/actions/completeExchange.ts",
     "src/hw/actions/customLockScreenFetch.ts",

--- a/libs/ledger-live-common/src/hooks/useDeviceTransactionConfig.test.tsx
+++ b/libs/ledger-live-common/src/hooks/useDeviceTransactionConfig.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { TextDecoder, TextEncoder } from "util";
+
+// Polyfill for TextDecoder/TextEncoder required by Cardano dependencies
+global.TextDecoder = TextDecoder as any;
+global.TextEncoder = TextEncoder as any;
+
+// Mock the deviceTransactionConfig module before importing anything else
+jest.mock("../transaction/deviceTransactionConfig", () => ({
+  getDeviceTransactionConfig: jest.fn(),
+}));
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { useDeviceTransactionConfig } from "./useDeviceTransactionConfig";
+import { getDeviceTransactionConfig } from "../transaction/deviceTransactionConfig";
+import { Account } from "@ledgerhq/types-live";
+import { Transaction, TransactionStatus } from "../generated/types";
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "../currencies/index";
+
+const mockGetDeviceTransactionConfig = getDeviceTransactionConfig as jest.MockedFunction<
+  typeof getDeviceTransactionConfig
+>;
+
+const btc = getCryptoCurrencyById("bitcoin");
+
+describe("useDeviceTransactionConfig", () => {
+  const mockAccount: Account = {
+    type: "Account",
+    id: "test-account-id",
+    seedIdentifier: "seed-id",
+    derivationMode: "" as const,
+    index: 0,
+    freshAddress: "test-address",
+    freshAddressPath: "44'/0'/0'/0/0",
+    used: true,
+    balance: new BigNumber(1000000),
+    spendableBalance: new BigNumber(1000000),
+    creationDate: new Date(),
+    blockHeight: 100,
+    currency: btc,
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    lastSyncDate: new Date(),
+    balanceHistoryCache: {
+      HOUR: { latestDate: null, balances: [] },
+      DAY: { latestDate: null, balances: [] },
+      WEEK: { latestDate: null, balances: [] },
+    },
+    swapHistory: [],
+  };
+
+  const mockTransaction: Transaction = {
+    family: "bitcoin" as any,
+    amount: new BigNumber(100),
+    recipient: "test-recipient",
+    useAllAmount: false,
+  } as Transaction;
+
+  const mockStatus: TransactionStatus = {
+    errors: {},
+    warnings: {},
+    estimatedFees: new BigNumber(10),
+    amount: new BigNumber(100),
+    totalSpent: new BigNumber(110),
+  } as TransactionStatus;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should load device transaction config fields successfully", async () => {
+    const mockFields = [
+      { type: "amount", label: "Amount" },
+      { type: "fees", label: "Fees" },
+    ];
+
+    mockGetDeviceTransactionConfig.mockResolvedValue(mockFields as any);
+
+    const { result } = renderHook(() =>
+      useDeviceTransactionConfig({
+        account: mockAccount,
+        parentAccount: null,
+        transaction: mockTransaction,
+        status: mockStatus,
+      }),
+    );
+
+    // Initially loading
+    expect(result.current.loading).toBe(true);
+    expect(result.current.fields).toEqual([]);
+
+    // Wait for async operation
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.fields).toEqual(mockFields);
+    expect(mockGetDeviceTransactionConfig).toHaveBeenCalledWith({
+      account: mockAccount,
+      parentAccount: null,
+      transaction: mockTransaction,
+      status: mockStatus,
+    });
+  });
+
+  it("should handle errors gracefully", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    mockGetDeviceTransactionConfig.mockRejectedValue(new Error("Test error"));
+
+    const { result } = renderHook(() =>
+      useDeviceTransactionConfig({
+        account: mockAccount,
+        parentAccount: null,
+        transaction: mockTransaction,
+        status: mockStatus,
+      }),
+    );
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.fields).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to load device transaction config:",
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should reload fields when dependencies change", async () => {
+    const mockFields1 = [{ type: "amount", label: "Amount 1" }];
+    const mockFields2 = [{ type: "amount", label: "Amount 2" }];
+
+    mockGetDeviceTransactionConfig
+      .mockResolvedValueOnce(mockFields1 as any)
+      .mockResolvedValueOnce(mockFields2 as any);
+
+    const { result, rerender } = renderHook(
+      ({ transaction }) =>
+        useDeviceTransactionConfig({
+          account: mockAccount,
+          parentAccount: null,
+          transaction,
+          status: mockStatus,
+        }),
+      {
+        initialProps: { transaction: mockTransaction },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.fields).toEqual(mockFields1);
+
+    // Change transaction
+    const newTransaction = {
+      ...mockTransaction,
+      amount: new BigNumber(200),
+    };
+
+    rerender({ transaction: newTransaction });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.fields).toEqual(mockFields2);
+    expect(mockGetDeviceTransactionConfig).toHaveBeenCalledTimes(2);
+  });
+
+  it("should cleanup on unmount", async () => {
+    const mockFields = [{ type: "amount", label: "Amount" }];
+    mockGetDeviceTransactionConfig.mockResolvedValue(mockFields as any);
+
+    const { unmount } = renderHook(() =>
+      useDeviceTransactionConfig({
+        account: mockAccount,
+        parentAccount: null,
+        transaction: mockTransaction,
+        status: mockStatus,
+      }),
+    );
+
+    unmount();
+
+    // Should not throw any errors
+    expect(mockGetDeviceTransactionConfig).toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-live-common/src/hooks/useDeviceTransactionConfig.ts
+++ b/libs/ledger-live-common/src/hooks/useDeviceTransactionConfig.ts
@@ -1,0 +1,65 @@
+import { useState, useEffect } from "react";
+import { Account, AccountLike } from "@ledgerhq/types-live";
+import { Transaction, TransactionStatus } from "../generated/types";
+import {
+  getDeviceTransactionConfig,
+  DeviceTransactionField,
+} from "../transaction/deviceTransactionConfig";
+
+type UseDeviceTransactionConfigParams = {
+  account: AccountLike;
+  parentAccount: Account | null | undefined;
+  transaction: Transaction;
+  status: TransactionStatus;
+};
+
+/**
+ * Hook to fetch device transaction configuration fields asynchronously.
+ * This anticipates the future async nature of crypto assets store operations.
+ */
+export function useDeviceTransactionConfig({
+  account,
+  parentAccount,
+  transaction,
+  status,
+}: UseDeviceTransactionConfigParams): {
+  fields: DeviceTransactionField[];
+  loading: boolean;
+} {
+  const [fields, setFields] = useState<DeviceTransactionField[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadFields() {
+      try {
+        setLoading(true);
+        const result = await getDeviceTransactionConfig({
+          account,
+          parentAccount,
+          transaction,
+          status,
+        });
+        if (mounted) {
+          setFields(result);
+          setLoading(false);
+        }
+      } catch (error) {
+        console.error("Failed to load device transaction config:", error);
+        if (mounted) {
+          setFields([]);
+          setLoading(false);
+        }
+      }
+    }
+
+    loadFields();
+
+    return () => {
+      mounted = false;
+    };
+  }, [account, parentAccount, transaction, status]);
+
+  return { fields, loading };
+}

--- a/libs/ledger-live-common/src/transaction/deviceTransactionConfig.ts
+++ b/libs/ledger-live-common/src/transaction/deviceTransactionConfig.ts
@@ -6,14 +6,14 @@ import { getMainAccount } from "../account";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 
 export type DeviceTransactionField = CommonDeviceTransactionField | ExtraDeviceTransactionField;
-export function getDeviceTransactionConfig(arg: {
+export async function getDeviceTransactionConfig(arg: {
   account: AccountLike;
   parentAccount: Account | null | undefined;
   transaction: Transaction;
   status: TransactionStatus;
-}): Array<DeviceTransactionField> {
+}): Promise<Array<DeviceTransactionField>> {
   const mainAccount = getMainAccount(arg.account, arg.parentAccount);
   const f = perFamily[mainAccount.currency.family];
   if (!f) return [];
-  return f(arg);
+  return await f(arg);
 }


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD and LLM
  - UI during the device validation on any transaction flow

### 📝 Description

**Why is it going async?** because in https://github.com/LedgerHQ/ledger-live/pull/11905 we identified that some of the implementations actively lookup `TokenById`.
By propagating the future async rework of `findTokenById`, we anticipate here the requirement for this function to become async and be used asynchronously by also introducing a hook, making the rework more convenient.

<img width="717" height="413" alt="Screenshot 2025-10-16 at 13 44 24" src="https://github.com/user-attachments/assets/851c0177-aad2-426c-aab6-957fd62159b4" />


### ❓ Context


- **JIRA or GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/11905


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
