### PR TITLE
ci: Changeset rate limiting

### DIFF
--- a/patches/@changesets__get-github-info@0.6.0.patch
+++ b/patches/@changesets__get-github-info@0.6.0.patch
@@ -1,8 +1,46 @@
 diff --git a/dist/changesets-get-github-info.cjs.js b/dist/changesets-get-github-info.cjs.js
-index a74df59f8a5988f458a3476087399f5e6dfe4818..6cb2dbab81854301c5ad1525a4bf9bb12072a9ef 100644
+index a74df59f8a5988f458a3476087399f5e6dfe4818..c4e4a072deb098a0efb3e5fa8098e0cd1cc84650 100644
 --- a/dist/changesets-get-github-info.cjs.js
 +++ b/dist/changesets-get-github-info.cjs.js
-@@ -211,7 +211,7 @@ const GHDataLoader = new DataLoader__default["default"](async requests => {
+@@ -148,6 +148,19 @@ function makeQuery(repos) {
+ // getReleaseLine will be called a large number of times but it'll be called at the same time
+ // so instead of doing a bunch of network requests, we can do a single one.
+ 
++//Chain promises to provide rate limiting
++function createQueue() {
++  let last = Promise.resolve();
++
++  function add(fn) {
++    last = last.then(() => fn());
++    return last;
++  }
++
++  return { add };
++}
++
++const queue = createQueue();
+ 
+ const GHDataLoader = new DataLoader__default["default"](async requests => {
+   if (!process.env.GITHUB_TOKEN) {
+@@ -167,7 +180,7 @@ const GHDataLoader = new DataLoader__default["default"](async requests => {
+ 
+     repos[repo].push(data);
+   });
+-  const data = await fetch__default["default"]("https://api.github.com/graphql", {
++  const data = await queue.add(async () => { return await fetch__default["default"]("https://api.github.com/graphql", {
+     method: "POST",
+     headers: {
+       Authorization: `Token ${process.env.GITHUB_TOKEN}`
+@@ -175,7 +188,7 @@ const GHDataLoader = new DataLoader__default["default"](async requests => {
+     body: JSON.stringify({
+       query: makeQuery(repos)
+     })
+-  }).then(x => x.json());
++  }).then(x => x.json())});
+ 
+   if (data.errors) {
+     throw new Error(`An error occurred when fetching data from GitHub\n${JSON.stringify(data.errors, null, 2)}`);
+@@ -211,7 +224,7 @@ const GHDataLoader = new DataLoader__default["default"](async requests => {
  
      return cleanedData[repo][data.kind][data.kind === "pull" ? data.pull : data.commit];
    });
@@ -12,7 +50,7 @@ index a74df59f8a5988f458a3476087399f5e6dfe4818..6cb2dbab81854301c5ad1525a4bf9bb1
    if (!request.commit) {
      throw new Error("Please pass a commit SHA to getInfo");
 diff --git a/dist/changesets-get-github-info.esm.js b/dist/changesets-get-github-info.esm.js
-index 27e5c972ab1202ff16f5124b471f4bbcc46be2b5..e15e719adf9a6fda8d1ba003b6528120cd37a8df 100644
+index 27e5c972ab1202ff16f5124b471f4bbcc46be2b5..d50f176e9656d511bad296eee10bf7bfa02ec8f7 100644
 --- a/dist/changesets-get-github-info.esm.js
 +++ b/dist/changesets-get-github-info.esm.js
 @@ -1,5 +1,5 @@
@@ -22,7 +60,45 @@ index 27e5c972ab1202ff16f5124b471f4bbcc46be2b5..e15e719adf9a6fda8d1ba003b6528120
  
  function _defineProperty(obj, key, value) {
    if (key in obj) {
-@@ -202,7 +202,7 @@ const GHDataLoader = new DataLoader(async requests => {
+@@ -139,6 +139,19 @@ function makeQuery(repos) {
+ // getReleaseLine will be called a large number of times but it'll be called at the same time
+ // so instead of doing a bunch of network requests, we can do a single one.
+ 
++//Chain promises to provide rate limiting
++function createQueue() {
++  let last = Promise.resolve();
++
++  function add(fn) {
++    last = last.then(() => fn());
++    return last;
++  }
++
++  return { add };
++}
++
++const queue = createQueue();
+ 
+ const GHDataLoader = new DataLoader(async requests => {
+   if (!process.env.GITHUB_TOKEN) {
+@@ -158,7 +171,7 @@ const GHDataLoader = new DataLoader(async requests => {
+ 
+     repos[repo].push(data);
+   });
+-  const data = await fetch("https://api.github.com/graphql", {
++  const data = await queue.add(async () => { return await fetch("https://api.github.com/graphql", {
+     method: "POST",
+     headers: {
+       Authorization: `Token ${process.env.GITHUB_TOKEN}`
+@@ -166,7 +179,7 @@ const GHDataLoader = new DataLoader(async requests => {
+     body: JSON.stringify({
+       query: makeQuery(repos)
+     })
+-  }).then(x => x.json());
++  }).then(x => x.json())});
+ 
+   if (data.errors) {
+     throw new Error(`An error occurred when fetching data from GitHub\n${JSON.stringify(data.errors, null, 2)}`);
+@@ -202,7 +215,7 @@ const GHDataLoader = new DataLoader(async requests => {
  
      return cleanedData[repo][data.kind][data.kind === "pull" ? data.pull : data.commit];
    });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ pnpmfileChecksum: zwmwtmjd66yqvssrjrebeenwyu
 
 patchedDependencies:
   '@changesets/get-github-info@0.6.0':
-    hash: ihbfttx3a3q6odiznwmem6m4ay
+    hash: 3je6vc5oigzdzi6dv4a6zsaahi
     path: patches/@changesets__get-github-info@0.6.0.patch
   '@datadog/datadog-ci@3.11.0':
     hash: hshtsvjisk4nrwuydtrlg3tpk4
@@ -40484,7 +40484,7 @@ snapshots:
 
   '@changesets/changelog-github@0.5.0':
     dependencies:
-      '@changesets/get-github-info': 0.6.0(patch_hash=ihbfttx3a3q6odiznwmem6m4ay)
+      '@changesets/get-github-info': 0.6.0(patch_hash=3je6vc5oigzdzi6dv4a6zsaahi)
       '@changesets/types': 6.0.0
       dotenv: 8.6.0
     transitivePeerDependencies:
@@ -40547,7 +40547,7 @@ snapshots:
       fs-extra: 7.0.1
       semver: 7.7.1
 
-  '@changesets/get-github-info@0.6.0(patch_hash=ihbfttx3a3q6odiznwmem6m4ay)':
+  '@changesets/get-github-info@0.6.0(patch_hash=3je6vc5oigzdzi6dv4a6zsaahi)':
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.7.0


### PR DESCRIPTION
**So far**

Some changes to the GitHub graphql API have made it impossible to continue with the previous pagination of 500 graphQL queries in a single batch. With any more than 10 queries per batch the GitHub API now returns html. This was discussed with the support team and it has been confirmed that the html response is a timeout on the graphql server side.

As a result of reducing the batch size to 10, multiple API requests are made. While this was functioning correctly, it appears that another change has been put in place resulting in us hitting secondary API limits.

**Temporary fix**

The graphql dataloader submits all requests at the same time, meaning that for our reduced batch sizes, we're raising a large number of requests. This change provides promise chaining to ensure that only one request happens concurrently.

**Backlog item**

This fix needs to be expanded to allow for parallelism while observing githubs rate limit headers to back off appropriately. This would be more resilient and would result in quicker changeset computation

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-22380