### PR TITLE
fix(signer-eth): Add locked error mapping

### DIFF
--- a/.changeset/heavy-fireants-guess.md
+++ b/.changeset/heavy-fireants-guess.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-signer-evm": patch
+---
+
+Add locked error mapping

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -17,7 +17,11 @@ import {
   hexaStringToBuffer,
 } from "@ledgerhq/device-management-kit";
 import { EIP712Message } from "@ledgerhq/types-live";
-import { EthAppPleaseEnableContractData, UserRefusedOnDevice } from "@ledgerhq/errors";
+import {
+  EthAppPleaseEnableContractData,
+  LockedDeviceError,
+  UserRefusedOnDevice,
+} from "@ledgerhq/errors";
 import { EvmAddress, EvmSigner, EvmSignerEvent } from "@ledgerhq/coin-evm/types/signer";
 import type { LoadConfig, ResolutionConfig } from "@ledgerhq/hw-app-eth/lib/services/types";
 
@@ -46,6 +50,8 @@ export class DmkSignerEth implements EvmSigner {
     }
 
     switch (error.errorCode) {
+      case "5515":
+        return new LockedDeviceError();
       case "6985":
         return new UserRefusedOnDevice();
       case "6a80":


### PR DESCRIPTION
Added locked error mapping in DMK adapter in live-signer-evm

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-22336](https://ledgerhq.atlassian.net/browse/LIVE-22336)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22336]: https://ledgerhq.atlassian.net/browse/LIVE-22336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ