### PR TITLE
ci: Fix bundle size reporting

### DIFF
--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -35,6 +35,7 @@ jobs:
     secrets: inherit
     with:
       macos-specificity-runner-label: "performance-pool"
+      skip-bundle-size-reporting: true
       max-shards: 1
       skip-pod-checks: "true"
 

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -600,7 +600,7 @@ jobs:
   report-bundle-sizes:
     name: "Build Mobile > Report Bundle Sizes"
     runs-on: [ ubuntu-22.04 ]
-    if: needs.build-ios.outputs.js-bundle-size != '' && needs.build-android.outputs.js-bundle-size != '' && !inputs.skip-bundle-size-reporting
+    if: needs.build-ios.outputs.js-bundle-size != '' && needs.build-android.outputs.js-bundle-size != ''
     needs: [ build-ios, build-android ]
     steps:
       - name: generate token
@@ -616,6 +616,7 @@ jobs:
               \"main.android.jsbundle\" : { \"size\": ${{ needs.build-android.outputs.js-bundle-size }}}
           }" > mobile.metafile.json
       - uses: LedgerHQ/ledger-live/tools/actions/build-checks@develop
+        if: ${{ !inputs.skip-bundle-size-reporting }}
         with:
           token: ${{ steps.generate-token.outputs.token }}
           baseBranch: ${{ inputs.base_ref || 'develop' }}


### PR DESCRIPTION
Bundle size generation is required for push flows but it should not report to a PR. This currently results in Push flow failures