### PR TITLE
test(e2e): Add workaround to ignore Detox Webview sync issue

### DIFF
--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -121,4 +121,13 @@ export default class CommonPage {
   async enableSynchronization() {
     await device.enableSynchronization();
   }
+
+  // Switching from webview to native view causes Detox issues. This workaround waits for a non existing element to flush detox queue
+  async flushDetoxSyncQueue(): Promise<void> {
+    try {
+      await waitForElementById("__flush_queue__", 500);
+    } catch {
+      console.log("Intentional failure to flush detox queue");
+    }
+  }
 }

--- a/e2e/mobile/page/trade/earnDasboard.page.ts
+++ b/e2e/mobile/page/trade/earnDasboard.page.ts
@@ -149,6 +149,7 @@ export default class EarnDashboardPage {
     const earnButton = getWebElementByTestId(this.stakeCryptoAssetsButton, 0, "data-test-id");
     await scrollToWebElement(earnButton);
     await tapWebElementByElement(earnButton);
+    await app.common.flushDetoxSyncQueue();
     await app.stake.verifyChooseAssetPage();
   }
 }

--- a/e2e/mobile/specs/earn/correctEarnPage_ETH_1_noStaking.spec.ts
+++ b/e2e/mobile/specs/earn/correctEarnPage_ETH_1_noStaking.spec.ts
@@ -3,7 +3,6 @@ import { runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest } from ".
 
 const testConfig = {
   account: Account.ETH_1,
-  earnButtonId: "3bd9fab1-fb6c-5fc2-a8b6-a1d810365b1e",
   staking: false,
   tmsLinks: ["B2CQA-3679"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
@@ -14,5 +13,4 @@ runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest(
   testConfig.staking,
   testConfig.tmsLinks,
   testConfig.tags,
-  testConfig.earnButtonId,
 );

--- a/e2e/mobile/specs/earn/correctEarnPage_NEAR_2_noStaking.spec.ts
+++ b/e2e/mobile/specs/earn/correctEarnPage_NEAR_2_noStaking.spec.ts
@@ -3,7 +3,6 @@ import { runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest } from ".
 
 const testConfig = {
   account: Account.NEAR_2,
-  earnButtonId: "4969e17f-213a-5180-809b-ee16abe3f400",
   staking: false,
   tmsLinks: ["B2CQA-3682"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
@@ -14,5 +13,4 @@ runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest(
   testConfig.staking,
   testConfig.tmsLinks,
   testConfig.tags,
-  testConfig.earnButtonId,
 );

--- a/e2e/mobile/specs/earn/correctEarnPage_SOL_2_noStaking.spec.ts
+++ b/e2e/mobile/specs/earn/correctEarnPage_SOL_2_noStaking.spec.ts
@@ -3,7 +3,6 @@ import { runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest } from ".
 
 const testConfig = {
   account: Account.SOL_2,
-  earnButtonId: "7db7743d-3e2f-592b-b3f8-db5916290ec0",
   staking: false,
   tmsLinks: ["B2CQA-3680"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
@@ -14,5 +13,4 @@ runCorrectEarnPageIsLoadedDependingOnUserStakingSituationTest(
   testConfig.staking,
   testConfig.tmsLinks,
   testConfig.tags,
-  testConfig.earnButtonId,
 );

--- a/e2e/mobile/specs/earn/earn.ts
+++ b/e2e/mobile/specs/earn/earn.ts
@@ -56,7 +56,6 @@ export async function runInlineAddAccountTest(
 
 export async function runStartETHStakingFromEarnDashboardTest(
   account: Account,
-  earnButtonId: string,
   provider: Provider,
   tmsLinks: string[],
   tags: string[],

--- a/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_KILN.spec.ts
+++ b/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_KILN.spec.ts
@@ -3,7 +3,6 @@ import { runStartETHStakingFromEarnDashboardTest } from "./earn";
 
 const testConfig = {
   account: Account.ETH_1,
-  earnButtonId: "3bd9fab1-fb6c-5fc2-a8b6-a1d810365b1e",
   provider: Provider.KILN,
   tmsLinks: ["B2CQA-3678"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
@@ -11,7 +10,6 @@ const testConfig = {
 
 runStartETHStakingFromEarnDashboardTest(
   testConfig.account,
-  testConfig.earnButtonId,
   testConfig.provider,
   testConfig.tmsLinks,
   testConfig.tags,

--- a/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_LIDO.spec.ts
+++ b/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_LIDO.spec.ts
@@ -3,7 +3,6 @@ import { runStartETHStakingFromEarnDashboardTest } from "./earn";
 
 const testConfig = {
   account: Account.ETH_1,
-  earnButtonId: "3bd9fab1-fb6c-5fc2-a8b6-a1d810365b1e",
   provider: Provider.LIDO,
   tmsLinks: ["B2CQA-3676, B2CQA-1713"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
@@ -11,7 +10,6 @@ const testConfig = {
 
 runStartETHStakingFromEarnDashboardTest(
   testConfig.account,
-  testConfig.earnButtonId,
   testConfig.provider,
   testConfig.tmsLinks,
   testConfig.tags,

--- a/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_STADER_LABS.spec.ts
+++ b/e2e/mobile/specs/earn/startStakingFromEarnDashboard_ETH_STADER_LABS.spec.ts
@@ -3,7 +3,6 @@ import { runStartETHStakingFromEarnDashboardTest } from "./earn";
 
 const testConfig = {
   account: Account.ETH_1,
-  earnButtonId: "3bd9fab1-fb6c-5fc2-a8b6-a1d810365b1e",
   provider: Provider.STADER_LABS,
   tmsLinks: ["B2CQA-3677"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax"],
@@ -11,7 +10,6 @@ const testConfig = {
 
 runStartETHStakingFromEarnDashboardTest(
   testConfig.account,
-  testConfig.earnButtonId,
   testConfig.provider,
   testConfig.tmsLinks,
   testConfig.tags,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* Workaround to bypass Detox sync issue when switching from Webview to Native View
* Deleting not needed parameters

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA**: [QAA-860](https://ledgerhq.atlassian.net/browse/QAA-860)
- [CI RUN](https://github.com/LedgerHQ/ledger-live/actions/runs/18691188642)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-860]: https://ledgerhq.atlassian.net/browse/QAA-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ