### PR TITLE
fix(lld-llm): Wrong error "Device connection error" when user is on wrong experimental provider

### DIFF
--- a/.changeset/bright-tigers-swim.md
+++ b/.changeset/bright-tigers-swim.md
@@ -1,0 +1,8 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-dmk-desktop": patch
+"@ledgerhq/live-dmk-mobile": patch
+---
+
+Map DMK InvalidGetFirmwareMetadataResponseError error to FirmwareNotRecognizedErrorComponent

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackDmkErrorsEvents.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackDmkErrorsEvents.ts
@@ -60,6 +60,10 @@ const ErrorEvents = [
       "UnknownDeviceExchangeError",
     ],
   },
+  {
+    name: "Invalid Provider",
+    tags: ["InvalidGetFirmwareMetadataResponseError"],
+  },
 ];
 
 export const useTrackDmkErrorsEvents = ({

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -75,7 +75,7 @@ import { isSyncOnboardingSupported } from "@ledgerhq/live-common/device/use-case
 import NoSuchAppOnProviderErrorComponent from "./NoSuchAppOnProviderErrorComponent";
 import Image from "~/renderer/components/Image";
 import Nano from "~/renderer/images/nanoS.v4.svg";
-import { DmkError } from "@ledgerhq/live-dmk-desktop";
+import { DmkError, isInvalidGetFirmwareMetadataResponseError } from "@ledgerhq/live-dmk-desktop";
 import { isDmkError } from "@ledgerhq/live-common/deviceSDK/tasks/core";
 import { isDisconnectedWhileSendingApduError } from "@ledgerhq/live-dmk-desktop";
 
@@ -749,8 +749,10 @@ const FirmwareNotRecognizedErrorComponent: React.FC<{
 }> = ({ onRetry }) => {
   const { t } = useTranslation();
   const history = useHistory();
+  const dispatch = useDispatch();
   const goToExperimentalSettings = () => {
     setDrawer();
+    dispatch(closeAllModal());
     history.push("/settings/experimental");
   };
   return (
@@ -827,7 +829,10 @@ export const renderError = ({
     return renderLockedDeviceError({ t, onRetry, device, inlineRetry });
   } else if (tmpError instanceof DeviceNotOnboarded) {
     return <DeviceNotOnboardedErrorComponent t={t} device={device} />;
-  } else if (tmpError instanceof FirmwareNotRecognized) {
+  } else if (
+    tmpError instanceof FirmwareNotRecognized ||
+    isInvalidGetFirmwareMetadataResponseError(tmpError)
+  ) {
     return <FirmwareNotRecognizedErrorComponent onRetry={onRetry} />;
   } else if (tmpError instanceof CompleteExchangeError) {
     if (tmpError.title === "userRefused") {

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackDmkErrorsEvents.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackDmkErrorsEvents.ts
@@ -60,6 +60,10 @@ const ErrorEvents = [
       "UnknownDeviceExchangeError",
     ],
   },
+  {
+    name: "Invalid Provider",
+    tags: ["InvalidGetFirmwareMetadataResponseError"],
+  },
 ];
 
 export const useTrackDmkErrorsEvents = ({

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -4,6 +4,7 @@ import {
   LockedDeviceError,
   PeerRemovedPairing,
   WrongDeviceForAccount,
+  FirmwareNotRecognized,
 } from "@ledgerhq/errors";
 import { isSyncOnboardingSupported } from "@ledgerhq/live-common/device/use-cases/screenSpecs";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
@@ -53,6 +54,7 @@ import ModalLock from "../ModalLock";
 import { RootStackParamList } from "../RootNavigator/types/RootNavigator";
 import TermsFooter, { TermsProviders } from "../TermsFooter";
 import { BleForgetDeviceIllustration } from "../BleDevicePairingFlow/BleDevicePairingContent/BleForgetDeviceIllustration";
+import { isInvalidGetFirmwareMetadataResponseError } from "@ledgerhq/live-dmk-mobile";
 
 export const Wrapper = styled(Flex).attrs({
   flex: 1,
@@ -528,65 +530,116 @@ export function renderError({
   device?: Device;
   hasExportLogButton?: boolean;
 }) {
-  const onPress = () => {
-    if (managerAppName && navigation) {
-      navigation.navigate(NavigatorName.Base, {
-        screen: NavigatorName.Main,
-        params: {
-          screen: NavigatorName.MyLedger,
-          params: {
-            screen: ScreenName.MyLedgerChooseDevice,
-            params: {
-              tab: MANAGER_TABS.INSTALLED_APPS,
-              updateModalOpened: true,
-              device,
-            },
-          },
-        },
-      });
-    } else if (onRetry) {
-      onRetry();
+  switch (true) {
+    case error instanceof LockedDeviceError:
+      return renderLockedDeviceError({ t, onRetry, device });
+
+    case error instanceof PeerRemovedPairing: {
+      // User needs to forget the device on their phone settings
+      const productName = device ? getDeviceModel(device?.modelId).productName : "Ledger Device";
+      return (
+        <Flex flex={1}>
+          <BleForgetDeviceIllustration productName={productName} onRetry={() => onRetry?.()} />
+        </Flex>
+      );
     }
-  };
 
-  if (error instanceof LockedDeviceError) {
-    return renderLockedDeviceError({ t, onRetry, device });
+    default: {
+      const renderErrorButtons = (error: Error, managerAppName?: string) => {
+        type CTA = "OpenExperimentalSettings" | "Retry" | "None";
+        const getCTA = (error: Error, hasRetry: boolean): CTA => {
+          if (
+            isInvalidGetFirmwareMetadataResponseError(error) ||
+            error instanceof FirmwareNotRecognized
+          ) {
+            return "OpenExperimentalSettings";
+          } else if (!(error instanceof PeerRemovedPairing) && hasRetry) {
+            return "Retry";
+          }
+          return "None";
+        };
+
+        const hasRetry = Boolean(onRetry || managerAppName);
+        const cta = getCTA(error, hasRetry);
+
+        switch (cta) {
+          case "OpenExperimentalSettings": {
+            const onPressGoToExperimentalSettings = () => {
+              if (navigation) {
+                navigation.navigate(NavigatorName.Base, {
+                  screen: NavigatorName.Settings,
+                  params: {
+                    screen: ScreenName.ExperimentalSettings,
+                  },
+                });
+              }
+            };
+            return (
+              <Flex alignSelf="stretch" mb={0} mt={0}>
+                <StyledButton
+                  event="DeviceActionErrorRetry"
+                  type="main"
+                  size="large"
+                  outline={false}
+                  title={t("errors.InvalidGetFirmwareMetadataResponseError.openSettings")}
+                  onPress={onPressGoToExperimentalSettings}
+                />
+              </Flex>
+            );
+          }
+          case "Retry": {
+            const onPressRetry = () => {
+              if (managerAppName && navigation) {
+                navigation.navigate(NavigatorName.Base, {
+                  screen: NavigatorName.Main,
+                  params: {
+                    screen: NavigatorName.MyLedger,
+                    params: {
+                      screen: ScreenName.MyLedgerChooseDevice,
+                      params: {
+                        tab: MANAGER_TABS.INSTALLED_APPS,
+                        updateModalOpened: true,
+                        device,
+                      },
+                    },
+                  },
+                });
+              } else {
+                onRetry?.();
+              }
+            };
+            return (
+              <Flex alignSelf="stretch" mb={0} mt={error instanceof BluetoothRequired ? 0 : 8}>
+                <StyledButton
+                  event="DeviceActionErrorRetry"
+                  type="main"
+                  size="large"
+                  outline={false}
+                  title={managerAppName ? t("DeviceAction.button.openManager") : t("common.retry")}
+                  onPress={onPressRetry}
+                />
+              </Flex>
+            );
+          }
+          default:
+            return null;
+        }
+      };
+      return (
+        <Wrapper>
+          <GenericErrorView
+            error={error}
+            withDescription
+            Icon={Icon}
+            iconColor={iconColor}
+            hasExportLogButton={hasExportLogButton}
+          >
+            {renderErrorButtons(error, managerAppName)}
+          </GenericErrorView>
+        </Wrapper>
+      );
+    }
   }
-
-  // User needs to forget the device on their phone settings
-  if (error instanceof PeerRemovedPairing) {
-    const productName = device ? getDeviceModel(device?.modelId).productName : "Ledger Device";
-    return (
-      <Flex flex={1}>
-        <BleForgetDeviceIllustration productName={productName} onRetry={() => onRetry?.()} />
-      </Flex>
-    );
-  }
-
-  return (
-    <Wrapper>
-      <GenericErrorView
-        error={error}
-        withDescription
-        Icon={Icon}
-        iconColor={iconColor}
-        hasExportLogButton={hasExportLogButton}
-      >
-        {onRetry || managerAppName ? (
-          <Flex alignSelf="stretch" mb={0} mt={error instanceof BluetoothRequired ? 0 : 8}>
-            <StyledButton
-              event="DeviceActionErrorRetry"
-              type="main"
-              size="large"
-              outline={false}
-              title={managerAppName ? t("DeviceAction.button.openManager") : t("common.retry")}
-              onPress={onPress}
-            />
-          </Flex>
-        ) : null}
-      </GenericErrorView>
-    </Wrapper>
-  );
 }
 
 export function RequiredFirmwareUpdate({

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1154,6 +1154,11 @@
       "title": "Invalid Provider",
       "description": "You have to change \"My Ledger provider\" setting. To change it, open Ledger Wallet \"Settings\", select \"Experimental features\", and then select a different provider."
     },
+    "InvalidGetFirmwareMetadataResponseError": {
+      "title": "Invalid Provider",
+      "description": "You have to change \"My Ledger provider\" setting. To change it, open Ledger Live \"Settings\", select \"Experimental features\", and then select a different provider.",
+      "openSettings": "Go to settings"
+    },
     "GasLessThanEstimate": {
       "title": "This may be too low. Please increase"
     },

--- a/apps/ledger-live-mobile/src/screens/PairDevices/RenderError.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/RenderError.tsx
@@ -23,6 +23,7 @@ import { urls } from "~/utils/urls";
 import LocationDisabled from "~/components/RequiresLocation/LocationDisabled";
 import LocationPermissionDenied from "~/components/RequiresLocation/LocationPermissionDenied";
 import { trace } from "@ledgerhq/logs";
+import { isInvalidGetFirmwareMetadataResponseError } from "@ledgerhq/live-dmk-mobile";
 
 type Props = {
   error: HwTransportError | DeprecatedError | Error;
@@ -53,7 +54,8 @@ const getIsBrokenPairing = (error: Error) => {
 function RenderError({ error, status, onBypassGenuine, onRetry }: Props) {
   const { colors } = useTheme();
   const isPairingStatus = status === "pairing";
-  const isFirmwareNotRecognized = error instanceof FirmwareNotRecognized;
+  const isFirmwareNotRecognized =
+    error instanceof FirmwareNotRecognized || isInvalidGetFirmwareMetadataResponseError(error);
   const isGenuineCheckStatus = status === "genuinecheck";
   const isGenuineCheckSkippableError = isGenuineCheckStatus && !isFirmwareNotRecognized;
   const isBrokenPairing = useMemo(() => getIsBrokenPairing(error), [error]);

--- a/libs/live-dmk-desktop/src/errors.ts
+++ b/libs/live-dmk-desktop/src/errors.ts
@@ -2,6 +2,7 @@ import {
   DeviceBusyError,
   DeviceDisconnectedBeforeSendingApdu,
   DeviceDisconnectedWhileSendingError,
+  InvalidGetFirmwareMetadataResponseError,
   DmkError,
 } from "@ledgerhq/device-management-kit";
 import { WebHidSendReportError } from "@ledgerhq/device-transport-kit-web-hid";
@@ -26,6 +27,13 @@ export const isAllowedOnboardingStatePollingErrorDmk = (error: unknown): boolean
     );
   }
 
+  return false;
+};
+
+export const isInvalidGetFirmwareMetadataResponseError = (error: unknown): boolean => {
+  if (error) {
+    return error instanceof InvalidGetFirmwareMetadataResponseError;
+  }
   return false;
 };
 

--- a/libs/live-dmk-desktop/src/index.ts
+++ b/libs/live-dmk-desktop/src/index.ts
@@ -4,6 +4,7 @@ export { DeviceManagementKitTransport } from "./transport/DeviceManagementKitTra
 export {
   isAllowedOnboardingStatePollingErrorDmk,
   isDisconnectedWhileSendingApduError,
+  isInvalidGetFirmwareMetadataResponseError,
   isDmkError,
 } from "./errors";
 export type { DmkError } from "@ledgerhq/device-management-kit";

--- a/libs/live-dmk-mobile/src/errors.ts
+++ b/libs/live-dmk-mobile/src/errors.ts
@@ -1,6 +1,7 @@
 import {
   DeviceBusyError,
   DmkError,
+  InvalidGetFirmwareMetadataResponseError,
   OpeningConnectionError,
   SendApduTimeoutError,
 } from "@ledgerhq/device-management-kit";
@@ -38,6 +39,13 @@ export const isAllowedOnboardingStatePollingErrorDmk = (error: unknown): boolean
       error instanceof DeviceBusyError ||
       error._tag === "DeviceSessionNotFound"
     );
+  }
+  return false;
+};
+
+export const isInvalidGetFirmwareMetadataResponseError = (error: unknown): boolean => {
+  if (error) {
+    return error instanceof InvalidGetFirmwareMetadataResponseError;
   }
   return false;
 };

--- a/libs/live-dmk-mobile/src/hooks/useBleDevicePairing.ts
+++ b/libs/live-dmk-mobile/src/hooks/useBleDevicePairing.ts
@@ -43,6 +43,7 @@ export const useBleDevicePairing = ({
         sessionRefresherOptions: { isRefresherDisabled: true },
       });
       const transport = new DeviceManagementKitTransport(dmk, sessionId);
+
       activeDeviceSessionSubject.next({ sessionId, transport });
       setIsPaired(true);
     } catch (error) {

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitTransport.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitTransport.ts
@@ -148,7 +148,6 @@ export class DeviceManagementKitTransport extends Transport {
         tracer.trace(
           "[DMKTransport] [open] reusing existing session and instantiating a new DmkTransport",
         );
-
         return activeDeviceSessionSubject.value.transport;
       }
     }
@@ -230,6 +229,7 @@ export class DeviceManagementKitTransport extends Transport {
         sessionRefresherOptions: { isRefresherDisabled: true },
       });
       const transport = new DeviceManagementKitTransport(getDeviceManagementKit(), sessionId);
+
       activeDeviceSessionSubject.next({ sessionId, transport });
 
       return transport;


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Mapped DMK's InvalidFirmwareMetadataError to LL's FirmwareNotRecognizedErrorComponent

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-22278](https://ledgerhq.atlassian.net/browse/LIVE-22278)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22278]: https://ledgerhq.atlassian.net/browse/LIVE-22278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ