### PR TITLE
[LIVE-19387][LIVE-20772] Fix RN HID error remapping

### DIFF
--- a/libs/live-dmk-mobile/src/errors.ts
+++ b/libs/live-dmk-mobile/src/errors.ts
@@ -2,6 +2,7 @@ import {
   DeviceBusyError,
   DeviceDisconnectedWhileSendingError,
   DmkError,
+  SendApduEmptyResponseError,
   OpeningConnectionError,
   SendApduTimeoutError,
 } from "@ledgerhq/device-management-kit";
@@ -37,10 +38,7 @@ export const isAllowedOnboardingStatePollingErrorDmk = (error: unknown): boolean
       error instanceof SendApduTimeoutError ||
       error instanceof DeviceBusyError ||
       error instanceof DeviceDisconnectedWhileSendingError ||
-      // FIXME: use instanceof SendApduEmptyResponseError and DeviceSessionNotFoundError, and test it
-      (typeof error === "object" &&
-        "_tag" in error &&
-        error._tag === "SendApduEmptyResponseError") ||
+      error instanceof SendApduEmptyResponseError ||
       (typeof error === "object" && "_tag" in error && error._tag === "DeviceSessionNotFound")
     );
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When disconnecting the device during an exchange with the device, the errors should be remapped to `DisconnectedDevice`.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
