### PR TITLE
feat: add direct add accounts receive flow onboarding

### DIFF
--- a/.changeset/eight-snails-rush.md
+++ b/.changeset/eight-snails-rush.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Use direct add accounts to receive flow in new seed onboarding

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/SyncOnboardingCompanion/NewSeedPanel/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/SyncOnboardingCompanion/NewSeedPanel/index.tsx
@@ -2,7 +2,6 @@ import { Button, Flex, Text } from "@ledgerhq/react-ui/index";
 import React, { useCallback, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
-import { openModal } from "~/renderer/actions/modals";
 import NewSeedIllustration from "./NewSeedIllustration";
 import {
   onboardingReceiveFlowSelector,
@@ -12,6 +11,8 @@ import {
 import { track } from "~/renderer/analytics/segment";
 import { analyticsFlowName } from "../../shared";
 import { SeedOriginType } from "@ledgerhq/types-live";
+import { useOpenAssetFlow } from "~/newArch/features/ModularDrawer/hooks/useOpenAssetFlow";
+import { ModularDrawerLocation } from "~/newArch/features/ModularDrawer";
 
 const NewSeedPanel = ({
   handleComplete,
@@ -24,7 +25,11 @@ const NewSeedPanel = ({
   const dispatch = useDispatch();
   const isOnboardingReceiveFlow = useSelector(onboardingReceiveFlowSelector);
   const isOnboardingReceiveSuccess = useSelector(onboardingReceiveSuccessSelector);
-
+  const { openAssetFlow } = useOpenAssetFlow(
+    { location: ModularDrawerLocation.ADD_ACCOUNT },
+    "receive",
+    "MODAL_RECEIVE",
+  );
   const handlePressFund = useCallback(() => {
     track("button_clicked", {
       button: "Secure my crypto",
@@ -37,8 +42,8 @@ const NewSeedPanel = ({
         isSuccess: false,
       }),
     );
-    dispatch(openModal("MODAL_RECEIVE", {}));
-  }, [dispatch, seedConfiguration]);
+    openAssetFlow();
+  }, [dispatch, seedConfiguration, openAssetFlow]);
 
   const handleSkip = useCallback(() => {
     track("button_clicked", { button: "Maybe later", flow: analyticsFlowName, seedConfiguration });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

There was an issue where previous accounts on LL meant that the add flow modular drawer wasn't opening for onboarding. This fix directs the user direct to add accounts with receive modal at end of flow.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: LIVE-21984


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
