### PR TITLE
fix: replace whitespace in device name in selection

### DIFF
--- a/.changeset/three-penguins-explain.md
+++ b/.changeset/three-penguins-explain.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Remove whitespace preventing text wrap on device name in selection

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/SelectDevice/DeviceSelectorOption.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/SelectDevice/DeviceSelectorOption.tsx
@@ -92,7 +92,7 @@ export function DeviceSelectorOption({
     <Container data-testid={`v3-container-${id}`} {...{ id, isFirst, isLast }}>
       <ContentContainer>
         <DeviceIllustrationContainer>{illustration}</DeviceIllustrationContainer>
-        <DeviceName>{label}</DeviceName>
+        <DeviceName>{label.replace("\u00a0", " ")}</DeviceName>
         <SelectButton data-testid={`v3-${id}`} variant="main" onClick={onClick}>
           {t("onboarding.screens.selectDevice.selectLabel")}
         </SelectButton>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
Device name was not wrapping and causing overflow issues on small view sizes.

Before:
<img width="1015" height="686" alt="Screenshot 2025-10-24 at 16 34 18" src="https://github.com/user-attachments/assets/a30081a9-9554-46dc-9e42-24bd1c4b203b" />

After:
<img width="1007" height="673" alt="Screenshot 2025-10-24 at 16 34 49" src="https://github.com/user-attachments/assets/ff4d6e25-8184-4234-9a05-be425608f4fe" />

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
