### PR TITLE
fix: canton receive flow on acc creation

### DIFF
--- a/.changeset/serious-melons-peel.md
+++ b/.changeset/serious-melons-peel.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: canton fix id and xpub for new accounts

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/steps/Accept.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/steps/Accept.tsx
@@ -129,6 +129,11 @@ export default function Accept({ navigation, route }: Props) {
         take(1),
       )
       .subscribe(() => {
+        const newAccount = accs.find(a => a.freshAddressPath === result.account.freshAddressPath);
+        if (newAccount) {
+          newAccount.id = result.account.id;
+          newAccount.xpub = result.account.xpub;
+        }
         setError(null);
         dispatch(
           addAccountsAction({


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

override xpub and accountId to make receive flow works properly

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:
- [LIVE-22592](https://ledgerhq.atlassian.net/browse/LIVE-22592)
- [LIVE-22596](https://ledgerhq.atlassian.net/browse/LIVE-22596)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22592]: https://ledgerhq.atlassian.net/browse/LIVE-22592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-22596]: https://ledgerhq.atlassian.net/browse/LIVE-22596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ