### PR TITLE
feat(coin-stellar): add await to token lookups for async migration

### DIFF
--- a/libs/coin-modules/coin-stellar/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/getBalance.test.ts
@@ -1,9 +1,18 @@
 import { getBalance } from "./getBalance";
 import { fetchAccount } from "../network";
+import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/legacy/legacy-store";
+import { initializeLegacyTokens } from "@ledgerhq/cryptoassets/legacy/legacy-data";
+import { addTokens as addTokensLegacy } from "@ledgerhq/cryptoassets/legacy/legacy-utils";
 
 jest.mock("../network", () => ({
   fetchAccount: jest.fn(),
 }));
+
+beforeAll(() => {
+  initializeLegacyTokens(addTokensLegacy);
+  setCryptoAssetsStore(legacyCryptoAssetsStore);
+});
 
 describe("getBalance", () => {
   it("returns native balance when no assets are present", async () => {
@@ -32,7 +41,7 @@ describe("getBalance", () => {
         {
           asset_type: "credit_alphanum4",
           asset_code: "USDC",
-          asset_issuer: "issuer-address",
+          asset_issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
           balance: "50.1234567",
         },
       ],
@@ -51,7 +60,7 @@ describe("getBalance", () => {
         asset: {
           type: "credit_alphanum4",
           assetReference: "USDC",
-          assetOwner: "issuer-address",
+          assetOwner: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
         },
       },
     ]);

--- a/libs/coin-modules/coin-stellar/src/logic/getTokenFromAsset.test.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/getTokenFromAsset.test.ts
@@ -1,15 +1,17 @@
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import * as tokenModule from "@ledgerhq/cryptoassets/tokens";
+import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/legacy/legacy-store";
+import { initializeLegacyTokens } from "@ledgerhq/cryptoassets/legacy/legacy-data";
+import { addTokens as addTokensLegacy } from "@ledgerhq/cryptoassets/legacy/legacy-utils";
 import { getAssetFromToken, getTokenFromAsset } from "./getTokenFromAsset";
 
+beforeAll(() => {
+  initializeLegacyTokens(addTokensLegacy);
+  setCryptoAssetsStore(legacyCryptoAssetsStore);
+});
+
 describe("getTokenFromAsset", () => {
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it("computes the token of the USDC asset, trusting the CAL", async () => {
-    const findTokenById = jest.spyOn(tokenModule, "findTokenById");
-
+  it("computes the token of the USDC asset", async () => {
     expect(
       await getTokenFromAsset({
         type: "token",
@@ -21,14 +23,9 @@ describe("getTokenFromAsset", () => {
       contractAddress: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
       name: "USDC",
     });
-    expect(findTokenById).toHaveBeenCalledWith(
-      "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-    );
   });
 
   it("does not compute the token of an unknown asset, trusting the CAL", async () => {
-    const findTokenById = jest.spyOn(tokenModule, "findTokenById");
-
     expect(
       await getTokenFromAsset({
         type: "token",
@@ -36,7 +33,6 @@ describe("getTokenFromAsset", () => {
         assetOwner: "unknown-owner",
       }),
     ).toBeUndefined();
-    expect(findTokenById).toHaveBeenCalledWith("stellar/asset/unknown-reference:unknown-owner");
   });
 });
 

--- a/libs/coin-modules/coin-stellar/src/logic/getTokenFromAsset.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/getTokenFromAsset.ts
@@ -1,5 +1,5 @@
 import { AssetInfo } from "@ledgerhq/coin-framework/api/types";
-import { findTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { getCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 export async function getTokenFromAsset(asset: AssetInfo): Promise<TokenCurrency | undefined> {
@@ -7,7 +7,7 @@ export async function getTokenFromAsset(asset: AssetInfo): Promise<TokenCurrency
     asset.type !== "native" && "assetReference" in asset && "assetOwner" in asset
       ? `${asset.assetReference}:${asset.assetOwner}`
       : "";
-  return findTokenById(`stellar/asset/${assetId}`);
+  return await getCryptoAssetsStore().findTokenById(`stellar/asset/${assetId}`);
 }
 
 export function getAssetFromToken(token: TokenCurrency): AssetInfo {


### PR DESCRIPTION

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Prepares Stellar coin module for async CryptoAssetsStore migration
  - Adds `await` to token lookup calls
  - No breaking changes
  - Testing focus: Stellar asset operations, trustline management

### 📝 Description

Part of the CryptoAssetsStore async migration strategy - prepares the Stellar coin module.

**Changes:**
- Added `await` to `decodeTokenAccountId()` calls
- Updated asset handling logic for async patterns
- Adapted test mocks
- No functional changes - preparing for Phase 2

### ❓ Context

- **GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/11905
- **Migration strategy**: Multi-phase approach to enable async token loading from APIs
