### PR TITLE
feat(coin-hedera): add await to token lookups for async migration

### DIFF
--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
@@ -78,7 +78,7 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
     mirrorTokens,
   );
   const subAccounts = mergeSubAccounts(initialAccount, newSubAccounts);
-  const newOperations = prepareOperations(
+  const newOperations = await prepareOperations(
     latestAccountOperations.coinOperations,
     latestAccountOperations.tokenOperations,
   );

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.integration.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.integration.test.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { encodeTokenAccountId } from "@ledgerhq/coin-framework/account";
 import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/legacy/legacy-store";
 import { HEDERA_OPERATION_TYPES, HEDERA_TRANSACTION_MODES } from "../constants";
 import { estimateFees } from "../logic/estimateFees";
 import { getMockedAccount, getMockedTokenAccount } from "../test/fixtures/account.fixture";
@@ -229,7 +229,7 @@ describe("utils", () => {
   describe("prepareOperations", () => {
     const tokenCurrencyFromCAL = getTokenCurrencyFromCAL(0);
 
-    test("links token operation to existing coin operation with matching hash", () => {
+    test("links token operation to existing coin operation with matching hash", async () => {
       const mockedTokenAccount = getMockedTokenAccount(tokenCurrencyFromCAL);
       const mockedCoinOperation = getMockedOperation({ hash: "shared" });
       const mockedTokenOperation = getMockedOperation({
@@ -237,20 +237,20 @@ describe("utils", () => {
         accountId: encodeTokenAccountId(mockedTokenAccount.parentId, tokenCurrencyFromCAL),
       });
 
-      const result = prepareOperations([mockedCoinOperation], [mockedTokenOperation]);
+      const result = await prepareOperations([mockedCoinOperation], [mockedTokenOperation]);
 
       expect(result).toHaveLength(1);
       expect(result[0].subOperations).toEqual([mockedTokenOperation]);
     });
 
-    test("creates NONE coin operation as parent if no coin op with matching hash exists", () => {
+    test("creates NONE coin operation as parent if no coin op with matching hash exists", async () => {
       const mockedTokenAccount = getMockedTokenAccount(tokenCurrencyFromCAL);
       const mockedOrphanTokenOperation = getMockedOperation({
         hash: "unknown-hash",
         accountId: encodeTokenAccountId(mockedTokenAccount.parentId, tokenCurrencyFromCAL),
       });
 
-      const result = prepareOperations([], [mockedOrphanTokenOperation]);
+      const result = await prepareOperations([], [mockedOrphanTokenOperation]);
       const noneOp = result.find(op => op.type === "NONE");
 
       expect(typeof noneOp).toBe("object");

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
@@ -1,6 +1,6 @@
 import type { Balance } from "@ledgerhq/coin-framework/api/types";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets/tokens";
+import { getCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
 import { apiClient } from "../network/api";
 
 export async function getBalance(currency: CryptoCurrency, address: string): Promise<Balance[]> {
@@ -17,7 +17,10 @@ export async function getBalance(currency: CryptoCurrency, address: string): Pro
   ];
 
   for (const mirrorToken of mirrorTokens) {
-    const calToken = findTokenByAddressInCurrency(mirrorToken.token_id, currency.id);
+    const calToken = await getCryptoAssetsStore().findTokenByAddressInCurrency(
+      mirrorToken.token_id,
+      currency.id,
+    );
 
     if (!calToken) {
       continue;

--- a/libs/coin-modules/coin-hedera/src/logic/getTokenFromAsset.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getTokenFromAsset.test.ts
@@ -1,17 +1,28 @@
 import { getTokenFromAsset } from "./getTokenFromAsset";
-import { getMockedCurrency } from "../test/fixtures/currency.fixture";
+import { getMockedCurrency, getMockedTokenCurrency } from "../test/fixtures/currency.fixture";
+import * as cryptoAssets from "@ledgerhq/coin-framework/crypto-assets/index";
+
+jest.mock("@ledgerhq/coin-framework/crypto-assets/index");
 
 describe("getTokenFromAsset", () => {
   const mockCurrency = getMockedCurrency();
+  const mockToken = getMockedTokenCurrency();
 
-  it("returns token from USDC asset", async () => {
-    const asset1 = { type: "hts", assetReference: "0.0.5022567" };
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
-    expect(await getTokenFromAsset(mockCurrency, asset1)).toMatchObject({
-      id: "hedera/hts/hbark_0.0.5022567",
-      contractAddress: "0.0.5022567",
-      name: "hBARK",
+  it("returns token from token asset", async () => {
+    const asset1 = { type: "hts", assetReference: mockToken.contractAddress };
+
+    (cryptoAssets.getCryptoAssetsStore as jest.Mock).mockReturnValue({
+      findTokenByAddressInCurrency: jest.fn().mockReturnValue(mockToken),
     });
+
+    const result = await getTokenFromAsset(mockCurrency, asset1);
+    expect(result).toEqual(mockToken);
+    expect(result?.id).toBe(mockToken.id);
+    expect(result?.contractAddress).toBe(mockToken.contractAddress);
   });
 
   it("returns undefined for native asset", async () => {

--- a/libs/coin-modules/coin-hedera/src/logic/getTokenFromAsset.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getTokenFromAsset.ts
@@ -1,6 +1,6 @@
 import type { AssetInfo } from "@ledgerhq/coin-framework/api/types";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets/tokens";
+import { getCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
 
 export async function getTokenFromAsset(
   currency: CryptoCurrency,
@@ -13,5 +13,5 @@ export async function getTokenFromAsset(
     return;
   }
 
-  return findTokenByAddressInCurrency(tokenId, currency.id);
+  return getCryptoAssetsStore().findTokenByAddressInCurrency(tokenId, currency.id);
 }

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.test.ts
@@ -1,4 +1,3 @@
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets/tokens";
 import { encodeTokenAccountId } from "@ledgerhq/coin-framework/account/accountId";
 import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
 import type { Pagination } from "@ledgerhq/coin-framework/api/types";
@@ -6,8 +5,9 @@ import { listOperations } from "./listOperations";
 import { apiClient } from "../network/api";
 import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import * as utils from "./utils";
+import * as cryptoAssets from "@ledgerhq/coin-framework/crypto-assets/index";
 
-jest.mock("@ledgerhq/cryptoassets/tokens");
+jest.mock("@ledgerhq/coin-framework/crypto-assets/index");
 jest.mock("@ledgerhq/coin-framework/account/accountId");
 jest.mock("@ledgerhq/coin-framework/operation");
 jest.mock("../network/api");
@@ -163,7 +163,9 @@ describe("listOperations", () => {
       transactions: mockTransactions,
       nextCursor: null,
     });
-    (findTokenByAddressInCurrency as jest.Mock).mockReturnValue(mockToken);
+    (cryptoAssets.getCryptoAssetsStore as jest.Mock).mockReturnValue({
+      findTokenByAddressInCurrency: jest.fn().mockReturnValue(mockToken),
+    });
 
     const result = await listOperations({
       currency: mockCurrency,
@@ -288,7 +290,9 @@ describe("listOperations", () => {
       transactions: mockTransactions,
       nextCursor: null,
     });
-    (findTokenByAddressInCurrency as jest.Mock).mockReturnValue(null);
+    (cryptoAssets.getCryptoAssetsStore as jest.Mock).mockReturnValue({
+      findTokenByAddressInCurrency: jest.fn().mockReturnValue(null),
+    });
 
     const result = await listOperations({
       currency: mockCurrency,


### PR DESCRIPTION

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Prepares Hedera coin module for async CryptoAssetsStore migration
  - Adds `await` to token lookup calls
  - No breaking changes
  - Testing focus: Hedera token association flows

### 📝 Description

Part of the CryptoAssetsStore async migration strategy - prepares the Hedera coin module.

**Changes:**
- Added `await` to `decodeTokenAccountId()` calls
- Updated token association logic for async patterns
- Adapted test fixtures
- No functional changes - preparing for Phase 2

### ❓ Context

- **GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/11905
- **Migration strategy**: Multi-phase approach to enable async token loading from APIs

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.
