### PR TITLE
feat(coin-ton): add await to token lookups for async migration

### DIFF
--- a/libs/coin-modules/coin-ton/src/__tests__/unit/logic.unit.test.ts
+++ b/libs/coin-modules/coin-ton/src/__tests__/unit/logic.unit.test.ts
@@ -1,5 +1,12 @@
-import { getCryptoCurrencyById, findTokenById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
+import { initializeLegacyTokens } from "@ledgerhq/cryptoassets/legacy/legacy-data";
+import { addTokens } from "@ledgerhq/cryptoassets/legacy/legacy-utils";
 import { getSyncHash } from "../../logic";
+
+initializeLegacyTokens(addTokens);
+
+jest.mock("@ledgerhq/coin-framework/crypto-assets/index");
 
 describe("getSyncHash", () => {
   const currency = getCryptoCurrencyById("ton");
@@ -9,9 +16,17 @@ describe("getSyncHash", () => {
     expect(getSyncHash(currency, [])).toStrictEqual(expect.stringMatching(/^0x[A-Fa-f0-9]{8}$/));
   });
 
-  it("should provide a new hash if a token is added to the blacklistedTokenIds", () => {
-    const token = findTokenById("ton/jetton/eqcxe6mutqjkfngfarotkot1lzbdiix1kcixrv7nw2id_sds");
-    if (!token) throw new Error("TON jetton token not found");
-    expect(getSyncHash(currency, [])).not.toEqual(getSyncHash(currency, [token.id]));
+  it("should provide a new hash if a token is added to the blacklistedTokenIds", async () => {
+    (getCryptoAssetsStore as jest.Mock).mockReturnValue({
+      findTokenById: jest.fn().mockResolvedValue({
+        id: "ton/jetton/eqcxe6mutqjkfngfarotkot1lzbdiix1kcixrv7nw2id_sds",
+        type: "TokenCurrency",
+      }),
+    });
+
+    const token = await getCryptoAssetsStore().findTokenById(
+      "ton/jetton/eqcxe6mutqjkfngfarotkot1lzbdiix1kcixrv7nw2id_sds",
+    );
+    expect(getSyncHash(currency, [])).not.toEqual(getSyncHash(currency, [token!.id]));
   });
 });

--- a/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/txn.ts
+++ b/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/txn.ts
@@ -1,6 +1,6 @@
 import { decodeAccountId, encodeTokenAccountId } from "@ledgerhq/coin-framework/account/index";
 import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets/tokens";
+import { getCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
 import { Operation } from "@ledgerhq/types-live";
 import { Address, BitReader, BitString, Cell, Slice } from "@ton/core";
 import BigNumber from "bignumber.js";
@@ -203,8 +203,8 @@ export function mapJettonTxToOps(
   addr: string,
   addressBook: TonAddressBook,
   jettonTxMessageHashesMap?: Map<string, string>,
-): (tx: TonJettonTransfer) => TonOperation[] {
-  return (tx: TonJettonTransfer): TonOperation[] => {
+): (tx: TonJettonTransfer) => Promise<TonOperation[]> {
+  return async (tx: TonJettonTransfer): Promise<TonOperation[]> => {
     const accountAddr = Address.parse(addr).toString({ urlSafe: true, bounceable: false });
     if (accountAddr !== addr) throw Error(`[ton] unexpected address ${accountAddr} ${addr}`);
 
@@ -212,7 +212,7 @@ export function mapJettonTxToOps(
       urlSafe: true,
       bounceable: true,
     });
-    const tokenCurrency = findTokenByAddressInCurrency(
+    const tokenCurrency = await getCryptoAssetsStore().findTokenByAddressInCurrency(
       jettonMasterAddr.toLowerCase(),
       decodeAccountId(accountId).currencyId,
     );


### PR DESCRIPTION

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Prepares TON coin module for async CryptoAssetsStore migration
  - Adds `await` to token lookup calls
  - No breaking changes
  - Testing focus: TON jetton operations

### 📝 Description

Part of the CryptoAssetsStore async migration strategy - prepares the TON coin module.

**Changes:**
- Added `await` to `decodeTokenAccountId()` calls if applicable
- Updated jetton handling for async patterns
- Adapted test fixtures
- No functional changes - preparing for Phase 2

### ❓ Context

- **GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/11905
- **Migration strategy**: Multi-phase approach to enable async token loading from APIs

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.
