### PR TITLE
test(e2e): adapt swap tests for new tailwind css

### DIFF
--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -19,16 +19,16 @@ export const NativeElementHelpers = {
     return detoxExpect(element);
   },
 
+  waitForElement(nativeElement: NativeElement, timeout: number = DEFAULT_TIMEOUT) {
+    return waitFor(nativeElement).toBeVisible().withTimeout(timeout);
+  },
+
   waitForElementById(id: string | RegExp, timeout: number = DEFAULT_TIMEOUT) {
-    return waitFor(element(by.id(id)))
-      .toBeVisible()
-      .withTimeout(timeout);
+    return NativeElementHelpers.waitForElement(element(by.id(id)), timeout);
   },
 
   waitForElementByText(text: string | RegExp, timeout: number = DEFAULT_TIMEOUT) {
-    return waitFor(element(by.text(text)))
-      .toBeVisible()
-      .withTimeout(timeout);
+    return NativeElementHelpers.waitForElement(element(by.text(text)), timeout);
   },
 
   async waitForElementNotVisible(id: string | RegExp, timeout = DEFAULT_TIMEOUT): Promise<boolean> {
@@ -175,9 +175,7 @@ export const WebElementHelpers = {
   },
 
   getWebElementByCssSelector(selector: string, index = 0): WebElement {
-    const base = web.element(
-      by.web.cssSelector(selector),
-    )
+    const base = web.element(by.web.cssSelector(selector));
     return index > 0 ? base.atIndex(index) : base;
   },
 

--- a/e2e/mobile/jest.globalSetup.ts
+++ b/e2e/mobile/jest.globalSetup.ts
@@ -141,6 +141,7 @@ export default async function setup(): Promise<void> {
   global.tapByText = NativeElementHelpers.tapByText;
   global.typeTextByElement = NativeElementHelpers.typeTextByElement;
   global.typeTextById = NativeElementHelpers.typeTextById;
+  global.waitForElement = NativeElementHelpers.waitForElement;
   global.waitForElementById = NativeElementHelpers.waitForElementById;
   global.waitForElementByText = NativeElementHelpers.waitForElementByText;
   global.waitForElementNotVisible = NativeElementHelpers.waitForElementNotVisible;

--- a/e2e/mobile/package.json
+++ b/e2e/mobile/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.0",
   "private": true,
   "scripts": {
+    "lint": "eslint . --ext .ts,.tsx --cache",
     "lint:fix": "pnpm lint --fix",
     "test:detox": "pnpm detox test",
     "test:ios": "pnpm test:detox --configuration ios.sim.release",

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -14,6 +14,7 @@ export default class SwapLiveAppPage {
   quotesCountDown = "quotes-countdown";
   quoteCardProviderName = "compact-quote-card-provider-";
   executeSwapButton = "execute-button";
+  executeSwapButtonStepApproval = "execute-swap-button-step-approval";
   deviceActionErrorDescriptionId = "error-description-deviceAction";
   fromAccountErrorId = "from-account-error";
   showDetailslink = "show-details-link";
@@ -119,6 +120,13 @@ export default class SwapLiveAppPage {
     await tapWebElementByTestId(this.executeSwapButton);
   }
 
+  @Step("Tap execute swap button on step approval")
+  async tapExecuteSwapOnStepApproval() {
+    await waitWebElementByTestId(this.executeSwapButtonStepApproval);
+    await waitForWebElementToBeEnabled(this.executeSwapButtonStepApproval);
+    await tapWebElementByTestId(this.executeSwapButtonStepApproval);
+  }
+
   @Step("Get minimum amount for swap")
   async getMinimumAmount(fromAccount: Account, toAccount: Account) {
     return (await getMinimumSwapAmount(fromAccount, toAccount))?.toString() ?? "";
@@ -169,18 +177,11 @@ export default class SwapLiveAppPage {
   }
 
   @Step("Check exchange button has provider name: $0")
-  async checkExchangeButtonHasProviderName(provider: string) {
-    const expectedButtonText = [
-      Provider.ONE_INCH.uiName,
-      Provider.VELORA.uiName,
-      Provider.MOONPAY.uiName,
-    ].includes(provider)
-      ? `Continue with ${provider}`
-      : `Swap with ${provider}`;
-
+  async checkExchangeButtonHasProviderName(provider: string): Promise<string> {
     await waitWebElementByTestId(this.executeSwapButton);
     const actualButtonText = await getWebElementText(this.executeSwapButton);
-    jestExpect(actualButtonText).toEqual(expectedButtonText);
+    jestExpect(actualButtonText).toMatch(new RegExp(`^(Swap|Continue) with ${provider}$`, "i"));
+    return actualButtonText;
   }
 
   @Step('Check "Best Offer" corresponds to the best quote')
@@ -258,7 +259,7 @@ export default class SwapLiveAppPage {
 
   @Step("Retrieve receive currency amount value")
   async getAmountToReceive() {
-    return await getValueByWebTestId(this.toAmountInput);
+    return await getWebElementText(this.toAmountInput);
   }
 
   @Step("Tap on Switch currencies button")
@@ -302,8 +303,16 @@ export default class SwapLiveAppPage {
   async goToProviderLiveApp(provider: string) {
     const continueButton = getWebElementByTestId(this.executeSwapButton);
     await detoxExpect(continueButton).toExist();
-    await this.checkExchangeButtonHasProviderName(provider);
-    await this.tapExecuteSwap();
+    const actualButtonText = await app.swapLiveApp.checkExchangeButtonHasProviderName(provider);
+    await app.swapLiveApp.tapExecuteSwap();
+    if (provider === "1inch" && actualButtonText.includes("Swap with")) {
+      await app.swapLiveApp.tapExecuteSwapOnStepApproval();
+      const summaryContinueButton = app.send.summaryContinueButton();
+      await waitForElement(summaryContinueButton);
+      //Test will fail here with a known issue: LIVE-21138
+      await tapByElement(summaryContinueButton);
+      await app.common.selectKnownDevice();
+    }
   }
 
   @Step("Verify live app title contains $0")

--- a/e2e/mobile/specs/deeplinks.spec.ts
+++ b/e2e/mobile/specs/deeplinks.spec.ts
@@ -1,3 +1,5 @@
+import { waitSwapReady } from "../bridge/server";
+
 $TmsLink("B2CQA-1837");
 const tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax"];
 tags.forEach(tag => $Tag(tag));
@@ -80,6 +82,7 @@ describe("DeepLinks Tests", () => {
 
   it("should open Swap Form page", async () => {
     await app.swap.openViaDeeplink();
+    await waitSwapReady();
     await app.swap.expectSwapPage();
   });
 

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -429,7 +429,7 @@ export function runSwapSwitchSendAndReceiveCurrenciesTest(
       );
       await app.swapLiveApp.switchYouSendAndYouReceive();
       await app.swapLiveApp.checkAssetFrom(swap.accountToCredit.currency.ticker, "");
-      await app.swapLiveApp.checkAssetTo(swap.accountToDebit.currency.ticker, "");
+      await app.swapLiveApp.checkAssetTo(swap.accountToDebit.currency.ticker, "-");
     });
   });
 }

--- a/e2e/mobile/types/global.d.ts
+++ b/e2e/mobile/types/global.d.ts
@@ -68,6 +68,7 @@ declare global {
   var tapByText: typeof NativeElementHelpers.tapByText;
   var typeTextByElement: typeof NativeElementHelpers.typeTextByElement;
   var typeTextById: typeof NativeElementHelpers.typeTextById;
+  var waitForElement: typeof NativeElementHelpers.waitForElement;
   var waitForElementById: typeof NativeElementHelpers.waitForElementById;
   var waitForElementByText: typeof NativeElementHelpers.waitForElementByText;
   var waitForElementNotVisible: typeof NativeElementHelpers.waitForElementNotVisible;

--- a/e2e/mobile/utils/fileUtils.ts
+++ b/e2e/mobile/utils/fileUtils.ts
@@ -19,8 +19,9 @@ export class FileUtils {
       try {
         await fs.access(filePath);
         return true;
-      } catch (e: any) {
-        console.error("Error in waitForFileToExist : ", e);
+      } catch (e: unknown) {
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        console.error("Error in waitForFileToExist:", errorMessage);
         await new Promise(resolve => setTimeout(resolve, 100));
       }
     }

--- a/e2e/mobile/utils/swapUtils.ts
+++ b/e2e/mobile/utils/swapUtils.ts
@@ -1,4 +1,3 @@
-import { SwapType } from "@ledgerhq/live-common/lib/e2e/models/Swap";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 
 async function selectCurrency(account: Account, isFromCurrency: boolean = true) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* Extracted common `waitForElement` logic to reduce code duplication
* Added 1inch-specific flow handling
* Code quality improvements: Added lint script, better error handling, and type safety
* [CI run with impacted tests](https://github.com/LedgerHQ/ledger-live/actions/runs/18836812386/job/53746258480)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA**: [QAA-864](https://ledgerhq.atlassian.net/browse/QAA-864)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-864]: https://ledgerhq.atlassian.net/browse/QAA-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ