### PR TITLE
feat(coin-bitcoin): prepare for async CryptoAssetsStore migration

### DIFF
--- a/.changeset/async-coin-bitcoin.md
+++ b/.changeset/async-coin-bitcoin.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-bitcoin": minor
+---
+
+Prepare bitcoin for async CryptoAssetsStore migration - update test mocks to handle async token lookups

--- a/libs/coin-modules/coin-bitcoin/src/descriptor.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/descriptor.test.ts
@@ -18,10 +18,16 @@ setCryptoAssetsStore({
 setSupportedCurrencies(["bitcoin"]);
 describe("inferDescriptorFromAccount", () => {
   invariant(bitcoinDatasets.accounts, "bitcoin datasets have accounts");
-  // FIXME: migrate away from invariant for more type guard
-  const [bitcoin1, bitcoin2] = bitcoinDatasets.accounts.map(a =>
-    fromAccountRaw(a.raw, { assignFromAccountRaw }),
-  );
+
+  let bitcoin1: any, bitcoin2: any;
+
+  beforeAll(async () => {
+    invariant(bitcoinDatasets.accounts, "bitcoin datasets have accounts in beforeAll");
+    [bitcoin1, bitcoin2] = await Promise.all(
+      bitcoinDatasets.accounts.map(a => fromAccountRaw(a.raw, { assignFromAccountRaw })),
+    );
+  });
+
   it("should work on bitcoin account 1", () => {
     expect(inferDescriptorFromAccount(bitcoin1)).toEqual({
       external:


### PR DESCRIPTION

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Prepares Bitcoin test suite for async CryptoAssetsStore migration
  - Updates test mocks to return `Promise` for async token lookups
  - No breaking changes - tests adapted for future async behavior
  - Testing focus: descriptor generation tests

### 📝 Description

Part of the CryptoAssetsStore async migration strategy - prepares the Bitcoin coin module tests.

**Changes:**
- Updated `CryptoAssetsStore` test mocks to return `Promise.resolve()` for `findTokenById` and `findTokenByAddressInCurrency`
- Converted synchronous test setup to async using `beforeAll` for account deserialization
- No functional changes to Bitcoin logic - only test infrastructure updates

**Strategy:** This PR updates test mocks to match the future async interface. The Bitcoin module itself doesn't use tokens extensively, so changes are minimal.

### ❓ Context

- **GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/11905
- **Migration strategy**: Multi-phase approach to enable async token loading from APIs

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.
