### PR TITLE
feat(coin-cardano): add await to token lookups for async migration

### DIFF
--- a/.changeset/async-coin-cardano.md
+++ b/.changeset/async-coin-cardano.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cardano": minor
+---
+
+Prepare cardano for async CryptoAssetsStore migration - add await to token lookups

--- a/libs/coin-modules/coin-cardano/src/synchronisation.ts
+++ b/libs/coin-modules/coin-cardano/src/synchronisation.ts
@@ -127,14 +127,16 @@ export const makeGetAccountShape =
     const utxos = prepareUtxos(newTransactions, stableUtxos, accountCredentialsMap);
     const utxosSum = utxos.reduce((total, u) => total.plus(u.amount), new BigNumber(0));
     const tokenBalance = mergeTokens(utxos.map(u => u.tokens).flat());
-    const subAccounts = buildSubAccounts({
-      initialAccount,
-      parentAccountId: accountId,
-      parentCurrency: currency,
-      newTransactions,
-      tokens: tokenBalance,
-      accountCredentialsMap,
-    }).filter(a => !blacklistedTokenIds?.includes(a.token.id));
+    const subAccounts = (
+      await buildSubAccounts({
+        initialAccount,
+        parentAccountId: accountId,
+        parentCurrency: currency,
+        newTransactions,
+        tokens: tokenBalance,
+        accountCredentialsMap,
+      })
+    ).filter(a => !blacklistedTokenIds?.includes(a.token.id));
 
     const stakeCredential = getAccountStakeCredential(xpub, accountIndex);
     const networkParams = getNetworkParameters(currency.id);

--- a/libs/coin-modules/coin-cardano/src/synchronisation.unit.test.ts
+++ b/libs/coin-modules/coin-cardano/src/synchronisation.unit.test.ts
@@ -65,7 +65,7 @@ describe("makeGetAccountShape", () => {
       deviceId: "id",
     };
     const buildSubAccountsMock = jest.mocked(buildSubAccounts);
-    buildSubAccountsMock.mockReturnValue([]);
+    buildSubAccountsMock.mockResolvedValue([]);
     getTransactionsMock = jest.mocked(getTransactions);
     const getNetworkInfoMock = jest.mocked(fetchNetworkInfo);
     getNetworkInfoMock.mockReturnValue(


### PR DESCRIPTION

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Prepares Cardano coin module for async CryptoAssetsStore migration
  - Adds `await` to token lookup calls
  - No breaking changes
  - Testing focus: Cardano token operations

### 📝 Description

Part of the CryptoAssetsStore async migration strategy - prepares the Cardano coin module.

**Changes:**
- Added `await` to `decodeTokenAccountId()` calls throughout the module
- Made functions async where token lookups occur
- Updated test fixtures to handle async patterns
- No functional changes - preparing for Layer 1 when `CryptoAssetsStore` becomes truly async

**Strategy:** This PR adds `await` keywords without breaking existing functionality. The actual async behavior will be introduced later when the framework layer is updated.

### ❓ Context

- **GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/11905
- **Migration strategy**: Multi-phase approach to enable async token loading from APIs

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.
