### PR TITLE
feat(coin-sui): add await to token lookups for async migration

### DIFF
--- a/.changeset/async-coin-sui.md
+++ b/.changeset/async-coin-sui.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": minor
+---
+
+Prepare sui for async CryptoAssetsStore migration - add await to token lookups

--- a/libs/coin-modules/coin-sui/src/bridge/preload.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/preload.ts
@@ -4,7 +4,7 @@ import type { SuiPreloadData, SuiToken } from "../types";
 import { getValidators } from "../network/sdk";
 import suiTokens, { hash } from "@ledgerhq/cryptoassets/data/sui";
 import { fetchTokensFromCALService } from "@ledgerhq/cryptoassets/crypto-assets-importer/fetch/index";
-import { addTokens, convertSuiTokens } from "@ledgerhq/cryptoassets/tokens";
+import { addTokens, convertSuiTokens } from "@ledgerhq/cryptoassets/legacy/legacy-utils";
 import { AxiosError } from "axios";
 
 const PRELOAD_MAX_AGE = 30 * 60 * 1000; // 30 minutes

--- a/libs/coin-modules/coin-sui/src/bridge/synchronisation.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/synchronisation.test.ts
@@ -10,8 +10,23 @@ import coinConfig from "../config";
 import { getFullnodeUrl } from "@mysten/sui/client";
 import * as networkModule from "../network";
 import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/types-live";
-import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+
+// Mock findTokenById and listTokensForCryptoCurrency
+jest.mock("@ledgerhq/cryptoassets/tokens", () => ({
+  findTokenById: async (coinType: string) => ({
+    id: coinType,
+    ticker: "TEST",
+    name: "Test Token",
+    countervalueTicker: "TEST",
+    standard: "SUI-20",
+    tokenType: "sui",
+    parentCurrency: { id: "sui" },
+    contract: "0x123",
+  }),
+  listTokensForCryptoCurrency: () => [{ id: "0x123::sui::TEST" }],
+}));
 
 jest.mock("../network", () => {
   const mockGetAccountBalances = jest.fn();


### PR DESCRIPTION

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Prepares Sui coin module for async CryptoAssetsStore migration
  - Adds `await` to token lookup calls
  - No breaking changes
  - Testing focus: Sui token operations

### 📝 Description

Part of the CryptoAssetsStore async migration strategy - prepares the Sui coin module.

**Changes:**
- Added `await` to `decodeTokenAccountId()` calls throughout the module
- Made functions async where token lookups occur
- Updated test fixtures to handle async patterns
- No functional changes - preparing for Layer 1 when `CryptoAssetsStore` becomes truly async

**Strategy:** This PR adds `await` keywords without breaking existing functionality. The actual async behavior will be introduced later when the framework layer is updated.

### ❓ Context

- **GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/11905
- **Migration strategy**: Multi-phase approach to enable async token loading from APIs

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.
