### PR TITLE
e2e tests: Remove token selection that no longer exists

### DIFF
--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -106,7 +106,6 @@ for (const token of subAccountReceive) {
         await app.account.expectAccountVisibility(getParentAccountName(token.account));
 
         await app.account.clickAddToken();
-        await app.receive.selectToken(token.account);
 
         await app.receive.continue();
 


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** https://ledger-live.allure.green.ledgerlabs.net/allure/reports/e5d21f21-eb57-4a4a-a438-c9eea88326f3/#suites/838ee5f9a3d61c5dff95b29bb8d63c07/3a39d0ed02ba5160/
- [x] **Impact of the changes:**

### 📝 Description

This should fix e2e fails on the `Add subAccount when parent exists`

the new Add Tokens flow is simply doing a Receive on the parent account, so as the previous feature was dropped, we converge the tests to do a regular receive

<img width="934" height="444" alt="Screenshot 2025-10-27 at 18 33 35" src="https://github.com/user-attachments/assets/9332defd-96cf-49a8-9be5-b139d48a3bc8" />


### ❓ Context

- **JIRA or GitHub link**:  https://ledger.slack.com/archives/C081T58FFHA/p1761584373371199


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
