### PR TITLE
feat: make Hedera using hook and disable Add Tokens for other fam

### DIFF
--- a/.changeset/small-boxes-warn.md
+++ b/.changeset/small-boxes-warn.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"ledger-live-desktop-e2e-tests": minor
+---
+
+feat(hedera): migrate receive token selection to useTokensData hook

--- a/apps/ledger-live-desktop/src/renderer/components/SelectCurrency.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SelectCurrency.tsx
@@ -36,6 +36,10 @@ type Props = {
   stylesMap?: (a: ThemeConfig) => CreateStylesReturnType<CurrencyOption>;
   onMenuOpen?: () => void;
   small?: boolean;
+  onMenuScrollToBottom?: () => void;
+  lastItemIndex?: number;
+  keepLastScrollPosition?: boolean;
+  isLoading?: boolean;
 };
 const getOptionValue = (data: CurrencyOption) => (data.currency as CryptoOrTokenCurrency).id;
 
@@ -56,6 +60,10 @@ const SelectCurrency = ({
   stylesMap,
   onMenuOpen,
   small,
+  onMenuScrollToBottom,
+  lastItemIndex,
+  keepLastScrollPosition,
+  isLoading,
 }: Props) => {
   const { t } = useTranslation();
   const devMode = useEnv("MANAGER_DEV_MODE");
@@ -143,6 +151,10 @@ const SelectCurrency = ({
       rowHeight={rowHeight}
       stylesMap={stylesMap}
       small={small}
+      onScrollEnd={onMenuScrollToBottom}
+      lastItemIndex={lastItemIndex}
+      keepLastScrollPosition={keepLastScrollPosition}
+      isLoading={isLoading}
     />
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/index.ts
@@ -23,6 +23,9 @@ const family: HederaFamily = {
   NoAssociatedAccounts,
   getTransactionExplorer,
   sendRecipientCanNext,
+  receiveTokensConfig: {
+    networkFamily: "hedera",
+  },
 };
 
 export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/types.ts
@@ -320,6 +320,17 @@ export type LLDCoinFamily<
   StepReceiveAccountCustomAlert?: React.ComponentType<ReceiveStepProps & { account: AccountLike }>;
 
   /**
+   * Configuration for receive tokens mode using cal-client
+   * When present, the receive flow will use useTokensData hook instead of listTokensForCryptoCurrency
+   */
+  receiveTokensConfig?: {
+    /**
+     * The network family to pass to useTokensData hook (e.g. "hedera")
+     */
+    networkFamily: string;
+  };
+
+  /**
    * Change Receive funds with this component (example: Hedera)
    */
   StepReceiveFunds?: React.ComponentType<ReceiveStepProps>;

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepAccount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepAccount.tsx
@@ -1,12 +1,10 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useState } from "react";
 import { Trans } from "react-i18next";
 import { Account, AccountLike } from "@ledgerhq/types-live";
-import { TokenCurrency, CryptoCurrency, CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { TokenCurrency, CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import {
-  listTokensForCryptoCurrency,
-  listTokenTypesForCryptoCurrency,
-} from "@ledgerhq/live-common/currencies/index";
+import { listTokenTypesForCryptoCurrency } from "@ledgerhq/live-common/currencies/index";
+import { useTokensData } from "@ledgerhq/cryptoassets/cal-client/hooks/useTokensData";
 import { supportLinkByTokenType } from "~/config/urls";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
@@ -61,15 +59,61 @@ const TokenParentSelection = ({
   );
 };
 const TokenSelection = ({
-  currency,
   token,
   onChangeToken,
+  networkFamily,
 }: {
-  currency: CryptoCurrency;
   token: TokenCurrency | undefined | null;
   onChangeToken: (token?: TokenCurrency | null) => void;
+  networkFamily: string;
 }) => {
-  const tokens = useMemo(() => listTokensForCryptoCurrency(currency), [currency]);
+  const [lastItemIndex, setLastItemIndex] = useState<number | undefined>(undefined);
+  const [keepLastScrollPosition, setKeepLastScrollPosition] = useState(false);
+
+  const {
+    data: tokensData,
+    isLoading,
+    error,
+    loadNext,
+  } = useTokensData({
+    networkFamily: networkFamily,
+    pageSize: 100,
+  });
+
+  const handleMenuScrollToBottom = useCallback(() => {
+    if (loadNext) {
+      setLastItemIndex(tokensData ? tokensData.tokens.length - 1 : 0);
+      setKeepLastScrollPosition(true);
+      loadNext();
+    }
+  }, [loadNext, tokensData]);
+
+  if (error) {
+    return (
+      <>
+        <Label mt={30}>
+          <Trans i18nKey="receive.steps.chooseAccount.token" />
+        </Label>
+        <Box>
+          <Trans i18nKey="receive.steps.chooseAccount.errorLoadingTokens" />
+        </Box>
+      </>
+    );
+  }
+
+  if (isLoading && !tokensData?.tokens.length) {
+    return (
+      <>
+        <Label mt={30}>
+          <Trans i18nKey="receive.steps.chooseAccount.token" />
+        </Label>
+        <Box>
+          <Trans i18nKey="common.loading" />
+        </Box>
+      </>
+    );
+  }
+
   return (
     <>
       <Label mt={30}>
@@ -77,8 +121,12 @@ const TokenSelection = ({
       </Label>
       <SelectCurrency
         onChange={onChangeToken as (token?: CryptoOrTokenCurrency | null) => void}
-        currencies={tokens}
+        currencies={tokensData?.tokens || []}
         value={token}
+        onMenuScrollToBottom={handleMenuScrollToBottom}
+        lastItemIndex={lastItemIndex}
+        keepLastScrollPosition={keepLastScrollPosition}
+        isLoading={isLoading}
       />
     </>
   );
@@ -105,6 +153,7 @@ export default function StepAccount(props: Readonly<StepProps>) {
   const url = supportLinkByTokenType[tokenTypes[0] as keyof typeof supportLinkByTokenType];
   const specific = mainAccount ? getLLDCoinFamily(mainAccount.currency.family) : null;
   const StepReceiveAccountCustomAlert = specific?.StepReceiveAccountCustomAlert;
+  const receiveTokensConfig = specific?.receiveTokensConfig;
 
   return (
     <Box flow={1}>
@@ -121,11 +170,11 @@ export default function StepAccount(props: Readonly<StepProps>) {
       ) : (
         <AccountSelection account={account} onChangeAccount={onChangeAccount} />
       )}
-      {receiveTokenMode && mainAccount ? (
+      {receiveTokenMode && mainAccount && receiveTokensConfig ? (
         <TokenSelection
-          currency={mainAccount.currency}
           token={token}
           onChangeToken={onChangeToken}
+          networkFamily={receiveTokensConfig.networkFamily}
         />
       ) : null}
 
@@ -167,11 +216,17 @@ export function StepAccountFooter({
   token,
   account,
   accountError,
+  parentAccount,
 }: StepProps) {
+  const mainAccount = account ? getMainAccount(account, parentAccount) : null;
+  const specific = mainAccount ? getLLDCoinFamily(mainAccount.currency.family) : null;
+  const receiveTokensConfig = specific?.receiveTokensConfig;
+  const shouldRequireToken = receiveTokenMode && receiveTokensConfig;
+
   return (
     <Button
       data-testid="modal-continue-button"
-      disabled={!account || (receiveTokenMode && !token) || accountError}
+      disabled={!account || (shouldRequireToken && !token) || accountError}
       primary
       onClick={() => transitionTo("device")}
     >

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2286,6 +2286,7 @@
         "label": "Account to credit",
         "parentAccount": "1. Select {{currencyName}} account",
         "token": "2. Select a token",
+        "errorLoadingTokens": "Error loading tokens",
         "verifyTokenType": "Please verify that <0>{{token}}</0> is an <0>{{tokenType}}</0> token. Any other crypto asset sent to an {{currency}} account may be lost.",
         "warningTokenType": "Please only send <0>{{ticker}}</0> or <0>{{tokenType}}</0> tokens to {{currency}} accounts. Sending other crypto assets may result in the permanent loss of funds.",
         "depositFromCexBannerTitle": "Deposit crypto from your Coinbase account"

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -106,7 +106,10 @@ for (const token of subAccountReceive) {
         await app.account.expectAccountVisibility(getParentAccountName(token.account));
 
         await app.account.clickAddToken();
-        await app.receive.selectToken(token.account);
+        if (token.shouldSelectTokenOnReceiveFlow) {
+          // e.g. for Hedera. This works together with the fact a family activate or not the receiveTokensConfig
+          await app.receive.selectToken(token.account);
+        }
 
         await app.receive.continue();
 


### PR DESCRIPTION
WIP , we need to work on https://ledgerhq.atlassian.net/browse/LIVE-21990 and https://ledgerhq.atlassian.net/browse/LIVE-21905 together due to fact we can't generically allow this for all families.

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
  - e2e run: https://github.com/LedgerHQ/ledger-live/actions/runs/18936630273
  - ⚠️  manually QA needed on Hedera to confirm this is still working
  - ⚠️  manually QA needed on Canton to confirm there is no problem on this modification
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD only
  - Hedera flow on the Add Tokens (Receive)
  - all other coin family will have a Add Tokens flow that is doing a Receive on main account

### 📝 Description

This re-address https://github.com/LedgerHQ/ledger-live/pull/12455 to also have a generic solution that can be enabled by coin families (here Hedera still needs a custom flow)

### ❓ Context

- **JIRA or GitHub link**:
  - https://ledgerhq.atlassian.net/browse/LIVE-21990
  - https://ledgerhq.atlassian.net/browse/LIVE-21905


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
