### PR TITLE
fix: canton spendable balance to include locked amount

### DIFF
--- a/.changeset/orange-zebras-hear.md
+++ b/.changeset/orange-zebras-hear.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-canton": minor
+---
+
+fix canton spendable balance to include locked amount

--- a/libs/coin-modules/coin-canton/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/sync.test.ts
@@ -132,7 +132,7 @@ describe("makeGetAccountShape", () => {
 
     expect(shape).toBeDefined();
     expect(shape.balance).toEqual(BigNumber(1010));
-    expect(shape.spendableBalance).toEqual(BigNumber(10));
+    expect(shape.spendableBalance).toEqual(BigNumber(1010));
   });
 
   it("should handle empty balances correctly", async () => {

--- a/libs/coin-modules/coin-canton/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/sync.ts
@@ -122,7 +122,7 @@ export function makeGetAccountShape(
     );
     const totalBalance = unlockedAmount.plus(lockedAmount);
     const reserveMin = new BigNumber(coinConfig.getCoinConfig(currency).minReserve || 0);
-    const spendableBalance = BigNumber.max(0, unlockedAmount.minus(reserveMin));
+    const spendableBalance = BigNumber.max(0, totalBalance.minus(reserveMin));
 
     const instrumentUtxoCounts: Record<string, number> = {};
     for (const [instrumentId, balance] of Object.entries(balancesData)) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - coin-canton

### 📝 Description

fix canton spendable balance to include locked amount

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
