### PR TITLE
ci: add flake reporting for detox

### DIFF
--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -362,6 +362,11 @@ jobs:
           path: apps/ledger-live-mobile/artifacts/e2e-test-results-ios-shard-${{ matrix.shardIndex }}.json
           name: "${{ needs.determine-builds.outputs.ios_timing_cache_key }}-${{ matrix.shardIndex }}"
 
+      - name: Record Flake
+        if: ${{ steps.detox.outcome == 'success' && hashFiles('apps/ledger-live-mobile/artifacts/ios.**') != '' }}
+        run: |
+          echo "Flake detected for iOS tests"
+
   detox-tests-android:
     name: "Android Build / Android Detox"
     needs: [ build-android, determine-builds ]
@@ -591,6 +596,11 @@ jobs:
         with:
           path: apps/ledger-live-mobile/artifacts/e2e-test-results-android-shard-${{ matrix.shardIndex }}.json
           name: "${{ needs.determine-builds.outputs.android_timing_cache_key }}-${{ matrix.shardIndex }}"
+
+      - name: Record Flake
+        if: ${{ steps.detox.outcome == 'success' && hashFiles('apps/ledger-live-mobile/artifacts/android.**') != '' }}
+        run: |
+          echo "Flake detected for Android tests"
 
       - name: Set job output based on detox result
         id: set-output


### PR DESCRIPTION
Report re-tries to enable easy flake detection for detox tests

Flake detected: https://github.com/LedgerHQ/ledger-live/actions/runs/18875066803/job/53862677200
Fail - no flake reported: https://github.com/LedgerHQ/ledger-live/actions/runs/18875066803/job/53862677197
Success - no flake reported: https://github.com/LedgerHQ/ledger-live/actions/runs/18875066803/job/53863243033