### PR TITLE
fix: canton uses onboarding endpoint directly without existing party …

### DIFF
--- a/.changeset/brown-crews-help.md
+++ b/.changeset/brown-crews-help.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-canton": minor
+---
+
+fix canton uses onboarding endpoint directly without existing party check

--- a/libs/coin-modules/coin-canton/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/onboard.ts
@@ -88,16 +88,14 @@ export const buildOnboardAccount =
 
         o.next({ status: OnboardStatus.PREPARE });
 
-        let { partyId } = await isAccountOnboarded(currency, publicKey);
+        const preparedTransaction = await prepareOnboarding(currency, publicKey);
+        const partyId = preparedTransaction.party_id;
 
         if (partyId) {
           const onboardedAccount = createOnboardedAccount(account, partyId, currency);
           o.next({ partyId, account: onboardedAccount }); // success
           return;
         }
-
-        const preparedTransaction = await prepareOnboarding(currency, publicKey);
-        partyId = preparedTransaction.party_id;
 
         o.next({ status: OnboardStatus.SIGN });
 


### PR DESCRIPTION
…check

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - coin-canton

### 📝 Description

fix canton uses onboarding endpoint directly without request to existing party check endpoint to properly manage validators change 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
