### PR TITLE
fix: no discreet mode in summary send flow

### DIFF
--- a/.changeset/shiny-shoes-kiss.md
+++ b/.changeset/shiny-shoes-kiss.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: no discreet mode in summary send flow

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepSummary.tsx
@@ -251,6 +251,7 @@ const StepSummary = (props: StepProps) => {
               fontSize={4}
               inline
               showCode
+              alwaysShowValue
               data-testid="transaction-amount"
             />
             <Box textAlign="right">
@@ -260,6 +261,7 @@ const StepSummary = (props: StepProps) => {
                 currency={currency}
                 value={amount}
                 alwaysShowSign={false}
+                alwaysShowValue
               />
             </Box>
           </Box>

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/steps/StepSummary.tsx
@@ -222,6 +222,7 @@ const StepSummary = (props: StepProps) => {
                 fontSize={4}
                 inline
                 showCode
+                alwaysShowValue
               />
               <Box textAlign="right">
                 <CounterValue
@@ -230,6 +231,7 @@ const StepSummary = (props: StepProps) => {
                   currency={currency}
                   value={amount}
                   alwaysShowSign={false}
+                  alwaysShowValue
                 />
               </Box>
             </Box>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When in discreet mode, still display the amount value in the send flow (summary step)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/465?selectedIssue=LIVE-22389)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
