### PR TITLE
test(e2e): LLM wait for webview to be loaded before interacting with …

### DIFF
--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -12,6 +12,7 @@ export default class CommonPage {
   accountItemNameRegExp = new RegExp(`${this.accountItemId}.*-name`);
   deviceItem = (deviceId: string): string => `device-item-${deviceId}`;
   deviceItemRegex = /device-item-.*/;
+  walletApiWebview = "wallet-api-webview";
 
   searchBar = () => getElementById(this.searchBarId);
   closeButton = () => getElementById("NavigationHeaderCloseButton");

--- a/e2e/mobile/page/trade/buySell.page.ts
+++ b/e2e/mobile/page/trade/buySell.page.ts
@@ -27,6 +27,7 @@ export default class BuySellPage {
   @Step("Open page via deeplink")
   async openViaDeeplink(page: "Buy" | "Sell") {
     await openDeeplink(page.toLowerCase());
+    await waitForElementById(app.common.walletApiWebview);
     await waitWebElementByTestId(this.cryptoCurrencySelector);
   }
 

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -50,6 +50,7 @@ export default class SwapPage {
   @Step("Open swap via deeplink")
   async openViaDeeplink() {
     await openDeeplink(this.baseLink);
+    await waitForElementById(app.common.walletApiWebview);
   }
 
   @Step("Expect swap page")


### PR DESCRIPTION
…live app

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* Make sure live app webview is loaded before interacting with live app elements

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA**: [QAA-869](https://ledgerhq.atlassian.net/browse/QAA-869)
- [Buy/Sell CI](https://github.com/LedgerHQ/ledger-live/actions/runs/18906573037)
- [SWAP CI](https://github.com/LedgerHQ/ledger-live/actions/runs/18906579049)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-869]: https://ledgerhq.atlassian.net/browse/QAA-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ