### PR TITLE
ci: nightly snapshot releases

### DIFF
--- a/.github/workflows/release-final-nightly.yml
+++ b/.github/workflows/release-final-nightly.yml
@@ -2,10 +2,11 @@ name: "[Nightly] - Build & Publish - Scheduled"
 
 on:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "0 2 * * TUE-SAT"  # At 02:00 on Tuesday, Wednesday, Thursday, Friday and Saturday (UTC)
   workflow_dispatch:
 
 jobs:
+
   nightly-release:
     name: Nightly Release
     runs-on: ubuntu-24.04
@@ -18,73 +19,74 @@ jobs:
         with:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: nightly
-          fetch-depth: 0
+          ref: develop
+          fetch-depth: 1
           token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Get checked out commit SHA
+        id: get-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Setup git user
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
-      - name: merge develop
-        run: |
-          git merge origin/develop -X theirs
+
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: setup-caches
         with:
           install-proto: true
           skip-turbo-cache: "false"
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.0
-          # Not needed with a .ruby-version file
-          # runs 'bundle install' and caches installed gems automatically
-      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
-        id: desktop-version
-        with:
-          path: ${{ github.workspace }}/apps/ledger-live-desktop
-      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
-        id: mobile-version
-        with:
-          path: ${{ github.workspace }}/apps/ledger-live-mobile
+
       - name: install dependencies
         run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli"
+
       - name: build libs
         run: pnpm run build:libs
-      - name: versioning
+
+      - name: snapshot versioning
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm changeset version
-      - name: commit
-        run: |
-          git add .
-          if [ "$(git status --porcelain --untracked-files=no)" ]; then 
-            git commit -m "chore(nightly): :rocket: nightly release"
-          fi
+        run: pnpm changeset version --snapshot nightly
+
       - name: authenticate with npm
         uses: actions/setup-node@v4
         with:
           registry-url: "https://registry.npmjs.org"
+
       - name: publish nightly
-        run: pnpm changeset publish --no-git-tag
+        run: pnpm changeset publish --tag nightly --no-git-tag
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+
       - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
         id: post-desktop-version
         with:
           path: ${{ github.workspace }}/apps/ledger-live-desktop
+
       - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
         id: post-mobile-version
         with:
           path: ${{ github.workspace }}/apps/ledger-live-mobile
-      - name: push changes
-        if: ${{ !cancelled() }}
-        run: |
-          git push origin nightly
+
+      - name: tag nightly ref
+        uses: LedgerHQ/ledger-live/tools/actions/composites/create-or-update-tag@develop
+        with:
+          ref: ${{ steps.get-sha.outputs.sha }}
+          tagName: nightly
+          token: ${{ steps.generate-token.outputs.token }}
+          overwrite: true
+
       - uses: actions/github-script@v7
         name: trigger nightly build of desktop
-        if: ${{ steps.desktop-version.outputs.version != steps.post-desktop-version.outputs.version }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -93,10 +95,13 @@ jobs:
               repo: "ledger-live-build",
               ref: "main",
               workflow_id: "nightly-desktop.yml",
+              inputs: {
+                  version_override: "${{ steps.post-desktop-version.outputs.version }}"
+              }
             });
+
       - uses: actions/github-script@v7
         name: trigger nightly build of mobile
-        if: ${{ steps.mobile-version.outputs.version != steps.post-mobile-version.outputs.version }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -105,6 +110,9 @@ jobs:
               repo: "ledger-live-build",
               ref: "main",
               workflow_id: "nightly-mobile.yml",
+              inputs: {
+                  version_override: "${{ steps.post-mobile-version.outputs.version }}"
+              }
             });
 
   nightly-fail:

--- a/tools/actions/composites/create-or-update-tag/action.yml
+++ b/tools/actions/composites/create-or-update-tag/action.yml
@@ -1,0 +1,78 @@
+name: "Create or Update Tag"
+description: "Create or update a Git tag using the GitHub API. Can overwrite existing tags if specified."
+inputs:
+  ref:
+    description: "The ref (commit SHA) to tag"
+    required: true
+  tagName:
+    description: "The name of the tag"
+    required: true
+  token:
+    description: "GitHub token for authentication"
+    required: true
+  overwrite:
+    description: "Whether to overwrite the tag if it already exists"
+    type: boolean
+    default: "true"
+    required: false
+outputs:
+  created:
+    description: "Whether a new tag was created"
+    value: ${{ steps.tag.outputs.created }}
+  updated:
+    description: "Whether an existing tag was updated"
+    value: ${{ steps.tag.outputs.updated }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create or update tag
+      id: tag
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const ref = '${{ inputs.ref }}';
+          const tagName = '${{ inputs.tagName }}';
+          const overwrite = '${{ inputs.overwrite }}' === 'true';
+          
+          try {
+            // Try to get the existing tag
+            await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${tagName}`
+            });
+            
+            // Tag exists
+            if (overwrite) {
+              // Update the existing tag
+              await github.rest.git.updateRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${tagName}`,
+                sha: ref,
+                force: true
+              });
+              console.log(`Updated tag '${tagName}' to point to ${ref}`);
+              core.setOutput('updated', 'true');
+              core.setOutput('created', 'false');
+            } else {
+              core.setFailed(`Tag '${tagName}' already exists and overwrite is disabled`);
+            }
+          } catch (error) {
+            if (error.status === 404) {
+              // Tag doesn't exist, create it
+              await github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `refs/tags/${tagName}`,
+                sha: ref
+              });
+              console.log(`Created tag '${tagName}' pointing to ${ref}`);
+              core.setOutput('created', 'true');
+              core.setOutput('updated', 'false');
+            } else {
+              throw error;
+            }
+          }


### PR DESCRIPTION
Aim: Retire the nightly branch in favour of using a tag. Utilise snapshot releases to manage versioning to avoid need to store version "state" in a branch

Nightly testing tag: https://github.com/LedgerHQ/ledger-live/tree/nightly-test

Initial green run (creating tag): https://github.com/LedgerHQ/ledger-live/actions/runs/18909532192/job/53976164183
Tag updated: https://github.com/LedgerHQ/ledger-live/actions/runs/18910384316/job/53979203872

Successful builds with new naming: 
https://github.com/LedgerHQ/ledger-live-build/actions/runs/18939513300
https://github.com/LedgerHQ/ledger-live-build/actions/runs/18939513651

LLD auto update test:
<img width="735" height="110" alt="Screenshot 2025-10-30 at 12 30 28" src="https://github.com/user-attachments/assets/1b9a6d07-ea67-4127-94bd-3a42120a6371" />

Tickets:
https://ledgerhq.atlassian.net/browse/LIVE-13916
https://ledgerhq.atlassian.net/browse/LIVE-22199
https://ledgerhq.atlassian.net/browse/LIVE-20589
https://ledgerhq.atlassian.net/browse/LIVE-20044
