### PR TITLE
ci: configure snapshots to use calculated versions and adjust tagging

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,5 +12,9 @@
   "access": "public",
   "baseBranch": "develop",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "snapshot": {
+    "useCalculatedVersion": true,
+    "prereleaseTemplate": "{tag}.{datetime}"
+  }
 }


### PR DESCRIPTION
Precursor for nightly snapshot builds. 

- Configure the format of the timestamps to match our current formatting of tags
- Configure snapshots to utilise computed versions so they are not 0.0.0-tag.timstamp and are instead x.y.z-tag.timestamp