### PR TITLE
fix: guide user for ble address migration

### DIFF
--- a/apps/ledger-live-mobile/src/components/SelectDevice2/DeviceItem.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/DeviceItem.tsx
@@ -31,11 +31,11 @@ function DeviceIcon({ deviceModelId }: { deviceModelId: DeviceModelId }) {
 }
 
 export default function DeviceItem({ device, onPress }: Props) {
-  const { wired, available } = device;
+  const { wired, available, needsMigration } = device;
   const [isRemoveDeviceMenuOpen, setIsRemoveDeviceMenuOpen] = useState<boolean>(false);
 
-  const wording = wired ? "usb" : available ? "available" : "unavailable";
-  const color = wording === "unavailable" ? "neutral.c60" : "primary.c80";
+  const wording = wired ? "usb" : available ? needsMigration ? "needsMigration" : "available" : "unavailable";
+  const color = wording === "unavailable" ? "neutral.c60" : needsMigration ? "warning.c80" : "primary.c80";
   const testID = `device-item-${device.deviceId}`;
 
   const onItemContextPress = useCallback(() => {

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -220,11 +220,22 @@ export default function SelectDevice({
   }, []);
 
   const deviceList = useMemo(() => {
+
+    // Helper function to get the last 6 bytes (12 hex characters) of a device ID
+    const getDeviceIdSuffix = (id: string): string => {
+      // Remove any non-hex characters and get last 12 characters
+      const cleanId = id.replace(/[^a-fA-F0-9]/g, '');
+      return cleanId.slice(-12).toLowerCase();
+    };
+
+
     const devices: Device[] = knownDevices
       .map(device => {
         const equivalentScannedDevice = filteredScannedDevices.find(
-          ({ deviceId }) => device.id === deviceId,
+          ({ deviceId }) => device.id === deviceId || getDeviceIdSuffix(device.deviceId) === getDeviceIdSuffix(device.id),
         );
+
+        const needsMigration = equivalentScannedDevice.id !== device.deviceId;
 
         return {
           ...device,
@@ -232,6 +243,7 @@ export default function SelectDevice({
           deviceId: device.id,
           deviceName: equivalentScannedDevice?.deviceName ?? device.name,
           available: Boolean(equivalentScannedDevice),
+          needsMigration
         };
       })
       .sort((a, b) => Number(b.available) - Number(a.available));
@@ -317,11 +329,11 @@ export default function SelectDevice({
     () =>
       withMyLedgerTracking
         ? {
-            event: "button_clicked",
-            eventProperties: {
-              button: "Add new device",
-            },
-          }
+          event: "button_clicked",
+          eventProperties: {
+            button: "Add new device",
+          },
+        }
         : {},
     [withMyLedgerTracking],
   );
@@ -396,8 +408,7 @@ export default function SelectDevice({
                       <Flex flexDirection="row" alignItems="center">
                         <Text color="primary.c90" mr={3} fontWeight="semiBold">
                           {t(
-                            `manager.selectDevice.${
-                              Platform.OS === "android" ? "addWithBluetooth" : "addNewCTA"
+                            `manager.selectDevice.${Platform.OS === "android" ? "addWithBluetooth" : "addNewCTA"
                             }`,
                           )}
                         </Text>
@@ -433,8 +444,7 @@ export default function SelectDevice({
                         <IconsLegacy.PlusMedium color="neutral.c90" size={20} />
                         <Text variant="large" fontWeight="semiBold" ml={5}>
                           {t(
-                            `manager.selectDevice.${
-                              Platform.OS === "android" ? "addWithBluetooth" : "addALedger"
+                            `manager.selectDevice.${Platform.OS === "android" ? "addWithBluetooth" : "addALedger"
                             }`,
                           )}
                         </Text>
@@ -477,12 +487,12 @@ export default function SelectDevice({
                 testID="manager_setup_new_device"
                 {...(withMyLedgerTracking
                   ? {
-                      event: "button_clicked",
-                      eventProperties: {
-                        button: "Set up a new Ledger",
-                        drawer: "Add a Ledger device",
-                      },
-                    }
+                    event: "button_clicked",
+                    eventProperties: {
+                      button: "Set up a new Ledger",
+                      drawer: "Add a Ledger device",
+                    },
+                  }
                   : {})}
               >
                 <Flex backgroundColor="neutral.c30" mb={4} px={6} py={7} borderRadius={8}>
@@ -508,12 +518,12 @@ export default function SelectDevice({
                 testID="manager_connect_device"
                 {...(withMyLedgerTracking
                   ? {
-                      event: "button_clicked",
-                      eventProperties: {
-                        button: "Connect with Bluetooth",
-                        drawer: "Add a Ledger device",
-                      },
-                    }
+                    event: "button_clicked",
+                    eventProperties: {
+                      button: "Connect with Bluetooth",
+                      drawer: "Add a Ledger device",
+                    },
+                  }
                   : {})}
               >
                 <Flex backgroundColor="neutral.c30" px={6} py={7} borderRadius={8}>

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4612,7 +4612,8 @@
       "item": {
         "usb": "Connected with USB",
         "available": "Available. Tap to connect",
-        "unavailable": "Not connected"
+        "unavailable": "Not connected",
+        "needsMigration": "Migration needed"
       }
     },
     "connect": "Select your device",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
