### PR TITLE
[LIVE-22504][DMK][LLM] RefusedByUserDAError when user refuses secure connection before an open app

### DIFF
--- a/.changeset/poor-spoons-do.md
+++ b/.changeset/poor-spoons-do.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-dmk-mobile": minor
+---
+
+Fix an error recognition bug in ConnectApp DA

--- a/libs/ledger-live-common/src/hw/connectAppEventMapper.ts
+++ b/libs/ledger-live-common/src/hw/connectAppEventMapper.ts
@@ -12,11 +12,9 @@ import type {
 import {
   DeviceActionStatus,
   DeviceDisconnectedWhileSendingError,
-  DeviceLockedError,
   DeviceSessionStateType,
   UserInteractionRequired,
   OutOfMemoryDAError,
-  SecureChannelError,
   UnsupportedFirmwareDAError,
 } from "@ledgerhq/device-management-kit";
 import type {
@@ -254,10 +252,10 @@ export class ConnectAppEventMapper {
             deviceState.firmwareUpdateContext!.currentFirmware.version,
         }),
       );
-    } else if (error instanceof DeviceLockedError) {
+    } else if ("_tag" in error && error._tag === "DeviceLockedError") {
       this.eventSubject.next({ type: "lockedDevice" });
       this.eventSubject.complete();
-    } else if (error instanceof SecureChannelError) {
+    } else if ("_tag" in error && error._tag === "RefusedByUserDAError") {
       this.eventSubject.error(new UserRefusedAllowManager());
     } else if (error instanceof DeviceDisconnectedWhileSendingError) {
       this.eventSubject.next({ type: "disconnected", expected: false });

--- a/libs/live-dmk-mobile/src/errors.ts
+++ b/libs/live-dmk-mobile/src/errors.ts
@@ -6,9 +6,10 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { PeerRemovedPairingError } from "@ledgerhq/device-transport-kit-react-native-ble";
 
-export const isDmkError = (error: any): error is DmkError => !!error && "_tag" in error;
+export const isDmkError = (error: unknown): error is DmkError =>
+  !!error && typeof error === "object" && error !== null && "_tag" in error;
 
-export const isiOSPeerRemovedPairingError = (error: any): boolean => {
+export const isiOSPeerRemovedPairingError = (error: unknown): boolean => {
   return (
     error instanceof OpeningConnectionError &&
     "originalError" in error &&
@@ -31,13 +32,12 @@ export const isPeerRemovedPairingError = (error: unknown): boolean => {
 };
 
 export const isAllowedOnboardingStatePollingErrorDmk = (error: unknown): boolean => {
-  if (error) {
+  if (isDmkError(error)) {
     return (
       error instanceof SendApduTimeoutError ||
       error instanceof DeviceBusyError ||
-      (typeof error === "object" && "_tag" in error && error._tag === "DeviceSessionNotFound")
+      error._tag === "DeviceSessionNotFound"
     );
   }
-
   return false;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Now `RefusedByUserDAError` and `DeviceLockedError` can behave as expected.

### 📝 Description

In these two videos, I initialised a receive flow then:
1. Refuse on the device;
2. Lock device.

The `instanceof` keyword cannot identify the errors emitted by DMK in this case, so checking the `_tag` property instead.

**Before:**

https://github.com/user-attachments/assets/b8fa815a-e717-43aa-b5ed-e8945d7903d8

**After:**

https://github.com/user-attachments/assets/f7e9a4f4-1d14-42c3-9eb9-e63414628ceb


### ❓ Context

- **JIRA or GitHub link**: [LIVE-22504]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22504]: https://ledgerhq.atlassian.net/browse/LIVE-22504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ