### PR TITLE
fix: run integration tests when modification in coin-modules

### DIFF
--- a/.changeset/tender-dragons-turn.md
+++ b/.changeset/tender-dragons-turn.md
@@ -1,0 +1,5 @@
+---
+"@actions/live-common-affected": minor
+---
+
+Fix integration tests not running when a coin-modules is modified

--- a/.github/workflows/test-coin-modules-integ.yml
+++ b/.github/workflows/test-coin-modules-integ.yml
@@ -3,6 +3,12 @@ name: "[Coin] - Test Coin modules - Scheduled"
 on:
   schedule:
     - cron: "20 9 * * *"
+
+  pull_request:
+    branches-ignore:
+      - "smartling-content-updated**"
+      - "smartling-translation-completed**"
+
   workflow_dispatch:
     inputs:
       ref:
@@ -15,8 +21,44 @@ permissions:
   contents: read
 
 jobs:
+  is-affected:
+    outputs:
+      is-affected: ${{ steps.affected.outputs.is-affected }}
+      paths: ${{ steps.affected.outputs.paths }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+      - name: checkout branch (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr checkout ${{ github.event.pull_request.number }}
+      - name: checkout branch (not PR)
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          git checkout $GITHUB_SHA
+      - uses: LedgerHQ/ledger-live/tools/actions/live-common-affected@develop
+        id: affected
+        with:
+          ref: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || 'HEAD^' }}
+      - name: Force affected on schedule
+        id: set-affected
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "Forcing affected=true (scheduled run)"
+            echo "is-affected=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-affected=${{ steps.affected.outputs.is-affected }}" >> "$GITHUB_OUTPUT"
+          fi
+
   integ-tests:
     name: "Coin modules integration tests"
+    needs: is-affected
+    if: ${{ needs.is-affected.outputs.is-affected == 'true' }}
     runs-on: ubuntu-22.04
 
     env:
@@ -44,14 +86,28 @@ jobs:
       - name: Build
         run: pnpm build:coin-modules:deps
 
-      - name: Test
+      - name: Test (PR)
+        if: ${{ github.event_name == 'pull_request' }}
         shell: bash
+        env:
+          FILTER: ${{ needs.is-affected.outputs.paths }}
+          VERBOSE_FILE: logs.txt
+        run: |
+          for coin in $FILTER; do
+            pnpm coin:$coin test-integ
+          done
+
+      - name: Test (Scheduled)
+        if: ${{ github.event_name == 'schedule' }}
+        shell: bash
+        env:
+          VERBOSE_FILE: logs.txt
         run: pnpm coin-modules:test-integ
 
   integ-tests-fail:
     name: failure report
     needs: integ-tests
-    if: failure() && github.event_name != 'workflow_dispatch'
+    if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == 'develop'))
     runs-on: ubuntu-latest
     steps:
       - name: post to live-repo-health slack channel
@@ -71,10 +127,27 @@ jobs:
                 text:
                   type: "mrkdwn"
                   text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow run>"
+      - name: post to coin-integration-private slack channel
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          method: chat.postMessage
+          payload: |
+            channel: "C06RTDKT324"
+            text: "[Test] Coin modules"
+            blocks: 
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "❌ *Coin modules integration tests failed*"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow run>"
   integ-tests-success:
     name: success report
     needs: integ-tests
-    if: success() && github.event_name != 'workflow_dispatch'
+    if: success() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: post to live-repo-health slack channel

--- a/tools/actions/live-common-affected/build/main.js
+++ b/tools/actions/live-common-affected/build/main.js
@@ -19090,7 +19090,9 @@ function main(ref) {
             const m = line.match(combinedRegex);
             if (m) {
               const [first, second, third] = m;
-              if (second === "families") {
+              if (first.startsWith("coin-modules/")) {
+                return first.replace(/^.*coin-/, "");
+              } else if (second === "families") {
                 return `${second}/${third}`;
               } else if (second === "live-common/src/bridge/generic-alpaca") {
                 return GENERIC_ALPACA_CHAINS;

--- a/tools/actions/live-common-affected/src/main.ts
+++ b/tools/actions/live-common-affected/src/main.ts
@@ -37,7 +37,9 @@ function main(ref: string) {
               const m = line.match(combinedRegex);
               if (m) {
                 const [first, second, third] = m;
-                if (second === "families") {
+                if (first.startsWith("coin-modules/")) {
+                  return first.replace(/^.*coin-/, "");
+                } else if (second === "families") {
                   // in case of coin implementations, we will stop at the coin family level
                   return `${second}/${third}`;
                 } else if (second === "live-common/src/bridge/generic-alpaca") {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Integration tests are not run properly when you change the coin-module because it try to run `pnpm --filter live-common "ci-test-integration" "coin-xrp` for exemple.
Now it runs `pnpm --filter live-common "ci-test-integration" "xrp"`.

Run test-integ tests if you change con-module !

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-19519](https://ledgerhq.atlassian.net/browse/LIVE-19519)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-19519]: https://ledgerhq.atlassian.net/browse/LIVE-19519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ