### PR TITLE
test: fix integration tests that uses getTokensSyncHash

### DIFF
--- a/apps/ledger-live-desktop/src/newArch/hooks/useStake.test.ts
+++ b/apps/ledger-live-desktop/src/newArch/hooks/useStake.test.ts
@@ -43,7 +43,11 @@ const rawTron: AccountRaw = {
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-setCryptoAssetsStore({} as CryptoAssetsStore);
+setCryptoAssetsStore({
+  findTokenById: (_: string) => undefined,
+  findTokenByAddressInCurrency: (_: string, __: string) => undefined,
+  getTokensSyncHash: (_: string) => Promise.resolve("test_hash"),
+} as CryptoAssetsStore);
 
 const mockEthereumAccount = fromAccountRaw(raw);
 const mockTronAccount = fromAccountRaw(rawTron);

--- a/apps/ledger-live-mobile/src/newArch/hooks/useStake/useStake.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/hooks/useStake/useStake.test.ts
@@ -44,7 +44,11 @@ const rawTron: AccountRaw = {
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-setCryptoAssetsStore({} as CryptoAssetsStore);
+setCryptoAssetsStore({
+  findTokenById: (_: string) => undefined,
+  findTokenByAddressInCurrency: (_: string, __: string) => undefined,
+  getTokensSyncHash: (_: string) => Promise.resolve("test_hash"),
+} as CryptoAssetsStore);
 const mockEthereumAccount = fromAccountRaw(raw);
 const mockTronAccount = fromAccountRaw(rawTron);
 

--- a/libs/coin-modules/coin-sui/src/bridge/synchronisation.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/synchronisation.test.ts
@@ -44,6 +44,8 @@ const mockedFindTokenByAddressInCurrency = jest.fn();
 setCryptoAssetsStore({
   findTokenByAddressInCurrency: (address: string, currencyId: string) =>
     mockedFindTokenByAddressInCurrency(address, currencyId),
+  findTokenById: (_: string) => undefined,
+  getTokensSyncHash: (_: string) => Promise.resolve("test_hash"),
 } as unknown as CryptoAssetsStore);
 
 describe("getAccountShape", () => {

--- a/libs/ledger-live-common/src/DataModel.test.ts
+++ b/libs/ledger-live-common/src/DataModel.test.ts
@@ -68,6 +68,7 @@ describe("DataModel", () => {
   setCryptoAssetsStoreForCoinFramework({
     findTokenById: (_: string) => undefined,
     findTokenByAddressInCurrency: (_: string, __: string) => undefined,
+    getTokensSyncHash: (_: string) => Promise.resolve("test_hash"),
   } as CryptoAssetsStore);
 
   test("createDataModel for crypto.org account", () => {

--- a/libs/ledger-live-common/src/__tests__/test-helpers/setup.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/setup.ts
@@ -1,5 +1,5 @@
 import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
-import type { CryptoAssetsStore } from "@ledgerhq/types-live";
+import { legacyCryptoAssetsStore } from "@ledgerhq/cryptoassets/tokens";
 import "./environment";
 import BigNumber from "bignumber.js";
 
@@ -14,8 +14,5 @@ expect.extend({
   },
 });
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-setCryptoAssetsStoreForCoinFramework({
-  findTokenById: (_: string) => undefined,
-  findTokenByAddressInCurrency: (_: string, __: string) => undefined,
-} as CryptoAssetsStore);
+// Use legacyCryptoAssetsStore for integration tests so tokens can be found
+setCryptoAssetsStoreForCoinFramework(legacyCryptoAssetsStore);

--- a/libs/ledger-live-common/src/deposit/deposit.integration.test.ts
+++ b/libs/ledger-live-common/src/deposit/deposit.integration.test.ts
@@ -7,6 +7,21 @@ import { useGroupedCurrenciesByProvider } from ".";
 import { GroupedCurrencies, LoadingBasedGroupedCurrencies, MappedAsset } from "./type";
 import * as api from "./api";
 
+// Mock dependencies for useAcceptedCurrency
+jest.mock("../featureFlags", () => ({
+  useFeature: jest.fn().mockReturnValue({ enabled: true }),
+}));
+
+jest.mock("../hooks/useEnv", () => jest.fn().mockReturnValue(false));
+
+// Mock the countervalues API for currenciesByMarketcap
+jest.mock("@ledgerhq/live-countervalues/api/index", () => ({
+  __esModule: true,
+  default: {
+    fetchIdsSortedByMarketcap: jest.fn().mockResolvedValue(["bitcoin", "ethereum"]),
+  },
+}));
+
 // Mock the API module
 jest.mock("./api");
 const mockGetMappedAssets = api.getMappedAssets as jest.MockedFunction<typeof api.getMappedAssets>;

--- a/libs/ledger-live-common/src/families/tron/data.mock.ts
+++ b/libs/ledger-live-common/src/families/tron/data.mock.ts
@@ -11,6 +11,7 @@ export const __LAST_VOTING_DATE__ = new Date(Date.now() - 6 * 60 * 60 * 1000);
 setCryptoAssetsStoreForCoinFramework({
   findTokenById: (_: string) => undefined,
   findTokenByAddressInCurrency: (_: string, __: string) => undefined,
+  getTokensSyncHash: (_: string) => Promise.resolve("test_hash"),
 } as unknown as CryptoAssetsStore);
 
 export const mockAccount = fromAccountRaw({

--- a/libs/live-wallet/src/liveqr/importAccounts.test.ts
+++ b/libs/live-wallet/src/liveqr/importAccounts.test.ts
@@ -14,6 +14,7 @@ import {
 setCryptoAssetsStore({
   findTokenById: (_: string) => undefined,
   findTokenByAddressInCurrency: (_: string, __: string) => undefined,
+  getTokensSyncHash: (_: string) => Promise.resolve("test_hash"),
 } as unknown as CryptoAssetsStore);
 
 // Mock account factory using fromAccountRaw for proper Account structure


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - only tests

### 📝 Description

I noticed integration recently seems to fail, this fix a bunch of bad patterns we had in existing tests regarding the fact we didn't provide `getTokensSyncHash` in mock and when https://github.com/LedgerHQ/ledger-live/pull/12500 was merged yesterday, this issue started to appear on Integration Tests

### ❓ Context

- **JIRA or GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/12500


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
