### PR TITLE
:test_tube: (MAD) add account coverage

### DIFF
--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -34,6 +34,12 @@ jest.mock("react-native-gesture-handler", () => {
   };
 });
 
+jest.mock("react-native-haptic-feedback", () => ({
+  default: {
+    trigger: jest.fn(),
+  },
+}));
+
 jest.mock("@segment/analytics-react-native", () => mockAnalytics);
 
 jest.mock("react-native-launch-arguments", () => ({}));

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/addAccountFlow.test.tsx
@@ -1,0 +1,205 @@
+import React from "react";
+import { act, render, waitFor } from "@tests/test-renderer";
+import { ModularDrawerSharedNavigator, WITH_ACCOUNT_SELECTION } from "./shared";
+import { BTC_ACCOUNT } from "@ledgerhq/live-common/modularDrawer/__mocks__/accounts.mock";
+import { Account } from "@ledgerhq/types-live";
+import { of, Observable } from "rxjs";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+
+// Needed for receive navigator
+jest.mock("@ledgerhq/live-config/LiveConfig", () => {
+  const mockConfig = { mock: { type: "string", default: "test" } };
+  return {
+    LiveConfig: {
+      instance: {
+        config: mockConfig,
+        provider: {
+          getValueByKey: jest.fn(),
+        },
+      },
+      getValueByKey: jest.fn((key: string) => {
+        if (key === "config_currency") {
+          return { checkSanctionedAddress: false };
+        } else if (key.startsWith("config_currency_")) {
+          return {};
+        } else if (key === "tmp_sanctioned_addresses") {
+          return [];
+        }
+        return undefined;
+      }),
+      setConfig: jest.fn(),
+      setProvider: jest.fn(),
+      setAppinfo: jest.fn(),
+      isConfigSet: jest.fn(() => true),
+    },
+  };
+});
+
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: () => mockUseAcceptedCurrency(),
+}));
+
+jest.mock("@ledgerhq/live-common/hw/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/hw/index"),
+  discoverDevices: jest.fn((_filter?: (module: { id: string }) => boolean) => {
+    const deviceEvent = {
+      type: "add" as const,
+      id: "usb|1",
+      name: "Ledger Stax",
+      deviceModel: { id: DeviceModelId.stax },
+      wired: true,
+    };
+    return of(deviceEvent);
+  }),
+}));
+
+jest.mock("~/hooks/deviceActions", () => ({
+  __esModule: true,
+  useAppDeviceAction: () => {
+    const device = { modelId: "stax" as const, deviceId: "usb|1" };
+    const appAndVersion = { name: "Bitcoin", version: "1.0.0" };
+    return {
+      useHook: () => ({
+        device,
+        isLocked: false,
+        opened: true,
+        appAndVersion,
+      }),
+      mapResult: () => ({
+        device,
+        appAndVersion,
+      }),
+    };
+  },
+}));
+
+let triggerNext: (accounts: Account[]) => void = () => null;
+let triggerComplete: () => void = () => null;
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  __esModule: true,
+  getCurrencyBridge: () => ({
+    scanAccounts: () =>
+      new Observable<{ account: Account }>(subscriber => {
+        const originalNext = triggerNext;
+        const originalComplete = triggerComplete;
+        triggerNext = (accounts: Account[]) => {
+          accounts.forEach(account => subscriber.next({ account }));
+        };
+        triggerComplete = () => {
+          subscriber.complete();
+        };
+        return () => {
+          triggerNext = originalNext;
+          triggerComplete = originalComplete;
+        };
+      }),
+    preload: () => Promise.resolve(true),
+    hydrate: () => true,
+  }),
+}));
+
+const mockScanAccountsSubscription = async (accounts: Account[]) => {
+  for (let i = 0; i < accounts.length; i++) {
+    await act(() => triggerNext(accounts.slice(0, i + 1)));
+  }
+  await act(() => triggerComplete());
+};
+
+const mockUseAcceptedCurrency = jest.fn(() => () => true);
+
+const advanceTimers = () => {
+  act(() => {
+    jest.advanceTimersByTime(500);
+  });
+};
+
+describe("AddAccountFlow with MAD", () => {
+  it("should do the add account flow then go back to the previous screen", async () => {
+    const { getByText, queryByText, user } = render(
+      <ModularDrawerSharedNavigator flow="add_account" />,
+    );
+    expect(getByText(WITH_ACCOUNT_SELECTION)).toBeVisible();
+    await user.press(getByText(WITH_ACCOUNT_SELECTION));
+    advanceTimers();
+    expect(getByText(/bitcoin/i)).toBeVisible();
+    await user.press(getByText(/bitcoin/i));
+    advanceTimers();
+    expect(getByText(/add new or existing account/i)).toBeVisible();
+    await user.press(getByText(/add new or existing account/i));
+    advanceTimers();
+    expect(getByText(/connect device/i)).toBeVisible();
+    advanceTimers();
+    const deviceItem = getByText(/ledger stax/i);
+    expect(deviceItem).toBeVisible();
+    await user.press(deviceItem);
+    advanceTimers();
+    await waitFor(() => {
+      expect(getByText(/checking the blockchain/i)).toBeVisible();
+    });
+    await mockScanAccountsSubscription([BTC_ACCOUNT]);
+    expect(getByText(/we found 1 account/i)).toBeVisible();
+    await user.press(getByText(/confirm/i));
+    expect(getByText(/account added to your portfolio/i)).toBeVisible();
+    await user.press(getByText(/close/i));
+    expect(queryByText(/account added to your portfolio/i)).not.toBeVisible();
+    expect(getByText(WITH_ACCOUNT_SELECTION)).toBeVisible();
+  });
+
+  it("should do the add account flow and go back to the previous screen automatically", async () => {
+    const { getByText, user, queryByText } = render(
+      <ModularDrawerSharedNavigator flow="not_add_account" />,
+    );
+    expect(getByText(WITH_ACCOUNT_SELECTION)).toBeVisible();
+    await user.press(getByText(WITH_ACCOUNT_SELECTION));
+    advanceTimers();
+    expect(getByText(/bitcoin/i)).toBeVisible();
+    await user.press(getByText(/bitcoin/i));
+    advanceTimers();
+    expect(getByText(/add new or existing account/i)).toBeVisible();
+    await user.press(getByText(/add new or existing account/i));
+    advanceTimers();
+    expect(getByText(/connect device/i)).toBeVisible();
+    advanceTimers();
+    const deviceItem = getByText(/ledger stax/i);
+    expect(deviceItem).toBeVisible();
+    await user.press(deviceItem);
+    advanceTimers();
+    await waitFor(() => {
+      expect(getByText(/checking the blockchain/i)).toBeVisible();
+    });
+    await mockScanAccountsSubscription([BTC_ACCOUNT]);
+    expect(getByText(/we found 1 account/i)).toBeVisible();
+    await user.press(getByText(/confirm/i));
+    expect(queryByText(/account added to your portfolio/i)).not.toBeVisible();
+    expect(getByText(WITH_ACCOUNT_SELECTION)).toBeVisible();
+  });
+
+  it("should do the add account flow then add funds actions", async () => {
+    const { getByText, getByTestId, user } = render(
+      <ModularDrawerSharedNavigator flow="add_account" />,
+    );
+    expect(getByText(WITH_ACCOUNT_SELECTION)).toBeVisible();
+    await user.press(getByText(WITH_ACCOUNT_SELECTION));
+    advanceTimers();
+    await user.press(getByText(/bitcoin/i));
+    advanceTimers();
+    await user.press(getByText(/add new or existing account/i));
+    advanceTimers();
+    const deviceItem = getByText(/ledger stax/i);
+    expect(deviceItem).toBeVisible();
+    await user.press(deviceItem);
+    advanceTimers();
+    await waitFor(() => {
+      expect(getByText(/checking the blockchain/i)).toBeVisible();
+    });
+    await mockScanAccountsSubscription([BTC_ACCOUNT]);
+    expect(getByText(/we found 1 account/i)).toBeVisible();
+    await user.press(getByText(/confirm/i));
+    await user.press(getByText(/add funds to my account/i));
+    await user.press(getByText(/receive crypto from another wallet/i));
+    expect(getByText(/receive BTC/i)).toBeVisible();
+    await user.press(getByTestId(/NavigationHeaderCloseButton/i));
+    expect(getByText(/add funds to my account/i)).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/shared.tsx
@@ -3,6 +3,7 @@ import { createStackNavigator } from "@react-navigation/stack";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { ScreenName, NavigatorName } from "~/const";
 import DeviceSelectionNavigator from "LLM/features/DeviceSelection/Navigator";
+import AddAccountsNavigator from "LLM/features/Accounts/Navigator";
 
 import { Button } from "@ledgerhq/native-ui";
 import {
@@ -16,6 +17,7 @@ import {
 import { BigNumber } from "bignumber.js";
 import { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
 import { ModularDrawer, useModularDrawerController } from "..";
+import ReceiveFundsNavigator from "~/components/RootNavigator/ReceiveFundsNavigator";
 
 export const WITH_ACCOUNT_SELECTION = "Open Drawer (with account selection)";
 export const WITHOUT_ACCOUNT_SELECTION = "Open Drawer (without account selection)";
@@ -45,19 +47,21 @@ const Stack = createStackNavigator<BaseNavigatorStackParamList>();
 type MockModularDrawerComponentProps = {
   networksConfiguration?: EnhancedModularDrawerConfiguration["networks"];
   assetsConfiguration?: EnhancedModularDrawerConfiguration["assets"];
+  flow?: string;
 };
 
 const MockModularDrawerComponent = ({
   networksConfiguration,
   assetsConfiguration,
+  flow = "integration_test",
 }: MockModularDrawerComponentProps) => {
   const { openDrawer, closeDrawer, isOpen } = useModularDrawerController();
 
   const handleOpenDrawer = useCallback(
-    (withAccountSelection: boolean) => {
+    (withAccountSelection: boolean, flow: string) => {
       openDrawer({
         enableAccountSelection: withAccountSelection,
-        flow: "integration_test",
+        flow,
         source: "modular_drawer_shared",
       });
     },
@@ -72,7 +76,7 @@ const MockModularDrawerComponent = ({
         outline
         mt={6}
         mb={8}
-        onPress={() => handleOpenDrawer(true)}
+        onPress={() => handleOpenDrawer(true, flow)}
         role="button"
       >
         {WITH_ACCOUNT_SELECTION}
@@ -83,7 +87,7 @@ const MockModularDrawerComponent = ({
         outline
         mt={6}
         mb={8}
-        onPress={() => handleOpenDrawer(false)}
+        onPress={() => handleOpenDrawer(false, flow)}
         role="button"
       >
         {WITHOUT_ACCOUNT_SELECTION}
@@ -107,6 +111,16 @@ export const ModularDrawerSharedNavigator = (props: MockModularDrawerComponentPr
     <Stack.Screen
       name={NavigatorName.DeviceSelection}
       component={DeviceSelectionNavigator}
+      options={{ headerShown: false }}
+    />
+    <Stack.Screen
+      name={NavigatorName.AddAccounts}
+      component={AddAccountsNavigator}
+      options={{ headerShown: false }}
+    />
+    <Stack.Screen
+      name={NavigatorName.ReceiveFunds}
+      component={ReceiveFundsNavigator}
       options={{ headerShown: false }}
     />
   </Stack.Navigator>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. NO NEED
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add some tests to have a better and more coverage on Add account with the MAD

It covers close, add account, auto close, fund accounts receive action

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-22870](https://ledgerhq.atlassian.net/browse/LIVE-22870)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22870]: https://ledgerhq.atlassian.net/browse/LIVE-22870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ