### PR TITLE
fix(MAD): prevent random 'Connection failed' error while scrolling asset list

### DIFF
--- a/.changeset/silver-ducks-poke.md
+++ b/.changeset/silver-ducks-poke.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix issue where the GenericError component would randomly appear

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -60,7 +60,7 @@ const AssetSelection = ({
   loadNext,
   assetsSorted,
 }: Readonly<AssetSelectionStepProps>) => {
-  const { isConnected } = useNetInfo();
+  const { isInternetReachable } = useNetInfo();
 
   const flow = useSelector(modularDrawerFlowSelector);
   const source = useSelector(modularDrawerSourceSelector);
@@ -140,8 +140,13 @@ const AssetSelection = ({
   const renderContent = () => {
     if (isLoading) return <SkeletonList />;
 
-    if (hasError || !isConnected) {
-      return <GenericError onClick={refetch} type={!isConnected ? "internet" : "backend"} />;
+    if (hasError || isInternetReachable === false) {
+      return (
+        <GenericError
+          onClick={refetch}
+          type={isInternetReachable === false ? "internet" : "backend"}
+        />
+      );
     }
 
     return (


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description


The `GenericError` component was randomly appearing while users scrolled through the asset selection list, showing a "Connection failed" message even when the device had proper internet connectivity.

Root Cause :
The `useNetInfo()` hook from `@react-native-community/netinfo` returns `isConnected: null` (or `isInternetReachable: null`) during initialization before it can determine the actual network state.



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-22849


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
