### PR TITLE
ci: fix detox uploads

### DIFF
--- a/.github/workflows/test-mobile-build-android-reusable.yml
+++ b/.github/workflows/test-mobile-build-android-reusable.yml
@@ -151,18 +151,17 @@ jobs:
           SKIP_JS_BUNDLING: true
 
       - name: Upload Detox Native Build
-        uses: tespkg/actions-cache/save@v1
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop
         with:
           path: |
-            ${{ env.ANDROID_APK_PATH }}
-            ${{ env.ANDROID_TESTBINARY_PATH }}
+            ${{ github.workspace }}/${{ env.ANDROID_APK_PATH }}
+            ${{ github.workspace }}/${{ env.ANDROID_TESTBINARY_PATH }}
           key: ${{ inputs.android-native-cache-key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
           secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
           sessionToken: ${{ env.AWS_SESSION_TOKEN}}
           bucket: ${{ env.cache-bucket }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
 
   build-android-js:
     name: "Android Build JS"
@@ -224,16 +223,15 @@ jobs:
           echo size=`ls -l ${{ env.ANDROID_JSBUNDLE_PATH }}  | cut -d " " -f5` >> $GITHUB_OUTPUT
 
       - name: Upload Detox JS Build
-        uses: tespkg/actions-cache/save@v1
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop
         with:
-          path: ${{ env.ANDROID_JSBUNDLE_PATH }}
+          path: ${{ github.workspace }}/${{ env.ANDROID_JSBUNDLE_PATH }}
           key: ${{ inputs.android-js-cache-key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
           secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
           sessionToken: ${{ env.AWS_SESSION_TOKEN}}
           bucket: ${{ env.cache-bucket }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
 
   skip-android-js:
     name: "Android Build JS - Skip"

--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -236,16 +236,15 @@ jobs:
         run: echo size=`ls -l ${{ github.workspace }}/apps/ledger-live-mobile/main.jsbundle  | cut -d " " -f5` >> $GITHUB_OUTPUT
 
       - name: Upload Detox JS Build
-        uses: tespkg/actions-cache/save@v1
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop
         with:
-          path: ${{ github.workspace }}/apps/ledger-live-mobile/main.jsbundle
+          path: apps/ledger-live-mobile/main.jsbundle
           key: ${{ inputs.ios-js-cache-key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
           secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
           sessionToken: ${{ env.AWS_SESSION_TOKEN}}
           bucket: ${{ env.cache-bucket }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
 
   skip-ios-js:
     name: "iOS Build JS - Skip"

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -168,8 +168,8 @@ jobs:
       - name: Determine cache keys
         id: cache-keys
         run: |
-          echo "ios_native_key=${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios" >> $GITHUB_OUTPUT
-          echo "android_native_key=${{ hashFiles('apps/ledger-live-mobile/android') }}-detox-native-android" >> $GITHUB_OUTPUT
+          echo "ios_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios-2" >> $GITHUB_OUTPUT
+          echo "android_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/android') }}-detox-native-android" >> $GITHUB_OUTPUT
           echo "ios_js_key=${{ inputs.ref || github.sha }}-detox-js-ios" >> $GITHUB_OUTPUT
           echo "android_js_key=${{ inputs.ref || github.sha }}-detox-js-android" >> $GITHUB_OUTPUT
           echo "android_timing_cache_key=android-e2e-timing-${{ hashFiles('e2e/mobile/specs') }}" >> $GITHUB_OUTPUT
@@ -386,32 +386,28 @@ jobs:
         run: node apps/ledger-live-mobile/node_modules/detox/scripts/postinstall.js
 
       - name: Download Native Build
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
         if: inputs.production_firebase != true
-        uses: tespkg/actions-cache/restore@v1
         with:
           endpoint: ${{ secrets.S3_DIRECTCONNECT_ENDPOINT }}
-          path: ${{ env.IOS_NATIVE_PATH }}
           key: ${{ needs.determine-builds.outputs.ios_native_key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
           secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
           sessionToken: ${{ env.AWS_SESSION_TOKEN}}
           bucket: ${{ env.cache-bucket }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
 
       - name: Download JS Build
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
         if: inputs.production_firebase != true
-        uses: tespkg/actions-cache/restore@v1
         with:
           endpoint: ${{ secrets.S3_DIRECTCONNECT_ENDPOINT }}
-          path: apps/ledger-live-mobile/main.jsbundle
           key: ${{ needs.determine-builds.outputs.ios_js_key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
           secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
           sessionToken: ${{ env.AWS_SESSION_TOKEN}}
           bucket: ${{ env.cache-bucket }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
 
       - name: Copy JS build
         if: inputs.production_firebase != true
@@ -594,31 +590,25 @@ jobs:
 
       - name: Download Native Build
         if: inputs.production_firebase != true
-        uses: tespkg/actions-cache/restore@v1
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
         with:
-          path: |
-            ${{ env.ANDROID_APK_PATH }}
-            ${{ env.ANDROID_TESTBINARY_PATH }}
           key: ${{ needs.determine-builds.outputs.android_native_key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
           secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
           sessionToken: ${{ env.AWS_SESSION_TOKEN}}
           bucket: ${{ env.cache-bucket }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
 
       - name: Download JS Bundle
         if: inputs.production_firebase != true
-        uses: tespkg/actions-cache/restore@v1
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
         with:
-          path: ${{ env.ANDROID_JSBUNDLE_PATH }}
           key: ${{ needs.determine-builds.outputs.android_js_key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
           secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
           sessionToken: ${{ env.AWS_SESSION_TOKEN}}
           bucket: ${{ env.cache-bucket }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
 
       - name: Prepare APK
         if: inputs.production_firebase != true

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -115,8 +115,8 @@ jobs:
       - name: Determine cache keys
         id: cache-keys
         run: |
-          echo "ios_native_key=${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios-2" >> $GITHUB_OUTPUT
-          echo "android_native_key=${{ hashFiles('apps/ledger-live-mobile/android') }}-detox-native-android" >> $GITHUB_OUTPUT
+          echo "ios_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios-2" >> $GITHUB_OUTPUT
+          echo "android_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/android') }}-detox-native-android" >> $GITHUB_OUTPUT
           echo "ios_js_key=${{ inputs.ref || github.sha }}-detox-js-ios" >> $GITHUB_OUTPUT
           echo "android_js_key=${{ inputs.ref || github.sha }}-detox-js-android" >> $GITHUB_OUTPUT
           echo "android_timing_cache_key=android-mock-timing-${{ hashFiles('apps/ledger-live-mobile/e2e') }}" >> $GITHUB_OUTPUT
@@ -295,30 +295,26 @@ jobs:
         run: node apps/ledger-live-mobile/node_modules/detox/scripts/postinstall.js
 
       - name: Download Native Build
-        uses: tespkg/actions-cache/restore@v1
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
         with:
           endpoint: ${{ secrets.S3_DIRECTCONNECT_ENDPOINT }}
-          path: ${{ env.IOS_NATIVE_PATH }}
           key: ${{ needs.determine-builds.outputs.ios_native_key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
           secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
           sessionToken: ${{ env.AWS_SESSION_TOKEN}}
           bucket: ${{ env.cache-bucket }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
 
       - name: Download JS Build
-        uses: tespkg/actions-cache/restore@v1
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
         with:
           endpoint: ${{ secrets.S3_DIRECTCONNECT_ENDPOINT }}
-          path: apps/ledger-live-mobile/main.jsbundle
           key: ${{ needs.determine-builds.outputs.ios_js_key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
           secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
           sessionToken: ${{ env.AWS_SESSION_TOKEN}}
           bucket: ${{ env.cache-bucket }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
 
       - name: Copy JS build
         run: |
@@ -421,30 +417,24 @@ jobs:
           aws-region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Download Native Build
-        uses: tespkg/actions-cache/restore@v1
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
         with:
-          path: |
-            ${{ env.ANDROID_APK_PATH }}
-            ${{ env.ANDROID_TESTBINARY_PATH }}
           key: ${{ needs.determine-builds.outputs.android_native_key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
           secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
           sessionToken: ${{ env.AWS_SESSION_TOKEN}}
           bucket: ${{ env.cache-bucket }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
 
       - name: Download JS Bundle
-        uses: tespkg/actions-cache/restore@v1
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
         with:
-          path: ${{ env.ANDROID_JSBUNDLE_PATH }}
           key: ${{ needs.determine-builds.outputs.android_js_key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
           secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
           sessionToken: ${{ env.AWS_SESSION_TOKEN}}
           bucket: ${{ env.cache-bucket }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
 
       - name: Prepare APK
         run: |

--- a/tools/actions/composites/cache/download/action.yml
+++ b/tools/actions/composites/cache/download/action.yml
@@ -5,7 +5,6 @@ inputs:
     description: the S3 endpoint URL, e.g., 's3.amazonaws.com'
     type: string
     required: false
-    default: 's3.amazonaws.com'
   key:
     type: string
     required: true
@@ -34,9 +33,8 @@ runs:
     - name: Downloading files
       id: download-cache
       shell: bash
-      continue-on-error: true
       run: |
-        aws s3 cp s3://${{ inputs.bucket }}/${{ inputs.key }}/cache.tzst /tmp/cache.tzst --endpoint-url https://${{ inputs.endpoint }} --region ${{ inputs.region }} --no-progress
+        aws s3 cp s3://${{ inputs.bucket }}/${{ inputs.key }}/cache.tzst /tmp/cache.tzst --endpoint-url https://${{ inputs.endpoint || format('s3.{0}.amazonaws.com', inputs.region) }} --region ${{ inputs.region }} --no-progress
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.accessKey }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.secretKey }}

--- a/tools/actions/composites/cache/upload/action.yml
+++ b/tools/actions/composites/cache/upload/action.yml
@@ -2,10 +2,9 @@ name: "Cache upload"
 description: "Compress and upload cache files to S3"
 inputs:
   endpoint:
-    description: the S3 endpoint URL, e.g., 's3.amazonaws.com'
+    description: the S3 endpoint URL, e.g., 'bucket.s3.amazonaws.com'
     type: string
     required: false
-    default: 's3.amazonaws.com'
   key:
     type: string
     required: true
@@ -69,7 +68,7 @@ runs:
         echo "Uploading files to S3 bucket ${{ inputs.bucket }}"
         aws configure set default.s3.max_concurrent_requests 240
         aws configure set default.s3.multipart_chunksize 2MB
-        aws s3 cp /tmp/cache.tzst s3://${{ inputs.bucket }}/${{ inputs.key }}/cache.tzst --endpoint-url https://${{ inputs.endpoint }} --region ${{ inputs.region }}  --no-progress
+        aws s3 cp --endpoint-url https://${{ inputs.endpoint || format('s3.{0}.amazonaws.com', inputs.region) }} --region ${{ inputs.region }} /tmp/cache.tzst s3://${{ inputs.bucket }}/${{ inputs.key }}/cache.tzst
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.accessKey }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.secretKey }}


### PR DESCRIPTION
- Introduces "long term" storage of native caches (3 weeks, up from 5 days)
  - Reduces number of builds needed
  - Fixes issues with cache being deleted by lifecycle policy during run
- No longer ignores when caches cannot be uploaded, leading to inaccurate failure reporting and general confusion

Green PR run: https://github.com/LedgerHQ/ledger-live/actions/runs/19334458084
"Green" E2E run: https://github.com/LedgerHQ/ledger-live/actions/runs/19365198309

Tickets: 
https://ledgerhq.atlassian.net/browse/LIVE-22356
https://ledgerhq.atlassian.net/browse/LIVE-20963