### PR TITLE
Fix flaky test for getRescaledDimensions (custom lock screen)

### DIFF
--- a/apps/ledger-live-mobile/src/components/CustomImage/useCenteredImage/getRescaledDimensions.test.ts
+++ b/apps/ledger-live-mobile/src/components/CustomImage/useCenteredImage/getRescaledDimensions.test.ts
@@ -68,7 +68,7 @@ describe("getRescaledDimensions", () => {
     expect(
       getRescaledDimensions({ width: 1362, height: 1302 }, { width: 400, height: 670 }),
     ).toEqual({
-      width: 700,
+      width: 701,
       height: 670,
     });
 
@@ -76,7 +76,7 @@ describe("getRescaledDimensions", () => {
       getRescaledDimensions({ width: 1302, height: 1362 }, { width: 670, height: 400 }),
     ).toEqual({
       width: 670,
-      height: 700,
+      height: 701,
     });
   });
 
@@ -101,7 +101,7 @@ describe("getRescaledDimensions", () => {
     });
   });
 
-  it("always returns a result that satisfies the properties of object-fit:contain", () => {
+  it("always returns a result that satisfies the properties of object-fit:cover", () => {
     function generateRandomDimensions(maxSize: number) {
       return {
         height: Math.floor(Math.random() * maxSize + 1),

--- a/apps/ledger-live-mobile/src/components/CustomImage/useCenteredImage/getRescaledDimensions.ts
+++ b/apps/ledger-live-mobile/src/components/CustomImage/useCenteredImage/getRescaledDimensions.ts
@@ -3,7 +3,7 @@ import { ImageDimensions } from "../types";
 /**
  * Returns the dimensions of an image that has been resized to fully cover a box,
  * while keeping its aspect ratio.
- * This should behave like the CSS `object-fit: contain` property.
+ * This should behave like the CSS `object-fit: cover` property.
  *
  * @param imageDimensions The dimensions of the image to fit
  * @param containerDimensions The dimensions of the container to fit in
@@ -39,10 +39,10 @@ export function getRescaledDimensions(
     width:
       limitingDimensions === "width"
         ? containerDimensions.width
-        : Math.floor(imageDimensions.width * resizeRatio),
+        : Math.ceil(imageDimensions.width * resizeRatio),
     height:
       limitingDimensions === "height"
         ? containerDimensions.height
-        : Math.floor(imageDimensions.height * resizeRatio),
+        : Math.ceil(imageDimensions.height * resizeRatio),
   };
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-19129] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-19129]: https://ledgerhq.atlassian.net/browse/LIVE-19129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ