### PR TITLE
fix: remove duplicate react-redux version in package.json and pnpm-lock.yaml

### DIFF
--- a/libs/ledgerjs/packages/cryptoassets/package.json
+++ b/libs/ledgerjs/packages/cryptoassets/package.json
@@ -57,8 +57,7 @@
     "rimraf": "^4.4.1",
     "source-map-support": "^0.5.21",
     "ts-jest": "^29.1.1",
-    "ts-node": "^10.7.0",
-    "react-redux": "^9.1.2"
+    "ts-node": "^10.7.0"
   },
   "typesVersions": {
     "*": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5965,7 +5965,7 @@ importers:
         version: link:../types-live
       '@reduxjs/toolkit':
         specifier: 'catalog:'
-        version: 2.8.2(react-redux@9.2.0(@types/react@18.2.73)(react@18.3.1))(react@18.3.1)
+        version: 2.8.2(react-redux@7.2.9(@types/react@18.2.73)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       axios:
         specifier: 'catalog:'
         version: 1.12.2
@@ -6010,8 +6010,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.1(react@18.3.1)
       react-redux:
-        specifier: ^9.1.2
-        version: 9.2.0(@types/react@18.2.73)(react@18.3.1)
+        specifier: 'catalog:'
+        version: 7.2.9(@types/react@18.2.73)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rimraf:
         specifier: ^4.4.1
         version: 4.4.1
@@ -48358,18 +48358,6 @@ snapshots:
       react: 18.3.1
       react-redux: 7.2.9(@types/react@18.2.73)(react@18.3.1)
 
-  '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@18.2.73)(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@standard-schema/spec': 1.0.0
-      '@standard-schema/utils': 0.3.0
-      immer: 10.0.3
-      redux: 5.0.1
-      redux-thunk: 3.1.0(redux@5.0.1)
-      reselect: 5.1.1
-    optionalDependencies:
-      react: 18.3.1
-      react-redux: 9.2.0(@types/react@18.2.73)(react@18.3.1)
-
   '@reduxjs/toolkit@2.9.0(react-redux@7.2.9(@types/react@18.2.73)(react@18.3.1))(react@19.2.0)':
     dependencies:
       '@standard-schema/spec': 1.0.0
@@ -71989,14 +71977,6 @@ snapshots:
       react-is: 17.0.2
     transitivePeerDependencies:
       - '@types/react'
-
-  react-redux@9.2.0(@types/react@18.2.73)(react@18.3.1):
-    dependencies:
-      '@types/use-sync-external-store': 0.0.6
-      react: 18.3.1
-      use-sync-external-store: 1.5.0(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.2.73
 
   react-redux@9.2.0(@types/react@18.2.73)(react@19.2.0)(redux@5.0.1):
     dependencies:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - all stores on both apps

### 📝 Description

This pull request updates the dependency management for `react-redux` and related packages, primarily reverting from version 9.x to 7.x and switching how dependencies are specified in `pnpm-lock.yaml`. This helps ensure compatibility and consistency across the project.

Dependency management updates:

* Changed `react-redux` dependency from version `^9.1.2` to use a catalog specifier and reverted to version `7.2.9` in both `package.json` and `pnpm-lock.yaml`, likely to address compatibility or stability issues. [[1]](diffhunk://#diff-f98b470006a8fa793cf54c5ac9636dae2cc4e55b9e0a48dea41a035feb3b9a43L60-R60) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6013-R6014)
* Updated the way `@reduxjs/toolkit` and `react-redux` dependencies are resolved in `pnpm-lock.yaml`, ensuring they use compatible versions and correct peer dependencies.
* Removed references to `react-redux@9.2.0` and its peer dependency snapshots from `pnpm-lock.yaml`, cleaning up unused or incompatible dependency entries. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL48361-L48372) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL71993-L72000)

### ❓ Context

- **JIRA or GitHub link**: 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
