### PR TITLE
feat: add tracking at the end of send and add account flow

### DIFF
--- a/.changeset/fast-ducks-march.md
+++ b/.changeset/fast-ducks-march.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat: add tracking at the end of send and add account flow to trigger braze campaign

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountSuccess/useAddAccountSuccessViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountSuccess/useAddAccountSuccessViewModel.ts
@@ -1,5 +1,5 @@
 import { useNavigation } from "@react-navigation/core";
-import { useCallback } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useTheme } from "styled-components/native";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { NavigatorName, ScreenName } from "~/const";
@@ -21,6 +21,21 @@ export default function useAddAccountSuccessViewModel({ route }: Props) {
   const keyExtractor = useCallback((item: AccountLikeEnhanced) => item?.id, []);
 
   const statusColor = colors.neutral.c100;
+
+  const network = useMemo(() => {
+    if (currency.type === "TokenCurrency") {
+      return currency.parentCurrency?.name;
+    }
+    return currency.name;
+  }, [currency]);
+
+  useEffect(() => {
+    track("add_account_done", {
+      asset: currency.name,
+      network,
+      page: "Add Accounts Success",
+    });
+  }, [currency, network]);
 
   const goToAccounts = useCallback(
     (accountId: string) => () => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Send_done and add_account_done tracking must be sent to braze

### 📝 Description

Currently, when a receive is completed, an event is sent to Braze to trigger a campaign. We want to extend this logic to also cover the send and add account flows.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-22915]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22915]: https://ledgerhq.atlassian.net/browse/LIVE-22915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ