### PR TITLE
fix: correct mapping of 'apex' in DeviceModel for CAL certificates [LIVE-22939]

### DIFF
--- a/.changeset/great-dots-approve.md
+++ b/.changeset/great-dots-approve.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/ledger-cal-service": minor
+---
+
+fix: correct mapping of 'apex' in DeviceModel for CAL certificates

--- a/libs/ledger-services/cal/src/certificate.ts
+++ b/libs/ledger-services/cal/src/certificate.ts
@@ -11,7 +11,7 @@ const DeviceModel = {
   /** Ledger Flex ("europa" is the internal name) */
   europa: "flex",
   flex: "flex",
-  apex: "apex",
+  apex: "apexp",
 } as const;
 export type Device = keyof typeof DeviceModel;
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually but faking the device, so it would better to QA on real device
- [x] **Impact of the changes:**
  - Solana tokens send with nano gen5
  - Hedera swaps with nano gen5

### 📝 Description

This pull request addresses an issue with the device model mapping for CAL certificates in the `@ledgerhq/ledger-cal-service` package. The main change corrects the mapping for the 'apex' device to ensure the correct internal identifier is used.

Device model mapping fix:

* Updated the `DeviceModel` mapping in `certificate.ts` to map `'apex'` to `'apexp'` instead of `'apex'`, ensuring accurate identification of the device for CAL certificates.
* Added a changeset entry documenting the fix and marking it as a minor version update for the `@ledgerhq/ledger-cal-service` package.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-22939]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22939]: https://ledgerhq.atlassian.net/browse/LIVE-22939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ