### PR TITLE
fix: redirection for SanctionedAccountModal to use MAD

### DIFF
--- a/.changeset/dry-tigers-own.md
+++ b/.changeset/dry-tigers-own.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix redirection for SanctionedAccountModal to use MAD

--- a/apps/ledger-live-mobile/src/newArch/features/Receive/index.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Receive/index.ts
@@ -13,12 +13,14 @@ type Props = {
   currency?: CryptoOrTokenCurrency;
   sourceScreenName: string;
   navigationOverride?: RootNavigation;
+  hideBackButton?: boolean;
 };
 export function useOpenReceiveDrawer({
   currency,
   sourceScreenName,
   onClick,
   navigationOverride,
+  hideBackButton,
 }: Props) {
   const defaultNavigation = useNavigation();
   const { openDrawer } = useModularDrawerController();
@@ -56,12 +58,12 @@ export function useOpenReceiveDrawer({
           screen: ScreenName.ReceiveConfirmation,
           params: {
             ...confirmationParams,
-            hideBackButton: true,
+            hideBackButton: hideBackButton ?? true,
           },
         });
       }
     },
-    [defaultNavigation, navigationOverride],
+    [defaultNavigation, navigationOverride, hideBackButton],
   );
 
   const handleOnclick = useCallback(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

SanctionedAccountModal in Receive confirmation step was redirecting to old SelectAccount flow when MAD is enabled

https://github.com/user-attachments/assets/d3613f09-c04d-460c-9223-623be38dbf6f


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-22953


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
