### PR TITLE
ci: do not stop on first `test-integ` fail

### DIFF
--- a/.github/workflows/test-coin-modules-integ.yml
+++ b/.github/workflows/test-coin-modules-integ.yml
@@ -94,9 +94,16 @@ jobs:
           FILTER: ${{ needs.is-affected.outputs.coins }}
           VERBOSE_FILE: logs.txt
         run: |
-          for coin in $FILTER; do
-            pnpm coin:$coin test-integ
-          done
+          if [ -z $FILTER ]; then
+            echo "No coin module affected"
+          else
+            cmd="pnpm --no-bail"
+            for coin in $FILTER; do
+              cmd="$cmd --filter=@ledgerhq/coin-$coin"
+            done
+            cmd="$cmd test-integ"
+            $cmd
+          fi
 
       - name: Test (Scheduled)
         if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Use `pnpm` filtering capabilities to run integration tests on several coins. This ensures that
- the job does not stop after the first fail thanks to `no-bail`
- integration tests are run in parallel 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
