### PR TITLE
add VET to send test cases QAA-877

### DIFF
--- a/e2e/mobile/specs/send/sendVET.spec.ts
+++ b/e2e/mobile/specs/send/sendVET.spec.ts
@@ -1,0 +1,4 @@
+import { runSendValidAddressTest } from "./send";
+
+const transaction = new Transaction(Account.VET_1, Account.VET_2, "0.00001", undefined, "123456");
+runSendValidAddressTest(transaction, ["B2CQA-2720"], "with Tag");

--- a/libs/ledger-live-common/src/e2e/enum/Account.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Account.ts
@@ -529,6 +529,20 @@ export class Account {
     1,
   );
 
+  static readonly VET_1 = new Account(
+    Currency.VET,
+    "Vet 1",
+    "0x6644c1ce77c5e5ef8d8bd3ae2a4e18239e5d418a5e0800ed5037818399e3a7f6",
+    1,
+  );
+
+  static readonly VET_2 = new Account(
+    Currency.VET,
+    "Vet 2",
+    "0x6644c1ce77c5e5ef8d8bd3ae2a4e18239e5d418a5e0800ed5037818399e3a7f6",
+    1,
+  );
+
   static readonly EMPTY = new Account(Currency.BTC, "Empty", "", 0);
 }
 

--- a/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
+++ b/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
@@ -66,4 +66,6 @@ export class AppInfos {
   static readonly HEDERA = new AppInfos("Hedera");
 
   static readonly SUI = new AppInfos("Sui");
+
+  static readonly VECHAIN = new AppInfos("Vechain");
 }

--- a/libs/ledger-live-common/src/e2e/enum/Currency.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Currency.ts
@@ -211,4 +211,8 @@ export class Currency {
     [Network.SUI],
     "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7",
   );
+
+  static readonly VET = new Currency("Vechain", "VET", "vechain", AppInfos.VECHAIN, [
+    Network.VECHAIN,
+  ]);
 }

--- a/libs/ledger-live-common/src/e2e/enum/Network.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Network.ts
@@ -34,4 +34,5 @@ export enum Network {
   KASPA = "Kaspa",
   HEDERA = "Hedera",
   SUI = "Sui",
+  VECHAIN = "Vechain",
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
