### PR TITLE
chore(llm): defer some of the store init and the bridge sync

### DIFF
--- a/.changeset/fifty-otters-clean.md
+++ b/.changeset/fifty-otters-clean.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Defer some of the store init and the bridge sync

--- a/apps/ledger-live-mobile/src/AppProviders.tsx
+++ b/apps/ledger-live-mobile/src/AppProviders.tsx
@@ -7,7 +7,6 @@ import { InViewProvider } from "LLM/contexts/InViewContext";
 import { ModularDrawerProvider } from "LLM/features/ModularDrawer";
 import { WalletSyncProvider } from "LLM/features/WalletSync/components/WalletSyncContext";
 import React from "react";
-import { BridgeSyncProvider } from "~/bridge/BridgeSyncContext";
 import { CountervaluesMarketcapBridgedProvider } from "~/components/CountervaluesMarketcapProvider";
 import { CountervaluesBridgedProvider } from "~/components/CountervaluesProvider";
 import PostOnboardingProviderWrapped from "~/logic/postOnboarding/PostOnboardingProviderWrapped";
@@ -26,26 +25,24 @@ function AppProviders({ initialCountervalues, children }: AppProvidersProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <BridgeSyncProvider>
-        <WalletSyncProvider>
-          <DeviceManagementKitProvider dmkEnabled={dmkEnabled}>
-            <CountervaluesMarketcapBridgedProvider>
-              <CountervaluesBridgedProvider initialState={initialCountervalues}>
-                <BottomSheetModalProvider>
-                  <PostOnboardingProviderWrapped>
-                    <NotificationsProvider>
-                      <SnackbarContainer />
-                      <InViewProvider>
-                        <ModularDrawerProvider>{children}</ModularDrawerProvider>
-                      </InViewProvider>
-                    </NotificationsProvider>
-                  </PostOnboardingProviderWrapped>
-                </BottomSheetModalProvider>
-              </CountervaluesBridgedProvider>
-            </CountervaluesMarketcapBridgedProvider>
-          </DeviceManagementKitProvider>
-        </WalletSyncProvider>
-      </BridgeSyncProvider>
+      <WalletSyncProvider>
+        <DeviceManagementKitProvider dmkEnabled={dmkEnabled}>
+          <CountervaluesMarketcapBridgedProvider>
+            <CountervaluesBridgedProvider initialState={initialCountervalues}>
+              <BottomSheetModalProvider>
+                <PostOnboardingProviderWrapped>
+                  <NotificationsProvider>
+                    <SnackbarContainer />
+                    <InViewProvider>
+                      <ModularDrawerProvider>{children}</ModularDrawerProvider>
+                    </InViewProvider>
+                  </NotificationsProvider>
+                </PostOnboardingProviderWrapped>
+              </BottomSheetModalProvider>
+            </CountervaluesBridgedProvider>
+          </CountervaluesMarketcapBridgedProvider>
+        </DeviceManagementKitProvider>
+      </WalletSyncProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -28,10 +28,15 @@ import { importMarket } from "~/actions/market";
 import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { importWalletState } from "@ledgerhq/live-wallet/store";
 import { importLargeMoverState } from "~/actions/largeMoverLandingPage";
+import { SettingsState } from "~/reducers/types";
 
 interface Props {
   onInitFinished: () => void;
-  children: (ready: boolean, initialCountervalues?: CounterValuesStateRaw) => ReactNode;
+  children: (props: {
+    ready: boolean;
+    initialCountervalues?: CounterValuesStateRaw;
+    currencyInitialized: boolean;
+  }) => ReactNode;
   store: Store;
 }
 
@@ -56,14 +61,13 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
   const [initialCountervalues, setInitialCountervalues] = useState<
     CounterValuesStateRaw | undefined
   >(undefined);
+  const [currencyInitialized, setCurrencyInitialized] = useState(false);
 
   const init = useCallback(async () => {
     try {
       const [
         bleData,
         settingsData,
-        cachedCurrencyIds,
-        supportedFiats,
         accountsData,
         postOnboardingState,
         marketState,
@@ -75,8 +79,6 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       ] = await Promise.all([
         retry(getBle, MAX_RETRIES, RETRY_DELAY),
         retry(getSettings, MAX_RETRIES, RETRY_DELAY),
-        retry(listCachedCurrencyIds, MAX_RETRIES, RETRY_DELAY),
-        retry(listSupportedFiats, MAX_RETRIES, RETRY_DELAY),
         retry(getAccounts, MAX_RETRIES, RETRY_DELAY),
         retry(getPostOnboardingState, MAX_RETRIES, RETRY_DELAY),
         retry(getMarketState, MAX_RETRIES, RETRY_DELAY),
@@ -88,44 +90,6 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       ]);
 
       store.dispatch(importBle(bleData));
-
-      // hydrate the store with the bridge/cache
-      // Promise.allSettled doesn't exist in RN
-      await Promise.all(
-        cachedCurrencyIds
-          .map(id => {
-            const currency = findCryptoCurrencyById?.(id);
-            return currency ? hydrateCurrency(currency) : Promise.reject();
-          })
-          .map(promise =>
-            promise
-              .then((value: unknown) => ({ status: "fulfilled", value }))
-              .catch((reason: unknown) => ({ status: "rejected", reason })),
-          ),
-      );
-
-      const bitcoin = getCryptoCurrencyById("bitcoin");
-      const ethereum = getCryptoCurrencyById("ethereum");
-      const possibleIntermediaries = [bitcoin, ethereum];
-
-      const supportedCounterValues = [...supportedFiats, ...possibleIntermediaries]
-        .map(currency => ({
-          value: currency.ticker,
-          ticker: currency.ticker,
-          label: `${currency.name} - ${currency.ticker}`,
-          currency,
-        }))
-        .sort((a, b) => (a.currency.name < b.currency.name ? -1 : 1));
-
-      store.dispatch(setSupportedCounterValues(supportedCounterValues));
-
-      if (
-        settingsData &&
-        settingsData.counterValue &&
-        !supportedCounterValues.find(({ ticker }) => ticker === settingsData.counterValue)
-      ) {
-        settingsData.counterValue = settingsState.counterValue;
-      }
 
       store.dispatch(importSettings(settingsData));
       store.dispatch(importAccountsRaw(accountsData));
@@ -158,6 +122,11 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       setInitialCountervalues(initialCountervalues);
       setReady(true);
       onInitFinished();
+
+      await Promise.all([
+        hydrateCurrencies(),
+        updateSupportedCountervalues(store, settingsData),
+      ]).finally(() => setCurrencyInitialized(true)); // Don't block the App rendering for this
     } catch (error) {
       console.error(
         error instanceof Error
@@ -173,9 +142,57 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
 
   return (
     <Provider store={store}>
-      <InitialQueriesProvider>{children(ready, initialCountervalues)}</InitialQueriesProvider>
+      <InitialQueriesProvider>
+        {children({ ready, initialCountervalues, currencyInitialized })}
+      </InitialQueriesProvider>
     </Provider>
   );
 };
 
 export default LedgerStoreProvider;
+
+async function hydrateCurrencies() {
+  const cachedCurrencyIds = await retry(listCachedCurrencyIds, MAX_RETRIES, RETRY_DELAY);
+
+  // hydrate the store with the bridge/cache
+  // Promise.allSettled doesn't exist in RN
+  await Promise.all(
+    cachedCurrencyIds
+      .map(id => {
+        const currency = findCryptoCurrencyById?.(id);
+        return currency ? hydrateCurrency(currency) : Promise.reject();
+      })
+      .map(promise =>
+        promise
+          .then((value: unknown) => ({ status: "fulfilled", value }))
+          .catch((reason: unknown) => ({ status: "rejected", reason })),
+      ),
+  );
+}
+
+async function updateSupportedCountervalues(store: Store, settingsData: Partial<SettingsState>) {
+  const supportedFiats = await retry(listSupportedFiats, MAX_RETRIES, RETRY_DELAY);
+  const bitcoin = getCryptoCurrencyById("bitcoin");
+  const ethereum = getCryptoCurrencyById("ethereum");
+  const possibleIntermediaries = [bitcoin, ethereum];
+
+  const supportedCounterValues = [...supportedFiats, ...possibleIntermediaries]
+    .map(currency => ({
+      value: currency.ticker,
+      ticker: currency.ticker,
+      label: `${currency.name} - ${currency.ticker}`,
+      currency,
+    }))
+    .sort((a, b) => (a.currency.name < b.currency.name ? -1 : 1));
+
+  store.dispatch(setSupportedCounterValues(supportedCounterValues));
+
+  if (
+    settingsData?.counterValue &&
+    !supportedCounterValues.find(({ ticker }) => ticker === settingsData.counterValue) &&
+    settingsData.counterValue !== settingsState.counterValue
+  ) {
+    settingsData.counterValue = settingsState.counterValue;
+    store.dispatch(importSettings(settingsData));
+  }
+}

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -18,6 +18,7 @@ import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useDispatch, useSelector } from "react-redux";
 import { init } from "../e2e/bridge/client";
 import logger from "./logger";
+import { BridgeSyncProvider } from "~/bridge/BridgeSyncContext";
 import {
   osThemeSelector,
   hasSeenAnalyticsOptInPromptSelector,
@@ -300,7 +301,7 @@ export default class Root extends Component {
   render() {
     return (
       <LedgerStoreProvider onInitFinished={this.onInitFinished} store={store}>
-        {(ready, initialCountervalues) =>
+        {({ ready, initialCountervalues, currencyInitialized }) =>
           ready ? (
             <RebootProvider>
               <SetEnvsFromSettings />
@@ -326,8 +327,10 @@ export default class Root extends Component {
                                   <AppProviders initialCountervalues={initialCountervalues}>
                                     <AppGeoBlocker>
                                       <AppVersionBlocker>
-                                        <WaitForAppReady>
-                                          <App />
+                                        <WaitForAppReady currencyInitialized={currencyInitialized}>
+                                          <BridgeSyncProvider>
+                                            <App />
+                                          </BridgeSyncProvider>
                                         </WaitForAppReady>
                                       </AppVersionBlocker>
                                     </AppGeoBlocker>

--- a/apps/ledger-live-mobile/src/newArch/contexts/WaitForAppReady.tsx
+++ b/apps/ledger-live-mobile/src/newArch/contexts/WaitForAppReady.tsx
@@ -2,9 +2,16 @@ import React, { useContext } from "react";
 import { InitialQueriesContext } from "./InitialQueriesContext";
 import LoadingApp from "~/components/LoadingApp";
 
-export function WaitForAppReady({ children }: React.PropsWithChildren) {
+export function WaitForAppReady({
+  children,
+  currencyInitialized,
+}: React.PropsWithChildren<{ currencyInitialized: boolean }>) {
   const initialQueries = useContext(InitialQueriesContext);
-  if (!initialQueries.firebaseIsReady || initialQueries.ofacResult.isLoading) {
+  if (
+    !currencyInitialized ||
+    !initialQueries.firebaseIsReady ||
+    initialQueries.ofacResult.isLoading
+  ) {
     return <LoadingApp />;
   }
 

--- a/apps/ledger-live-mobile/src/newArch/contexts/__tests__/WaitForAppReady.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/contexts/__tests__/WaitForAppReady.test.tsx
@@ -4,28 +4,51 @@ import { render, screen } from "@testing-library/react-native";
 import { InitialQueriesContext } from "../InitialQueriesContext";
 import { WaitForAppReady } from "../WaitForAppReady";
 
-type InitialQueriesValue = Parameters<typeof InitialQueriesContext.Provider>[0]["value"];
+type RenderParams = Parameters<typeof InitialQueriesContext.Provider>[0]["value"] & {
+  currencyInitialized: boolean;
+};
 
 describe("WaitForAppReady", () => {
   it("renders children when app is ready", () => {
-    renderApp({ firebaseIsReady: true, ofacResult: { blocked: false, isLoading: false } });
+    renderApp({
+      currencyInitialized: true,
+      firebaseIsReady: true,
+      ofacResult: { blocked: false, isLoading: false },
+    });
     expect(screen.getByText("App is Ready")).toBeTruthy();
   });
 
   it("renders null when firebase is not ready", () => {
-    renderApp({ firebaseIsReady: false, ofacResult: { blocked: false, isLoading: false } });
+    renderApp({
+      currencyInitialized: true,
+      firebaseIsReady: false,
+      ofacResult: { blocked: false, isLoading: false },
+    });
     expect(screen.toJSON()).toBeNull();
   });
 
   it("renders null when OFAC check is loading", () => {
-    renderApp({ firebaseIsReady: true, ofacResult: { blocked: false, isLoading: true } });
+    renderApp({
+      currencyInitialized: true,
+      firebaseIsReady: true,
+      ofacResult: { blocked: false, isLoading: true },
+    });
     expect(screen.toJSON()).toBeNull();
   });
 
-  function renderApp(value: InitialQueriesValue) {
+  it("renders null when currency is not initialized", () => {
+    renderApp({
+      currencyInitialized: false,
+      firebaseIsReady: true,
+      ofacResult: { blocked: false, isLoading: false },
+    });
+    expect(screen.toJSON()).toBeNull();
+  });
+
+  function renderApp({ currencyInitialized, ...value }: RenderParams) {
     return render(
       <InitialQueriesContext.Provider value={value}>
-        <WaitForAppReady>
+        <WaitForAppReady currencyInitialized={currencyInitialized}>
           <Text>App is Ready</Text>
         </WaitForAppReady>
       </InitialQueriesContext.Provider>,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Defer the currency hydration (quick but still second slowest of the store init) and the supported countervalues update [LIVE-22925] (which is a lot slower as it includes a network call) to after the store initialization. This allow the rest of the providers to start initializing a hundreds of ms earlier. But usually the bottleneck remains firebase remote config.

As a result the `BridgeSyncProvider` as to be moved as the last provider to mount before the App and after the currency hydration is done. This should also ensure that the background bridge sync doesn't start too early [LIVE-22922] even with a slow network.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-22922]
- [LIVE-22925]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22925]: https://ledgerhq.atlassian.net/browse/LIVE-22925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-22922]: https://ledgerhq.atlassian.net/browse/LIVE-22922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ