### PR TITLE
:bug: (LWM) stop scan account

### DIFF
--- a/.changeset/odd-worms-fry.md
+++ b/.changeset/odd-worms-fry.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Don't show stop scan until there is at least one visible account in add account scan and remove old account list screen

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/index.tsx
@@ -176,7 +176,7 @@ function ScanDeviceAccounts() {
           );
         })}
       </NavigationScrollView>
-      {!!scannedAccounts.length && (
+      {sections.some(s => s.data.length > 0) && (
         <ScanDeviceAccountsFooter
           isScanning={scanning}
           canRetry={

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -120,9 +120,16 @@ export default function useScanDeviceAccountsViewModel({
 
   const quitFlow = useCallback(() => {
     navigation.navigate(NavigatorName.Accounts, {
-      screen: ScreenName.Accounts,
+      screen: ScreenName.AccountsList,
+      params: {
+        sourceScreenName: ScreenName.ScanDeviceAccounts,
+        showHeader: true,
+        canAddAccount: false,
+        isSyncEnabled: false,
+        specificAccounts: scannedAccounts,
+      },
     });
-  }, [navigation]);
+  }, [navigation, scannedAccounts]);
   const onPressAccount = useCallback(
     (account: Account) => {
       const isChecked = selectedIds.indexOf(account.id) > -1;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - scan account

### 📝 Description

Sometimes the stop scan button could be displayed and led to an empty screen then to the old accounts list screen. This PR fixes the issue. We won't display the button until there is at least 1 account scanned (it was already the case but some accounts could be filtered in the UI so now we use data sections as source of truth for that) and I updated the navigation to be sure it will display the accounts scanned with the new UI

Normal flow 

https://github.com/user-attachments/assets/1bb9aa15-ae16-4f20-a61e-d22ba2ba9888

Forced flow to navigate to accounts list

https://github.com/user-attachments/assets/4e8a7f8d-91a4-4941-a794-ba2b8c54eccc



### ❓ Context

- **JIRA or GitHub link**: [LIVE-22664](https://ledgerhq.atlassian.net/browse/LIVE-22664)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22664]: https://ledgerhq.atlassian.net/browse/LIVE-22664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ