### PR TITLE
chore(lld): force resolution of crypto-icons-ui to avoid dup issue

### DIFF
--- a/apps/ledger-live-desktop/tools/config/renderer.esbuild.js
+++ b/apps/ledger-live-desktop/tools/config/renderer.esbuild.js
@@ -33,6 +33,17 @@ module.exports = {
       // It prevents the global styles from working.
       // See: https://github.com/styled-components/styled-components/issues/3714#issuecomment-1112672142
       "styled-components": [require.resolve("styled-components/dist/styled-components")],
+      // Force resolution of crypto-icons-ui to workspace to avoid duplication
+      "@ledgerhq/crypto-icons-ui": path.resolve(
+        path.dirname(__dirname),
+        "..",
+        "..",
+        "..",
+        "libs",
+        "ui",
+        "packages",
+        "crypto-icons",
+      ),
       "buffer/": "buffer",
     }),
     HtmlPlugin({


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

**Problem:** in current LLD bundle, the crypto-icons icons ui library was appearing twice in node_modules and ui/ which is overhead for the performance and bundle size.

<img width="580" height="851" alt="Screenshot 2025-11-07 at 10 48 50" src="https://github.com/user-attachments/assets/75852789-74ec-47c9-880d-840848b03c78" />

after this, we have a proper bundle


<img width="857" height="693" alt="Screenshot 2025-11-07 at 12 22 42" src="https://github.com/user-attachments/assets/facac9c5-3707-49b0-b7d0-9909f3b3e541" />

**beware: i'm testing this from the Remove CAL initiative, so the bundle size isn't like this on develop, but it's to show the diff**

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
