### PR TITLE
chore(lld): stop listing tokens in old AddAccounts step choose currency

### DIFF
--- a/.changeset/sharp-years-compare.md
+++ b/.changeset/sharp-years-compare.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Stop listing tokens in old Add Accounts step choose currency

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.tsx
@@ -1,10 +1,6 @@
 import React, { useMemo, useCallback } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import {
-  listSupportedCurrencies,
-  listTokens,
-  isCurrencySupported,
-} from "@ledgerhq/live-common/currencies/index";
+import { listSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
 import { findTokenAccountByCurrency } from "@ledgerhq/live-common/account/index";
 import { supportLinkByTokenType } from "~/config/urls";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -29,18 +25,13 @@ import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
 
-const listSupportedTokens = () =>
-  listTokens().filter(token => isCurrencySupported(token.parentCurrency));
-
 const StepChooseCurrency = ({ currency, setCurrency }: StepProps) => {
   const isAcceptedCurrency = useAcceptedCurrency();
 
   const currencies = useMemo(() => {
-    const supportedCurrenciesAndTokens =
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      (listSupportedCurrencies() as CryptoOrTokenCurrency[]).concat(listSupportedTokens());
-
-    return supportedCurrenciesAndTokens.filter(isAcceptedCurrency);
+    // Only list supported currencies, tokens are no longer listed here
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return (listSupportedCurrencies() as CryptoOrTokenCurrency[]).filter(isAcceptedCurrency);
   }, [isAcceptedCurrency]);
 
   const url =


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** 
  - https://github.com/LedgerHQ/ledger-live/actions/runs/19168370313
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD
  - we modify something that is actually no longer used

### 📝 Description

remove the ability to select a token in the Currency Select of the **old** Add Accounts flow – that flow being actually legacy and no longer activated in prod.

### ❓ Context

- **JIRA or GitHub link**: LIVE-23022


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
