### PR TITLE
:bug: (LWM) clear the drawer queue with closeAllDrawer

### DIFF
--- a/.changeset/five-geckos-tickle.md
+++ b/.changeset/five-geckos-tickle.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Reset the drawer queue when calling closeAllDrawers to prevent issue

--- a/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/QueuedDrawersContextProvider.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/QueuedDrawersContextProvider.tsx
@@ -72,8 +72,11 @@ const QueuedDrawersContextProvider: React.FC<{ children: React.ReactNode }> = ({
   const closeAllDrawers = useCallback(() => {
     logDrawer("closeAllDrawers");
     if (queueRef.current.length === 0) return;
-    queueRef.current.forEach(queueItem => queueItem.setDrawerOpenedCallback(false));
-    queueRef.current = [{ ...queueRef.current[0], markedForClose: true }];
+    queueRef.current.forEach(queueItem => {
+      queueItem.markedForClose = true;
+      queueItem.setDrawerOpenedCallback(false);
+    });
+    queueRef.current = [];
     logQueueLength();
   }, [logQueueLength]);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - queuedDrawers

### 📝 Description

The markedForClose flag prevented that drawer from being reopened when it removed itself 
When we call closeAllDrawers it makes sense to totally clean the queue

| Before        | After         |
| ------------- | ------------- |
|https://github.com/user-attachments/assets/35d01844-5928-4507-8598-3fb5c13c2593|https://github.com/user-attachments/assets/8e8c5ba4-46e2-4245-a3ce-f9ae32f672e4|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23096](https://ledgerhq.atlassian.net/browse/LIVE-23096)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23096]: https://ledgerhq.atlassian.net/browse/LIVE-23096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ