### PR TITLE
feat: add redirect on modular asset drawer on onboarding

### DIFF
--- a/.changeset/selfish-lamps-hug.md
+++ b/.changeset/selfish-lamps-hug.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add redirect on modular asset drawer in onboarding new seed flow

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -67,6 +67,7 @@ import {
   SettingsSetSelectedTabPortfolioAssetsPayload,
   SettingsSetIsRebornPayload,
   SettingsIsOnboardingFlowPayload,
+  SettingsIsOnboardingFlowReceiveSuccessPayload,
 } from "./types";
 import { ImageType } from "~/components/CustomImage/types";
 
@@ -121,6 +122,10 @@ export const completeOnboarding = createAction<SettingsCompleteOnboardingPayload
 export const setIsOnboardingFlow = createAction<SettingsIsOnboardingFlowPayload>(
   SettingsActionTypes.SETTINGS_SET_IS_ONBOARDING_FlOW,
 );
+export const setIsOnboardingFlowReceiveSuccess =
+  createAction<SettingsIsOnboardingFlowReceiveSuccessPayload>(
+    SettingsActionTypes.SETTINGS_SET_IS_ONBOARDING_FlOW_RECEIVE_SUCCESS,
+  );
 export const setHasInstalledAnyApp = createAction<SettingsSetHasInstalledAnyAppPayload>(
   SettingsActionTypes.SETTINGS_SET_HAS_INSTALLED_ANY_APP,
 );

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -263,6 +263,7 @@ export enum SettingsActionTypes {
   SETTINGS_SET_SELECTED_TIME_RANGE = "SETTINGS_SET_SELECTED_TIME_RANGE",
   SETTINGS_COMPLETE_ONBOARDING = "SETTINGS_COMPLETE_ONBOARDING",
   SETTINGS_SET_IS_ONBOARDING_FlOW = "SETTINGS_SET_IS_ONBOARDING_FlOW",
+  SETTINGS_SET_IS_ONBOARDING_FlOW_RECEIVE_SUCCESS = "SETTINGS_SET_IS_ONBOARDING_FlOW_RECEIVE_SUCCESS",
   SETTINGS_COMPLETE_CUSTOM_IMAGE_FLOW = "SETTINGS_COMPLETE_CUSTOM_IMAGE_FLOW",
   SETTINGS_SET_HAS_INSTALLED_ANY_APP = "SETTINGS_SET_HAS_INSTALLED_ANY_APP",
   SETTINGS_SET_READONLY_MODE = "SETTINGS_SET_READONLY_MODE",
@@ -396,6 +397,9 @@ export type SettingsSetHasBeenRedirectedToPostOnboardingPayload =
 
 export type SettingsCompleteOnboardingPayload = void | SettingsState["hasCompletedOnboarding"];
 export type SettingsIsOnboardingFlowPayload = void | SettingsState["isOnboardingFlow"];
+export type SettingsIsOnboardingFlowReceiveSuccessPayload =
+  | void
+  | SettingsState["isOnboardingFlowReceiveSuccess"];
 export type SettingsSetGeneralTermsVersionAccepted = SettingsState["generalTermsVersionAccepted"];
 export type SettingsSetUserNps = number;
 export type SettingsSetSupportedCounterValues = SettingsState["supportedCounterValues"];
@@ -451,6 +455,7 @@ export type SettingsPayload =
   | SettingsSetFeatureFlagsBannerVisiblePayload
   | SettingsCompleteOnboardingPayload
   | SettingsIsOnboardingFlowPayload
+  | SettingsIsOnboardingFlowReceiveSuccessPayload
   | SettingsSetDebugAppLevelDrawerOpenedPayload
   | SettingsSetGeneralTermsVersionAccepted
   | SettingsSetHasBeenUpsoldProtectPayload

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
@@ -26,7 +26,7 @@ import { ReceiveFundsStackParamList } from "./types/ReceiveFundsNavigator";
 import { NavigationHeaderBackButton } from "../NavigationHeaderBackButton";
 import { Flex } from "@ledgerhq/native-ui";
 import HelpButton from "~/screens/ReceiveFunds/HelpButton";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import {
   hasClosedNetworkBannerSelector,
   hasClosedWithdrawBannerSelector,
@@ -35,6 +35,7 @@ import {
 import { urls } from "~/utils/urls";
 import ReceiveProvider from "~/screens/ReceiveFunds/01b-ReceiveProvider.";
 import { useReceiveNoahEntry } from "~/hooks/useNoahEntryPoint";
+import { setIsOnboardingFlowReceiveSuccess } from "~/actions/settings";
 
 export default function ReceiveFundsNavigator() {
   const { colors } = useTheme();
@@ -44,6 +45,7 @@ export default function ReceiveFundsNavigator() {
   const hasClosedNetworkBanner = useSelector(hasClosedNetworkBannerSelector);
   const isOnboardingFlow = useSelector(isOnboardingFlowSelector);
   const receiveNoahEntry = useReceiveNoahEntry();
+  const dispatchRedux = useDispatch();
 
   const onClose = useCallback(() => {
     track("button_clicked", {
@@ -78,7 +80,9 @@ export default function ReceiveFundsNavigator() {
       button: "HeaderRight Close",
       page: ScreenName.ReceiveConfirmation,
     });
-  }, []);
+
+    dispatchRedux(setIsOnboardingFlowReceiveSuccess(true));
+  }, [dispatchRedux]);
 
   const onVerificationConfirmationClose = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -77,6 +77,7 @@ import type {
   SettingsSetSelectedTabPortfolioAssetsPayload,
   SettingsSetIsRebornPayload,
   SettingsIsOnboardingFlowPayload,
+  SettingsIsOnboardingFlowReceiveSuccessPayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -167,6 +168,7 @@ export const INITIAL_STATE: SettingsState = {
   mevProtection: true,
   selectedTabPortfolioAssets: "Assets",
   isOnboardingFlow: false,
+  isOnboardingFlowReceiveSuccess: false,
 };
 
 const pairHash = (from: { ticker: string }, to: { ticker: string }) =>
@@ -292,6 +294,14 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     return {
       ...state,
       isOnboardingFlow: !!payload,
+    };
+  },
+
+  [SettingsActionTypes.SETTINGS_SET_IS_ONBOARDING_FlOW_RECEIVE_SUCCESS]: (state, action) => {
+    const payload = (action as Action<SettingsIsOnboardingFlowReceiveSuccessPayload>).payload;
+    return {
+      ...state,
+      isOnboardingFlowReceiveSuccess: !!payload,
     };
   },
 
@@ -739,6 +749,8 @@ export const hasCompletedCustomImageFlowSelector = (state: State) =>
 export const hasCompletedOnboardingSelector = (state: State) =>
   state.settings.hasCompletedOnboarding;
 export const isOnboardingFlowSelector = (state: State) => state.settings.isOnboardingFlow;
+export const isOnboardingFlowReceiveSuccessSelector = (state: State) =>
+  state.settings.isOnboardingFlowReceiveSuccess;
 export const hasInstalledAnyAppSelector = (state: State) => state.settings.hasInstalledAnyApp;
 export const countervalueFirstSelector = (state: State) => state.settings.graphCountervalueFirst;
 export const readOnlyModeEnabledSelector = (state: State) => state.settings.readOnlyModeEnabled;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -226,6 +226,7 @@ export type SettingsState = {
   hasCompletedCustomImageFlow: boolean;
   hasCompletedOnboarding: boolean;
   isOnboardingFlow: boolean;
+  isOnboardingFlowReceiveSuccess: boolean;
   hasInstalledAnyApp: boolean;
   readOnlyModeEnabled: boolean;
   hasOrderedNano: boolean;


### PR DESCRIPTION
chore: changeset

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

In LLM the addition of the new modular asset drawer caused a change in the flow for the secure my crypto step which resulted in the user being sent to the completion screen if they exit it out before they finish the receive flow, this PR fixes the issues and ensures the user only gets redirected on receive flow completion. This requires both the incr1 and llm modular asset drawer to be enabled.


https://github.com/user-attachments/assets/818b199b-e5f9-4b8e-a3cf-b680a0f5e9d2



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-22908


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
