### PR TITLE
fix: Double signing on send flows

### DIFF
--- a/.changeset/green-moles-deliver.md
+++ b/.changeset/green-moles-deliver.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Double signing on send flows

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
@@ -4,8 +4,6 @@ import { StyleSheet } from "react-native";
 import { useSelector } from "react-redux";
 import { Edge, SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
-import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useTheme } from "styled-components/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { accountScreenSelector } from "~/reducers/accounts";
@@ -134,12 +132,7 @@ export default function ConnectDevice({ route, navigation }: Props) {
   const { t } = useTranslation();
   const { account, parentAccount } = useSelector(accountScreenSelector(route));
   invariant(account, "account is required");
-  const { appName, onSuccess, onError, analyticsPropertyFlow } = route.params;
-  const mainAccount = getMainAccount(account, parentAccount);
-  const { transaction, status } = useBridgeTransaction(() => ({
-    account: mainAccount,
-    transaction: route.params.transaction,
-  }));
+  const { appName, onSuccess, onError, analyticsPropertyFlow, transaction, status } = route.params;
   const tokenCurrency = account.type === "TokenAccount" ? account.token : undefined;
   const handleTx = useSignedTxHandler({
     account,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The issue indeed occurs when the last call to prepareTransaction updates the transaction we are already trying to sign with signOperation.
This is fixable fix passing the transaction (and its status) from one screen to another (more especially the last one, [ConnectDevice](https://github.com/LedgerHQ/ledger-live/blob/develop/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx)) instead of re-computing them at the very end [here](https://github.com/LedgerHQ/ledger-live/blob/323268ce5491fe14738efcbe5b65bdd9834fa393/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx#L139-L142).

Manual test has been performed on LLM.
Need to run e2e tests.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-22962](https://ledgerhq.atlassian.net/browse/LIVE-22962)

Allure Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/70cdc6b0-2e49-4477-aed0-991bc0c2bcb0/
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22962]: https://ledgerhq.atlassian.net/browse/LIVE-22962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ