### PR TITLE
:sparkles: (LWM) use json instead of base64 to export logs

### DIFF
--- a/apps/ledger-live-mobile/src/newArch/components/CustomNavigationHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/CustomNavigationHeader/index.tsx
@@ -33,6 +33,11 @@ export default function CustomNavigationHeader({ options, route }: NativeStackHe
         const title = options.title !== undefined ? options.title : route.name;
         return <HeaderTitleComponent>{title}</HeaderTitleComponent>;
       }
+
+      if (typeof HeaderTitleComponent === "string") {
+        return <HeaderTitle>{HeaderTitleComponent}</HeaderTitle>;
+      }
+
       return HeaderTitleComponent;
     }
     const title = options.title !== undefined ? options.title : route.name;

--- a/apps/ledger-live-mobile/src/newArch/utils/exportFile.ts
+++ b/apps/ledger-live-mobile/src/newArch/utils/exportFile.ts
@@ -1,0 +1,54 @@
+import Share, { ShareOptions } from "react-native-share";
+import RNFetchBlob from "rn-fetch-blob";
+import { getEnv } from "@ledgerhq/live-env";
+import { sendFile } from "../../../e2e/bridge/client";
+import logger from "~/logger";
+
+type ExportFileOptions = {
+  content: string;
+  filename: string;
+  type: string;
+  title?: string;
+  message?: string;
+  detoxFileName?: string;
+};
+
+export async function exportFile({
+  content,
+  filename,
+  type,
+  title,
+  message,
+  detoxFileName,
+}: ExportFileOptions): Promise<void> {
+  const filePath = `${RNFetchBlob.fs.dirs.DocumentDir}/${filename}`;
+  await RNFetchBlob.fs.writeFile(filePath, content, "utf8");
+
+  if (getEnv("DETOX")) {
+    const fileContent = await RNFetchBlob.fs.readFile(filePath, "utf8");
+    sendFile({ fileName: detoxFileName || filename, fileContent });
+  } else {
+    const fileExists = await RNFetchBlob.fs.exists(filePath);
+    if (!fileExists) {
+      throw new Error("Failed to create export file");
+    }
+
+    const options: ShareOptions = {
+      failOnCancel: false,
+      saveToFiles: true,
+      type,
+      filename,
+      url: filePath,
+      ...(title && { title }),
+      ...(message && { message }),
+    };
+
+    try {
+      await Share.open(options);
+    } catch (err) {
+      if ((err as { error?: { code?: string } })?.error?.code !== "ECANCELLED500") {
+        logger.critical(err as Error);
+      }
+    }
+  }
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Store.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Store.tsx
@@ -9,8 +9,8 @@ import { StyleSheet, ScrollView } from "react-native";
 import { useDispatch, useSelector } from "react-redux";
 import { Alert, Flex } from "@ledgerhq/native-ui";
 import { useTheme } from "@react-navigation/native";
-import Share from "react-native-share";
 import Node from "./Node";
+import { exportFile } from "LLM/utils/exportFile";
 import logger from "../../../../logger";
 import { dangerouslyOverrideState } from "~/actions/settings";
 import Button from "~/components/Button";
@@ -118,20 +118,16 @@ export default function Store() {
 
   const onExportState = () => {
     const exportState = async () => {
-      const base64 = Buffer.from(JSON.stringify(state)).toString("base64");
+      const jsonString = JSON.stringify(state);
       const date = new Date().toISOString().split("T")[0];
-      const humanReadableName = `ledgerwallet-mob-${date}-state`;
-
-      const options = {
-        failOnCancel: false,
-        saveToFiles: true,
-        type: "text/plain",
-        filename: humanReadableName,
-        url: `data:text/plain;base64,${base64}`,
-      };
+      const humanReadableName = `ledgerwallet-mob-${date}-state.json`;
 
       try {
-        await Share.open(options);
+        await exportFile({
+          content: jsonString,
+          filename: humanReadableName,
+          type: "application/json",
+        });
       } catch (err) {
         if ((err as { error?: { code?: string } })?.error?.code !== "ECANCELLED500") {
           logger.critical(err as Error);

--- a/apps/ledger-live-mobile/src/screens/Swap/History/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/History/index.tsx
@@ -18,7 +18,6 @@ import {
   Pressable,
   View,
 } from "react-native";
-import Share from "react-native-share";
 import { useDispatch, useSelector } from "react-redux";
 import { updateAccountWithUpdater } from "~/actions/accounts";
 import { track, TrackScreen } from "~/analytics";
@@ -32,9 +31,8 @@ import logger from "../../../logger";
 import { useSyncAllAccounts } from "../LiveApp/hooks/useSyncAllAccounts";
 import EmptyState from "./EmptyState";
 import OperationRow from "./OperationRow";
-import { getEnv } from "@ledgerhq/live-env";
-import { sendFile } from "../../../../e2e/bridge/client";
 import { Text } from "react-native";
+import { exportFile } from "LLM/utils/exportFile";
 import ExternalLink from "@ledgerhq/icons-ui/native/ExternalLink";
 import SafeAreaView from "~/components/SafeAreaView";
 
@@ -142,30 +140,17 @@ const History = () => {
 
   const exportSwapHistory = async () => {
     const mapped = mappedSwapOperationsToCSV(sections);
-    if (!getEnv("DETOX")) {
-      try {
-        const base64 = Buffer.from(mapped).toString("base64");
-        const options = {
-          title: t("transfer.swap.history.exportButton"),
-          message: t("transfer.swap.history.exportButton"),
-          failOnCancel: false,
-          saveToFiles: true,
-          type: "text/csv",
-          filename: t("transfer.swap.history.exportFilename"),
-          url: `data:text/csv;base64,${base64}`,
-        };
-
-        await Share.open(options);
-      } catch (err) {
-        // `failOnCancel: false` is not enough to prevent throwing on cancel apparently ¯\_(ツ)_/¯
-        if ((err as { error?: { code?: string } })?.error?.code !== "ECANCELLED500") {
-          logger.critical(err as Error);
-        }
-      }
-    } else {
-      try {
-        sendFile({ fileName: "ledgerwallet-swap-history.csv", fileContent: mapped });
-      } catch (err) {
+    try {
+      await exportFile({
+        content: mapped,
+        filename: t("transfer.swap.history.exportFilename"),
+        type: "text/csv",
+        title: t("transfer.swap.history.exportButton"),
+        message: t("transfer.swap.history.exportButton"),
+        detoxFileName: "ledgerwallet-swap-history.csv",
+      });
+    } catch (err) {
+      if ((err as { error?: { code?: string } })?.error?.code !== "ECANCELLED500") {
         logger.critical(err as Error);
       }
     }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Use json instead of base64 as it's not working on android with RNNA

https://github.com/user-attachments/assets/5ebf8b52-08c3-4939-9bb8-6437c8de0369


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23087](https://ledgerhq.atlassian.net/browse/LIVE-23087)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23087]: https://ledgerhq.atlassian.net/browse/LIVE-23087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ