### PR TITLE
:sparkles: (LWM) toggle pressability and pressable opacity feedback

### DIFF
--- a/apps/ledger-live-mobile/src/components/Touchable.tsx
+++ b/apps/ledger-live-mobile/src/components/Touchable.tsx
@@ -92,6 +92,9 @@ export default class Touchable extends Component<
 
     return (
       <Pressable
+        style={({ pressed }) => ({
+          opacity: pressed ? 0.5 : 1,
+        })}
         unstable_pressDelay={50}
         onPress={this.onPress}
         disabled={disabled}

--- a/libs/ui/packages/native/src/components/Form/Checkbox/index.tsx
+++ b/libs/ui/packages/native/src/components/Form/Checkbox/index.tsx
@@ -32,7 +32,7 @@ const Checkbox = ({ checked, onChange, disabled, label }: CheckboxProps): JSX.El
   const { colors, space } = useTheme();
 
   return (
-    <Pressable onPress={onChange} disabled={disabled}>
+    <Pressable onPressIn={onChange} disabled={disabled}>
       <Flex flexDirection="row" alignItems="center">
         <Square checked={checked}>
           {checked ? <CheckAlone size={13} color={colors.neutral.c00} /> : null}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We can use onPressIn as it makes sense for a toggle to be fastly responsive

For the other bug with header buttons I added a small UI opacity change


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23085](https://ledgerhq.atlassian.net/browse/LIVE-23085)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23085]: https://ledgerhq.atlassian.net/browse/LIVE-23085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ