### PR TITLE
fix: drawers are closed when coming from deeplinks

### DIFF
--- a/.changeset/tasty-rockets-joke.md
+++ b/.changeset/tasty-rockets-joke.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Fix close drawer when coming from Deeplink and one drawer was previously opened

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -44,6 +44,7 @@ import {
 import { getDrawerFlowConfigs } from "./deeplinks/modularDrawerFlowConfigs";
 import { viewNamePredicate } from "~/datadog";
 import { AppLoadingManager } from "LLM/features/LaunchScreen";
+import { useDeeplinkDrawerCleanup } from "./deeplinks/useDeeplinkDrawerCleanup";
 
 const themes: {
   [key: string]: Theme;
@@ -337,6 +338,9 @@ export const DeeplinksProvider = ({
   const dispatch = useDispatch();
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
 
+  // Hook to close drawers when deeplink is triggered after app was in background
+  const onDeeplinkReceived = useDeeplinkDrawerCleanup();
+
   const { state } = useRemoteLiveAppContext();
   const liveAppProviderInitialized = !!state.value || !!state.error;
   const manifests = state?.value?.liveAppByIndex || emptyObject;
@@ -514,6 +518,9 @@ export const DeeplinksProvider = ({
           : getOnboardingLinkingOptions(!!userAcceptedTerms)),
         subscribe(listener) {
           const sub = Linking.addEventListener("url", ({ url }) => {
+            // Close all drawers if app was in background before deeplink
+            onDeeplinkReceived();
+
             // Prevent default deep link if we're already in a wallet connect route.
             const navigationState = navigationRef.current?.getState();
             if (
@@ -712,6 +719,7 @@ export const DeeplinksProvider = ({
     storylyContext,
     liveAppProviderInitialized,
     manifests,
+    onDeeplinkReceived,
   ]);
   const [isReady, setIsReady] = React.useState(false);
 

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/useDeeplinkDrawerCleanup.test.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/useDeeplinkDrawerCleanup.test.ts
@@ -1,0 +1,84 @@
+import { renderHook, act } from "@testing-library/react-native";
+import { AppState, AppStateStatus } from "react-native";
+import { useDeeplinkDrawerCleanup } from "../useDeeplinkDrawerCleanup";
+
+const mockCloseAllDrawers = jest.fn();
+
+jest.mock("LLM/components/QueuedDrawer/QueuedDrawersContext", () => ({
+  useQueuedDrawerContext: () => ({
+    closeAllDrawers: mockCloseAllDrawers,
+  }),
+}));
+
+describe("useDeeplinkDrawerCleanup", () => {
+  let appStateListener: (nextAppState: AppStateStatus) => void;
+  let mockSubscription: { remove: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    mockSubscription = { remove: jest.fn() };
+
+    jest.spyOn(AppState, "addEventListener").mockImplementation((_event, listener) => {
+      appStateListener = listener;
+      return mockSubscription;
+    });
+
+    Object.defineProperty(AppState, "currentState", {
+      value: "active",
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("should close all drawers when deeplink received after coming from background", () => {
+    const { result } = renderHook(() => useDeeplinkDrawerCleanup());
+
+    act(() => {
+      appStateListener("background");
+    });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockCloseAllDrawers).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not close drawers when deeplink received without coming from background", () => {
+    const { result } = renderHook(() => useDeeplinkDrawerCleanup());
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockCloseAllDrawers).not.toHaveBeenCalled();
+  });
+
+  it("should reset background flag after returning to foreground", () => {
+    const { result } = renderHook(() => useDeeplinkDrawerCleanup());
+
+    act(() => {
+      appStateListener("background");
+    });
+
+    act(() => {
+      appStateListener("active");
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockCloseAllDrawers).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/useDeeplinkDrawerCleanup.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/useDeeplinkDrawerCleanup.ts
@@ -1,0 +1,49 @@
+import { useRef, useEffect, useCallback } from "react";
+import { AppState, AppStateStatus } from "react-native";
+import { useQueuedDrawerContext } from "LLM/components/QueuedDrawer/QueuedDrawersContext";
+
+/**
+ * Automatically closes all open drawers when the app receives a deeplink
+ * after returning from background, preventing UI conflicts during navigation.
+ *
+ * @returns A callback to invoke when a deeplink is received
+ */
+export function useDeeplinkDrawerCleanup() {
+  const { closeAllDrawers } = useQueuedDrawerContext();
+  const cameFromBackgroundRef = useRef(false);
+  const previousAppStateRef = useRef(AppState.currentState);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (nextAppState: AppStateStatus) => {
+      const wasActive = previousAppStateRef.current === "active";
+      const isGoingToBackground = nextAppState.match(/inactive|background/);
+
+      // Track when app transitions to background
+      if (wasActive && isGoingToBackground) {
+        cameFromBackgroundRef.current = true;
+      }
+
+      // Reset flag after app returns to foreground
+      // Delay allows deeplink navigation to occur first
+      if (nextAppState === "active" && cameFromBackgroundRef.current) {
+        setTimeout(() => {
+          cameFromBackgroundRef.current = false;
+        }, 250);
+      }
+
+      previousAppStateRef.current = nextAppState;
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, []);
+
+  const onDeeplinkReceived = useCallback(() => {
+    if (cameFromBackgroundRef.current) {
+      closeAllDrawers();
+    }
+  }, [closeAllDrawers]);
+
+  return onDeeplinkReceived;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description


Close drawer when app coming back foreground when it comes from deeplink

https://github.com/user-attachments/assets/cb5ae4d6-b057-4e53-adf1-682d738109fd



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-23269


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
