### PR TITLE
✨ (LWM) useFetchCurrencyAll with defaut providers to be faster

### DIFF
--- a/libs/ledger-live-common/src/exchange/providers/swap.ts
+++ b/libs/ledger-live-common/src/exchange/providers/swap.ts
@@ -328,3 +328,7 @@ export const getAvailableProviders = async (): Promise<string[]> => {
   }
   return Object.keys(await fetchAndMergeProviderData({ ledgerSignatureEnv, partnerSignatureEnv }));
 };
+
+export const getDefaultSwapProviderKeys = (): string[] => {
+  return Object.keys(DEFAULT_SWAP_PROVIDERS);
+};

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFetchCurrencyAll.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFetchCurrencyAll.ts
@@ -6,7 +6,7 @@ import { useFilteredProviders } from "./useFilteredProviders";
 
 export function useFetchCurrencyAll() {
   const fetchAdditionalCoins = useFeature("fetchAdditionalCoins");
-  const { providers, loading, error } = useFilteredProviders();
+  const { providers, error } = useFilteredProviders();
 
   const { data, ...rest } = useAPI({
     queryFn: fetchCurrencyAll,
@@ -14,9 +14,8 @@ export function useFetchCurrencyAll() {
       additionalCoinsFlag: fetchAdditionalCoins?.enabled,
       providers,
     },
-    // assume the all currency list for the given props won't change during a users session.
     staleTimeout: FETCH_CURRENCIES_TIMEOUT_MS,
-    enabled: !loading && !error,
+    enabled: !error && providers.length > 0,
   });
   return {
     ...rest,

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFilteredProviders.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFilteredProviders.ts
@@ -1,27 +1,52 @@
 import { getEnv } from "@ledgerhq/live-env";
-import { useCallback, useEffect, useState } from "react";
-import { fetchAndMergeProviderData } from "../../../providers/swap";
+import { useCallback, useEffect, useState, useMemo } from "react";
+import { fetchAndMergeProviderData, getDefaultSwapProviderKeys } from "../../../providers/swap";
 import { useFeature } from "../../../../featureFlags";
 
+const filterProvidersByFeatureFlags = (
+  providers: string[],
+  ptxSwapMoonpayProviderFlag?: { enabled?: boolean },
+  ptxSwapExodusProviderFlag?: { enabled?: boolean },
+): string[] => {
+  let filtered = providers;
+  if (!ptxSwapMoonpayProviderFlag?.enabled) {
+    filtered = filtered.filter(provider => provider !== "moonpay");
+  }
+  if (!ptxSwapExodusProviderFlag?.enabled) {
+    filtered = filtered.filter(provider => provider !== "exodus");
+  }
+  return filtered;
+};
+
 export const useFilteredProviders = () => {
-  const [providers, setProviders] = useState<string[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<unknown>(null);
   const ptxSwapMoonpayProviderFlag = useFeature("ptxSwapMoonpayProvider");
   const ptxSwapExodusProviderFlag = useFeature("ptxSwapExodusProvider");
+
+  const defaultProviders = useMemo(
+    () =>
+      filterProvidersByFeatureFlags(
+        getDefaultSwapProviderKeys(),
+        ptxSwapMoonpayProviderFlag ?? undefined,
+        ptxSwapExodusProviderFlag ?? undefined,
+      ),
+    [ptxSwapMoonpayProviderFlag, ptxSwapExodusProviderFlag],
+  );
+
+  const [providers, setProviders] = useState<string[]>(defaultProviders);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+
   const fetchProviders = useCallback(async () => {
     try {
       const ledgerSignatureEnv = getEnv("MOCK_EXCHANGE_TEST_CONFIG") ? "test" : "prod";
       const partnerSignatureEnv = getEnv("MOCK_EXCHANGE_TEST_PARTNER") ? "test" : "prod";
 
       const data = await fetchAndMergeProviderData({ ledgerSignatureEnv, partnerSignatureEnv });
-      let filteredProviders = Object.keys(data);
-      if (!ptxSwapMoonpayProviderFlag?.enabled) {
-        filteredProviders = filteredProviders.filter(provider => provider !== "moonpay");
-      }
-      if (!ptxSwapExodusProviderFlag?.enabled) {
-        filteredProviders = filteredProviders.filter(provider => provider !== "exodus");
-      }
+      const filteredProviders = filterProvidersByFeatureFlags(
+        Object.keys(data),
+        ptxSwapMoonpayProviderFlag ?? undefined,
+        ptxSwapExodusProviderFlag ?? undefined,
+      );
 
       setProviders(filteredProviders);
     } catch (error) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...


### 📝 Description

Use the default list to trigger useFetchCurrencyAll to speed up the render


https://github.com/user-attachments/assets/154f8abe-040a-4e63-9d47-bb94792c0074



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23308](https://ledgerhq.atlassian.net/browse/LIVE-23308)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23308]: https://ledgerhq.atlassian.net/browse/LIVE-23308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ