### PR TITLE
🐛 RNNA - Android - fix few issues

### DIFF
--- a/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/index.tsx
@@ -273,7 +273,7 @@ const QueuedDrawerNative = ({
               width: "100%",
               paddingHorizontal: 16,
               paddingTop: 16,
-              paddingBottom: insets.bottom,
+              paddingBottom: insets.bottom + 16,
             }}
           >
             {shouldShowHeader && !CustomHeader ? (

--- a/libs/ui/packages/native/src/components/Tabs/Chip/index.tsx
+++ b/libs/ui/packages/native/src/components/Tabs/Chip/index.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import styled from "styled-components/native";
 import Text from "../../Text";
-import { TouchableOpacity } from "react-native";
+import { Pressable } from "react-native";
 import TemplateTabs, { BaseTabsProps, TabItemProps } from "../TemplateTabs";
 
-const TabBox = styled(TouchableOpacity)<
+const TabBox = styled(Pressable)<
   Pick<TabItemProps, "isActive" | "size" | "activeBg" | "inactiveBg" | "stretchItems">
 >`
   text-align: center;
@@ -34,7 +34,7 @@ export const ChipTab = ({
     inactiveBg={inactiveBg}
     isActive={isActive}
     stretchItems={stretchItems}
-    onPress={onPress}
+    onPressIn={onPress}
     size={size}
   >
     <Text


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description


Add + 16 at the bottom to all Drawers to ensure nothing gets cropped
TabBox now uses pressable and onPressIn instead of TouchableOpacity and onPress (onPressIn is better in this case)


https://github.com/user-attachments/assets/f019097d-2907-4180-b4dd-b49905e2d9a9

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23437](https://ledgerhq.atlassian.net/browse/LIVE-23437) [LIVE-23438](https://ledgerhq.atlassian.net/browse/LIVE-23438)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23437]: https://ledgerhq.atlassian.net/browse/LIVE-23437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-23438]: https://ledgerhq.atlassian.net/browse/LIVE-23438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ