### PR TITLE
feat: add check for ledger sync active state in post onboarding hub

### DIFF
--- a/.changeset/itchy-horses-carry.md
+++ b/.changeset/itchy-horses-carry.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add check for ledger sync active state in post onboarding hub

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/PostOnboardingActionRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/PostOnboardingActionRow.tsx
@@ -19,6 +19,7 @@ import { EntryPoint } from "LLD/features/LedgerSyncEntryPoints/types";
 export type Props = PostOnboardingAction &
   PostOnboardingActionState & {
     deviceModelId: DeviceModelId | null;
+    isLedgerSyncActive: boolean;
   };
 
 const ActionRowWrapper = styled(Flex)<{ completed: boolean }>`
@@ -34,9 +35,10 @@ const PostOnboardingActionRow: React.FC<Props> = props => {
     tagLabel,
     buttonLabelForAnalyticsEvent,
     completed,
-    getIsAlreadyCompleted,
     deviceModelId,
     shouldCompleteOnStart,
+    getIsAlreadyCompletedByState,
+    isLedgerSyncActive,
   } = props;
   const { t } = useTranslation();
   const dispatch: Dispatch = useDispatch();
@@ -53,8 +55,9 @@ const PostOnboardingActionRow: React.FC<Props> = props => {
   const [isActionCompleted, setIsActionCompleted] = useState(false);
 
   const initIsActionCompleted = useCallback(async () => {
-    setIsActionCompleted(completed || !!(await getIsAlreadyCompleted?.({ protectId })));
-  }, [setIsActionCompleted, completed, getIsAlreadyCompleted, protectId]);
+    const isAlreadyCompleted = getIsAlreadyCompletedByState?.({ isLedgerSyncActive });
+    setIsActionCompleted(completed || !!isAlreadyCompleted);
+  }, [setIsActionCompleted, completed, getIsAlreadyCompletedByState, isLedgerSyncActive]);
 
   useEffect(() => {
     initIsActionCompleted();

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/index.tsx
@@ -4,20 +4,26 @@ import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/
 import PostOnboardingActionRow from "./PostOnboardingActionRow";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import { setHasRedirectedToPostOnboarding } from "~/renderer/actions/settings";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/lib-es/store";
 
 const PostOnboardingHub = () => {
   const dispatch = useDispatch();
   const { actionsState, deviceModelId } = usePostOnboardingHubState();
+  const isLedgerSyncActive = Boolean(useSelector(trustchainSelector)?.rootId);
 
   const postOnboardingRows = useMemo(
     () =>
       actionsState.map((action, index) => (
         <React.Fragment key={index}>
-          <PostOnboardingActionRow {...action} deviceModelId={deviceModelId} />
+          <PostOnboardingActionRow
+            {...action}
+            deviceModelId={deviceModelId}
+            isLedgerSyncActive={isLedgerSyncActive}
+          />
         </React.Fragment>
       )),
-    [actionsState, deviceModelId],
+    [actionsState, deviceModelId, isLedgerSyncActive],
   );
 
   useEffect(() => {

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/index.tsx
@@ -47,6 +47,9 @@ const syncAccounts: PostOnboardingAction = {
   startAction: ({ openActivationDrawer }: StartActionArgs) => {
     openActivationDrawer?.();
   },
+  getIsAlreadyCompletedByState: ({ isLedgerSyncActive }) => {
+    return !!isLedgerSyncActive;
+  },
 };
 
 const customImage: PostOnboardingAction = {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

On LWD the state of ledger sync active for post onboarding hub was only being set at the end of the ledger sync flow and didn't account for other conditions where the device would be active already.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-23473


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
