### PR TITLE
fix(LWM): prevent double loading on market page

### DIFF
--- a/.changeset/loud-birds-share.md
+++ b/.changeset/loud-birds-share.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Prevent double loading on market page

--- a/apps/ledger-live-mobile/src/newArch/features/Market/hooks/usePullToRefresh.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/hooks/usePullToRefresh.ts
@@ -35,7 +35,7 @@ function usePullToRefresh({ loading, refetch }: UsePullToRefreshProps) {
 
   return {
     handlePullToRefresh,
-    refreshControlVisible: isRefreshing || loading,
+    refreshControlVisible: isRefreshing,
   };
 }
 

--- a/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketDetail/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketDetail/index.tsx
@@ -136,8 +136,8 @@ function View({
         }
       >
         <MarketGraph
+          isLoading={loadingChart && !refreshControlVisible}
           setHoverItem={setHoverItem}
-          isLoading={loadingChart}
           refreshChart={updateMarketParams}
           chartData={dataChart}
           range={range}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - View market page for asset Android

### 📝 Description

Android had two loading icons on Market info page. This fixes it

Before

https://github.com/user-attachments/assets/234388a5-4e13-4ca3-8869-24bc2e22702f

After 

https://github.com/user-attachments/assets/0fc46589-a30e-4cd9-9649-c85e30a461fd


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23512](https://ledgerhq.atlassian.net/browse/LIVE-23512)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23512]: https://ledgerhq.atlassian.net/browse/LIVE-23512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ