### PR TITLE
feat: post onboarding accounts with funds check

### DIFF
--- a/.changeset/dirty-fireants-heal.md
+++ b/.changeset/dirty-fireants-heal.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add funds check to accounts with funds listener for post onboarding state

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -64,6 +64,7 @@ import { AppGeoBlocker } from "LLD/features/AppBlockers/components/AppGeoBlocker
 import { AppVersionBlocker } from "LLD/features/AppBlockers/components/AppVersionBlocker";
 import { initMixpanel } from "./analytics/mixpanel";
 import { setSolanaLdmkEnabled } from "@ledgerhq/live-common/families/solana/setup";
+import useCheckAccountWithFunds from "./components/PostOnboardingHub/logic/useCheckAccountWithFunds";
 
 const PlatformCatalog = lazy(() => import("~/renderer/screens/platform"));
 const Dashboard = lazy(() => import("~/renderer/screens/dashboard"));
@@ -202,8 +203,9 @@ export default function Default() {
   const ldmkSolanaSignerFeatureFlag = useFeature("ldmkSolanaSigner");
 
   const dmk = useDeviceManagementKit();
+  const checkAccountsWithFunds = useCheckAccountWithFunds();
 
-  useAccountsWithFundsListener(accounts, updateIdentify);
+  useAccountsWithFundsListener(accounts, updateIdentify, checkAccountsWithFunds);
   useListenToHidDevices();
   useDeeplink();
   useUSBTroubleshooting();

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/PostOnboardingActionRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/PostOnboardingActionRow.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Flex, Icons, Tag, Text } from "@ledgerhq/react-ui";
 import { useTranslation } from "react-i18next";
-import { PostOnboardingActionState, PostOnboardingAction } from "@ledgerhq/types-live";
+import { PostOnboardingActionState, PostOnboardingAction, Account } from "@ledgerhq/types-live";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { track } from "~/renderer/analytics/segment";
@@ -20,6 +20,7 @@ export type Props = PostOnboardingAction &
   PostOnboardingActionState & {
     deviceModelId: DeviceModelId | null;
     isLedgerSyncActive: boolean;
+    accounts: Account[];
   };
 
 const ActionRowWrapper = styled(Flex)<{ completed: boolean }>`
@@ -39,6 +40,7 @@ const PostOnboardingActionRow: React.FC<Props> = props => {
     shouldCompleteOnStart,
     getIsAlreadyCompletedByState,
     isLedgerSyncActive,
+    accounts,
   } = props;
   const { t } = useTranslation();
   const dispatch: Dispatch = useDispatch();
@@ -55,9 +57,9 @@ const PostOnboardingActionRow: React.FC<Props> = props => {
   const [isActionCompleted, setIsActionCompleted] = useState(false);
 
   const initIsActionCompleted = useCallback(async () => {
-    const isAlreadyCompleted = getIsAlreadyCompletedByState?.({ isLedgerSyncActive });
+    const isAlreadyCompleted = getIsAlreadyCompletedByState?.({ isLedgerSyncActive, accounts });
     setIsActionCompleted(completed || !!isAlreadyCompleted);
-  }, [setIsActionCompleted, completed, getIsAlreadyCompletedByState, isLedgerSyncActive]);
+  }, [setIsActionCompleted, completed, getIsAlreadyCompletedByState, isLedgerSyncActive, accounts]);
 
   useEffect(() => {
     initIsActionCompleted();

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/index.tsx
@@ -6,11 +6,13 @@ import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import { setHasRedirectedToPostOnboarding } from "~/renderer/actions/settings";
 import { useDispatch, useSelector } from "react-redux";
 import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/lib-es/store";
+import { accountsSelector } from "~/renderer/reducers/accounts";
 
 const PostOnboardingHub = () => {
   const dispatch = useDispatch();
   const { actionsState, deviceModelId } = usePostOnboardingHubState();
   const isLedgerSyncActive = Boolean(useSelector(trustchainSelector)?.rootId);
+  const accounts = useSelector(accountsSelector);
 
   const postOnboardingRows = useMemo(
     () =>
@@ -20,10 +22,11 @@ const PostOnboardingHub = () => {
             {...action}
             deviceModelId={deviceModelId}
             isLedgerSyncActive={isLedgerSyncActive}
+            accounts={accounts}
           />
         </React.Fragment>
       )),
-    [actionsState, deviceModelId, isLedgerSyncActive],
+    [actionsState, deviceModelId, isLedgerSyncActive, accounts],
   );
 
   useEffect(() => {

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/index.tsx
@@ -19,6 +19,9 @@ const assetsTransfer: PostOnboardingAction = {
   actionCompletedPopupLabel: "postOnboarding.actions.assetsTransfer.popupLabel",
   buttonLabelForAnalyticsEvent: "Secure your assets on Ledger",
   startAction: ({ openModalCallback }: StartActionArgs) => openModalCallback?.("MODAL_RECEIVE"),
+  getIsAlreadyCompletedByState: ({ accounts }) => {
+    return !!accounts && accounts.some(account => account?.balance.isGreaterThan(0));
+  },
 };
 
 const buyCrypto: PostOnboardingAction = {

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useCheckAccountWithFunds.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useCheckAccountWithFunds.ts
@@ -1,0 +1,12 @@
+import { useCheckAccountWithFundsAction } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { useCompleteActionCallback } from "./useCompleteAction";
+import { Account } from "@ledgerhq/types-live";
+
+const useCheckAccountWithFunds = (): ((accounts: Account[]) => void) => {
+  const completeAction = useCompleteActionCallback();
+  const handleAccountsUpdate = useCheckAccountWithFundsAction(completeAction);
+
+  return handleAccountsUpdate;
+};
+
+export default useCheckAccountWithFunds;

--- a/apps/ledger-live-desktop/src/renderer/families/canton/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/StepReceiveFunds.tsx
@@ -19,7 +19,7 @@ import LinkShowQRCode from "~/renderer/components/LinkShowQRCode";
 import SuccessDisplay from "~/renderer/components/SuccessDisplay";
 import Receive2NoDevice from "~/renderer/components/Receive2NoDevice";
 import { renderVerifyUnwrapped } from "~/renderer/components/DeviceAction/rendering";
-import { Account, PostOnboardingActionId } from "@ledgerhq/types-live";
+import { Account } from "@ledgerhq/types-live";
 import { track } from "~/renderer/analytics/segment";
 import Modal from "~/renderer/components/Modal";
 import ModalBody from "~/renderer/components/Modal/ModalBody";
@@ -30,7 +30,6 @@ import { FeatureToggle, useFeature } from "@ledgerhq/live-common/featureFlags/in
 import { LOCAL_STORAGE_KEY_PREFIX } from "~/renderer/modals/Receive/steps/StepReceiveStakingFlow";
 import { StepProps } from "~/renderer/modals/Receive/Body";
 import { useAccountName } from "~/renderer/reducers/wallet";
-import { useCompleteActionCallback } from "~/renderer/components/PostOnboardingHub/logic/useCompleteAction";
 import { UTXOAddressAlert } from "~/renderer/components/UTXOAddressAlert";
 import { isUTXOCompliant } from "@ledgerhq/live-common/currencies/helpers";
 import MemoTagInfo from "LLD/features/MemoTag/components/MemoTagInfo";
@@ -190,7 +189,6 @@ const StepReceiveFunds = ({
     onResetSkip();
   }, [device, isAddressVerified, onChangeAddressVerified, onResetSkip, transitionTo]);
 
-  const completeAction = useCompleteActionCallback();
   const receiveStakingFlowConfig = useFeature("receiveStakingFlowConfigDesktop");
   const receivedCurrencyId: string | undefined =
     account && account.type !== "TokenAccount" ? account?.currency?.id : undefined;
@@ -199,9 +197,6 @@ const StepReceiveFunds = ({
     receiveStakingFlowConfig?.enabled &&
     receiveStakingFlowConfig?.params?.[receivedCurrencyId]?.enabled;
   const onFinishReceiveFlow = useCallback(() => {
-    if (!isOnboardingReceiveFlow) {
-      completeAction(PostOnboardingActionId.assetsTransfer);
-    }
     const dismissModal =
       global.localStorage.getItem(`${LOCAL_STORAGE_KEY_PREFIX}${receivedCurrencyId}`) === "true";
     if (
@@ -235,7 +230,6 @@ const StepReceiveFunds = ({
     name,
     onClose,
     transitionTo,
-    completeAction,
     isOnboardingReceiveFlow,
   ]);
   return (

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -21,7 +21,7 @@ import SuccessDisplay from "~/renderer/components/SuccessDisplay";
 import Receive2NoDevice from "~/renderer/components/Receive2NoDevice";
 import { renderVerifyUnwrapped } from "~/renderer/components/DeviceAction/rendering";
 import { StepProps } from "../Body";
-import { Account, PostOnboardingActionId } from "@ledgerhq/types-live";
+import { Account } from "@ledgerhq/types-live";
 import { track } from "~/renderer/analytics/segment";
 import Modal from "~/renderer/components/Modal";
 import Alert from "~/renderer/components/Alert";
@@ -36,7 +36,6 @@ import { openModal } from "~/renderer/actions/modals";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { getLLDCoinFamily } from "~/renderer/families";
 import { firstValueFrom } from "rxjs";
-import { useCompleteActionCallback } from "~/renderer/components/PostOnboardingHub/logic/useCompleteAction";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import { useMaybeAccountName } from "~/renderer/reducers/wallet";
 import { UTXOAddressAlert } from "~/renderer/components/UTXOAddressAlert";
@@ -182,7 +181,6 @@ const StepReceiveFunds = (props: StepProps) => {
     isFromPostOnboardingEntryPoint,
   } = props;
   const dispatch = useDispatch();
-  const completeAction = useCompleteActionCallback();
   const isOnboardingReceiveFlow = useSelector(onboardingReceiveFlowSelector);
 
   const receiveStakingFlowConfig = useFeature("receiveStakingFlowConfigDesktop");
@@ -244,10 +242,6 @@ const StepReceiveFunds = (props: StepProps) => {
   }, [onChangeAddressVerified, onResetSkip, transitionTo]);
 
   const onFinishReceiveFlow = useCallback(() => {
-    if (!isOnboardingReceiveFlow) {
-      completeAction(PostOnboardingActionId.assetsTransfer);
-    }
-
     const dismissModal =
       global.localStorage.getItem(`${LOCAL_STORAGE_KEY_PREFIX}${receivedCurrencyId}`) === "true";
     if (
@@ -298,7 +292,6 @@ const StepReceiveFunds = (props: StepProps) => {
     mainAccount,
     onClose,
     transitionTo,
-    completeAction,
     isSPLToken,
     isOnboardingReceiveFlow,
     hasStakeProgramsRedirect,

--- a/apps/ledger-live-mobile/src/components/PostOnboarding/PostOnboardingActionRow.tsx
+++ b/apps/ledger-live-mobile/src/components/PostOnboarding/PostOnboardingActionRow.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { Flex, IconsLegacy, Tag, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
-import { PostOnboardingActionState, PostOnboardingAction } from "@ledgerhq/types-live";
+import { PostOnboardingActionState, PostOnboardingAction, Account } from "@ledgerhq/types-live";
 import Touchable from "../Touchable";
 import { track } from "~/analytics";
 import { BaseNavigationComposite, StackNavigatorNavigation } from "../RootNavigator/types/helpers";
@@ -19,6 +19,7 @@ export type Props = PostOnboardingAction &
     productName: string;
     isLedgerSyncActive: boolean;
     openActivationDrawer: () => void;
+    accounts: Account[];
   };
 
 const PostOnboardingActionRow: React.FC<Props> = props => {
@@ -38,6 +39,7 @@ const PostOnboardingActionRow: React.FC<Props> = props => {
     shouldCompleteOnStart,
     openActivationDrawer,
     isLedgerSyncActive,
+    accounts,
   } = props;
   const { t } = useTranslation();
   const recoverServices = useFeature("protectServicesMobile");
@@ -51,9 +53,9 @@ const PostOnboardingActionRow: React.FC<Props> = props => {
   const [isActionCompleted, setIsActionCompleted] = useState(false);
 
   const initIsActionCompleted = useCallback(async () => {
-    const isAlreadyCompleted = getIsAlreadyCompletedByState?.({ isLedgerSyncActive });
+    const isAlreadyCompleted = getIsAlreadyCompletedByState?.({ isLedgerSyncActive, accounts });
     setIsActionCompleted(completed || !!isAlreadyCompleted);
-  }, [setIsActionCompleted, completed, getIsAlreadyCompletedByState, isLedgerSyncActive]);
+  }, [setIsActionCompleted, completed, getIsAlreadyCompletedByState, isLedgerSyncActive, accounts]);
 
   useEffect(() => {
     initIsActionCompleted();

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -102,6 +102,7 @@ import { ConfigureDBSaveEffects } from "./components/DBSave";
 import { useRef } from "react";
 import HookDevTools from "./devTools/useDevTools";
 import { setSolanaLdmkEnabled } from "@ledgerhq/live-common/families/solana/setup";
+import useCheckAccountWithFunds from "./logic/postOnboarding/useCheckAccountWithFunds";
 
 if (Config.DISABLE_YELLOW_BOX) {
   LogBox.ignoreAllLogs();
@@ -231,7 +232,9 @@ function App() {
     }
   }, [sentryFF?.enabled, automaticBugReportingEnabled]);
 
-  useAccountsWithFundsListener(accounts, updateIdentify);
+  const checkAccountsWithFunds = useCheckAccountWithFunds();
+
+  useAccountsWithFundsListener(accounts, updateIdentify, checkAccountsWithFunds);
   useFetchCurrencyAll();
   useFetchCurrencyFrom();
   useAutoDismissPostOnboardingEntryPoint();

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/actions.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/actions.ts
@@ -16,6 +16,9 @@ export const assetsTransferAction: PostOnboardingAction = {
   description: "postOnboarding.actions.assetsTransfer.description",
   buttonLabelForAnalyticsEvent: "Secure your assets on Ledger",
   getNavigationParams: () => [undefined],
+  getIsAlreadyCompletedByState: ({ accounts }) => {
+    return !!accounts && accounts.some(account => account?.balance.isGreaterThan(0));
+  },
 };
 
 export const buyCryptoAction: PostOnboardingAction = {

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/mockActions.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/mockActions.ts
@@ -45,6 +45,9 @@ export const buyCryptoMock: PostOnboardingAction = {
       },
     },
   ],
+  getIsAlreadyCompletedByState: ({ accounts }) => {
+    return !!accounts && accounts.some(account => account?.balance.isGreaterThan(0));
+  },
 };
 
 export const customImageMock: PostOnboardingAction = {

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/useCheckAccountWithFunds.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/useCheckAccountWithFunds.ts
@@ -1,0 +1,11 @@
+import { useCheckAccountWithFundsAction } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { useCompleteActionCallback } from "./useCompleteAction";
+
+const useCheckAccountWithFunds = () => {
+  const completeAction = useCompleteActionCallback();
+  const handleAccountsUpdate = useCheckAccountWithFundsAction(completeAction);
+
+  return handleAccountsUpdate;
+};
+
+export default useCheckAccountWithFunds;

--- a/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
@@ -20,6 +20,7 @@ import { Steps } from "LLM/features/WalletSync/types/Activation";
 import useLedgerSyncEntryPointViewModel from "LLM/features/LedgerSyncEntryPoint/useLedgerSyncEntryPointViewModel";
 import { EntryPoint } from "LLM/features/LedgerSyncEntryPoint/types";
 import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
+import { accountsSelector } from "~/reducers/accounts";
 
 const PostOnboardingHub = () => {
   const dispatch = useDispatch();
@@ -27,6 +28,7 @@ const PostOnboardingHub = () => {
   const { actionsState, deviceModelId } = usePostOnboardingHubState();
   const closePostOnboarding = useCompletePostOnboarding();
   const isLedgerSyncActive = Boolean(useSelector(trustchainSelector)?.rootId);
+  const accounts = useSelector(accountsSelector);
 
   const { isActivationDrawerVisible, closeActivationDrawer, openActivationDrawer } =
     useLedgerSyncEntryPointViewModel({
@@ -104,6 +106,7 @@ const PostOnboardingHub = () => {
                   productName={productName}
                   openActivationDrawer={openActivationDrawer}
                   isLedgerSyncActive={isLedgerSyncActive}
+                  accounts={accounts}
                 />
                 {index !== arr.length - 1 && <Divider />}
               </React.Fragment>

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
@@ -5,7 +5,6 @@ import QRCode from "react-native-qrcode-svg";
 import { useTranslation } from "react-i18next";
 import ReactNativeHapticFeedback from "react-native-haptic-feedback";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
-import { PostOnboardingActionId } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import {
   makeEmptyTokenAccount,
@@ -38,7 +37,6 @@ import { BankMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { hasClosedWithdrawBannerSelector } from "~/reducers/settings";
 import { setCloseWithdrawBanner } from "~/actions/settings";
-import { useCompleteActionCallback } from "~/logic/postOnboarding/useCompleteAction";
 import { urls } from "~/utils/urls";
 import { useMaybeAccountName } from "~/reducers/wallet";
 import Animated, {
@@ -172,13 +170,6 @@ function ReceiveConfirmationInner({ navigation, route, account, parentAccount }:
       }
     }
   }, [currency, route.params?.createTokenAccount, mainAccount, dispatch, hasAddedTokenAccount]);
-
-  const completeAction = useCompleteActionCallback();
-
-  useEffect(() => {
-    completeAction(PostOnboardingActionId.assetsTransfer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     navigation.setOptions({

--- a/libs/ledger-live-common/src/hooks/useAccountsWithFundsListener.ts
+++ b/libs/ledger-live-common/src/hooks/useAccountsWithFundsListener.ts
@@ -54,6 +54,7 @@ export function hasAccountsWithFundsChanged(accounts: Account[], oldAccounts: Ac
 function useAccountsWithFundsListener(
   accounts: Account[],
   callback: () => void,
+  callbackForAccounts: (accounts: Account[]) => void,
   debounceTimer: number = 3000,
 ) {
   const oldAccounts = useRef<Account[]>([]);
@@ -64,6 +65,7 @@ function useAccountsWithFundsListener(
         if (hasAccountsWithFundsChanged(accounts, oldAccounts.current)) {
           callback();
         }
+        callbackForAccounts(accounts);
         oldAccounts.current = accounts;
       }, debounceTimer),
     [accounts],

--- a/libs/ledger-live-common/src/postOnboarding/hooks/index.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/index.ts
@@ -5,3 +5,4 @@ export * from "./usePostOnboardingHubState";
 export * from "./useStartPostOnboardingCallback";
 export * from "./useAutoDismissPostOnboardingEntryPoint";
 export * from "./usePostOnboardingDeeplinkHandler";
+export * from "./useCheckAccountWithFundsAction";

--- a/libs/ledger-live-common/src/postOnboarding/hooks/useCheckAccountWithFundsAction.test.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/useCheckAccountWithFundsAction.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook, act } from "@testing-library/react";
+import { hubStateSelector } from "../reducer";
+import { useCheckAccountWithFundsAction } from "./useCheckAccountWithFundsAction";
+import { PostOnboardingActionId } from "@ledgerhq/types-live";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { createFixtureCryptoCurrency } from "../../mock/fixtures/cryptoCurrencies";
+import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
+import { BigNumber } from "bignumber.js";
+
+jest.mock("../reducer");
+jest.mock("react-redux", () => ({
+  useSelector: val => val(),
+}));
+
+const mockedHubStateSelector = jest.mocked(hubStateSelector);
+
+const defaultHubState = {
+  deviceModelId: DeviceModelId.nanoX,
+  actionsToComplete: [],
+  actionsCompleted: {},
+  lastActionCompleted: null,
+  postOnboardingInProgress: false,
+};
+
+const stateFundsTransferCompleted = {
+  deviceModelId: DeviceModelId.nanoX,
+  actionsToComplete: [PostOnboardingActionId.assetsTransfer],
+  actionsCompleted: {
+    [PostOnboardingActionId.assetsTransfer]: true,
+  },
+  lastActionCompleted: PostOnboardingActionId.personalizeMock,
+  postOnboardingInProgress: true,
+};
+
+const mockCompleteAction = jest.fn();
+
+const ethereumCurrency = createFixtureCryptoCurrency("ethereum");
+const ethereumAccountZero = genAccount("ethereum-account-zero", {
+  currency: ethereumCurrency,
+});
+ethereumAccountZero.balance = new BigNumber("0");
+const nonFundedAccount = [ethereumAccountZero];
+
+const ethereumAccountWithBalance = genAccount("ethereum-account-balance", {
+  currency: ethereumCurrency,
+});
+ethereumAccountWithBalance.balance = new BigNumber("10000");
+const fundedAccount = [ethereumAccountWithBalance];
+
+describe("useCheckAccountWithFundsAction", () => {
+  beforeEach(() => {
+    mockCompleteAction.mockClear();
+    mockedHubStateSelector.mockClear();
+  });
+
+  it("should not run completeAction when asset transfer not complete and account with no funds", () => {
+    const state = defaultHubState;
+    mockedHubStateSelector.mockReturnValue(state);
+
+    const { result } = renderHook(() => useCheckAccountWithFundsAction(mockCompleteAction));
+
+    act(() => {
+      result.current(nonFundedAccount);
+    });
+
+    expect(mockCompleteAction).not.toHaveBeenCalled();
+  });
+
+  it("should run completeAction when asset transfer not complete and account with funds", () => {
+    const state = defaultHubState;
+    mockedHubStateSelector.mockReturnValue(state);
+
+    const { result } = renderHook(() => useCheckAccountWithFundsAction(mockCompleteAction));
+
+    act(() => {
+      result.current(fundedAccount);
+    });
+
+    expect(mockCompleteAction).toHaveBeenCalled();
+    expect(mockCompleteAction).toHaveBeenNthCalledWith(1, PostOnboardingActionId.assetsTransfer);
+  });
+
+  it("should not run completeAction when asset transfer complete and account with funds", () => {
+    const state = stateFundsTransferCompleted;
+    mockedHubStateSelector.mockReturnValue(state);
+
+    const { result } = renderHook(() => useCheckAccountWithFundsAction(mockCompleteAction));
+
+    act(() => {
+      result.current(fundedAccount);
+    });
+
+    expect(mockCompleteAction).not.toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-live-common/src/postOnboarding/hooks/useCheckAccountWithFundsAction.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/useCheckAccountWithFundsAction.ts
@@ -1,0 +1,24 @@
+import { useSelector } from "react-redux";
+import { Account, PostOnboardingActionId } from "@ledgerhq/types-live";
+import { useCallback } from "react";
+import { hubStateSelector } from "../reducer";
+
+export function useCheckAccountWithFundsAction(
+  completeAction: (action: PostOnboardingActionId) => void,
+) {
+  const hubState = useSelector(hubStateSelector);
+  const isAssetTransferComplete =
+    hubState.actionsCompleted?.[PostOnboardingActionId.assetsTransfer];
+
+  const handleAccountsUpdate = useCallback(
+    (accounts: Account[]) => {
+      if (!isAssetTransferComplete) {
+        const hasAccountsWithFunds = accounts.some(account => account?.balance.isGreaterThan(0));
+        if (hasAccountsWithFunds) completeAction(PostOnboardingActionId.assetsTransfer);
+      }
+    },
+    [completeAction, isAssetTransferComplete],
+  );
+
+  return handleAccountsUpdate;
+}

--- a/libs/ledgerjs/packages/types-live/src/postOnboarding.ts
+++ b/libs/ledgerjs/packages/types-live/src/postOnboarding.ts
@@ -1,5 +1,5 @@
 import { DeviceModelId } from "@ledgerhq/types-devices";
-import { FeatureId } from ".";
+import { Account, FeatureId } from ".";
 
 /**
  * Unique identifier of a post onboarding action.
@@ -120,7 +120,10 @@ export type PostOnboardingAction = {
   /**
    * Check if passed state shows the action has already been completed
    */
-  getIsAlreadyCompletedByState?: (args: { isLedgerSyncActive?: boolean }) => boolean;
+  getIsAlreadyCompletedByState?: (args: {
+    isLedgerSyncActive?: boolean;
+    accounts?: Account[];
+  }) => boolean;
 
   /**
    * Used to set the action as complete when clicking on it.


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We were setting the assets transfer post onboarding action to complete at the end of the receive flow, however this didn't reflect whether the user had actually received any funds.  This PR adds a hook which checks the balances of the accounts and completes the action when it detects that funds have been received into any account the user has.
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-21005


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
