### PR TITLE
fix(wallet-api): apply currency limit logic to legacy account drawer

### DIFF
--- a/.changeset/two-radios-behave.md
+++ b/.changeset/two-radios-behave.md
@@ -1,0 +1,21 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+fix(wallet-api): apply currency limit logic to legacy account drawer
+
+Fixes the swap live-app by ensuring the legacy SelectAccountAndCurrencyDrawer
+applies the same currency filtering logic as the modular drawer.
+
+Previously, only the modular drawer path checked shouldUseCurrencies
+(limiting to 50 currencies when useCase is provided). The legacy drawer
+was passing currencyIds directly without this check, causing issues.
+
+Changes:
+- Extract shouldUseCurrencies calculation before drawer branching
+- Apply filtering consistently to both modular and legacy drawer paths
+- Forward useCase parameter through account selection flows (desktop & mobile)
+- Pass useCase to useAssetsData hook for proper asset filtering
+
+This ensures consistent behavior across both drawer implementations.

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -88,13 +88,13 @@ function useUiHook(manifest: AppManifest, tracking: TrackingAPI): UiHook {
       }) => {
         ipcRenderer.send("show-app", {});
 
+        // We agree that for useCase, we should send max 50 currencies if provided else use only useCase (e.g. buy)
+        const shouldUseCurrencies =
+          (useCase && currencyIds && currencyIds.length <= 50) || !useCase;
+
         if (modularDrawerVisible) {
           dispatch(setFlowValue(flow));
           dispatch(setSourceValue(source));
-
-          // We agree that for useCase, we should send max 50 currencies if provided else use only useCase (e.g. buy)
-          const shouldUseCurrencies =
-            (useCase && currencyIds && currencyIds.length <= 50) || !useCase;
 
           const finalDrawerConfiguration = createDrawerConfiguration(drawerConfiguration, useCase);
 
@@ -110,7 +110,8 @@ function useUiHook(manifest: AppManifest, tracking: TrackingAPI): UiHook {
           setDrawer(
             SelectAccountAndCurrencyDrawer,
             {
-              currencyIds,
+              currencyIds: areCurrenciesFiltered && shouldUseCurrencies ? currencyIds : undefined,
+              useCase,
               onAccountSelected: (account, parentAccount) => {
                 setDrawer();
                 onSuccess(account, parentAccount);

--- a/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/SelectAccountAndCurrencyDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/SelectAccountAndCurrencyDrawer.tsx
@@ -50,6 +50,7 @@ export const Loader = styled.div`
 export type SelectAccountAndCurrencyDrawerProps = {
   onClose?: () => void;
   currencyIds?: string[];
+  useCase?: string;
   onAccountSelected: (account: AccountLike, parentAccount?: Account) => void;
   flow?: string;
   source?: string;
@@ -60,7 +61,7 @@ const SearchInputContainer = styled.div`
 `;
 
 function SelectAccountAndCurrencyDrawer(props: SelectAccountAndCurrencyDrawerProps) {
-  const { currencyIds, onAccountSelected, onClose, flow, source } = props;
+  const { currencyIds, useCase, onAccountSelected, onClose, flow, source } = props;
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState<string>("");
 
@@ -75,6 +76,7 @@ function SelectAccountAndCurrencyDrawer(props: SelectAccountAndCurrencyDrawerPro
     areCurrenciesFiltered: currencyIds && currencyIds.length > 0,
     isStaging: false,
     includeTestNetworks: devMode,
+    useCase,
   });
 
   // Pagination is a bit strange with this because we order by market cap

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/RequestAccountNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/RequestAccountNavigator.ts
@@ -8,6 +8,7 @@ import { DeviceSelectionNavigatorParamsList } from "LLM/features/DeviceSelection
 export type RequestAccountNavigatorParamList = {
   [ScreenName.RequestAccountsSelectCrypto]: {
     currencyIds?: string[];
+    useCase?: string;
     allowAddAccount?: boolean;
     onSuccess?: (account: AccountLike, parentAccount?: Account) => void;
   };

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
@@ -418,10 +418,10 @@ function useUiHook({ isModularDrawerVisible, openModularDrawer, manifest }: Prop
         useCase,
         drawerConfiguration,
       }) => {
+        // We agree that for useCase, we should send max 50 currencies if provided else use only useCase (e.g. buy)
+        const shouldUseCurrencies =
+          (useCase && currencyIds && currencyIds.length <= 50) || !useCase;
         if (isModularDrawerVisible) {
-          // We agree that for useCase, we should send max 50 currencies if provided else use only useCase (e.g. buy)
-          const shouldUseCurrencies =
-            (useCase && currencyIds && currencyIds.length <= 50) || !useCase;
           const finalDrawerConfiguration = createDrawerConfiguration(drawerConfiguration, useCase);
 
           openModularDrawer?.({
@@ -461,7 +461,8 @@ function useUiHook({ isModularDrawerVisible, openModularDrawer, manifest }: Prop
             navigation.navigate(NavigatorName.RequestAccount, {
               screen: ScreenName.RequestAccountsSelectCrypto,
               params: {
-                currencyIds,
+                currencyIds: areCurrenciesFiltered && shouldUseCurrencies ? currencyIds : undefined,
+                useCase,
                 allowAddAccount: true,
                 onSuccess,
               },

--- a/apps/ledger-live-mobile/src/screens/RequestAccount/01-SelectCrypto.tsx
+++ b/apps/ledger-live-mobile/src/screens/RequestAccount/01-SelectCrypto.tsx
@@ -42,7 +42,7 @@ const Loader = () => (
 
 export default function RequestAccountsSelectCrypto({ navigation, route }: Props) {
   const { colors } = useTheme();
-  const { currencyIds } = route.params;
+  const { currencyIds, useCase } = route.params;
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState<string>("");
 
@@ -57,6 +57,7 @@ export default function RequestAccountsSelectCrypto({ navigation, route }: Props
     areCurrenciesFiltered: currencyIds && currencyIds.length > 0,
     isStaging: false,
     includeTestNetworks: devMode,
+    useCase,
   });
 
   // Pagination is a bit strange with this because we order by market cap


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - old request account drawer that will be behind a FF

### 📝 Description

Fixes the swap live-app by ensuring the legacy SelectAccountAndCurrencyDrawer applies the same currency filtering logic as the modular drawer.

Previously, only the modular drawer path checked shouldUseCurrencies (limiting to 50 currencies when useCase is provided). The legacy drawer was passing currencyIds directly without this check, causing issues.

Changes:
- Extract shouldUseCurrencies calculation before drawer branching
- Apply filtering consistently to both modular and legacy drawer paths
- Forward useCase parameter through account selection flows (desktop & mobile)
- Pass useCase to useAssetsData hook for proper asset filtering

This ensures consistent behavior across both drawer implementations.

| Desktop| Mobile |
|----|----|
| <video src="https://github.com/user-attachments/assets/e431116e-cd9b-49db-8a0b-d45449d1a65e" /> | <video src="https://github.com/user-attachments/assets/e06982a6-2453-439a-8ff1-7bc1c83cb197" /> |

### ❓ Context

- **JIRA or GitHub link**: 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
