### PR TITLE
fix(wallet-api): include parent currency when requesting tokens with family pattern

### DIFF
--- a/.changeset/soft-fishes-lie.md
+++ b/.changeset/soft-fishes-lie.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix(wallet-api): include parent currency when requesting tokens with family pattern
+
+When using currency patterns like "ethereum/\*\*" in currency.list requests,
+ensure the parent currency (e.g., "ethereum") is included alongside its
+tokens. This prevents scenarios where token accounts are requested but the
+parent currency itself is missing from the response.

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -370,6 +370,8 @@ export function useWalletAPIServer({
             // Pattern like "ethereum/**" or "solana/**" - include tokens for this family
             const family = id.slice(0, -3);
             tokenFamilies.add(family);
+            // Additionally include the parent currency itself
+            specificCurrencies.add(family);
           } else if (id.includes("/")) {
             // Specific token ID like "ethereum/erc20/usd__coin"
             specificTokenIds.add(id);


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Not really but I'm preparing a refactor where I'm splitting the file and we'll be testing everything
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - wallet-api list.currencies when the manifest contains `ethereum/**` or similar

### 📝 Description

When using currency patterns like "ethereum/**" in currency.list requests, ensure the parent currency (e.g., "ethereum") is included alongside its tokens. This prevents scenarios where token accounts are requested but the parent currency itself is missing from the response.

### ❓ Context

- **JIRA or GitHub link**:


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
