### PR TITLE
:bug: (LWM) autofocus ledgersync code input

### DIFF
--- a/.changeset/yellow-kangaroos-tan.md
+++ b/.changeset/yellow-kangaroos-tan.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+LedgerSync PinCodeInput autofocus

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/PinCodeInput.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/PinCodeInput.tsx
@@ -104,6 +104,7 @@ const DigitInput = forwardRef<TextInput, DigitInputProps>(
         onChangeText={handleChange}
         keyboardType="numeric"
         maxLength={1}
+        autoFocus={index === 0}
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
         isFocused={isFocused}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - pincode ledger sync

### 📝 Description

add an autofocus on the first input to display the keyboard

https://github.com/user-attachments/assets/93004427-a799-4249-855d-ca9c636eb223


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23611](https://ledgerhq.atlassian.net/browse/LIVE-23611)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23611]: https://ledgerhq.atlassian.net/browse/LIVE-23611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ