### PR TITLE
:bug: (LWD) solana memo tag overflows

### DIFF
--- a/.changeset/itchy-pillows-listen.md
+++ b/.changeset/itchy-pillows-listen.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Solana memo tag description remove extra box

--- a/apps/ledger-live-desktop/src/renderer/families/solana/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/SendRecipientFields.tsx
@@ -31,10 +31,9 @@ const Root = (props: Props) => {
           </Label>
         </Box>
       )}
-      <Box mb={15} horizontal grow alignItems="center" justifyContent="space-between">
-        <Box grow={1}>
-          <MemoValueField {...props} />
-        </Box>
+
+      <Box flow={1}>
+        <MemoValueField {...props} />
       </Box>
     </Box>
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - solana memo tag

### 📝 Description

Remove unused box that created an overflow in french

| Before        | After         |
| ------------- | ------------- |
|<img width="1024" height="613" alt="image" src="https://github.com/user-attachments/assets/6d1183a5-f795-415b-b8bf-3c4341eaee2d" />|https://github.com/user-attachments/assets/fb9218f0-0eba-4ab9-b2c6-bc86cdfbf03c|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23543](https://ledgerhq.atlassian.net/browse/LIVE-23543)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23543]: https://ledgerhq.atlassian.net/browse/LIVE-23543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ