### PR TITLE
Fix/test integration pr

### DIFF
--- a/.changeset/grumpy-lemons-clap.md
+++ b/.changeset/grumpy-lemons-clap.md
@@ -1,0 +1,5 @@
+---
+"@actions/live-common-affected": minor
+---
+
+Fix run integration tests if families or coin-modules is affected

--- a/.github/workflows/test-integration-pr.yml
+++ b/.github/workflows/test-integration-pr.yml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       is-affected: ${{ steps.affected.outputs.is-affected }}
       paths: ${{ steps.affected.outputs.paths }}
+      coins: ${{ steps.affected.outputs.coins }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -80,11 +81,13 @@ jobs:
       - name: Test
         shell: bash
         env:
-          FILTER: ${{ needs.is-affected.outputs.paths }}
+          COINS: ${{ needs.is-affected.outputs.coins }}
           VERBOSE_FILE: logs.txt
         run: |
-          echo $FILTER | xargs pnpm common ci-test-integration
-          git diff --exit-code libs/ledger-live-common/src
+          for COIN in $COINS; do
+            echo "families/$COIN" | xargs pnpm common ci-test-integration
+            git diff --exit-code libs/ledger-live-common/src
+          done
       - name: (On Failure) Upload live-common snapshots and source
         uses: actions/upload-artifact@v4
         if: failure()

--- a/tools/actions/live-common-affected/build/main.js
+++ b/tools/actions/live-common-affected/build/main.js
@@ -19093,6 +19093,8 @@ function main(ref) {
               const [first, second, third] = m;
               if (first.startsWith("coin-modules/")) {
                 coins.add(first.replace(/^.*coin-/, ""));
+              } else if (first.startsWith("live-common/src/families/")) {
+                coins.add(first.replace(/^live-common\/src\/families\//, ""));
               }
               if (second === "families") {
                 return `${second}/${third}`;

--- a/tools/actions/live-common-affected/src/main.ts
+++ b/tools/actions/live-common-affected/src/main.ts
@@ -40,6 +40,8 @@ function main(ref: string) {
                 const [first, second, third] = m;
                 if (first.startsWith("coin-modules/")) {
                   coins.add(first.replace(/^.*coin-/, ""));
+                } else if (first.startsWith("live-common/src/families/")) {
+                  coins.add(first.replace(/^live-common\/src\/families\//, ""));
                 }
                 if (second === "families") {
                   // in case of coin implementations, we will stop at the coin family level


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We want to run integration tests if `families` or `coin-modules` are affected!
Previously, when a coin-module was affected, the command wasn’t correct because it used the path directly:
`pnpm common ci-test-integration coin-modules/...`

Now, we are using the family instead. So, if `coin-modules/solana` is affected, we run:
`pnpm common ci-test-integration families/solana`


which works correctly!

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
