### PR TITLE
feat: fix padding on header back button on sync companion

### DIFF
--- a/.changeset/great-fishes-clap.md
+++ b/.changeset/great-fishes-clap.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix padding on header back button on sync companion

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -119,12 +119,7 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
       header: () => (
         <>
           <SafeAreaView edges={["top", "left", "right"]}>
-            <Flex
-              my={isSyncIncr1Enabled ? 0 : 5}
-              flexDirection="row"
-              justifyContent="flex-start"
-              alignItems="center"
-            >
+            <Flex my={5} pl={5} flexDirection="row" justifyContent="flex-start" alignItems="center">
               <NavigationHeaderBackButton onPress={onCloseButtonPress} />
             </Flex>
           </SafeAreaView>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

There is a padding issue on the back button in the sync onboarding companion in LLM. This fix aligns the spacing of the back button to be the same as other screens in onboarding:

Before:
<img width="332" height="720" alt="image-20251121-091216" src="https://github.com/user-attachments/assets/4024985a-00ae-4d19-96c8-04328ecf0c7a" />

After:

https://github.com/user-attachments/assets/6d2d356c-5b15-4d35-8fd1-920915e1089d


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-23594


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
