### PR TITLE
fix: graph color when no ledgerIds provided

### DIFF
--- a/.changeset/proud-horses-dress.md
+++ b/.changeset/proud-horses-dress.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fetch currency info (color) only if ledgerIds provided

--- a/apps/ledger-live-desktop/src/renderer/screens/market/hooks/useMarketCoin.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/hooks/useMarketCoin.ts
@@ -49,7 +49,7 @@ export const useMarketCoin = () => {
       includeTestNetworks: false,
     },
     {
-      skip: !currency,
+      skip: !currency?.ledgerIds?.length,
     },
   );
 

--- a/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketDetail/useMarketDetailViewModel.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketDetail/useMarketDetailViewModel.tsx
@@ -37,7 +37,7 @@ function useMarketDetailViewModel({ navigation, route }: NavigationProps) {
       includeTestNetworks: false,
     },
     {
-      skip: !currency,
+      skip: !currency?.ledgerIds?.length,
     },
   );
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When no ledgerIDs, first coin was fetched (means Bitcoin) so the color on the graph was wrong

<img width="2543" height="1303" alt="Screenshot 2025-11-24 at 15 13 36" src="https://github.com/user-attachments/assets/d48caf20-cd16-4747-af29-5bf3383ca362" />


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-23636


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
