### PR TITLE
test(wallet-api): improve currency list stability test and remove token fetching

### DIFF
--- a/apps/ledger-live-desktop/tests/fixtures/wallet-api.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/wallet-api.ts
@@ -573,6 +573,15 @@ export const expectedCurrencyList = [
   },
   {
     type: "CryptoCurrency",
+    id: "bitcoin_regtest",
+    ticker: "BTC",
+    name: "Bitcoin Regtest",
+    family: "bitcoin",
+    color: "#00ff00",
+    decimals: 8,
+  },
+  {
+    type: "CryptoCurrency",
     id: "ethereum_sepolia",
     ticker: "ETH",
     name: "Ethereum Sepolia",

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -1,3 +1,4 @@
+import "../../../src/live-common-set-supported-currencies";
 import test from "../../fixtures/common";
 import { expect } from "@playwright/test";
 import { DiscoverPage } from "../../page/discover.page";
@@ -8,6 +9,7 @@ import { DeviceAction } from "../../models/DeviceAction";
 import { LiveAppWebview } from "../../models/LiveAppWebview";
 import { version as LLD_VERSION } from "../../../package.json";
 import { expectedCurrencyList, mockedAccountList } from "tests/fixtures/wallet-api";
+import { listSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
 
 const methods = [
   "currency.list",
@@ -188,7 +190,7 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
       "bitcoin",
       "ethereum",
       "ethereum/erc20/usd_tether__erc20_",
-      // "arbitrum/erc20/arbitrum", // Still not able to get the test fetching tokens with an account present
+      "arbitrum/erc20/arbitrum",
     ]);
 
     await liveAppWebview.currencyList();
@@ -224,32 +226,28 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
         color: "#0ebdcd",
         decimals: 6,
       },
-      // {
-      //   type: "TokenCurrency",
-      //   standard: "ERC20",
-      //   id: "arbitrum/erc20/arbitrum",
-      //   ticker: "ARB",
-      //   contract: "0x912CE59144191C1204E64559FE8253a0e49E6548",
-      //   name: "Arbitrum",
-      //   parent: "arbitrum",
-      //   color: "#28a0f0",
-      //   decimals: 18,
-      // },
+      {
+        type: "TokenCurrency",
+        standard: "ERC20",
+        id: "arbitrum/erc20/arbitrum",
+        ticker: "ARB",
+        contract: "0x912CE59144191C1204E64559FE8253a0e49E6548",
+        name: "Arbitrum",
+        parent: "arbitrum",
+        color: "#28a0f0",
+        decimals: 18,
+      },
     ]);
 
     await resetWebview();
   });
 
   await test.step("currency.list should stay stable for CryptoCurrency", async () => {
+    await liveAppWebview.setCurrencyIds(listSupportedCurrencies().map(c => c.id));
     await liveAppWebview.currencyList();
 
     const res = await liveAppWebview.getResOutput();
-    // We remove TokenCurrency because they might change a lot more frequently and we really care if a family disappear
-    const currencies = res.filter(
-      (currency: { type: string; id: string }) =>
-        currency.type === "CryptoCurrency" && currency.id !== "bitcoin_regtest",
-    );
-    expect(currencies).toMatchObject(expectedCurrencyList);
+    expect(res).toMatchObject(expectedCurrencyList);
 
     await resetWebview();
   });


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. Not needed, only tests updates
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Wallet-api tests

### 📝 Description

- Import live-common-set-supported-currencies to ensure all currencies are initialized
- Import listSupportedCurrencies to dynamically get all currency IDs
- Remove filter excluding tokens from expected currencies
- Add Bitcoin Regtest to expected currency list fixtures
- Re-enable Arbitrum token in currency.list test assertions
- Use listSupportedCurrencies() for comprehensive currency list testing and avoid fetching tokens

### ❓ Context

- **JIRA or GitHub link**: 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
