### PR TITLE
chore(crypto-icons): add a test that forbid to introduce big icons

### DIFF
--- a/.changeset/hip-eagles-relate.md
+++ b/.changeset/hip-eagles-relate.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/crypto-icons-ui": minor
+---
+
+Introduce a test that forbid too big icons

--- a/libs/ui/packages/crypto-icons/.gitignore
+++ b/libs/ui/packages/crypto-icons/.gitignore
@@ -2,3 +2,6 @@
 /src/react
 /native
 /src/native
+*.test.js
+*.test.d.ts
+*.test.js.map

--- a/libs/ui/packages/crypto-icons/README.md
+++ b/libs/ui/packages/crypto-icons/README.md
@@ -6,6 +6,25 @@
 
 #### This package contains a collection of React and React Native cryptocurrency icon components.
 
+> ⚠️ **Deprecation Notice**: This package is deprecated and will eventually be replaced by a unified icon approach using `@ledgerhq/icons-ui`. The current implementation is a legacy approach that will be phased out.
+
+## Important Notes
+
+### Icon Size Constraints
+
+These SVG icons are **minimal versions** specifically designed for creating masks. They are transpiled to React components at build time, which is an older approach that will eventually be dropped in favor of the unified `@ledgerhq/icons-ui` system.
+
+**Performance Impact**: These icons are highly sensitive to performance impact. It is **critical** to keep them very small (under 10KB per file). Large icons significantly impact bundle size and application performance, especially on mobile devices.
+
+### Why Size Matters
+
+- These icons are transpiled to React components, meaning each icon adds to the JavaScript bundle size
+- They are used extensively throughout the application for currency representations
+- Large icons can cause noticeable performance degradation, especially on lower-end devices
+- The build process includes all icons in the bundle, so oversized files have a multiplicative effect
+
+**All SVG files in this package must be under 10KB.** This is enforced by automated tests.
+
 ## Reference
 
 [**🔗 Icons list**](https://react-ui-storybook.vercel.app/?path=/story/asorted-cryptoicons--list-crypto-icons)

--- a/libs/ui/packages/crypto-icons/package.json
+++ b/libs/ui/packages/crypto-icons/package.json
@@ -30,7 +30,8 @@
     "build": "pnpm run clean && node scripts/buildReactIcons && tsc --noEmit false && node scripts/transpile",
     "prepublishOnly": "pnpm run build",
     "clean": "rimraf react native src/react src/native",
-    "unimported": "unimported"
+    "unimported": "unimported",
+    "test": "node scripts/verify-svg-file-size.mjs"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/libs/ui/packages/crypto-icons/scripts/verify-svg-file-size.mjs
+++ b/libs/ui/packages/crypto-icons/scripts/verify-svg-file-size.mjs
@@ -1,0 +1,36 @@
+import { readdirSync, statSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const svgDir = join(__dirname, "../src/svg");
+const maxSizeBytes = 10 * 1024; // 10KB
+
+const svgFiles = readdirSync(svgDir).filter(file => file.endsWith(".svg"));
+const oversizedFiles = [];
+
+for (const file of svgFiles) {
+  const filePath = join(svgDir, file);
+  const stats = statSync(filePath);
+  const sizeInBytes = stats.size;
+
+  if (sizeInBytes > maxSizeBytes) {
+    oversizedFiles.push({
+      file,
+      size: sizeInBytes,
+    });
+  }
+}
+
+if (oversizedFiles.length > 0) {
+  const errorMessage = `Found ${oversizedFiles.length} SVG file(s) exceeding 10KB:\n${oversizedFiles
+    .map(({ file, size }) => `  - ${file}: ${(size / 1024).toFixed(2)}KB`)
+    .join(
+      "\n",
+    )}\n\nFor more information about icon size constraints, see:\nhttps://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui/packages/crypto-icons#readme`;
+  // Print error message and exit with error code for CI compatibility
+  console.error(errorMessage);
+  process.exit(1);
+} else {
+  console.log("All SVG files are within the 10KB size limit.");
+}


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - adding a test
  - improve documentation

### 📝 Description

It happened 2-3 times already that some PR introduces big crypto-icons badly impacting our performance.
This PR introduces a test that will ❌  if a crypto icons is *> 10kb*. We managed to have 500+ icons that are *< 10kb*. These are a bit special icons: they are implementing a subset of svg so they can be transpiled to React components and then used as a small mask coloured and used in minor parts of our app => actually we will soon migrate to a unified approach which is why these are also deprecated and this PR documents it.

### ❓ Context

- **JIRA or GitHub link**: NA


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
