### PR TITLE
fix: large mover price font

### DIFF
--- a/.changeset/grumpy-camels-attend.md
+++ b/.changeset/grumpy-camels-attend.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: large mover price font

--- a/apps/ledger-live-mobile/src/newArch/features/LandingPages/screens/LargeMoverLandingPage/components/PriceAndVariation.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/LandingPages/screens/LargeMoverLandingPage/components/PriceAndVariation.tsx
@@ -38,13 +38,7 @@ export const PriceAndVariation: React.FC<PriceAndVariationProps> = ({
 
   return (
     <Flex flexDirection="column" alignItems="center" justifyContent="center">
-      <Text
-        fontWeight="semiBold"
-        fontSize="26px"
-        color="neutral.c100"
-        numberOfLines={1}
-        adjustsFontSizeToFit
-      >
+      <Text fontWeight="semiBold" fontSize="26px" color="neutral.c100" numberOfLines={1}>
         {counterValueFormatter({
           currency: counterValueCurrency.ticker,
           value: price,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - font size should be fixed on price in Large Mover

### 📝 Description

fix: large mover price font

Removed adjustsFontSizeToFit as it’s not needed and its behavior is affected by the new architecture

-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-23685]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

<img width="526" height="573" alt="Screenshot 2025-11-25 at 15 02 45" src="https://github.com/user-attachments/assets/4fb45f81-d75c-4caa-8dad-eb8f8cac4a34" />
<img width="400" height="607" alt="Screenshot 2025-11-25 at 15 03 09" src="https://github.com/user-attachments/assets/9cc51ffa-079b-4db8-8518-cc5df9343be9" />

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23685]: https://ledgerhq.atlassian.net/browse/LIVE-23685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ