### PR TITLE
fix(cal-client): evict cache when CAL Service hash changes

### DIFF
--- a/.changeset/healthy-rocks-look.md
+++ b/.changeset/healthy-rocks-look.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": minor
+---
+
+Evict CryptoAssetsStore cache when the CAL API hash changes

--- a/apps/cli/src/commands/live/liveData.ts
+++ b/apps/cli/src/commands/live/liveData.ts
@@ -9,7 +9,7 @@ import { getReduxStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
 import {
   extractTokensFromState,
   PERSISTENCE_VERSION,
-  type PersistedTokens,
+  type PersistedCAL,
 } from "@ledgerhq/cryptoassets/cal-client/persistence";
 
 export type LiveDataJobOpts = ScanCommonOpts &
@@ -66,7 +66,7 @@ export default {
         const reduxStore = getReduxStore();
         const state = reduxStore.getState();
         const tokens = extractTokensFromState(state);
-        const persistedTokens: PersistedTokens = { version: PERSISTENCE_VERSION, tokens };
+        const persistedTokens: PersistedCAL = { version: PERSISTENCE_VERSION, tokens };
         appjsondata.data.cryptoAssets = persistedTokens;
 
         if (opts.appjson) {

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -134,7 +134,7 @@ async function init() {
     if (persistedData?.tokens) {
       if (persistedData.version === PERSISTENCE_VERSION) {
         const TOKEN_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
-        restoreTokensToCache(store.dispatch, persistedData.tokens, TOKEN_CACHE_TTL);
+        await restoreTokensToCache(store.dispatch, persistedData, TOKEN_CACHE_TTL);
       } else {
         logger.warn(
           `Crypto assets cache version mismatch (expected ${PERSISTENCE_VERSION}, got ${persistedData.version}), skipping restore`,

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -18,11 +18,7 @@ import {
   trustchainStoreActionTypePrefix,
   trustchainStoreSelector,
 } from "@ledgerhq/ledger-key-ring-protocol/store";
-import {
-  extractTokensFromState,
-  PERSISTENCE_VERSION,
-  type PersistedTokens,
-} from "@ledgerhq/cryptoassets/cal-client/persistence";
+import { extractPersistedCALFromState } from "@ledgerhq/cryptoassets/cal-client/persistence";
 
 import { marketStoreSelector } from "../reducers/market";
 
@@ -48,12 +44,8 @@ function accountsExportSelector(state: State) {
 // Throttled save for crypto assets cache (save at most once per 5 seconds)
 const saveCryptoAssetsCache = throttle((state: State) => {
   try {
-    const tokens = extractTokensFromState(state);
-    if (tokens.length > 0) {
-      const persistedData: PersistedTokens = {
-        version: PERSISTENCE_VERSION,
-        tokens,
-      };
+    const persistedData = extractPersistedCALFromState(state);
+    if (persistedData.tokens.length > 0) {
       setKey("app", "cryptoAssets", persistedData);
     }
   } catch (error) {

--- a/apps/ledger-live-desktop/src/renderer/storage.ts
+++ b/apps/ledger-live-desktop/src/renderer/storage.ts
@@ -25,7 +25,7 @@ import logger from "./logger";
 import { trustchainStoreSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { marketStoreSelector } from "./reducers/market";
 import { ExportedWalletState } from "@ledgerhq/live-wallet/store";
-import type { PersistedTokens } from "@ledgerhq/cryptoassets/cal-client/persistence";
+import type { PersistedCAL } from "@ledgerhq/cryptoassets/cal-client/persistence";
 
 /*
   This file serve as an interface for the RPC binding to the main thread that now manage the config file.
@@ -62,7 +62,7 @@ type DatabaseValues = {
   trustchain: TrustchainStore;
   wallet: ExportedWalletState;
   market: Market;
-  cryptoAssets: PersistedTokens;
+  cryptoAssets: PersistedCAL;
   PLAYWRIGHT_RUN: {
     localStorage?: Record<string, string>;
   };

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -29,7 +29,7 @@ import { settingsStoreSelector } from "~/reducers/settings";
 import type { State } from "~/reducers/types";
 import { walletSelector } from "~/reducers/wallet";
 import { Maybe } from "../types/helpers";
-import { extractTokensFromState } from "@ledgerhq/cryptoassets/cal-client/persistence";
+import { extractPersistedCALFromState } from "@ledgerhq/cryptoassets/cal-client/persistence";
 
 type MaybeState = Maybe<State>;
 
@@ -215,7 +215,7 @@ export const ConfigureDBSaveEffects = () => {
     save: saveCryptoAssetsCacheState,
     throttle: 1000,
     getChangesStats: cryptoAssetsNotEquals,
-    lense: extractTokensFromState,
+    lense: extractPersistedCALFromState,
   });
 
   return null;

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -106,7 +106,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       if (cryptoAssetsCache?.tokens) {
         if (cryptoAssetsCache.version === PERSISTENCE_VERSION) {
           const TOKEN_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
-          restoreTokensToCache(store.dispatch, cryptoAssetsCache.tokens, TOKEN_CACHE_TTL);
+          await restoreTokensToCache(store.dispatch, cryptoAssetsCache, TOKEN_CACHE_TTL);
         } else {
           // eslint-disable-next-line no-console
           console.warn(

--- a/apps/ledger-live-mobile/src/db.ts
+++ b/apps/ledger-live-mobile/src/db.ts
@@ -19,11 +19,7 @@ import type {
 } from "./reducers/types";
 import { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { ExportedWalletState } from "@ledgerhq/live-wallet/store";
-import {
-  PERSISTENCE_VERSION,
-  type PersistedTokens,
-  type PersistedTokenEntry,
-} from "@ledgerhq/cryptoassets/cal-client/persistence";
+import { type PersistedCAL } from "@ledgerhq/cryptoassets/cal-client/persistence";
 
 const ACCOUNTS_KEY = "accounts";
 const ACCOUNTS_KEY_SORT = "accounts.sort";
@@ -308,15 +304,11 @@ export async function saveLargeMoverState(state: LargeMoverState): Promise<void>
   await storage.save("largeMover", state);
 }
 
-export function getCryptoAssetsCacheState(): Promise<PersistedTokens | null> {
-  return storage.get("cryptoAssetsCache") as Promise<PersistedTokens | null>;
+export function getCryptoAssetsCacheState(): Promise<PersistedCAL | null> {
+  return storage.get("cryptoAssetsCache") as Promise<PersistedCAL | null>;
 }
-export async function saveCryptoAssetsCacheState(tokens: PersistedTokenEntry[]): Promise<void> {
-  if (tokens.length > 0) {
-    const persistedData: PersistedTokens = {
-      version: PERSISTENCE_VERSION,
-      tokens,
-    };
+export async function saveCryptoAssetsCacheState(persistedData: PersistedCAL): Promise<void> {
+  if (persistedData.tokens.length > 0) {
     await storage.save("cryptoAssetsCache", persistedData);
   }
 }

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/persistence.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/persistence.test.ts
@@ -7,10 +7,14 @@ import {
   toTokenCurrencyRaw,
   fromTokenCurrencyRaw,
   extractTokensFromState,
+  extractHashesFromState,
+  extractPersistedCALFromState,
   filterExpiredTokens,
   restoreTokensToCache,
+  PERSISTENCE_VERSION,
   type TokenCurrencyRaw,
   type PersistedTokenEntry,
+  type PersistedCAL,
   type StateWithCryptoAssets,
 } from "./persistence";
 import { cryptoAssetsApi } from "./state-manager/api";
@@ -215,6 +219,24 @@ describe("Token Persistence", () => {
 
       expect(tokens).toEqual([]);
     });
+
+    it("should return empty array if no RTK Query state", () => {
+      const mockState = {} as unknown as StateWithCryptoAssets;
+
+      const tokens = extractTokensFromState(mockState);
+
+      expect(tokens).toEqual([]);
+    });
+
+    it("should return empty array if queries is undefined", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {},
+      } as unknown as StateWithCryptoAssets;
+
+      const tokens = extractTokensFromState(mockState);
+
+      expect(tokens).toEqual([]);
+    });
   });
 
   describe("filterExpiredTokens", () => {
@@ -293,69 +315,505 @@ describe("Token Persistence", () => {
   });
 
   describe("restoreTokensToCache", () => {
-    it("should restore valid tokens to RTK Query cache", () => {
+    it("should restore valid tokens to RTK Query cache", async () => {
       const mockDispatch = jest.fn();
       const now = Date.now();
       const ttl = 24 * 60 * 60 * 1000;
 
-      const tokens: PersistedTokenEntry[] = [
-        {
-          data: toTokenCurrencyRaw(mockToken),
-          timestamp: now,
-        },
-      ];
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [
+          {
+            data: toTokenCurrencyRaw(mockToken),
+            timestamp: now,
+          },
+        ],
+      };
 
-      restoreTokensToCache(mockDispatch, tokens, ttl);
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
 
       // Should dispatch once with upsertQueryEntries (which contains both ID and address entries)
       expect(mockDispatch).toHaveBeenCalledTimes(1);
 
-      // upsertQueryEntries returns action objects, not functions
       expect(mockDispatch).toHaveBeenCalled();
     });
 
-    it("should skip expired tokens", () => {
+    it("should skip expired tokens", async () => {
       const mockDispatch = jest.fn();
       const now = Date.now();
       const ttl = 24 * 60 * 60 * 1000;
 
-      const tokens: PersistedTokenEntry[] = [
-        {
-          data: toTokenCurrencyRaw(mockToken),
-          timestamp: now - 25 * 60 * 60 * 1000, // Expired
-        },
-      ];
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [
+          {
+            data: toTokenCurrencyRaw(mockToken),
+            timestamp: now - 25 * 60 * 60 * 1000,
+          },
+        ],
+      };
 
-      restoreTokensToCache(mockDispatch, tokens, ttl);
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
 
-      // Should not dispatch anything for expired tokens
       expect(mockDispatch).not.toHaveBeenCalled();
     });
 
-    it("should skip tokens with missing parent currency", () => {
+    it("should skip tokens with missing parent currency", async () => {
       const mockDispatch = jest.fn();
       const now = Date.now();
       const ttl = 24 * 60 * 60 * 1000;
 
-      const tokens: PersistedTokenEntry[] = [
-        {
-          data: {
-            id: "unknown/token/test",
-            contractAddress: "0xabc",
-            parentCurrencyId: "unknown_currency",
-            tokenType: "erc20",
-            name: "Test",
-            ticker: "TEST",
-            units: [{ name: "TEST", code: "TEST", magnitude: 18 }],
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [
+          {
+            data: {
+              id: "unknown/token/test",
+              contractAddress: "0xabc",
+              parentCurrencyId: "unknown_currency",
+              tokenType: "erc20",
+              name: "Test",
+              ticker: "TEST",
+              units: [{ name: "TEST", code: "TEST", magnitude: 18 }],
+            },
+            timestamp: now,
           },
-          timestamp: now,
-        },
-      ];
+        ],
+      };
 
-      restoreTokensToCache(mockDispatch, tokens, ttl);
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
 
-      // Should not dispatch for tokens with missing parent
       expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it("should restore tokens when hash matches", async () => {
+      const mockDispatch = jest.fn();
+      const now = Date.now();
+      const ttl = 24 * 60 * 60 * 1000;
+      const storedHash = "hash123";
+
+      mockDispatch.mockImplementation(async action => {
+        if (typeof action === "function") {
+          const thunkResult = await action(mockDispatch, () => ({}), undefined);
+          return thunkResult;
+        }
+        const actionStr = String(action);
+        if (
+          actionStr.includes("getTokensSyncHash") ||
+          (action as any)?.type?.includes("getTokensSyncHash")
+        ) {
+          return { data: storedHash, error: undefined };
+        }
+        return action;
+      });
+
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [
+          {
+            data: toTokenCurrencyRaw(mockToken),
+            timestamp: now,
+          },
+        ],
+        hashes: { ethereum: storedHash },
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      const invalidateCalls = mockDispatch.mock.calls.filter(call => {
+        const action = call[0];
+        if (!action) return false;
+        const callStr = String(action);
+        return (
+          callStr.includes("invalidateTags") || (action as any)?.type?.includes("invalidateTags")
+        );
+      });
+      expect(invalidateCalls).toHaveLength(0);
+      expect(mockDispatch).toHaveBeenCalled();
+    });
+
+    it("should skip restore when hash changed", async () => {
+      const mockDispatch = jest.fn();
+      const now = Date.now();
+      const ttl = 24 * 60 * 60 * 1000;
+      const storedHash = "hash123";
+      const currentHash = "hash456";
+      const upsertActions: any[] = [];
+
+      mockDispatch.mockImplementation(async action => {
+        if (typeof action === "function") {
+          const actionStr = String(action);
+          if (actionStr.includes("getTokensSyncHash")) {
+            return { data: currentHash, error: undefined };
+          }
+          const result = await action(mockDispatch, () => ({}), undefined);
+          return result;
+        }
+        const actionType = (action as any)?.type || "";
+        if (actionType.includes("upsertQueryEntries") || actionType.includes("upsert")) {
+          upsertActions.push(action);
+        }
+        return action;
+      });
+
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [
+          {
+            data: toTokenCurrencyRaw(mockToken),
+            timestamp: now,
+          },
+        ],
+        hashes: { ethereum: storedHash },
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      expect(upsertActions).toHaveLength(0);
+    });
+
+    it("should return early when all tokens are evicted after hash validation", async () => {
+      const mockDispatch = jest.fn();
+      const now = Date.now();
+      const ttl = 24 * 60 * 60 * 1000;
+      const storedHash = "hash123";
+      const currentHash = "hash456";
+      const upsertActions: any[] = [];
+
+      mockDispatch.mockImplementation(async action => {
+        if (typeof action === "function") {
+          const actionStr = String(action);
+          if (actionStr.includes("getTokensSyncHash")) {
+            return { data: currentHash, error: undefined };
+          }
+          const result = await action(mockDispatch, () => ({}), undefined);
+          return result;
+        }
+        const actionType = (action as any)?.type || "";
+        if (actionType.includes("upsertQueryEntries") || actionType.includes("upsert")) {
+          upsertActions.push(action);
+        }
+        return action;
+      });
+
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [
+          {
+            data: toTokenCurrencyRaw(mockToken),
+            timestamp: now,
+          },
+        ],
+        hashes: { ethereum: storedHash },
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      expect(upsertActions).toHaveLength(0);
+    });
+
+    it("should skip restore when hash fetch fails", async () => {
+      const mockDispatch = jest.fn();
+      const now = Date.now();
+      const ttl = 24 * 60 * 60 * 1000;
+      const storedHash = "hash123";
+      const upsertActions: any[] = [];
+
+      mockDispatch.mockImplementation(async action => {
+        if (typeof action === "function") {
+          const actionStr = String(action);
+          if (actionStr.includes("getTokensSyncHash")) {
+            throw new Error("Network error");
+          }
+          const result = await action(mockDispatch, () => ({}), undefined);
+          return result;
+        }
+        const actionType = (action as any)?.type || "";
+        if (actionType.includes("upsertQueryEntries") || actionType.includes("upsert")) {
+          upsertActions.push(action);
+        }
+        return action;
+      });
+
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [
+          {
+            data: toTokenCurrencyRaw(mockToken),
+            timestamp: now,
+          },
+        ],
+        hashes: { ethereum: storedHash },
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      expect(upsertActions).toHaveLength(0);
+    });
+
+    it("should restore tokens when currentHash is undefined (cannot validate)", async () => {
+      const mockDispatch = jest.fn();
+      const now = Date.now();
+      const ttl = 24 * 60 * 60 * 1000;
+      const storedHash = "hash123";
+      const upsertActions: any[] = [];
+
+      mockDispatch.mockImplementation(async action => {
+        if (typeof action === "function") {
+          const actionStr = String(action);
+          if (actionStr.includes("getTokensSyncHash")) {
+            return { data: undefined, error: undefined };
+          }
+          if (actionStr.includes("upsertQueryEntries") || actionStr.includes("upsert")) {
+            upsertActions.push(action);
+          }
+          const result = await action(mockDispatch, () => ({}), undefined);
+          return result;
+        }
+        const actionType = (action as any)?.type || "";
+        if (actionType.includes("upsertQueryEntries") || actionType.includes("upsert")) {
+          upsertActions.push(action);
+        }
+        return action;
+      });
+
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [
+          {
+            data: toTokenCurrencyRaw(mockToken),
+            timestamp: now,
+          },
+        ],
+        hashes: { ethereum: storedHash },
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      expect(upsertActions.length).toBeGreaterThan(0);
+    });
+
+    it("should restore tokens without hash (backward compatibility)", async () => {
+      const mockDispatch = jest.fn();
+      const now = Date.now();
+      const ttl = 24 * 60 * 60 * 1000;
+
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [
+          {
+            data: toTokenCurrencyRaw(mockToken),
+            timestamp: now,
+          },
+        ],
+        // No hashes field - old persisted data
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      const invalidateCalls = mockDispatch.mock.calls.filter(call => {
+        const action = call[0];
+        if (!action) return false;
+        const callStr = String(action);
+        return (
+          callStr.includes("invalidateTags") || (action as any)?.type?.includes("invalidateTags")
+        );
+      });
+      expect(invalidateCalls).toHaveLength(0);
+      expect(mockDispatch).toHaveBeenCalled();
+    });
+
+    it("should handle multiple currencies with different hash states", async () => {
+      const mockDispatch = jest.fn();
+      const now = Date.now();
+      const ttl = 24 * 60 * 60 * 1000;
+      let getHashCallCount = 0;
+      const upsertActions: any[] = [];
+
+      const polygonToken: TokenCurrency = {
+        ...mockToken,
+        id: "polygon/erc20/usdt",
+        parentCurrency: findCryptoCurrencyById("polygon")!,
+      };
+
+      mockDispatch.mockImplementation(async action => {
+        if (typeof action === "function") {
+          const actionStr = String(action);
+          if (actionStr.includes("getTokensSyncHash")) {
+            getHashCallCount++;
+            if (getHashCallCount === 2) {
+              return { data: "hash999", error: undefined };
+            }
+            return { data: "hash123", error: undefined };
+          }
+          if (actionStr.includes("upsertQueryEntries") || actionStr.includes("upsert")) {
+            upsertActions.push(action);
+          }
+          const result = await action(mockDispatch, () => ({}), undefined);
+          return result;
+        }
+        const actionType = (action as any)?.type || "";
+        if (actionType.includes("upsertQueryEntries") || actionType.includes("upsert")) {
+          upsertActions.push(action);
+        }
+        return action;
+      });
+
+      const persistedData: PersistedCAL = {
+        version: PERSISTENCE_VERSION,
+        tokens: [
+          {
+            data: toTokenCurrencyRaw(mockToken),
+            timestamp: now,
+          },
+          {
+            data: toTokenCurrencyRaw(polygonToken),
+            timestamp: now,
+          },
+        ],
+        hashes: {
+          ethereum: "hash123",
+          polygon: "hash456",
+        },
+      };
+
+      await restoreTokensToCache(mockDispatch, persistedData, ttl);
+
+      expect(upsertActions.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("extractHashesFromState", () => {
+    it("should extract hashes from getTokensSyncHash queries", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'getTokensSyncHash("ethereum")': {
+              status: "fulfilled",
+              data: "hash123",
+              endpointName: "getTokensSyncHash",
+            },
+            'getTokensSyncHash("polygon")': {
+              status: "fulfilled",
+              data: "hash456",
+              endpointName: "getTokensSyncHash",
+            },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const hashes = extractHashesFromState(mockState);
+
+      expect(hashes).toEqual({
+        ethereum: "hash123",
+        polygon: "hash456",
+      });
+    });
+
+    it("should return empty object when no hash queries exist", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+            },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const hashes = extractHashesFromState(mockState);
+
+      expect(hashes).toEqual({});
+    });
+
+    it("should return empty object if no RTK Query state", () => {
+      const mockState = {} as unknown as StateWithCryptoAssets;
+
+      const hashes = extractHashesFromState(mockState);
+
+      expect(hashes).toEqual({});
+    });
+
+    it("should return empty object if queries is undefined", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {},
+      } as unknown as StateWithCryptoAssets;
+
+      const hashes = extractHashesFromState(mockState);
+
+      expect(hashes).toEqual({});
+    });
+  });
+
+  describe("extractPersistedCALFromState", () => {
+    it("should extract complete PersistedCAL with tokens and hashes", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              fulfilledTimeStamp: Date.now(),
+            },
+            'getTokensSyncHash("ethereum")': {
+              status: "fulfilled",
+              data: "hash123",
+              endpointName: "getTokensSyncHash",
+            },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const persistedData = extractPersistedCALFromState(mockState);
+
+      expect(persistedData.version).toBe(PERSISTENCE_VERSION);
+      expect(persistedData.tokens).toHaveLength(1);
+      expect(persistedData.tokens[0].data.id).toBe("ethereum/erc20/usdt");
+      expect(persistedData.hashes).toEqual({ ethereum: "hash123" });
+    });
+
+    it("should extract PersistedCAL without hashes if none exist", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              fulfilledTimeStamp: Date.now(),
+            },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const persistedData = extractPersistedCALFromState(mockState);
+
+      expect(persistedData.version).toBe(PERSISTENCE_VERSION);
+      expect(persistedData.tokens).toHaveLength(1);
+      expect(persistedData.hashes).toBeUndefined();
+    });
+
+    it("should return empty tokens array if no tokens found", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'getTokensSyncHash("ethereum")': {
+              status: "fulfilled",
+              data: "hash123",
+              endpointName: "getTokensSyncHash",
+            },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const persistedData = extractPersistedCALFromState(mockState);
+
+      expect(persistedData.version).toBe(PERSISTENCE_VERSION);
+      expect(persistedData.tokens).toHaveLength(0);
+      expect(persistedData.hashes).toEqual({ ethereum: "hash123" });
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - CryptoAssetsStore cache when CAL Service changes data

### 📝 Description

with this evolution, we will also store in app.json the CAL API hash that we loaded

<img width="599" height="249" alt="Screenshot 2025-11-25 at 14 57 32" src="https://github.com/user-attachments/assets/5c420d36-7c51-4ab9-bb94-12a125574282" />

and then whenever the hash changes, we propagate a proper cache eviction in order for coin modules implementation to have a working "full resync". Without this evolution, it would have still used the old cache and new tokens would not be discovered.

**a manual way to test this is to manually modify the app.json and edit the hashes and reload the Live**, we can then confirm that tokens gets fetch again at app start:

<img width="629" height="292" alt="Screenshot 2025-11-25 at 15 00 42" src="https://github.com/user-attachments/assets/f9f2f32e-88ff-40f4-ba01-2c81a17f6322" />

whereas it would not be refetched otherwise as the persisted tokens would still exists from the loaded app.json


### ❓ Context

- **JIRA or GitHub link**: [LIVE-23681](https://ledgerhq.atlassian.net/browse/LIVE-23681)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23681]: https://ledgerhq.atlassian.net/browse/LIVE-23681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ