### PR TITLE
fix(LIVE-22634): adapt swap entry point e2e test cases

### DIFF
--- a/.changeset/fifty-plums-rhyme.md
+++ b/.changeset/fifty-plums-rhyme.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+---
+
+Adapt Swap entry point e2e test cases. Links to Swap initializing the receive account now as default instead of the send account it used to be.

--- a/e2e/desktop/tests/specs/swap.other.spec.ts
+++ b/e2e/desktop/tests/specs/swap.other.spec.ts
@@ -938,10 +938,7 @@ test.describe("Swap flow from different entry point", () => {
       await app.portfolio.clickOnSelectedAssetRow(swapEntryPoint.swap.accountToDebit.currency.name);
 
       await app.swap.goAndWaitForSwapToBeReady(() => app.assetPage.startSwapFlow());
-      await app.swap.expectSelectedAssetDisplayed(
-        swapEntryPoint.swap.accountToDebit.currency.name,
-        electronApp,
-      );
+      await app.swap.checkAssetTo(electronApp, swapEntryPoint.swap.accountToDebit.currency.name);
     },
   );
 
@@ -961,14 +958,8 @@ test.describe("Swap flow from different entry point", () => {
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.market.startSwapForSelectedTicker(swapEntryPoint.swap.accountToDebit.currency.ticker),
       );
-      await app.swap.expectSelectedAssetDisplayed(
-        swapEntryPoint.swap.accountToDebit.currency.name,
-        electronApp,
-      );
-      await app.swap.expectSelectedAssetDisplayed(
-        swapEntryPoint.swap.accountToDebit.accountName,
-        electronApp,
-      );
+      await app.swap.checkAssetTo(electronApp, swapEntryPoint.swap.accountToDebit.currency.name);
+      await app.swap.checkAssetTo(electronApp, swapEntryPoint.swap.accountToDebit.accountName);
     },
   );
 
@@ -986,10 +977,7 @@ test.describe("Swap flow from different entry point", () => {
       await app.layout.goToMarket();
       await app.market.openCoinPage(swapEntryPoint.swap.accountToDebit.currency.ticker);
       await app.swap.goAndWaitForSwapToBeReady(() => app.market.clickOnSwapButtonOnAsset());
-      await app.swap.expectSelectedAssetDisplayed(
-        swapEntryPoint.swap.accountToDebit.currency.name,
-        electronApp,
-      );
+      await app.swap.checkAssetTo(electronApp, swapEntryPoint.swap.accountToDebit.currency.name);
     },
   );
 


### PR DESCRIPTION
Adapt Swap entry point e2e test cases. Links to Swap initializing the receive account now as default instead of the send account it used to be.

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-22634


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
