### PR TITLE
:bug: (LWM) customNavigationHeader customTitle

### DIFF
--- a/.changeset/thick-steaks-drum.md
+++ b/.changeset/thick-steaks-drum.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix custom header stack screen. We were always displaying the headerTitle if we used a custom header.

--- a/apps/ledger-live-mobile/src/newArch/components/CustomNavigationHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/CustomNavigationHeader/index.tsx
@@ -28,7 +28,7 @@ export default function CustomNavigationHeader({ options, route }: NativeStackHe
   const HeaderRight = options.headerRight;
 
   const renderTitle = () => {
-    if (HeaderTitleComponent) {
+    if (HeaderTitleComponent !== undefined) {
       if (typeof HeaderTitleComponent === "function") {
         const title = options.title !== undefined ? options.title : route.name;
         return <HeaderTitleComponent>{title}</HeaderTitleComponent>;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - all the screens that use HeaderTitle: "" => the impact is really low and will just hide titles we don't want

### 📝 Description

Since an empty string "" is falsy in JS, the check fails, and the component falls back to displaying the default route name
To avoid this, we can do a stricter check with undefined 
The main issue is that we don't want them, and also they are not translated, as it's the route name



| Before        | After         |
| ------------- | ------------- |
|<img width="447" height="889" alt="image" src="https://github.com/user-attachments/assets/1bab8d07-eb8c-4e02-b754-08118bfedfce" />|<img width="447" height="889" alt="image" src="https://github.com/user-attachments/assets/2aec2f0e-d43c-4bb9-ac44-f08ca1c12709" />|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-23723](https://ledgerhq.atlassian.net/browse/LIVE-23723)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23723]: https://ledgerhq.atlassian.net/browse/LIVE-23723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ