### PR TITLE
feat: (LLD) broadcast errors: differ invalid tx from network issues

### DIFF
--- a/.changeset/three-fireants-sit.md
+++ b/.changeset/three-fireants-sit.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat: differ broadcast errors behavior

--- a/apps/ledger-live-desktop/src/renderer/components/AbortButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/AbortButton.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import Button from "~/renderer/components/Button";
+import { useTranslation } from "react-i18next";
+
+type Props = Omit<React.ComponentProps<typeof Button>, "t">;
+
+const AbortButton = (props: Props) => {
+  const { t } = useTranslation();
+  return <Button {...props}>{t("common.close")}</Button>;
+};
+
+export default AbortButton;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.test.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { render, screen, fireEvent } from "tests/testSetup";
+import { StepConfirmationFooter } from "./StepConfirmation";
+import BigNumber from "bignumber.js";
+import { TFunction } from "i18next";
+
+const mockT: TFunction = jest.fn((k: string) => k) as unknown as TFunction;
+
+const baseProps = {
+  t: mockT,
+  transitionTo: jest.fn(),
+  onRetry: jest.fn(),
+  closeModal: jest.fn(),
+  account: null,
+  parentAccount: null,
+  optimisticOperation: null,
+  openedFromAccount: false,
+  device: null,
+  transaction: null,
+  status: {
+    errors: {},
+    estimatedFees: new BigNumber(0),
+    amount: new BigNumber(0),
+    totalSpent: new BigNumber(0),
+    warnings: {},
+  },
+  bridgePending: false,
+  error: null,
+  setTransaction: jest.fn(),
+  updateTransaction: jest.fn(),
+  resetTransaction: jest.fn(),
+  onChangeAccount: jest.fn(),
+  onChangeTransaction: jest.fn(),
+  onChangeStatus: jest.fn(),
+  onChangeBridgePending: jest.fn(),
+  onChangeDevice: jest.fn(),
+  onChangeOpenedFromAccount: jest.fn(),
+  openModal: jest.fn(),
+  onTransactionError: jest.fn(),
+  onOperationBroadcasted: jest.fn(),
+  setSigned: jest.fn(),
+  onClose: jest.fn(),
+  onBack: jest.fn(),
+  onStepChange: jest.fn(),
+  onError: jest.fn(),
+  onSuccess: jest.fn(),
+  signed: false,
+  onResetMaybeRecipient: jest.fn(),
+  onResetMaybeAmount: jest.fn(),
+  onConfirmationHandler: jest.fn(),
+  onBroadcast: jest.fn(),
+  onFailHandler: jest.fn(),
+  currencyName: "Bitcoin",
+};
+
+describe("StepConfirmationFooter", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders RetryButton when error is 5xx (LedgerAPI5xx)", () => {
+    render(<StepConfirmationFooter {...baseProps} error={{ name: "LedgerAPI5xx" } as Error} />);
+
+    expect(screen.getByRole("button")).toHaveTextContent("Retry");
+  });
+
+  it("renders RetryButton when error is NetworkDown", () => {
+    render(<StepConfirmationFooter {...baseProps} error={{ name: "NetworkDown" } as Error} />);
+
+    expect(screen.getByRole("button")).toHaveTextContent("Retry");
+  });
+
+  it("renders AbortButton when error is not 5xx", () => {
+    render(<StepConfirmationFooter {...baseProps} error={{ name: "LedgerAPI4xx" } as Error} />);
+
+    expect(screen.getByRole("button")).toHaveTextContent("Close");
+  });
+
+  it("clicking AbortButton triggers closeModal()", () => {
+    render(<StepConfirmationFooter {...baseProps} error={{ name: "SomeOtherError" } as Error} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(baseProps.closeModal).toHaveBeenCalled();
+  });
+
+  it("clicking RetryButton triggers onRetry() and transitionTo('summary')", () => {
+    render(<StepConfirmationFooter {...baseProps} error={{ name: "LedgerAPI5xx" } as Error} />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(baseProps.onRetry).toHaveBeenCalled();
+    expect(baseProps.transitionTo).toHaveBeenCalledWith("summary");
+  });
+
+  it("renders success CTA when optimisticOperation exists", () => {
+    render(
+      <StepConfirmationFooter
+        {...baseProps}
+        error={null}
+        optimisticOperation={{
+          id: "123",
+          accountId: "acc",
+          subOperations: [],
+          hash: "mockHash",
+          type: "OUT",
+          value: new BigNumber(0),
+          fee: new BigNumber(0),
+          senders: ["mockSender"],
+          recipients: ["mockRecipient"],
+          blockHeight: 0,
+          blockHash: null,
+          date: new Date(),
+          extra: {},
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent("send.steps.confirmation.success.cta");
+  });
+
+  it("renders nothing when no error and no optimisticOperation", () => {
+    const { container } = render(<StepConfirmationFooter {...baseProps} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.tsx
@@ -18,6 +18,7 @@ import NodeError from "./Confirmation/NodeError";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
 import { AccountLike } from "@ledgerhq/types-live";
 import { createTransactionBroadcastError } from "@ledgerhq/live-common/errors/transactionBroadcastErrors";
+import AbortButton from "~/renderer/components/AbortButton";
 
 const Container = styled(Box).attrs(() => ({
   alignItems: "center",
@@ -135,14 +136,24 @@ export function StepConfirmationFooter({
           {t("send.steps.confirmation.success.cta")}
         </Button>
       ) : error ? (
-        <RetryButton
-          ml={2}
-          primary
-          onClick={() => {
-            onRetry();
-            transitionTo("summary");
-          }}
-        />
+        ["LedgerAPI5xx", "NetworkDown"].includes(error.name) ? (
+          <RetryButton
+            ml={2}
+            primary
+            onClick={() => {
+              onRetry();
+              transitionTo("summary");
+            }}
+          />
+        ) : (
+          <AbortButton
+            ml={2}
+            primary
+            onClick={() => {
+              closeModal();
+            }}
+          />
+        )
       ) : null}
     </>
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** LLD broadcast
### 📝 Description

Differ 5xx errors from 4xx behavior on broadcast

5xx error or network errors are issues that can be fixed with a retry

4xx error (except 429 and maybe 408 that we'll deal with later) are related to an invalid tx

In this PR we show a close button instead of retry when encountering invalid tx errors, because retrying won't help and we have users retrying a lot (3-7 times in latest logs)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-23683


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
