### PR TITLE
ci: bundle dd ci tool into base images

### DIFF
--- a/.github/workflows/test-mobile-synthetics-reusable.yml
+++ b/.github/workflows/test-mobile-synthetics-reusable.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload mobile application file as new version
         run: >
-          npx @datadog/datadog-ci@3.11.0 synthetics upload-application
+          datadog-ci synthetics upload-application
           --datadogSite ${{ inputs.datadog-site }}
           --apiKey ${{ secrets.DATADOG_API_KEY }}
           --appKey ${{ secrets.DATADOG_APP_KEY }}


### PR DESCRIPTION
Utilise locally installed DD ci tool to upload synthetic binary

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-23725