### PR TITLE
fix(LIVE-17887): show Hedera address in receive modal if device is not connected

### DIFF
--- a/.changeset/curvy-squids-reflect.md
+++ b/.changeset/curvy-squids-reflect.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+ensure Hedera address is visible in Receive flow even when a device isn't connected

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/StepReceiveFunds.tsx
@@ -102,30 +102,27 @@ const StepReceiveFunds = ({
           name="Step 3"
           currencyName={currencyName}
         />
-        {
-          verifyAddressError ? (
-            <ErrorDisplay error={verifyAddressError} onRetry={onVerify} />
-          ) : device ? (
-            // verification with device
-            <>
-              <Receive1ShareAddress
-                account={mainAccount}
-                address={address}
-                showQRCodeModal={showQRCodeModal}
-              />
+        {verifyAddressError ? (
+          <ErrorDisplay error={verifyAddressError} onRetry={onVerify} />
+        ) : (
+          <>
+            <Receive1ShareAddress
+              account={mainAccount}
+              address={address}
+              showQRCodeModal={showQRCodeModal}
+            />
 
-              {/* show warning for unverified address */}
-              <Alert type="security" mt={4}>
-                <Trans
-                  i18nKey="hedera.currentAddress.messageIfVirtual"
-                  values={{
-                    name,
-                  }}
-                />
-              </Alert>
-            </>
-          ) : null // should not happen
-        }
+            {/* show warning for unverified address */}
+            <Alert type="security" mt={4}>
+              <Trans
+                i18nKey="hedera.currentAddress.messageIfVirtual"
+                values={{
+                  name,
+                }}
+              />
+            </Alert>
+          </>
+        )}
       </Box>
 
       <Modal isOpened={modalVisible} onClose={hideQRCodeModal} centered width={460}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Receive flow should work as expected with Hedera if device is not connected

### 📝 Description

This PR fixes the "Don't have your device?" flow in the Hedera receive modal in LWD.

Before:

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/2769647b-698d-489c-8823-ad795daf2366" />


After:

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/d4760d61-f993-4479-9e68-904097ce6813" />

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-17887


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
