### PR TITLE
test(e2e): llm add function to wait for element regex

### DIFF
--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -364,6 +364,18 @@ export const WebElementHelpers = {
     return currentUrl;
   },
 
+    async waitForWebElementToMatchRegex(webElementId: string, regexPattern: RegExp, timeout = 10000): Promise<string> {
+    let webElementText = "";
+    await retryUntilTimeout(async () => {
+      webElementText = await WebElementHelpers.getWebElementText(webElementId)
+      if (new RegExp(regexPattern).test(webElementText)) {
+        return webElementText;
+      }
+      throw new Error(`Web Element "${webElementId}" with text "${webElementText}" does not contain the expected regex: ${regexPattern}`);
+    }, timeout);
+    return webElementText;
+  },
+
   async isWebElementEnabled(element: WebElement) {
     const isEnabled = await element.runScript(
       (el: HTMLButtonElement | HTMLInputElement, android: boolean) => {

--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -98,6 +98,7 @@ Object.assign(globalThis, {
   typeTextByWebTestId: WebElementHelpers.typeTextByWebTestId,
   waitForCurrentWebviewUrlToContain: WebElementHelpers.waitForCurrentWebviewUrlToContain,
   waitForWebElementToBeEnabled: WebElementHelpers.waitForWebElementToBeEnabled,
+  waitForWebElementToMatchRegex: WebElementHelpers.waitForWebElementToMatchRegex,
   waitWebElementByTestId: WebElementHelpers.waitWebElementByTestId,
 });
 

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -2,6 +2,7 @@ import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { getMinimumSwapAmount } from "@ledgerhq/live-common/e2e/swap";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { retryUntilTimeout } from "../../utils/retry";
+import { floatNumberRegex } from "@ledgerhq/live-common/lib/e2e/data/regexes";
 
 export default class SwapLiveAppPage {
   fromSelector = "from-account-coin-selector";
@@ -163,7 +164,7 @@ export default class SwapLiveAppPage {
       `[data-testid^='${this.quoteCardProviderName}']`,
     );
     const numberOfQuotesText: string = await getWebElementText(this.numberOfQuotes);
-    jestExpect(numberOfQuotesText).toEqual(`${providerList.length} quotes found`);
+    jestExpect(numberOfQuotesText).toMatch(new RegExp(`${providerList.length} quotes? found`));
     return providerList;
   }
 
@@ -274,6 +275,7 @@ export default class SwapLiveAppPage {
   @Step("Click on swap max")
   async clickSwapMax() {
     await tapWebElementByTestId(this.swapMaxToggle);
+    await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, floatNumberRegex);
   }
 
   @Step("Retrieve send currency amount value")

--- a/e2e/mobile/types/global.d.ts
+++ b/e2e/mobile/types/global.d.ts
@@ -92,5 +92,6 @@ declare global {
   var typeTextByWebTestId: typeof WebElementHelpers.typeTextByWebTestId;
   var waitForCurrentWebviewUrlToContain: typeof WebElementHelpers.waitForCurrentWebviewUrlToContain;
   var waitForWebElementToBeEnabled: typeof WebElementHelpers.waitForWebElementToBeEnabled;
+  var waitForWebElementToMatchRegex: typeof WebElementHelpers.waitForWebElementToMatchRegex;
   var waitWebElementByTestId: typeof WebElementHelpers.waitWebElementByTestId;
 }

--- a/e2e/mobile/utils/swapUtils.ts
+++ b/e2e/mobile/utils/swapUtils.ts
@@ -1,5 +1,5 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-
+import { floatNumberRegex } from "@ledgerhq/live-common/lib-es/e2e/data/regexes";
 async function selectCurrency(account: Account, isFromCurrency: boolean = true) {
   const currentCurrencyText = await app.swapLiveApp.getFromCurrencyTexts();
   if (currentCurrencyText.includes(account.currency.ticker)) {
@@ -30,6 +30,7 @@ export async function performSwapUntilQuoteSelectionStep(
   await selectCurrency(accountToCredit, false);
   await app.swapLiveApp.inputAmount(amount);
   if (continueToQuotes) {
+    await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, floatNumberRegex);
     await app.swapLiveApp.tapGetQuotesButton();
     await app.swapLiveApp.waitForQuotes();
   }

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -57,6 +57,7 @@
     "src/deviceWordings.ts",
     "src/domain/getTokensWithFunds.ts",
     "src/e2e/data/assetsDrawer.ts",
+    "src/e2e/data/regexes.ts",
     "src/e2e/index.ts",
     "src/e2e/speculos.ts",
     "src/e2e/speculosAppVersion.ts",

--- a/libs/ledger-live-common/src/e2e/data/regexes.ts
+++ b/libs/ledger-live-common/src/e2e/data/regexes.ts
@@ -1,0 +1,1 @@
+export const floatNumberRegex = /^\d+\.?\d+$/;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* Added `waitForWebElementToMatchRegex` so the test will wait for the `to` input to have data to be able to continue

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA**: [QAA-909](https://ledgerhq.atlassian.net/browse/QAA-909)
- [CI](https://github.com/LedgerHQ/ledger-live/actions/runs/19742390463) 🤖 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-909]: https://ledgerhq.atlassian.net/browse/QAA-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ