### PR TITLE
ci: relative zip urls

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -168,8 +168,8 @@ jobs:
       - name: Determine cache keys
         id: cache-keys
         run: |
-          echo "ios_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios-2" >> $GITHUB_OUTPUT
-          echo "android_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/android') }}-detox-native-android" >> $GITHUB_OUTPUT
+          echo "ios_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios-3" >> $GITHUB_OUTPUT
+          echo "android_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/android') }}-detox-native-android-3" >> $GITHUB_OUTPUT
           echo "ios_js_key=${{ inputs.ref || github.sha }}-detox-js-ios" >> $GITHUB_OUTPUT
           echo "android_js_key=${{ inputs.ref || github.sha }}-detox-js-android" >> $GITHUB_OUTPUT
           echo "android_timing_cache_key=android-e2e-timing-${{ hashFiles('e2e/mobile/specs') }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -115,8 +115,8 @@ jobs:
       - name: Determine cache keys
         id: cache-keys
         run: |
-          echo "ios_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios-2" >> $GITHUB_OUTPUT
-          echo "android_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/android') }}-detox-native-android" >> $GITHUB_OUTPUT
+          echo "ios_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios-3" >> $GITHUB_OUTPUT
+          echo "android_native_key=longterm-${{ hashFiles('apps/ledger-live-mobile/android') }}-detox-native-android-3" >> $GITHUB_OUTPUT
           echo "ios_js_key=${{ inputs.ref || github.sha }}-detox-js-ios" >> $GITHUB_OUTPUT
           echo "android_js_key=${{ inputs.ref || github.sha }}-detox-js-android" >> $GITHUB_OUTPUT
           echo "android_timing_cache_key=android-mock-timing-${{ hashFiles('apps/ledger-live-mobile/e2e') }}" >> $GITHUB_OUTPUT

--- a/tools/actions/composites/cache/download/action.yml
+++ b/tools/actions/composites/cache/download/action.yml
@@ -44,13 +44,13 @@ runs:
       if: runner.os == 'Linux' && steps.download-cache.outcome == 'success'
       shell: bash
       run: |
-        tar -xf /tmp/cache.tzst -P -C ${{ github.workspace }} --use-compress-program unzstd
+        tar -xf /tmp/cache.tzst -C ${{ github.workspace }} --use-compress-program unzstd
 
     - name: Un-Compress files (macOS)
       if: runner.os == 'macOS' && steps.download-cache.outcome == 'success'
       shell: bash
       run: |
-        gtar -xf /tmp/cache.tzst -P -C ${{ github.workspace }} --use-compress-program unzstd
+        gtar -xf /tmp/cache.tzst -C ${{ github.workspace }} --use-compress-program unzstd
 
     - name: Cleanup
       shell: bash

--- a/tools/actions/composites/cache/upload/action.yml
+++ b/tools/actions/composites/cache/upload/action.yml
@@ -41,10 +41,22 @@ runs:
       shell: bash
       run: |
         touch /tmp/cache-path.txt
+        WORKSPACE="${{ github.workspace }}"
 
         echo "${{ inputs.path }}" | while IFS= read -r filePath; do
           if [ -d "$filePath" ] || [ -f "$filePath" ]; then
-              find $filePath -type f >> ${{ steps.create_tempfile.outputs.file-list }}
+              find "$filePath" -type f | while IFS= read -r foundPath; do
+                # Convert absolute paths to relative paths from workspace
+                # This preserves the directory hierarchy after the workspace
+                if [[ "$foundPath" == "$WORKSPACE"/* ]]; then
+                  # Strip workspace prefix, preserving subdirectory structure
+                  echo "${foundPath#$WORKSPACE/}" >> ${{ steps.create_tempfile.outputs.file-list }}
+                elif [[ "$foundPath" == "$WORKSPACE" ]]; then
+                  echo "." >> ${{ steps.create_tempfile.outputs.file-list }}
+                else
+                  echo "$foundPath" >> ${{ steps.create_tempfile.outputs.file-list }}
+                fi
+              done
           else
             echo "Warning: Path $filePath not found, skipping."
           fi
@@ -54,13 +66,13 @@ runs:
       shell: bash
       if: runner.os == 'Linux'
       run: |
-        /usr/bin/tar --posix -cf /tmp/cache.tzst --exclude cache.tzst -P -C ${{ github.workspace }} --files-from ${{ steps.create_tempfile.outputs.file-list }} --use-compress-program zstdmt
+        /usr/bin/tar --posix -cf /tmp/cache.tzst --exclude cache.tzst -C ${{ github.workspace }} --files-from ${{ steps.create_tempfile.outputs.file-list }} --use-compress-program zstdmt
 
     - name: Compressing files (macOS)
       shell: bash
       if: runner.os == 'macOS'
       run: |
-        gtar --posix --delay-directory-restore --use-compress-program zstdmt -P -C ${{ github.workspace }} -cf /tmp/cache.tzst -T ${{ steps.create_tempfile.outputs.file-list }}
+        gtar --posix --delay-directory-restore --use-compress-program zstdmt -C ${{ github.workspace }} -cf /tmp/cache.tzst -T ${{ steps.create_tempfile.outputs.file-list }}
 
     - name: Uploading to S3
       shell: bash


### PR DESCRIPTION
When running cross-repo, unzipping of assets is using an absolute path which breaks unpacking. This change makes the zip files relative to the workspace they're currently working in

Green Run: https://github.com/LedgerHQ/swap-live-app/actions/runs/19767725825