### PR TITLE
fix:  Deprecate Ledger node for Persistence & Quicksilver

### DIFF
--- a/.changeset/red-rings-sleep.md
+++ b/.changeset/red-rings-sleep.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/cryptoassets": minor
+"@ledgerhq/coin-cosmos": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Staking : Deprecate Ledger node for Persistence & Quicksilver on LWD and LWM

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
@@ -5,7 +5,7 @@ import {
   TransactionStatus,
 } from "@ledgerhq/live-common/families/cosmos/types";
 import { Account } from "@ledgerhq/types-live";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState, useEffect } from "react";
 import { TFunction } from "i18next";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
@@ -34,13 +34,23 @@ const ValidatorField = ({ account, onChangeValidator, chosenVoteAccAddr }: Props
     (evt: React.ChangeEvent<HTMLInputElement>) => setSearch(evt.target.value),
     [setSearch],
   );
+  //Check if the account is a Persistence or Quicksilver account
+  const isPerOrQuickAccount =
+    account.type === "Account" &&
+    (account.currency.id === "quicksilver" || account.currency.id === "persistence");
+
+  useEffect(() => {
+    if (isPerOrQuickAccount) {
+      setShowAll(true);
+    }
+  }, [isPerOrQuickAccount]);
 
   const chosenValidator = useMemo(() => {
     if (validators.length === 0) return [];
     return [validators.find(v => v.validatorAddress === chosenVoteAccAddr) || validators[0]];
   }, [validators, chosenVoteAccAddr]);
 
-  if (chosenVoteAccAddr === "" && validators.length > 0) {
+  if (chosenVoteAccAddr === "" && validators.length > 0 && !isPerOrQuickAccount) {
     onChangeValidator({ address: validators[0].validatorAddress });
   }
 

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/steps/StepDelegation.tsx
@@ -82,6 +82,7 @@ export function StepDelegationFooter({
     !errors.validators &&
     transaction &&
     transaction.validators.length > 0 &&
+    transaction.validators.some(v => v.address) &&
     !errors.sender;
   return (
     <>

--- a/apps/ledger-live-mobile/src/components/ValidateOnDeviceDataRow.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateOnDeviceDataRow.tsx
@@ -101,9 +101,13 @@ export function TextValueField({
         {label}
       </LText>
       <View style={styles.dataRowValue}>
-        <LText numberOfLines={numberOfLines} testID={testID} style={styles.valueText}>
-          {value}
-        </LText>
+        {typeof value === "string" || typeof value === "number" ? (
+          <LText numberOfLines={numberOfLines} testID={testID} style={styles.valueText}>
+            {value}
+          </LText>
+        ) : (
+          value
+        )}
       </View>
     </View>
   );

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
@@ -56,9 +56,11 @@ export default function DelegationSummary({ navigation, route }: Props) {
     if (validator !== undefined) {
       return validator;
     }
-
+    if (mainAccount.currency.id === "persistence" || mainAccount.currency.id === "quicksilver") {
+      return undefined;
+    }
     return validators[0];
-  }, [validators, validator]);
+  }, [validators, validator, mainAccount.currency.id]);
 
   const { transaction, updateTransaction, setTransaction, status, bridgePending, bridgeError } =
     useBridgeTransaction(() => {
@@ -92,7 +94,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
       updateTransaction(_ => tmpTransaction);
     }
 
-    if (chosenValidator.validatorAddress !== transaction.validators[0].address) {
+    if (chosenValidator && chosenValidator.validatorAddress !== transaction.validators[0].address) {
       setTransaction(
         bridge.updateTransaction(transaction, {
           validators: [
@@ -176,7 +178,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
       parentId: parentAccount?.id,
       transaction,
       status,
-      validatorName: chosenValidator.name,
+      validatorName: chosenValidator ? chosenValidator.name : "",
     });
   }, [
     navigation,
@@ -184,7 +186,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
     parentAccount?.id,
     transaction,
     status,
-    chosenValidator.name,
+    chosenValidator,
     route.params.source,
   ]);
 
@@ -225,7 +227,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
                 >
                   <ValidatorImage
                     isLedger={cosmosBase.COSMOS_FAMILY_LEDGER_VALIDATOR_ADDRESSES.includes(
-                      chosenValidator.validatorAddress,
+                      chosenValidator?.validatorAddress ?? "",
                     )}
                     name={chosenValidator?.name ?? chosenValidator?.validatorAddress}
                   />

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/index.tsx
@@ -1,4 +1,3 @@
-import { CosmosValidatorItem } from "@ledgerhq/live-common/families/cosmos/types";
 import { useTheme } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import React, { useMemo } from "react";
@@ -66,11 +65,15 @@ function DelegationFlow() {
       <Stack.Screen
         name={ScreenName.CosmosDelegationAmount}
         component={DelegationAmount}
-        options={({ route }: { route: { params: { validator: CosmosValidatorItem } } }) => ({
+        options={({ route }) => ({
           headerRight: undefined,
           headerTitle: () => (
             <StepHeader
-              title={route.params.validator?.name ?? route.params.validator.validatorAddress}
+              title={
+                route.params?.validator?.name ??
+                route.params?.validator?.validatorAddress ??
+                t("cosmos.delegation.stepperHeader.amountSubTitle")
+              }
               subtitle={t("cosmos.delegation.stepperHeader.amountSubTitle")}
             />
           ),

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/types.ts
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/types.ts
@@ -33,7 +33,7 @@ export type CosmosDelegationFlowParamList = {
     accountId: string;
     transaction: Transaction;
     status: TransactionStatus;
-    validator: CosmosValidatorItem;
+    validator: CosmosValidatorItem | undefined;
     validatorSrc?: CosmosValidatorItem;
     min?: BigNumber;
     max?: BigNumber;

--- a/apps/ledger-live-mobile/src/families/cosmos/shared/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/shared/02-SelectAmount.tsx
@@ -69,7 +69,7 @@ function DelegationAmount({ navigation, route }: Props) {
   const min = useMemo(() => route?.params?.min ?? BigNumber(0), [route]);
   const onNext = useCallback(() => {
     const validators = tx.validators;
-    const validatorAddress = route.params.validator.validatorAddress;
+    const validatorAddress = route.params.validator ? route.params.validator.validatorAddress : "";
     const i = validators.findIndex(({ address }) => address === validatorAddress);
 
     if (i >= 0) {
@@ -97,7 +97,7 @@ function DelegationAmount({ navigation, route }: Props) {
     // @ts-expect-error navigate cannot infer the correct navigator + route
     navigation.navigate(route.params.nextScreen, {
       ...route.params,
-      validatorName: route.params.validator.name,
+      validatorName: route.params.validator ? route.params.validator.name : "",
       transaction,
       fromSelectAmount: true,
     });

--- a/libs/coin-modules/coin-cosmos/src/config.ts
+++ b/libs/coin-modules/coin-cosmos/src/config.ts
@@ -80,7 +80,6 @@ export const cosmosConfig: CosmosConfig = {
     default: {
       lcd: "https://rest.core.persistence.one",
       minGasPrice: 0.025,
-      ledgerValidator: "persistencevaloper1fgklp9hemczlwtqp9jqzq3xahh38hznxatty38",
       status: {
         type: "active",
       },
@@ -91,7 +90,6 @@ export const cosmosConfig: CosmosConfig = {
     default: {
       lcd: "https://lcd.quicksilver.zone",
       minGasPrice: 0.0025,
-      ledgerValidator: "quickvaloper1fgklp9hemczlwtqp9jqzq3xahh38hznx02n4pp",
       status: {
         type: "active",
       },

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cosmos.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cosmos.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`cosmos currency bridge scanAccounts cosmos seed 1 1`] = `
 [
   {
-    "balance": "7291071",
+    "balance": "7289352",
     "currencyId": "cosmos",
     "derivationMode": "",
     "freshAddress": "cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl",
@@ -12,14 +12,14 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "0388459b2653519948b12492f1a0b464720110c147a8155d23d423a5cc3c21d89a",
-    "spendableBalance": "4656860",
+    "spendableBalance": "2655141",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,
     "xpub": "cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl",
   },
   {
-    "balance": "1095084",
+    "balance": "1095085",
     "currencyId": "cosmos",
     "derivationMode": "",
     "freshAddress": "cosmos108uy5q9jt59gwugq5yrdhkzcd9jryslmpcstk5",
@@ -28,7 +28,7 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 1`] = `
     "index": 1,
     "pendingOperations": [],
     "seedIdentifier": "0388459b2653519948b12492f1a0b464720110c147a8155d23d423a5cc3c21d89a",
-    "spendableBalance": "887584",
+    "spendableBalance": "887585",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,
@@ -786,6 +786,29 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
       "blockHash": null,
+      "blockHeight": 28615251,
+      "extra": {
+        "memo": "Ledger Live",
+        "validators": [
+          {
+            "address": "cosmosvaloper10wljxpl03053h9690apmyeakly3ylhejrucvtm",
+            "amount": "1000000",
+          },
+        ],
+      },
+      "fee": "15217",
+      "hasFailed": false,
+      "hash": "37D1A48254F3C1DED61C1C6E093595A750CBF5C79BBACD10A34DE6B70C3E1D0F",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-37D1A48254F3C1DED61C1C6E093595A750CBF5C79BBACD10A34DE6B70C3E1D0F-DELEGATE",
+      "recipients": [],
+      "senders": [],
+      "transactionSequenceNumber": "185",
+      "type": "DELEGATE",
+      "value": "15217",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
       "blockHeight": 10348199,
       "extra": {},
       "fee": "3345",
@@ -1231,6 +1254,29 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
       "transactionSequenceNumber": "127",
       "type": "OUT",
       "value": "3729",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
+      "blockHeight": 28615228,
+      "extra": {
+        "memo": "Ledger Live",
+        "validators": [
+          {
+            "address": "cosmosvaloper10wljxpl03053h9690apmyeakly3ylhejrucvtm",
+            "amount": "1000000",
+          },
+        ],
+      },
+      "fee": "19524",
+      "hasFailed": false,
+      "hash": "6FE3C64E57224720FAE82136656CE087CD84EA18E55F54F6BB180881EAA56004",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-6FE3C64E57224720FAE82136656CE087CD84EA18E55F54F6BB180881EAA56004-DELEGATE",
+      "recipients": [],
+      "senders": [],
+      "transactionSequenceNumber": "184",
+      "type": "DELEGATE",
+      "value": "19524",
     },
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
@@ -1793,6 +1839,29 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
       "transactionSequenceNumber": "149",
       "type": "REDELEGATE",
       "value": "24612",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
+      "blockHeight": 28513219,
+      "extra": {
+        "memo": "Ledger Live",
+        "validators": [
+          {
+            "address": "cosmosvaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4epsluffn",
+            "amount": "17874",
+          },
+        ],
+      },
+      "fee": "17705",
+      "hasFailed": false,
+      "hash": "9A71C2ADCECCC8837EA95C20CF19758CB3ABBB72FA96230ED0517D0C2C3CC372",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-9A71C2ADCECCC8837EA95C20CF19758CB3ABBB72FA96230ED0517D0C2C3CC372-REWARD",
+      "recipients": [],
+      "senders": [],
+      "transactionSequenceNumber": "183",
+      "type": "REWARD",
+      "value": "17874",
     },
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cryptoOrg.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cryptoOrg.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`crypto_org currency bridge scanAccounts crypto_org seed 1 1`] = `
 [
   {
-    "balance": "10000006",
+    "balance": "10000009",
     "cosmosResources": {
       "delegatedBalance": "0",
       "delegations": [],
@@ -23,7 +23,7 @@ exports[`crypto_org currency bridge scanAccounts crypto_org seed 1 1`] = `
     "operationsCount": 0,
     "pendingOperations": [],
     "seedIdentifier": "0346289788c2f518a158232e7028e8e86b30cff0670326d3a2507183cb0d81cecb",
-    "spendableBalance": "10000006",
+    "spendableBalance": "10000009",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/injective.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/injective.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`injective currency bridge scanAccounts injective seed 1 1`] = `
 [
   {
-    "balance": "607564000016393",
+    "balance": "607564000016394",
     "currencyId": "injective",
     "derivationMode": "",
     "freshAddress": "inj1hn46zvx43mxq47vsecvw84k5chjhuhwp6d62dt",
@@ -12,7 +12,7 @@ exports[`injective currency bridge scanAccounts injective seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "03f8e9b05b4de510b0b7d970060eac6a0f76d3c4eb07e11418c0747bc593c91c7d",
-    "spendableBalance": "506664000000018",
+    "spendableBalance": "506664000000019",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/mantra.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/mantra.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`mantra currency bridge scanAccounts mantra seed 1 1`] = `
 [
   {
-    "balance": "714928",
+    "balance": "714929",
     "currencyId": "mantra",
     "derivationMode": "",
     "freshAddress": "mantra1gyauvl44q2apn3u3aujm36q8zrj74vry7n5nvn",
@@ -12,7 +12,7 @@ exports[`mantra currency bridge scanAccounts mantra seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "03d5e0ebb3f1ae2afe87e5d5a24b5029a59cc12f8fd1056840091b2f0b97e54e83",
-    "spendableBalance": "204928",
+    "spendableBalance": "204929",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/osmosis.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/osmosis.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`osmo currency bridge scanAccounts osmo seed 1 1`] = `
 [
   {
-    "balance": "124345",
+    "balance": "124347",
     "currencyId": "osmo",
     "derivationMode": "",
     "freshAddress": "osmo17gmcxyc5ccd5kwqqatpgfdgh380w2hc77zm0zw",
@@ -12,7 +12,7 @@ exports[`osmo currency bridge scanAccounts osmo seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "02dc75cfe8137450ae2259dc7f29fd8767951956cc943adb4387e91c37a058a9f0",
-    "spendableBalance": "124345",
+    "spendableBalance": "124347",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/persistence.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/persistence.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`persistence currency bridge scanAccounts persistence seed 1 1`] = `
 [
   {
-    "balance": "2636575",
+    "balance": "2636576",
     "currencyId": "persistence",
     "derivationMode": "",
     "freshAddress": "persistence1gyauvl44q2apn3u3aujm36q8zrj74vrym5cypd",
@@ -12,14 +12,14 @@ exports[`persistence currency bridge scanAccounts persistence seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "03d5e0ebb3f1ae2afe87e5d5a24b5029a59cc12f8fd1056840091b2f0b97e54e83",
-    "spendableBalance": "1202571",
+    "spendableBalance": "1202572",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,
     "xpub": "persistence1gyauvl44q2apn3u3aujm36q8zrj74vrym5cypd",
   },
   {
-    "balance": "230006",
+    "balance": "230007",
     "currencyId": "persistence",
     "derivationMode": "",
     "freshAddress": "persistence1v2mp0m7k96dm9qv60fkspcqlzpkzrwnevf47z2",
@@ -28,7 +28,7 @@ exports[`persistence currency bridge scanAccounts persistence seed 1 1`] = `
     "index": 1,
     "pendingOperations": [],
     "seedIdentifier": "03d5e0ebb3f1ae2afe87e5d5a24b5029a59cc12f8fd1056840091b2f0b97e54e83",
-    "spendableBalance": "230006",
+    "spendableBalance": "230007",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/stargaze.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/stargaze.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`stargaze currency bridge scanAccounts stargaze seed 1 1`] = `
 [
   {
-    "balance": "2000006",
+    "balance": "2000007",
     "currencyId": "stargaze",
     "derivationMode": "",
     "freshAddress": "stars1gyauvl44q2apn3u3aujm36q8zrj74vrypyf2yc",
@@ -12,7 +12,7 @@ exports[`stargaze currency bridge scanAccounts stargaze seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "03d5e0ebb3f1ae2afe87e5d5a24b5029a59cc12f8fd1056840091b2f0b97e54e83",
-    "spendableBalance": "2000006",
+    "spendableBalance": "2000007",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -2526,8 +2526,8 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ],
     explorerViews: [
       {
-        tx: "https://www.mintscan.io/quicksilver/txs/$hash",
-        address: "https://www.mintscan.io/quicksilver/validators/$address",
+        tx: "https://explorer.quicksilver.zone/transactions/$hash",
+        address: "https://explorer.quicksilver.zone/validators/$address",
       },
     ],
   },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Remove ledgerValidator from quicksilver and persistence config
  - Change  explorerViews from quicksilver currencies (old one wasn't working)
  - Add a currency check to determine whether it is a Quicksilver or Persistence ID, because the logic is common to every Cosmos chain.
  - change apps/ledger-live-mobile/src/components/ValidateOnDeviceDataRow.tsx to fix UI on LWM check this old PR (The problem still persists) https://github.com/LedgerHQ/ledger-live/pull/10340

### 📝 Description

We need to remove Ledger validator as the default one for Persistence & Quicksilver


https://github.com/user-attachments/assets/b28ba531-c707-4de0-816d-cd55da63c262


### ❓ Context

- **JIRA or GitHub link**: [LIVE-23730](https://ledgerhq.atlassian.net/browse/LIVE-23730)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23730]: https://ledgerhq.atlassian.net/browse/LIVE-23730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ