### PR TITLE
ci: fix CI Adhoc Builds

### DIFF
--- a/apps/ledger-live-mobile/fastlane/.env.android.staging
+++ b/apps/ledger-live-mobile/fastlane/.env.android.staging
@@ -1,6 +1,6 @@
 ENVFILE=.env.android.staging
-APP_IDENTIFIER="com.ledger.live.dev"
-MY_APP_BUNDLE_ID="com.ledger.live.dev"
+APP_IDENTIFIER="com.ledger.live"
+MY_APP_BUNDLE_ID="com.ledger.live"
 APP_NAME="LW [Adhoc]"
 SENTRY_ENVIRONMENT=staging
 SENTRY_PROJECT=llm-android-staging


### PR DESCRIPTION
Reverting app identifier to match it's state pre-Firebase App Deployment (n.b. the value was not used - and the suffix was applied to the default (i.e. com.ledger.live)