### PR TITLE
fix: update manager app name for Avalanche C-Chain to Ethereum [LIVE-24623]

### DIFF
--- a/.changeset/brown-ways-greet.md
+++ b/.changeset/brown-ways-greet.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": patch
+---
+
+fix: update manager app name for Avalanche C-Chain to Ethereum

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -320,7 +320,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     id: "avalanche_c_chain",
     coinType: CoinType.ETH,
     name: "Avalanche C-Chain",
-    managerAppName: "Avalanche",
+    managerAppName: "Ethereum",
     ticker: "AVAX",
     scheme: "avalanche_c_chain",
     color: "#E84142",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Avalanche C-Chain default app used in send flows and wallet-api

### 📝 Description

This pull request makes a targeted fix to the Avalanche C-Chain configuration in the `@ledgerhq/cryptoassets` package. The main change is updating the manager app name for Avalanche C-Chain to "Ethereum" to ensure correct app handling in Ledger devices.

Configuration update:

* Changed the `managerAppName` for `avalanche_c_chain` in `libs/ledgerjs/packages/cryptoassets/src/currencies.ts` from "Avalanche" to "Ethereum".

Documentation:

* Added a changeset file `.changeset/brown-ways-greet.md` describing the patch and the manager app name update.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24623]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24623]: https://ledgerhq.atlassian.net/browse/LIVE-24623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ