### PR TITLE
feat: add new earn-prd-eks manifest id to expected earn ids

### DIFF
--- a/.changeset/old-bats-hide.md
+++ b/.changeset/old-bats-hide.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add new production earn manifest id to expected internal live apps lists. Hides top bar dev tools on new prod app.

--- a/apps/ledger-live-desktop/src/newArch/hooks/useStake.ts
+++ b/apps/ledger-live-desktop/src/newArch/hooks/useStake.ts
@@ -128,9 +128,9 @@ export function useStake() {
         ...(assetId ? { asset_id: assetId } : {}),
         accountId: accountIdForManifestVersion,
       })?.toString();
-
+      const isEarnManifest = ["earn", "earn-stg", "earn-prd-eks"].includes(manifest.id);
       return {
-        pathname: manifest.id === "earn" ? "/earn" : `/platform/${manifest.id}`,
+        pathname: isEarnManifest ? "/earn" : `/platform/${manifest.id}`,
         state: {
           ...customPartnerParams,
           appId: manifest.id,

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.tsx
@@ -162,7 +162,7 @@ export const TopBar = ({
     shouldDisplaySelectAccount = !!manifest.dapp,
   } = config;
 
-  const isInternalApp = id === "earn";
+  const isInternalProductionApp = ["earn", "earn-prd-eks"].includes(id);
 
   const enablePlatformDevTools = useSelector(enablePlatformDevToolsSelector);
   const dispatch = useDispatch();
@@ -228,7 +228,7 @@ export const TopBar = ({
 
   const isLoading = useDebounce(webviewState.loading, 100);
 
-  if (!enablePlatformDevTools && isInternalApp) {
+  if (!enablePlatformDevTools && isInternalProductionApp) {
     return null;
   }
 

--- a/apps/ledger-live-mobile/src/newArch/hooks/useStake/useStake.tsx
+++ b/apps/ledger-live-mobile/src/newArch/hooks/useStake/useStake.tsx
@@ -170,7 +170,8 @@ export function useStake() {
         accountId: accountIdForManifestVersion,
       })?.toString();
 
-      if (manifest.id === "earn" || manifest.id === "earn-stg") {
+      const isEarnManifest = ["earn", "earn-stg", "earn-prd-eks"].includes(manifest.id);
+      if (isEarnManifest) {
         // Earn live app uses a different navigator
         return {
           screen: NavigatorName.Earn,

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
@@ -15,6 +15,12 @@ function isValidIntent(intent?: string): intent is "deposit" | "withdraw" {
   return ["deposit", "withdraw"].includes(intent ?? "");
 }
 
+export function isValidEarnManifestId(
+  manifestId?: string,
+): manifestId is "earn" | "earn-stg" | "earn-prd-eks" {
+  return ["earn", "earn-stg", "earn-prd-eks"].includes(manifestId ?? "");
+}
+
 /** TODO Should be a shared constant throughout the app for all events */
 const BUTTON_CLICKED_TRACK_EVENT = "button_clicked";
 
@@ -53,7 +59,7 @@ export function EarnMenuDrawer({ navigation }: { navigation: NavigationProp<Para
                 onPress={async () => {
                   await track(BUTTON_CLICKED_TRACK_EVENT, { live_app, ...tracked });
                   closeDrawer();
-                  if (live_app === "earn" || live_app === "earn-stg") {
+                  if (isValidEarnManifestId(live_app)) {
                     const pathSegments = link.split("?");
                     const earnSearchParams = new URLSearchParams(pathSegments.pop());
                     const intent = earnSearchParams.get("intent") ?? undefined;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - To test, change the `ptxEarnLiveApp` feature flag ID from "earn-prd-eks", disable dev tools, navigate to Earn dashboard. The dev tools bar shoul no longer be visible



### 📝 Description

We have a new deployment of the production earn app on EKS. To roll-out, we need this to not show the dev top bar and to act like the `earn` id app

Before
<img width="821" height="657" alt="image" src="https://github.com/user-attachments/assets/1e18a18c-e810-44bc-b256-2aceb5eb60b3" />


After
Earn displays without dev tools
<img width="794" height="742" alt="image" src="https://github.com/user-attachments/assets/0519c098-ef2c-4dc3-8dc9-fd5bf4ecf2e3" />



### ❓ Context

- **JIRA or GitHub link**: [LIVE-22867](https://ledgerhq.atlassian.net/browse/LIVE-22867)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22867]: https://ledgerhq.atlassian.net/browse/LIVE-22867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ