### PR TITLE
ci: removal of ui package to get changesets through

### DIFF
--- a/.changeset/funny-buttons-reflect.md
+++ b/.changeset/funny-buttons-reflect.md
@@ -1,7 +1,6 @@
 ---
 "@ledgerhq/cryptoassets": minor
 "@ledgerhq/types-live": minor
-"@ledgerhq/crypto-icons-ui": minor
 "@ledgerhq/coin-evm": minor
 "ledger-live-desktop": minor
 "live-mobile": minor

--- a/.changeset/hip-eagles-relate.md
+++ b/.changeset/hip-eagles-relate.md
@@ -1,5 +1,0 @@
----
-"@ledgerhq/crypto-icons-ui": minor
----
-
-Introduce a test that forbid too big icons

--- a/.changeset/many-shoes-wait.md
+++ b/.changeset/many-shoes-wait.md
@@ -1,7 +1,6 @@
 ---
 "@ledgerhq/cryptoassets": minor
 "@ledgerhq/types-live": minor
-"@ledgerhq/crypto-icons-ui": minor
 "@ledgerhq/coin-evm": minor
 "ledger-live-desktop": minor
 "live-mobile": minor

--- a/.changeset/silver-impalas-grin.md
+++ b/.changeset/silver-impalas-grin.md
@@ -1,5 +1,0 @@
----
-"@ledgerhq/crypto-icons-ui": patch
----
-
-Fix Somnia icon

--- a/.changeset/ten-lizards-complain.md
+++ b/.changeset/ten-lizards-complain.md
@@ -1,6 +1,5 @@
 ---
 "@ledgerhq/hw-app-vet": minor
-"@ledgerhq/crypto-icons-ui": minor
 "live-mobile": minor
 "@ledgerhq/live-common": minor
 "@ledgerhq/native-ui": minor


### PR DESCRIPTION
The [removal](https://github.com/LedgerHQ/ledger-live/pull/13038) of the crypto icons ui package has caused changesets to crash. This PR removes references to this package from changesets