### PR TITLE
fix(live-common): Close apps on device before onboarding state polling

### DIFF
--- a/.changeset/real-teachers-impress.md
+++ b/.changeset/real-teachers-impress.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Close opened apps before onboarding state polling


### PR DESCRIPTION
Close app before to run the getVersion in getOnboardingStatePolling so it won't error

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-959](https://ledgerhq.atlassian.net/browse/DSDK-959)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[DSDK-959]: https://ledgerhq.atlassian.net/browse/DSDK-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ