### PR TITLE
:bug: (LWM Android) fix android manifest in debug

### DIFF
--- a/.changeset/early-queens-pull.md
+++ b/.changeset/early-queens-pull.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix android manifest. There was a conflict with android:theme since the braze bump

--- a/apps/ledger-live-mobile/android/app/src/debug/AndroidManifest.xml
+++ b/apps/ledger-live-mobile/android/app/src/debug/AndroidManifest.xml
@@ -13,5 +13,18 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning"
-        android:networkSecurityConfig="@xml/network_security_config"/>
+        android:networkSecurityConfig="@xml/network_security_config">
+        <activity
+            android:name="androidx.test.core.app.InstrumentationActivityInvoker$BootstrapActivity"
+            android:theme="@android:style/Theme"
+            tools:replace="android:theme" />
+        <activity
+            android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyActivity"
+            android:theme="@android:style/Theme"
+            tools:replace="android:theme" />
+        <activity
+            android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyFloatingActivity"
+            android:theme="@android:style/Theme.Dialog"
+            tools:replace="android:theme" />
+    </application>
 </manifest>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - debug build android

### 📝 Description

Android builds are broken on develop. 

The issue is that we have some test dependencies embedded that also declare android:theme. When we do a debug build android merges main + debug and as we have an android:theme in main, we now have 2 android:theme in conflicts, and it's blocking for android. 

To fix it we force in the debug manifest to use our own android theme (the one set up in the main android manifest). 


It's caused by the fact braze now uses androidx.test:core 
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
