### PR TITLE
chore: Remove palette (deprecated) from styled-components/native & theme

### DIFF
--- a/.changeset/giant-coins-switch.md
+++ b/.changeset/giant-coins-switch.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/native-ui": minor
+---
+
+Remove palette (deprecated) from styled-components/native & theme

--- a/apps/ledger-live-mobile/src/StyleProvider.tsx
+++ b/apps/ledger-live-mobile/src/StyleProvider.tsx
@@ -18,7 +18,6 @@ export default function StyleProvider({ children, selectedPalette }: Props): Rea
       colors: {
         ...selectedTheme.colors,
         ...palettes[selectedPalette],
-        palette: palettes[selectedPalette],
       },
       theme: selectedPalette,
     }),

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -188,9 +188,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
   request?: R;
 }): JSX.Element | null {
   const { colors, dark } = useTheme();
-  const {
-    colors: { palette },
-  } = useThemeFromStyledComponents();
+  const { colors: colorsFromStyled } = useThemeFromStyledComponents();
   const dispatch = useDispatch();
   const theme: "dark" | "light" = dark ? "dark" : "light";
   const { t } = useTranslation();
@@ -437,7 +435,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
           theme,
           hasExportLogButton: false,
           Icon: Icons.InformationFill,
-          iconColor: palette.primary.c80,
+          iconColor: colorsFromStyled.primary.c80,
           device: device ?? undefined,
         });
       }

--- a/apps/ledger-live-mobile/src/components/NavigationModalContainer.tsx
+++ b/apps/ledger-live-mobile/src/components/NavigationModalContainer.tsx
@@ -48,7 +48,7 @@ export default function NavigationModalContainer({
   children,
   contentContainerProps,
   deadZoneProps,
-  backgroundColor = "palette.neutral.c00",
+  backgroundColor = "neutral.c00",
 }: Props) {
   return (
     <SafeContainer>

--- a/apps/ledger-live-mobile/src/components/RecoverBanner/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RecoverBanner/index.tsx
@@ -117,10 +117,10 @@ function RecoverBanner() {
           <ProgressLoader
             progress={stepNumber / maxStepNumber}
             radius={20}
-            mainColor={isWarning ? colors.palette.warning.c40 : undefined}
+            mainColor={isWarning ? colors.warning.c40 : undefined}
           >
             {isWarning ? (
-              <Icons.WarningFill color="palette.warning.c40" size="S" />
+              <Icons.WarningFill color="warning.c40" size="S" />
             ) : (
               <Text display="block" flex={1} textAlign="center" fontSize={2}>
                 {`${stepNumber}/${maxStepNumber - 1}`}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
@@ -77,8 +77,8 @@ export default function MainNavigator() {
           },
         ],
         tabBarShowLabel: false,
-        tabBarActiveTintColor: colors.palette.primary.c80,
-        tabBarInactiveTintColor: colors.palette.neutral.c70,
+        tabBarActiveTintColor: colors.primary.c80,
+        tabBarInactiveTintColor: colors.neutral.c70,
         headerShown: false,
         popToTopOnBlur: true,
       }}

--- a/apps/ledger-live-mobile/src/components/SettingsCard.tsx
+++ b/apps/ledger-live-mobile/src/components/SettingsCard.tsx
@@ -37,7 +37,7 @@ function Card({
 }
 
 const StyledCard = styled(Card)`
-  background-color: ${p => p.theme.colors.palette.background.main};
+  background-color: ${p => p.theme.colors.background.main};
   padding: ${p => p.theme.space[7]}px ${p => p.theme.space[6]}px;
   flex-direction: row;
   align-items: center;

--- a/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/Evm1559CustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/Evm1559CustomFees.tsx
@@ -122,9 +122,9 @@ const Evm1559CustomFees = ({
         onChange={onFeesChange(setMaxPriorityFeePerGas)}
         title={"send.summary.maxPriorityFee"}
       />
-      <LText color="palette.neutral.c70">
+      <LText color="neutral.c70">
         {`${t("send.summary.suggested")} : `}
-        <LText color="palette.neutral.c90">
+        <LText color="neutral.c90">
           {lowPriorityFeeValue} - {highPriorityFeeValue} {unitName}
         </LText>
       </LText>
@@ -148,9 +148,9 @@ const Evm1559CustomFees = ({
         onChange={onFeesChange(setMaxFeePerGas)}
         title={"send.summary.maxFee"}
       />
-      <LText color="palette.neutral.c70">
+      <LText color="neutral.c70">
         {`${t("send.summary.nextBlock")} : `}
-        <LText color="palette.neutral.c90">{nextBaseFeeValue}</LText>
+        <LText color="neutral.c90">{nextBaseFeeValue}</LText>
       </LText>
       {maxFeeWarning ? (
         <LText style={styles.warning} color="orange">

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/SummaryFromSection.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/SummaryFromSection.tsx
@@ -22,8 +22,8 @@ function SummaryFromSection({ token }: Readonly<Props>) {
     <SummaryRowCustom
       label={t("hedera.associate.summary.from")}
       iconLeft={
-        <Circle bg={colors.palette.opacityDefault.c05} size={34}>
-          <Wallet size="S" color={colors.palette.primary.c80} />
+        <Circle bg={colors.opacityDefault.c05} size={34}>
+          <Wallet size="S" color={colors.primary.c80} />
         </Circle>
       }
       data={

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/SummaryToSection.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/SummaryToSection.tsx
@@ -23,8 +23,8 @@ function SummaryToSection({ account }: Readonly<Props>) {
     <SummaryRowCustom
       label={t("hedera.associate.summary.to")}
       iconLeft={
-        <Circle bg={colors.palette.opacityDefault.c05} size={34}>
-          <QrCode size="S" color={colors.palette.primary.c80} />
+        <Circle bg={colors.opacityDefault.c05} size={34}>
+          <QrCode size="S" color={colors.primary.c80} />
         </Circle>
       }
       data={

--- a/apps/ledger-live-mobile/src/families/hedera/shared/ValidatorRow.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/shared/ValidatorRow.tsx
@@ -48,8 +48,8 @@ const ValidatorRow = ({ onPress, validator, account }: Props) => {
           </Text>
           {validator.overstaked ? (
             <View style={styles.overstakedWarning}>
-              <Icons.Warning size="XS" color="palette.warning.c70" style={styles.overstakedIcon} />
-              <Text numberOfLines={1} fontSize={10} color="palette.warning.c70">
+              <Icons.Warning size="XS" color="warning.c70" style={styles.overstakedIcon} />
+              <Text numberOfLines={1} fontSize={10} color="warning.c70">
                 <Trans i18nKey="hedera.delegation.steps.validator.rowSubtitleOverstaked" />
               </Text>
             </View>

--- a/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketCurrencySelect/components/EmptyList/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketCurrencySelect/components/EmptyList/index.tsx
@@ -9,13 +9,13 @@ interface EmptyListProps {
 }
 
 function EmptyList({ search }: EmptyListProps) {
-  const { colors } = useTheme();
+  const { theme } = useTheme();
   return (
     <Flex alignItems="center">
       <Image
         style={{ width: 164, height: 164 }}
         source={
-          colors.palette.type === "light"
+          theme === "light"
             ? require("~/images/marketNoResultslight.webp")
             : require("~/images/marketNoResultsdark.webp")
         }

--- a/apps/ledger-live-mobile/src/screens/CustomImage/PreviewPreEdit.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/PreviewPreEdit.tsx
@@ -87,7 +87,7 @@ function Tab({
         <Text
           variant={"paragraph"}
           fontWeight={"semiBold"}
-          color={isActive ? "palette.neutral.c100" : "palette.neutral.c70"}
+          color={isActive ? "neutral.c100" : "neutral.c70"}
           textAlign={"center"}
         >
           {children}

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Benchmarking.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Benchmarking.tsx
@@ -6,7 +6,7 @@ import { useAppInstallProgress } from "@ledgerhq/live-common/apps/react";
 import Config from "react-native-config";
 
 const Wrapper = styled(Flex).attrs({
-  bg: "palette.background.default",
+  bg: "background.default",
   p: 4,
   mt: 4,
   borderWidth: 1,

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Device/DeviceAppStorage.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Device/DeviceAppStorage.tsx
@@ -64,11 +64,11 @@ const DeviceAppStorage = ({
           <Text
             variant={"small"}
             fontWeight={"medium"}
-            color={"palette.neutral.c100"}
+            color={"neutral.c100"}
             mr={3}
             testID="manager-storage-used"
           >
-            <Text variant={"small"} fontWeight={"medium"} color={"palette.neutral.c80"}>
+            <Text variant={"small"} fontWeight={"medium"} color={"neutral.c80"}>
               <Trans i18nKey="manager.storage.used" />
             </Text>{" "}
             <ByteSize
@@ -80,7 +80,7 @@ const DeviceAppStorage = ({
           <Text
             variant={"small"}
             fontWeight={"medium"}
-            color={"palette.neutral.c80"}
+            color={"neutral.c80"}
             testID="manager-installedApp-number"
           >
             <Trans
@@ -88,10 +88,10 @@ const DeviceAppStorage = ({
               values={{ number: apps.length }}
               i18nKey="manager.storage.appsInstalled"
             >
-              <Text variant={"small"} fontWeight={"medium"} color={"palette.neutral.c100"}>
+              <Text variant={"small"} fontWeight={"medium"} color={"neutral.c100"}>
                 {"placeholder"}
               </Text>
-              <Text variant={"small"} fontWeight={"medium"} color={"palette.neutral.c80"}>
+              <Text variant={"small"} fontWeight={"medium"} color={"neutral.c80"}>
                 {"placeholder"}
               </Text>
             </Trans>
@@ -101,18 +101,18 @@ const DeviceAppStorage = ({
         <Flex flexDirection={"row"} alignItems={"center"}>
           {shouldWarnMemory && (
             <Box mr={2}>
-              <WarningMedium color={"palette.warning.c30"} size={14} />
+              <WarningMedium color={"warning.c30"} size={14} />
             </Box>
           )}
           {isDeviceFull ? (
-            <Text variant={"small"} fontWeight={"medium"} color={"palette.warning.c30"}>
+            <Text variant={"small"} fontWeight={"medium"} color={"warning.c30"}>
               <Trans i18nKey="manager.storage.noFreeSpace" />
             </Text>
           ) : (
             <Text
               variant={"small"}
               fontWeight={"medium"}
-              color={"palette.neutral.c80"}
+              color={"neutral.c80"}
               testID="manager-storage-available"
             >
               <ByteSize

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Device/DeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Device/DeviceName.tsx
@@ -63,14 +63,14 @@ export default function DeviceName({ device, initialDeviceName, disabled, device
         <TouchableOpacity onPress={onPress} disabled={disabled} hitSlop={hitSlop}>
           <Flex
             ml={3}
-            backgroundColor={disabled ? "palette.neutral.c30" : "palette.primary.c30"}
+            backgroundColor={disabled ? "neutral.c30" : "primary.c30"}
             borderRadius={14}
             width={28}
             height={28}
             alignItems="center"
             justifyContent="center"
           >
-            <PenMedium size={16} color={disabled ? "palette.neutral.c80" : "palette.primary.c80"} />
+            <PenMedium size={16} color={disabled ? "neutral.c80" : "primary.c80"} />
           </Flex>
         </TouchableOpacity>
       )}

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Device/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Device/index.tsx
@@ -130,11 +130,11 @@ const DeviceCard = ({
             </Text>
           </Flex>
           <Flex flexDirection={"row"} alignItems={"center"} mt={2} mb={3}>
-            <Icons.CheckmarkCircleFill size="S" color={"palette.success.c50"} />
+            <Icons.CheckmarkCircleFill size="S" color={"success.c50"} />
             <Text
               variant={"body"}
               fontWeight={"medium"}
-              color={"palette.neutral.c80"}
+              color={"neutral.c80"}
               numberOfLines={1}
               ml={2}
             >

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ExistingRecoveryPhrase.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ExistingRecoveryPhrase.tsx
@@ -8,13 +8,13 @@ const ExistingRecoveryPhraseScene = () => {
 
   return (
     <>
-      <Text variant="h2" color="palette.neutral.c100" mb={3} uppercase>
+      <Text variant="h2" color="neutral.c100" mb={3} uppercase>
         {t("onboarding.stepRecoveryPhrase.existingRecoveryPhrase.title")}
       </Text>
-      <Text variant="paragraph" color="palette.neutral.c80" mb={3}>
+      <Text variant="paragraph" color="neutral.c80" mb={3}>
         {t("onboarding.stepRecoveryPhrase.existingRecoveryPhrase.paragraph1")}
       </Text>
-      <Text variant="paragraph" color="palette.neutral.c80" mb={10}>
+      <Text variant="paragraph" color="neutral.c80" mb={10}>
         {t("onboarding.stepRecoveryPhrase.existingRecoveryPhrase.paragraph2")}
       </Text>
     </>

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/HideRecoveryPhrase.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/HideRecoveryPhrase.tsx
@@ -23,10 +23,10 @@ const HideRecoveryPhraseScene = () => {
 
   return (
     <>
-      <Text variant="h2" color="palette.neutral.c100" mb={3} uppercase>
+      <Text variant="h2" color="neutral.c100" mb={3} uppercase>
         {t("onboarding.stepSetupDevice.hideRecoveryPhrase.title")}
       </Text>
-      <Text variant="paragraph" color="palette.neutral.c80" mb={16}>
+      <Text variant="paragraph" color="neutral.c80" mb={16}>
         {t("onboarding.stepSetupDevice.hideRecoveryPhrase.desc")}
       </Text>
       <IconBoxList items={items.map(item => ({ ...item, title: t(item.title) }))} />

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/PinCode.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/PinCode.tsx
@@ -8,10 +8,10 @@ const PinCodeScene = () => {
 
   return (
     <>
-      <Text variant="h2" color="palette.neutral.c100" mb={3} uppercase>
+      <Text variant="h2" color="neutral.c100" mb={3} uppercase>
         {t("onboarding.stepSetupDevice.pinCode.title")}
       </Text>
-      <Text variant="paragraph" color="palette.neutral.c80" mb={10}>
+      <Text variant="paragraph" color="neutral.c80" mb={10}>
         {t("onboarding.stepSetupDevice.pinCode.desc")}
       </Text>
     </>

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/QuizzFinal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/QuizzFinal.tsx
@@ -8,10 +8,10 @@ const QuizzFinalScene = ({ success }: { success: boolean }) => {
 
   return (
     <>
-      <Text variant="h2" color="palette.neutral.c100" mb={3} uppercase lineHeight="34.8px">
+      <Text variant="h2" color="neutral.c100" mb={3} uppercase lineHeight="34.8px">
         {t(`onboarding.quizz.final.${success ? "successTitle" : "failTitle"}`)}
       </Text>
-      <Text variant="paragraph" color="palette.neutral.c80" mb={10}>
+      <Text variant="paragraph" color="neutral.c80" mb={10}>
         {t(`onboarding.quizz.final.${success ? "successText" : "failText"}`)}
       </Text>
     </>

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/RecoveryPhrase.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/RecoveryPhrase.tsx
@@ -8,13 +8,13 @@ const RecoveryPhraseScene = () => {
 
   return (
     <>
-      <Text variant="h2" color="palette.neutral.c100" mb={4} uppercase lineHeight="34.8px">
+      <Text variant="h2" color="neutral.c100" mb={4} uppercase lineHeight="34.8px">
         {t("onboarding.stepSetupDevice.recoveryPhrase.title")}
       </Text>
-      <Text variant="paragraph" color="palette.neutral.c80" mb={4}>
+      <Text variant="paragraph" color="neutral.c80" mb={4}>
         {t("onboarding.stepSetupDevice.recoveryPhrase.desc")}
       </Text>
-      <Text variant="paragraph" color="palette.neutral.c80" mb={10}>
+      <Text variant="paragraph" color="neutral.c80" mb={10}>
         {t("onboarding.stepSetupDevice.recoveryPhrase.desc_1")}
       </Text>
     </>

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/terms.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/terms.tsx
@@ -33,13 +33,13 @@ const LinkBox = React.memo(({ text, url, event, mb = 0 }: LinkBoxProps) => (
       flexDirection="row"
       paddingX={6}
       paddingY={6}
-      backgroundColor="palette.primary.c20"
+      backgroundColor="primary.c20"
       mb={mb}
     >
-      <Text color="palette.primary.c80" variant="body" fontSize="14px" fontWeight="semiBold" mr={3}>
+      <Text color="primary.c80" variant="body" fontSize="14px" fontWeight="semiBold" mr={3}>
         {text}
       </Text>
-      <IconsLegacy.ExternalLinkMedium color="palette.primary.c80" size="18px" />
+      <IconsLegacy.ExternalLinkMedium color="primary.c80" size="18px" />
     </Flex>
   </Touchable>
 ));

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
@@ -336,7 +336,7 @@ function ReceiveConfirmationInner({ navigation, route, account, parentAccount }:
         <Flex p={0} alignItems="center" justifyContent="center">
           <StyledTouchableHightlight
             activeOpacity={1}
-            underlayColor={colors.palette.opacityDefault.c10}
+            underlayColor={colors.opacityDefault.c10}
             alignItems="center"
             justifyContent="center"
             width={QRContainerSize}

--- a/apps/ledger-live-mobile/src/screens/SendFunds/SummaryFromSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/SummaryFromSection.tsx
@@ -25,8 +25,8 @@ function SummaryFromSection({ account }: Props) {
     <SummaryRowCustom
       label={t("send.summary.from")}
       iconLeft={
-        <Circle bg={colors.palette.opacityDefault.c05} size={34}>
-          <Wallet size="S" color={colors.palette.primary.c80} />
+        <Circle bg={colors.opacityDefault.c05} size={34}>
+          <Wallet size="S" color={colors.primary.c80} />
         </Circle>
       }
       data={

--- a/apps/ledger-live-mobile/src/screens/SendFunds/SummaryToSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/SummaryToSection.tsx
@@ -84,8 +84,8 @@ function SummaryToSection({ transaction, currency }: Props) {
     <SummaryRowCustom
       label={t("send.summary.to")}
       iconLeft={
-        <Circle bg={colors.palette.opacityDefault.c05} size={34}>
-          <QrCode size="S" color={colors.palette.primary.c80} />
+        <Circle bg={colors.opacityDefault.c05} size={34}>
+          <QrCode size="S" color={colors.primary.c80} />
         </Circle>
       }
       data={

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Node.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Node.tsx
@@ -8,11 +8,11 @@ import { State } from "~/reducers/types";
 import Touchable from "~/components/Touchable";
 
 const StyledTouchable = styled(Touchable)`
-  background-color: ${p => p.theme.colors.palette.background.main};
+  background-color: ${p => p.theme.colors.background.main};
   padding: ${p => p.theme.space[5]}px ${p => p.theme.space[4]}px;
   flex-direction: row;
   align-items: center;
-  border-bottom-color: ${p => p.theme.colors.palette.neutral.c40};
+  border-bottom-color: ${p => p.theme.colors.neutral.c40};
   border-bottom-width: 1px;
 `;
 

--- a/libs/ui/packages/native/src/components/Tabs/Chip/index.tsx
+++ b/libs/ui/packages/native/src/components/Tabs/Chip/index.tsx
@@ -40,9 +40,7 @@ export const ChipTab = ({
     <Text
       variant="small"
       fontWeight="semiBold"
-      color={
-        isActive ? activeColor ?? "palette.neutral.c100" : inactiveColor ?? "palette.neutral.c80"
-      }
+      color={isActive ? activeColor ?? "neutral.c100" : inactiveColor ?? "neutral.c80"}
       textAlign="center"
     >
       {label}

--- a/libs/ui/packages/native/src/pre-ldls/components/Tag/Tag.tsx
+++ b/libs/ui/packages/native/src/pre-ldls/components/Tag/Tag.tsx
@@ -22,12 +22,7 @@ export const Tag = ({
 }) => {
   return (
     <Wrapper testID="tag" $spacing={spacing}>
-      <Text
-        color="palette.neutral.c70"
-        fontSize="10px"
-        lineHeight="16px"
-        textTransform={textTransform}
-      >
+      <Text color="neutral.c70" fontSize="10px" lineHeight="16px" textTransform={textTransform}>
         {children}
       </Text>
     </Wrapper>

--- a/libs/ui/packages/native/src/pre-ldls/components/sharedStoryBook.tsx
+++ b/libs/ui/packages/native/src/pre-ldls/components/sharedStoryBook.tsx
@@ -13,12 +13,7 @@ export const leftElement = <Tag>{"1.34% APY"}</Tag>;
 
 export const createRightElement = (discreetMode: boolean) => (
   <BalanceContainer>
-    <Text
-      fontSize="14px"
-      variant="largeLineHeight"
-      fontWeight="semiBold"
-      color="palette.neutral.c100"
-    >
+    <Text fontSize="14px" variant="largeLineHeight" fontWeight="semiBold" color="neutral.c100">
       {discreetMode ? "$***" : "$5,969.83"}
     </Text>
     <Text
@@ -26,7 +21,7 @@ export const createRightElement = (discreetMode: boolean) => (
       lineHeight="16px"
       variant="bodyLineHeight"
       fontWeight="medium"
-      color="palette.neutral.c70"
+      color="neutral.c70"
     >
       {discreetMode ? "*** BTC" : "0.118 BTC"}
     </Text>

--- a/libs/ui/packages/native/src/styles/theme.ts
+++ b/libs/ui/packages/native/src/styles/theme.ts
@@ -64,12 +64,7 @@ export type Theme = {
   radii: number[];
   fontSizes: number[];
   space: number[];
-  colors: ColorPalette & {
-    /**
-     * @deprecated Do not use the .palette prefix anymore!
-     */
-    palette: ColorPalette;
-  };
+  colors: ColorPalette;
   zIndexes: number[];
 };
 
@@ -82,10 +77,7 @@ const theme: Theme = {
   radii,
   fontSizes,
   space,
-  colors: {
-    ...palettes.light,
-    palette: palettes.light,
-  },
+  colors: palettes.light,
   zIndexes,
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description


This PR updates **LWM** components to stop using deprecated `palette` values (e.g., `palette.`).
All color references have been replaced with the **V3 color** (e.g., `neutral`, `primary`, etc.).

This change is part of the initiative [[LIVE-23412](https://ledgerhq.atlassian.net/browse/LIVE-23412)](https://ledgerhq.atlassian.net/browse/LIVE-23412) to enforce proper usage via ESLint rules.



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-24041


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23412]: https://ledgerhq.atlassian.net/browse/LIVE-23412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ