### PR TITLE
fix(llc): pass missing `assetOwner` and `assetReference`

### DIFF
--- a/.changeset/three-mails-fold.md
+++ b/.changeset/three-mails-fold.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix(llc): fill missing `assetOwner` and `assetReference`

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/getAccountShape.ts
@@ -102,10 +102,12 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
           internalOperations,
         });
       });
-    // Try to refresh known pending operations (if not already updated)
+    // Try to refresh known pending and broadcasted operations (if not already updated)
     // Useful for integrations without explorers
     const operationsToRefresh = initialAccount?.pendingOperations.filter(
-      pendingOp => !newOpsWithSubs.some(newOp => pendingOp.hash === newOp.hash),
+      pendingOp =>
+        pendingOp.hash && // operation has been broadcasted
+        !newOpsWithSubs.some(newOp => pendingOp.hash === newOp.hash), // operation is not confirmed yet
     );
     const confirmedOperations =
       alpacaApi.refreshOperations && operationsToRefresh?.length

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/prepareTransaction.ts
@@ -71,10 +71,15 @@ export function genericPrepareTransaction(
     }
 
     // Pass any parameters that help estimating fees
+    // This includes `assetOwner` and `assetReference` that are not used by some apps that only rely on `subAccountId`
+    // TODO Remove `assetOwner` and `assetReference` in order to maintain one unique way of identifying the type of asset
+    // https://ledgerhq.atlassian.net/browse/LIVE-24044
     const intent = transactionToIntent(
       account,
       {
         ...transaction,
+        assetOwner,
+        assetReference,
         amount,
       },
       computeIntentType,
@@ -125,6 +130,8 @@ export function genericPrepareTransaction(
             account,
             {
               ...transaction,
+              assetOwner,
+              assetReference,
             },
             computeIntentType,
           ),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Swap from Ethereum token account

### 📝 Description

Identifying the type of currency used to be done using the `subAccountId` instead of the newly promoted `assetOwer` and `assetReference`.
This is deriving the later from the former, and passing them when creating the intent.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
