### PR TITLE
fix(wallet-api): align dapp JSON-RPC errors with EIP-1193 [LIVE-22815]

### DIFF
--- a/.changeset/quick-turtles-design.md
+++ b/.changeset/quick-turtles-design.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/live-common": minor
+"@ledgerhq/ethereum-provider": minor
+---
+
+fix(wallet-api): align dapp JSON-RPC errors with EIP-1193
+
+Normalize dapp error codes and payload shape in useDappLogic
+Make ethereum provider message parsing accept object payloads as well as strings

--- a/libs/ethereum-provider/src/LedgerLiveEthereumProvider.ts
+++ b/libs/ethereum-provider/src/LedgerLiveEthereumProvider.ts
@@ -360,7 +360,7 @@ export class LedgerLiveEthereumProvider extends EventEmitter implements EIP1193P
     }
 
     try {
-      const message = JSON.parse(data) as ReceivedMessageType;
+      const message: ReceivedMessageType = typeof data === "object" ? data : JSON.parse(data);
 
       // Always expect jsonrpc to be set to '2.0'
       if (message.jsonrpc !== JSON_RPC_VERSION) {

--- a/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
+++ b/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
@@ -29,15 +29,27 @@ interface JsonRpcRequestMessage<TParams = any> {
   params?: TParams;
 }
 
-const rejectedError = (message: string) => ({
-  code: 3,
+const errors = {
+  ParseError: -32700,
+  InvalidRequest: -32600,
+  MethodNotFound: -32601,
+  InvalidParams: -32602,
+  InternalError: -32603,
+  UserRejected: 4001,
+  Unauthorized: 4100,
+  UnsupportedMethod: 4200,
+  Disconnected: 4900,
+  ChainDisconnected: 4901,
+} as const;
+
+const rejectedError = (code: number, message: string, data: object = {}) => ({
+  code,
   message,
-  data: [
-    {
-      code: 104,
-      message: "Rejected",
-    },
-  ],
+  data: {
+    code,
+    message,
+    ...data,
+  },
 });
 
 // TODO remove any usage
@@ -331,7 +343,7 @@ export function useDappLogic({
           JSON.stringify({
             id: data.id,
             jsonrpc: "2.0",
-            error: rejectedError("No network selected"),
+            error: rejectedError(errors.InternalError, "No network selected"),
           }),
         );
         return;
@@ -343,7 +355,7 @@ export function useDappLogic({
           JSON.stringify({
             id: data.id,
             jsonrpc: "2.0",
-            error: rejectedError("No account selected"),
+            error: rejectedError(errors.InternalError, "No account selected"),
           }),
         );
         return;
@@ -355,7 +367,7 @@ export function useDappLogic({
           JSON.stringify({
             id: data.id,
             jsonrpc: "2.0",
-            error: rejectedError("No parent account found"),
+            error: rejectedError(errors.InternalError, "No parent account found"),
           }),
         );
         return;
@@ -410,7 +422,7 @@ export function useDappLogic({
               JSON.stringify({
                 id: data.id,
                 jsonrpc: "2.0",
-                error: rejectedError("Invalid chainId"),
+                error: rejectedError(errors.InvalidParams, "Invalid chainId"),
               }),
             );
             break;
@@ -426,7 +438,7 @@ export function useDappLogic({
               JSON.stringify({
                 id: data.id,
                 jsonrpc: "2.0",
-                error: rejectedError(`Chain ID ${chainId} is not supported`),
+                error: rejectedError(errors.InvalidParams, `Chain ID ${chainId} is not supported`),
               }),
             );
             break;
@@ -459,7 +471,7 @@ export function useDappLogic({
               JSON.stringify({
                 id: data.id,
                 jsonrpc: "2.0",
-                error: rejectedError(`error switching chain: ${error}`),
+                error: rejectedError(errors.UserRejected, `error switching chain: ${error}`),
               }),
             );
           }
@@ -561,7 +573,7 @@ export function useDappLogic({
                 JSON.stringify({
                   id: data.id,
                   jsonrpc: "2.0",
-                  error: rejectedError("Transaction declined"),
+                  error: rejectedError(errors.UserRejected, "Transaction declined"),
                 }),
               );
             }
@@ -615,7 +627,7 @@ export function useDappLogic({
               JSON.stringify({
                 id: data.id,
                 jsonrpc: "2.0",
-                error: rejectedError("Personal message signed declined"),
+                error: rejectedError(errors.UserRejected, "Personal message signed declined"),
               }),
             );
           }
@@ -662,7 +674,7 @@ export function useDappLogic({
               JSON.stringify({
                 id: data.id,
                 jsonrpc: "2.0",
-                error: rejectedError("Typed Data message signed declined"),
+                error: rejectedError(errors.UserRejected, "Typed Data message signed declined"),
               }),
             );
           }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually, we would need to create our own local dapp and test using it instead of metamask test dapp
- [x] **Impact of the changes:**
  - dapp browser v3 error handling and user rejection

### 📝 Description

This pull request updates error handling in the wallet API and Ethereum provider to better align with the EIP-1193 standard. The main improvements include normalizing JSON-RPC error codes and payloads returned to dapps, and enhancing message parsing to accept both object and string payloads.

**Wallet API error handling improvements:**

* Standardized JSON-RPC error codes and payload shapes in `useDappLogic`, using EIP-1193 and JSON-RPC 2.0 codes for all dapp error responses.
* Updated all error responses in `useDappLogic` to use the new error format and appropriate codes, such as `InternalError`, `InvalidParams`, and `UserRejected` [[1]](diffhunk://#diff-b3773e9d287acc0c470457b525735f8c5a48f0baf26ecb49849844ff254d979dL334-R346) [[2]](diffhunk://#diff-b3773e9d287acc0c470457b525735f8c5a48f0baf26ecb49849844ff254d979dL346-R358) [[3]](diffhunk://#diff-b3773e9d287acc0c470457b525735f8c5a48f0baf26ecb49849844ff254d979dL358-R370) [[4]](diffhunk://#diff-b3773e9d287acc0c470457b525735f8c5a48f0baf26ecb49849844ff254d979dL413-R425) [[5]](diffhunk://#diff-b3773e9d287acc0c470457b525735f8c5a48f0baf26ecb49849844ff254d979dL429-R441) [[6]](diffhunk://#diff-b3773e9d287acc0c470457b525735f8c5a48f0baf26ecb49849844ff254d979dL462-R474) [[7]](diffhunk://#diff-b3773e9d287acc0c470457b525735f8c5a48f0baf26ecb49849844ff254d979dL564-R576) [[8]](diffhunk://#diff-b3773e9d287acc0c470457b525735f8c5a48f0baf26ecb49849844ff254d979dL618-R630) [[9]](diffhunk://#diff-b3773e9d287acc0c470457b525735f8c5a48f0baf26ecb49849844ff254d979dL665-R677).

**Ethereum provider improvements:**

* Enhanced message parsing in `LedgerLiveEthereumProvider` to accept both object and string payloads, increasing compatibility with different dapp implementations.

**Documentation and release notes:**

* Added a changeset documenting these improvements and indicating minor version bumps for `@ledgerhq/live-common` and `@ledgerhq/ethereum-provider`.

| Before        | After         |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/054b8e59-bb21-4dfa-a8a5-aced0d865120" /> | <video src="https://github.com/user-attachments/assets/abc9efad-4486-4188-af70-20b5b3b86bde" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-22815]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22815]: https://ledgerhq.atlassian.net/browse/LIVE-22815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ