### PR TITLE
feat: add llmRebornABtest feature flag no device welcome redirect

### DIFF
--- a/.changeset/shy-otters-retire.md
+++ b/.changeset/shy-otters-retire.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add llmRebornABtest feature flag no device welcome redirect

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/postWelcomeSelection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/postWelcomeSelection.tsx
@@ -1,6 +1,7 @@
 import { Button, Icons } from "@ledgerhq/native-ui";
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import React, { useCallback, useState } from "react";
+import { Linking } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { useTheme } from "styled-components/native";
@@ -12,6 +13,9 @@ import { NavigatorName, ScreenName } from "~/const";
 import { SelectionCards } from "./Cards/SelectionCard";
 import { NoLedgerYetModal } from "./NoLedgerYetModal";
 import OnboardingView from "./OnboardingView";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { urls } from "~/utils/urls";
+import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 
 type NavigationProps = StackNavigatorProps<
   OnboardingNavigatorParamList,
@@ -25,15 +29,21 @@ function PostWelcomeSelection() {
   const navigation = useNavigation<NavigationProps["navigation"]>();
   const currentNavigation = navigation.getParent()?.getParent()?.getState().routes[0].name;
   const isInOnboarding = currentNavigation === NavigatorName.BaseOnboarding;
+  const llmRebornABtest = useFeature("llmRebornABtest");
+  const localizedRebornUrl = useLocalizedUrl(urls.reborn);
 
   const [modalOpen, setModalOpen] = useState(false);
 
   const openModal = () => {
     identifyUser(null);
-    setModalOpen(true);
     track("button_clicked", {
       button: "I don’t have a Ledger yet",
     });
+    if (llmRebornABtest?.enabled) {
+      Linking.openURL(localizedRebornUrl);
+    } else {
+      setModalOpen(true);
+    }
   };
 
   const closeModal = () => {

--- a/apps/ledger-live-mobile/src/utils/urls.tsx
+++ b/apps/ledger-live-mobile/src/utils/urls.tsx
@@ -28,6 +28,8 @@ export const urls = {
     ru: "https://www.ledger.com/ru/privacy-policy?utm_content=privacy&utm_medium=self_referral&utm_source=ledger_live_mobile",
     pt: "https://www.ledger.com/pt-br/privacy-policy?utm_content=privacy&utm_medium=self_referral&utm_source=ledger_live_mobile",
   },
+  reborn:
+    "https://shop.ledger.com/pages/unlock-ledger-wallet-mobile?utm_source=ledger_wallet_mobile&utm_medium=self_referral&utm_content=onboarding-2",
   trackingPolicy: {
     en: "https://shop.ledger.com/pages/ledger-live-tracking-policy?utm_content=privacy&utm_medium=self_referral&utm_source=ledger_live_mobile",
     fr: "https://shop.ledger.com/fr/pages/ledger-live-tracking-policy?utm_content=privacy&utm_medium=self_referral&utm_source=ledger_live_mobile",

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -735,6 +735,7 @@ export const DEFAULT_FEATURES: Features = {
   zcashShielded: DEFAULT_FEATURE,
   llmNanoOnboardingFundWallet: DEFAULT_FEATURE,
   lldRebornABtest: DEFAULT_FEATURE,
+  llmRebornABtest: DEFAULT_FEATURE,
 };
 
 // Firebase SDK treat JSON values as strings

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -283,6 +283,7 @@ export type Features = CurrencyFeatures & {
   zcashShielded: DefaultFeature;
   llmNanoOnboardingFundWallet: DefaultFeature;
   lldRebornABtest: DefaultFeature;
+  llmRebornABtest: DefaultFeature;
 };
 
 /**


### PR DESCRIPTION
chore: tidy imports

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add `llmRebornABtest` feature flag which when enabled redirects the user to a ledger shop page instead of the usual reborn experience.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-23964


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
