### PR TITLE
fix: unable to open newly added assets after adding a second account 

### DIFF
--- a/.changeset/wise-planets-fly.md
+++ b/.changeset/wise-planets-fly.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix Fabric rendering making unable to open newly added assets after adding a second account

--- a/apps/ledger-live-mobile/src/screens/Portfolio/TabSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/TabSection.tsx
@@ -84,6 +84,7 @@ export default function TabSection({
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showAssets]); // IMPORTANT: Only on tab change, not on height changes
+
   return (
     <>
       <Box height={40} mb={16}>
@@ -100,10 +101,10 @@ export default function TabSection({
       <Box testID="portfolio-assets-layout" minHeight={displayHeight}>
         {showAssets ? (
           <Animated.View
-            key="assets-view"
             entering={hasAnimated ? SlideInLeft.duration(ANIMATION_DURATION_MS) : undefined}
             exiting={hasAnimated ? SlideOutLeft.duration(ANIMATION_DURATION_MS) : undefined}
             style={{ height: assetsFullHeight }}
+            collapsable={false}
           >
             <AssetsListView
               sourceScreenName={ScreenName.Portfolio}
@@ -123,10 +124,10 @@ export default function TabSection({
           </Animated.View>
         ) : (
           <Animated.View
-            key="accounts-view"
             entering={hasAnimated ? SlideInRight.duration(ANIMATION_DURATION_MS) : undefined}
             exiting={hasAnimated ? SlideOutRight.duration(ANIMATION_DURATION_MS) : undefined}
             style={{ height: accountsFullHeight }}
+            collapsable={false}
           >
             <AccountsListView
               sourceScreenName={ScreenName.Portfolio}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Should fix the tap issue on asset items caused by the RN Fabric renderer.

### 📝 Description

The Fabric rendering engine in our version is still unstable. By disabling the optimisation explicitly on the animated components, the behavior is restored.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
https://ledgerhq.atlassian.net/browse/LIVE-23892

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
