### PR TITLE
ci: exclude ledgerhq from minReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,3 +61,5 @@ overrides:
   node-abi: ^4.9.0
 
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@ledgerhq/*'


### PR DESCRIPTION
Small change to exclude ledgerhq from minreleaseage as per teams suggestion to reduce cross-repo friction