### PR TITLE
chore:  :wrench: introduce deprecated rule from eslint inside `mono-repo` as a warn

### DIFF
--- a/.changeset/silent-brooms-joke.md
+++ b/.changeset/silent-brooms-joke.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Introduce "@typescript-eslint/no-deprecated": "warn" rule in linter

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,4 +52,26 @@ module.exports = {
     "@typescript-eslint/no-empty-object-type": "warn",
     "@typescript-eslint/no-unsafe-function-type": "warn",
   },
+  overrides: [
+    {
+      // Enable type-aware linting for TypeScript files only
+      files: ["**/*.ts", "**/*.tsx"],
+      excludedFiles: [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "spec.ts",
+        "spec.tsx",
+        "**/__tests__/**",
+        "**/tests/**",
+        "**/__mocks__/**",
+        "**/mocks/**",
+      ],
+      parserOptions: {
+        project: true,
+      },
+      rules: {
+        "@typescript-eslint/no-deprecated": "warn",
+      },
+    },
+  ],
 };

--- a/libs/ledger-live-common/.eslintrc.js
+++ b/libs/ledger-live-common/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     "@typescript-eslint/no-namespace": ["error", { allowDeclarations: true }],
     "@typescript-eslint/no-explicit-any": "warn",
   },
+  parser: "@typescript-eslint/parser",
   overrides: [
     {
       files: ["src/**/*.test.{ts,tsx}"],

--- a/libs/ledger-live-common/src/bridge/react/BridgeSync.tsx
+++ b/libs/ledger-live-common/src/bridge/react/BridgeSync.tsx
@@ -48,7 +48,7 @@ export const BridgeSync = ({
   prepareCurrency,
   hydrateCurrency,
   blacklistedTokenIds,
-}: Props): JSX.Element => {
+}: Props): React.JSX.Element => {
   useHydrate({
     accounts,
     hydrateCurrency,

--- a/libs/ledger-live-common/src/deposit/api.ts
+++ b/libs/ledger-live-common/src/deposit/api.ts
@@ -1,11 +1,11 @@
 import { getEnv } from "@ledgerhq/live-env";
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { MappedAsset } from "./type";
 
 const ROOT_PATH = getEnv("MAPPING_SERVICE");
 
 export async function getMappedAssets(): Promise<MappedAsset[]> {
   const url = `${ROOT_PATH}/v1/coingecko/mapped-assets`;
-  const { data } = await network({ method: "GET", url });
+  const { data } = await network<MappedAsset[]>({ method: "GET", url });
   return data;
 }

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/__tests__/fetchCurrencyAll.spec.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/__tests__/fetchCurrencyAll.spec.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { fetchCurrencyAll } from "../fetchCurrencyAll";
 import { fetchCurrencyAllMock } from "../__mocks__/fetchCurrencyAll.mocks";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../../const/timeout";

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/__tests__/fetchCurrencyFrom.spec.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/__tests__/fetchCurrencyFrom.spec.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { fetchCurrencyFrom } from "../fetchCurrencyFrom";
 import { fetchCurrencyFromMock } from "../__mocks__/fetchCurrencyFrom.mocks";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../../const/timeout";

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/__tests__/fetchCurrencyTo.spec.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/__tests__/fetchCurrencyTo.spec.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 
 import { fetchCurrencyTo } from "../fetchCurrencyTo";
 import { fetchCurrencyToMock } from "../__mocks__/fetchCurrencyTo.mocks";

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyAll.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyAll.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../const/timeout";
 import axios from "axios";
 import { LedgerAPI4xx } from "@ledgerhq/errors";

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyFrom.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyFrom.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../const/timeout";
 import { flattenV5CurrenciesToAndFrom } from "../../utils/flattenV5CurrenciesToAndFrom";
 import { fetchCurrencyFromMock } from "./__mocks__/fetchCurrencyFrom.mocks";

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyTo.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyTo.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { fetchCurrencyToMock } from "./__mocks__/fetchCurrencyTo.mocks";
 import { isIntegrationTestEnv } from "../../utils/isIntegrationTestEnv";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../const/timeout";

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchRates.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../const/timeout";
 import axios from "axios";
 import { LedgerAPI4xx } from "@ledgerhq/errors";

--- a/libs/ledger-live-common/src/families/bitcoin/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/bridge/api.ts
@@ -1,6 +1,6 @@
 import { FeeEstimationFailed } from "@ledgerhq/errors";
 import { makeLRUCache } from "@ledgerhq/live-network/cache";
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
@@ -13,7 +13,7 @@ const getEstimatedFees: (currency: CryptoCurrency) => Promise<Fees> = makeLRUCac
   async currency => {
     const baseURL = blockchainBaseURL(currency);
     invariant(baseURL, `Fees for ${currency.id} are not supported`);
-    const { data, status } = await network({
+    const { data, status } = await network<Fees>({
       method: "GET",
       url: `${baseURL}/fees`,
     });

--- a/libs/ledger-live-common/src/featureFlags/FeatureToggle.tsx
+++ b/libs/ledger-live-common/src/featureFlags/FeatureToggle.tsx
@@ -9,7 +9,7 @@ type Props = {
   children?: ReactNode;
 };
 
-const FeatureToggle = ({ featureId, fallback, children }: Props): JSX.Element => {
+const FeatureToggle = ({ featureId, fallback, children }: Props): React.JSX.Element => {
   const feature = useFeature(featureId);
 
   if (!feature || !feature.enabled) {

--- a/libs/ledger-live-common/src/market/api/index.ts
+++ b/libs/ledger-live-common/src/market/api/index.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { getEnv } from "@ledgerhq/live-env";
 import {
   MarketCurrencyChartDataRequestParams,
@@ -8,6 +8,7 @@ import {
   SupportedCoins,
   MarketCurrencyRequestParams,
   MarketCoinDataChart,
+  MarketChartApiResponse,
   Order,
 } from "../utils/types";
 import { rangeDataTable } from "../utils/rangeDataTable";
@@ -19,7 +20,7 @@ const ROOT_PATH = getEnv("MARKET_API_URL");
 
 export async function getSupportedCoinsList(): Promise<SupportedCoins> {
   const url = `${ROOT_PATH}/coins/list`;
-  const { data } = await network({ method: "GET", url });
+  const { data } = await network<SupportedCoins>({ method: "GET", url });
   return data;
 }
 
@@ -48,7 +49,7 @@ export async function fetchList({
     },
   });
 
-  const { data } = await network({
+  const { data } = await network<MarketItemResponse[]>({
     method: "GET",
     url,
   });
@@ -60,7 +61,7 @@ export async function fetchList({
 export async function supportedCounterCurrencies(): Promise<string[]> {
   const url = `${ROOT_PATH}/simple/supported_vs_currencies`;
 
-  const { data } = await network({
+  const { data } = await network<string[]>({
     method: "GET",
     url,
   });
@@ -84,7 +85,7 @@ export async function fetchCurrencyChartData({
     },
   });
 
-  const { data } = await network({
+  const { data } = await network<MarketChartApiResponse>({
     method: "GET",
     url,
   });
@@ -106,7 +107,7 @@ export async function fetchCurrency({
     },
   });
 
-  const { data } = await network({ method: "GET", url });
+  const { data } = await network<MarketItemResponse[]>({ method: "GET", url });
 
   return data[0];
 }
@@ -132,7 +133,7 @@ export async function fetchMarketPerformers({
     },
   });
 
-  const { data } = await network({ method: "GET", url });
+  const { data } = await network<MarketItemResponse[]>({ method: "GET", url });
 
   return data;
 }

--- a/libs/ledger-live-common/src/market/utils/types.ts
+++ b/libs/ledger-live-common/src/market/utils/types.ts
@@ -10,6 +10,12 @@ export type MarketCoin = {
 export type ChartDataPoint = [number, number];
 export type MarketCoinDataChart = Record<string, Array<ChartDataPoint>>;
 
+export type MarketChartApiResponse = {
+  prices: ChartDataPoint[];
+  market_caps: ChartDataPoint[];
+  total_volumes: ChartDataPoint[];
+};
+
 export enum Order {
   MarketCapDesc = "desc",
   MarketCapAsc = "asc",

--- a/libs/ledger-live-common/src/notifications/AnnouncementProvider/api/api.ts
+++ b/libs/ledger-live-common/src/notifications/AnnouncementProvider/api/api.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { getEnv } from "@ledgerhq/live-env";
 import type { AnnouncementsApi, RawAnnouncement } from "../types";
 
@@ -10,7 +10,7 @@ const announcementsVersion = () => getEnv("ANNOUNCEMENTS_API_VERSION");
 
 async function fetchAnnouncements(): Promise<RawAnnouncement[]> {
   const url = `${baseAnnouncementsUrl()}/v${announcementsVersion()}/data.json?t=${Date.now()}`;
-  const { data } = await network({
+  const { data } = await network<RawAnnouncement[]>({
     method: "GET",
     headers: {
       Origin: "http://localhost:3000",

--- a/libs/ledger-live-common/src/notifications/ServiceStatusProvider/api/api.ts
+++ b/libs/ledger-live-common/src/notifications/ServiceStatusProvider/api/api.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { getEnv } from "@ledgerhq/live-env";
 import type { ServiceStatusApi, ServiceStatusSummary } from "../types";
 
@@ -8,7 +8,7 @@ const statusVersion = () => getEnv("STATUS_API_VERSION");
 
 async function fetchStatusSummary(): Promise<ServiceStatusSummary> {
   const url = `${baseStatusUrl()}/v${statusVersion()}/summary.json`;
-  const { data } = await network({
+  const { data } = await network<ServiceStatusSummary>({
     method: "GET",
     url,
   });

--- a/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/api/index.ts
+++ b/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/api/index.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import { getEnv } from "@ledgerhq/live-env";
 import type { RampCatalog } from "../types";
 import mockData from "./mock.json";
@@ -10,14 +10,14 @@ const api = {
       return mockData as RampCatalog;
     }
 
-    const { data } = await network({
+    const { data } = await network<RampCatalog>({
       method: "GET",
       headers: {
         Origin: "http://localhost:3000",
       },
       url: `${getEnv("BUY_API_BASE")}/provider/currencies?currency=crypto`,
     });
-    return data as RampCatalog;
+    return data;
   },
 };
 

--- a/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/index.tsx
+++ b/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/index.tsx
@@ -42,7 +42,7 @@ export function useRampCatalogContext() {
 export function RampCatalogProvider({
   children,
   updateFrequency,
-}: RampCatalogProviderProps): JSX.Element {
+}: RampCatalogProviderProps): React.JSX.Element {
   const [state, setState] = useState<Loadable<RampCatalog>>(initialState);
 
   const updateCatalog = useCallback(async () => {

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
@@ -93,7 +93,7 @@ export function RemoteLiveAppProvider({
   children,
   parameters,
   updateFrequency,
-}: LiveAppProviderProps): JSX.Element {
+}: LiveAppProviderProps): React.JSX.Element {
   const isMounted = useIsMounted();
   const [state, setState] = useState<Loadable<LiveAppRegistry>>(initialState);
   const [provider, setProvider] = useState<string>(initialProvider);

--- a/libs/ledger-live-common/src/wallet-api/LocalLiveAppProvider/index.tsx
+++ b/libs/ledger-live-common/src/wallet-api/LocalLiveAppProvider/index.tsx
@@ -12,7 +12,7 @@ export const liveAppContext = createContext<LiveAppContextType>({
   getLocalLiveAppManifestById: id => id,
 });
 
-export function LocalLiveAppProvider({ children, db }: LiveAppProviderProps): JSX.Element {
+export function LocalLiveAppProvider({ children, db }: LiveAppProviderProps): React.JSX.Element {
   const { state, addLocalManifest, removeLocalManifestById, getLocalLiveAppManifestById } =
     useLocalLiveApp(db);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR adds an ESLint rule to detect the use of deprecated methods within LW mono-repo.
For now, the rule is configured as a warning, as some occurrences may be complex to address immediately.

Each team can enable the rule as an error within their own scope and progressively fix the deprecated usages.
I started to resolve some in `live-common` just to test that the rule was working well

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-23904


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
