### PR TITLE
fix(LIVE-24102): fix swap network warning issue on load

### DIFF
--- a/.changeset/late-cycles-yawn.md
+++ b/.changeset/late-cycles-yawn.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Show a Loader while the manifest is not loaded instead of a network error

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapLoader.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapLoader.tsx
@@ -17,7 +17,7 @@ interface SwapLoaderProps {
   isLoading: boolean;
 }
 
-export function SwapLoader({ isLoading }: SwapLoaderProps) {
+export function SwapLoader({ isLoading }: Readonly<SwapLoaderProps>) {
   if (!isLoading) return null;
 
   return (


### PR DESCRIPTION
do not show network error while the manifest is being loaded on swap on portfolio

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-24102


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
