### PR TITLE
:bug: (KASPA) remove showAllDigits

### DIFF
--- a/.changeset/dirty-insects-remember.md
+++ b/.changeset/dirty-insects-remember.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": minor
+---
+
+Don't display kaspa digits

--- a/libs/coin-framework/src/currencies/__snapshots__/formatCurrencyUnit.test.ts.snap
+++ b/libs/coin-framework/src/currencies/__snapshots__/formatCurrencyUnit.test.ts.snap
@@ -4064,7 +4064,7 @@ exports[`formatCurrencyUnit with default options should correctly format Injecti
 
 exports[`formatCurrencyUnit with default options should correctly format Internet Computer unit (ICP) 1`] = `"123,456,789"`;
 
-exports[`formatCurrencyUnit with default options should correctly format KASPA unit (KAS) 1`] = `"123,456,789.00000000"`;
+exports[`formatCurrencyUnit with default options should correctly format KASPA unit (KAS) 1`] = `"123,456,789"`;
 
 exports[`formatCurrencyUnit with default options should correctly format Kin unit (KIN) 1`] = `"123,456,789,000"`;
 

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -1751,7 +1751,6 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
         name: "KAS",
         code: "KAS",
         magnitude: 8,
-        showAllDigits: true,
       },
       {
         name: "Sompis",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - kaspa digits

### 📝 Description

Kaspa is the only crypto with showAllDigits; unless there are some specs I think it can be removed

| Before        | After         |
| ------------- | ------------- |
|<img width="1580" height="909" alt="Screenshot 2025-12-09 at 6 22 59 PM" src="https://github.com/user-attachments/assets/18caf4f2-472b-4129-b006-fd889e41ef35" />|<img width="1624" height="953" alt="Screenshot 2025-12-09 at 6 24 44 PM" src="https://github.com/user-attachments/assets/59096920-5346-4d25-bca6-36e55bacd8df" />|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-24104](https://ledgerhq.atlassian.net/browse/LIVE-24104)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24104]: https://ledgerhq.atlassian.net/browse/LIVE-24104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ