### PR TITLE
feat: canton update pending offers

### DIFF
--- a/.changeset/kind-camels-jump.md
+++ b/.changeset/kind-camels-jump.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+chore: canton update pending offers ui styles

--- a/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/PendingTransferProposalsDetails.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/PendingTransferProposalsDetails.test.tsx
@@ -28,6 +28,7 @@ jest.mock("~/renderer/components/CopyWithFeedback", () => ({
 }));
 
 jest.mock("~/renderer/components/OperationsList/AddressCell", () => ({
+  __esModule: true,
   SplitAddress: ({ value }: { value: string }) => (
     <span data-testid={`address-${value}`}>{value}</span>
   ),
@@ -133,15 +134,16 @@ describe("PendingTransactionDetails", () => {
         <PendingTransactionDetails
           account={account}
           parentAccount={parentAccount}
-          contractId="contract-456"
+          contractId="contract-789"
           onOpenModal={mockOnOpenModal}
           onClose={mockOnClose}
         />,
       );
 
       expect(screen.getByText("families.canton.pendingTransactions.amount")).toBeInTheDocument();
-      expect(screen.getByTestId("address-other-sender")).toBeInTheDocument();
+      // For outgoing: sender is xpub (receiver-address), receiver is other-receiver
       expect(screen.getByTestId("address-receiver-address")).toBeInTheDocument();
+      expect(screen.getByTestId("address-other-receiver")).toBeInTheDocument();
     });
 
     it("should display memo when present", () => {
@@ -408,7 +410,8 @@ describe("PendingTransactionDetails", () => {
         />,
       );
 
-      expect(screen.getByText("families.canton.pendingTransactions.withdraw")).toBeInTheDocument();
+      // Outgoing action uses the common cancel label
+      expect(screen.getByText("common.cancel")).toBeInTheDocument();
       expect(
         screen.queryByText("families.canton.pendingTransactions.accept"),
       ).not.toBeInTheDocument();
@@ -431,9 +434,7 @@ describe("PendingTransactionDetails", () => {
         />,
       );
 
-      const withdrawButton = screen
-        .getByText("families.canton.pendingTransactions.withdraw")
-        .closest("button");
+      const withdrawButton = screen.getByText("common.cancel").closest("button");
       fireEvent.click(withdrawButton!);
 
       await waitFor(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/PendingTransferProposalsDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/PendingTransferProposalsDetails.tsx
@@ -8,7 +8,6 @@ import Button from "~/renderer/components/Button";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import IconCheck from "~/renderer/icons/Check";
-import IconCross from "~/renderer/icons/Cross";
 import { CantonAccount } from "@ledgerhq/live-common/families/canton/types";
 import {
   OpDetailsSection,
@@ -118,7 +117,14 @@ const PendingTransferProposalsDetails: React.FC<PendingTransferProposalsDetailsP
   const isIncoming = proposal.sender !== parentAccount.xpub;
 
   return (
-    <Box flow={3} px={20} mt={20}>
+    <Box flow={3} px={20} style={{ display: "flex", flexDirection: "column", minHeight: "100%" }}>
+      <Box mb={4}>
+        <Text ff="Inter|SemiBold" fontSize={6} color="neutral.c100">
+          {isIncoming
+            ? t("families.canton.pendingTransactions.incoming.detailsTitle")
+            : t("families.canton.pendingTransactions.outgoing.detailsTitle")}
+        </Text>
+      </Box>
       <OpDetailsSection>
         <OpDetailsTitle>{t("families.canton.pendingTransactions.amount")}</OpDetailsTitle>
         <OpDetailsData>
@@ -205,40 +211,47 @@ const PendingTransferProposalsDetails: React.FC<PendingTransferProposalsDetailsP
 
       <Divider />
 
-      <Box horizontal mt={4} flow={2} justifyContent="center">
+      <Box horizontal mt="auto" pb={20} flow={2} style={{ width: "100%" }}>
         {isIncoming ? (
           <>
-            <Button
-              primary
-              disabled={proposal.isExpired}
-              onClick={() => {
-                if (!proposal.isExpired) {
-                  handleAcceptOffer(proposal.contract_id);
-                }
-              }}
-              style={{ minWidth: "120px", textTransform: "uppercase" }}
-            >
-              <IconCheck size={16} />
-              <Box ml={1}>{t("families.canton.pendingTransactions.accept")}</Box>
-            </Button>
-            <Button
-              outline
-              onClick={() => handleRejectOffer(proposal.contract_id)}
-              style={{ minWidth: "120px", textTransform: "uppercase" }}
-            >
-              <IconCross size={16} />
-              <Box ml={1}>{t("families.canton.pendingTransactions.reject")}</Box>
-            </Button>
+            <Box flex={1}>
+              <Button
+                isFull
+                disabled={proposal.isExpired}
+                onClick={() => {
+                  if (!proposal.isExpired) {
+                    handleAcceptOffer(proposal.contract_id);
+                  }
+                }}
+              >
+                <Box horizontal alignItems="center" style={{ gap: "8px" }}>
+                  {t("families.canton.pendingTransactions.accept")}
+                  <IconCheck size={16} />
+                </Box>
+              </Button>
+            </Box>
+            <Box flex={1}>
+              <Button
+                isFull
+                appearance="no-background"
+                style={{ borderColor: "neutral.c100", borderWidth: 1 }}
+                onClick={() => handleRejectOffer(proposal.contract_id)}
+              >
+                <Box horizontal alignItems="center" style={{ gap: "8px" }}>
+                  {t("families.canton.pendingTransactions.reject")}
+                </Box>
+              </Button>
+            </Box>
           </>
         ) : (
-          <Button
-            primary
-            onClick={() => handleWithdrawOffer(proposal.contract_id)}
-            style={{ minWidth: "120px", textTransform: "uppercase" }}
-          >
-            <IconCheck size={16} />
-            <Box ml={1}>{t("families.canton.pendingTransactions.withdraw")}</Box>
-          </Button>
+          <Box flex={1}>
+            <Button isFull onClick={() => handleWithdrawOffer(proposal.contract_id)}>
+              <Box horizontal alignItems="center" style={{ gap: "8px" }}>
+                {t("common.cancel")}
+                <IconCheck size={16} />
+              </Box>
+            </Button>
+          </Box>
         )}
       </Box>
     </Box>

--- a/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/index.test.tsx
@@ -54,6 +54,16 @@ jest.mock("./DeviceAppModal", () => ({
 jest.mock("~/renderer/hooks/useAccountUnit", () => ({
   useAccountUnit: jest.fn(() => ({ code: "AMU", magnitude: 18, name: "Amulet" })),
 }));
+jest.mock("~/renderer/components/OperationsList/AddressCell", () => ({
+  __esModule: true,
+  default: () => <div data-testid="address-cell" />,
+  splitAddress: (value: string) => ({ left: value.slice(0, 5), right: value.slice(5) }),
+  SplitAddress: ({ value }: { value: string }) => (
+    <span data-testid={`address-${value}`}>{value}</span>
+  ),
+  Address: ({ value }: { value: string }) => <span data-testid={`address-${value}`}>{value}</span>,
+  Cell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
 jest.mock("./PendingTransferProposalsDetails", () => ({
   __esModule: true,
   default: ({ account, contractId, onOpenModal }: any) => (
@@ -166,7 +176,9 @@ describe("PendingTransferProposals", () => {
       render(<PendingTransferProposals account={account} parentAccount={mockAccount} />, {
         initialState: buildInitialState(),
       });
-      fireEvent.click(screen.getByText(`families.canton.pendingTransactions.${action}`));
+      const buttonText =
+        action === "withdraw" ? "common.cancel" : `families.canton.pendingTransactions.${action}`;
+      fireEvent.click(screen.getByText(buttonText));
       fireEvent.click(await screen.findByTestId("modal-confirm"));
 
       await waitFor(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/index.tsx
@@ -18,6 +18,7 @@ import PendingTransferProposalsDetails from "./PendingTransferProposalsDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import SectionTitle from "~/renderer/components/OperationsList/SectionTitle";
 import OperationDate from "~/renderer/components/OperationsList/OperationDate";
+import { Address } from "~/renderer/components/OperationsList/AddressCell";
 import IconReceive from "~/renderer/icons/Receive";
 import IconSend from "~/renderer/icons/Send";
 import IconCross from "~/renderer/icons/Cross";
@@ -313,6 +314,12 @@ type ExpiresInDisplayProps = {
   t: (key: string) => string;
 };
 
+const MonospaceText = styled(Text)`
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+  letter-spacing: 0;
+`;
+
 const ExpiresInDisplay: React.FC<ExpiresInDisplayProps> = ({ expiresAtMicros, isExpired, t }) => {
   const timeRemaining = useTimeRemaining(expiresAtMicros, isExpired);
 
@@ -325,9 +332,9 @@ const ExpiresInDisplay: React.FC<ExpiresInDisplayProps> = ({ expiresAtMicros, is
   }
 
   return (
-    <Text fontSize={3} color="neutral.c80" ff="Inter">
+    <MonospaceText fontSize={3} color="neutral.c80" ff="Inter">
       {timeRemaining || "-"}
-    </Text>
+    </MonospaceText>
   );
 };
 
@@ -413,10 +420,15 @@ const ProposalRow: React.FC<ProposalRowProps> = ({
           </Box>
         </Box>
 
-        <Box px={4} horizontal={true} alignItems="center" style={{ flex: 1 }}>
-          <Text fontSize={3} color="neutral.c80" ff="Inter">
-            {addressToShow}
-          </Text>
+        <Box
+          px={4}
+          horizontal={true}
+          alignItems="center"
+          style={{ flex: 1, minWidth: 0, overflow: "hidden" }}
+        >
+          <Box style={{ width: "100%", minWidth: 0, overflow: "hidden" }}>
+            <Address value={addressToShow} />
+          </Box>
         </Box>
 
         <Box
@@ -460,38 +472,34 @@ const ProposalRow: React.FC<ProposalRowProps> = ({
           alignItems="center"
           style={{
             flex: "0 0 auto",
-            gap: "4px",
+            gap: "8px",
             minWidth: "150px",
           }}
         >
           {isIncoming ? (
             <>
+              {!isExpired && (
+                <Button size="sm" onClick={handleAcceptClick}>
+                  {t("families.canton.pendingTransactions.accept")}
+                </Button>
+              )}
               <Button
-                small
-                primary
-                disabled={isExpired}
-                onClick={handleAcceptClick}
-                style={{ minWidth: "auto", padding: "4px 8px" }}
-              >
-                {t("families.canton.pendingTransactions.accept")}
-              </Button>
-              <Button
-                small
-                outline
+                size="sm"
+                appearance="no-background"
+                style={{ borderColor: "neutral.c100", borderWidth: 1 }}
                 onClick={handleRejectClick}
-                style={{ minWidth: "auto", padding: "4px 8px" }}
               >
                 {t("families.canton.pendingTransactions.reject")}
               </Button>
             </>
           ) : (
             <Button
-              small
-              outline
+              size="sm"
+              appearance="no-background"
+              style={{ borderColor: "neutral.c100", borderWidth: 1 }}
               onClick={handleWithdrawClick}
-              style={{ minWidth: "auto", padding: "4px 8px" }}
             >
-              {t("families.canton.pendingTransactions.withdraw")}
+              {t("common.cancel")}
             </Button>
           )}
         </Box>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5928,10 +5928,12 @@
       "pendingTransactions": {
         "title": "Pending Transactions ({{count}})",
         "incoming": {
-          "title": "Incoming Offers ({{count}})"
+          "title": "Incoming transfer to review ({{count}})",
+          "detailsTitle": "Incoming transfer details"
         },
         "outgoing": {
-          "title": "Outgoing Offers ({{count}})"
+          "title": "Outgoing Offers ({{count}})",
+          "detailsTitle": "Outgoing transfer details"
         },
         "pending": "Pending",
         "expired": "Expired",

--- a/libs/ledger-live-common/src/families/canton/react.test.ts
+++ b/libs/ledger-live-common/src/families/canton/react.test.ts
@@ -26,35 +26,39 @@ describe("getRemainingTime", () => {
   test("should format seconds only", () => {
     expect(getRemainingTime(30 * SECOND)).toBe("30s");
     expect(getRemainingTime(59 * SECOND)).toBe("59s");
-    expect(getRemainingTime(1 * SECOND)).toBe("1s");
+    expect(getRemainingTime(1 * SECOND)).toBe("01s");
   });
 
   test("should format minutes and seconds", () => {
-    expect(getRemainingTime(1 * MINUTE + 30 * SECOND)).toBe("1m 30s");
-    expect(getRemainingTime(5 * MINUTE + 15 * SECOND)).toBe("5m 15s");
+    expect(getRemainingTime(1 * MINUTE + 30 * SECOND)).toBe("01m 30s");
+    expect(getRemainingTime(5 * MINUTE + 15 * SECOND)).toBe("05m 15s");
     expect(getRemainingTime(59 * MINUTE + 59 * SECOND)).toBe("59m 59s");
   });
 
   test("should format hours, minutes and seconds", () => {
-    expect(getRemainingTime(1 * HOUR + 30 * MINUTE + 15 * SECOND)).toBe("1h 30m 15s");
-    expect(getRemainingTime(2 * HOUR + 5 * MINUTE + 10 * SECOND)).toBe("2h 5m 10s");
+    expect(getRemainingTime(1 * HOUR + 30 * MINUTE + 15 * SECOND)).toBe("01h 30m 15s");
+    expect(getRemainingTime(2 * HOUR + 5 * MINUTE + 10 * SECOND)).toBe("02h 05m 10s");
     expect(getRemainingTime(23 * HOUR + 59 * MINUTE + 59 * SECOND)).toBe("23h 59m 59s");
   });
 
   test("should format days, hours, minutes and seconds", () => {
-    expect(getRemainingTime(1 * DAY + 2 * HOUR + 30 * MINUTE + 15 * SECOND)).toBe("1d 2h 30m 15s");
-    expect(getRemainingTime(5 * DAY + 10 * HOUR + 5 * MINUTE + 10 * SECOND)).toBe("5d 10h 5m 10s");
+    expect(getRemainingTime(1 * DAY + 2 * HOUR + 30 * MINUTE + 15 * SECOND)).toBe(
+      "01d 02h 30m 15s",
+    );
+    expect(getRemainingTime(5 * DAY + 10 * HOUR + 5 * MINUTE + 10 * SECOND)).toBe(
+      "05d 10h 05m 10s",
+    );
     expect(getRemainingTime(10 * DAY + 23 * HOUR + 59 * MINUTE + 59 * SECOND)).toBe(
       "10d 23h 59m 59s",
     );
   });
 
   test("should skip zero values", () => {
-    expect(getRemainingTime(1 * DAY)).toBe("1d 0s");
-    expect(getRemainingTime(1 * HOUR)).toBe("1h 0s");
-    expect(getRemainingTime(1 * MINUTE)).toBe("1m 0s");
-    expect(getRemainingTime(1 * DAY + 1 * MINUTE)).toBe("1d 1m 0s");
-    expect(getRemainingTime(1 * DAY + 1 * HOUR)).toBe("1d 1h 0s");
+    expect(getRemainingTime(1 * DAY)).toBe("01d 00h 00m 00s");
+    expect(getRemainingTime(1 * HOUR)).toBe("01h 00m 00s");
+    expect(getRemainingTime(1 * MINUTE)).toBe("01m 00s");
+    expect(getRemainingTime(1 * DAY + 1 * MINUTE)).toBe("01d 00h 01m 00s");
+    expect(getRemainingTime(1 * DAY + 1 * HOUR)).toBe("01d 01h 00m 00s");
   });
 });
 
@@ -89,41 +93,41 @@ describe("useTimeRemaining", () => {
   test("should return formatted time remaining for valid proposal", () => {
     const expiresAt = Date.now() + 2 * HOUR + 30 * MINUTE + 15 * SECOND;
     const { result } = renderHook(() => useTimeRemaining(expiresAt * 1000));
-    expect(result.current).toBe("2h 30m 15s");
+    expect(result.current).toBe("02h 30m 15s");
   });
 
   test("should update time remaining every second", () => {
     const expiresAt = Date.now() + 2 * MINUTE + 30 * SECOND;
     const { result } = renderHook(() => useTimeRemaining(expiresAt * 1000));
 
-    expect(result.current).toBe("2m 30s");
+    expect(result.current).toBe("02m 30s");
 
     act(() => {
       jest.advanceTimersByTime(1 * SECOND);
     });
-    expect(result.current).toBe("2m 29s");
+    expect(result.current).toBe("02m 29s");
 
     act(() => {
       jest.advanceTimersByTime(1 * SECOND);
     });
-    expect(result.current).toBe("2m 28s");
+    expect(result.current).toBe("02m 28s");
 
     act(() => {
       jest.advanceTimersByTime(30 * SECOND);
     });
-    expect(result.current).toBe("1m 58s");
+    expect(result.current).toBe("01m 58s");
   });
 
   test("should return empty string when time expires", () => {
     const expiresAt = Date.now() + 2 * SECOND;
     const { result } = renderHook(() => useTimeRemaining(expiresAt * 1000));
 
-    expect(result.current).toBe("2s");
+    expect(result.current).toBe("02s");
 
     act(() => {
       jest.advanceTimersByTime(1 * SECOND);
     });
-    expect(result.current).toBe("1s");
+    expect(result.current).toBe("01s");
 
     act(() => {
       jest.advanceTimersByTime(1 * SECOND);
@@ -135,7 +139,7 @@ describe("useTimeRemaining", () => {
     const expiresAt = Date.now() + 1 * HOUR;
     const { result, unmount } = renderHook(() => useTimeRemaining(expiresAt * 1000));
 
-    expect(result.current).toBe("1h 0s");
+    expect(result.current).toBe("01h 00m 00s");
 
     unmount();
 

--- a/libs/ledger-live-common/src/families/canton/react.ts
+++ b/libs/ledger-live-common/src/families/canton/react.ts
@@ -61,13 +61,18 @@ export const getRemainingTime = (diff: number): string => {
   const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
   const seconds = Math.floor((diff % (1000 * 60)) / 1000);
 
-  let format = "";
-  if (days > 0) format += `${days}d `;
-  if (hours > 0) format += `${hours}h `;
-  if (minutes > 0) format += `${minutes}m `;
-  format += `${seconds}s`;
+  const startIndex = days > 0 ? 0 : hours > 0 ? 1 : minutes > 0 ? 2 : 3;
+  const units = [
+    [days, "d"],
+    [hours, "h"],
+    [minutes, "m"],
+    [seconds, "s"],
+  ] as const;
 
-  return format.trim();
+  return units
+    .slice(startIndex)
+    .map(([value, suffix]) => `${value.toString().padStart(2, "0")}${suffix}`)
+    .join(" ");
 };
 
 export const useTimeRemaining = (expiresAtMicros = 0, isExpired = false): string => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ledger-live-desktop
  - @ledgerhq/live-common

### 📝 Description

[Canton][LLD] Pending offers : UI adjustment

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: 
- [LIVE-23718](https://ledgerhq.atlassian.net/browse/LIVE-23718)
- [LIVE-24069]( https://ledgerhq.atlassian.net/browse/LIVE-24069)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23718]: https://ledgerhq.atlassian.net/browse/LIVE-23718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-24069]: https://ledgerhq.atlassian.net/browse/LIVE-24069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ