### PR TITLE
feat: Ledger sync improvements

### DIFF
--- a/.changeset/olive-apples-repeat.md
+++ b/.changeset/olive-apples-repeat.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+feat: Ledger sync improvements

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/manageYourBackup.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/manageYourBackup.test.tsx
@@ -56,6 +56,6 @@ describe("ManageYourBackup", () => {
     await user.click(deleteButton);
 
     //Success message
-    expect(await screen.findByText("Your Ledger Wallet apps are no longer synched")).toBeDefined();
+    expect(await screen.findByText("Your Ledger Wallet apps are no longer synced")).toBeDefined();
   });
 });

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/components/Complete.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/components/Complete.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { GenericStatusDisplay, GenericProps } from "./GenericStatusDisplay";
+
+export const Complete = (props: GenericProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <GenericStatusDisplay
+      {...props}
+      title={t("walletSync.success.complete.title")}
+      description={t("walletSync.success.complete.description")}
+      specificCta={props.specificCta ?? t("walletSync.success.complete.syncAnother")}
+      fullHeight
+    />
+  );
+};

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/components/GenericStatusDisplay.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/components/GenericStatusDisplay.tsx
@@ -16,6 +16,8 @@ export type GenericProps = {
   analyticsPage?: AnalyticsPage;
   type?: "success" | "info";
   specificCta?: string;
+  /** When true, uses a full height layout with content centered and buttons at bottom */
+  fullHeight?: boolean;
 };
 
 const Container = styled(Box)`
@@ -38,13 +40,13 @@ export const GenericStatusDisplay = ({
   analyticsPage,
   type,
   specificCta,
+  fullHeight = false,
 }: GenericProps) => {
   const { t } = useTranslation();
   const { colors } = useTheme();
 
-  return (
-    <Flex flexDirection="column" alignItems="center" justifyContent="center" rowGap="24px">
-      <TrackPage category={String(analyticsPage)} flow={AnalyticsFlow} />
+  const content = (
+    <>
       <Container>
         {type === "info" ? (
           <Icons.InformationFill size={"L"} color={colors.primary.c60} />
@@ -58,28 +60,54 @@ export const GenericStatusDisplay = ({
       <Text variant="bodyLineHeight" color="neutral.c70" textAlign="center">
         {description}
       </Text>
+    </>
+  );
 
-      {withClose || withCta ? (
-        <BottomContainer
-          mb={3}
-          width={"100%"}
-          px={"40px"}
+  const buttons = (withClose || withCta) && (
+    <BottomContainer
+      mb={fullHeight ? undefined : 3}
+      width="100%"
+      px={fullHeight ? undefined : "40px"}
+      flexDirection="column"
+      justifyContent={fullHeight ? undefined : "center"}
+      rowGap="16px"
+    >
+      {withCta && onClick && (
+        <ButtonV3 variant="main" onClick={onClick} flex={1}>
+          {specificCta ?? t("walletSync.success.synchAnother")}
+        </ButtonV3>
+      )}
+      {withClose && (
+        <ButtonV3 variant="shade" onClick={onClose} flex={1}>
+          {t("walletSync.success.close")}
+        </ButtonV3>
+      )}
+    </BottomContainer>
+  );
+
+  if (fullHeight) {
+    return (
+      <Flex flexDirection="column" alignItems="center" height="80%">
+        <TrackPage category={String(analyticsPage)} flow={AnalyticsFlow} />
+        <Flex
           flexDirection="column"
+          alignItems="center"
           justifyContent="center"
-          rowGap={"16px"}
+          rowGap="24px"
+          flex={1}
         >
-          {withCta && onClick && (
-            <ButtonV3 variant="main" onClick={onClick} flex={1}>
-              {specificCta ?? t("walletSync.success.synchAnother")}
-            </ButtonV3>
-          )}
-          {withClose && (
-            <ButtonV3 variant="shade" onClick={onClose} flex={1}>
-              {t("walletSync.success.close")}
-            </ButtonV3>
-          )}
-        </BottomContainer>
-      ) : null}
+          {content}
+        </Flex>
+        {buttons}
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex flexDirection="column" alignItems="center" justifyContent="center" rowGap="24px">
+      <TrackPage category={String(analyticsPage)} flow={AnalyticsFlow} />
+      {content}
+      {buttons}
     </Flex>
   );
 };

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/components/Success.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/components/Success.tsx
@@ -1,4 +1,11 @@
 import React from "react";
 import { GenericProps, GenericStatusDisplay } from "./GenericStatusDisplay";
-
-export const Success = (props: GenericProps) => <GenericStatusDisplay {...props} type="success" />;
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
+import { Complete } from "./Complete";
+export const Success = (props: GenericProps) => {
+  const lwdLedgerSyncOptimisation = useFeature("lwdLedgerSyncOptimisation");
+  if (lwdLedgerSyncOptimisation?.enabled) {
+    return <Complete {...props} />;
+  }
+  return <GenericStatusDisplay {...props} type="success" />;
+};

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Manage/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Manage/index.tsx
@@ -14,6 +14,7 @@ import { AnalyticsPage, useLedgerSyncAnalytics } from "../../hooks/useLedgerSync
 import { useLedgerSyncInfo } from "../../hooks/useLedgerSyncInfo";
 import { AlertError } from "../../components/AlertError";
 import { AlertLedgerSyncDown } from "../../components/AlertLedgerSyncDown";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 const Separator = () => {
   const { colors } = useTheme();
@@ -55,11 +56,14 @@ const WalletSyncManage = ({ currentPage }: Props) => {
     dispatch(setFlow({ flow: Flow.ManageInstances, step: Step.SynchronizedInstances }));
     onClickTrack({ button: "Manage Instances", page: currentPage });
   };
+  const ledgerSyncOptimisationFlag = useFeature("lwdLedgerSyncOptimisation");
 
   const Options: OptionProps[] = [
     {
       label: t("walletSync.manage.synchronize.label"),
-      description: t("walletSync.manage.synchronize.description"),
+      description: ledgerSyncOptimisationFlag?.enabled
+        ? t("settings.display.walletSyncDescription")
+        : t("walletSync.manage.synchronize.description"),
       onClick: goToSync,
       testId: "walletSync-synchronize",
     },

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/index.tsx
@@ -47,7 +47,11 @@ const SectionGeneral = () => {
         {!shouldDisplayEntryPoint ? (
           <Row
             title={t("settings.display.walletSync")}
-            desc={t("settings.display.walletSyncDesc")}
+            desc={
+              ledgerSyncOptimisationFlag?.enabled
+                ? t("settings.display.walletSyncDescription")
+                : t("settings.display.walletSyncDesc")
+            }
             dataTestId="setting-walletSync"
             id="setting-walletSync"
           >

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4530,6 +4530,7 @@
       "stockDesc": "Choose Western to display market increases in blue or Eastern to display them in red.",
       "walletSync": "Ledger Sync",
       "walletSyncDesc": "Sync your Ledger Wallet crypto accounts across different phones and computers.",
+      "walletSyncDescription": "Keep your portfolio up to date when switching computers or use a phone",
       "mevProtection": "MEV Protection",
       "mevProtectionDesc": "Enable MEV Protection for more reliable transactions on Ethereum.",
       "mevProtectionLearnMore": "Privacy notice",
@@ -7694,6 +7695,11 @@
         "title": "Sync successful!",
         "desc": "Changes in your crypto accounts will now automatically appear across Ledger Wallet apps on synched phones and computers. "
       },
+      "complete": {
+        "title": "Sync complete",
+        "description": "From now on, your portfolio will automatically stay sync across all your devices.",
+        "syncAnother": "Using Ledger on Mobile? Scan QR code "
+      },
       "synchAnother": "Sync with another Ledger Wallet app",
       "close": "Close"
     },
@@ -7705,7 +7711,7 @@
         "cancel": "Keep sync"
       },
       "deleteBackupSuccess": {
-        "title": "Your Ledger Wallet apps are no longer synched",
+        "title": "Your Ledger Wallet apps are no longer synced",
         "description": "You can turn on sync anytime"
       },
       "deleteBackupError": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3165,6 +3165,7 @@
       "dateFormatDesc": "Set the date format for Ledger Wallet",
       "walletSync": "Ledger Sync",
       "walletSyncDesc": "Sync your Ledger Wallet crypto accounts across different phones and computers.",
+      "walletSyncDescription": "Keep your portfolio up to date when switching computers or use a phone",
       "region": "Region",
       "regionDesc": "Choose your region to update formats of dates, time and currencies.",
       "password": "App lock",
@@ -7823,13 +7824,18 @@
       "sync": "Sync successful",
       "syncDesc": "Changes in your crypto accounts will now automatically appear across Ledger Wallet apps on synched phones and computers.",
       "activation": "Ledger Sync turned on for this phone",
+      "complete" : {
+        "title": "Sync complete",
+        "description": "From now on, your portfolio will automatically stay sync across all your devices."
+      },
       "syncAnother": "Sync with another Ledger Wallet app",
       "close": "Close"
     },
     "walletSyncActivated": {
       "synchronize": {
         "title": "Sync with another Ledger Wallet app",
-        "description": "Sync your Ledger Wallet crypto accounts across different phones and computers."
+        "description": "Sync your Ledger Wallet crypto accounts across different phones and computers.",
+        "desc": "Keep your portfolio up to date when switching computers or use a phone"
       },
       "unauthorizeMember": {
         "error": {
@@ -7841,7 +7847,7 @@
       "manageKey": {
         "title": "Delete Sync",
         "description": "Your crypto accounts across different phones and computers will stop synching.",
-        "success": "Your Ledger Wallet apps are no longer synched",
+        "success": "Your Ledger Wallet apps are no longer synced",
         "successHint": "You can turn on sync again anytime.",
         "confirm": {
           "delete": "Yes, delete",

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/useAddAccountViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/useAddAccountViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { track } from "~/analytics";
 import { useQRCodeHost } from "LLM/features/WalletSync/hooks/useQRCodeHost";
 import { Options, Steps } from "LLM/features/WalletSync/types/Activation";
@@ -8,7 +8,9 @@ import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/t
 import { WalletSyncNavigatorStackParamList } from "~/components/RootNavigator/types/WalletSyncNavigator";
 import { useCurrentStep } from "LLM/features/WalletSync/hooks/useCurrentStep";
 import { blockPasswordLock } from "~/actions/appstate";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 type AddAccountDrawerProps = {
   isOpened: boolean;
@@ -19,11 +21,19 @@ type NavigationProps = BaseComposite<
   StackNavigatorProps<WalletSyncNavigatorStackParamList, ScreenName.WalletSyncActivationProcess>
 >;
 
-const startingStep = Steps.AddAccountMethod;
-
 const useAddAccountViewModel = ({ isOpened, onClose }: AddAccountDrawerProps) => {
   const dispatch = useDispatch();
   const { currentStep, setCurrentStep } = useCurrentStep();
+  const trustchain = useSelector(trustchainSelector);
+  const ledgerSyncOptimisationFlag = useFeature("lwmLedgerSyncOptimisation");
+
+  const startingStep = useMemo(
+    () =>
+      ledgerSyncOptimisationFlag?.enabled && trustchain?.rootId
+        ? Steps.ChooseSyncMethod
+        : Steps.AddAccountMethod,
+    [ledgerSyncOptimisationFlag?.enabled, trustchain?.rootId],
+  );
   const [currentOption, setCurrentOption] = useState<Options>(Options.SCAN);
   const navigateToChooseSyncMethod = () => {
     dispatch(blockPasswordLock(true)); // Avoid Background on Android
@@ -38,7 +48,7 @@ const useAddAccountViewModel = ({ isOpened, onClose }: AddAccountDrawerProps) =>
 
   useEffect(() => {
     setCurrentStep(startingStep);
-  }, [isOpened, setCurrentStep]);
+  }, [isOpened, setCurrentStep, startingStep]);
 
   const reset = () => {
     dispatch(blockPasswordLock(false));
@@ -46,16 +56,19 @@ const useAddAccountViewModel = ({ isOpened, onClose }: AddAccountDrawerProps) =>
     setCurrentOption(Options.SCAN);
   };
 
-  const getPreviousStep = useCallback((step: Steps): Steps => {
-    switch (step) {
-      case Steps.QrCodeMethod:
-        return Steps.ChooseSyncMethod;
-      case Steps.ChooseSyncMethod:
-        return Steps.AddAccountMethod;
-      default:
-        return startingStep;
-    }
-  }, []);
+  const getPreviousStep = useCallback(
+    (step: Steps): Steps => {
+      switch (step) {
+        case Steps.QrCodeMethod:
+          return Steps.ChooseSyncMethod;
+        case Steps.ChooseSyncMethod:
+          return startingStep;
+        default:
+          return startingStep;
+      }
+    },
+    [startingStep],
+  );
 
   const trackButtonClick = useCallback((button: string) => {
     track("button_clicked", {

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/manageKey.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/manageKey.integration.test.tsx
@@ -68,6 +68,6 @@ describe("ManageKey", () => {
 
     await user.press(await screen.findByTestId("delete-trustchain"));
 
-    expect(await screen.findByText(/Your Ledger Wallet apps are no longer synched/i)).toBeVisible();
+    expect(await screen.findByText(/Your Ledger Wallet apps are no longer synced/i)).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/ActivationFlow.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/ActivationFlow.tsx
@@ -82,7 +82,7 @@ const ActivationFlow = ({
           <>
             <TrackScreen category={AnalyticsPage.ActivateLedgerSync} />
             {lwmLedgerSyncOptimisation?.enabled ? (
-              <ActivationModal onSyncMethodPress={onCreateKey} />
+              <ActivationModal onSyncMethodPress={navigateToChooseSyncMethod} />
             ) : (
               <Activation
                 onSyncMethodPress={onCreateKey}

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Success/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Success/index.tsx
@@ -4,6 +4,7 @@ import styled, { useTheme } from "styled-components/native";
 import { TrackScreen } from "~/analytics";
 import PreventNativeBack from "~/components/PreventNativeBack";
 import SafeAreaView from "~/components/SafeAreaView";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 type Props = {
   title: string;
   desc?: string;
@@ -23,6 +24,7 @@ type Props = {
 
 export function Success({ title, desc, mainButton, secondaryButton, analyticsPage }: Props) {
   const { colors } = useTheme();
+  const ledgerSyncOptimisationFlag = useFeature("lwmLedgerSyncOptimisation");
   return (
     <SafeAreaView edges={["top", "left", "right", "bottom"]} isFlex>
       <PreventNativeBack />
@@ -40,6 +42,8 @@ export function Success({ title, desc, mainButton, secondaryButton, analyticsPag
           justifyContent="center"
           rowGap={16}
           testID="walletsync-success"
+          flex={ledgerSyncOptimisationFlag?.enabled ? 1 : undefined}
+          mb={ledgerSyncOptimisationFlag?.enabled ? 80 : undefined}
         >
           <Container borderRadius={50}>
             <Icons.CheckmarkCircleFill size={"L"} color={colors.success.c60} />

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationSuccess.tsx
@@ -7,6 +7,7 @@ import { ScreenName } from "~/const";
 import { AnalyticsButton, AnalyticsFlow, AnalyticsPage } from "../../hooks/useLedgerSyncAnalytics";
 import { track } from "~/analytics";
 import { useClose } from "../../hooks/useClose";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 type Props = BaseComposite<
   StackNavigatorProps<WalletSyncNavigatorStackParamList, ScreenName.WalletSyncSuccess>
@@ -14,9 +15,18 @@ type Props = BaseComposite<
 
 export function ActivationSuccess({ route }: Props) {
   const { t } = useTranslation();
+  const ledgerSyncOptimisationFlag = useFeature("lwmLedgerSyncOptimisation");
   const { created } = route.params;
-  const title = created ? "walletSync.success.activation" : "walletSync.success.sync";
-  const desc = created ? "" : "walletSync.success.syncDesc";
+  const title = ledgerSyncOptimisationFlag?.enabled
+    ? "walletSync.success.complete.title"
+    : created
+      ? "walletSync.success.activation"
+      : "walletSync.success.sync";
+  const desc = ledgerSyncOptimisationFlag?.enabled
+    ? "walletSync.success.complete.description"
+    : created
+      ? ""
+      : "walletSync.success.syncDesc";
   const page = created ? AnalyticsPage.BackupCreationSuccess : AnalyticsPage.SyncSuccess;
 
   const close = useClose();

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Manage/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Manage/index.tsx
@@ -24,6 +24,7 @@ import { useCustomTimeOut } from "../../hooks/useCustomTimeOut";
 import { useDispatch } from "react-redux";
 import { blockPasswordLock } from "~/actions/appstate";
 import { isNoTrustchainError } from "../../utils/errors";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 const WalletSyncManage = () => {
   const { t } = useTranslation();
@@ -78,10 +79,13 @@ const WalletSyncManage = () => {
     });
   };
 
+  const ledgerSyncOptimisationFlag = useFeature("lwmLedgerSyncOptimisation");
   const Options: OptionProps[] = [
     {
       label: t("walletSync.walletSyncActivated.synchronize.title"),
-      description: t("walletSync.walletSyncActivated.synchronize.description"),
+      description: ledgerSyncOptimisationFlag?.enabled
+        ? t("walletSync.walletSyncActivated.synchronize.desc")
+        : t("walletSync.walletSyncActivated.synchronize.description"),
       onClick: goToSync,
       testId: "walletSync-synchronize",
       id: "synchronize",

--- a/apps/ledger-live-mobile/src/screens/Settings/General/WalletSyncRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/WalletSyncRow.tsx
@@ -15,6 +15,7 @@ import { Steps } from "LLM/features/WalletSync/types/Activation";
 import { activateDrawerSelector } from "~/reducers/walletSync";
 import { setLedgerSyncActivateDrawer } from "~/actions/walletSync";
 import { useCurrentStep } from "LLM/features/WalletSync/hooks/useCurrentStep";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 const WalletSyncRow = () => {
   const { t } = useTranslation();
@@ -30,7 +31,7 @@ const WalletSyncRow = () => {
     setCurrentStep(Steps.Activation);
   }, [dispatch, setCurrentStep]);
   const trustchain = useSelector(trustchainSelector);
-
+  const ledgerSyncOptimisationFlag = useFeature("lwmLedgerSyncOptimisation");
   const navigateToWalletSyncActivationScreen = useCallback(() => {
     // Here we need to check if the user has a backup or not to determine the screen to navigate to
     onClickTrack({ button: AnalyticsButton.LedgerSync, page: AnalyticsPage.SettingsGeneral });
@@ -49,7 +50,11 @@ const WalletSyncRow = () => {
       <SettingsRow
         event="WalletSyncSettingsRow"
         title={t("settings.display.walletSync")}
-        desc={t("settings.display.walletSyncDesc")}
+        desc={
+          ledgerSyncOptimisationFlag?.enabled
+            ? t("settings.display.walletSyncDescription")
+            : t("settings.display.walletSyncDesc")
+        }
         arrowRight
         onPress={navigateToWalletSyncActivationScreen}
         testID="wallet-sync-button"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Update Sync complete screen (LWM-LWD)
- Update Copy in the settings  (LWM-LWD)
- After clicking on sync modal, I should have the option to use my device or scan a qr code (LWM)
- When ledger sync is activated, I don't see anymore the option to use ledger sync when adding an account which is not needed (LWM)
- When deleting a sync, update the wording from “synched” to “synced”  (LWM-LWD)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24114] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24114]: https://ledgerhq.atlassian.net/browse/LIVE-24114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ