### PR TITLE
[QAA][E2E][CI][Mobile] use 6 shard for iOS hotfix

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -148,6 +148,7 @@ jobs:
           test_directory: e2e/mobile
           test_filter: ${{ inputs.test_filter || '' }}
           event_name: ${{ github.event_name }}
+          ref: ${{ inputs.ref || github.ref_name }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/tools/actions/composites/generate-shards-matrix/action.yml
+++ b/tools/actions/composites/generate-shards-matrix/action.yml
@@ -12,6 +12,9 @@ inputs:
   event_name:
     description: "GitHub event name (workflow_dispatch or schedule)"
     required: true
+  ref:
+    description: "Branch ref"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -33,7 +36,7 @@ runs:
         if [ "${{ github.event_name }}" = "schedule" ]; then
           SHARD_COUNT_IOS=12
           SHARD_COUNT_ANDROID=12
-        elif [[ "${{ github.ref }}" == *"release"* ]]; then
+        elif [[ "${{ inputs.ref }}" == *"release"* || "${{ inputs.ref }}" == *"hotfix"* ]]; then
           SHARD_COUNT_IOS=6
           SHARD_COUNT_ANDROID=12
         else


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E Mobile workflow

### 📝 Description

Expanding use of 6 iOS runner to hotfix branch
Fixing shard number when targeting release/hotfix via ref branch input (instead of workflow branch)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

Launching Add Accounts tests :
- Normal branch -> 2 shard [Link](https://github.com/LedgerHQ/ledger-live/actions/runs/20159856775)
- Release branch -> 6 shard [Link](https://github.com/LedgerHQ/ledger-live/actions/runs/20159839069)
- Hotfix branch -> 6 shard [Link](https://github.com/LedgerHQ/ledger-live/actions/runs/20159806140)
- Normal worklfow with release branch ref -> 6 shard [Link](https://github.com/LedgerHQ/ledger-live/actions/runs/20160117988)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
