### PR TITLE
chore: update XLM send bug ticket number

### DIFF
--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -535,7 +535,7 @@ export class SwapPage extends AppPage {
 
   async getMinimumAmount(accountFrom: Account, accountTo: Account) {
     const amount = await getMinimumSwapAmount(accountFrom, accountTo);
-    return amount ? parseFloat(amount.toFixed(6)).toString() : "";
+    return amount ? Number.parseFloat(amount.toFixed(6)).toString() : "";
   }
 
   @step("Click on swap max")

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -174,7 +174,7 @@ const transactionE2E = [
   {
     transaction: new Transaction(Account.XLM_1, Account.XLM_2, "0.0001", undefined, "noTag"),
     xrayTicket: "B2CQA-2813",
-    bugTicket: "LIVE-20362",
+    bugTicket: "LIVE-24214",
   },
   {
     transaction: new Transaction(Account.ATOM_1, Account.ATOM_2, "0.00001", undefined, "noTag"),

--- a/libs/ledger-live-common/src/e2e/swap.ts
+++ b/libs/ledger-live-common/src/e2e/swap.ts
@@ -29,8 +29,8 @@ export async function getMinimumSwapAmount(AccountFrom: Account, AccountTo: Acco
 
     const minimumAmounts = data
       .filter((item: any) => item.parameter?.minAmount !== undefined)
-      .map((item: any) => parseFloat(item.parameter.minAmount))
-      .filter((amount: number) => !isNaN(amount));
+      .map((item: any) => Number.parseFloat(item.parameter.minAmount))
+      .filter((amount: number) => !Number.isNaN(amount));
 
     if (minimumAmounts.length === 0) {
       throw new Error("No valid minimum amounts returned from swap quote API.");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
