### PR TITLE
fix(coin-evm): allow custom `gasLimit` in `craftTransaction`

### DIFF
--- a/.changeset/lucky-walls-tan.md
+++ b/.changeset/lucky-walls-tan.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+fix(coin-evm): allow custom `gasLimit` in `craftTransaction`

--- a/libs/coin-modules/coin-evm/src/logic/common.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.ts
@@ -105,6 +105,7 @@ function getCallData(intent: TransactionIntent<MemoNotSupported, BufferTxData>):
 export async function prepareUnsignedTxParams(
   currency: CryptoCurrency,
   transactionIntent: TransactionIntent<MemoNotSupported, BufferTxData>,
+  customFeesParameters?: FeeEstimation["parameters"],
 ): Promise<TransactionLikeWithPreparedParams> {
   const { sender, type } = transactionIntent;
 
@@ -122,15 +123,18 @@ export async function prepareUnsignedTxParams(
         };
       })()
     : buildStakingTransactionParams(currency, transactionIntent);
-  // Implementations of `getGasEstimation` throw an error when
-  // trying to send more token asset than available.
-  // Fallback to an estimation of 0 to not break the UI.
-  const gasLimit = await node
-    .getGasEstimation(
-      { currency, freshAddress: sender },
-      { amount: BigNumber(value.toString()), recipient: to, data },
-    )
-    .catch(() => new BigNumber(0));
+  const gasLimit =
+    typeof customFeesParameters?.gasLimit === "bigint"
+      ? BigNumber(customFeesParameters.gasLimit.toString())
+      : // Implementations of `getGasEstimation` throw an error when
+        // trying to send more token asset than available.
+        // Fallback to an estimation of 0 to not break the UI.
+        await node
+          .getGasEstimation(
+            { currency, freshAddress: sender },
+            { amount: BigNumber(value.toString()), recipient: to, data },
+          )
+          .catch(() => new BigNumber(0));
 
   return {
     type: transactionType,

--- a/libs/coin-modules/coin-evm/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-evm/src/logic/craftTransaction.ts
@@ -25,6 +25,7 @@ export async function craftTransaction(
   const { type, to, data, value, gasLimit } = await prepareUnsignedTxParams(
     currency,
     transactionIntent,
+    customFees?.parameters,
   );
 
   // Some apps including, including Magic Eden, set the nonce to -1


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - EVM sign operation

### 📝 Description

Allow custom `gasLimit` to be passed in `craftTransaction`, the same way we already allow fee data (`gasPrice`, `maxFeePerGas` and `maxProprityFeePerGas`). This guarantees fees are not updated just before signing. 
In a swap scenarios, a mismatch between fees passed in Exchange app and fees passed in coin apps such as the Ethereum app results in `Incorrect transaction` on the device when signing

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
