### PR TITLE
ci: adjust codeowners to ensure mock tests are hub owned

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -213,8 +213,8 @@ apps/web-tools/trustchain/                               @ledgerhq/live-hub
 
 # UI tests
 apps/ledger-live-desktop/tests/                                             @ledgerhq/live-hub
-apps/ledger-live-mobile/e2e/                                                @ledgerhq/live-hub
 e2e/                                                                        @ledgerhq/qaa
+apps/ledger-live-mobile/e2e/                                                @ledgerhq/live-hub
 tools/actions/composites/merge-e2e-detox-timings/                           @ledgerhq/qaa
 
 # Cross-team generic files can be opted out (no strict ownership when it concerns everyone)


### PR DESCRIPTION
Re-order codeowners to reflect ownership

<img width="450" height="107" alt="Screenshot 2025-12-16 at 14 23 40" src="https://github.com/user-attachments/assets/8458c8b9-23d5-431a-8ac0-d608f7880ed9" />

