### PR TITLE
fix: should close drawer when selecting account on AddAccountDrawer when coming from Dialog

### DIFF
--- a/.changeset/giant-teachers-notice.md
+++ b/.changeset/giant-teachers-notice.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+After select an account should close Drawer when coming form MADialog

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDialog/hooks/useDetailedAccounts.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDialog/hooks/useDetailedAccounts.tsx
@@ -19,6 +19,7 @@ import { Account, AccountLike } from "@ledgerhq/types-live";
 import { useBatchMaybeAccountName } from "~/renderer/reducers/wallet";
 import orderBy from "lodash/orderBy";
 import { modularDrawerSourceSelector } from "~/renderer/reducers/modularDrawer";
+import { setDrawer } from "~/renderer/drawers/Provider";
 
 export const useDetailedAccounts = (
   asset: CryptoOrTokenCurrency,
@@ -31,6 +32,17 @@ export const useDetailedAccounts = (
   const { openAddAccountFlow } = useOpenAssetFlowDialog(
     { location: ModularDrawerLocation.ADD_ACCOUNT },
     source,
+  );
+
+  // Wrapper to close the drawer after account selection (from Dialog)
+  const wrappedOnAccountSelected = useCallback(
+    (account: AccountLike, parentAccount?: Account) => {
+      if (onAccountSelected) {
+        onAccountSelected(account, parentAccount);
+        setDrawer();
+      }
+    },
+    [onAccountSelected],
   );
 
   const nestedAccounts = useSelector(accountsSelector);
@@ -72,8 +84,8 @@ export const useDetailedAccounts = (
       button: "Add a new account",
       page: MODULAR_DRAWER_PAGE_NAME.MODULAR_ACCOUNT_SELECTION,
     });
-    openAddAccountFlow(asset, false, onAccountSelected);
-  }, [asset, openAddAccountFlow, trackModularDrawerEvent, onAccountSelected]);
+    openAddAccountFlow(asset, false, wrappedOnAccountSelected);
+  }, [asset, openAddAccountFlow, trackModularDrawerEvent, wrappedOnAccountSelected]);
 
   return { detailedAccounts, accounts, onAddAccountClick };
 };


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When working on e2e I saw that the drawer wasn't closing when clicking on "Continue" like it was the case in the MADrawer

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
