### PR TITLE
test(wallet-api): enhance visibility checks for asset and account selection [LIVE-24094]

### DIFF
--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -123,15 +123,20 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await liveAppWebview.accountRequest();
 
     await drawer.waitForDrawerToBeVisible();
+    await expect(drawer.selectAssetTitle).toBeVisible();
 
     await drawer.selectCurrency("tether usd");
+    await expect(drawer.selectAccountTitle).toBeVisible();
+
     // Test name and balance for tokens
     await expect(drawer.getAccountButton("tether usd", 2)).toContainText(
       "Ethereum 3 (USDT)71.8174 USDT",
     );
     await drawer.back();
+    await expect(drawer.selectAssetTitle).toBeVisible();
 
     await drawer.selectCurrency("bitcoin");
+    await expect(drawer.selectAccountTitle).toBeVisible();
     await drawer.selectAccount("bitcoin");
 
     await drawer.waitForDrawerToDisappear();


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. No need for tests
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Wallet-API mock test stability

### 📝 Description

This pull request adds additional UI assertions to the Wallet API smoke test to ensure that key drawer titles are visible at the appropriate steps. This helps verify that the user interface behaves as expected during account and asset selection, while also helping with flakiness.

UI test improvements:

* Added assertions to check that `drawer.selectAssetTitle` is visible after opening the drawer and after navigating back, ensuring the asset selection title appears at the correct times.
* Added assertions to check that `drawer.selectAccountTitle` is visible after selecting a currency, confirming that the account selection title is displayed appropriately.

Originally created to fix flakiness in this PR: https://github.com/LedgerHQ/ledger-live/pull/13340

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24094]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24094]: https://ledgerhq.atlassian.net/browse/LIVE-24094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ