### PR TITLE
fix(lwm): added animation to ledger sync drawer qr scan

### DIFF
--- a/.changeset/cyan-carpets-itch.md
+++ b/.changeset/cyan-carpets-itch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix(lwm): added animation to ledger sync drawer qr scan

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/QrCodeMethod.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/QrCodeMethod.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { DrawerTabSelector, Flex } from "@ledgerhq/native-ui";
 import QrCode from "LLM/features/WalletSync/components/Synchronize/QrCode";
 import ScanQrCode from "../../components/Synchronize/ScanQrCode";
@@ -10,6 +10,7 @@ import {
   AnalyticsButton,
 } from "../../hooks/useLedgerSyncAnalytics";
 import { TrackScreen } from "~/analytics";
+import Animated, { useSharedValue, useAnimatedStyle, withTiming } from "react-native-reanimated";
 
 interface Props {
   setSelectedOption: (option: OptionsType) => void;
@@ -26,6 +27,32 @@ const QrCodeMethod = ({
 }: Props) => {
   const { onClickTrack } = useLedgerSyncAnalytics();
   const { t } = useTranslation();
+  const prevOption = useRef(currentOption);
+
+  const opacity = useSharedValue(1);
+  const translateX = useSharedValue(0);
+
+  const animatedStyle = useAnimatedStyle(
+    () => ({
+      opacity: opacity.value,
+      transform: [{ translateX: translateX.value }],
+    }),
+    [opacity, translateX],
+  );
+
+  useEffect(() => {
+    if (prevOption.current === currentOption) return;
+
+    const direction = currentOption === Options.SCAN ? -1 : 1;
+
+    opacity.value = 0;
+    translateX.value = direction * 20;
+
+    opacity.value = withTiming(1, { duration: 200 });
+    translateX.value = withTiming(0, { duration: 200 });
+
+    prevOption.current = currentOption;
+  }, [currentOption, opacity, translateX]);
 
   const handleSelectOption = (option: OptionsType) => {
     setSelectedOption(option);
@@ -68,7 +95,7 @@ const QrCodeMethod = ({
           [Options.SHOW_QR]: t("walletSync.synchronize.qrCode.show.title"),
         }}
       />
-      {renderSwitch()}
+      <Animated.View style={animatedStyle}>{renderSwitch()}</Animated.View>
     </Flex>
   );
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - add transition animation to QR code drawer content when switching between tabs in Ledger Sync add flow

### 📝 Description

The Ledger Sync drawer on mobile does not show a transition when switching between 'Scan' and 'Show QR'. This PR fixes this bug and adds a smooth transition to the `QrCodeMethod.tsx` file.

Video showing before:

https://github.com/user-attachments/assets/204e8165-f06d-470f-a46b-83392503e6d3

Video showing after:


https://github.com/user-attachments/assets/ca16a9b4-d611-43e9-a9d7-6dc3ba480a55



### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
[LIVE-23624](https://ledgerhq.atlassian.net/browse/LIVE-23624)

In the JIRA ticket I've added a before and after screen recording.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
