### PR TITLE
feat(lwm): shorten the static splash screen

### DIFF
--- a/.changeset/breezy-paws-develop.md
+++ b/.changeset/breezy-paws-develop.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Shorten the static splash screen

--- a/apps/ledger-live-mobile/src/StartupTimeMarker.tsx
+++ b/apps/ledger-live-mobile/src/StartupTimeMarker.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { View } from "react-native";
-import { logStartupEvent } from "LLM/utils/logStartupTime";
-import { STARTUP_EVENTS } from "LLM/utils/resolveStartupEvents";
+import { LAST_STARTUP_EVENTS, logLastStartupEvents } from "LLM/utils/logLastStartupEvents";
 
 let nativeMethodInvokedOnce = false;
 
@@ -10,7 +9,7 @@ export const StartupTimeMarker = ({ children }: { children: React.ReactNode }) =
   const onLayout = React.useCallback(() => {
     if (!nativeMethodInvokedOnce) {
       nativeMethodInvokedOnce = true;
-      logStartupEvent(STARTUP_EVENTS.LEGACY_STARTED);
+      logLastStartupEvents(LAST_STARTUP_EVENTS.APP_STARTED);
     }
   }, []);
   return (

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -62,7 +62,8 @@ import { aggregateData, getUniqueModelIdList } from "../logic/modelIdList";
 import { getMigrationUserProps } from "LLM/storage/utils/migrations/analytics";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { getVersionedRedirects } from "LLM/hooks/useStake/useVersionedStakePrograms";
-import { resolveStartupEvents, STARTUP_EVENTS } from "LLM/utils/resolveStartupEvents";
+import { LAST_STARTUP_EVENTS } from "LLM/utils/logLastStartupEvents";
+import { resolveStartupEvents } from "LLM/utils/resolveStartupEvents";
 import { getTotalStakeableAssets } from "@ledgerhq/live-common/domain/getTotalStakeableAssets";
 
 const sessionId = uuid();
@@ -326,7 +327,7 @@ const extraProperties = async (store: AppStore) => {
 
   const startupEvents = await resolveStartupEvents();
   const legacyStartupTime = startupEvents.find(
-    ({ event }) => event === STARTUP_EVENTS.LEGACY_STARTED,
+    ({ event }) => event === LAST_STARTUP_EVENTS.APP_STARTED,
   )?.time;
 
   return {

--- a/apps/ledger-live-mobile/src/newArch/utils/__tests__/logLastStartupEvents.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/utils/__tests__/logLastStartupEvents.test.ts
@@ -1,0 +1,95 @@
+import { DdRumReactNavigationTracking } from "@datadog/mobile-react-navigation";
+import { track } from "~/analytics";
+import { navigationRef } from "~/rootnavigation";
+import { viewNamePredicate } from "~/datadog";
+import { logStartupEvent, startupEvents, startupFirstImportTime } from "../logStartupTime";
+import { logLastStartupEvents, LAST_STARTUP_EVENTS } from "../logLastStartupEvents";
+
+jest.mock("@datadog/mobile-react-navigation", () => ({
+  DdRumReactNavigationTracking: { startTrackingViews: jest.fn() },
+}));
+jest.mock("~/analytics", () => ({ track: jest.fn() }));
+jest.mock("~/rootnavigation", () => ({ navigationRef: { current: {} } }));
+jest.mock("~/datadog", () => ({ viewNamePredicate: jest.fn() }));
+
+describe("logLastStartupEvents", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    startupEvents.splice(0);
+  });
+
+  it("tracks all startup events once both APP_STARTED and NAV_READY are logged", async () => {
+    logStartupEvent("Step 1");
+    await logLastStartupEvents(LAST_STARTUP_EVENTS.NAV_READY);
+    const appStartedEvent = await logLastStartupEvents(LAST_STARTUP_EVENTS.APP_STARTED);
+
+    expect(DdRumReactNavigationTracking.startTrackingViews).toHaveBeenCalledTimes(1);
+    expect(DdRumReactNavigationTracking.startTrackingViews).toHaveBeenCalledWith(
+      navigationRef.current,
+      viewNamePredicate,
+    );
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith("app_startup_events", {
+      appStartupTime: appStartedEvent.time - startupFirstImportTime,
+      events: expect.arrayContaining([
+        expect.objectContaining({ event: "Step 1", count: 1 }),
+        expect.objectContaining({ event: LAST_STARTUP_EVENTS.APP_STARTED, count: 1 }),
+        expect.objectContaining({ event: LAST_STARTUP_EVENTS.NAV_READY, count: 1 }),
+      ]),
+    });
+  });
+
+  it("does not track startup events if APP_STARTED is not logged", async () => {
+    await logLastStartupEvents(LAST_STARTUP_EVENTS.NAV_READY);
+
+    expect(startupEvents).toEqual([
+      expect.objectContaining({ event: LAST_STARTUP_EVENTS.NAV_READY }),
+    ]);
+    expect(DdRumReactNavigationTracking.startTrackingViews).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("does not track startup events if NAV_READY is not logged", async () => {
+    await logLastStartupEvents(LAST_STARTUP_EVENTS.APP_STARTED);
+
+    expect(startupEvents).toEqual([
+      expect.objectContaining({ event: LAST_STARTUP_EVENTS.APP_STARTED }),
+    ]);
+    expect(DdRumReactNavigationTracking.startTrackingViews).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("triggers tracking only once", async () => {
+    await logLastStartupEvents(LAST_STARTUP_EVENTS.APP_STARTED);
+    await logLastStartupEvents(LAST_STARTUP_EVENTS.NAV_READY);
+    expect(track).toHaveBeenCalledTimes(1);
+
+    await logLastStartupEvents(LAST_STARTUP_EVENTS.APP_STARTED);
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  it("correctly extracts the LAST_STARTUP_EVENTS time as appStartupTime", async () => {
+    logStartupEvent("First");
+    logStartupEvent("Second");
+    await logLastStartupEvents(LAST_STARTUP_EVENTS.APP_STARTED);
+    const trackingCallEvent = logLastStartupEvents(LAST_STARTUP_EVENTS.NAV_READY);
+    const last = logStartupEvent("Last");
+    expect(last).toEqual(expect.objectContaining({ event: "Last" }));
+    last.time += 50; // Make sure the last event is a few ms after NAV_READY
+
+    const navReadyEvent = await trackingCallEvent;
+    const expectedStartupTime = navReadyEvent!.time - startupFirstImportTime;
+    expect(track).toHaveBeenCalledWith("app_startup_events", {
+      appStartupTime: expectedStartupTime,
+      events: expect.arrayContaining([
+        expect.objectContaining({ event: "First" }),
+        expect.objectContaining({ event: "Second" }),
+        expect.objectContaining({ event: LAST_STARTUP_EVENTS.APP_STARTED }),
+        expect.objectContaining({ event: LAST_STARTUP_EVENTS.NAV_READY }),
+        expect.objectContaining({ event: "Last", time: last!.time - startupFirstImportTime }),
+      ]),
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/newArch/utils/__tests__/logStartupTime.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/utils/__tests__/logStartupTime.test.ts
@@ -10,13 +10,10 @@ describe("logStartupTime", () => {
   it("should log startup events and resolve them correctly", async () => {
     startupEvents.splice(0);
     jest.useRealTimers();
-    logStartupEvent("Step 1");
+    const step1 = logStartupEvent("Step 1");
     const p = new Promise(r => setTimeout(() => r(logStartupEvent("Step 3"))));
-    logStartupEvent("Step 2");
-    expect(startupEvents).toEqual([
-      { event: "Step 1", time: expect.any(Number) },
-      { event: "Step 2", time: expect.any(Number) },
-    ]);
+    const step2 = logStartupEvent("Step 2");
+    expect(startupEvents).toEqual([step1, step2]);
     await p;
     expect(await resolveStartupEvents()).toEqual([
       { event: "Step 1", time: expect.any(Number), count: 1 },

--- a/apps/ledger-live-mobile/src/newArch/utils/logLastStartupEvents.ts
+++ b/apps/ledger-live-mobile/src/newArch/utils/logLastStartupEvents.ts
@@ -1,0 +1,47 @@
+import { DdRumReactNavigationTracking } from "@datadog/mobile-react-navigation";
+import { track } from "~/analytics";
+import { navigationRef } from "~/rootnavigation";
+import { viewNamePredicate } from "~/datadog";
+import { logStartupEvent, type StartupEvent, startupEvents } from "./logStartupTime";
+import { resolveStartupEvents } from "./resolveStartupEvents";
+
+type LastStartupEvent = (typeof LAST_STARTUP_EVENTS)[keyof typeof LAST_STARTUP_EVENTS];
+
+export const LAST_STARTUP_EVENTS = {
+  APP_STARTED: "App started",
+  NAV_READY: "Splash screen faded",
+} as const;
+export const LAST_STARTUP_EVENT_VALUES: string[] = Object.values(LAST_STARTUP_EVENTS);
+
+/**
+ * Logs a startup-related event and conditionally then triggers startup tracking once startup is complete.
+ *
+ * Startup is considered complete when:
+ * - Every value in {@link LAST_STARTUP_EVENT_VALUES} has been logged at least once in {@link startupEvents}
+ *
+ * In practice both "App started" and "Splash screen faded" might happen in different orders. Thus, this just makes sure
+ * both events happened and at least once before triggering the tracking.
+ * As the tracking functions should only be called once this also ensures this is the first time the given event was logged.
+ *
+ * @param eventName One of the last startup event labels defined in {@link LastStartupEvent}.
+ * @returns The {@link StartupEvent} instance recorded for this call.
+ */
+export async function logLastStartupEvents(eventName: LastStartupEvent): Promise<StartupEvent> {
+  const event = logStartupEvent(eventName);
+  const lastEventCalls = startupEvents.flatMap(e =>
+    LAST_STARTUP_EVENT_VALUES.includes(e.event) ? e.event : [],
+  );
+  const isStartupDone = new Set(lastEventCalls).size === LAST_STARTUP_EVENT_VALUES.length;
+  const isStartupLastCall = lastEventCalls.filter(e => e === eventName).length === 1;
+  if (isStartupDone && isStartupLastCall) {
+    try {
+      DdRumReactNavigationTracking.startTrackingViews(navigationRef.current, viewNamePredicate);
+      const events = await resolveStartupEvents();
+      const appStartupTime = events.find(e => e.event === eventName)?.time ?? 0;
+      await track("app_startup_events", { appStartupTime, events });
+    } catch (error) {
+      console.error("Error during app startup tracking:", error);
+    }
+  }
+  return event;
+}

--- a/apps/ledger-live-mobile/src/newArch/utils/logStartupTime.ts
+++ b/apps/ledger-live-mobile/src/newArch/utils/logStartupTime.ts
@@ -7,7 +7,9 @@ export const startupFirstImportTime = Date.now();
 export type StartupEvent = { event: string; time: number };
 export const startupEvents: StartupEvent[] = [];
 
-export function logStartupEvent(eventName: string) {
+export function logStartupEvent(eventName: string): StartupEvent {
   if (__DEV__) console.timeLog("LogStartupTime", eventName);
-  startupEvents.push({ event: eventName, time: Date.now() });
+  const event = { event: eventName, time: Date.now() };
+  startupEvents.push(event);
+  return event;
 }

--- a/apps/ledger-live-mobile/src/newArch/utils/resolveStartupEvents.ts
+++ b/apps/ledger-live-mobile/src/newArch/utils/resolveStartupEvents.ts
@@ -3,11 +3,6 @@ import { startupEvents, startupFirstImportTime, type StartupEvent } from "./logS
 
 export type GroupedStartupEvent = StartupEvent & { count: number };
 
-export const STARTUP_EVENTS = {
-  LEGACY_STARTED: "App started",
-  STARTED: "Splash screen faded",
-} as const;
-
 const startupTsp = new Promise<number>(resolve => {
   // On dev it doesn't make sense to compare to the app starting time due to metro start time
   // And also because react-native-startup-time does not reset on reload (so it keeps on increasing).

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Performance/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Performance/index.tsx
@@ -1,20 +1,20 @@
 import React, { useEffect, useState } from "react";
 import { Text } from "@ledgerhq/native-ui";
-import {
-  type GroupedStartupEvent,
-  resolveStartupEvents,
-  STARTUP_EVENTS,
-} from "LLM/utils/resolveStartupEvents";
+import { LAST_STARTUP_EVENT_VALUES } from "LLM/utils/logLastStartupEvents";
+import { type GroupedStartupEvent, resolveStartupEvents } from "LLM/utils/resolveStartupEvents";
 import SettingsRow from "~/components/SettingsRow";
 import SettingsNavigationScrollView from "../../SettingsNavigationScrollView";
 
 export default function Performance() {
   const [startupEvents, setStartupEvents] = useState<GroupedStartupEvent[]>([]);
   const [startupTime, setStartupTime] = useState<number>();
+
   useEffect(() => {
     resolveStartupEvents().then(events => {
+      setStartupTime(
+        [...events].reverse().find(e => LAST_STARTUP_EVENT_VALUES.includes(e.event))?.time ?? 0,
+      );
       setStartupEvents(events);
-      setStartupTime(events.find(({ event }) => event === STARTUP_EVENTS.STARTED)?.time);
     });
   }, []);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

An even faster static splash screen 🏎️ 

Start fading out the native splash screen before the app start but use a dark grey background (#18171A) which matches the splash screen to prevent the white screen flash. So the user sees the app as soon as it's ready and it makes the start feel even faster thanks to the fade out which starts a few ms before that.

Demo:

https://github.com/user-attachments/assets/c4cea3aa-3fdf-4622-9711-247208429a80



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24223]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24223]: https://ledgerhq.atlassian.net/browse/LIVE-24223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ