### PR TITLE
feat: save timestamp in the recentAddresses store

### DIFF
--- a/.changeset/soft-ladybugs-suffer.md
+++ b/.changeset/soft-ladybugs-suffer.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-wallet": minor
+---
+
+feat: save timestamp in the recentlAddresses store

--- a/libs/ledger-live-common/src/account/recentAddresses.test.ts
+++ b/libs/ledger-live-common/src/account/recentAddresses.test.ts
@@ -17,7 +17,13 @@ describe("RecentAddressesStore", () => {
     const addresses = store.getAddresses("ethereum");
     expect(addresses).toEqual([newAddress]);
     expect(onAddAddressCompleteMock).toHaveBeenCalledTimes(1);
-    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({ ethereum: [newAddress] });
+    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({
+      ethereum: [
+        expect.objectContaining({
+          address: newAddress,
+        }),
+      ],
+    });
   });
 
   it("should add a second address and return addresses sorted by insertion", async () => {
@@ -26,14 +32,21 @@ describe("RecentAddressesStore", () => {
     let addresses = store.getAddresses("ethereum");
     expect(addresses).toEqual([newAddress]);
     expect(onAddAddressCompleteMock).toHaveBeenCalledTimes(1);
-    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({ ethereum: [newAddress] });
+    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({
+      ethereum: [expect.objectContaining({ address: newAddress })],
+    });
 
     const newAddress2 = "0xB69B37A4Fb4A18b3258f974ff6e9f529AD2647b1";
     await store.addAddress("ethereum", newAddress2);
     addresses = store.getAddresses("ethereum");
     expect(addresses).toEqual([newAddress2, newAddress]);
     expect(onAddAddressCompleteMock).toHaveBeenCalledTimes(2);
-    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({ ethereum: [newAddress2, newAddress] });
+    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({
+      ethereum: [
+        expect.objectContaining({ address: newAddress2 }),
+        expect.objectContaining({ address: newAddress }),
+      ],
+    });
   });
 
   it("should replace at first place when an address is already saved", async () => {
@@ -42,43 +55,61 @@ describe("RecentAddressesStore", () => {
     let addresses = store.getAddresses("ethereum");
     expect(addresses).toEqual([newAddress]);
     expect(onAddAddressCompleteMock).toHaveBeenCalledTimes(1);
-    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({ ethereum: [newAddress] });
+    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({
+      ethereum: [expect.objectContaining({ address: newAddress })],
+    });
 
     const newAddress2 = "0xB69B37A4Fb4A18b3258f974ff6e9f529AD2647b1";
     await store.addAddress("ethereum", newAddress2);
     addresses = store.getAddresses("ethereum");
     expect(addresses).toEqual([newAddress2, newAddress]);
     expect(onAddAddressCompleteMock).toHaveBeenCalledTimes(2);
-    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({ ethereum: [newAddress2, newAddress] });
+    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({
+      ethereum: [
+        expect.objectContaining({ address: newAddress2 }),
+        expect.objectContaining({ address: newAddress }),
+      ],
+    });
 
     await store.addAddress("ethereum", newAddress);
     addresses = store.getAddresses("ethereum");
     expect(addresses).toEqual([newAddress, newAddress2]);
     expect(onAddAddressCompleteMock).toHaveBeenCalledTimes(3);
-    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({ ethereum: [newAddress, newAddress2] });
+    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({
+      ethereum: [
+        expect.objectContaining({ address: newAddress }),
+        expect.objectContaining({ address: newAddress2 }),
+      ],
+    });
   });
 
   it("should replace at first place and remove last element when addresses exceed count limit", async () => {
-    let expectedAddresses: string[] = [];
+    const expectedAddresses: string[] = [];
+    const expectedObjects: any[] = [];
     for (let index = 0; index < RECENT_ADDRESSES_COUNT_LIMIT; index++) {
-      await store.addAddress("ethereum", `0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3${index}`);
-      expectedAddresses.unshift(`0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3${index}`);
+      const addr = `0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3${index}`;
+      await store.addAddress("ethereum", addr);
+      expectedAddresses.unshift(addr);
+      expectedObjects.unshift(expect.objectContaining({ address: addr }));
     }
 
     let addresses = store.getAddresses("ethereum");
     expect(addresses).toEqual(expectedAddresses);
     expect(onAddAddressCompleteMock).toHaveBeenCalledTimes(RECENT_ADDRESSES_COUNT_LIMIT);
-    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({ ethereum: expectedAddresses });
+    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({ ethereum: expectedObjects });
 
     const newAddress2 = "0xB69B37A4Fb4A18b3258f974ff6e9f529AD2647b1";
     expectedAddresses.splice(expectedAddresses.length - 1, 1);
-    expectedAddresses = [newAddress2, ...expectedAddresses];
+    expectedAddresses.unshift(newAddress2);
+
+    expectedObjects.splice(expectedObjects.length - 1, 1);
+    expectedObjects.unshift(expect.objectContaining({ address: newAddress2 }));
 
     await store.addAddress("ethereum", newAddress2);
     addresses = store.getAddresses("ethereum");
     expect(addresses).toEqual(expectedAddresses);
     expect(onAddAddressCompleteMock).toHaveBeenCalledTimes(RECENT_ADDRESSES_COUNT_LIMIT + 1);
-    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({ ethereum: expectedAddresses });
+    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({ ethereum: expectedObjects });
   });
 
   it("should add an address of a different currency", async () => {
@@ -88,7 +119,9 @@ describe("RecentAddressesStore", () => {
     let addresses = store.getAddresses("ethereum");
     expect(addresses).toEqual([newAddress]);
     expect(onAddAddressCompleteMock).toHaveBeenCalledTimes(1);
-    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({ ethereum: [newAddress] });
+    expect(onAddAddressCompleteMock).toHaveBeenCalledWith({
+      ethereum: [expect.objectContaining({ address: newAddress })],
+    });
 
     const newAddress2 = "bc1pxlmrudqyq8qd8pfsc4mpmlaw56x6vtcr9m8nvp8kj3gckefc4kmqhkg4l7";
     await store.addAddress("bitcoin", newAddress2);
@@ -97,8 +130,75 @@ describe("RecentAddressesStore", () => {
     expect(addresses).toEqual([newAddress2]);
     expect(onAddAddressCompleteMock).toHaveBeenCalledTimes(2);
     expect(onAddAddressCompleteMock).toHaveBeenCalledWith({
-      ethereum: [newAddress],
-      bitcoin: [newAddress2],
+      ethereum: [expect.objectContaining({ address: newAddress })],
+      bitcoin: [expect.objectContaining({ address: newAddress2 })],
     });
+  });
+
+  it("should update timestamp and move to top when re-adding an existing address", async () => {
+    const address1 = "0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3";
+    const address2 = "0xB69B37A4Fb4A18b3258f974ff6e9f529AD2647b1";
+    const address3 = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0";
+
+    const now = Date.now();
+    const oneYear = 365 * 24 * 60 * 60 * 1000;
+    const threeYearsAgo = now - 3 * oneYear;
+    const oneYearAgo = now - oneYear;
+
+    const dateNowSpy = jest.spyOn(Date, "now");
+
+    // Add address1 3 years ago
+    dateNowSpy.mockReturnValue(threeYearsAgo);
+    await store.addAddress("ethereum", address1);
+
+    // Add address2 1 year ago
+    dateNowSpy.mockReturnValue(oneYearAgo);
+    await store.addAddress("ethereum", address2);
+
+    // Add address3 now
+    dateNowSpy.mockReturnValue(now);
+    await store.addAddress("ethereum", address3);
+
+    let addresses = store.getAddresses("ethereum");
+    expect(addresses).toEqual([address3, address2, address1]);
+
+    // Re-add address1 (the oldest one) now
+    const reAddTime = now + 1000;
+    dateNowSpy.mockReturnValue(reAddTime);
+    await store.addAddress("ethereum", address1);
+
+    addresses = store.getAddresses("ethereum");
+    expect(addresses).toEqual([address1, address3, address2]);
+
+    expect(onAddAddressCompleteMock).toHaveBeenLastCalledWith({
+      ethereum: [
+        expect.objectContaining({ address: address1, lastUsed: reAddTime }),
+        expect.objectContaining({ address: address3, lastUsed: now }),
+        expect.objectContaining({ address: address2, lastUsed: oneYearAgo }),
+      ],
+    });
+  });
+
+  it("should migrate legacy string addresses to RecentAddress objects on setup", async () => {
+    const legacyAddress1 = "0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3";
+    const legacyAddress2 = "0xB69B37A4Fb4A18b3258f974ff6e9f529AD2647b1";
+    const modernAddress = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0";
+    const modernTimestamp = 1234567890;
+
+    const legacyCache: any = {
+      ethereum: [
+        legacyAddress1,
+        { address: modernAddress, lastUsed: modernTimestamp },
+        legacyAddress2,
+      ],
+    };
+
+    setupRecentAddressesStore(legacyCache, onAddAddressCompleteMock);
+    store = getRecentAddressesStore();
+
+    const addresses = store.getAddresses("ethereum");
+
+    // Order should be preserved: legacy1, modern, legacy2
+    expect(addresses).toEqual([legacyAddress1, modernAddress, legacyAddress2]);
   });
 });

--- a/libs/ledgerjs/packages/types-live/src/recentAddresses.ts
+++ b/libs/ledgerjs/packages/types-live/src/recentAddresses.ts
@@ -1,1 +1,6 @@
-export type RecentAddressesState = Record<string, string[]>;
+export type RecentAddress = {
+  address: string;
+  lastUsed: number;
+};
+
+export type RecentAddressesState = Record<string, RecentAddress[]>;

--- a/libs/live-wallet/src/walletsync/__mocks__/modules/recentAddresses.ts
+++ b/libs/live-wallet/src/walletsync/__mocks__/modules/recentAddresses.ts
@@ -13,7 +13,10 @@ export const genState = (index: number) => {
   for (let i = 0; i < index + 1; i++) {
     recentAddressesState["currency-" + i.toString()] = [];
     for (let j = 0; j < 12; j++) {
-      recentAddressesState["currency-" + i.toString()].push(`some random address at index ${j}`);
+      recentAddressesState["currency-" + i.toString()].push({
+        address: `some random address at index ${j}`,
+        lastUsed: Date.now(),
+      });
     }
   }
 
@@ -38,7 +41,9 @@ export const similarLocalState = (
       return (
         state[key] &&
         state[key].length === otherState[key].length &&
-        otherState[key].every(address => state[key].includes(address))
+        otherState[key].every(otherAddr =>
+          state[key].some(stateAddr => stateAddr.address === otherAddr.address),
+        )
       );
     })
   );

--- a/libs/live-wallet/src/walletsync/__tests__/modules/recentAddresses.test.ts
+++ b/libs/live-wallet/src/walletsync/__tests__/modules/recentAddresses.test.ts
@@ -10,67 +10,76 @@ describe("recentAddress", () => {
       {
         localData: {} as RecentAddressesState,
         latestState: {
-          ethereum: [{ address: "some random address", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {} as RecentAddressesState,
         latestState: {
-          ethereum: [{ address: "some random address", index: 0 }],
-          solana: [{ address: "some random address on Solana", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
+          solana: [{ address: "some random address on Solana", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address"],
-        },
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
+        } as RecentAddressesState,
         latestState: {} as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
-        },
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
+        } as RecentAddressesState,
         latestState: {
-          ethereum: [{ address: "some random address", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          solana: ["some random address"],
-        },
+          solana: [{ address: "some random address", lastUsed: 1 }],
+        } as RecentAddressesState,
         latestState: {
-          ethereum: [{ address: "some random address", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address"],
-          solana: ["some random address on Solana"],
-        },
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
+          solana: [{ address: "some random address on Solana", lastUsed: 1 }],
+        } as RecentAddressesState,
         latestState: {
-          ethereum: [{ address: "some random address", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address"],
-          solana: ["some random address on Solana", "some random address on Solana 2"],
-        },
-        latestState: {
-          ethereum: [{ address: "some random address", index: 0 }],
-          solana: [{ address: "some random address on Solana", index: 0 }],
-        } as DistantRecentAddressesState,
-      },
-      {
-        localData: {
-          ethereum: ["some random address"],
-          solana: ["some random address on Solana 2", "some random address on Solana 3"],
-        },
-        latestState: {
-          ethereum: [{ address: "some random address", index: 0 }],
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
           solana: [
-            { address: "some random address on Solana", index: 0 },
-            { address: "some random address on Solana 2", index: 1 },
+            { address: "some random address on Solana", lastUsed: 1 },
+            { address: "some random address on Solana 2", lastUsed: 2 },
+          ],
+        } as RecentAddressesState,
+        latestState: {
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
+          solana: [{ address: "some random address on Solana", index: 0, lastUsed: 1 }],
+        } as DistantRecentAddressesState,
+      },
+      {
+        localData: {
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
+          solana: [
+            { address: "some random address on Solana 2", lastUsed: 2 },
+            { address: "some random address on Solana 3", lastUsed: 3 },
+          ],
+        } as RecentAddressesState,
+        latestState: {
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
+          solana: [
+            { address: "some random address on Solana", index: 0, lastUsed: 1 },
+            { address: "some random address on Solana 2", index: 1, lastUsed: 2 },
           ],
         } as DistantRecentAddressesState,
       },
@@ -87,7 +96,13 @@ describe("recentAddress", () => {
         Object.entries(localData).forEach(([key, value]) => {
           const nextState = result.nextState;
           expect(nextState[key]).toEqual(
-            expect.arrayContaining(value.map((address, index) => ({ address, index }))),
+            expect.arrayContaining(
+              value.map((entry, index) => ({
+                address: entry.address,
+                index,
+                lastUsed: entry.lastUsed,
+              })),
+            ),
           );
         });
       },
@@ -99,114 +114,146 @@ describe("recentAddress", () => {
         latestState: {} as DistantRecentAddressesState,
       },
       {
-        localData: { ethereum: ["some random address"] } as RecentAddressesState,
+        localData: {
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
+        } as RecentAddressesState,
         latestState: {
-          ethereum: [{ address: "some random address", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
         } as RecentAddressesState,
         latestState: {
           ethereum: [
-            { address: "some random address", index: 0 },
-            { address: "some random address 2", index: 1 },
+            { address: "some random address", index: 0, lastUsed: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
           ],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
         } as RecentAddressesState,
         latestState: {
           ethereum: [
-            { address: "some random address 2", index: 1 },
-            { address: "some random address", index: 0 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
+            { address: "some random address", index: 0, lastUsed: 1 },
           ],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address"],
-          solana: ["some random address on Solana"],
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
+          solana: [{ address: "some random address on Solana", lastUsed: 1 }],
         } as RecentAddressesState,
         latestState: {
-          ethereum: [{ address: "some random address", index: 0 }],
-          solana: [{ address: "some random address on Solana", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
+          solana: [{ address: "some random address on Solana", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
-          solana: ["some random address on Solana"],
-        } as RecentAddressesState,
-        latestState: {
           ethereum: [
-            { address: "some random address", index: 0 },
-            { address: "some random address 2", index: 1 },
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
           ],
-          solana: [{ address: "some random address on Solana", index: 0 }],
-        } as DistantRecentAddressesState,
-      },
-      {
-        localData: {
-          ethereum: ["some random address", "some random address 2"],
-          solana: ["some random address on Solana"],
+          solana: [{ address: "some random address on Solana", lastUsed: 1 }],
         } as RecentAddressesState,
         latestState: {
           ethereum: [
-            { address: "some random address 2", index: 1 },
-            { address: "some random address", index: 0 },
+            { address: "some random address", index: 0, lastUsed: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
           ],
-          solana: [{ address: "some random address on Solana", index: 0 }],
+          solana: [{ address: "some random address on Solana", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
-          solana: ["some random address on Solana", "some random address 2 on Solana"],
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
+          solana: [{ address: "some random address on Solana", lastUsed: 1 }],
         } as RecentAddressesState,
         latestState: {
           ethereum: [
-            { address: "some random address", index: 0 },
-            { address: "some random address 2", index: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
+            { address: "some random address", index: 0, lastUsed: 1 },
+          ],
+          solana: [{ address: "some random address on Solana", index: 0, lastUsed: 1 }],
+        } as DistantRecentAddressesState,
+      },
+      {
+        localData: {
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
           ],
           solana: [
-            { address: "some random address on Solana", index: 0 },
-            { address: "some random address 2 on Solana", index: 1 },
+            { address: "some random address on Solana", lastUsed: 1 },
+            { address: "some random address 2 on Solana", lastUsed: 2 },
+          ],
+        } as RecentAddressesState,
+        latestState: {
+          ethereum: [
+            { address: "some random address", index: 0, lastUsed: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
+          ],
+          solana: [
+            { address: "some random address on Solana", index: 0, lastUsed: 1 },
+            { address: "some random address 2 on Solana", index: 1, lastUsed: 2 },
           ],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
-          solana: ["some random address on Solana", "some random address 2 on Solana"],
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
+          solana: [
+            { address: "some random address on Solana", lastUsed: 1 },
+            { address: "some random address 2 on Solana", lastUsed: 2 },
+          ],
         } as RecentAddressesState,
         latestState: {
           ethereum: [
-            { address: "some random address", index: 0 },
-            { address: "some random address 2", index: 1 },
+            { address: "some random address", index: 0, lastUsed: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
           ],
           solana: [
-            { address: "some random address 2 on Solana", index: 1 },
-            { address: "some random address on Solana", index: 0 },
+            { address: "some random address 2 on Solana", index: 1, lastUsed: 2 },
+            { address: "some random address on Solana", index: 0, lastUsed: 1 },
           ],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
-          solana: ["some random address on Solana", "some random address 2 on Solana"],
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
+          solana: [
+            { address: "some random address on Solana", lastUsed: 1 },
+            { address: "some random address 2 on Solana", lastUsed: 2 },
+          ],
         } as RecentAddressesState,
         latestState: {
           ethereum: [
-            { address: "some random address 2", index: 1 },
-            { address: "some random address", index: 0 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
+            { address: "some random address", index: 0, lastUsed: 1 },
           ],
           solana: [
-            { address: "some random address 2 on Solana", index: 1 },
-            { address: "some random address on Solana", index: 0 },
+            { address: "some random address 2 on Solana", index: 1, lastUsed: 2 },
+            { address: "some random address on Solana", index: 0, lastUsed: 1 },
           ],
         } as DistantRecentAddressesState,
       },
@@ -237,12 +284,16 @@ describe("recentAddress", () => {
 
     it.each([
       [{} as DistantRecentAddressesState],
-      [{ ethereum: [{ address: "some random address", index: 0 }] } as DistantRecentAddressesState],
+      [
+        {
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
+        } as DistantRecentAddressesState,
+      ],
       [
         {
           ethereum: [
-            { address: "some random address", index: 0 },
-            { address: "some random address 2", index: 1 },
+            { address: "some random address", index: 0, lastUsed: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
           ],
         } as DistantRecentAddressesState,
       ],
@@ -267,114 +318,146 @@ describe("recentAddress", () => {
         incomingState: {} as DistantRecentAddressesState,
       },
       {
-        localData: { ethereum: ["some random address"] } as RecentAddressesState,
+        localData: {
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
+        } as RecentAddressesState,
         incomingState: {
-          ethereum: [{ address: "some random address", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
         } as RecentAddressesState,
         incomingState: {
           ethereum: [
-            { address: "some random address", index: 0 },
-            { address: "some random address 2", index: 1 },
+            { address: "some random address", index: 0, lastUsed: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
           ],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
         } as RecentAddressesState,
         incomingState: {
           ethereum: [
-            { address: "some random address 2", index: 1 },
-            { address: "some random address", index: 0 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
+            { address: "some random address", index: 0, lastUsed: 1 },
           ],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address"],
-          solana: ["some random address on Solana"],
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
+          solana: [{ address: "some random address on Solana", lastUsed: 1 }],
         } as RecentAddressesState,
         incomingState: {
-          ethereum: [{ address: "some random address", index: 0 }],
-          solana: [{ address: "some random address on Solana", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
+          solana: [{ address: "some random address on Solana", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
-          solana: ["some random address on Solana"],
-        } as RecentAddressesState,
-        incomingState: {
           ethereum: [
-            { address: "some random address", index: 0 },
-            { address: "some random address 2", index: 1 },
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
           ],
-          solana: [{ address: "some random address on Solana", index: 0 }],
-        } as DistantRecentAddressesState,
-      },
-      {
-        localData: {
-          ethereum: ["some random address", "some random address 2"],
-          solana: ["some random address on Solana"],
+          solana: [{ address: "some random address on Solana", lastUsed: 1 }],
         } as RecentAddressesState,
         incomingState: {
           ethereum: [
-            { address: "some random address 2", index: 1 },
-            { address: "some random address", index: 0 },
+            { address: "some random address", index: 0, lastUsed: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
           ],
-          solana: [{ address: "some random address on Solana", index: 0 }],
+          solana: [{ address: "some random address on Solana", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
-          solana: ["some random address on Solana", "some random address 2 on Solana"],
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
+          solana: [{ address: "some random address on Solana", lastUsed: 1 }],
         } as RecentAddressesState,
         incomingState: {
           ethereum: [
-            { address: "some random address", index: 0 },
-            { address: "some random address 2", index: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
+            { address: "some random address", index: 0, lastUsed: 1 },
+          ],
+          solana: [{ address: "some random address on Solana", index: 0, lastUsed: 1 }],
+        } as DistantRecentAddressesState,
+      },
+      {
+        localData: {
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
           ],
           solana: [
-            { address: "some random address on Solana", index: 0 },
-            { address: "some random address 2 on Solana", index: 1 },
+            { address: "some random address on Solana", lastUsed: 1 },
+            { address: "some random address 2 on Solana", lastUsed: 2 },
+          ],
+        } as RecentAddressesState,
+        incomingState: {
+          ethereum: [
+            { address: "some random address", index: 0, lastUsed: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
+          ],
+          solana: [
+            { address: "some random address on Solana", index: 0, lastUsed: 1 },
+            { address: "some random address 2 on Solana", index: 1, lastUsed: 2 },
           ],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
-          solana: ["some random address on Solana", "some random address 2 on Solana"],
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
+          solana: [
+            { address: "some random address on Solana", lastUsed: 1 },
+            { address: "some random address 2 on Solana", lastUsed: 2 },
+          ],
         } as RecentAddressesState,
         incomingState: {
           ethereum: [
-            { address: "some random address", index: 0 },
-            { address: "some random address 2", index: 1 },
+            { address: "some random address", index: 0, lastUsed: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
           ],
           solana: [
-            { address: "some random address 2 on Solana", index: 1 },
-            { address: "some random address on Solana", index: 0 },
+            { address: "some random address 2 on Solana", index: 1, lastUsed: 2 },
+            { address: "some random address on Solana", index: 0, lastUsed: 1 },
           ],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address", "some random address 2"],
-          solana: ["some random address on Solana", "some random address 2 on Solana"],
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
+          solana: [
+            { address: "some random address on Solana", lastUsed: 1 },
+            { address: "some random address 2 on Solana", lastUsed: 2 },
+          ],
         } as RecentAddressesState,
         incomingState: {
           ethereum: [
-            { address: "some random address 2", index: 1 },
-            { address: "some random address", index: 0 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
+            { address: "some random address", index: 0, lastUsed: 1 },
           ],
           solana: [
-            { address: "some random address 2 on Solana", index: 1 },
-            { address: "some random address on Solana", index: 0 },
+            { address: "some random address 2 on Solana", index: 1, lastUsed: 2 },
+            { address: "some random address on Solana", index: 0, lastUsed: 1 },
           ],
         } as DistantRecentAddressesState,
       },
@@ -397,53 +480,55 @@ describe("recentAddress", () => {
       {
         localData: {} as RecentAddressesState,
         incomingState: {
-          ethereum: [{ address: "some random address", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
-        localData: { ethereum: ["some random address"] } as RecentAddressesState,
+        localData: {
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
+        } as RecentAddressesState,
         incomingState: {
           ethereum: [
-            { address: "some random address", index: 0 },
-            { address: "some random address 2", index: 1 },
+            { address: "some random address", index: 0, lastUsed: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
           ],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address"],
-        },
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
+        } as RecentAddressesState,
         incomingState: {
-          ethereum: [{ address: "some random address", index: 0 }],
-          solana: [{ address: "some random address on Solana", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
+          solana: [{ address: "some random address on Solana", index: 0, lastUsed: 1 }],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address"],
-          solana: ["some random address on Solana"],
-        },
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
+          solana: [{ address: "some random address on Solana", lastUsed: 1 }],
+        } as RecentAddressesState,
         incomingState: {
-          ethereum: [{ address: "some random address", index: 0 }],
+          ethereum: [{ address: "some random address", index: 0, lastUsed: 1 }],
           solana: [
-            { address: "some random address on Solana", index: 0 },
-            { address: "some random address on Solana 2", index: 1 },
+            { address: "some random address on Solana", index: 0, lastUsed: 1 },
+            { address: "some random address on Solana 2", index: 1, lastUsed: 2 },
           ],
         } as DistantRecentAddressesState,
       },
       {
         localData: {
-          ethereum: ["some random address"],
-          solana: ["some random address on Solana"],
-        },
+          ethereum: [{ address: "some random address", lastUsed: 1 }],
+          solana: [{ address: "some random address on Solana", lastUsed: 1 }],
+        } as RecentAddressesState,
         incomingState: {
           ethereum: [
-            { address: "some random address", index: 0 },
-            { address: "some random address 2", index: 1 },
+            { address: "some random address", index: 0, lastUsed: 1 },
+            { address: "some random address 2", index: 1, lastUsed: 2 },
           ],
           solana: [
-            { address: "some random address on Solana", index: 0 },
-            { address: "some random address on Solana 2", index: 1 },
+            { address: "some random address on Solana", index: 0, lastUsed: 1 },
+            { address: "some random address on Solana 2", index: 1, lastUsed: 2 },
           ],
         } as DistantRecentAddressesState,
       },
@@ -461,7 +546,7 @@ describe("recentAddress", () => {
         Object.keys(incomingState).forEach(key => {
           update[key] = incomingState[key]
             .sort((current, other) => current.index - other.index)
-            .map(data => data.address);
+            .map(data => ({ address: data.address, lastUsed: data.lastUsed ?? Date.now() }));
         });
 
         expect(result).toEqual({
@@ -475,8 +560,15 @@ describe("recentAddress", () => {
   describe("applyUpdate", () => {
     it.each([
       [{}],
-      [{ ethereum: ["some random address"] }],
-      [{ ethereum: ["some random address", "some random address 2"] }],
+      [{ ethereum: [{ address: "some random address", lastUsed: 1 }] }],
+      [
+        {
+          ethereum: [
+            { address: "some random address", lastUsed: 1 },
+            { address: "some random address 2", lastUsed: 2 },
+          ],
+        },
+      ],
     ])("should return updated data #%#", (update: RecentAddressesState) => {
       const result = manager.applyUpdate({}, update);
       expect(result).toEqual(update);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

<img width="427" height="629" alt="image" src="https://github.com/user-attachments/assets/34975e63-723c-4424-86e4-0533a0d0d091" />


In order to be able to have this view, we need to store the timestamp of which we interacted with a specific address, so we can have the "x times ago" below the address tile element.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/465?selectedIssue=LIVE-24369)**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
