### PR TITLE
fix(modal): update crypto icon on the account page

### DIFF
--- a/.changeset/chilly-nails-hope.md
+++ b/.changeset/chilly-nails-hope.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Update the account network icon on the account page on the modular dialog

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDialog/screens/AccountSelector/components/AccountListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDialog/screens/AccountSelector/components/AccountListItem/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { ListItem } from "@ledgerhq/lumen-ui-react";
+import { SquaredCryptoIcon } from "LLD/components/SquaredCryptoIcon";
 import { formatAddress } from "../../../../components/Address/formatAddress";
 
 export type Account = {
@@ -37,19 +37,13 @@ export const AccountListItem = ({ onClick, account }: AccountListItemProps) => {
   const { name, balance, fiatValue, address, ticker, cryptoId, parentId } = account;
   const formattedAddress = formatAddress(address);
 
+  const networkId = parentId ?? cryptoId;
+
   return (
     <ListItem
       title={name}
       description={formattedAddress}
-      descriptionTag={
-        <CryptoIcon
-          size="16px"
-          ledgerId={cryptoId}
-          network={parentId}
-          ticker={ticker}
-          overridesRadius="4px"
-        />
-      }
+      descriptionTag={<SquaredCryptoIcon size="16px" ledgerId={networkId} ticker={ticker} />}
       trailingContent={renderTrailingContent(balance, fiatValue)}
       onClick={onClick}
       data-testid={`account-row-${name}`}


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
I've updated the cryptoicon to show only the network on the account page and use the squared icon.

for usdt on eth network:
<img width="1278" height="1396" alt="image" src="https://github.com/user-attachments/assets/689df9ce-bb9a-4f3e-b16a-07ca4ddf0e7e" />

### ❓ Context

- **JIRA or GitHub link**:[LIVE-24346]( https://ledgerhq.atlassian.net/browse/LIVE-24346)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24346]: https://ledgerhq.atlassian.net/browse/LIVE-24346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ