### PR TITLE
:bug: (fix) lwm hedera empty scan selection

### DIFF
--- a/.changeset/hedera-empty-scan.md
+++ b/.changeset/hedera-empty-scan.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Hedera empty account scan so single new accounts surface as creatable and can be added.

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceAccounts.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceAccounts.test.ts
@@ -1,0 +1,129 @@
+import { setupScanDeviceTests } from "./shared";
+import BigNumber from "bignumber.js";
+import { of, EMPTY, Observable } from "rxjs";
+import type { Account, ScanAccountEvent } from "@ledgerhq/types-live";
+import { renderHook, waitFor } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import useScanDeviceAccountsViewModel from "../useScanDeviceAccountsViewModel";
+
+const {
+  replace,
+  setRouteParams,
+  setScanObservable,
+  makeDiscoveredEvent,
+  resetSpies,
+  getCurrentCurrency,
+} = setupScanDeviceTests();
+
+const createAccount = (overrides?: Partial<Account>): Account => {
+  const balance = overrides?.balance ?? new BigNumber(0);
+  return {
+    type: "Account",
+    id: overrides?.id ?? "js:eth:0:eth",
+    seedIdentifier: "seed",
+    derivationMode: "",
+    index: 0,
+    freshAddress: "0xabc",
+    freshAddressPath: "44/60",
+    used: overrides?.used ?? false,
+    balance,
+    spendableBalance: balance,
+    creationDate: new Date(),
+    blockHeight: 0,
+    currency: getCurrentCurrency(),
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    lastSyncDate: new Date(),
+    balanceHistoryCache: {
+      HOUR: { latestDate: null, balances: [] },
+      DAY: { latestDate: null, balances: [] },
+      WEEK: { latestDate: null, balances: [] },
+    },
+    swapHistory: [],
+    subAccounts: [],
+    ...overrides,
+  };
+};
+
+describe("ScanDeviceAccounts (common coins)", () => {
+  beforeEach(() => {
+    resetSpies();
+    setRouteParams("ethereum");
+    setScanObservable(EMPTY);
+  });
+
+  it("stores a single discovered ETH account", async () => {
+    const ethAccount = createAccount({ balance: new BigNumber(1234), used: true });
+    setScanObservable(of(makeDiscoveredEvent(ethAccount)));
+
+    const { result } = renderHook(() =>
+      useScanDeviceAccountsViewModel({
+        existingAccounts: [],
+        blacklistedTokenIds: [],
+        analyticsMetadata: {},
+      }),
+    );
+
+    await waitFor(() => expect(result.current.scannedAccounts).toHaveLength(1));
+    await waitFor(() => expect(result.current.scanning).toBe(false));
+
+    expect(result.current.scannedAccounts[0].id).toBe(ethAccount.id);
+    expect(replace).not.toHaveBeenCalledWith(ScreenName.NoAssociatedAccounts, expect.anything());
+  });
+
+  it("stores multiple discovered BTC accounts", async () => {
+    setRouteParams("bitcoin");
+    const btcAccount1 = createAccount({
+      id: "js:btc:0:segwit",
+      balance: new BigNumber(10_000),
+      used: true,
+    });
+    const btcAccount2 = createAccount({
+      id: "js:btc:1:segwit",
+      balance: new BigNumber(0),
+      used: false,
+    });
+
+    setScanObservable(
+      new Observable<ScanAccountEvent>(subscriber => {
+        subscriber.next(makeDiscoveredEvent(btcAccount1));
+        setTimeout(() => {
+          subscriber.next(makeDiscoveredEvent(btcAccount2));
+          subscriber.complete();
+        }, 0);
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useScanDeviceAccountsViewModel({
+        existingAccounts: [],
+        blacklistedTokenIds: [],
+        analyticsMetadata: {},
+      }),
+    );
+
+    await waitFor(() => expect(result.current.scannedAccounts).toHaveLength(2));
+    await waitFor(() => expect(result.current.scanning).toBe(false));
+
+    expect(result.current.scannedAccounts.map(a => a.id)).toEqual(
+      expect.arrayContaining([btcAccount1.id, btcAccount2.id]),
+    );
+    expect(replace).not.toHaveBeenCalledWith(ScreenName.NoAssociatedAccounts, expect.anything());
+  });
+
+  it("does not navigate to NoAssociatedAccounts when no accounts found for ETH", async () => {
+    setScanObservable(EMPTY);
+
+    const { result } = renderHook(() =>
+      useScanDeviceAccountsViewModel({
+        existingAccounts: [],
+        blacklistedTokenIds: [],
+        analyticsMetadata: {},
+      }),
+    );
+
+    await waitFor(() => expect(result.current.scanning).toBe(false));
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceHederaAccounts.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceHederaAccounts.test.ts
@@ -1,0 +1,129 @@
+import { setupScanDeviceTests } from "./shared";
+import BigNumber from "bignumber.js";
+import { Observable, of, EMPTY } from "rxjs";
+import type { Account, ScanAccountEvent } from "@ledgerhq/types-live";
+import { renderHook, waitFor } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import useScanDeviceAccountsViewModel from "../useScanDeviceAccountsViewModel";
+
+const {
+  replace,
+  setRouteParams,
+  setScanObservable,
+  makeDiscoveredEvent,
+  resetSpies,
+  getCurrentCurrency,
+} = setupScanDeviceTests();
+
+const createHederaAccount = (overrides?: Partial<Account>): Account => {
+  const balance = overrides?.balance ?? new BigNumber(0);
+  return {
+    type: "Account",
+    id: overrides?.id ?? "js:hedera:0.0.12345:hederaBip44",
+    seedIdentifier: "seed",
+    derivationMode: "",
+    index: 0,
+    freshAddress: "0.0.12345",
+    freshAddressPath: "44/3030",
+    used: false,
+    balance,
+    spendableBalance: balance,
+    creationDate: new Date(),
+    blockHeight: 0,
+    currency: getCurrentCurrency(),
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    lastSyncDate: new Date(),
+    balanceHistoryCache: {
+      HOUR: { latestDate: null, balances: [] },
+      DAY: { latestDate: null, balances: [] },
+      WEEK: { latestDate: null, balances: [] },
+    },
+    swapHistory: [],
+    subAccounts: [],
+    ...overrides,
+  };
+};
+
+describe("ScanDeviceHederaAccounts", () => {
+  beforeEach(() => {
+    resetSpies();
+    setRouteParams("hedera");
+    setScanObservable(EMPTY);
+  });
+
+  it("keeps an empty Hedera account importable when scanned alone", async () => {
+    const emptyAccount = createHederaAccount({ balance: new BigNumber(0) });
+
+    setScanObservable(of<ScanAccountEvent>({ type: "discovered", account: emptyAccount }));
+
+    const { result } = renderHook(() =>
+      useScanDeviceAccountsViewModel({
+        existingAccounts: [],
+        blacklistedTokenIds: [],
+        analyticsMetadata: {},
+      }),
+    );
+
+    await waitFor(() => expect(result.current.scannedAccounts).toHaveLength(1));
+    await waitFor(() => expect(result.current.scanning).toBe(false));
+
+    expect(result.current.scannedAccounts).toHaveLength(1);
+    expect(result.current.scannedAccounts[0].id).toBe(emptyAccount.id);
+    expect(replace).not.toHaveBeenCalledWith(ScreenName.NoAssociatedAccounts, expect.anything());
+  });
+
+  it("does not navigate away when multiple Hedera accounts (including empty) are found", async () => {
+    const emptyAccount = createHederaAccount({ balance: new BigNumber(0) });
+    const fundedAccount = createHederaAccount({
+      id: "js:hedera:0.0.67890:hederaBip44",
+      balance: new BigNumber(1000000),
+      used: true,
+    });
+
+    setScanObservable(
+      new Observable<ScanAccountEvent>(subscriber => {
+        subscriber.next(makeDiscoveredEvent(emptyAccount));
+        setTimeout(() => {
+          subscriber.next(makeDiscoveredEvent(fundedAccount));
+          subscriber.complete();
+        }, 0);
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useScanDeviceAccountsViewModel({
+        existingAccounts: [],
+        blacklistedTokenIds: [],
+        analyticsMetadata: {},
+      }),
+    );
+
+    await waitFor(() => expect(result.current.scannedAccounts).toHaveLength(2));
+    await waitFor(() => expect(result.current.scanning).toBe(false));
+
+    expect(result.current.scannedAccounts.map(a => a.id)).toEqual(
+      expect.arrayContaining([emptyAccount.id, fundedAccount.id]),
+    );
+    expect(replace).not.toHaveBeenCalledWith(ScreenName.NoAssociatedAccounts, expect.anything());
+  });
+
+  it("navigates to NoAssociatedAccounts when no Hedera accounts are discovered", async () => {
+    setScanObservable(EMPTY);
+
+    renderHook(() =>
+      useScanDeviceAccountsViewModel({
+        existingAccounts: [],
+        blacklistedTokenIds: [],
+        analyticsMetadata: {},
+      }),
+    );
+
+    await waitFor(() => expect(replace).toHaveBeenCalled());
+
+    expect(replace).toHaveBeenCalledWith(ScreenName.NoAssociatedAccounts, {
+      CustomNoAssociatedAccounts: expect.any(Function),
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/__tests__/shared.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/__tests__/shared.ts
@@ -1,0 +1,103 @@
+import React from "react";
+import { Observable, EMPTY } from "rxjs";
+import type { Account, ScanAccountEvent } from "@ledgerhq/types-live";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+
+type Mocks = {
+  replace: jest.Mock;
+  navigate: jest.Mock;
+  goBack: jest.Mock;
+  pop: jest.Mock;
+  setRouteParams: (currencyId: string, deviceId?: string) => void;
+  setScanObservable: (observable: Observable<ScanAccountEvent>) => void;
+  makeDiscoveredEvent: (account: Account) => ScanAccountEvent;
+  resetSpies: () => void;
+  getCurrentCurrency: () => Account["currency"];
+};
+
+let routeParams = {
+  currency: getCryptoCurrencyById("ethereum"),
+  device: { deviceId: "device-1" },
+};
+
+let scanAccountsObservable: Observable<ScanAccountEvent> = EMPTY;
+
+const replace = jest.fn();
+const navigate = jest.fn();
+const goBack = jest.fn();
+const pop = jest.fn();
+
+jest.mock("@react-navigation/native", () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  const useNavigationIndependentTreeMock = actual.useNavigationIndependentTree || (() => ({}));
+
+  return {
+    ...actual,
+    NavigationContainer: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    useNavigationIndependentTree: useNavigationIndependentTreeMock,
+  };
+});
+
+jest.mock("@react-navigation/core", () => ({
+  useNavigation: () => ({
+    replace,
+    navigate,
+    goBack,
+    getParent: () => ({ pop }),
+  }),
+  useRoute: () => ({
+    params: routeParams,
+  }),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  getCurrencyBridge: jest.fn(() => ({
+    scanAccounts: jest.fn(() => scanAccountsObservable),
+    preload: jest.fn(() => Promise.resolve(undefined)),
+    hydrate: jest.fn(),
+  })),
+}));
+
+jest.mock("~/bridge/cache", () => ({
+  prepareCurrency: jest.fn().mockResolvedValue(undefined),
+}));
+
+export const setupScanDeviceTests = (): Mocks => {
+  const setRouteParams = (currencyId: string, deviceId = "device-1") => {
+    routeParams = {
+      currency: getCryptoCurrencyById(currencyId),
+      device: { deviceId },
+    };
+  };
+
+  const setScanObservable = (observable: Observable<ScanAccountEvent>) => {
+    scanAccountsObservable = observable;
+  };
+
+  const makeDiscoveredEvent = (account: Account): ScanAccountEvent => ({
+    type: "discovered",
+    account,
+  });
+
+  const getCurrentCurrency = () => routeParams.currency;
+
+  const resetSpies = () => {
+    replace.mockClear();
+    navigate.mockClear();
+    goBack.mockClear();
+    pop.mockClear();
+  };
+
+  return {
+    replace,
+    navigate,
+    goBack,
+    pop,
+    setRouteParams,
+    setScanObservable,
+    makeDiscoveredEvent,
+    resetSpies,
+    getCurrentCurrency,
+  };
+};

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -6,6 +6,7 @@ import { useDispatch } from "~/context/store";
 import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
 import uniq from "lodash/uniq";
 import type { Account } from "@ledgerhq/types-live";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
 import { isTokenCurrency } from "@ledgerhq/live-common/currencies/index";
 import logger from "~/logger";
@@ -20,6 +21,17 @@ import { setAccountName } from "@ledgerhq/live-wallet/store";
 import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
 import type { ScanDeviceAccountsNavigationProps, ScanDeviceAccountsViewModelProps } from "./types";
 import { track } from "~/analytics";
+
+const isNoAssociatedAccountsFamily = (
+  family: string,
+): family is keyof typeof noAssociatedAccountsByFamily =>
+  Object.prototype.hasOwnProperty.call(noAssociatedAccountsByFamily, family);
+
+const getCustomNoAssociatedAccounts = (currency: CryptoOrTokenCurrency) => {
+  if (currency.type !== "CryptoCurrency") return null;
+  if (!isNoAssociatedAccountsFamily(currency.family)) return null;
+  return noAssociatedAccountsByFamily[currency.family];
+};
 
 export default function useScanDeviceAccountsViewModel({
   existingAccounts,
@@ -236,21 +248,21 @@ export default function useScanDeviceAccountsViewModel({
     },
     [dispatch],
   );
+  const preferredNewAccountSchemes = useMemo(
+    () =>
+      showAllCreatedAccounts || !preferredNewAccountScheme
+        ? undefined
+        : [preferredNewAccountScheme],
+    [preferredNewAccountScheme, showAllCreatedAccounts],
+  );
+
   const { sections, alreadyEmptyAccount } = useMemo(
     () =>
       groupAddAccounts(existingAccounts, scannedAccounts, {
         scanning,
-        preferredNewAccountSchemes: showAllCreatedAccounts
-          ? undefined
-          : [preferredNewAccountScheme!],
+        preferredNewAccountSchemes,
       }),
-    [
-      existingAccounts,
-      scannedAccounts,
-      scanning,
-      showAllCreatedAccounts,
-      preferredNewAccountScheme,
-    ],
+    [existingAccounts, scannedAccounts, scanning, preferredNewAccountSchemes],
   );
   const alreadyEmptyAccountName = useMaybeAccountName(alreadyEmptyAccount);
   const cantCreateAccount = !sections.some(s => s.id === "creatable" && s.data.length > 0);
@@ -261,10 +273,7 @@ export default function useScanDeviceAccountsViewModel({
   const sanitizedSections = sections.filter(s => s.id !== "imported");
   const hasImportableAccounts = sections.find(s => s.id === "importable" && s.data.length > 0);
 
-  const CustomNoAssociatedAccounts =
-    currency.type === "CryptoCurrency"
-      ? noAssociatedAccountsByFamily[currency.family as keyof typeof noAssociatedAccountsByFamily]
-      : null;
+  const CustomNoAssociatedAccounts = getCustomNoAssociatedAccounts(currency);
   useEffect(() => {
     startSubscription();
     return () => stopSubscription(false);
@@ -296,6 +305,8 @@ export default function useScanDeviceAccountsViewModel({
   }, [existingAccounts, latestScannedAccount, onlyNewAccounts, scannedAccounts, selectedIds]);
 
   useEffect(() => {
+    const hasScannedAccounts = scannedAccounts.length > 0 || !!latestScannedAccount;
+
     if (!isAddingAccounts && !scanning) {
       if (alreadyEmptyAccount && !hasImportableAccounts) {
         navigation.replace(ScreenName.AddAccountsWarning, {
@@ -305,7 +316,7 @@ export default function useScanDeviceAccountsViewModel({
           context,
           onCloseNavigation,
         });
-      } else if (noImportableAccounts && CustomNoAssociatedAccounts) {
+      } else if (!hasScannedAccounts && CustomNoAssociatedAccounts) {
         navigation.replace(ScreenName.NoAssociatedAccounts, {
           CustomNoAssociatedAccounts,
         });
@@ -313,7 +324,6 @@ export default function useScanDeviceAccountsViewModel({
     }
   }, [
     hasImportableAccounts,
-    cantCreateAccount,
     isAddingAccounts,
     alreadyEmptyAccount,
     alreadyEmptyAccountName,
@@ -321,9 +331,10 @@ export default function useScanDeviceAccountsViewModel({
     navigation,
     currency,
     CustomNoAssociatedAccounts,
-    noImportableAccounts,
     context,
     onCloseNavigation,
+    scannedAccounts.length,
+    latestScannedAccount,
   ]);
   return {
     alreadyEmptyAccount,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - scan accounts

### 📝 Description

The original issue was only when you added an empty Hedera account (alone no other accounts scanned)

Fixed useScanDeviceAccountsViewModel to safely pick family-specific NoAssociatedAccounts without casting and to gate navigation on actual scan results
We now gate the “NoAssociatedAccounts” redirect on hasScannedAccounts (true when we’ve actually discovered at least one account, including the latest emission) so we only navigate when nothing was found. This prevents the Hedera empty-account case from being treated as “no accounts” and wrongly sending users to the no-associated screen, and it also guards against the brief moment where latestScannedAccount exists but hasn’t yet been pushed into scannedAccounts.

Added focused Hedera scan tests covering empty, multiple, and no-account scenarios
Many things are mocked, but as always, it's complex not to mock with bridges, etc

See [video](https://ledgerhq.atlassian.net/browse/LIVE-24349?focusedCommentId=632670)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24349](https://ledgerhq.atlassian.net/browse/LIVE-24349)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24349]: https://ledgerhq.atlassian.net/browse/LIVE-24349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ