### PR TITLE
lwd/lwm: retry button when device locked or user refused

### DIFF
--- a/.changeset/breezy-oranges-bake.md
+++ b/.changeset/breezy-oranges-bake.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Retry button when device is locked or user refused

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.test.tsx
@@ -70,6 +70,30 @@ describe("StepConfirmationFooter", () => {
     expect(screen.getByRole("button")).toHaveTextContent("Retry");
   });
 
+  it("renders RetryButton when error is DeviceLockedError", () => {
+    render(
+      <StepConfirmationFooter {...baseProps} error={{ name: "DeviceLockedError" } as Error} />,
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent("Retry");
+  });
+
+  it("renders RetryButton when error is LockedDeviceError", () => {
+    render(
+      <StepConfirmationFooter {...baseProps} error={{ name: "LockedDeviceError" } as Error} />,
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent("Retry");
+  });
+
+  it("renders RetryButton when error is UserRefusedOnDevice", () => {
+    render(
+      <StepConfirmationFooter {...baseProps} error={{ name: "UserRefusedOnDevice" } as Error} />,
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent("Retry");
+  });
+
   it("renders AbortButton when error is not 5xx", () => {
     render(<StepConfirmationFooter {...baseProps} error={{ name: "LedgerAPI4xx" } as Error} />);
 

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.tsx
@@ -136,7 +136,13 @@ export function StepConfirmationFooter({
           {t("send.steps.confirmation.success.cta")}
         </Button>
       ) : error ? (
-        ["LedgerAPI5xx", "NetworkDown"].includes(error.name) ? (
+        [
+          "LedgerAPI5xx",
+          "NetworkDown",
+          "DeviceLockedError",
+          "LockedDeviceError",
+          "UserRefusedOnDevice",
+        ].includes(error.name) ? (
           <RetryButton
             ml={2}
             primary

--- a/apps/ledger-live-mobile/src/screens/SendFunds/07-SendBroadcastError.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/07-SendBroadcastError.test.tsx
@@ -79,6 +79,39 @@ describe("SendBroadcastError", () => {
     expect(screen.queryByText(/Abort/i)).toBeNull();
   });
 
+  test("should show Retry button for 'DeviceLockedError' error", () => {
+    const networkError = {
+      name: "DeviceLockedError",
+      message: "Device is locked",
+    };
+    setup(networkError);
+
+    expect(screen.queryByText(/Retry/i)).toBeTruthy();
+    expect(screen.queryByText(/Abort/i)).toBeNull();
+  });
+
+  test("should show Retry button for 'LockedDeviceError' error", () => {
+    const networkError = {
+      name: "LockedDeviceError",
+      message: "Device is locked (bis)",
+    };
+    setup(networkError);
+
+    expect(screen.queryByText(/Retry/i)).toBeTruthy();
+    expect(screen.queryByText(/Abort/i)).toBeNull();
+  });
+
+  test("should show Retry button for 'UserRefusedOnDevice' error", () => {
+    const networkError = {
+      name: "UserRefusedOnDevice",
+      message: "User refused the action on device",
+    };
+    setup(networkError);
+
+    expect(screen.queryByText(/Retry/i)).toBeTruthy();
+    expect(screen.queryByText(/Abort/i)).toBeNull();
+  });
+
   test("should show Abort button for other errors", () => {
     const networkError = {
       name: "LedgerAPI4xx",

--- a/apps/ledger-live-mobile/src/screens/SendFunds/07-SendBroadcastError.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/07-SendBroadcastError.tsx
@@ -29,7 +29,13 @@ export default function SendBroadcastError({ navigation, route }: Props) {
 
   const { account } = useAccountScreen(route);
   const currency = account ? getAccountCurrency(account) : null;
-  const temporaryErrors = ["LedgerAPI5xx", "NetworkDown"];
+  const temporaryErrors = [
+    "LedgerAPI5xx",
+    "NetworkDown",
+    "DeviceLockedError",
+    "LockedDeviceError",
+    "UserRefusedOnDevice",
+  ];
 
   const error = route.params?.error;
   const helperUrl = error?.url ?? urls.faq;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** LWM / LWD

### 📝 Description

We introduced a difference between retryable errors and invalid txs that shouldn't be retried, but device locked/user refused case has been missed

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-24401


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
