### PR TITLE
test: Adding e2e tests for ETH L2 (base) - LWD LWM

### DIFF
--- a/e2e/desktop/tests/specs/add.account.spec.ts
+++ b/e2e/desktop/tests/specs/add.account.spec.ts
@@ -25,6 +25,7 @@ const currencies = [
   { currency: Currency.SOL, xrayTicket: "B2CQA-2642, B2CQA-2656, B2CQA-2684" },
   { currency: Currency.TON, xrayTicket: "B2CQA-2643, B2CQA-2657, B2CQA-2685" },
   { currency: Currency.APT, xrayTicket: "B2CQA-3644, B2CQA-3645, B2CQA-3646" },
+  { currency: Currency.BASE, xrayTicket: "B2CQA-4226, B2CQA-4227, B2CQA-4228" },
 ];
 
 for (const currency of currencies) {

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -213,6 +213,10 @@ const transactionE2E = [
     transaction: new Transaction(Account.SUI_1, Account.SUI_2, "0.0001", undefined),
     xrayTicket: "B2CQA-3802",
   },
+  {
+    transaction: new Transaction(Account.BASE_1, Account.BASE_2, "0.000001"),
+    xrayTicket: "B2CQA-4225",
+  },
 ];
 
 test.describe("Send flows", () => {

--- a/e2e/mobile/specs/addAccount/addAccountBASE.spec.ts
+++ b/e2e/mobile/specs/addAccount/addAccountBASE.spec.ts
@@ -1,0 +1,3 @@
+import { runAddAccountTest } from "./addAccount";
+
+runAddAccountTest(Currency.BASE, ["B2CQA-4226", "B2CQA-4227", "B2CQA-4228"]);

--- a/e2e/mobile/specs/send/sendBASE.spec.ts
+++ b/e2e/mobile/specs/send/sendBASE.spec.ts
@@ -1,0 +1,4 @@
+import { runSendTest } from "./send";
+
+const transaction = new Transaction(Account.BASE_1, Account.BASE_2, "0.000001");
+runSendTest(transaction, ["B2CQA-4225"]);

--- a/libs/ledger-live-common/src/e2e/enum/Account.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Account.ts
@@ -523,6 +523,19 @@ export class Account {
     1,
   );
 
+  static readonly BASE_1 = new Account(
+    Currency.BASE,
+    "Base 1",
+    "0x4BE2E2B8872AA298D6d123b9211B53E41f611566",
+    0,
+  );
+  static readonly BASE_2 = new Account(
+    Currency.BASE,
+    "Base 2",
+    "0xa1baa625c5E6A9304cB7AcD86d2fee6B710eC3eB",
+    1,
+  );
+
   static readonly EMPTY = new Account(Currency.BTC, "Empty", "", 0);
 }
 

--- a/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
+++ b/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
@@ -66,4 +66,6 @@ export class AppInfos {
   static readonly HEDERA = new AppInfos("Hedera");
 
   static readonly SUI = new AppInfos("Sui");
+
+  static readonly BASE = new AppInfos("Base");
 }

--- a/libs/ledger-live-common/src/e2e/enum/Currency.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Currency.ts
@@ -199,6 +199,8 @@ export class Currency {
 
   static readonly SUI = new Currency("Sui", "SUI", "sui", AppInfos.SUI, [Network.SUI]);
 
+  static readonly BASE = new Currency("Base", "ETH", "base", AppInfos.BASE, [Network.BASE]);
+
   static readonly SUI_USDC = new Currency(
     "USD Coin",
     "USDC",

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -349,6 +349,14 @@ export const specs: Specs = {
     },
     dependency: "",
   },
+  Base: {
+    currency: getCryptoCurrencyById("base"),
+    appQuery: {
+      model: getSpeculosModel(),
+      appName: "Ethereum",
+    },
+    dependency: "",
+  },
 };
 
 export async function startSpeculos(
@@ -814,6 +822,7 @@ export async function signSendTransaction(tx: Transaction) {
   const currencyName = tx.accountToDebit.currency;
   switch (currencyName) {
     case Currency.sepETH:
+    case Currency.BASE:
     case Currency.POL:
     case Currency.ETH:
       await sendEVM(tx);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Adding e2e tests for Ethereum L2 (BASE):
- Adding Send e2e test - Mobile and Desktop
- Adding Add account e2e test - Mobile and Desktop

CI:
Mobile: https://github.com/LedgerHQ/ledger-live/actions/runs/20458545307
Desktop: https://github.com/LedgerHQ/ledger-live/actions/runs/20458539817

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [QAA-825](https://ledgerhq.atlassian.net/browse/QAA-825) and [QAA-832](https://ledgerhq.atlassian.net/browse/QAA-832)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-825]: https://ledgerhq.atlassian.net/browse/QAA-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ