### PR TITLE
feat: display and enable withdrawable rewards of inactive stake for SOL

### DIFF
--- a/.changeset/five-squids-boil.md
+++ b/.changeset/five-squids-boil.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-solana": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+feat: display and enable withdrawable rewards of inactive stake for SOL

--- a/apps/ledger-live-desktop/src/renderer/families/solana/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/AccountBalanceSummaryFooter.tsx
@@ -64,6 +64,7 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
   const _delegatedBalance = new BigNumber(
     stakes.reduce((sum, s) => sum + (s.delegation?.stake ?? 0), 0),
   );
+  const _inactiveStake = new BigNumber(stakes.reduce((sum, s) => sum + s.activation.inactive, 0));
   const _delegatedWithdrawableBalance = new BigNumber(
     stakes.reduce((sum, s) => sum + s.withdrawable, 0),
   );
@@ -76,6 +77,7 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
   };
   const spendableBalance = formatCurrencyUnit(unit, _spendableBalance, formatConfig);
   const delegatedBalance = formatCurrencyUnit(unit, _delegatedBalance, formatConfig);
+  const inactiveStake = formatCurrencyUnit(unit, _inactiveStake, formatConfig);
   const delegatedWithdrawableBalance = formatCurrencyUnit(
     unit,
     _delegatedWithdrawableBalance,
@@ -109,6 +111,21 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
           <Discreet>{delegatedBalance}</Discreet>
         </AmountValue>
       </BalanceDetail>
+      {_inactiveStake.gt(0) && (
+        <BalanceDetail>
+          <ToolTip content={<Trans i18nKey="solana.delegation.inactiveStakeTooltip" />}>
+            <TitleWrapper>
+              <Title>
+                <Trans i18nKey="solana.delegation.inactiveStakeTitle" />
+              </Title>
+              <InfoCircle size={13} />
+            </TitleWrapper>
+          </ToolTip>
+          <AmountValue>
+            <Discreet>{inactiveStake}</Discreet>
+          </AmountValue>
+        </BalanceDetail>
+      )}
       {_delegatedWithdrawableBalance.gt(0) && (
         <BalanceDetail>
           <ToolTip content={<Trans i18nKey="solana.delegation.withdrawableInfoTooltip" />}>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -3715,6 +3715,8 @@
       "activeTooltip": "Active amount generate rewards",
       "inactiveTooltip": "Inactive amount does not generate rewards",
       "delegatedInfoTooltip": "Total amount that is delegated to validators.",
+      "inactiveStakeTooltip": "Inactive stake that can be withdrawn without deactivating your delegation.",
+      "inactiveStakeTitle": "Withdrawable Rewards",
       "withdrawableInfoTooltip": "Total amount that is withdrawable from delegations.",
       "withdrawableTitle": "Withdrawable",
       "statusUpdateNotice": "The status of the delegation will be updated when the transaction is confirmed.",

--- a/apps/ledger-live-mobile/src/families/solana/Delegations/index.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/Delegations/index.tsx
@@ -174,6 +174,24 @@ function Delegations({ account }: Props) {
           </Text>
         ),
       },
+      ...(stake.activation.inactive > 0
+        ? [
+            {
+              label: t("solana.delegation.inactiveStake"),
+              Component: (
+                <Text
+                  numberOfLines={1}
+                  fontWeight="semiBold"
+                  ellipsizeMode="middle"
+                  style={[styles.valueText]}
+                  color="live"
+                >
+                  {formatAmount(stake.activation.inactive)}
+                </Text>
+              ),
+            },
+          ]
+        : []),
       {
         label: t("solana.delegation.stakeAvailableBalance"),
         Component: (

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6375,6 +6375,7 @@
       "netApy": "Net APY",
       "stakeActivationState": "State",
       "stakeActivePercent": "Active",
+      "inactiveStake": "Withdrawable Rewards",
       "stakeAvailableBalance": "Available balance",
       "actions": {
         "activate": "Activate",

--- a/libs/coin-modules/coin-solana/src/logic.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic.test.ts
@@ -1,0 +1,143 @@
+import { withdrawableFromStake } from "./logic";
+import { SolanaStake } from "./types";
+
+describe("withdrawableFromStake", () => {
+  const rentExemptReserve = 2282880;
+
+  describe("active stake with inactive balance (e.g., Jito MEV rewards)", () => {
+    test("should allow withdrawal of inactive stake without deactivating delegation", () => {
+      const stakeAccBalance = 10000000;
+      const activation: SolanaStake["activation"] = {
+        state: "active",
+        active: 7000000,
+        inactive: 717120, // MEV rewards
+      };
+
+      const withdrawable = withdrawableFromStake({
+        stakeAccBalance,
+        activation,
+        rentExemptReserve,
+      });
+
+      // Should be able to withdraw inactive stake (rewards) + any excess
+      // stakeAccBalance - rentExemptReserve - active = 10000000 - 2282880 - 7000000 = 717120
+      expect(withdrawable).toBe(717120);
+    });
+
+    test("should handle zero inactive stake", () => {
+      const stakeAccBalance = 10000000;
+      const activation: SolanaStake["activation"] = {
+        state: "active",
+        active: 7717120,
+        inactive: 0,
+      };
+
+      const withdrawable = withdrawableFromStake({
+        stakeAccBalance,
+        activation,
+        rentExemptReserve,
+      });
+
+      // No inactive stake, no rewards to withdraw
+      expect(withdrawable).toBe(0);
+    });
+  });
+
+  describe("activating stake", () => {
+    test("should allow withdrawal of inactive balance during activation", () => {
+      const stakeAccBalance = 10000000;
+      const activation: SolanaStake["activation"] = {
+        state: "activating",
+        active: 5000000,
+        inactive: 2717120,
+      };
+
+      const withdrawable = withdrawableFromStake({
+        stakeAccBalance,
+        activation,
+        rentExemptReserve,
+      });
+
+      // Should be able to withdraw inactive portion
+      expect(withdrawable).toBe(2717120);
+    });
+  });
+
+  describe("deactivating stake", () => {
+    test("should allow withdrawal of deactivating portion", () => {
+      const stakeAccBalance = 10000000;
+      const activation: SolanaStake["activation"] = {
+        state: "deactivating",
+        active: 3000000,
+        inactive: 4717120,
+      };
+
+      const withdrawable = withdrawableFromStake({
+        stakeAccBalance,
+        activation,
+        rentExemptReserve,
+      });
+
+      // Should be able to withdraw everything except active portion and rent
+      expect(withdrawable).toBe(4717120);
+    });
+  });
+
+  describe("inactive stake", () => {
+    test("should allow full withdrawal when stake is fully inactive", () => {
+      const stakeAccBalance = 10000000;
+      const activation: SolanaStake["activation"] = {
+        state: "inactive",
+        active: 0,
+        inactive: 7717120,
+      };
+
+      const withdrawable = withdrawableFromStake({
+        stakeAccBalance,
+        activation,
+        rentExemptReserve,
+      });
+
+      // Should be able to withdraw entire balance
+      expect(withdrawable).toBe(stakeAccBalance);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("should handle exact balance (no excess)", () => {
+      const stakeAccBalance = 9282880;
+      const activation: SolanaStake["activation"] = {
+        state: "active",
+        active: 7000000,
+        inactive: 0,
+      };
+
+      const withdrawable = withdrawableFromStake({
+        stakeAccBalance,
+        activation,
+        rentExemptReserve,
+      });
+
+      // stakeAccBalance - rentExemptReserve - active = 9282880 - 2282880 - 7000000 = 0
+      expect(withdrawable).toBe(0);
+    });
+
+    test("should handle small inactive rewards", () => {
+      const stakeAccBalance = 9283880;
+      const activation: SolanaStake["activation"] = {
+        state: "active",
+        active: 7000000,
+        inactive: 1000, // Small reward
+      };
+
+      const withdrawable = withdrawableFromStake({
+        stakeAccBalance,
+        activation,
+        rentExemptReserve,
+      });
+
+      // Should be able to withdraw the small reward
+      expect(withdrawable).toBe(1000);
+    });
+  });
+});

--- a/libs/coin-modules/coin-solana/src/logic.ts
+++ b/libs/coin-modules/coin-solana/src/logic.ts
@@ -72,7 +72,8 @@ export function withdrawableFromStake({
   switch (activation.state) {
     case "active":
     case "activating":
-      return stakeAccBalance - rentExemptReserve - activation.active - activation.inactive;
+      // Allow withdrawal of inactive stake (e.g., Jito MEV rewards) without deactivating
+      return stakeAccBalance - rentExemptReserve - activation.active;
     case "deactivating":
       return stakeAccBalance - rentExemptReserve - activation.active;
     case "inactive":


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR fixes the Solana stake withdrawal calculation to properly account for inactive stake (like for Jito MEV rewards). Previously, the withdrawal functionality existed but incorrectly excluded inactives stake from withdrawable amounts for active stake accounts, preventing users from claiming their rewards without deactivating their delegation. The fix updates the `withdrawableFromStake` function to correctly calculate withdrawables amounts that include inactive stake portions (by removing the subtraction of `activation.inactive`), so that users can claim their rewards while maintaining their active stake delegation

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/465?selectedIssue=LIVE-22215)**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
