### PR TITLE
Merge pull request #13441 from LedgerHQ/bugfix/hedera-hardcoded-accou…

### DIFF
--- a/.changeset/smart-donkeys-dress.md
+++ b/.changeset/smart-donkeys-dress.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix: avoid hardcoding node account id

--- a/libs/coin-modules/coin-hedera/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/craftTransaction.ts
@@ -12,13 +12,9 @@ import {
 } from "@hashgraph/sdk";
 import type { FeeEstimation, TransactionIntent } from "@ledgerhq/coin-framework/api/index";
 import { DEFAULT_GAS_LIMIT, HEDERA_TRANSACTION_MODES } from "../constants";
+import { rpcClient } from "../network/rpc";
 import type { HederaMemo, HederaTxData } from "../types";
 import { serializeTransaction } from "./utils";
-
-// avoid "sign" prompt loop by having only one node (one transaction)
-// https://github.com/LedgerHQ/ledger-live/pull/72/commits/1e942687d4301660e43e0c4b5419fcfa2733b290
-// changing this will break `getHederaTransactionBodyBytes` from logic/utils.ts
-const nodeAccountIds: AccountId[] = [new AccountId(3)];
 
 interface BuilderOperator {
   accountId: string;
@@ -66,7 +62,6 @@ async function buildUnsignedCoinTransaction({
   const hbarAmount = Hbar.fromTinybars(transaction.amount);
 
   const tx = new TransferTransaction()
-    .setNodeAccountIds(nodeAccountIds)
     .setTransactionId(TransactionId.generate(accountId))
     .setTransactionMemo(transaction.memo)
     .addHbarTransfer(accountId, hbarAmount.negated())
@@ -76,7 +71,7 @@ async function buildUnsignedCoinTransaction({
     tx.setMaxTransactionFee(Hbar.fromTinybars(transaction.maxFee.toNumber()));
   }
 
-  return tx.freeze();
+  return tx.freezeWith(rpcClient.getInstance());
 }
 
 async function buildUnsignedHTSTokenTransaction({
@@ -90,7 +85,6 @@ async function buildUnsignedHTSTokenTransaction({
   const tokenId = transaction.tokenAddress;
 
   const tx = new TransferTransaction()
-    .setNodeAccountIds(nodeAccountIds)
     .setTransactionId(TransactionId.generate(accountId))
     .setTransactionMemo(transaction.memo)
     .addTokenTransfer(tokenId, accountId, transaction.amount.negated().toNumber())
@@ -100,7 +94,7 @@ async function buildUnsignedHTSTokenTransaction({
     tx.setMaxTransactionFee(Hbar.fromTinybars(transaction.maxFee.toNumber()));
   }
 
-  return tx.freeze();
+  return tx.freezeWith(rpcClient.getInstance());
 }
 
 async function buildUnsignedERC20TokenTransaction({
@@ -122,7 +116,6 @@ async function buildUnsignedERC20TokenTransaction({
     .addUint256(transaction.amount.toNumber());
 
   const tx = new ContractExecuteTransaction()
-    .setNodeAccountIds(nodeAccountIds)
     .setTransactionId(TransactionId.generate(accountId))
     .setTransactionMemo(transaction.memo ?? "")
     .setContractId(contractId)
@@ -133,7 +126,7 @@ async function buildUnsignedERC20TokenTransaction({
     tx.setMaxTransactionFee(Hbar.fromTinybars(transaction.maxFee.toNumber()));
   }
 
-  return tx.freeze();
+  return tx.freezeWith(rpcClient.getInstance());
 }
 
 async function buildTokenAssociateTransaction({
@@ -146,7 +139,6 @@ async function buildTokenAssociateTransaction({
   const accountId = account.accountId;
 
   const tx = new TokenAssociateTransaction()
-    .setNodeAccountIds(nodeAccountIds)
     .setTransactionId(TransactionId.generate(accountId))
     .setTransactionMemo(transaction.memo)
     .setAccountId(accountId)
@@ -156,7 +148,36 @@ async function buildTokenAssociateTransaction({
     tx.setMaxTransactionFee(Hbar.fromTinybars(transaction.maxFee.toNumber()));
   }
 
-  return tx.freeze();
+  return tx.freezeWith(rpcClient.getInstance());
+}
+
+async function buildUnsignedUpdateAccountTransaction({
+  account,
+  transaction,
+}: {
+  account: BuilderOperator;
+  transaction: BuilderUpdateAccountTransaction;
+}): Promise<AccountUpdateTransaction> {
+  const accountId = account.accountId;
+
+  const tx = new AccountUpdateTransaction()
+    .setTransactionId(TransactionId.generate(accountId))
+    .setTransactionMemo(transaction.memo ?? "")
+    .setAccountId(accountId);
+
+  if (transaction.maxFee) {
+    tx.setMaxTransactionFee(Hbar.fromTinybars(transaction.maxFee.toNumber()));
+  }
+
+  if (typeof transaction.stakingNodeId === "number") {
+    tx.setStakedNodeId(transaction.stakingNodeId);
+  }
+
+  if (transaction.stakingNodeId === null) {
+    tx.clearStakedNodeId();
+  }
+
+  return tx.freezeWith(rpcClient.getInstance());
 }
 
 export async function craftTransaction(

--- a/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
@@ -126,6 +126,11 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "freshAddress": "0.0.8313485",
     "freshAddressPath": "44/3030",
     "hederaResources": {
+      "delegation": {
+        "delegated": "334045080",
+        "nodeId": 18,
+        "pendingReward": "205470",
+      },
       "isAutoTokenAssociationEnabled": false,
       "maxAutomaticTokenAssociations": 0,
     },
@@ -152,7 +157,18 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "type": "TokenAccountRaw",
   },
   {
-    "balance": "100000000",
+    "balance": "40018",
+    "id": "js:2:hedera:0.0.8313485:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
+    "operationsCount": 4,
+    "parentId": "js:2:hedera:0.0.8313485:hederaBip44",
+    "pendingOperations": [],
+    "spendableBalance": "40018",
+    "swapHistory": [],
+    "tokenId": "hedera/erc20/bonzo_atoken_usdc_0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
+    "type": "TokenAccountRaw",
+  },
+  {
+    "balance": "36243023",
     "currencyId": "hedera",
     "derivationMode": "hederaBip44",
     "freshAddress": "0.0.10096785",


### PR DESCRIPTION
…nt-id

fix(LIVE-24387): avoid hardcoded node account id with Hedera transactions

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
