### PR TITLE
fix(LWD): MADialog empty asset list icon

### DIFF
--- a/.changeset/real-suits-sparkle.md
+++ b/.changeset/real-suits-sparkle.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+---
+
+amend madialog asset empty list component  
+

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDialog/__tests__/selectAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDialog/__tests__/selectAccountFlow.test.tsx
@@ -204,7 +204,7 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
 
     await waitFor(() => expect(screen.getAllByText(/select account/i)[0]).toBeVisible());
     expect(screen.getByText(/add account/i)).toBeVisible();
-    expect(screen.getAllByText(/please add bitcoin account to continue/i)[0]).toBeVisible();
+    expect(screen.getAllByText(/you don't have bitcoin accounts yet/i)[0]).toBeVisible();
   });
 
   it("should trigger add account with corresponding currency", async () => {
@@ -532,7 +532,7 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
 
     await waitFor(() => expect(screen.getAllByText(/select account/i)[0]).toBeVisible());
 
-    const descriptions = screen.getAllByText(/please add ethereum account to continue/i);
+    const descriptions = screen.getAllByText(/you don't have ethereum accounts yet/i);
     expect(descriptions[0]).toBeVisible();
   });
 
@@ -560,7 +560,7 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
 
     await waitFor(() => expect(screen.getAllByText(/select account/i)[0]).toBeVisible());
 
-    const description = screen.queryByText(/please add ethereum account to continue/i);
+    const description = screen.queryByText(/you don't have ethereum accounts yet/i);
     expect(description).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDialog/components/AnimatedScreenWrapper.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDialog/components/AnimatedScreenWrapper.tsx
@@ -15,7 +15,7 @@ const AnimatedScreenWrapper = ({
   return (
     <div
       className={cn(
-        "h-[480px] w-full overflow-hidden [scrollbar-width:none]",
+        "flex h-[450px] w-full flex-col overflow-hidden [scrollbar-width:none]",
         direction === "FORWARD" ? "animate-slide-in-from-right" : "animate-slide-in-from-left",
       )}
       data-testid={`modular-dialog-screen-${screenKey}`}

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDialog/components/EmptyList.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDialog/components/EmptyList.tsx
@@ -8,11 +8,11 @@ const EmptyList = () => {
   const Icon = <Search size={40} className="text-base" />;
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-16">
+    <div className="flex flex-1 flex-col items-center justify-center gap-16">
       <div className="flex items-center justify-center rounded-full bg-muted-transparent p-16">
         {Icon}
       </div>
-      <span className="text-base body-3-semi-bold">{text}</span>
+      <span className="text-base heading-4-semi-bold">{text}</span>
     </div>
   );
 };

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDialog/screens/AssetSelector/components/AssetVirtualList/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDialog/screens/AssetSelector/components/AssetVirtualList/index.tsx
@@ -36,7 +36,7 @@ export const AssetVirtualList = ({
       scrollToTop={scrollToTop}
       hasNextPage={hasNextPage}
       testId="asset-selector-list-container"
-      className="pb-40"
+      className="pb-80"
     />
   );
 };

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDialog/screens/AssetSelector/components/SearchInputContainer/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDialog/screens/AssetSelector/components/SearchInputContainer/index.tsx
@@ -11,7 +11,7 @@ const SearchInputContainer = () => {
   const { handleDebouncedChange, handleSearch, displayedValue } = useSearch();
 
   return (
-    <div className="mb-12 flex-1 px-8 pt-4">
+    <div className="mb-12 px-8 pt-4">
       <Search
         value={displayedValue ?? ""}
         placeholder={t("modularAssetDrawer.searchPlaceholder")}

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDialog/screens/NetworkSelector/components/NetworkVirtualList/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDialog/screens/NetworkSelector/components/NetworkVirtualList/index.tsx
@@ -36,7 +36,7 @@ export const NetworkVirtualList = ({ networks, onClick }: NetworkVirtualListProp
       itemHeight={64}
       items={networks}
       renderItem={renderNetworkItem}
-      className="pb-40"
+      className="pb-20"
     />
   );
 };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7467,7 +7467,7 @@
   },
   "dialogs": {
     "selectAccount": {
-      "description": "Please add {{network}} account to continue",
+      "description": "You don't have {{network}} accounts yet. Please add one to continue",
       "addAccount": "Add account"
     }
   },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - MADialog assets and networks padding corrections

### 📝 Description

Centred no assets warning. 
Padding for MADialog asset and network pages. 
Amended 'no accounts' description

<img width="534" height="664" alt="image" src="https://github.com/user-attachments/assets/28d4627d-19cf-4e7d-8b43-b68ef935e791" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-24466](https://ledgerhq.atlassian.net/browse/LIVE-24466)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24466]: https://ledgerhq.atlassian.net/browse/LIVE-24466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ