### PR TITLE
feat: add default of account in receive flow from add account flow

### DIFF
--- a/.changeset/nine-guests-divide.md
+++ b/.changeset/nine-guests-divide.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add default of newly added account in receive flow from add account flow

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDialog/hooks/useOpenAssetFlow.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDialog/hooks/useOpenAssetFlow.tsx
@@ -115,10 +115,10 @@ export function useOpenAssetFlowDialog(
         });
       };
 
-      const onFlowFinishedWithModalReopen = () => {
+      const onFlowFinishedWithModalReopen = (account: AccountLike, parentAccount?: Account) => {
         setDrawer();
         if (modalNameToReopen) {
-          dispatch(openModal(modalNameToReopen, undefined));
+          dispatch(openModal(modalNameToReopen, { account, parentAccount }));
         }
       };
       if (featureNetworkBasedAddAccount?.enabled) {


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Going from add account modal to receive flow in onboarding the newly added account was not defaulted when other accounts were already present.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-24513


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
