### PR TITLE
feat(lwm): removed largemoverLandingPage feature flag

### DIFF
--- a/.changeset/mean-panthers-speak.md
+++ b/.changeset/mean-panthers-speak.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat(lwm): removed largermoverLandingPage feature flag

--- a/apps/ledger-live-mobile/src/components/RootNavigator/LandingPagesNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/LandingPagesNavigator.tsx
@@ -7,7 +7,6 @@ import { LandingPagesNavigatorParamList } from "./types/LandingPagesNavigator";
 import GenericLandingPage from "LLM/features/LandingPages/screens/GenericLandingPage";
 import { NavigationHeaderCloseButton } from "../NavigationHeaderCloseButton";
 import { LargeMoverLandingPage } from "LLM/features/LandingPages/screens/LargeMoverLandingPage";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 const Stack = createNativeStackNavigator<LandingPagesNavigatorParamList>();
 
@@ -21,8 +20,6 @@ export default function LandingPagesNavigator() {
     headerRight: () => <NavigationHeaderCloseButton />,
   };
 
-  const isLargeMoverFeatureEnabled = useFeature("largemoverLandingpage")?.enabled;
-
   return (
     <Stack.Navigator screenOptions={stackNavigationConfig}>
       <Stack.Screen
@@ -30,15 +27,13 @@ export default function LandingPagesNavigator() {
         component={GenericLandingPage}
         options={navigationOptions}
       />
-      {isLargeMoverFeatureEnabled && (
-        <Stack.Screen
-          name={ScreenName.LargeMoverLandingPage}
-          component={LargeMoverLandingPage}
-          options={{
-            headerShown: false,
-          }}
-        />
-      )}
+      <Stack.Screen
+        name={ScreenName.LargeMoverLandingPage}
+        component={LargeMoverLandingPage}
+        options={{
+          headerShown: false,
+        }}
+      />
     </Stack.Navigator>
   );
 }

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -3,8 +3,6 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components/native";
 import { ScreenName } from "~/const";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-
 import DebugBenchmarkQRStream from "~/screens/Settings/Debug/Broken/BenchmarkQRStream";
 import DebugBLE from "~/screens/Settings/Debug/Connectivity/BLE";
 import DebugBLEBenchmark from "~/screens/Settings/Debug/Connectivity/BLEBenchmark";
@@ -91,9 +89,8 @@ export default function SettingsNavigator() {
   const { t } = useTranslation();
   const { colors } = useTheme();
   const stackNavConfig = useMemo(() => getStackNavigatorConfig(colors), [colors]);
-
   const noNanoBuyNanoWallScreenOptions = useNoNanoBuyNanoWallScreenOptions();
-  const isLargeMoverFeatureEnabled = useFeature("largemoverLandingpage")?.enabled;
+
   return (
     <Stack.Navigator screenOptions={stackNavConfig}>
       <Stack.Screen
@@ -516,15 +513,13 @@ export default function SettingsNavigator() {
           title: "QueuedDrawers (Auto force open)",
         }}
       />
-      {isLargeMoverFeatureEnabled && (
-        <Stack.Screen
-          name={ScreenName.LargeMoverLandingPage}
-          component={LargeMoverLandingPage}
-          options={{
-            headerShown: false,
-          }}
-        />
-      )}
+      <Stack.Screen
+        name={ScreenName.LargeMoverLandingPage}
+        component={LargeMoverLandingPage}
+        options={{
+          headerShown: false,
+        }}
+      />
       <Stack.Screen
         name={ScreenName.DebugSwipe}
         component={SwiperScreenDebug}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
@@ -117,14 +117,13 @@ export default function Features() {
         onPress={() => navigation.navigate(ScreenName.DebugTransactionsAlerts)}
       />
 
-      <FeatureToggle featureId="largemoverLandingpage">
-        <SettingsRow
-          title="Large Mover"
-          desc="See the large mover landing page"
-          iconLeft={<Icons.Dollar />}
-          onPress={navigateToLargeMover}
-        />
-      </FeatureToggle>
+      <SettingsRow
+        title="Large Mover"
+        desc="See the large mover landing page"
+        iconLeft={<Icons.Dollar />}
+        onPress={navigateToLargeMover}
+      />
+
       <SettingsRow
         title="Swiper"
         desc="Swipe cards"

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -650,7 +650,6 @@ export const DEFAULT_FEATURES: Features = {
   },
   llmThai: DEFAULT_FEATURE,
   lldThai: DEFAULT_FEATURE,
-  largemoverLandingpage: DEFAULT_FEATURE,
   llmMmkvMigration: {
     ...DEFAULT_FEATURE,
     params: {

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -242,7 +242,6 @@ export type Features = CurrencyFeatures & {
   llmNanoSUpsellBanners: Feature_LlmNanoSUpsellBanners;
   llmThai: DefaultFeature;
   lldThai: DefaultFeature;
-  largemoverLandingpage: DefaultFeature;
   llmMmkvMigration: Feature_LlmMmkvMigration;
   lldModularDrawer: Feature_ModularDrawer;
   llmModularDrawer: Feature_ModularDrawer;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - removed the `largemoverLandingPage` feature flag implementation across screens and definition in `defaultFeatures.ts`

### 📝 Description

Feature flag no longer required as part of the epic [LIVE-23909](https://ledgerhq.atlassian.net/browse/LIVE-23909) so has been removed - affects only mobile.

### ❓ Context

[LIVE-23912](https://ledgerhq.atlassian.net/browse/LIVE-23912)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23909]: https://ledgerhq.atlassian.net/browse/LIVE-23909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-23912]: https://ledgerhq.atlassian.net/browse/LIVE-23912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ