### PR TITLE
fix(LWM): prevent retry button from redirecting to wallet page in receive flow

### DIFF
--- a/.changeset/ninety-bags-taste.md
+++ b/.changeset/ninety-bags-taste.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+prevent retry button from redirecting to wallet page in receive flow

--- a/apps/ledger-live-mobile/__mocks__/react-native-gesture-handler/ReanimatedSwipeable.js
+++ b/apps/ledger-live-mobile/__mocks__/react-native-gesture-handler/ReanimatedSwipeable.js
@@ -1,8 +1,14 @@
 import React from "react";
 import { View } from "react-native";
 
-const ReanimatedSwipeable = ({ children, renderRightActions, ...props }) => {
-  return <View {...props}>{children}</View>;
-};
+const ReanimatedSwipeable = React.forwardRef(({ children, renderRightActions, ...props }, ref) => {
+  return (
+    <View ref={ref} {...props}>
+      {children}
+    </View>
+  );
+});
+
+ReanimatedSwipeable.displayName = "ReanimatedSwipeable";
 
 export default ReanimatedSwipeable;

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/types.ts
@@ -11,6 +11,8 @@ export type AddAccountContextType = `${AddAccountContexts}`;
 type CommonParams = {
   context?: AddAccountContextType;
   onCloseNavigation?: () => void;
+  // Number of navigators to pop when closing the flow (calculated at entry point)
+  navigationDepth?: number;
   currency: CryptoOrTokenCurrency;
   sourceScreenName?: string;
 };

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/index.tsx
@@ -60,7 +60,7 @@ function ScanDeviceAccounts() {
     onModalHide,
     onPressAccount,
     quitFlow,
-    restartSubscription,
+    handleRetry,
     scannedAccounts,
     scanning,
     sections,
@@ -187,7 +187,7 @@ function ScanDeviceAccounts() {
             (!scanning && scannedAccounts.length === 0)
           }
           canDone={!scanning && cantCreateAccount && noImportableAccounts}
-          onRetry={restartSubscription}
+          onRetry={handleRetry}
           onStop={stopSubscription}
           onDone={quitFlow}
           onContinue={importAccounts}
@@ -201,10 +201,10 @@ function ScanDeviceAccounts() {
         onModalHide={onModalHide}
         footerButtons={
           <>
-            <CancelButton containerStyle={styles.button} onPress={onCancel} />
+            <CancelButton containerStyle={styles.button} onPress={onCancel} outline />
             <RetryButton
               containerStyle={[styles.button, styles.buttonRight]}
-              onPress={restartSubscription}
+              onPress={handleRetry}
             />
           </>
         }

--- a/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/screens/SelectDevice/useSelectDeviceViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/screens/SelectDevice/useSelectDeviceViewModel.ts
@@ -40,23 +40,20 @@ export default function useSelectDeviceViewModel(
     (meta: AppResult) => {
       setDevice(null);
 
-      const { inline } = route.params;
       const params = {
         ...route.params,
         ...meta,
         context,
         sourceScreenName: ScreenName.SelectDevice,
       };
-      if (inline) {
-        navigation.replace(NavigatorName.AddAccounts, {
-          screen: ScreenName.ScanDeviceAccounts,
-          params,
-        });
-      } else
-        navigation.navigate(NavigatorName.AddAccounts, {
-          screen: ScreenName.ScanDeviceAccounts,
-          params,
-        });
+
+      // Always use navigate instead of replace to keep SelectDevice in the stack.
+      // This allows retry navigation when device errors occur (e.g., device locked).
+      // Previously, inline flows used replace which prevented retry navigation.
+      navigation.navigate(NavigatorName.AddAccounts, {
+        screen: ScreenName.ScanDeviceAccounts,
+        params,
+      });
     },
     [navigation, route, context],
   );

--- a/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/types.ts
@@ -12,6 +12,7 @@ type CommonParams = {
   context?: AddAccountContextType;
   onSuccess?: (res?: { scannedAccounts: Account[]; selected: Account[] }) => void;
   onCloseNavigation?: () => void;
+  navigationDepth?: number;
   sourceScreenName?: string;
 };
 

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/useDeviceNavigation.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/useDeviceNavigation.ts
@@ -38,6 +38,11 @@ export function useDeviceNavigation({
     (selectedAsset: CryptoCurrency, createTokenAccount?: boolean) => {
       onClose?.();
       resetSelection();
+
+      // Number of screens in the navigation stack to pop when closing:
+      // SelectDevice (1) + AddAccounts flow (1) = 2 screens to pop
+      const navigationDepth = isInline ? 2 : undefined;
+
       navigation.navigate(NavigatorName.DeviceSelection, {
         screen: ScreenName.SelectDevice,
         params: {
@@ -46,6 +51,7 @@ export function useDeviceNavigation({
           context: AddAccountContexts.AddAccounts,
           inline: isInline,
           onCloseNavigation: onClose,
+          navigationDepth,
           onSuccess,
         },
       });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR fixes a navigation bug where retrying after a device error (e.g., locked device) in the receive flow would redirect to the wallet page. The fix uses navigate() instead of replace() to preserve the device selection screen in the stack, allowing proper retry navigation. A navigationDepth parameter is introduced to correctly close inline flows, with integration tests added to validate the behavior.

Add `forwardRef` support to ReanimatedSwipeable mock for proper ref handling in integration tests.



https://github.com/user-attachments/assets/26a770b4-78ef-48d3-a092-e2e9786aa211



### ❓ Context

- **JIRA or GitHub link**: 
- https://ledgerhq.atlassian.net/browse/LIVE-22846
- https://ledgerhq.atlassian.net/browse/LIVE-24631


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
