### PR TITLE
Proof of Concept: study the use "main" instead of "browser" for some libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "node-abi": "^4.9.0"
   },
   "scripts": {
+    "postinstall": "node scripts/patch-browser-fields.js",
     "bump": "changeset version",
     "clean": "git clean -fdX",
     "changelog": "changeset add",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77588,7 +77588,7 @@ snapshots:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.36.0
-      webpack: 5.94.0
+      webpack: 5.94.0(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - metro
 

--- a/scripts/patch-browser-fields.js
+++ b/scripts/patch-browser-fields.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+/**
+ * This script removes the "browser" field from specific packages in node_modules.
+ * This forces bundlers (esbuild, Vite) to use the "main" entry point instead,
+ * which allows proper tree-shaking and significantly reduces bundle size.
+ *
+ * Run after pnpm install.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+// Packages to patch - these ship pre-bundled minified browser builds
+// that cannot be tree-shaken
+const PACKAGES_TO_PATCH = [
+  "@stellar/stellar-sdk", // browser → dist/stellar-sdk.min.js (~936KB) vs main → lib/index.js
+  "@stellar/stellar-base", // browser → dist/stellar-base.min.js (~442KB) vs main → lib/index.js
+  "web3", // browser → dist/web3.min.js (~1.36MB) vs main → lib/index.js
+  "icon-sdk-js", // browser → build/icon-sdk-js.web.min.js (~2.74MB) vs main → build/icon-sdk-js.node.min.js
+  "casper-js-sdk", // browser → dist/lib.web.js (~1.03MB) vs main → dist/lib.node.js
+  "algosdk", // browser → dist/browser/algosdk.min.js (~406KB) vs main → dist/cjs/index.js
+  "@solana/web3.js", // browser → lib/index.browser.esm.js (~321KB) vs main → lib/index.cjs.js
+];
+
+function findPackageDirs(packageName) {
+  const pnpmDir = path.join(__dirname, "..", "node_modules", ".pnpm");
+  const dirs = [];
+
+  if (!fs.existsSync(pnpmDir)) {
+    return dirs;
+  }
+
+  // pnpm uses a flat structure like: .pnpm/@stellar+stellar-sdk@14.0.0/node_modules/@stellar/stellar-sdk
+  const entries = fs.readdirSync(pnpmDir);
+  const escapedName = packageName.replace("/", "+").replace("@", "");
+  const prefix = packageName.startsWith("@")
+    ? packageName.replace("/", "+")
+    : packageName;
+
+  for (const entry of entries) {
+    if (entry.startsWith(prefix + "@") || entry.startsWith(escapedName + "@")) {
+      const packagePath = path.join(pnpmDir, entry, "node_modules", packageName);
+      if (fs.existsSync(packagePath)) {
+        dirs.push(packagePath);
+      }
+    }
+  }
+
+  return dirs;
+}
+
+function patchPackage(packageDir) {
+  const packageJsonPath = path.join(packageDir, "package.json");
+
+  if (!fs.existsSync(packageJsonPath)) {
+    return false;
+  }
+
+  const content = fs.readFileSync(packageJsonPath, "utf-8");
+  const pkg = JSON.parse(content);
+
+  let modified = false;
+
+  // Remove top-level browser field
+  if (pkg.browser) {
+    console.log(`  Removing "browser": "${pkg.browser}"`);
+    delete pkg.browser;
+    modified = true;
+  }
+
+  // Remove browser from exports
+  if (pkg.exports && typeof pkg.exports === "object") {
+    const removeBrowserFromExports = (obj, path = "exports") => {
+      if (obj && typeof obj === "object") {
+        if (obj.browser) {
+          console.log(`  Removing "${path}.browser": "${obj.browser}"`);
+          delete obj.browser;
+          modified = true;
+        }
+        for (const [key, val] of Object.entries(obj)) {
+          if (val && typeof val === "object") {
+            removeBrowserFromExports(val, `${path}.${key}`);
+          }
+        }
+      }
+    };
+    removeBrowserFromExports(pkg.exports);
+  }
+
+  if (modified) {
+    fs.writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + "\n");
+  }
+
+  return modified;
+}
+
+console.log("Patching browser fields in node_modules...\n");
+
+let patchedCount = 0;
+
+for (const packageName of PACKAGES_TO_PATCH) {
+  const dirs = findPackageDirs(packageName);
+
+  if (dirs.length === 0) {
+    console.log(`[SKIP] ${packageName} - not found in node_modules`);
+    continue;
+  }
+
+  for (const dir of dirs) {
+    console.log(`[PATCH] ${packageName}`);
+    console.log(`  Path: ${dir}`);
+    if (patchPackage(dir)) {
+      patchedCount++;
+    } else {
+      console.log("  No browser field found");
+    }
+  }
+}
+
+console.log(`\nDone! Patched ${patchedCount} package(s).`);
+


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

studying a way to unlock way more bundle size: a bunch of our libraries are exposed via the `"browser"` field in their package.json which exposes a browser front that is often a huge bundle size and that isn't tree shakable in our current build systems. Therefore, a workaround is to remove that field to force the build resolver to use the `"main"` field.

I don't consider the current approach of this PR to be viable but we're doing a study here.


this study includes:

Package | before (browser) | after (main) | gain
-- | -- | -- | --
icon-sdk-js | 2.74 MB | 1.72 MB | ↓ 1 MB
web3 | 1.36 MB | tree-shaked | ↓ ~1.36 MB
casper-js-sdk | 1.03 MB | 484 KB | ↓ 545 KB
@stellar/stellar-sdk | 936 KB | tree-shaked | ↓ ~936 KB
algosdk | 406 KB | tree-shaked | ↓ ~400 KB



### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
