### PR TITLE
feat(LWD): call addAddress in broadcast instead of recipient

### DIFF
--- a/.changeset/hungry-poets-bathe.md
+++ b/.changeset/hungry-poets-bathe.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(LWD): call to addAddress to RecentAddressStore from Recipient to Broadcast

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
@@ -7,7 +7,11 @@ import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
+import {
+  addPendingOperation,
+  getMainAccount,
+  getRecentAddressesStore,
+} from "@ledgerhq/live-common/account/index";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -249,8 +253,14 @@ const Body = ({
       );
       setOptimisticOperation(optimisticOperation);
       setTransactionError(null);
+      // Add address to recent addresses store after successful broadcast
+      if (transaction && mainAccount) {
+        const store = getRecentAddressesStore();
+        const ensName = transaction.recipientDomain?.domain;
+        store.addAddress(mainAccount.currency.id, transaction.recipient, ensName);
+      }
     },
-    [account, parentAccount, updateAccountWithUpdater],
+    [account, parentAccount, updateAccountWithUpdater, transaction],
   );
   const handleStepChange = useCallback(
     (e: { id: StepId }) => onChangeStepId(e.id),

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
 import { Trans } from "react-i18next";
-import { getMainAccount, getRecentAddressesStore } from "@ledgerhq/live-common/account/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -177,11 +177,6 @@ export const StepRecipientFooter = ({
   const alwaysShowMemoTagInfo = useSelector(alwaysShowMemoTagInfoSelector);
 
   const handleOnNext = async () => {
-    if (mainAccount && transaction) {
-      const store = getRecentAddressesStore();
-      const ensName = transaction.recipientDomain?.domain;
-      store.addAddress(mainAccount.currency.id, transaction.recipient, ensName);
-    }
     if (
       transaction &&
       lldMemoTag?.enabled &&


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - `addAddress` is not called in the Recipient step anymore but during the Broadcast

### 📝 Description

Changes the placement of `addAddress` of the `RecentAddressStore`
Not called in Recipient step but when the tx is broadcasted successfully

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
