### PR TITLE
fix(search): fix the debounce on mobile

### DIFF
--- a/.changeset/tender-ghosts-happen.md
+++ b/.changeset/tender-ghosts-happen.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update the search bar for the market

--- a/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketList/components/SearchHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketList/components/SearchHeader/index.tsx
@@ -1,6 +1,6 @@
 import { SearchInput } from "@ledgerhq/native-ui";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
-import React, { memo, useState, useEffect } from "react";
+import React, { memo, useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { MarketListRequestParams } from "@ledgerhq/live-common/market/utils/types";
 import { track } from "~/analytics";
@@ -15,6 +15,7 @@ function SearchHeader({ search, updateMarketParams }: Props) {
   const [inputSearch, setInputSearch] = useState(search);
   const debouncedSearch = useDebounce(inputSearch, 300);
   const { t } = useTranslation();
+  const prevSearchRef = useRef(search);
 
   useEffect(() => {
     track("Page Market Query", {
@@ -29,7 +30,12 @@ function SearchHeader({ search, updateMarketParams }: Props) {
   }, [debouncedSearch, updateMarketParams]);
 
   useEffect(() => {
-    setInputSearch(search);
+    // Only sync when search prop is externally reset (e.g. via "Clear" button)
+    // Detect this by checking if search changed FROM non-empty TO empty
+    if (!!prevSearchRef.current && !search) {
+      setInputSearch(search);
+    }
+    prevSearchRef.current = search;
   }, [search]);
 
   return (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - I've changed the way that we update the content of the search input on the market page. I think it's worth it to test it correctly to see if the fix works well. It was not easy to reproduce on local i had to use a staging build.

### 📝 Description
We had a debounce that was deleting characters when typing slowly in the search bar on the market page

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24359](https://ledgerhq.atlassian.net/browse/LIVE-24359)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24359]: https://ledgerhq.atlassian.net/browse/LIVE-24359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ