### PR TITLE
[LWD/LWM] LW doesn't prevent transacting to/from a XTZ banned address - update cache to 15min instead of 12h

### DIFF
--- a/.changeset/five-hairs-jog.md
+++ b/.changeset/five-hairs-jog.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-framework": minor
+---
+
+[LWD/LWM] LW doesn't prevent transacting to/from a XTZ banned address - update cache to 15min instead of 12h

--- a/libs/coin-framework/src/sanction/index.ts
+++ b/libs/coin-framework/src/sanction/index.ts
@@ -1,10 +1,10 @@
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import axios from "axios";
-import { hours, makeLRUCache } from "@ledgerhq/live-network/cache";
+import { makeLRUCache, minutes } from "@ledgerhq/live-network/cache";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getEnv } from "@ledgerhq/live-env";
 
-const cache = makeLRUCache(fetchSanctionedAddresses, () => "all_sanctioned_addresses", hours(12));
+const cache = makeLRUCache(fetchSanctionedAddresses, () => "all_sanctioned_addresses", minutes(15));
 
 async function fetchSanctionedAddresses(): Promise<Record<string, string[]>> {
   try {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Change OFAC check cache to 15 minutes instead 12 hours 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> [LIVE-24502](https://ledgerhq.atlassian.net/browse/LIVE-24502)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24502]: https://ledgerhq.atlassian.net/browse/LIVE-24502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ