### PR TITLE
fix(LIVE-24654): add missing portfolio banner margin

### DIFF
--- a/.changeset/shy-rabbits-tell.md
+++ b/.changeset/shy-rabbits-tell.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add missing margin below banners when Swap on Portfolio Widget is active

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/index.tsx
@@ -90,7 +90,7 @@ export default function DashboardPage() {
         ) : totalAccounts > 0 ? (
           <>
             {ptxSwapLiveAppOnPortfolio?.enabled ? (
-              <SwapPortfolioGrid>
+              <PortfolioGrid marginTop={4}>
                 <Box>
                   <FeaturedButtons hideSwapButton />
                   <BalanceSummary
@@ -103,7 +103,7 @@ export default function DashboardPage() {
                 <Box ml={2} minWidth={375} maxWidth={700}>
                   <SwapWebViewEmbedded height="550px" />
                 </Box>
-              </SwapPortfolioGrid>
+              </PortfolioGrid>
             ) : marketPerformanceEnabled ? (
               <PortfolioGrid>
                 <BalanceSummary
@@ -148,13 +148,6 @@ export default function DashboardPage() {
 }
 
 const PortfolioGrid = styled(Grid).attrs(() => ({
-  columnGap: 2,
-  columns: 2,
-}))`
-  grid-template-columns: 2fr 1fr;
-`;
-
-const SwapPortfolioGrid = styled(Grid).attrs(() => ({
   columnGap: 2,
   columns: 2,
 }))`


### PR DESCRIPTION
add missing margin below banners when swap on portfolio widget is active

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->
<img width="1000" alt="Screenshot 2026-01-06 at 10 27 45" src="https://github.com/user-attachments/assets/5989442b-d23c-4611-ab7a-001633f1366a" />

After
<img width="1000" alt="Screenshot 2026-01-06 at 13 39 35" src="https://github.com/user-attachments/assets/a004d407-66b9-427a-8c39-d2cd75666908" />


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
