### PR TITLE
[LWD/LWM] LW doesn't prevent transacting to/from a XTZ banned address - revert and remove cache

### DIFF
--- a/.changeset/violet-papayas-rest.md
+++ b/.changeset/violet-papayas-rest.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-framework": minor
+---
+
+[LWD/LWM] LW doesn't prevent transacting to/from a XTZ banned address - revert and remove cache

--- a/libs/coin-framework/src/sanction/index.ts
+++ b/libs/coin-framework/src/sanction/index.ts
@@ -1,10 +1,7 @@
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import axios from "axios";
-import { makeLRUCache, minutes } from "@ledgerhq/live-network/cache";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getEnv } from "@ledgerhq/live-env";
-
-const cache = makeLRUCache(fetchSanctionedAddresses, () => "all_sanctioned_addresses", minutes(15));
 
 async function fetchSanctionedAddresses(): Promise<Record<string, string[]>> {
   try {
@@ -30,9 +27,7 @@ export async function isAddressSanctioned(
     "tmp_sanctioned_addresses",
   );
 
-  const data: Record<string, string[]> = getEnv("MOCK")
-    ? await fetchSanctionedAddresses()
-    : await cache();
+  const data: Record<string, string[]> = await fetchSanctionedAddresses();
   const addresses = data["bannedAddresses"] || [];
 
   if (temporarySanctionedAddress) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Revert previous fix (cache decreased) and remove cache

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> [LIVE-24502](https://ledgerhq.atlassian.net/browse/LIVE-24502?atlOrigin=eyJpIjoiNWIwNmNlZmJjNDg0NGNmNmExN2U0YzI0ZDY5OWZiZDciLCJwIjoiaiJ9)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24502]: https://ledgerhq.atlassian.net/browse/LIVE-24502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ