### PR TITLE
fix(coin-evm): reduce batch size in `getBalance`

### DIFF
--- a/.changeset/tidy-seas-travel.md
+++ b/.changeset/tidy-seas-travel.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-evm": minor
+"live-mobile": minor
+---
+
+fix(coin-evm): reduce batch size in `getBalance`

--- a/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
@@ -282,6 +282,30 @@ describe.each([
         expect(balance.value).toBeGreaterThanOrEqual(0);
       });
     });
+
+    /**
+     * Ensure non regression and avoid
+     * "To send batches over 10 items, consider using a dedicated API provider"
+     */
+    it("returns at least 10 token balances on Optimisim", async () => {
+      const module = createApi(
+        {
+          node: {
+            type: "external",
+            uri: "https://mainnet.optimism.io",
+          },
+          explorer: {
+            type: "blockscout",
+            uri: "https://optimism.blockscout.com/api",
+          },
+        } as EvmConfig,
+        "optimism",
+      );
+
+      const result = await module.getBalance("0x1CDDb825910426644e00e769072Ce1Ea7d4e34BB");
+
+      expect(result.length).toBeGreaterThan(10);
+    });
   });
 
   describe("listOperations", () => {

--- a/libs/coin-modules/coin-evm/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBalance.ts
@@ -7,7 +7,7 @@ import { NodeApi } from "../network/node/types";
 import { ExplorerApi } from "../network/explorer/types";
 import { getStakes } from "./getStakes";
 
-export const TOKEN_BALANCE_BATCH_SIZE = 10;
+export const TOKEN_BALANCE_BATCH_SIZE = 8;
 
 /**
  * Get all assets linked to the user (native, tokens, ...)


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Current batch size used in Alpaca `getBalance` is too high for some nodes, including the ones we use for Optimism

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
