### PR TITLE
fix: Persistent state in ModularDialog on reopening

### DIFF
--- a/.changeset/twelve-countries-yawn.md
+++ b/.changeset/twelve-countries-yawn.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix Persistent state in ModularDialog on reopening

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDialog/ModularDialogRoot.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDialog/ModularDialogRoot.tsx
@@ -1,10 +1,15 @@
 import React, { useCallback } from "react";
 import { useSelector, useDispatch } from "LLD/hooks/redux";
-import { modularDialogOnCloseSelector, closeDialog } from "~/renderer/reducers/modularDrawer";
+import {
+  modularDialogOnCloseSelector,
+  closeDialog,
+  modularDialogIsOpenSelector,
+} from "~/renderer/reducers/modularDrawer";
 import ModularDialogFlowManager from "./ModularDialogFlowManager";
 
 export const ModularDialogRoot: React.FC = () => {
   const onClose = useSelector(modularDialogOnCloseSelector);
+  const isOpen = useSelector(modularDialogIsOpenSelector);
   const dispatch = useDispatch();
 
   const handleClose = useCallback(() => {
@@ -13,6 +18,8 @@ export const ModularDialogRoot: React.FC = () => {
     }
     dispatch(closeDialog());
   }, [dispatch, onClose]);
+
+  if (!isOpen) return null;
 
   return <ModularDialogFlowManager onClose={handleClose} />;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix Persistent state in ModularDialog on reopening


### ❓ Context

- **JIRA or GitHub link**: 
- https://ledgerhq.atlassian.net/browse/LIVE-24743
- https://ledgerhq.atlassian.net/browse/LIVE-24739


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
