### PR TITLE
ci: composite cleanup

### DIFF
--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -33,11 +33,6 @@ jobs:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
 
-      - name: Checkout composite actions
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: tools/actions/composites
-
       - name: Generate ref/tag version to use when running changeset status
         uses: LedgerHQ/ledger-live/tools/actions/composites/generate-tag@develop
         id: format-app-tag


### PR DESCRIPTION
Removes composite checkout - this is performed by github on initialisation of the job and is surplus to requirements