### PR TITLE
chore(desktop): for dev mode, animationJsonLoader must not be used

### DIFF
--- a/apps/ledger-live-desktop/tools/rspack/animationJsonLoader.cjs
+++ b/apps/ledger-live-desktop/tools/rspack/animationJsonLoader.cjs
@@ -1,5 +1,5 @@
 /**
- * Loader for animation JSON files.
+ * Loader for animation JSON files (production only).
  * Emits the JSON as an asset and exports require() call for runtime loading.
  * This replicates esbuild's JsonPlugin behavior for reduced bundle size.
  * Works in Electron where nodeIntegration is enabled.
@@ -8,7 +8,6 @@ const crypto = require("crypto");
 const path = require("path");
 
 module.exports = function animationJsonLoader(source) {
-  // Compute content hash for unique filename
   const hash = crypto.createHash("md5").update(source).digest("hex").slice(0, 16);
   const baseName = path.basename(this.resourcePath, ".json");
   const fileName = `assets/${hash}-${baseName}.json`;
@@ -19,7 +18,6 @@ module.exports = function animationJsonLoader(source) {
   // Return a module that uses __dirname to resolve the asset path
   // __dirname points to the directory of the bundle file (.webpack/)
   // We use __non_webpack_require__ which becomes actual require() at runtime
-  // and is not processed by rspack
   return `
 var path = __non_webpack_require__("path");
 var assetPath = path.join(__dirname, ${JSON.stringify(fileName)});

--- a/apps/ledger-live-desktop/tools/rspack/rspack.renderer.ts
+++ b/apps/ledger-live-desktop/tools/rspack/rspack.renderer.ts
@@ -193,14 +193,19 @@ export function createRendererConfig(
             filename: "assets/[name]-[hash][ext]",
           },
         },
-        // JSON files in src/ - emit as assets and load via require() at runtime
-        // This replicates esbuild's JsonPlugin behavior for reduced bundle size
-        {
-          test: /\.json$/,
-          include: path.resolve(rootFolder, "src"),
-          type: "javascript/auto",
-          use: [path.resolve(__dirname, "animationJsonLoader.cjs")],
-        },
+        // JSON files in src/ - emit as assets and load via require() at runtime (prod only)
+        // In dev mode, rspack's default JSON handler inlines them for HMR compatibility
+        // In prod mode, this replicates esbuild's JsonPlugin behavior for reduced bundle size
+        ...(isDev
+          ? []
+          : [
+              {
+                test: /\.json$/,
+                include: path.resolve(rootFolder, "src"),
+                type: "javascript/auto" as const,
+                use: [path.resolve(__dirname, "animationJsonLoader.cjs")],
+              },
+            ]),
       ],
     },
     plugins: [


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Unfortunately the latest iteration of Rspack to make the .json external did a regression in **dev mode** of running the desktop app.

This is resolved by not using any custom json loader in dev mode and only having it for the desktop optimisation (bundle size).

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
