### PR TITLE
fix: Prevent crash when tapping search input on empty asset list

### DIFF
--- a/.changeset/nine-ladybugs-live.md
+++ b/.changeset/nine-ladybugs-live.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Search crash in MAD

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
@@ -192,6 +192,33 @@ describe("ModularDrawer integration", () => {
     });
   });
 
+  it("should not crash when tapping search input with empty asset list", async () => {
+    const { getByText, getByPlaceholderText, getByTestId, user } = render(
+      <ModularDrawerSharedNavigator />,
+    );
+
+    await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
+    advanceTimers();
+
+    const searchInput = getByPlaceholderText(/search/i);
+
+    // First, search for something that returns no results
+    await user.type(searchInput, "zzzzzzz");
+
+    await waitFor(() => {
+      expect(getByText(/no assets found/i)).toBeVisible();
+    });
+
+    // Now tap on the search input again - this should not crash
+    await user.press(searchInput);
+
+    advanceTimers();
+
+    // Verify the drawer is still visible and functional
+    expect(getByTestId("modular-drawer-search-input")).toBeVisible();
+    expect(getByText(/no assets found/i)).toBeVisible();
+  });
+
   it("should allow full navigation: asset → network → account", async () => {
     const { getByText, user } = render(<ModularDrawerSharedNavigator />, {
       ...INITIAL_STATE,

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -68,7 +68,9 @@ const AssetSelection = ({
 
   const expandToFullHeight = () => {
     snapToIndex(1);
-    listRef.current?.scrollToIndex({ index: 0 });
+    if (formattedAssets.length > 0) {
+      listRef.current?.scrollToIndex({ index: 0 });
+    }
   };
 
   const assetsMap = groupCurrenciesByAsset(assetsSorted || []);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The app crashes when the user taps the search input in the Modular Asset Drawer while the asset list is empty.

In AssetSelection/index.tsx, the expandToFullHeight function calls scrollToIndex({ index: 0 }) without checking if the list contains any items. When the list is empty, React Native's virtualized list throws an error because it cannot scroll to a non-existent index.

Added a guard to only call scrollToIndex when formattedAssets.length > 0:


https://github.com/user-attachments/assets/ed208ea4-729a-4073-91a3-52efc7ac2987




### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-24791

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
