### PR TITLE
fix(coin-evm): only expose `refreshOperations` if no explorer is available

### DIFF
--- a/.changeset/poor-bags-smile.md
+++ b/.changeset/poor-bags-smile.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/coin-tester-evm": minor
+---
+
+fix(coin-evm): only expose `refreshOperations` if no explorers is available

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/api/explorer/index.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/api/explorer/index.unit.test.ts
@@ -18,6 +18,12 @@ mockGetConfig.mockImplementation((currency: any): any => {
     case "blockscout-coin": {
       return { info: { explorer: { type: "blockscout", uri: "working" } } };
     }
+    case "etherscan-coin-no-cache": {
+      return { info: { explorer: { type: "etherscan", uri: "working", noCache: true } } };
+    }
+    case "blockscout-coin-no-cache": {
+      return { info: { explorer: { type: "blockscout", uri: "working", noCache: true } } };
+    }
     case "ledger-coin": {
       return { info: { explorer: { type: "ledger", explorerId: "eth" } } };
     }
@@ -45,8 +51,16 @@ describe("EVM Family", () => {
         const explorerA = getExplorerApi({ id: "etherscan-coin" } as any);
         const explorerB = getExplorerApi({ id: "blockscout-coin" } as any);
 
-        expect(explorerA).toBe(etherscanLikeApi);
-        expect(explorerB).toBe(etherscanLikeApi);
+        expect(explorerA).toBe(etherscanLikeApi.explorerApi);
+        expect(explorerB).toBe(etherscanLikeApi.explorerApi);
+      });
+
+      it("should return the no cache etherscan api", () => {
+        const explorerA = getExplorerApi({ id: "etherscan-coin-no-cache" } as any);
+        const explorerB = getExplorerApi({ id: "blockscout-coin-no-cache" } as any);
+
+        expect(explorerA).toBe(etherscanLikeApi.explorerApiNoChache);
+        expect(explorerB).toBe(etherscanLikeApi.explorerApiNoChache);
       });
 
       it("should return the ledger api", () => {

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
@@ -51,7 +51,12 @@ jest.mock("../../network/explorer/etherscan", () => {
     getLastERC1155Operations: jest.fn(),
     getLastERC721Operations: jest.fn(),
     default: {
-      getLastOperations: mockGetLastOperations,
+      explorerApi: {
+        getLastOperations: mockGetLastOperations,
+      },
+      explorerApiNoChache: {
+        getLastOperations: mockGetLastOperations,
+      },
     },
   };
 });
@@ -272,7 +277,7 @@ describe("EVM Family", () => {
       describe("With no transactions fetched", () => {
         beforeAll(() => {
           // @ts-expect-error reseting cache
-          etherscanAPI?.default.getLastOperations.reset();
+          etherscanAPI?.default.explorerApi.getLastOperations.reset();
           jest.spyOn(etherscanAPI, "getLastOperations").mockImplementation(() =>
             Promise.resolve({
               lastCoinOperations: [],
@@ -281,14 +286,16 @@ describe("EVM Family", () => {
               lastInternalOperations: [],
             }),
           );
-          jest.spyOn(etherscanAPI?.default, "getLastOperations").mockImplementation(() =>
-            Promise.resolve({
-              lastCoinOperations: [],
-              lastTokenOperations: [],
-              lastNftOperations: [],
-              lastInternalOperations: [],
-            }),
-          );
+          jest
+            .spyOn(etherscanAPI?.default.explorerApi, "getLastOperations")
+            .mockImplementation(() =>
+              Promise.resolve({
+                lastCoinOperations: [],
+                lastTokenOperations: [],
+                lastNftOperations: [],
+                lastInternalOperations: [],
+              }),
+            );
         });
 
         afterAll(() => {
@@ -371,7 +378,7 @@ describe("EVM Family", () => {
             {} as any,
           );
 
-          expect(etherscanAPI?.default.getLastOperations).toHaveBeenCalledWith(
+          expect(etherscanAPI?.default.explorerApi.getLastOperations).toHaveBeenCalledWith(
             getAccountShapeParameters.currency,
             getAccountShapeParameters.address,
             account.id,
@@ -399,7 +406,7 @@ describe("EVM Family", () => {
             {} as any,
           );
 
-          expect(etherscanAPI?.default.getLastOperations).toHaveBeenCalledWith(
+          expect(etherscanAPI?.default.explorerApi.getLastOperations).toHaveBeenCalledWith(
             getAccountShapeParameters.currency,
             getAccountShapeParameters.address,
             account.id,
@@ -412,7 +419,7 @@ describe("EVM Family", () => {
       describe("With transactions fetched", () => {
         beforeAll(() => {
           // Mock getLastOperations to return combined operations data
-          (etherscanAPI.default.getLastOperations as jest.Mock).mockResolvedValue({
+          (etherscanAPI.default.explorerApi.getLastOperations as jest.Mock).mockResolvedValue({
             lastCoinOperations: [{ ...coinOperations[0] }, { ...coinOperations[1] }],
             lastTokenOperations: [{ ...tokenOperations[0] }, { ...tokenOperations[1] }],
             lastNftOperations: [
@@ -520,7 +527,7 @@ describe("EVM Family", () => {
 
         it("should return a partial account based on blockHeight", async () => {
           jest
-            .spyOn(etherscanAPI?.default, "getLastOperations")
+            .spyOn(etherscanAPI?.default.explorerApi, "getLastOperations")
             .mockImplementationOnce(async () => ({
               lastTokenOperations: [],
               lastNftOperations: [],
@@ -670,7 +677,7 @@ describe("EVM Family", () => {
       describe("With Blockscout", () => {
         beforeAll(() => {
           // Mock getLastOperations for blockscout explorer
-          (etherscanAPI.default.getLastOperations as jest.Mock).mockResolvedValue({
+          (etherscanAPI.default.explorerApi.getLastOperations as jest.Mock).mockResolvedValue({
             lastCoinOperations: [{ ...coinOperations[0] }, { ...coinOperations[1] }],
             lastTokenOperations: [{ ...tokenOperations[0] }, { ...tokenOperations[1] }],
             lastNftOperations: [
@@ -724,7 +731,7 @@ describe("EVM Family", () => {
           );
 
           // Verify the mock was called
-          expect(etherscanAPI.default.getLastOperations).toHaveBeenCalled();
+          expect(etherscanAPI.default.explorerApi.getLastOperations).toHaveBeenCalled();
           expect(typeof accountShape.id).toBe("string");
         });
       });

--- a/libs/coin-modules/coin-evm/src/api/index.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.test.ts
@@ -1,0 +1,58 @@
+import { EvmConfig } from "../config";
+import { createApi } from "./index";
+
+describe.each([
+  [
+    "with explorer",
+    { explorer: { type: "ledger" } },
+    {
+      broadcast: expect.any(Function),
+      combine: expect.any(Function),
+      computeIntentType: expect.any(Function),
+      craftRawTransaction: expect.any(Function),
+      craftTransaction: expect.any(Function),
+      estimateFees: expect.any(Function),
+      getAssetFromToken: expect.any(Function),
+      getBalance: expect.any(Function),
+      getBlock: expect.any(Function),
+      getBlockInfo: expect.any(Function),
+      getRewards: expect.any(Function),
+      getSequence: expect.any(Function),
+      getStakes: expect.any(Function),
+      getTokenFromAsset: expect.any(Function),
+      getValidators: expect.any(Function),
+      lastBlock: expect.any(Function),
+      listOperations: expect.any(Function),
+      validateIntent: expect.any(Function),
+    },
+  ],
+  [
+    "without explorer",
+    { explorer: { type: "none" } },
+    {
+      broadcast: expect.any(Function),
+      combine: expect.any(Function),
+      computeIntentType: expect.any(Function),
+      craftRawTransaction: expect.any(Function),
+      craftTransaction: expect.any(Function),
+      estimateFees: expect.any(Function),
+      getAssetFromToken: expect.any(Function),
+      getBalance: expect.any(Function),
+      getBlock: expect.any(Function),
+      getBlockInfo: expect.any(Function),
+      getRewards: expect.any(Function),
+      getSequence: expect.any(Function),
+      getStakes: expect.any(Function),
+      getTokenFromAsset: expect.any(Function),
+      getValidators: expect.any(Function),
+      lastBlock: expect.any(Function),
+      listOperations: expect.any(Function),
+      validateIntent: expect.any(Function),
+      refreshOperations: expect.any(Function),
+    },
+  ],
+])("Alpaca methods %s", (_s, config, methods) => {
+  it("ensures methods are presents", () => {
+    expect(createApi(config as EvmConfig, "ethereum")).toEqual(methods);
+  });
+});

--- a/libs/coin-modules/coin-evm/src/api/index.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.ts
@@ -106,7 +106,17 @@ export function createApi(
     getAssetFromToken: (token: TokenCurrency, owner: string): AssetInfo =>
       getAssetFromToken(currency, token, owner),
     computeIntentType,
-    refreshOperations: (operations: LiveOperation[]): Promise<LiveOperation[]> =>
-      refreshOperations(currency, operations),
+    /**
+     * Only expose this method if the chain has no explorer (the only chain that passes a function
+     * is Celo that works with an explorer)
+     * Not exposing this methods ensures that we don't try to force the update of pending operations
+     * in the context of the generic adapter and wait for explorers more accurate results instead
+     */
+    ...(typeof config !== "function" && config.explorer.type === "none"
+      ? {
+          refreshOperations: (operations: LiveOperation[]): Promise<LiveOperation[]> =>
+            refreshOperations(currency, operations),
+        }
+      : {}),
   };
 }

--- a/libs/coin-modules/coin-evm/src/config.ts
+++ b/libs/coin-modules/coin-evm/src/config.ts
@@ -14,6 +14,7 @@ export type EvmConfig = {
   explorer:
     | {
         type: "etherscan" | "blockscout" | "teloscan" | "klaytnfinder" | "corescan";
+        noCache?: boolean | undefined;
         uri: string;
       }
     | {

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
@@ -7,10 +7,15 @@ import { listOperations } from "./listOperations";
 
 describe("listOperations", () => {
   it.each([
-    ["an etherscan explorer", "etherscan", etherscanExplorer],
-    ["a ledger explorer", "ledger", ledgerExplorer],
-  ])("lists latest operations using %s", async (_, type, explorer) => {
-    setCoinConfig(() => ({ info: { explorer: { type } } }) as unknown as EvmCoinConfig);
+    ["an etherscan explorer", { type: "etherscan" }, etherscanExplorer.explorerApi],
+    [
+      "a no cache etherscan explorer",
+      { type: "etherscan", noCache: true },
+      etherscanExplorer.explorerApiNoChache,
+    ],
+    ["a ledger explorer", { type: "ledger" }, ledgerExplorer],
+  ])("lists latest operations using %s", async (_, config, explorer) => {
+    setCoinConfig(() => ({ info: { explorer: config } }) as unknown as EvmCoinConfig);
     jest.spyOn(explorer, "getLastOperations").mockResolvedValue({
       lastCoinOperations: [
         {

--- a/libs/coin-modules/coin-evm/src/network/explorer/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/etherscan.ts
@@ -359,7 +359,7 @@ export const getLastInternalOperations = async (
  * do not use a Promise.all here, it would
  * break because of the rate limits
  */
-export const getLastOperations: ExplorerApi["getLastOperations"] = makeLRUCache<
+export const getLastOperations = makeLRUCache<
   [
     currency: CryptoCurrency,
     address: string,
@@ -423,4 +423,8 @@ const explorerApi: ExplorerApi = {
   getLastOperations,
 };
 
-export default explorerApi;
+const explorerApiNoChache: ExplorerApi = {
+  getLastOperations: getLastOperations.force,
+};
+
+export default { explorerApi, explorerApiNoChache };

--- a/libs/coin-modules/coin-evm/src/network/explorer/index.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/index.ts
@@ -11,15 +11,16 @@ import noExplorerAPI from "./none";
  */
 export const getExplorerApi = (currency: CryptoCurrency): ExplorerApi => {
   const config = getCoinConfig(currency).info;
-  const apiType = config?.explorer?.type;
 
-  switch (apiType) {
+  switch (config?.explorer?.type) {
     case "etherscan":
     case "blockscout":
     case "teloscan":
     case "klaytnfinder":
     case "corescan":
-      return etherscanLikeApi;
+      return config.explorer.noCache
+        ? etherscanLikeApi.explorerApiNoChache
+        : etherscanLikeApi.explorerApi;
     case "ledger":
       return ledgerExplorerApi;
     case "none":

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/blast.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/blast.ts
@@ -77,6 +77,7 @@ export const scenarioBlast: Scenario<EvmTransaction, Account> = {
         },
         explorer: {
           type: "etherscan",
+          noCache: true,
           uri: "https://proxyetherscan.api.live.ledger.com/v2/api/81457",
         },
         showNfts: true,
@@ -95,6 +96,7 @@ export const scenarioBlast: Scenario<EvmTransaction, Account> = {
           },
           explorer: {
             type: "etherscan",
+            noCache: true,
             uri: "https://proxyetherscan.api.live.ledger.com/v2/api/81457",
           },
           showNfts: true,

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/scroll.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/scroll.ts
@@ -81,6 +81,7 @@ export const scenarioScroll: Scenario<EvmTransaction, Account> = {
         },
         explorer: {
           type: "blockscout",
+          noCache: true,
           uri: "https://scroll.blockscout.com/api",
         },
         showNfts: true,
@@ -99,6 +100,7 @@ export const scenarioScroll: Scenario<EvmTransaction, Account> = {
           },
           explorer: {
             type: "blockscout",
+            noCache: true,
             uri: "https://scroll.blockscout.com/api",
           },
           showNfts: true,

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/sonic.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/sonic.ts
@@ -73,6 +73,7 @@ export const scenarioSonic: Scenario<EvmTransaction, Account> = {
         },
         explorer: {
           type: "etherscan",
+          noCache: true,
           uri: "https://proxyetherscan.api.live.ledger.com/v2/api/146",
         },
         showNfts: true,
@@ -91,6 +92,7 @@ export const scenarioSonic: Scenario<EvmTransaction, Account> = {
           },
           explorer: {
             type: "etherscan",
+            noCache: true,
             uri: "https://proxyetherscan.api.live.ledger.com/v2/api/146",
           },
           showNfts: true,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - update of transaction histories on EVMs after sending tokens

### 📝 Description

Method `refreshOperations` is used, when existing, to refresh operations that have not been updated due to no explorer available. However it is currently working all the time, even if explorers are used. It results in the two entering in conflict.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
