### PR TITLE
fix: multiversX add account

### DIFF
--- a/.changeset/clean-ways-smell.md
+++ b/.changeset/clean-ways-smell.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-multiversx": minor
+---
+
+Fix: Clamp MultiversX API timestamp parameter to minimum value of 1 to prevent "Timestamp must be a positive number" error

--- a/libs/coin-modules/coin-multiversx/jest.config.js
+++ b/libs/coin-modules/coin-multiversx/jest.config.js
@@ -1,3 +1,5 @@
+const swcJest = require.resolve("@swc/jest");
+
 module.exports = {
   passWithNoTests: true,
   collectCoverageFrom: [
@@ -13,7 +15,7 @@ module.exports = {
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   transform: {
     "^.+\\.(ts|tsx)$": [
-      "@swc/jest",
+      swcJest,
       {
         jsc: {
           target: "esnext",

--- a/libs/coin-modules/coin-multiversx/src/api/apiCalls.test.ts
+++ b/libs/coin-modules/coin-multiversx/src/api/apiCalls.test.ts
@@ -1,0 +1,73 @@
+import MultiversXApi from "./apiCalls";
+
+jest.mock("@ledgerhq/live-network", () => {
+  const fn = jest.fn();
+  return { __esModule: true, default: fn };
+});
+
+import network from "@ledgerhq/live-network";
+
+describe("MultiversXApi startAt clamping", () => {
+  const api = new MultiversXApi("https://api.example.com", "https://deleg.example.com");
+
+  beforeEach(() => {
+    (network as unknown as jest.Mock).mockReset();
+  });
+
+  test("getHistory clamps startAt=0 to after=1", async () => {
+    // First call gets the count, 0 means no pagination loop
+    (network as unknown as jest.Mock).mockResolvedValueOnce({ data: 0 });
+
+    await api.getHistory("erd1testaddress", 0);
+
+    expect(network).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        url: expect.stringContaining("/accounts/erd1testaddress/transactions/count?after=1"),
+      }),
+    );
+  });
+
+  test("getHistory uses positive startAt unchanged", async () => {
+    (network as unknown as jest.Mock).mockResolvedValueOnce({ data: 0 });
+
+    await api.getHistory("erd1positive", 123);
+
+    expect(network).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        url: expect.stringContaining("/accounts/erd1positive/transactions/count?after=123"),
+      }),
+    );
+  });
+
+  test("getESDTTransactionsForAddress clamps startAt=0 to after=1", async () => {
+    (network as unknown as jest.Mock).mockResolvedValueOnce({ data: 0 });
+
+    await api.getESDTTransactionsForAddress("erd1tokaddr", "TOKEN-abc", 0);
+
+    expect(network).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        url: expect.stringContaining(
+          "/accounts/erd1tokaddr/transactions/count?token=TOKEN-abc&after=1",
+        ),
+      }),
+    );
+  });
+
+  test("getESDTTransactionsForAddress uses positive startAt unchanged", async () => {
+    (network as unknown as jest.Mock).mockResolvedValueOnce({ data: 0 });
+
+    await api.getESDTTransactionsForAddress("erd1tokaddr", "TOKEN-abc", 456);
+
+    expect(network).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        url: expect.stringContaining(
+          "/accounts/erd1tokaddr/transactions/count?token=TOKEN-abc&after=456",
+        ),
+      }),
+    );
+  });
+});

--- a/libs/coin-modules/coin-multiversx/src/api/apiCalls.ts
+++ b/libs/coin-modules/coin-multiversx/src/api/apiCalls.ts
@@ -136,9 +136,11 @@ export default class MultiversXApi {
   }
 
   async getHistory(addr: string, startAt: number): Promise<MultiversXApiTransaction[]> {
+    // API requires a strictly positive timestamp for `after`
+    const after = Math.max(1, startAt);
     const { data: transactionsCount } = await network<number>({
       method: "GET",
-      url: `${this.API_URL}/accounts/${addr}/transactions/count?after=${startAt}`,
+      url: `${this.API_URL}/accounts/${addr}/transactions/count?after=${after}`,
     });
 
     let allTransactions: MultiversXApiTransaction[] = [];
@@ -146,7 +148,7 @@ export default class MultiversXApi {
     while (from < transactionsCount) {
       const { data: transactions } = await network<MultiversXApiTransaction[]>({
         method: "GET",
-        url: `${this.API_URL}/accounts/${addr}/transactions?after=${startAt}&from=${from}&size=${MAX_PAGINATION_SIZE}&withOperations=true&withScResults=true`,
+        url: `${this.API_URL}/accounts/${addr}/transactions?after=${after}&from=${from}&size=${MAX_PAGINATION_SIZE}&withOperations=true&withScResults=true`,
       });
 
       for (const transaction of transactions) {
@@ -175,9 +177,11 @@ export default class MultiversXApi {
     token: string,
     startAt: number,
   ): Promise<MultiversXApiTransaction[]> {
+    // API requires a strictly positive timestamp for `after`
+    const after = Math.max(1, startAt);
     const { data: tokenTransactionsCount } = await network<number>({
       method: "GET",
-      url: `${this.API_URL}/accounts/${addr}/transactions/count?token=${token}&after=${startAt}`,
+      url: `${this.API_URL}/accounts/${addr}/transactions/count?token=${token}&after=${after}`,
     });
 
     let allTokenTransactions: MultiversXApiTransaction[] = [];
@@ -185,7 +189,7 @@ export default class MultiversXApi {
     while (from < tokenTransactionsCount) {
       const { data: tokenTransactions } = await network<MultiversXApiTransaction[]>({
         method: "GET",
-        url: `${this.API_URL}/accounts/${addr}/transactions?token=${token}&from=${from}&after=${startAt}&size=${MAX_PAGINATION_SIZE}`,
+        url: `${this.API_URL}/accounts/${addr}/transactions?token=${token}&from=${from}&after=${after}&size=${MAX_PAGINATION_SIZE}`,
       });
 
       allTokenTransactions = [...allTokenTransactions, ...tokenTransactions];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Set startAt to a minimum of 1 in the MultiversX API calls so the "Timestamp must be a positive number" error cannot occur.



https://github.com/user-attachments/assets/c6efeb5f-631a-41c1-af65-8e91415d2bbd




### ❓ Context

- **JIRA or GitHub link**:  [LIVE-24800](https://ledgerhq.atlassian.net/browse/LIVE-24800)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24800]: https://ledgerhq.atlassian.net/browse/LIVE-24800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ