### PR TITLE
fix(LIVE-24639): Prevent continue button overflow on SOL delegation flow

### DIFF
--- a/.changeset/chilled-boxes-hammer.md
+++ b/.changeset/chilled-boxes-hammer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: Prevent Continue button overflow on Solana delegation flow.

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectAmount.tsx
@@ -135,7 +135,10 @@ export default function DelegationSelectAmount({ navigation, route }: Props) {
         action="delegation"
         currency="sol"
       />
-      <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>
+      <SafeAreaView
+        edges={["left", "right", "bottom"]}
+        style={[styles.root, { backgroundColor: colors.background }]}
+      >
         <KeyboardView style={styles.container}>
           <TouchableWithoutFeedback onPress={blur}>
             <View style={styles.amountWrapper}>


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
  - Visual bug fix, only regression suite needed.
- [x] **Impact of the changes:**
  - When selecting amount during the SOL delegation flow, the continue button should no longer overflow the lower bounds of the screen.

### 📝 Description

Visual bug fixed on the Solana delegation flow preventing the continue button overflowing the bottom bounds of the screen.

| Before        | After         |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/d643686f-3638-49fb-ba28-7e5acd19fd45"> | <video src="https://github.com/user-attachments/assets/a91cc6be-f5d9-44e2-a2d5-99c9461b5b07"> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24639](https://ledgerhq.atlassian.net/browse/LIVE-24639)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24639]: https://ledgerhq.atlassian.net/browse/LIVE-24639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ