### PR TITLE
fix(coin-evm): display native internal operations

### DIFF
--- a/.changeset/friendly-buttons-rescue.md
+++ b/.changeset/friendly-buttons-rescue.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+fix(coin-evm): display native internal operations

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
@@ -91,6 +91,21 @@ describe("listOperations", () => {
           hasFailed: true,
           extra: {},
         },
+        {
+          id: "coin-op-6",
+          accountId: "",
+          type: "NONE",
+          senders: ["contract-address"],
+          recipients: ["address"],
+          value: new BigNumber(0),
+          hash: "coin-op-6-tx-hash",
+          blockHeight: 20,
+          blockHash: "coin-op-6-block-hash",
+          fee: new BigNumber(0),
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(6),
+          extra: {},
+        },
       ],
       lastTokenOperations: [
         {
@@ -159,6 +174,21 @@ describe("listOperations", () => {
           transactionSequenceNumber: new BigNumber(5),
           extra: {},
         },
+        {
+          id: "internal-op-2",
+          accountId: "",
+          type: "IN",
+          senders: ["contract-address"],
+          recipients: ["address"],
+          value: new BigNumber(5),
+          hash: "coin-op-6-tx-hash",
+          blockHeight: 20,
+          blockHash: "token-op-3-block-hash",
+          fee: new BigNumber(0),
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(6),
+          extra: {},
+        },
       ],
     });
 
@@ -203,6 +233,25 @@ describe("listOperations", () => {
             failed: true,
           },
           details: { sequence: BigNumber(2) },
+        },
+        {
+          id: "coin-op-6",
+          type: "NONE",
+          senders: ["contract-address"],
+          recipients: ["address"],
+          value: 0n,
+          asset: { type: "native" },
+          tx: {
+            hash: "coin-op-6-tx-hash",
+            block: {
+              height: 20,
+              hash: "coin-op-6-block-hash",
+            },
+            fees: 0n,
+            date: new Date("2025-02-20"),
+            failed: false,
+          },
+          details: { sequence: BigNumber(6) },
         },
         {
           id: "token-op-1",
@@ -309,6 +358,28 @@ describe("listOperations", () => {
           details: {
             internal: true,
             sequence: new BigNumber(5),
+          },
+        },
+        {
+          id: "internal-op-2",
+          type: "IN",
+          recipients: ["address"],
+          senders: ["contract-address"],
+          value: 5n,
+          asset: { type: "native" },
+          tx: {
+            block: {
+              hash: "coin-op-6-block-hash",
+              height: 20,
+            },
+            date: new Date("2025-02-20"),
+            failed: false,
+            fees: 0n,
+            hash: "coin-op-6-tx-hash",
+          },
+          details: {
+            internal: true,
+            sequence: new BigNumber(6),
           },
         },
       ],

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.ts
@@ -113,9 +113,7 @@ export async function listOperations(
     );
 
   const isNativeOperation = (coinOperation: LiveOperation): boolean =>
-    ![...lastTokenOperations, ...lastNftOperations, ...lastInternalOperations]
-      .map(op => op.hash)
-      .includes(coinOperation.hash);
+    ![...lastTokenOperations, ...lastNftOperations].map(op => op.hash).includes(coinOperation.hash);
   const isTokenOrInternalOperation = (coinOperation: LiveOperation): boolean =>
     [...lastTokenOperations, ...lastNftOperations, ...lastInternalOperations]
       .map(op => op.hash)


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - EVM native internal operations

### 📝 Description

Native internal operations (that can occur after an exchange for instance) won't appear on LW. This fix ensures they are not skipped anymore, hence returned in `listOperations`.

Example with [`0x7a1c4b8cdB40Fce77ccD06E5E2Bc7a8f40CFa0e9`](https://etherscan.io/address/0x7a1c4b8cdB40Fce77ccD06E5E2Bc7a8f40CFa0e9)
| Before        | After         |
| ------------- | ------------- |
| <img width="1440" height="939" alt="image" src="https://github.com/user-attachments/assets/de0006d9-aa34-4b9d-80b7-b072770cf486" /> | <img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/3f47c7e7-14cb-4a9b-9b79-1b319d7e36e1" /> |

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
