### PR TITLE
fix: blast send max

### DIFF
--- a/.changeset/forty-chicken-cross.md
+++ b/.changeset/forty-chicken-cross.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+Fix: Blast need to use getOptimismAdditionalFees in order to perform a send max

--- a/libs/coin-modules/coin-evm/src/logic.ts
+++ b/libs/coin-modules/coin-evm/src/logic.ts
@@ -56,6 +56,8 @@ export const getAdditionalLayer2Fees = async (
   switch (currency.id) {
     case "optimism":
     case "optimism_sepolia":
+    case "blast":
+    case "blast_sepolia":
     case "base":
     case "base_sepolia": {
       const nodeApi = getNodeApi(currency);

--- a/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
@@ -277,7 +277,16 @@ export const getBlockByHeight: NodeApi["getBlockByHeight"] = (currency, blockHei
 export const getOptimismAdditionalFees: NodeApi["getOptimismAdditionalFees"] = makeLRUCache(
   async (currency, transaction) =>
     withApi(currency, async api => {
-      if (!["optimism", "optimism_sepolia", "base", "base_sepolia"].includes(currency.id)) {
+      if (
+        ![
+          "optimism",
+          "optimism_sepolia",
+          "base",
+          "base_sepolia",
+          "blast",
+          "blast_sepolia",
+        ].includes(currency.id)
+      ) {
         return new BigNumber(0);
       }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Send max is working now.

### 📝 Description

Perform send flow on Blast, send all amount, The transaction fails with “insufficient funds” !
This is because Blast doesn't use oracle for additional fees like Optimism, base or scroll !
The address use by `getOptimismAdditionalFees` exist on Blast network and can be use the same way it is used on Optimism and Base.


https://github.com/user-attachments/assets/d95af4a3-3e56-43ba-ba03-b8aae6e1531a


### ❓ Context

- **JIRA or GitHub link**: [LIVE-23859](https://ledgerhq.atlassian.net/browse/LIVE-23859)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-23859]: https://ledgerhq.atlassian.net/browse/LIVE-23859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ