### PR TITLE
fix(coin-evm): harmonize contract addresses

### DIFF
--- a/.changeset/fuzzy-bats-raise.md
+++ b/.changeset/fuzzy-bats-raise.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+fix(coin-evm): harmonize contract addresses

--- a/libs/coin-modules/coin-evm/src/logic/getTokenFromAsset.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getTokenFromAsset.test.ts
@@ -119,6 +119,32 @@ describe("getAssetFromToken", () => {
     });
   });
 
+  it("computes the asset of the FXRP token", () => {
+    expect(
+      getAssetFromToken(
+        { id: "flare" } as CryptoCurrency,
+        {
+          parentCurrency: { id: "flare" },
+          tokenType: "erc20",
+          contractAddress: "0xad552a648c74d49e10027ab8a618a3ad4901c5be",
+          name: "FXRP",
+          units: [{ name: "FXRP", code: "FXRP", magnitude: 6 }],
+        } as unknown as TokenCurrency,
+        "owner",
+      ),
+    ).toEqual({
+      assetReference: "0xAd552A648C74D49E10027AB8a618A3ad4901c5bE",
+      assetOwner: "owner",
+      name: "FXRP",
+      type: "erc20",
+      unit: {
+        code: "FXRP",
+        magnitude: 6,
+        name: "FXRP",
+      },
+    });
+  });
+
   it("fails to compute an asset from a token if the main currency is not its parent", () => {
     expect(() =>
       getAssetFromToken(

--- a/libs/coin-modules/coin-evm/src/logic/getTokenFromAsset.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getTokenFromAsset.ts
@@ -1,3 +1,4 @@
+import eip55 from "eip55";
 import { AssetInfo } from "@ledgerhq/coin-framework/api/types";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
@@ -22,7 +23,7 @@ export function getAssetFromToken(
 
   return {
     type: token.tokenType,
-    assetReference: token.contractAddress,
+    assetReference: eip55.encode(token.contractAddress),
     assetOwner: owner,
     name: token.name,
     unit: token.units[0],


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - EVM balance discovery

### 📝 Description

Contract addresses use eip55 encoding (on [etherscan](https://github.com/LedgerHQ/ledger-live/blob/8582d72ccd476b9f67079caeb019d87962fc9661/libs/coin-modules/coin-evm/src/adapters/etherscan.ts#L114-L132) and [ledger](https://github.com/LedgerHQ/ledger-live/blob/8582d72ccd476b9f67079caeb019d87962fc9661/libs/coin-modules/coin-evm/src/adapters/ledger.ts#L102-L120) providers).
However the CAL returns a different encoding on some tokens. Example on Flare with FXRP
- from the CAL: `0xad552a648c74d49e10027ab8a618a3ad4901c5be`
- EIP55 encoded: `0x0B2F01B752806d05374962da0CaDf0cC12BFf6d0`

This difference breaks balance discoverability.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
