### PR TITLE
chore: introduce a "lite" mode for metafiles to fix build-checks

### DIFF
--- a/.github/workflows/build-desktop-reusable.yml
+++ b/.github/workflows/build-desktop-reusable.yml
@@ -76,7 +76,7 @@ jobs:
         id: build-app
         run: pnpm build:lld --api="http://127.0.0.1:${{ steps.setup-caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo"
         env:
-          GENERATE_METAFILES: 1
+          GENERATE_METAFILES: "lite"
 
       - name: Upload ${{ matrix.config.name }} app
         uses: actions/upload-artifact@v4

--- a/apps/ledger-live-desktop/docs/debug_bundle.md
+++ b/apps/ledger-live-desktop/docs/debug_bundle.md
@@ -2,8 +2,20 @@
 
 Analyze the renderer bundle to identify large dependencies, duplicates, or optimization opportunities.
 
+## Full mode (for detailed analysis)
+
+Generates complete metafiles with all module information, sourcemaps, and reasons. Use this for detailed analysis with tools like [statoscope.tech](https://statoscope.tech/):
+
 ```bash
 GENERATE_METAFILES=1 pnpm desktop build:js
 ```
 
 Then drop `metafile.renderer.json` into [statoscope.tech](https://statoscope.tech/)
+
+## Lite mode (for CI/CD)
+
+Generates minimized metafiles with only essential data (bundle size and duplicate detection). Use this in CI/CD to reduce artifact size:
+
+```bash
+GENERATE_METAFILES="lite" pnpm desktop build:js
+```


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - metafiles generation for build-checks

### 📝 Description

The metafile JSON files were too large (containing sourcemaps, reasons, etc.), causing a Z_BUF_ERROR when downloading GitHub Actions artifacts; we added a "lite" mode that minimizes metafiles (keeping only assets with name/size and modules with identifier/name) for CI/CD, while preserving full mode for local analysis.

### ❓ Context

- **JIRA or GitHub link**: N/A


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
