### PR TITLE
fix(LIVE-24831): better handle large mover deeplink

### DIFF
--- a/.changeset/gorgeous-mails-tan.md
+++ b/.changeset/gorgeous-mails-tan.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: handle large mover deeplink edge cases

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -40,6 +40,7 @@ import {
   logSecurityEvent,
   EarnDeeplinkAction,
   validateEarnDepositScreen,
+  validateLargeMoverCurrencyIds,
 } from "./deeplinks/validation";
 import { AppLoadingManager, AppLoadingManagerProps } from "LLM/features/LaunchScreen";
 import { useDeeplinkDrawerCleanup } from "./deeplinks/useDeeplinkDrawerCleanup";
@@ -595,6 +596,18 @@ export const DeeplinksProvider = ({
             });
 
           const platform = pathname.split("/")[1];
+
+          if (hostname === "landing-page-large-mover") {
+            const currencyIds = searchParams.get("currencyIds");
+
+            const validatedCurrencyIds = validateLargeMoverCurrencyIds(currencyIds);
+            if (!validatedCurrencyIds) {
+              // Redirect to market list when currencyIds is missing or invalid
+              return;
+            }
+            url.searchParams.set("currencyIds", validatedCurrencyIds);
+            return getStateFromPath(url.href?.split("://")[1], config);
+          }
 
           // Handle modular drawer deeplinks (receive & add-account)
           if (hostname === "receive" || hostname === "add-account") {

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/validation.test.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/validation.test.ts
@@ -1,0 +1,48 @@
+import { validateLargeMoverCurrencyIds } from "../validation";
+
+describe("validateLargeMoverCurrencyIds", () => {
+  it("should return null when currencyIds is null", () => {
+    const result = validateLargeMoverCurrencyIds(null);
+    expect(result).toBeNull();
+  });
+
+  it("should return null when currencyIds is undefined", () => {
+    const result = validateLargeMoverCurrencyIds(null);
+    expect(result).toBeNull();
+  });
+
+  it("should return null when currencyIds is an empty string", () => {
+    const result = validateLargeMoverCurrencyIds("");
+    expect(result).toBeNull();
+  });
+
+  it("should return null when currencyIds is only whitespace", () => {
+    const result = validateLargeMoverCurrencyIds("   ");
+    expect(result).toBeNull();
+  });
+
+  it("should uppercase single currencyId", () => {
+    const result = validateLargeMoverCurrencyIds("btc");
+    expect(result).toBe("BTC");
+  });
+
+  it("should uppercase multiple currencyIds separated by commas", () => {
+    const result = validateLargeMoverCurrencyIds("btc,eth,xrp");
+    expect(result).toBe("BTC,ETH,XRP");
+  });
+
+  it("should uppercase and trim currencyIds with whitespace", () => {
+    const result = validateLargeMoverCurrencyIds("  btc,eth  ");
+    expect(result).toBe("BTC,ETH");
+  });
+
+  it("should handle already uppercase currencyIds", () => {
+    const result = validateLargeMoverCurrencyIds("BTC,ETH");
+    expect(result).toBe("BTC,ETH");
+  });
+
+  it("should handle mixed case currencyIds", () => {
+    const result = validateLargeMoverCurrencyIds("BtC,eTh,XrP");
+    expect(result).toBe("BTC,ETH,XRP");
+  });
+});

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/validation.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/validation.ts
@@ -290,6 +290,14 @@ export function validateEarnDepositScreen(
   };
 }
 
+export function validateLargeMoverCurrencyIds(currencyIds: string | null): string | null {
+  if (!currencyIds || currencyIds?.trim() === "") {
+    return null;
+  }
+
+  return currencyIds.trim().toUpperCase();
+}
+
 /**
  * Validates earn menu modal parameters
  */


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:**

### 📝 Description

This fix handles two error scenarios:
1. When `large-mover-landing-page` deep link is used without `currencyIds` in the query params.
2. When `large-mover-landing-page` deep link is used with lowercased `currencyIds`.

The fixes ensure:
1. Navigation does not occur if the `currencyIds` parameter is not present.
2. When `currencyIds` are provided in lowercase, they are parsed to uppercase before navigating to the screen handler.

This provides a much better experience for the user.

| Before        | After         |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/6d3033d1-0fc1-4cbd-b9fc-f5b2a03d3df8" /> | <video src="https://github.com/user-attachments/assets/04c010d9-50e2-4f5c-98ff-e2d1e06c8970" /> |

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-24831


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
