### PR TITLE
fix(BACK-10242): fix hedera lastBlock returning non-finalized block

### DIFF
--- a/.changeset/tricky-oranges-repair.md
+++ b/.changeset/tricky-oranges-repair.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix(BACK-10242): fix hedera lastBlock returning non-finalized block

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -565,6 +565,17 @@ describe("createApi", () => {
         },
       ]);
     });
+
+    it("returns block for latest finalized height from lastBlock", async () => {
+      const latestBlockInfo = await api.lastBlock();
+      const block = await api.getBlock(latestBlockInfo.height);
+
+      expect(block.info.height).toBe(latestBlockInfo.height);
+      expect(block.info.hash).toBe(latestBlockInfo.hash);
+      // Note: lastBlock().time is the transaction timestamp, while getBlock().info.time is the block start time
+      expect(block.info.time).toBeInstanceOf(Date);
+      expect(block.transactions).toBeInstanceOf(Array);
+    });
   });
 
   describe("lastBlock", () => {

--- a/libs/coin-modules/coin-hedera/src/logic/lastBlock.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/lastBlock.ts
@@ -1,7 +1,7 @@
 import type { BlockInfo } from "@ledgerhq/coin-framework/api/index";
 import { apiClient } from "../network/api";
 import { getSyntheticBlock } from "./utils";
-import { FINALITY_MS } from "../constants";
+import { FINALITY_MS, SYNTHETIC_BLOCK_WINDOW_SECONDS } from "../constants";
 
 /**
  * Gets the latest "block" information for Hedera.
@@ -13,9 +13,9 @@ import { FINALITY_MS } from "../constants";
  * 3. Convert this timestamp into a synthetic block using a hardcoded time window (10 seconds by default)
  */
 export async function lastBlock(): Promise<BlockInfo> {
-  // see getBlock implementation, block data should be immutable: we do not allow querying blocks on non-finalized time range
+  // see getBlock implementation, block data should be immutable: we do not allow querying blocks on non-finalized time range.
   // => we search the most recent transaction, but only in finalized time range (ending 10 seconds ago).
-  const before = new Date(Date.now() - FINALITY_MS);
+  const before = new Date(Date.now() - FINALITY_MS - SYNTHETIC_BLOCK_WINDOW_SECONDS * 1000);
   const latestTransaction = await apiClient.getLatestTransaction(before);
   const syntheticBlock = getSyntheticBlock(latestTransaction.consensus_timestamp);
 

--- a/libs/coin-modules/coin-hedera/src/network/api.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.ts
@@ -165,7 +165,7 @@ async function getLatestTransaction(before: Date): Promise<HederaMirrorTransacti
   const params = new URLSearchParams({
     limit: "1",
     order: "desc",
-    timestamp: `lte:${before.getTime() / 1000}`,
+    timestamp: `lt:${before.getTime() / 1000}`,
   });
 
   const res = await network<HederaMirrorTransactionsResponse>({

--- a/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
@@ -25,7 +25,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "spendableBalance": "2125992",
     "subAccounts": [],
     "swapHistory": [],
-    "syncHash": "0x87bd2dc9",
+    "syncHash": "0x624e3c6a",
     "used": true,
   },
   {
@@ -84,7 +84,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "spendableBalance": "38038675",
     "subAccounts": [],
     "swapHistory": [],
-    "syncHash": "0x87bd2dc9",
+    "syncHash": "0x624e3c6a",
     "used": true,
   },
   {
@@ -132,7 +132,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "spendableBalance": "80189",
     "subAccounts": [],
     "swapHistory": [],
-    "syncHash": "0x87bd2dc9",
+    "syncHash": "0x624e3c6a",
     "used": true,
   },
   {
@@ -158,7 +158,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "spendableBalance": "99442073",
     "subAccounts": [],
     "swapHistory": [],
-    "syncHash": "0x87bd2dc9",
+    "syncHash": "0x624e3c6a",
     "used": true,
   },
   {
@@ -171,7 +171,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
       "delegation": {
         "delegated": "333985159",
         "nodeId": 18,
-        "pendingReward": "0",
+        "pendingReward": "20547",
       },
       "isAutoTokenAssociationEnabled": false,
       "maxAutomaticTokenAssociations": 0,
@@ -184,7 +184,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "spendableBalance": "333985159",
     "subAccounts": [],
     "swapHistory": [],
-    "syncHash": "0x87bd2dc9",
+    "syncHash": "0x624e3c6a",
     "used": true,
   },
   {
@@ -199,12 +199,12 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "type": "TokenAccountRaw",
   },
   {
-    "balance": "40040",
+    "balance": "40042",
     "id": "js:2:hedera:0.0.8313485:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
     "operationsCount": 4,
     "parentId": "js:2:hedera:0.0.8313485:hederaBip44",
     "pendingOperations": [],
-    "spendableBalance": "40040",
+    "spendableBalance": "40042",
     "swapHistory": [],
     "tokenId": "hedera/erc20/bonzo_atoken_usdc_0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
     "type": "TokenAccountRaw",
@@ -232,7 +232,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "spendableBalance": "36243023",
     "subAccounts": [],
     "swapHistory": [],
-    "syncHash": "0x87bd2dc9",
+    "syncHash": "0x624e3c6a",
     "used": true,
   },
   {
@@ -280,7 +280,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "spendableBalance": "0",
     "subAccounts": [],
     "swapHistory": [],
-    "syncHash": "0x87bd2dc9",
+    "syncHash": "0x624e3c6a",
     "used": false,
   },
 ]


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - hedera alpaca getBlock

### 📝 Description

Fix some miscalculation in my previous PR #13631: `getBlock` checks that the requested block **ends** before `now - 10s`, but `lastBlock` returned a block that **starts** before `now - 10s`. Also, block boundaries are `[start time, end time[`, so `lastBlock` must query `transactions < start time`, instead of `transactions <= start time`.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
