### PR TITLE
fix: only uses 'in' operator on objects (dmk-desktop)

### DIFF
--- a/.changeset/slow-bobcats-poke.md
+++ b/.changeset/slow-bobcats-poke.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-dmk-desktop": minor
+---
+
+fix: only uses "in" operator on object (dmk-desktop)

--- a/libs/live-dmk-desktop/src/errors.test.ts
+++ b/libs/live-dmk-desktop/src/errors.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   isAllowedOnboardingStatePollingErrorDmk,
   isDisconnectedWhileSendingApduError,
+  isDmkError,
 } from "./errors";
 import { WebHidSendReportError } from "@ledgerhq/device-transport-kit-web-hid";
 
@@ -79,5 +80,27 @@ describe("isDisconnectedWhileSendingApduError", () => {
   it("should return false if the error is an object with same shape but not instance", () => {
     const fake = { name: "WebHidSendReportError", message: "fake error" };
     expect(isDisconnectedWhileSendingApduError(fake)).toBe(false);
+  });
+});
+
+describe("isDmkError", () => {
+  it("returns true for a DMK error instance", () => {
+    expect(isDmkError(new DeviceBusyError())).toBe(true);
+  });
+
+  it("returns false for a regular Error instance", () => {
+    expect(isDmkError(new Error("error"))).toBe(false);
+  });
+
+  it("returns false for a string error (e.g. 'Invalid extension provided')", () => {
+    expect(isDmkError("Invalid extension provided")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isDmkError(undefined)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isDmkError(null)).toBe(false);
   });
 });

--- a/libs/live-dmk-desktop/src/errors.ts
+++ b/libs/live-dmk-desktop/src/errors.ts
@@ -37,4 +37,5 @@ export const isInvalidGetFirmwareMetadataResponseError = (error: unknown): boole
   return false;
 };
 
-export const isDmkError = (error: any): error is DmkError => !!error && "_tag" in error;
+export const isDmkError = (error: unknown): error is DmkError =>
+  !!error && typeof error === "object" && error !== null && "_tag" in error;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix the `Cannot use 'in' operator to search for '_tag' in Invalid extension provided` issue
The logs indicates this:
```
"data": {
   "type": "error",
   "error": "Invalid extension provided"
}
...
{
    "logIndex": 142,
    "timestamp": "2026-01-13T17:04:31.224Z",
    "pname": "electron-renderer",
    "level": "error",
    "message": "Cannot use 'in' operator to search for '_tag' in Invalid extension provided",
    ......
```

`error` here is not an object, so we cannot use `in` operator on it
In this case it might not be a DMK issue ? (open to discussion)

Typeguard the `isDmkError` returns.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-20326)**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
