### PR TITLE
feat(LWD): Amount screen new send flow

### DIFF
--- a/.changeset/spicy-wasps-brush.md
+++ b/.changeset/spicy-wasps-brush.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(LWD): Amount screen of send flow revamp

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/index.tsx
@@ -10,11 +10,12 @@ import { SignatureScreen } from "./screens/Signature/SignatureScreen";
 import { ConfirmationScreen } from "./screens/Confirmation/ConfirmationScreen";
 import { SendFlowLayout } from "./components/SendFlowLayout";
 import { RecipientScreen } from "./screens/Recipient/RecipientScreen";
+import { AmountScreen } from "./screens/Amount/AmountScreen";
 import type { StepRegistry } from "@ledgerhq/live-common/flows/wizard/types";
 
 const stepRegistry: StepRegistry<SendFlowStep> = {
   [SEND_FLOW_STEP.RECIPIENT]: RecipientScreen,
-  [SEND_FLOW_STEP.AMOUNT]: () => <></>,
+  [SEND_FLOW_STEP.AMOUNT]: AmountScreen,
   [SEND_FLOW_STEP.SIGNATURE]: SignatureScreen,
   [SEND_FLOW_STEP.CONFIRMATION]: ConfirmationScreen,
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/AmountScreen.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/AmountScreen.tsx
@@ -1,0 +1,52 @@
+import React, { useCallback } from "react";
+import { useNavigate } from "react-router";
+import { useSendFlowActions, useSendFlowData } from "../../context/SendFlowContext";
+import { getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
+import { AmountScreenInner } from "./components/AmountScreenInner";
+import { useFlowWizard } from "LLD/features/FlowWizard/FlowWizardContext";
+
+export function AmountScreen() {
+  const { state, uiConfig } = useSendFlowData();
+  const { transaction: transactionActions, close } = useSendFlowActions();
+  const { navigation } = useFlowWizard();
+  const navigate = useNavigate();
+
+  const { account, parentAccount } = state.account;
+  const { bridgePending, bridgeError, status, transaction } = state.transaction;
+
+  const handleGetFunds = useCallback(() => {
+    if (!account) return;
+    const mainAccount = getMainAccount(account, parentAccount ?? undefined);
+    const currencyId = "currency" in mainAccount ? mainAccount.currency.id : undefined;
+
+    // Navigate to exchange (Buy) page with preselected currency (same behavior as Buy button)
+    navigate("/exchange", {
+      state: {
+        currency: currencyId,
+        account: mainAccount.id,
+        mode: "buy",
+      },
+    });
+    // Close the send flow dialog
+    close();
+  }, [account, close, navigate, parentAccount]);
+
+  if (!account || !transaction || !status) {
+    return null;
+  }
+
+  return (
+    <AmountScreenInner
+      account={account}
+      parentAccount={parentAccount}
+      transaction={transaction}
+      status={status}
+      bridgePending={bridgePending}
+      bridgeError={bridgeError}
+      uiConfig={uiConfig}
+      transactionActions={transactionActions}
+      onReview={() => navigation.goToNextStep()}
+      onGetFunds={handleGetFunds}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountFooter.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountFooter.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
+import type { FeePresetOption } from "../hooks/useFeePresetOptions";
+import type { FeeFiatMap } from "../hooks/useFeePresetFiatValues";
+import type { FeePresetLegendMap } from "../hooks/useFeePresetLegends";
+import { useSendFlowData } from "../../../context/SendFlowContext";
+import { NetworkFeesMenu } from "./Fees/NetworkFeesMenu";
+
+type AmountFooterProps = Readonly<{
+  feesRowLabel: string;
+  feesRowValue: string;
+  feesRowStrategyLabel: string;
+  selectedFeeStrategy: string | null;
+  feePresetOptions: readonly FeePresetOption[];
+  fiatByPreset: FeeFiatMap;
+  legendByPreset: FeePresetLegendMap;
+  onSelectFeeStrategy: (strategy: string) => void;
+  reviewLabel: string;
+  reviewShowIcon: boolean;
+  reviewDisabled: boolean;
+  reviewLoading: boolean;
+  onReview: () => void;
+  onGetFunds?: () => void;
+}>;
+
+export function AmountFooter({
+  feesRowLabel,
+  feesRowValue,
+  feesRowStrategyLabel,
+  selectedFeeStrategy,
+  feePresetOptions,
+  fiatByPreset,
+  legendByPreset,
+  onSelectFeeStrategy,
+  reviewLabel,
+  reviewShowIcon,
+  reviewDisabled,
+  reviewLoading,
+  onReview,
+  onGetFunds,
+}: AmountFooterProps) {
+  const { state } = useSendFlowData();
+  const { account } = state.account;
+  const { transaction } = state.transaction;
+
+  if (!account || !transaction) {
+    return null;
+  }
+  return (
+    <div className="mt-56 pt-12">
+      <div className="border-t border-muted-subtle" />
+      <NetworkFeesMenu
+        display={{
+          label: feesRowLabel,
+          value: feesRowValue,
+          strategyLabel: feesRowStrategyLabel,
+        }}
+        selection={{
+          selectedStrategy: selectedFeeStrategy,
+          onSelectStrategy: onSelectFeeStrategy,
+        }}
+        presets={{
+          options: feePresetOptions,
+          fiatByPreset,
+          legendByPreset,
+        }}
+      />
+      <Button
+        appearance="base"
+        size="lg"
+        isFull
+        onClick={reviewShowIcon ? onReview : onGetFunds}
+        disabled={reviewDisabled}
+        loading={reviewLoading}
+        icon={reviewShowIcon ? LedgerLogo : undefined}
+        className="rounded-full"
+      >
+        {reviewLoading ? "" : reviewLabel}
+      </Button>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountInputSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountInputSection.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { AmountInput, IconButton } from "@ledgerhq/lumen-ui-react";
+import { TransferVertical } from "@ledgerhq/lumen-ui-react/symbols";
+import { cn } from "LLD/utils/cn";
+import type { AmountScreenMessage } from "../types";
+import { AmountMessageText } from "./AmountMessageText";
+
+type AmountInputSectionProps = Readonly<{
+  amountValue: string;
+  amountInputMaxDecimalLength: number;
+  currencyText: string;
+  currencyPosition: "left" | "right";
+  isInputDisabled: boolean;
+  onAmountChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onToggleInputMode: () => void;
+  toggleLabel: string;
+  secondaryValue: string;
+  amountMessage: AmountScreenMessage | null | undefined;
+}>;
+
+export function AmountInputSection({
+  amountValue,
+  amountInputMaxDecimalLength,
+  currencyText,
+  currencyPosition,
+  isInputDisabled,
+  onAmountChange,
+  onToggleInputMode,
+  toggleLabel,
+  secondaryValue,
+  amountMessage,
+}: AmountInputSectionProps) {
+  return (
+    <section className="relative flex flex-col items-center pt-56 text-center">
+      <div className="relative flex w-full items-center justify-center">
+        <AmountInput
+          value={amountValue}
+          placeholder="0"
+          onChange={onAmountChange}
+          maxDecimalLength={amountInputMaxDecimalLength}
+          currencyText={currencyText}
+          currencyPosition={currencyPosition}
+          disabled={isInputDisabled}
+          autoFocus
+          aria-invalid={amountMessage?.type === "error"}
+          className={cn(
+            "heading-0-semi-bold text-base placeholder:text-muted",
+            amountMessage?.type === "error" && "text-error",
+          )}
+        />
+        <IconButton
+          icon={TransferVertical}
+          size="xs"
+          appearance="gray"
+          aria-label={toggleLabel}
+          className="absolute top-12 right-8"
+          onClick={onToggleInputMode}
+        />
+      </div>
+      <p className="mt-8 body-2 text-muted">{secondaryValue}</p>
+      <div className="mt-8 min-h-20">
+        <AmountMessageText message={amountMessage} />
+      </div>
+    </section>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountMessageText.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountMessageText.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { cn } from "LLD/utils/cn";
+import type { AmountScreenMessage } from "../types";
+
+type AmountMessageTextProps = Readonly<{
+  message: AmountScreenMessage | null | undefined;
+}>;
+
+export function AmountMessageText({ message }: AmountMessageTextProps) {
+  if (!message) return null;
+
+  return (
+    <p
+      className={cn(
+        "text-center body-2",
+        message.type === "error" && "text-error",
+        message.type === "warning" && "text-warning",
+        message.type === "info" && "text-base",
+      )}
+    >
+      {message.text}
+    </p>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountPluginsHost.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountPluginsHost.tsx
@@ -1,0 +1,40 @@
+import React, { useMemo } from "react";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { SendFlowTransactionActions } from "@ledgerhq/live-common/flows/send/types";
+import { getAccountCurrency, getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
+import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor";
+import { EvmGasOptionsSyncPlugin } from "./plugins/EvmGasOptionsSyncPlugin";
+
+type AmountPluginProps = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  transaction: Transaction;
+  transactionActions: SendFlowTransactionActions;
+}>;
+
+type AmountPluginComponent = (props: AmountPluginProps) => React.ReactElement | null;
+
+const pluginRegistry: Readonly<Record<string, AmountPluginComponent>> = {
+  evmGasOptionsSync: EvmGasOptionsSyncPlugin,
+};
+
+export function AmountPluginsHost(props: AmountPluginProps) {
+  const mainAccount = useMemo(
+    () => getMainAccount(props.account, props.parentAccount ?? undefined),
+    [props.account, props.parentAccount],
+  );
+  const currency = useMemo(() => getAccountCurrency(mainAccount), [mainAccount]);
+
+  const pluginIds = useMemo(() => sendFeatures.getAmountPlugins(currency), [currency]);
+
+  return (
+    <>
+      {pluginIds.map(id => {
+        const Plugin = pluginRegistry[id];
+        if (!Plugin) return null;
+        return <Plugin key={id} {...props} />;
+      })}
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
@@ -1,0 +1,63 @@
+import React, { useCallback } from "react";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import type {
+  SendFlowTransactionActions,
+  SendFlowUiConfig,
+} from "@ledgerhq/live-common/flows/send/types";
+import { useAmountScreenViewModel } from "../hooks/useAmountScreenViewModel";
+import { AmountScreenView } from "./AmountScreenView";
+import { AmountPluginsHost } from "./AmountPluginsHost";
+
+type AmountScreenInnerProps = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  transaction: Transaction;
+  status: TransactionStatus;
+  bridgePending: boolean;
+  bridgeError: Error | null;
+  uiConfig: SendFlowUiConfig;
+  transactionActions: SendFlowTransactionActions;
+  onReview: () => void;
+  onGetFunds: () => void;
+}>;
+
+export function AmountScreenInner({
+  account,
+  parentAccount,
+  transaction,
+  status,
+  bridgePending,
+  bridgeError,
+  uiConfig,
+  transactionActions,
+  onReview,
+  onGetFunds,
+}: AmountScreenInnerProps) {
+  const handleReview = useCallback(() => {
+    onReview();
+  }, [onReview]);
+
+  const viewModel = useAmountScreenViewModel({
+    account,
+    parentAccount,
+    transaction,
+    status,
+    bridgePending,
+    bridgeError,
+    uiConfig,
+    transactionActions,
+  });
+
+  return (
+    <>
+      <AmountPluginsHost
+        account={account}
+        parentAccount={parentAccount}
+        transaction={transaction}
+        transactionActions={transactionActions}
+      />
+      <AmountScreenView {...viewModel} onReview={handleReview} onGetFunds={onGetFunds} />
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenView.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import type { AmountScreenViewProps } from "../types";
+import { AmountFooter } from "./AmountFooter";
+import { AmountInputSection } from "./AmountInputSection";
+import { QuickActionsRow } from "./QuickActionsRow";
+
+export function AmountScreenView({
+  amountValue,
+  amountInputMaxDecimalLength,
+  currencyText,
+  currencyPosition,
+  isInputDisabled,
+  onAmountChange,
+  onToggleInputMode,
+  toggleLabel,
+  secondaryValue,
+  feesRowLabel,
+  feesRowValue,
+  feesRowStrategyLabel,
+  feePresetOptions,
+  fiatByPreset,
+  legendByPreset,
+  quickActions,
+  showQuickActions,
+  amountMessage,
+  reviewLabel,
+  reviewShowIcon,
+  reviewDisabled,
+  reviewLoading,
+  selectedFeeStrategy,
+  onSelectFeeStrategy,
+  onReview,
+  onGetFunds,
+}: AmountScreenViewProps) {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-1 flex-col gap-24">
+        <AmountInputSection
+          amountValue={amountValue}
+          amountInputMaxDecimalLength={amountInputMaxDecimalLength}
+          currencyText={currencyText}
+          currencyPosition={currencyPosition}
+          isInputDisabled={isInputDisabled}
+          onAmountChange={onAmountChange}
+          onToggleInputMode={onToggleInputMode}
+          toggleLabel={toggleLabel}
+          secondaryValue={secondaryValue}
+          amountMessage={amountMessage}
+        />
+
+        {showQuickActions ? <QuickActionsRow actions={quickActions} /> : null}
+      </div>
+
+      <AmountFooter
+        feesRowLabel={feesRowLabel}
+        feesRowValue={feesRowValue}
+        feesRowStrategyLabel={feesRowStrategyLabel}
+        selectedFeeStrategy={selectedFeeStrategy}
+        feePresetOptions={feePresetOptions}
+        fiatByPreset={fiatByPreset}
+        legendByPreset={legendByPreset}
+        onSelectFeeStrategy={onSelectFeeStrategy}
+        reviewLabel={reviewLabel}
+        reviewShowIcon={reviewShowIcon}
+        reviewDisabled={reviewDisabled}
+        reviewLoading={reviewLoading}
+        onReview={onReview}
+        onGetFunds={onGetFunds}
+      />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/EvmGasOptionsSync.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/EvmGasOptionsSync.tsx
@@ -1,0 +1,45 @@
+import { useRef } from "react";
+import isEqual from "lodash/isEqual";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { GasOptions, Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import { SendFlowTransactionActions } from "@ledgerhq/live-common/flows/send/types";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+
+type EvmGasOptionsSyncProps = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  transaction: EvmTransaction;
+  transactionActions: SendFlowTransactionActions;
+  evmGasOptions: GasOptions | undefined;
+}>;
+
+export function EvmGasOptionsSync({
+  account,
+  parentAccount,
+  transaction,
+  transactionActions,
+  evmGasOptions,
+}: EvmGasOptionsSyncProps) {
+  const scheduledGasOptionsRef = useRef<GasOptions | undefined>(undefined);
+
+  const shouldApply =
+    evmGasOptions !== undefined && !isEqual(transaction.gasOptions ?? null, evmGasOptions);
+
+  if (shouldApply) {
+    // schedule transaction update as a microtask
+    if (!isEqual(scheduledGasOptionsRef.current ?? null, evmGasOptions)) {
+      scheduledGasOptionsRef.current = evmGasOptions;
+      queueMicrotask(() => {
+        transactionActions.updateTransaction(currentTx => {
+          if ("gasOptions" in currentTx && currentTx.gasOptions) {
+            if (isEqual(currentTx.gasOptions, evmGasOptions)) return currentTx;
+          }
+          const bridge = getAccountBridge(account, parentAccount ?? undefined);
+          return bridge.updateTransaction(currentTx, { gasOptions: evmGasOptions });
+        });
+      });
+    }
+  }
+
+  return null;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/FeePresetMenuItems.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/FeePresetMenuItems.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { MenuRadioGroup, MenuRadioItem, MenuSeparator, MenuItem } from "@ledgerhq/lumen-ui-react";
+
+type FeeOption = Readonly<{
+  id: string;
+  fiatValue: string | null;
+  legendValue: string | null;
+}>;
+
+type FeePresetMenuItemsProps = Readonly<{
+  hasPresets: boolean;
+  hasCustom: boolean;
+  hasCoinControl: boolean;
+  selectedStrategy: string | null;
+  onSelectStrategy: (strategy: string) => void;
+  onSelectCustomFees?: () => void;
+  onSelectCoinControl?: () => void;
+  feeOptionsWithFiat: readonly FeeOption[];
+  shouldShowFeeRateLegend: boolean;
+}>;
+
+export function FeePresetMenuItems({
+  hasPresets,
+  hasCustom,
+  hasCoinControl,
+  selectedStrategy,
+  onSelectStrategy,
+  onSelectCustomFees,
+  onSelectCoinControl,
+  feeOptionsWithFiat,
+  shouldShowFeeRateLegend,
+}: FeePresetMenuItemsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      {hasPresets ? (
+        <>
+          <MenuRadioGroup value={selectedStrategy ?? "medium"} onValueChange={onSelectStrategy}>
+            {feeOptionsWithFiat.map(option => {
+              const labelKey = `fees.${option.id}`;
+              const label =
+                option.id && t(labelKey) !== labelKey ? t(labelKey) : option.id.toUpperCase();
+              const subLabel = shouldShowFeeRateLegend ? option.legendValue : option.fiatValue;
+              return (
+                <MenuRadioItem key={option.id} value={option.id}>
+                  <div className="flex flex-col">
+                    <span className="text-base">{label}</span>
+                    {subLabel ? <span className="body-3 text-muted">{subLabel}</span> : null}
+                  </div>
+                </MenuRadioItem>
+              );
+            })}
+          </MenuRadioGroup>
+          {(hasCustom || hasCoinControl) && <MenuSeparator />}
+        </>
+      ) : null}
+      {hasCustom ? (
+        <MenuItem
+          onSelect={() => {
+            onSelectCustomFees?.();
+          }}
+        >
+          {t("fees.custom")}
+        </MenuItem>
+      ) : null}
+      {hasCoinControl ? (
+        <MenuItem
+          onSelect={() => {
+            onSelectCoinControl?.();
+          }}
+        >
+          {t("fees.coinControl")}
+        </MenuItem>
+      ) : null}
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
@@ -1,0 +1,176 @@
+import React, { useMemo } from "react";
+import {
+  Menu,
+  MenuTrigger,
+  MenuContent,
+  MenuLabel,
+  TooltipTrigger,
+  TooltipContent,
+  Tooltip,
+} from "@ledgerhq/lumen-ui-react";
+import { ChevronUpDown, Information } from "@ledgerhq/lumen-ui-react/symbols";
+import { sendFeatures, getSendDescriptor } from "@ledgerhq/live-common/bridge/descriptor";
+import { getAccountCurrency, getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
+import { useTranslation } from "react-i18next";
+import { useSendFlowData } from "../../../../context/SendFlowContext";
+import type { FeePresetOption } from "../../hooks/useFeePresetOptions";
+import type { FeeFiatMap } from "../../hooks/useFeePresetFiatValues";
+import type { FeePresetLegendMap } from "../../hooks/useFeePresetLegends";
+import { FeePresetMenuItems } from "./FeePresetMenuItems";
+
+type FeeOptionDisplay = Readonly<{
+  id: string;
+  fiatValue: string | null;
+  legendValue: string | null;
+  disabled?: boolean;
+}>;
+
+type FeesDisplay = Readonly<{
+  label: string;
+  value: string;
+  strategyLabel: string;
+}>;
+
+type FeesSelection = Readonly<{
+  selectedStrategy: string | null;
+  onSelectStrategy: (strategy: string) => void;
+}>;
+
+type FeesPresetsData = Readonly<{
+  options: readonly FeePresetOption[];
+  fiatByPreset: FeeFiatMap;
+  legendByPreset: FeePresetLegendMap;
+}>;
+
+type FeesActions = Readonly<{
+  onSelectCustomFees?: () => void;
+  onSelectCoinControl?: () => void;
+}>;
+
+type NetworkFeesMenuProps = Readonly<{
+  display: FeesDisplay;
+  selection: FeesSelection;
+  presets: FeesPresetsData;
+  actions?: FeesActions;
+}>;
+
+export function NetworkFeesMenu({ display, selection, presets, actions }: NetworkFeesMenuProps) {
+  const { label: feesLabel, value: feesValue, strategyLabel: feesStrategyLabel } = display;
+  const { selectedStrategy, onSelectStrategy } = selection;
+  const { options: feePresetOptions, fiatByPreset, legendByPreset } = presets;
+  const { onSelectCustomFees, onSelectCoinControl } = actions ?? {};
+  const { t } = useTranslation();
+  const { state } = useSendFlowData();
+  const { account, parentAccount } = state.account;
+  const { transaction } = state.transaction;
+
+  const mainAccount = useMemo(
+    () => (account ? getMainAccount(account, parentAccount ?? undefined) : null),
+    [account, parentAccount],
+  );
+  const currency = useMemo(
+    () => (mainAccount ? getAccountCurrency(mainAccount) : null),
+    [mainAccount],
+  );
+
+  const hasPresetsForCurrency = useMemo(
+    () => (currency ? sendFeatures.hasFeePresets(currency) : false),
+    [currency],
+  );
+
+  const feeOptionsWithFiat = useMemo(() => {
+    if (feePresetOptions.length > 0) {
+      return feePresetOptions.map(option => {
+        return {
+          ...option,
+          fiatValue: fiatByPreset[option.id] ?? null,
+          legendValue: legendByPreset[option.id] ?? null,
+        };
+      });
+    }
+
+    if (hasPresetsForCurrency) {
+      const strategies = ["slow", "medium", "fast"] as const;
+      return strategies.map(strategy => {
+        return {
+          id: strategy,
+          fiatValue: fiatByPreset[strategy] ?? null,
+          legendValue: legendByPreset[strategy] ?? null,
+        } satisfies FeeOptionDisplay;
+      });
+    }
+
+    return [];
+  }, [feePresetOptions, fiatByPreset, legendByPreset, hasPresetsForCurrency]);
+
+  if (!account || !transaction || !mainAccount || !currency) {
+    return null;
+  }
+
+  const hasPresets = sendFeatures.hasFeePresets(currency);
+  const hasCustom = sendFeatures.hasCustomFees(currency);
+  const hasCoinControl = sendFeatures.hasCoinControl(currency);
+  const legendConfig = getSendDescriptor(currency)?.fees.presets?.legend;
+  const shouldShowFeeRateLegend = legendConfig?.type === "feeRate";
+
+  const hasMenuOptions = hasPresets || hasCustom || hasCoinControl;
+
+  const informationIcon = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Information size={16} className="text-muted" />
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{t("newSendFlow.feesPaid")}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+
+  if (!hasMenuOptions) {
+    return (
+      <div className="flex w-full items-center justify-between py-16">
+        <span className="flex items-center gap-8">
+          <span className="body-2">{feesLabel}</span>
+          {informationIcon}
+        </span>
+        <span className="body-2 text-base">{feesValue}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full items-center justify-between py-16">
+      <span className="flex items-center gap-8">
+        <span className="body-2">{feesLabel}</span>
+        {informationIcon}
+      </span>
+      <Menu>
+        <MenuTrigger asChild>
+          <button
+            type="button"
+            className="flex items-center gap-8 transition-colors hover:opacity-70"
+          >
+            <span className="body-2 text-base">
+              {feesValue} • {feesStrategyLabel}
+            </span>
+            <ChevronUpDown size={16} className="text-muted" />
+          </button>
+        </MenuTrigger>
+        <MenuContent className="w-256" side="top">
+          <MenuLabel>{feesLabel}</MenuLabel>
+          <FeePresetMenuItems
+            hasPresets={hasPresets}
+            hasCustom={hasCustom}
+            hasCoinControl={hasCoinControl}
+            selectedStrategy={selectedStrategy}
+            onSelectStrategy={onSelectStrategy}
+            onSelectCustomFees={onSelectCustomFees}
+            onSelectCoinControl={onSelectCoinControl}
+            feeOptionsWithFiat={feeOptionsWithFiat}
+            shouldShowFeeRateLegend={shouldShowFeeRateLegend}
+          />
+        </MenuContent>
+      </Menu>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/QuickActionsRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/QuickActionsRow.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import type { AmountScreenQuickAction } from "../types";
+
+type QuickActionsRowProps = Readonly<{
+  actions: AmountScreenQuickAction[];
+}>;
+
+export function QuickActionsRow({ actions }: QuickActionsRowProps) {
+  return (
+    <div className="-mt-12 flex w-full gap-12">
+      {actions.map(action => (
+        <Button
+          key={action.id}
+          appearance={action.active ? "accent" : "gray"}
+          size="sm"
+          disabled={action.disabled}
+          onClick={action.onClick}
+          className="min-w-0 flex-1"
+        >
+          {action.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/EvmGasOptionsSyncPlugin.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/EvmGasOptionsSyncPlugin.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { SendFlowTransactionActions } from "@ledgerhq/live-common/flows/send/types";
+import { isEvmTransaction } from "../../utils/isEvmTransaction";
+import { EvmGasOptionsSyncPluginEvm } from "./EvmGasOptionsSyncPluginEvm";
+
+type Props = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  transaction: Transaction;
+  transactionActions: SendFlowTransactionActions;
+}>;
+
+export function EvmGasOptionsSyncPlugin({
+  account,
+  parentAccount,
+  transaction,
+  transactionActions,
+}: Props) {
+  if (!isEvmTransaction(transaction)) return null;
+
+  return (
+    <EvmGasOptionsSyncPluginEvm
+      account={account}
+      parentAccount={parentAccount}
+      transaction={transaction}
+      transactionActions={transactionActions}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/EvmGasOptionsSyncPluginEvm.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/plugins/EvmGasOptionsSyncPluginEvm.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { Banner } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import { getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
+import type { SendFlowTransactionActions } from "@ledgerhq/live-common/flows/send/types";
+import { useGasOptions } from "@ledgerhq/live-common/families/evm/react";
+import { EvmGasOptionsSync } from "../Fees/EvmGasOptionsSync";
+
+type Props = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  transaction: EvmTransaction;
+  transactionActions: SendFlowTransactionActions;
+}>;
+
+export function EvmGasOptionsSyncPluginEvm({
+  account,
+  parentAccount,
+  transaction,
+  transactionActions,
+}: Props) {
+  const { t } = useTranslation();
+
+  const mainAccount = getMainAccount(account, parentAccount ?? undefined);
+  const gasOptionsInterval = mainAccount.currency.blockAvgTime
+    ? mainAccount.currency.blockAvgTime * 1000
+    : undefined;
+
+  const [evmGasOptions, gasOptionsError, gasOptionsLoading] = useGasOptions({
+    currency: mainAccount.currency,
+    transaction,
+    interval: gasOptionsInterval,
+  });
+
+  return (
+    <>
+      {gasOptionsError && !gasOptionsLoading ? (
+        <Banner
+          appearance="warning"
+          title={t("newSendFlow.gasOptionsSync.warningTitle")}
+          description={t("newSendFlow.gasOptionsSync.warningDescription")}
+        />
+      ) : null}
+      <EvmGasOptionsSync
+        account={account}
+        parentAccount={parentAccount}
+        transaction={transaction}
+        transactionActions={transactionActions}
+        evmGasOptions={evmGasOptions}
+      />
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
@@ -1,0 +1,206 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { BigNumber } from "bignumber.js";
+import { renderHook } from "tests/testSetup";
+import { INITIAL_STATE as INITIAL_STATE_SETTINGS } from "~/renderer/reducers/settings";
+import { useAmountScreenViewModel } from "../useAmountScreenViewModel";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { getAccountCurrency, getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
+import { useTranslatedBridgeError } from "../../../Recipient/hooks/useTranslatedBridgeError";
+import type { Account } from "@ledgerhq/types-live";
+import type { TokenAccount } from "@ledgerhq/types-live";
+import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { createMockAccount } from "../../../Recipient/__integrations__/__fixtures__/accounts";
+
+jest.mock("react-i18next", () => ({
+  ...jest.requireActual("react-i18next"),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/impl");
+jest.mock("@ledgerhq/coin-framework/account/helpers");
+jest.mock("@ledgerhq/live-common/bridge/descriptor", () => ({
+  sendFeatures: {
+    hasFeePresets: () => false,
+    shouldEstimateFeePresetsWithBridge: () => false,
+    hasCustomFees: () => false,
+    hasCoinControl: () => false,
+  },
+}));
+
+jest.mock("../useAmountInput", () => ({
+  useAmountInput: () => ({
+    amountValue: "0",
+    amountInputMaxDecimalLength: 8,
+    currencyText: "BTC",
+    currencyPosition: "right",
+    secondaryValue: "$0",
+    onAmountChange: jest.fn(),
+    onToggleInputMode: jest.fn(),
+    cancelPendingUpdates: jest.fn(),
+    updateBothInputs: jest.fn(),
+  }),
+}));
+
+jest.mock("../useQuickActions", () => ({
+  useQuickActions: () => [],
+}));
+
+jest.mock("../useFeeInfo", () => ({
+  useFeeInfo: () => ({ feeSummary: null }),
+}));
+
+jest.mock("../useFeePresetOptions", () => ({
+  useFeePresetOptions: () => [],
+}));
+
+jest.mock("../useFeePresetFiatValues", () => ({
+  useFeePresetFiatValues: () => ({}),
+}));
+
+jest.mock("../useFeePresetLegends", () => ({
+  useFeePresetLegends: () => ({}),
+}));
+
+jest.mock("../../../Recipient/hooks/useTranslatedBridgeError");
+
+const mockedGetAccountBridge = jest.mocked(getAccountBridge);
+const mockedGetMainAccount = jest.mocked(getMainAccount);
+const mockedGetAccountCurrency = jest.mocked(getAccountCurrency);
+const mockedUseTranslatedBridgeError = jest.mocked(useTranslatedBridgeError);
+
+function createNamedError(name: string): Error {
+  const err = new Error("");
+  err.name = name;
+  return err;
+}
+
+function isAccount(account: Account | TokenAccount): account is Account {
+  return account.type === "Account";
+}
+
+describe("useAmountScreenViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedGetAccountBridge.mockReturnValue({
+      updateTransaction: (tx: Record<string, unknown>, patch: Record<string, unknown>) => ({
+        ...tx,
+        ...patch,
+      }),
+    } as never);
+
+    mockedGetMainAccount.mockImplementation((account: Account | TokenAccount) => {
+      if (!isAccount(account)) {
+        throw new Error("TokenAccount is not supported by this test helper");
+      }
+      return account;
+    });
+
+    mockedUseTranslatedBridgeError.mockImplementation((error?: Error) =>
+      error ? { title: error.name, description: "" } : null,
+    );
+  });
+
+  it("shows a blocking Stellar multisign error and disables the amount input", () => {
+    mockedGetAccountCurrency.mockReturnValue(getCryptoCurrencyById("stellar"));
+
+    const account = createMockAccount({
+      id: "acc",
+      currency: getCryptoCurrencyById("stellar"),
+    });
+    const transaction = {
+      family: "stellar",
+      recipient: "GRECIPIENT",
+      amount: new BigNumber(0),
+      useAllAmount: false,
+    } as Transaction;
+    const status = {
+      errors: { recipient: createNamedError("StellarSourceHasMultiSign") },
+      warnings: {},
+      estimatedFees: new BigNumber(0),
+      amount: new BigNumber(0),
+      totalSpent: new BigNumber(0),
+    } as TransactionStatus;
+
+    const { result } = renderHook(
+      () =>
+        useAmountScreenViewModel({
+          account,
+          parentAccount: null,
+          transaction,
+          status,
+          bridgePending: false,
+          bridgeError: null,
+          uiConfig: { hasFeePresets: true } as never,
+          transactionActions: { updateTransaction: jest.fn() } as never,
+        }),
+      {
+        initialState: {
+          settings: {
+            ...INITIAL_STATE_SETTINGS,
+            counterValue: "USD",
+          },
+        },
+      },
+    );
+
+    expect(result.current.isInputDisabled).toBe(true);
+    expect(result.current.amountMessage).toEqual({
+      type: "error",
+      text: "StellarSourceHasMultiSign",
+    });
+  });
+
+  it("shows a BTC dust/minimum error when review is disabled due to dustLimit", () => {
+    mockedGetAccountCurrency.mockReturnValue(getCryptoCurrencyById("bitcoin"));
+
+    const account = createMockAccount({
+      id: "acc",
+      currency: getCryptoCurrencyById("bitcoin"),
+      balance: new BigNumber(10),
+    });
+    const transaction = {
+      family: "bitcoin",
+      recipient: "bc1qrecipient",
+      amount: new BigNumber(1),
+      useAllAmount: false,
+    } as Transaction;
+    const status = {
+      errors: { dustLimit: createNamedError("DustLimit") },
+      warnings: {},
+      estimatedFees: new BigNumber(0),
+      amount: new BigNumber(0),
+      totalSpent: new BigNumber(0),
+    } as TransactionStatus;
+
+    const { result } = renderHook(
+      () =>
+        useAmountScreenViewModel({
+          account,
+          parentAccount: null,
+          transaction,
+          status,
+          bridgePending: false,
+          bridgeError: null,
+          uiConfig: { hasFeePresets: true } as never,
+          transactionActions: { updateTransaction: jest.fn() } as never,
+        }),
+      {
+        initialState: {
+          settings: {
+            ...INITIAL_STATE_SETTINGS,
+            counterValue: "USD",
+          },
+        },
+      },
+    );
+
+    expect(result.current.isInputDisabled).toBe(false);
+    expect(result.current.amountMessage).toEqual({
+      type: "error",
+      text: "DustLimit",
+    });
+    expect(result.current.reviewDisabled).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useFeePresetFiatValues.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useFeePresetFiatValues.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { BigNumber } from "bignumber.js";
+import { renderHook, waitFor } from "tests/testSetup";
+import { useFeePresetFiatValues } from "../useFeePresetFiatValues";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useCalculateCountervalueCallback } from "@ledgerhq/live-countervalues-react";
+import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/formatCurrencyUnit";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import {
+  getCryptoCurrencyById,
+  getFiatCurrencyByTicker,
+} from "@ledgerhq/live-common/currencies/index";
+import { createMockAccount } from "../../../Recipient/__integrations__/__fixtures__/accounts";
+import type { FeePresetOption } from "../useFeePresetOptions";
+
+jest.mock("@ledgerhq/live-common/bridge/index");
+jest.mock("@ledgerhq/live-countervalues-react", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues-react"),
+  useCalculateCountervalueCallback: jest.fn(),
+}));
+jest.mock("@ledgerhq/coin-framework/currencies/formatCurrencyUnit");
+
+const mockedGetAccountBridge = jest.mocked(getAccountBridge);
+const mockedUseCalculateCountervalueCallback = jest.mocked(useCalculateCountervalueCallback);
+const mockedFormatCurrencyUnit = jest.mocked(formatCurrencyUnit);
+
+describe("useFeePresetFiatValues", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedUseCalculateCountervalueCallback.mockReturnValue((_from, value) => value);
+    mockedFormatCurrencyUnit.mockImplementation((_unit, value) => value.toString());
+  });
+
+  it("returns direct fiat values when preset amounts are available", () => {
+    const mainAccount = createMockAccount({
+      id: "main",
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
+    const fiatCurrency = getFiatCurrencyByTicker("USD");
+    const feePresetOptions = [
+      { id: "slow", amount: new BigNumber(1) },
+      { id: "fast", amount: new BigNumber(3) },
+    ] satisfies readonly FeePresetOption[];
+    const transaction = {
+      family: "bitcoin",
+      recipient: "bc1qrecipient",
+      amount: new BigNumber(1),
+      useAllAmount: false,
+    } as Transaction;
+
+    const { result } = renderHook(() =>
+      useFeePresetFiatValues({
+        account: mainAccount,
+        parentAccount: null,
+        mainAccount,
+        transaction,
+        feePresetOptions,
+        counterValueCurrency: fiatCurrency,
+        fiatUnit: fiatCurrency.units[0],
+        enabled: true,
+        shouldEstimateWithBridge: false,
+      }),
+    );
+
+    expect(result.current).toEqual({
+      slow: "1",
+      fast: "3",
+    });
+  });
+
+  it("estimates preset fiat values via bridge when using fallback preset ids (EVM)", async () => {
+    const bridge = {
+      updateTransaction: (tx: Record<string, unknown>, patch: Record<string, unknown>) => ({
+        ...tx,
+        ...patch,
+      }),
+      prepareTransaction: async (_account: unknown, tx: Record<string, unknown>) => tx,
+      getTransactionStatus: async (_account: unknown, tx: Record<string, unknown>) => {
+        const feesByStrategy: Record<string, BigNumber> = {
+          slow: new BigNumber(1),
+          medium: new BigNumber(2),
+          fast: new BigNumber(3),
+        };
+        const strategy = typeof tx.feesStrategy === "string" ? tx.feesStrategy : "";
+        return { estimatedFees: feesByStrategy[strategy] ?? new BigNumber(0), errors: {} };
+      },
+    };
+    mockedGetAccountBridge.mockReturnValue(bridge as never);
+
+    const mainAccount = createMockAccount({
+      id: "main",
+      currency: getCryptoCurrencyById("ethereum"),
+    });
+    const fiatCurrency = getFiatCurrencyByTicker("USD");
+    const transaction = {
+      family: "evm",
+      recipient: "0xrecipient",
+      amount: new BigNumber(0),
+      useAllAmount: false,
+    } as Transaction;
+
+    const { result } = renderHook(() =>
+      useFeePresetFiatValues({
+        account: mainAccount,
+        parentAccount: null,
+        mainAccount,
+        transaction,
+        feePresetOptions: [],
+        fallbackPresetIds: ["slow", "medium", "fast"],
+        counterValueCurrency: fiatCurrency,
+        fiatUnit: fiatCurrency.units[0],
+        enabled: true,
+        shouldEstimateWithBridge: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        slow: "1",
+        medium: "2",
+        fast: "3",
+      });
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useFeePresetLegends.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useFeePresetLegends.test.ts
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { BigNumber } from "bignumber.js";
+import { renderHook } from "tests/testSetup";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { getSendDescriptor, type SendDescriptor } from "@ledgerhq/live-common/bridge/descriptor";
+import { useFeePresetLegends } from "../useFeePresetLegends";
+import type { FeePresetOption } from "../useFeePresetOptions";
+
+jest.mock("@ledgerhq/live-common/bridge/descriptor", () => ({
+  getSendDescriptor: jest.fn(),
+}));
+
+const mockedGetSendDescriptor = jest.mocked(getSendDescriptor);
+
+const currency = {
+  type: "CryptoCurrency",
+  id: "bitcoin",
+  name: "Bitcoin",
+  ticker: "BTC",
+  units: [{ code: "BTC", magnitude: 8, name: "BTC" }],
+} as unknown as CryptoCurrency;
+
+describe("useFeePresetLegends", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns fee rate legends when descriptor config is feeRate from presetAmount", () => {
+    mockedGetSendDescriptor.mockReturnValue({
+      fees: {
+        hasPresets: true,
+        hasCustom: false,
+        presets: {
+          legend: { type: "feeRate", unit: "sat/vbyte", valueFrom: "presetAmount" },
+        },
+      },
+      inputs: {},
+    } as unknown as SendDescriptor);
+
+    const feePresetOptions = [
+      { id: "slow", amount: new BigNumber(2.9) },
+      { id: "medium", amount: new BigNumber(5) },
+      { id: "invalid", amount: new BigNumber(NaN) },
+    ] satisfies readonly FeePresetOption[];
+
+    const { result } = renderHook(() => useFeePresetLegends({ currency, feePresetOptions }));
+
+    expect(result.current).toEqual({
+      slow: "2 sat/vbyte",
+      medium: "5 sat/vbyte",
+    });
+  });
+
+  it("returns empty map when descriptor has no legend config", () => {
+    mockedGetSendDescriptor.mockReturnValue({
+      fees: { hasPresets: true, hasCustom: false },
+      inputs: {},
+    } as unknown as SendDescriptor);
+
+    const feePresetOptions = [
+      { id: "slow", amount: new BigNumber(2) },
+    ] satisfies readonly FeePresetOption[];
+    const { result } = renderHook(() => useFeePresetLegends({ currency, feePresetOptions }));
+
+    expect(result.current).toEqual({});
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useFeePresetOptions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useFeePresetOptions.test.ts
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { BigNumber } from "bignumber.js";
+import { renderHook } from "tests/testSetup";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor";
+import { useFeePresetOptions } from "../useFeePresetOptions";
+
+jest.mock("@ledgerhq/live-common/bridge/descriptor", () => ({
+  sendFeatures: {
+    getFeePresetOptions: jest.fn(() => []),
+  },
+}));
+
+const mockedSendFeatures = jest.mocked(sendFeatures);
+
+function createEvmTransaction(params: {
+  gasLimit: BigNumber;
+  gasOptions: Record<string, unknown>;
+}): Transaction {
+  return {
+    family: "evm",
+    type: 2,
+    nonce: 1,
+    chainId: 1,
+    gasLimit: params.gasLimit,
+    mode: "send",
+    recipient: "0xrecipient",
+    amount: new BigNumber(0),
+    gasOptions: params.gasOptions,
+  } as unknown as Transaction;
+}
+
+describe("useFeePresetOptions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("passes through the transaction as-is when not EVM", () => {
+    const tx = { family: "bitcoin" } as unknown as Transaction;
+
+    renderHook(() => useFeePresetOptions(undefined, tx));
+
+    expect(mockedSendFeatures.getFeePresetOptions).toHaveBeenCalledWith(undefined, tx);
+  });
+
+  it("keeps the last distinct EVM gasOptions when current gasOptions are not distinct", () => {
+    const distinctGasOptions = {
+      slow: { maxFeePerGas: new BigNumber(1) },
+      medium: { maxFeePerGas: new BigNumber(2) },
+      fast: { maxFeePerGas: new BigNumber(3) },
+    };
+    const nonDistinctGasOptions = {
+      slow: { maxFeePerGas: new BigNumber(1) },
+      medium: { maxFeePerGas: new BigNumber(1) },
+      fast: { maxFeePerGas: new BigNumber(1) },
+    };
+
+    const tx1 = createEvmTransaction({
+      gasLimit: new BigNumber(21000),
+      gasOptions: distinctGasOptions,
+    });
+    const tx2 = createEvmTransaction({
+      gasLimit: new BigNumber(21000),
+      gasOptions: nonDistinctGasOptions,
+    });
+
+    const { rerender } = renderHook(({ tx }) => useFeePresetOptions(undefined, tx), {
+      initialProps: { tx: tx1 },
+    });
+
+    expect(mockedSendFeatures.getFeePresetOptions).toHaveBeenCalledTimes(1);
+    const firstCallTx = mockedSendFeatures.getFeePresetOptions.mock.calls[0]?.[1] as Transaction;
+    const firstCallTxWithGasOptions = firstCallTx as unknown as Transaction & {
+      gasOptions: Record<string, unknown>;
+    };
+    expect(firstCallTxWithGasOptions.gasOptions).toBe(distinctGasOptions);
+
+    rerender({ tx: tx2 });
+
+    expect(mockedSendFeatures.getFeePresetOptions).toHaveBeenCalledTimes(2);
+    const secondCallTx = mockedSendFeatures.getFeePresetOptions.mock.calls[1]?.[1] as Transaction;
+    const secondCallTxWithGasOptions = secondCallTx as unknown as Transaction & {
+      gasOptions: Record<string, unknown>;
+    };
+    expect(secondCallTxWithGasOptions.gasOptions).toBe(distinctGasOptions);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountInput.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountInput.ts
@@ -1,0 +1,265 @@
+import { useCallback, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { BigNumber } from "bignumber.js";
+import { useSelector } from "LLD/hooks/redux";
+import {
+  useSendAmount,
+  useCalculateCountervalueCallback,
+} from "@ledgerhq/live-countervalues-react";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/formatCurrencyUnit";
+import { getAccountCurrency, getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
+import {
+  formatAmountForInput,
+  formatFiatForInput,
+  processRawInput,
+  processFiatInput,
+  calculateFiatEquivalent,
+} from "../utils/amountInput";
+import { syncAmountInputs } from "../utils/amountInputSync";
+
+type UseAmountInputParams = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  transaction: Transaction;
+  status: TransactionStatus;
+  onUpdateTransaction: (patch: Partial<Transaction>) => void;
+}>;
+
+export function useAmountInput({
+  account,
+  parentAccount,
+  transaction,
+  status,
+  onUpdateTransaction,
+}: UseAmountInputParams) {
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const locale = useSelector(localeSelector);
+
+  const mainAccount = useMemo(
+    () => getMainAccount(account, parentAccount ?? undefined),
+    [account, parentAccount],
+  );
+
+  const accountCurrency = useMemo(() => getAccountCurrency(mainAccount), [mainAccount]);
+  const accountUnit = useMaybeAccountUnit(mainAccount) ?? accountCurrency.units[0];
+  const fiatUnit = counterValueCurrency.units[0];
+
+  // When useAllAmount is true, the bridge calculates the actual amount (balance - fees)
+  // This calculated amount is available in status.amount
+  const cryptoAmount = useMemo(() => {
+    if (transaction.useAllAmount) {
+      // Use status.amount which already accounts for fees when useAllAmount is true
+      return status.amount ?? new BigNumber(0);
+    }
+    return transaction.amount ?? new BigNumber(0);
+  }, [transaction.amount, transaction.useAllAmount, status.amount]);
+
+  const { fiatAmount, calculateCryptoAmount } = useSendAmount({
+    account,
+    fiatCurrency: counterValueCurrency,
+    cryptoAmount,
+  });
+  const calculateFiatFromCrypto = useCalculateCountervalueCallback({
+    to: counterValueCurrency,
+  });
+
+  const [inputMode, setInputMode] = useState<"fiat" | "crypto">("fiat");
+  const [fiatInputValue, setFiatInputValue] = useState<string>("");
+  const [cryptoInputValue, setCryptoInputValue] = useState<string>("");
+  const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const lastTransactionAmountRef = useRef<BigNumber>(cryptoAmount);
+  const lastFiatAmountRef = useRef<BigNumber>(fiatAmount);
+  const lastUseAllAmountRef = useRef<boolean>(transaction.useAllAmount ?? false);
+  const lastUserInputTimeRef = useRef<number>(0);
+
+  // Sync input values when transaction amount changes externally (e.g., from quick actions)
+  syncAmountInputs({
+    cryptoAmount,
+    fiatAmount,
+    transactionUseAllAmount: Boolean(transaction.useAllAmount),
+    inputMode,
+    cryptoInputValue,
+    fiatInputValue,
+    locale,
+    accountUnit,
+    fiatUnit,
+    lastTransactionAmountRef,
+    lastFiatAmountRef,
+    lastUseAllAmountRef,
+    lastUserInputTimeRef,
+    setCryptoInputValue,
+    setFiatInputValue,
+  });
+
+  const amountValue = inputMode === "fiat" ? fiatInputValue : cryptoInputValue;
+  const currencyText =
+    inputMode === "fiat" ? counterValueCurrency.symbol ?? fiatUnit.code : accountUnit.code;
+  const currencyPosition: "left" | "right" = inputMode === "fiat" ? "left" : "right";
+
+  const secondaryValue = useMemo(() => {
+    if (inputMode === "fiat") {
+      const cryptoSource =
+        cryptoInputValue && cryptoInputValue.length > 0
+          ? lastTransactionAmountRef.current
+          : lastTransactionAmountRef.current ?? cryptoAmount;
+      return formatCurrencyUnit(accountUnit, cryptoSource ?? new BigNumber(0), {
+        showCode: true,
+        disableRounding: true,
+        locale,
+      });
+    }
+    const fiatSource =
+      fiatInputValue && fiatInputValue.length > 0
+        ? lastFiatAmountRef.current
+        : lastFiatAmountRef.current ?? fiatAmount;
+    return formatCurrencyUnit(fiatUnit, fiatSource ?? new BigNumber(0), {
+      showCode: true,
+      disableRounding: true,
+      locale,
+    });
+  }, [
+    accountUnit,
+    cryptoAmount,
+    cryptoInputValue,
+    fiatAmount,
+    fiatInputValue,
+    fiatUnit,
+    inputMode,
+    locale,
+  ]);
+
+  const cancelPendingUpdates = useCallback(() => {
+    if (debounceTimeoutRef.current) {
+      clearTimeout(debounceTimeoutRef.current);
+      debounceTimeoutRef.current = null;
+    }
+  }, []);
+
+  const debouncedUpdateTransaction = useCallback(
+    (patch: Partial<Transaction>) => {
+      cancelPendingUpdates();
+      debounceTimeoutRef.current = setTimeout(() => {
+        onUpdateTransaction(patch);
+        debounceTimeoutRef.current = null;
+      }, 500);
+    },
+    [cancelPendingUpdates, onUpdateTransaction],
+  );
+
+  const handleFiatInput = useCallback(
+    (rawValue: string) => {
+      const processed = processFiatInput(rawValue, fiatUnit, locale);
+      setFiatInputValue(processed.clampedDisplay);
+
+      if (processed.isOverLimit) {
+        return;
+      }
+
+      const nextAmount = calculateCryptoAmount(processed.value) ?? new BigNumber(0);
+      lastFiatAmountRef.current = processed.value;
+      lastTransactionAmountRef.current = nextAmount;
+      debouncedUpdateTransaction({
+        amount: nextAmount.integerValue(BigNumber.ROUND_DOWN),
+        useAllAmount: false,
+      });
+    },
+    [calculateCryptoAmount, debouncedUpdateTransaction, fiatUnit, locale],
+  );
+
+  const handleCryptoInput = useCallback(
+    (rawValue: string) => {
+      const processed = processRawInput(rawValue, accountUnit, locale);
+      setCryptoInputValue(processed.display);
+
+      lastTransactionAmountRef.current = processed.value;
+      const fiatEquivalent = calculateFiatFromCrypto(accountCurrency, processed.value);
+      lastFiatAmountRef.current =
+        fiatEquivalent?.isFinite() && !fiatEquivalent.isNaN() ? fiatEquivalent : new BigNumber(0);
+      debouncedUpdateTransaction({
+        amount: processed.value.integerValue(BigNumber.ROUND_DOWN),
+        useAllAmount: false,
+      });
+    },
+    [accountCurrency, accountUnit, calculateFiatFromCrypto, debouncedUpdateTransaction, locale],
+  );
+
+  const handleAmountChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      lastUserInputTimeRef.current = Date.now();
+      const raw = event.target.value;
+
+      if (inputMode === "fiat") {
+        handleFiatInput(raw);
+      } else {
+        handleCryptoInput(raw);
+      }
+    },
+    [handleCryptoInput, handleFiatInput, inputMode],
+  );
+
+  const handleToggleMode = useCallback(() => {
+    lastUserInputTimeRef.current = Date.now();
+    setInputMode(prev => {
+      const next = prev === "fiat" ? "crypto" : "fiat";
+
+      if (next === "fiat") {
+        const source = lastFiatAmountRef.current ?? fiatAmount;
+        const formatted = formatFiatForInput(fiatUnit, source, locale);
+        setFiatInputValue(formatted);
+      } else {
+        const source = lastTransactionAmountRef.current ?? cryptoAmount;
+        const formatted = formatAmountForInput(accountUnit, source, locale);
+        setCryptoInputValue(formatted);
+      }
+
+      return next;
+    });
+  }, [accountUnit, cryptoAmount, fiatAmount, fiatUnit, locale]);
+
+  const updateBothInputs = useCallback(
+    (amount: BigNumber) => {
+      // Quick action: update inputs immediately for instant feedback,
+      // then let bridge sync take over once it responds.
+      lastUserInputTimeRef.current = 0;
+
+      // Update crypto input
+      const cryptoFormatted = formatAmountForInput(accountUnit, amount, locale);
+      setCryptoInputValue(cryptoFormatted);
+
+      // Calculate and update fiat input
+      const fiatEquivalent = calculateFiatEquivalent({
+        amount,
+        lastTransactionAmount: lastTransactionAmountRef.current,
+        lastFiatAmount: lastFiatAmountRef.current,
+        calculateFiatFromCrypto: value => calculateFiatFromCrypto(accountCurrency, value),
+      });
+
+      if (fiatEquivalent?.isFinite() && !fiatEquivalent?.isNaN() && fiatEquivalent?.gt(0)) {
+        const formatted = formatFiatForInput(fiatUnit, fiatEquivalent, locale);
+        setFiatInputValue(formatted);
+      } else if (amount.isZero()) {
+        setFiatInputValue("");
+      }
+    },
+    [accountCurrency, accountUnit, calculateFiatFromCrypto, fiatUnit, locale],
+  );
+
+  const amountInputMaxDecimalLength = inputMode === "fiat" ? 2 : Math.max(0, accountUnit.magnitude);
+
+  return {
+    amountValue,
+    currencyText,
+    currencyPosition,
+    secondaryValue,
+    inputMode,
+    amountInputMaxDecimalLength,
+    onAmountChange: handleAmountChange,
+    onToggleInputMode: handleToggleMode,
+    updateBothInputs,
+    cancelPendingUpdates,
+    debounceTimeoutRef,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenMessage.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenMessage.ts
@@ -1,0 +1,72 @@
+import { useMemo } from "react";
+import type { TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { useTranslatedBridgeError } from "../../Recipient/hooks/useTranslatedBridgeError";
+import { getAmountScreenMessage } from "../utils/messages";
+import { getStatusError, pickBlockingError } from "../utils/errors";
+import type { AmountScreenMessage } from "../types";
+
+export function useAmountScreenMessage(params: {
+  status: TransactionStatus;
+  accountCurrency: CryptoOrTokenCurrency | undefined;
+  amountComputationPending: boolean;
+  hasRawAmount: boolean;
+}): Readonly<{
+  amountMessage: AmountScreenMessage | null;
+  isStellarMultisignBlocked: boolean;
+}> {
+  const amountError = useTranslatedBridgeError(params.status.errors?.amount);
+
+  // Some bridges (e.g., Bitcoin) put FeeTooHigh in warnings.feeTooHigh, others in warnings.amount
+  const amountWarningRaw = params.status.warnings?.amount ?? params.status.warnings?.feeTooHigh;
+  const amountWarning = useTranslatedBridgeError(amountWarningRaw);
+
+  const recipientErrorRaw = getStatusError(params.status.errors, "recipient");
+  const recipientError = useTranslatedBridgeError(recipientErrorRaw);
+
+  const otherBlockingErrorRaw = useMemo(() => {
+    const candidate = pickBlockingError(params.status.errors);
+    return candidate?.name === "AmountRequired" ? undefined : candidate;
+  }, [params.status.errors]);
+  const otherBlockingError = useTranslatedBridgeError(otherBlockingErrorRaw);
+
+  // Always hide "AmountRequired" error - the Review button is already disabled when there's no amount,
+  // so this error message provides no value and causes visual glitches during input
+  const isAmountRequiredError = params.status.errors?.amount?.name === "AmountRequired";
+
+  const amountErrorTitle = amountError && !isAmountRequiredError ? amountError.title : undefined;
+  const amountWarningTitle = amountWarning ? amountWarning.title : undefined;
+
+  const isFeeTooHigh =
+    params.status.warnings?.amount?.name === "FeeTooHigh" ||
+    params.status.warnings?.feeTooHigh?.name === "FeeTooHigh";
+
+  const cryptoCurrency =
+    params.accountCurrency?.type === "TokenCurrency"
+      ? params.accountCurrency.parentCurrency
+      : params.accountCurrency;
+
+  const isStellarMultisignBlocked =
+    cryptoCurrency?.family === "stellar" && recipientErrorRaw?.name === "StellarSourceHasMultiSign";
+
+  const multisignMessage =
+    isStellarMultisignBlocked && recipientError?.title
+      ? ({ type: "error", text: recipientError.title } as const)
+      : null;
+
+  const baseAmountMessage = getAmountScreenMessage({
+    amountErrorTitle,
+    amountWarningTitle: amountErrorTitle ? undefined : amountWarningTitle,
+    isFeeTooHigh,
+    hasRawAmount: params.hasRawAmount,
+  });
+
+  const fallbackBlockingMessage =
+    !multisignMessage && !baseAmountMessage && params.hasRawAmount && otherBlockingError?.title
+      ? ({ type: "error", text: otherBlockingError.title } as const)
+      : null;
+
+  const amountMessage = multisignMessage ?? baseAmountMessage ?? fallbackBlockingMessage;
+
+  return { amountMessage, isStellarMultisignBlocked };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
@@ -1,0 +1,253 @@
+import { useCallback, useMemo } from "react";
+import { BigNumber } from "bignumber.js";
+import { useTranslation } from "react-i18next";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import type {
+  SendFlowTransactionActions,
+  SendFlowUiConfig,
+} from "@ledgerhq/live-common/flows/send/types";
+import type { AmountScreenViewModel } from "../types";
+import { getAccountCurrency, getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAmountInput } from "./useAmountInput";
+import { useQuickActions } from "./useQuickActions";
+import { useFeeInfo } from "./useFeeInfo";
+import { useFeePresetOptions } from "./useFeePresetOptions";
+import { useFeePresetFiatValues } from "./useFeePresetFiatValues";
+import { useFeePresetLegends } from "./useFeePresetLegends";
+import { useSelector } from "LLD/hooks/redux";
+import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
+import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor";
+import { useInitialTransactionPreparation } from "./useInitialTransactionPreparation";
+import { useAmountScreenMessage } from "./useAmountScreenMessage";
+
+type UseAmountScreenViewModelParams = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  transaction: Transaction;
+  status: TransactionStatus;
+  bridgePending: boolean;
+  bridgeError: Error | null;
+  uiConfig: SendFlowUiConfig;
+  transactionActions: SendFlowTransactionActions;
+}>;
+
+export function useAmountScreenViewModel({
+  account,
+  parentAccount,
+  transaction,
+  status,
+  bridgePending,
+  bridgeError: _bridgeError,
+  uiConfig,
+  transactionActions,
+}: UseAmountScreenViewModelParams): AmountScreenViewModel {
+  const { t } = useTranslation();
+
+  const mainAccount = useMemo(
+    () => getMainAccount(account, parentAccount ?? undefined),
+    [account, parentAccount],
+  );
+  const accountCurrency = useMemo(() => getAccountCurrency(mainAccount), [mainAccount]);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const fiatUnit = counterValueCurrency.units[0];
+  const feePresetOptions = useFeePresetOptions(accountCurrency, transaction);
+  const hasFeePresets = sendFeatures.hasFeePresets(accountCurrency);
+  const shouldEstimateFeePresetsWithBridge = sendFeatures.shouldEstimateFeePresetsWithBridge(
+    accountCurrency,
+    transaction,
+  );
+  const shouldForceBridgeEstimationForEvm =
+    hasFeePresets && transaction.family === "evm" && feePresetOptions.length === 0;
+  const shouldEstimateFeePresets =
+    shouldEstimateFeePresetsWithBridge || shouldForceBridgeEstimationForEvm;
+  const fiatByPreset = useFeePresetFiatValues({
+    account,
+    parentAccount,
+    mainAccount,
+    transaction,
+    feePresetOptions,
+    fallbackPresetIds: shouldForceBridgeEstimationForEvm ? ["slow", "medium", "fast"] : undefined,
+    counterValueCurrency,
+    fiatUnit,
+    enabled: hasFeePresets,
+    shouldEstimateWithBridge: shouldEstimateFeePresets,
+  });
+  const legendByPreset = useFeePresetLegends({
+    currency: accountCurrency,
+    feePresetOptions,
+  });
+
+  const updateTransactionWithPatch = useCallback(
+    (patch: Partial<Transaction>) => {
+      transactionActions.updateTransaction(currentTx => {
+        const bridge = getAccountBridge(account, parentAccount ?? undefined);
+        return bridge.updateTransaction(currentTx, patch);
+      });
+    },
+    [account, parentAccount, transactionActions],
+  );
+
+  const amountInput = useAmountInput({
+    account,
+    parentAccount,
+    transaction,
+    status,
+    onUpdateTransaction: updateTransactionWithPatch,
+  });
+
+  const rawTransactionAmount = transaction.amount ?? new BigNumber(0);
+  const hasRawAmount = transaction.useAllAmount || rawTransactionAmount.gt(0);
+  const shouldPrepare = Boolean(transaction.recipient) && hasRawAmount;
+  const amountComputationPending = bridgePending && shouldPrepare;
+
+  useInitialTransactionPreparation({
+    shouldPrepare,
+    mainAccountId: mainAccount.id,
+    recipientAddress: transaction.recipient ?? "",
+    bridgePending,
+    updateTransactionWithPatch: () => updateTransactionWithPatch({}),
+  });
+
+  const maxAvailable = useMemo(() => {
+    if (!account) return new BigNumber(0);
+    const spendable = "spendableBalance" in account ? account.spendableBalance : undefined;
+    const balance = spendable ?? account.balance ?? new BigNumber(0);
+
+    // For ratios (25%, 50%, 75%), we need to account for fees to avoid insufficient funds
+    // Subtract estimated fees to get a safer maxAvailable
+    const estimatedFees = status.estimatedFees ?? new BigNumber(0);
+    const safeMax = balance.minus(estimatedFees);
+
+    return BigNumber.max(0, safeMax);
+  }, [account, status.estimatedFees]);
+
+  const quickActionsAvailableBalance = useMemo(() => {
+    const spendable = "spendableBalance" in account ? account.spendableBalance : undefined;
+    const balance = "balance" in account ? account.balance : new BigNumber(0);
+    return spendable ?? balance ?? new BigNumber(0);
+  }, [account]);
+
+  const setAmountFromRatio = useCallback(
+    (nextAmount: BigNumber) => {
+      if (maxAvailable.lte(0)) return;
+      amountInput.cancelPendingUpdates();
+      const safeAmount = BigNumber.max(nextAmount, 0);
+      amountInput.updateBothInputs(safeAmount);
+      updateTransactionWithPatch({
+        amount: safeAmount,
+        useAllAmount: false,
+      });
+    },
+    [amountInput, maxAvailable, updateTransactionWithPatch],
+  );
+
+  const handleSelectMax = useCallback(() => {
+    amountInput.cancelPendingUpdates();
+    updateTransactionWithPatch({
+      useAllAmount: true,
+      amount: new BigNumber(0),
+    });
+  }, [updateTransactionWithPatch, amountInput]);
+
+  const quickActions = useQuickActions({
+    account,
+    parentAccount,
+    transaction,
+    maxAvailable,
+    onSetAmountFromRatio: setAmountFromRatio,
+    onSelectMax: handleSelectMax,
+  });
+
+  const { feeSummary } = useFeeInfo({
+    account,
+    parentAccount,
+    status,
+  });
+
+  const { amountMessage, isStellarMultisignBlocked } = useAmountScreenMessage({
+    status,
+    accountCurrency,
+    amountComputationPending,
+    hasRawAmount,
+  });
+
+  const hasInsufficientFundsError = useMemo(() => {
+    if (!status.errors?.amount) return false;
+    const errorName = status.errors.amount.name;
+    return (
+      errorName === "NotEnoughBalance" ||
+      errorName === "NotEnoughBalanceFees" ||
+      errorName === "NotEnoughBalanceSwap" ||
+      errorName === "NotEnoughBalanceBecauseDestinationNotCreated" ||
+      errorName === "NotEnoughBalanceInParentAccount" ||
+      errorName === "NotEnoughBalanceToDelegate" ||
+      errorName.includes("Insufficient")
+    );
+  }, [status.errors?.amount]);
+
+  const hasErrors = Object.keys(status.errors ?? {}).length > 0;
+  // For enabling the CTA, rely on the user-entered transaction amount (no bridge lag)
+  const hasAmount = hasRawAmount;
+  const reviewDisabled =
+    (hasErrors && !hasInsufficientFundsError) || !hasAmount || amountComputationPending;
+  const showNetworkFees = true;
+
+  const selectedFeeStrategy = transaction.feesStrategy ?? null;
+  const selectedPresetFiatValue =
+    selectedFeeStrategy && selectedFeeStrategy !== "custom"
+      ? fiatByPreset[selectedFeeStrategy] ?? null
+      : null;
+
+  const onSelectFeeStrategy = useCallback(
+    (strategy: string) => {
+      const feesStrategy: Transaction["feesStrategy"] =
+        strategy === "slow" || strategy === "medium" || strategy === "fast" || strategy === "custom"
+          ? strategy
+          : null;
+
+      updateTransactionWithPatch({ feesStrategy });
+    },
+    [updateTransactionWithPatch],
+  );
+
+  const reviewLabel = hasInsufficientFundsError
+    ? t("newSendFlow.getCta", { currency: accountCurrency?.ticker ?? "CRYPTO" })
+    : t("newSendFlow.reviewCta");
+
+  const getFeeStrategyLabel = (strategy: string | null): string => {
+    if (!strategy) return t("fees.medium");
+    if (strategy === "custom") return t("fees.custom");
+    return t(`fees.${strategy}`);
+  };
+
+  return {
+    amountValue: amountInput.amountValue,
+    amountInputMaxDecimalLength: amountInput.amountInputMaxDecimalLength,
+    currencyText: amountInput.currencyText,
+    currencyPosition: amountInput.currencyPosition,
+    isInputDisabled: isStellarMultisignBlocked,
+    onAmountChange: amountInput.onAmountChange,
+    onToggleInputMode: amountInput.onToggleInputMode,
+    toggleLabel: t("newSendFlow.switchInputMode"),
+    secondaryValue: amountInput.secondaryValue,
+    feesRowLabel: t("fees.networkFees"),
+    feesRowValue: selectedPresetFiatValue ?? feeSummary?.fiatValue ?? "--",
+    feesRowStrategyLabel: getFeeStrategyLabel(selectedFeeStrategy),
+    quickActions,
+    showQuickActions: quickActionsAvailableBalance.gt(0),
+    amountMessage,
+    showNetworkFees,
+    reviewLabel,
+    reviewShowIcon: !hasInsufficientFundsError,
+    reviewDisabled,
+    reviewLoading: amountComputationPending,
+    showFeePresets: uiConfig.hasFeePresets,
+    selectedFeeStrategy,
+    onSelectFeeStrategy,
+    feePresetOptions,
+    fiatByPreset,
+    legendByPreset,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useFeeInfo.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useFeeInfo.ts
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+import { BigNumber } from "bignumber.js";
+import { useTranslation } from "react-i18next";
+import { useSelector } from "LLD/hooks/redux";
+import { useCalculate } from "@ledgerhq/live-countervalues-react";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/formatCurrencyUnit";
+import { getAccountCurrency, getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
+
+type UseFeeInfoParams = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  status: TransactionStatus;
+}>;
+
+export function useFeeInfo({ account, parentAccount, status }: UseFeeInfoParams) {
+  const { t } = useTranslation();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const locale = useSelector(localeSelector);
+
+  const mainAccount = useMemo(
+    () => getMainAccount(account, parentAccount ?? undefined),
+    [account, parentAccount],
+  );
+
+  const accountCurrency = useMemo(() => getAccountCurrency(mainAccount), [mainAccount]);
+  const accountUnit = useMaybeAccountUnit(mainAccount) ?? accountCurrency.units[0];
+  const fiatUnit = counterValueCurrency.units[0];
+
+  const estimatedFees = useMemo(
+    () => status.estimatedFees ?? new BigNumber(0),
+    [status.estimatedFees],
+  );
+  const estimatedFeesCountervalue = useCalculate({
+    from: accountCurrency,
+    to: counterValueCurrency,
+    value: estimatedFees.toNumber(),
+    disableRounding: true,
+  });
+  const estimatedFeesFiat = useMemo(
+    () => new BigNumber(estimatedFeesCountervalue ?? 0),
+    [estimatedFeesCountervalue],
+  );
+
+  const feeSummary = useMemo(
+    () =>
+      estimatedFees.gt(0) || estimatedFeesFiat.gt(0)
+        ? {
+            fiatLabel: t("newSendFlow.networkFeesInFiat", {
+              currency: counterValueCurrency.ticker,
+            }),
+            fiatValue: formatCurrencyUnit(fiatUnit, estimatedFeesFiat, {
+              showCode: true,
+              disableRounding: true,
+              locale,
+            }),
+            cryptoLabel: t("newSendFlow.feesAmount", {
+              unit: accountUnit.code,
+            }),
+            cryptoValue: formatCurrencyUnit(accountUnit, estimatedFees, {
+              showCode: true,
+              disableRounding: true,
+              locale,
+            }),
+            description: t("newSendFlow.feesPaid"),
+          }
+        : null,
+    [
+      accountUnit,
+      counterValueCurrency.ticker,
+      estimatedFees,
+      estimatedFeesFiat,
+      fiatUnit,
+      locale,
+      t,
+    ],
+  );
+
+  return { feeSummary };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useFeePresetFiatValues.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useFeePresetFiatValues.ts
@@ -1,0 +1,199 @@
+import { useMemo, useRef, useState } from "react";
+import { BigNumber } from "bignumber.js";
+import type { Account, AccountLike, AccountBridge } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import type { FeePresetOption } from "./useFeePresetOptions";
+import { useCalculateCountervalueCallback } from "@ledgerhq/live-countervalues-react";
+import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/formatCurrencyUnit";
+import type { Currency, Unit } from "@ledgerhq/types-cryptoassets";
+import { buildEstimationKey } from "../utils/feeEstimation";
+
+export type FeeFiatMap = Readonly<Record<string, string | null>>;
+
+type Params = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  mainAccount: Account;
+  transaction: Transaction;
+  feePresetOptions: readonly FeePresetOption[];
+  fallbackPresetIds?: readonly string[];
+  counterValueCurrency: Currency;
+  fiatUnit: Unit;
+  enabled: boolean;
+  shouldEstimateWithBridge: boolean;
+}>;
+
+async function estimateFiatValuesForPresets(params: {
+  bridge: AccountBridge<Transaction>;
+  mainAccount: Account;
+  transaction: Transaction;
+  presetIds: readonly string[];
+  convertCountervalue: (currency: Currency, value: BigNumber) => BigNumber | null | undefined;
+  fiatUnit: Unit;
+  requestId: number;
+  requestIdRef: React.MutableRefObject<number>;
+  inFlightRef: React.MutableRefObject<string | null>;
+  setFiatByPreset: (value: FeeFiatMap) => void;
+}): Promise<void> {
+  try {
+    const entries = await Promise.all(
+      params.presetIds.map(async presetId => {
+        const feesStrategy: Transaction["feesStrategy"] =
+          presetId === "slow" ||
+          presetId === "medium" ||
+          presetId === "fast" ||
+          presetId === "custom"
+            ? presetId
+            : null;
+        const txWithStrategy = params.bridge.updateTransaction(params.transaction, {
+          feesStrategy,
+        });
+        const preparedTx = await params.bridge.prepareTransaction(
+          params.mainAccount,
+          txWithStrategy,
+        );
+        const status = await params.bridge.getTransactionStatus(params.mainAccount, preparedTx);
+        const estimatedFees = status.estimatedFees ?? new BigNumber(0);
+
+        const countervalue = params.convertCountervalue(params.mainAccount.currency, estimatedFees);
+        const fiatValue =
+          countervalue !== null && countervalue !== undefined
+            ? formatCurrencyUnit(params.fiatUnit, countervalue, {
+                showCode: true,
+                disableRounding: true,
+              })
+            : null;
+
+        return [presetId, fiatValue] as const;
+      }),
+    );
+
+    if (params.requestIdRef.current !== params.requestId) return;
+
+    const next: Record<string, string | null> = {};
+    for (const [id, value] of entries) {
+      next[id] = value;
+    }
+    params.setFiatByPreset(next);
+  } finally {
+    if (params.requestIdRef.current === params.requestId) {
+      params.inFlightRef.current = null;
+    }
+  }
+}
+
+export function useFeePresetFiatValues({
+  account,
+  parentAccount,
+  mainAccount,
+  transaction,
+  feePresetOptions,
+  fallbackPresetIds,
+  counterValueCurrency,
+  fiatUnit,
+  enabled,
+  shouldEstimateWithBridge,
+}: Params): FeeFiatMap {
+  const convertCountervalue = useCalculateCountervalueCallback({ to: counterValueCurrency });
+  const [fiatByPreset, setFiatByPreset] = useState<FeeFiatMap>({});
+
+  const recipient = transaction.recipient ?? "";
+  const amount = useMemo(() => transaction.amount ?? new BigNumber(0), [transaction.amount]);
+  const useAllAmount = Boolean(transaction.useAllAmount);
+  const presetIdsToEstimate = useMemo(
+    () => (feePresetOptions.length > 0 ? feePresetOptions.map(o => o.id) : fallbackPresetIds ?? []),
+    [fallbackPresetIds, feePresetOptions],
+  );
+
+  const key = useMemo(
+    () =>
+      buildEstimationKey({
+        mainAccountId: mainAccount.id,
+        recipient,
+        amount,
+        useAllAmount,
+        family: transaction.family,
+        feePresetOptions,
+        fallbackPresetIds,
+      }),
+    [
+      amount,
+      fallbackPresetIds,
+      feePresetOptions,
+      mainAccount.id,
+      recipient,
+      transaction.family,
+      useAllAmount,
+    ],
+  );
+
+  const lastKeyRef = useRef<string | null>(null);
+  const inFlightRef = useRef<string | null>(null);
+  const requestIdRef = useRef(0);
+
+  const directFiatValues = useMemo<FeeFiatMap>(() => {
+    if (!enabled || shouldEstimateWithBridge || feePresetOptions.length === 0) {
+      return {};
+    }
+
+    const next: Record<string, string | null> = {};
+    for (const option of feePresetOptions) {
+      const countervalue = convertCountervalue(mainAccount.currency, option.amount);
+      next[option.id] =
+        countervalue !== null && countervalue !== undefined
+          ? formatCurrencyUnit(fiatUnit, countervalue, {
+              showCode: true,
+              disableRounding: true,
+            })
+          : null;
+    }
+    return next;
+  }, [
+    convertCountervalue,
+    enabled,
+    feePresetOptions,
+    fiatUnit,
+    mainAccount.currency,
+    shouldEstimateWithBridge,
+  ]);
+
+  const allowZeroAmountEstimation = transaction.family === "evm";
+  const hasAmountForEstimation = allowZeroAmountEstimation ? true : useAllAmount || amount.gt(0);
+
+  const canEstimate =
+    shouldEstimateWithBridge &&
+    enabled &&
+    recipient &&
+    hasAmountForEstimation &&
+    presetIdsToEstimate.length > 0;
+
+  // Schedule fee estimation as a microtask to avoid render-phase side effects
+  // This pattern is used instead of useEffect to prevent unnecessary re-renders
+  // while maintaining deterministic execution order
+  if (canEstimate && lastKeyRef.current !== key && inFlightRef.current !== key) {
+    lastKeyRef.current = key;
+    inFlightRef.current = key;
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+
+    const bridge = getAccountBridge(account, parentAccount ?? undefined);
+
+    queueMicrotask(() => {
+      estimateFiatValuesForPresets({
+        bridge,
+        mainAccount,
+        transaction,
+        presetIds: presetIdsToEstimate,
+        convertCountervalue,
+        fiatUnit,
+        requestId,
+        requestIdRef,
+        inFlightRef,
+        setFiatByPreset,
+      });
+    });
+  }
+
+  return shouldEstimateWithBridge ? fiatByPreset : directFiatValues;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useFeePresetLegends.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useFeePresetLegends.ts
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+import { getSendDescriptor } from "@ledgerhq/live-common/bridge/descriptor";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { FeePresetOption } from "./useFeePresetOptions";
+import { formatFeeRate } from "../utils/gas";
+
+export type FeePresetLegendMap = Readonly<Record<string, string>>;
+
+type Params = Readonly<{
+  currency: CryptoOrTokenCurrency | undefined;
+  feePresetOptions: readonly FeePresetOption[];
+}>;
+
+export function useFeePresetLegends({ currency, feePresetOptions }: Params): FeePresetLegendMap {
+  return useMemo(() => {
+    const descriptor = getSendDescriptor(currency);
+    const legendConfig = descriptor?.fees.presets?.legend;
+
+    if (!legendConfig || legendConfig.type === "none") return {};
+    if (legendConfig.type !== "feeRate" || legendConfig.valueFrom !== "presetAmount") return {};
+
+    const unit = legendConfig.unit?.trim();
+    if (!unit) return {};
+
+    const next: Record<string, string> = {};
+    for (const option of feePresetOptions) {
+      const rate = formatFeeRate(option.amount);
+      if (!rate) continue;
+      next[option.id] = `${rate} ${unit}`;
+    }
+    return next;
+  }, [currency, feePresetOptions]);
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useFeePresetOptions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useFeePresetOptions.ts
@@ -1,0 +1,35 @@
+import { useMemo, useRef } from "react";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor";
+import type { FeePresetOption as DescriptorFeePresetOption } from "@ledgerhq/live-common/bridge/descriptor";
+import isEqual from "lodash/isEqual";
+import { isEvmTransaction } from "../utils/isEvmTransaction";
+import { hasDistinctGasOptions } from "../utils/gas";
+
+export type FeePresetOption = DescriptorFeePresetOption;
+
+export function useFeePresetOptions(
+  currency: CryptoOrTokenCurrency | undefined,
+  transaction: Transaction,
+): readonly FeePresetOption[] {
+  const lastValidGasOptionsRef = useRef<unknown>(null);
+  const isEvm = isEvmTransaction(transaction);
+  const currentGasOptions = isEvm ? transaction.gasOptions : null;
+  const hasDistinct = hasDistinctGasOptions(currentGasOptions);
+
+  if (isEvm && hasDistinct && !isEqual(lastValidGasOptionsRef.current, currentGasOptions)) {
+    lastValidGasOptionsRef.current = currentGasOptions;
+  }
+
+  const effectiveTransaction = useMemo(() => {
+    if (!isEvm) return transaction;
+    const gasOptions = hasDistinct ? currentGasOptions : lastValidGasOptionsRef.current;
+    return gasOptions ? { ...transaction, gasOptions } : transaction;
+  }, [currentGasOptions, hasDistinct, isEvm, transaction]);
+
+  return useMemo(
+    () => sendFeatures.getFeePresetOptions(currency, effectiveTransaction),
+    [currency, effectiveTransaction],
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useInitialTransactionPreparation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useInitialTransactionPreparation.ts
@@ -1,0 +1,29 @@
+import { useRef } from "react";
+
+export function useInitialTransactionPreparation(params: {
+  shouldPrepare: boolean;
+  mainAccountId: string;
+  recipientAddress: string;
+  bridgePending: boolean;
+  updateTransactionWithPatch: (patch: Record<string, unknown>) => void;
+}): void {
+  // Trigger initial transaction preparation to fetch fee estimates (networkInfo for Bitcoin).
+  // Scheduled as a microtask to avoid render-phase side effects while maintaining deterministic order.
+  const lastPreparedKeyRef = useRef<string | null>(null);
+  const prepareKey = params.shouldPrepare
+    ? `${params.mainAccountId}-${params.recipientAddress}`
+    : null;
+
+  if (
+    prepareKey &&
+    lastPreparedKeyRef.current !== prepareKey &&
+    !params.bridgePending &&
+    params.recipientAddress
+  ) {
+    lastPreparedKeyRef.current = prepareKey;
+
+    queueMicrotask(() => {
+      params.updateTransactionWithPatch({});
+    });
+  }
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useQuickActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useQuickActions.ts
@@ -1,0 +1,118 @@
+import { useMemo, useState } from "react";
+import { BigNumber } from "bignumber.js";
+import { useTranslation } from "react-i18next";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { areAmountsEqual } from "../utils/amount";
+import type { AmountScreenQuickAction } from "../types";
+import { getAccountCurrency, getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
+
+type UseQuickActionsParams = Readonly<{
+  account: AccountLike;
+  parentAccount: Account | null;
+  transaction: Transaction;
+  maxAvailable: BigNumber;
+  onSetAmountFromRatio: (amount: BigNumber) => void;
+  onSelectMax: () => void;
+}>;
+
+const QUICK_ACTIONS_CONFIG = [
+  { id: "quarter", ratio: 0.25 },
+  { id: "half", ratio: 0.5 },
+  { id: "threeQuarters", ratio: 0.75 },
+];
+
+// Cap tolerance calculation at 8 decimals to prevent floating-point precision errors
+// and handle edge cases with very high magnitude currencies
+const TOLERANCE_MAGNITUDE_CAP = 8;
+
+export function useQuickActions({
+  account,
+  parentAccount,
+  transaction,
+  maxAvailable,
+  onSetAmountFromRatio,
+  onSelectMax,
+}: UseQuickActionsParams): AmountScreenQuickAction[] {
+  const { t } = useTranslation();
+  const [lastSelection, setLastSelection] = useState<null | { id: string; amount: BigNumber }>(
+    null,
+  );
+  const mainAccount = useMemo(
+    () => getMainAccount(account, parentAccount ?? undefined),
+    [account, parentAccount],
+  );
+  const accountCurrency = useMemo(() => getAccountCurrency(mainAccount), [mainAccount]);
+  const accountUnit = useMaybeAccountUnit(mainAccount) ?? accountCurrency.units[0];
+
+  const tolerance = useMemo(() => {
+    const magnitude = Math.min(Math.max(accountUnit.magnitude, 0), TOLERANCE_MAGNITUDE_CAP);
+    return new BigNumber(1).dividedBy(new BigNumber(10).pow(magnitude));
+  }, [accountUnit.magnitude]);
+
+  const quickActions = useMemo(() => {
+    // Don't disable quick actions just because maxAvailable changed due to fee updates
+    // Only disable if account balance is actually 0 (use main account)
+    const disabled = mainAccount.balance.lte(0);
+    const currentAmount = transaction.amount ?? new BigNumber(0);
+
+    const actions = QUICK_ACTIONS_CONFIG.map(config => {
+      const targetAmount = maxAvailable
+        .multipliedBy(config.ratio)
+        .integerValue(BigNumber.ROUND_DOWN);
+
+      // A button is active only if:
+      // 1. We're not in "useAllAmount" mode (Max is selected)
+      // 2. The current amount matches the target amount
+      // 3. AND either we explicitly selected this button OR the amount is not zero
+      //    (to avoid all buttons being active when amount is 0)
+      const matchesTarget = areAmountsEqual(currentAmount, targetAmount, tolerance);
+      const explicitlySelected =
+        lastSelection?.id === config.id &&
+        areAmountsEqual(currentAmount, lastSelection.amount, tolerance);
+      const isActive =
+        !transaction.useAllAmount &&
+        (explicitlySelected || (matchesTarget && !currentAmount.isZero()));
+
+      return {
+        id: config.id,
+        label: t(`newSendFlow.quickActions.${config.id}`),
+        onClick: () => {
+          if (isActive) return;
+          setLastSelection({ id: config.id, amount: targetAmount });
+          onSetAmountFromRatio(targetAmount);
+        },
+        active: isActive,
+        disabled,
+      };
+    });
+
+    const isMaxActive = transaction.useAllAmount ?? false;
+    actions.push({
+      id: "max",
+      label: t("newSendFlow.quickActions.max"),
+      onClick: () => {
+        if (isMaxActive) return;
+        setLastSelection(null);
+        onSelectMax();
+      },
+      active: isMaxActive,
+      disabled,
+    });
+
+    return actions;
+  }, [
+    lastSelection,
+    maxAvailable,
+    mainAccount.balance,
+    onSelectMax,
+    onSetAmountFromRatio,
+    t,
+    transaction.amount,
+    transaction.useAllAmount,
+    tolerance,
+  ]);
+
+  return quickActions;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
@@ -1,0 +1,76 @@
+import type { ChangeEvent } from "react";
+import type { FeePresetOption } from "./hooks/useFeePresetOptions";
+import type { FeeFiatMap } from "./hooks/useFeePresetFiatValues";
+import type { FeePresetLegendMap } from "./hooks/useFeePresetLegends";
+
+export type AmountScreenMessage = Readonly<{
+  type: "error" | "warning" | "info";
+  text: string;
+}>;
+
+export type AmountScreenQuickAction = Readonly<{
+  id: string;
+  label: string;
+  onClick: () => void;
+  active: boolean;
+  disabled: boolean;
+}>;
+
+export type AmountScreenFeeSummary = Readonly<{
+  fiatLabel: string;
+  fiatValue: string;
+  cryptoLabel: string;
+  cryptoValue: string;
+  description: string;
+}>;
+
+export type AmountScreenBanner = Readonly<{
+  title: string;
+  description: string;
+}>;
+
+type AmountInputProps = Readonly<{
+  amountValue: string;
+  amountInputMaxDecimalLength: number;
+  currencyText: string;
+  currencyPosition: "left" | "right";
+  isInputDisabled: boolean;
+  onAmountChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onToggleInputMode: () => void;
+  toggleLabel: string;
+  secondaryValue: string;
+  amountMessage?: AmountScreenMessage | null;
+}>;
+
+type FeesProps = Readonly<{
+  feesRowLabel: string;
+  feesRowValue: string;
+  feesRowStrategyLabel: string;
+  feePresetOptions: readonly FeePresetOption[];
+  fiatByPreset: FeeFiatMap;
+  legendByPreset: FeePresetLegendMap;
+  showNetworkFees: boolean;
+  selectedFeeStrategy: string | null;
+  onSelectFeeStrategy: (strategy: string) => void;
+}>;
+
+type QuickActionsProps = Readonly<{
+  quickActions: AmountScreenQuickAction[];
+  showQuickActions: boolean;
+}>;
+
+type ReviewProps = Readonly<{
+  reviewLabel: string;
+  reviewShowIcon: boolean;
+  reviewDisabled: boolean;
+  reviewLoading: boolean;
+  onReview: () => void;
+  onGetFunds?: () => void;
+}>;
+
+export type AmountScreenViewProps = AmountInputProps & FeesProps & QuickActionsProps & ReviewProps;
+
+export type AmountScreenViewModel = Omit<AmountScreenViewProps, "onReview" | "onGetFunds"> &
+  Readonly<{
+    showFeePresets: boolean;
+  }>;

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/amount.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/amount.test.ts
@@ -1,0 +1,44 @@
+import { BigNumber } from "bignumber.js";
+import { areAmountsEqual } from "../amount";
+
+describe("areAmountsEqual", () => {
+  it("returns true when amounts are equal within tolerance", () => {
+    const a = new BigNumber(100);
+    const b = new BigNumber(100);
+    const tolerance = new BigNumber(0.01);
+
+    expect(areAmountsEqual(a, b, tolerance)).toBe(true);
+  });
+
+  it("returns true when amounts differ by less than tolerance", () => {
+    const a = new BigNumber(100);
+    const b = new BigNumber(100.005);
+    const tolerance = new BigNumber(0.01);
+
+    expect(areAmountsEqual(a, b, tolerance)).toBe(true);
+  });
+
+  it("returns false when amounts differ by more than tolerance", () => {
+    const a = new BigNumber(100);
+    const b = new BigNumber(100.02);
+    const tolerance = new BigNumber(0.01);
+
+    expect(areAmountsEqual(a, b, tolerance)).toBe(false);
+  });
+
+  it("handles zero tolerance correctly", () => {
+    const a = new BigNumber(100);
+    const b = new BigNumber(100);
+    const tolerance = new BigNumber(0);
+
+    expect(areAmountsEqual(a, b, tolerance)).toBe(true);
+  });
+
+  it("handles negative differences correctly", () => {
+    const a = new BigNumber(100);
+    const b = new BigNumber(99.995);
+    const tolerance = new BigNumber(0.01);
+
+    expect(areAmountsEqual(a, b, tolerance)).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/amountInput.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/amountInput.test.ts
@@ -1,0 +1,169 @@
+import { BigNumber } from "bignumber.js";
+import {
+  formatAmountForInput,
+  formatFiatForInput,
+  processRawInput,
+  processFiatInput,
+  calculateFiatEquivalent,
+  shouldSyncInput,
+} from "../amountInput";
+
+const mockUnit = {
+  code: "BTC",
+  name: "bitcoin",
+  magnitude: 8,
+  symbol: "₿",
+};
+
+const mockFiatUnit = {
+  code: "USD",
+  name: "US Dollar",
+  magnitude: 2,
+  symbol: "$",
+};
+
+describe("amountInput utils", () => {
+  describe("formatAmountForInput", () => {
+    it("returns empty string for zero amount", () => {
+      expect(formatAmountForInput(mockUnit, new BigNumber(0), "en-US")).toBe("");
+    });
+
+    it("formats non-zero amount without grouping", () => {
+      // formatCurrencyUnit expects atomic values (sats for BTC)
+      const result = formatAmountForInput(mockUnit, new BigNumber("123456789"), "en-US");
+      expect(result).toBe("1.23456789");
+    });
+  });
+
+  describe("formatFiatForInput", () => {
+    it("returns empty string for zero amount", () => {
+      expect(formatFiatForInput(mockFiatUnit, new BigNumber(0), "en-US")).toBe("");
+    });
+
+    it("clamps and trims fiat amount", () => {
+      // formatCurrencyUnit expects atomic values (cents for USD)
+      const result = formatFiatForInput(mockFiatUnit, new BigNumber("123456"), "en-US");
+      expect(result).toBe("1234.56");
+    });
+
+    it("removes trailing zeros", () => {
+      // 100.00 USD
+      const result = formatFiatForInput(mockFiatUnit, new BigNumber("10000"), "en-US");
+      expect(result).toBe("100");
+    });
+  });
+
+  describe("processRawInput", () => {
+    it("processes valid input", () => {
+      const result = processRawInput("123.456", mockUnit, "en-US");
+      expect(result.value.toString()).toBe("12345600000");
+      expect(result.display).toBe("123.456");
+    });
+
+    it("handles empty input", () => {
+      const result = processRawInput("", mockUnit, "en-US");
+      expect(result.value.toString()).toBe("0");
+      expect(result.display).toBe("");
+    });
+
+    it("handles invalid input", () => {
+      const result = processRawInput("abc", mockUnit, "en-US");
+      expect(result.value.toString()).toBe("0");
+    });
+  });
+
+  describe("processFiatInput", () => {
+    it("processes and clamps fiat input", () => {
+      const result = processFiatInput("123.456", mockFiatUnit, "en-US");
+      expect(result.clampedDisplay).toBe("123.45");
+      expect(result.value.toString()).toBe("12345");
+      expect(typeof result.isOverLimit).toBe("boolean");
+    });
+
+    it("detects when input is within limit", () => {
+      const result = processFiatInput("123.45", mockFiatUnit, "en-US");
+      expect(result.clampedDisplay).toBe("123.45");
+      expect(result.isOverLimit).toBe(false);
+    });
+  });
+
+  describe("calculateFiatEquivalent", () => {
+    const mockCalculate = (amount: BigNumber) => amount.multipliedBy(50000);
+
+    it("uses direct calculation when available", () => {
+      const result = calculateFiatEquivalent({
+        amount: new BigNumber(1),
+        lastTransactionAmount: new BigNumber(0.5),
+        lastFiatAmount: new BigNumber(25000),
+        calculateFiatFromCrypto: mockCalculate,
+      });
+      expect(result?.toString()).toBe("50000");
+    });
+
+    it("uses ratio calculation when direct is null", () => {
+      const result = calculateFiatEquivalent({
+        amount: new BigNumber(1),
+        lastTransactionAmount: new BigNumber(0.5),
+        lastFiatAmount: new BigNumber(25000),
+        calculateFiatFromCrypto: () => null,
+      });
+      expect(result?.toString()).toBe("50000");
+    });
+
+    it("returns null when both methods fail", () => {
+      const result = calculateFiatEquivalent({
+        amount: new BigNumber(1),
+        lastTransactionAmount: new BigNumber(0),
+        lastFiatAmount: new BigNumber(0),
+        calculateFiatFromCrypto: () => null,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("shouldSyncInput", () => {
+    it("syncs on quick action", () => {
+      expect(
+        shouldSyncInput({
+          isQuickAction: true,
+          useAllAmountChanged: false,
+          isActiveInput: true,
+          hasInputValue: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("syncs when useAllAmount changed", () => {
+      expect(
+        shouldSyncInput({
+          isQuickAction: false,
+          useAllAmountChanged: true,
+          isActiveInput: true,
+          hasInputValue: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("does not sync when actively typing", () => {
+      expect(
+        shouldSyncInput({
+          isQuickAction: false,
+          useAllAmountChanged: false,
+          isActiveInput: true,
+          hasInputValue: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("syncs when not actively typing", () => {
+      expect(
+        shouldSyncInput({
+          isQuickAction: false,
+          useAllAmountChanged: false,
+          isActiveInput: false,
+          hasInputValue: false,
+        }),
+      ).toBe(true);
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/decimals.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/decimals.test.ts
@@ -1,0 +1,90 @@
+import { clampDecimals, isOverDecimalLimit, trimTrailingZeros } from "../decimals";
+
+describe("clampDecimals", () => {
+  it("returns string unchanged when decimals are 2 or less", () => {
+    expect(clampDecimals("123.45")).toBe("123.45");
+    expect(clampDecimals("123.4")).toBe("123.4");
+    expect(clampDecimals("123")).toBe("123");
+  });
+
+  it("clamps decimals to 2 when more than 2", () => {
+    expect(clampDecimals("123.456")).toBe("123.45");
+    expect(clampDecimals("123.456789")).toBe("123.45");
+  });
+
+  it("handles comma as decimal separator", () => {
+    expect(clampDecimals("123,456")).toBe("123,45");
+    expect(clampDecimals("123,4")).toBe("123,4");
+  });
+
+  it("handles multiple separators by using the last one", () => {
+    expect(clampDecimals("1.234.567")).toBe("1.234.56");
+    expect(clampDecimals("1,234,567")).toBe("1,234,56");
+  });
+
+  it("preserves the separator character", () => {
+    expect(clampDecimals("123.456")).toBe("123.45");
+    expect(clampDecimals("123,456")).toBe("123,45");
+  });
+});
+
+describe("isOverDecimalLimit", () => {
+  it("returns false when no decimal separator", () => {
+    expect(isOverDecimalLimit("123")).toBe(false);
+    expect(isOverDecimalLimit("")).toBe(false);
+  });
+
+  it("returns false when decimals are 2 or less", () => {
+    expect(isOverDecimalLimit("123.45")).toBe(false);
+    expect(isOverDecimalLimit("123.4")).toBe(false);
+    expect(isOverDecimalLimit("123.1")).toBe(false);
+  });
+
+  it("returns true when decimals exceed 2", () => {
+    expect(isOverDecimalLimit("123.456")).toBe(true);
+    expect(isOverDecimalLimit("123.456789")).toBe(true);
+  });
+
+  it("handles comma as decimal separator", () => {
+    expect(isOverDecimalLimit("123,456")).toBe(true);
+    expect(isOverDecimalLimit("123,45")).toBe(false);
+  });
+
+  it("uses the last separator when multiple exist", () => {
+    expect(isOverDecimalLimit("1.234.567")).toBe(true);
+    expect(isOverDecimalLimit("1,234,567")).toBe(true);
+  });
+});
+
+describe("trimTrailingZeros", () => {
+  it("returns string unchanged when no decimal separator", () => {
+    expect(trimTrailingZeros("123")).toBe("123");
+    expect(trimTrailingZeros("0")).toBe("0");
+  });
+
+  it("removes trailing zeros", () => {
+    expect(trimTrailingZeros("123.450")).toBe("123.45");
+    expect(trimTrailingZeros("123.400")).toBe("123.4");
+    expect(trimTrailingZeros("123.000")).toBe("123");
+  });
+
+  it("preserves non-zero decimals", () => {
+    expect(trimTrailingZeros("123.456")).toBe("123.456");
+    expect(trimTrailingZeros("123.4506")).toBe("123.4506");
+  });
+
+  it("handles comma as decimal separator", () => {
+    expect(trimTrailingZeros("123,450")).toBe("123,45");
+    expect(trimTrailingZeros("123,000")).toBe("123");
+  });
+
+  it("removes all decimals when only zeros", () => {
+    expect(trimTrailingZeros("123.00")).toBe("123");
+    expect(trimTrailingZeros("123,000")).toBe("123");
+  });
+
+  it("handles edge case with single zero", () => {
+    expect(trimTrailingZeros("123.0")).toBe("123");
+    expect(trimTrailingZeros("0.0")).toBe("0");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/errors.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/errors.test.ts
@@ -1,0 +1,95 @@
+import { getStatusError, pickBlockingError } from "../errors";
+
+describe("getStatusError", () => {
+  it("returns undefined when errors is undefined", () => {
+    expect(getStatusError(undefined, "amount")).toBeUndefined();
+  });
+
+  it("returns error for existing key", () => {
+    const error = new Error("Amount too high");
+    const errors = { amount: error };
+
+    expect(getStatusError(errors, "amount")).toBe(error);
+  });
+
+  it("returns undefined for non-existent key", () => {
+    const errors = { amount: new Error("Amount too high") };
+
+    expect(getStatusError(errors, "recipient")).toBeUndefined();
+  });
+
+  it("handles empty errors object", () => {
+    expect(getStatusError({}, "amount")).toBeUndefined();
+  });
+});
+
+describe("pickBlockingError", () => {
+  it("returns undefined when errors is undefined", () => {
+    expect(pickBlockingError(undefined)).toBeUndefined();
+  });
+
+  it("returns priority error when present", () => {
+    const dustLimitError = new Error("Dust limit");
+    const recipientError = new Error("Recipient");
+    const errors = {
+      dustLimit: dustLimitError,
+      recipient: recipientError,
+      other: new Error("Other"),
+    };
+
+    expect(pickBlockingError(errors)).toBe(dustLimitError);
+  });
+
+  it("respects priority order: dustLimit > recipient > fees > transaction", () => {
+    const recipientError = new Error("Recipient");
+    const feesError = new Error("Fees");
+    const transactionError = new Error("Transaction");
+    const errors = {
+      recipient: recipientError,
+      fees: feesError,
+      transaction: transactionError,
+    };
+
+    expect(pickBlockingError(errors)).toBe(recipientError);
+  });
+
+  it("returns first priority error found in order", () => {
+    const feesError = new Error("Fees");
+    const transactionError = new Error("Transaction");
+    const errors = {
+      fees: feesError,
+      transaction: transactionError,
+      other: new Error("Other"),
+    };
+
+    expect(pickBlockingError(errors)).toBe(feesError);
+  });
+
+  it("returns first non-priority error when no priority errors exist", () => {
+    const otherError = new Error("Other error");
+    const anotherError = new Error("Another error");
+    const errors = {
+      other: otherError,
+      another: anotherError,
+    };
+
+    expect(pickBlockingError(errors)).toBe(otherError);
+  });
+
+  it("handles empty errors object", () => {
+    expect(pickBlockingError({})).toBeUndefined();
+  });
+
+  it("skips falsy values", () => {
+    const validError = new Error("Valid");
+    // Test runtime behavior: Object.values().find(Boolean) skips null/undefined
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const errors: any = {
+      dustLimit: null,
+      recipient: undefined,
+      other: validError,
+    };
+
+    expect(pickBlockingError(errors)).toBe(validError);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/gas.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/gas.test.ts
@@ -1,0 +1,144 @@
+import { BigNumber } from "bignumber.js";
+import { formatFeeRate, getGasOptionValue, hasDistinctGasOptions, isGasOptionRecord } from "../gas";
+
+describe("isGasOptionRecord", () => {
+  it("returns true for valid objects", () => {
+    expect(isGasOptionRecord({})).toBe(true);
+    expect(isGasOptionRecord({ maxFeePerGas: 100 })).toBe(true);
+    expect(isGasOptionRecord({ gasPrice: 50 })).toBe(true);
+  });
+
+  it("returns false for null", () => {
+    expect(isGasOptionRecord(null)).toBe(false);
+  });
+
+  it("returns false for primitives", () => {
+    expect(isGasOptionRecord(undefined)).toBe(false);
+    expect(isGasOptionRecord(123)).toBe(false);
+    expect(isGasOptionRecord("string")).toBe(false);
+    expect(isGasOptionRecord(true)).toBe(false);
+  });
+
+  it("returns false for arrays", () => {
+    expect(isGasOptionRecord([])).toBe(false);
+    expect(isGasOptionRecord([1, 2, 3])).toBe(false);
+  });
+});
+
+describe("getGasOptionValue", () => {
+  it("returns maxFeePerGas when present", () => {
+    const maxFeePerGas = new BigNumber(100);
+    const option = { maxFeePerGas };
+
+    expect(getGasOptionValue(option)).toEqual(maxFeePerGas);
+  });
+
+  it("returns gasPrice when maxFeePerGas is not present", () => {
+    const gasPrice = new BigNumber(50);
+    const option = { gasPrice };
+
+    expect(getGasOptionValue(option)).toEqual(gasPrice);
+  });
+
+  it("prefers maxFeePerGas over gasPrice", () => {
+    const maxFeePerGas = new BigNumber(100);
+    const gasPrice = new BigNumber(50);
+    const option = { maxFeePerGas, gasPrice };
+
+    expect(getGasOptionValue(option)).toEqual(maxFeePerGas);
+  });
+
+  it("returns null for invalid option", () => {
+    expect(getGasOptionValue(null)).toBeNull();
+    expect(getGasOptionValue(undefined)).toBeNull();
+    expect(getGasOptionValue("invalid")).toBeNull();
+  });
+
+  it("returns null when neither maxFeePerGas nor gasPrice is BigNumber", () => {
+    const option = { maxFeePerGas: "100", gasPrice: "50" };
+    expect(getGasOptionValue(option)).toBeNull();
+  });
+});
+
+describe("hasDistinctGasOptions", () => {
+  it("returns false for invalid input", () => {
+    expect(hasDistinctGasOptions(null)).toBe(false);
+    expect(hasDistinctGasOptions(undefined)).toBe(false);
+    expect(hasDistinctGasOptions("invalid")).toBe(false);
+  });
+
+  it("returns false when less than 2 valid options", () => {
+    const gasOptions = {
+      slow: { maxFeePerGas: new BigNumber(10) },
+    };
+    expect(hasDistinctGasOptions(gasOptions)).toBe(false);
+  });
+
+  it("returns false when all options have same value", () => {
+    const value = new BigNumber(10);
+    const gasOptions = {
+      slow: { maxFeePerGas: value },
+      medium: { maxFeePerGas: value },
+      fast: { maxFeePerGas: value },
+    };
+    expect(hasDistinctGasOptions(gasOptions)).toBe(false);
+  });
+
+  it("returns true when options have different values", () => {
+    const gasOptions = {
+      slow: { maxFeePerGas: new BigNumber(10) },
+      medium: { maxFeePerGas: new BigNumber(20) },
+      fast: { maxFeePerGas: new BigNumber(30) },
+    };
+    expect(hasDistinctGasOptions(gasOptions)).toBe(true);
+  });
+
+  it("handles mix of maxFeePerGas and gasPrice", () => {
+    const gasOptions = {
+      slow: { gasPrice: new BigNumber(10) },
+      medium: { maxFeePerGas: new BigNumber(20) },
+      fast: { gasPrice: new BigNumber(30) },
+    };
+    expect(hasDistinctGasOptions(gasOptions)).toBe(true);
+  });
+
+  it("ignores invalid options", () => {
+    const gasOptions = {
+      slow: { maxFeePerGas: new BigNumber(10) },
+      medium: { maxFeePerGas: new BigNumber(20) },
+      fast: { invalid: "value" },
+    };
+    expect(hasDistinctGasOptions(gasOptions)).toBe(true);
+  });
+});
+
+describe("formatFeeRate", () => {
+  it("formats valid BigNumber to integer string", () => {
+    expect(formatFeeRate(new BigNumber(2.9))).toBe("2");
+    expect(formatFeeRate(new BigNumber(5))).toBe("5");
+    expect(formatFeeRate(new BigNumber(100.99))).toBe("100");
+  });
+
+  it("returns empty string for NaN", () => {
+    expect(formatFeeRate(new BigNumber(NaN))).toBe("");
+  });
+
+  it("returns empty string for Infinity", () => {
+    expect(formatFeeRate(new BigNumber(Infinity))).toBe("");
+    expect(formatFeeRate(new BigNumber(-Infinity))).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    // @ts-expect-error - Testing runtime behavior with undefined, function handles it with optional chaining
+    expect(formatFeeRate(undefined)).toBe("");
+  });
+
+  it("handles zero", () => {
+    expect(formatFeeRate(new BigNumber(0))).toBe("0");
+  });
+
+  it("rounds down to integer", () => {
+    expect(formatFeeRate(new BigNumber(2.9))).toBe("2");
+    expect(formatFeeRate(new BigNumber(2.1))).toBe("2");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/messages.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/__tests__/messages.test.ts
@@ -1,0 +1,96 @@
+import { getAmountScreenMessage } from "../messages";
+
+describe("getAmountScreenMessage", () => {
+  it("returns error message when amountErrorTitle and hasRawAmount are true", () => {
+    const result = getAmountScreenMessage({
+      amountErrorTitle: "Amount too high",
+      hasRawAmount: true,
+      isFeeTooHigh: false,
+    });
+
+    expect(result).toEqual({
+      type: "error",
+      text: "Amount too high",
+    });
+  });
+
+  it("returns null when amountErrorTitle exists but hasRawAmount is false", () => {
+    const result = getAmountScreenMessage({
+      amountErrorTitle: "Amount too high",
+      hasRawAmount: false,
+      isFeeTooHigh: false,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns warning message when amountWarningTitle exists, hasRawAmount is true, and isFeeTooHigh is false", () => {
+    const result = getAmountScreenMessage({
+      amountWarningTitle: "Amount is high",
+      hasRawAmount: true,
+      isFeeTooHigh: false,
+    });
+
+    expect(result).toEqual({
+      type: "warning",
+      text: "Amount is high",
+    });
+  });
+
+  it("returns info message when amountWarningTitle exists, hasRawAmount is true, and isFeeTooHigh is true", () => {
+    const result = getAmountScreenMessage({
+      amountWarningTitle: "Amount is high",
+      hasRawAmount: true,
+      isFeeTooHigh: true,
+    });
+
+    expect(result).toEqual({
+      type: "info",
+      text: "Amount is high",
+    });
+  });
+
+  it("returns null when amountWarningTitle exists but hasRawAmount is false", () => {
+    const result = getAmountScreenMessage({
+      amountWarningTitle: "Amount is high",
+      hasRawAmount: false,
+      isFeeTooHigh: false,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("prioritizes error over warning", () => {
+    const result = getAmountScreenMessage({
+      amountErrorTitle: "Amount too high",
+      amountWarningTitle: "Amount is high",
+      hasRawAmount: true,
+      isFeeTooHigh: false,
+    });
+
+    expect(result).toEqual({
+      type: "error",
+      text: "Amount too high",
+    });
+  });
+
+  it("returns null when no titles are provided", () => {
+    const result = getAmountScreenMessage({
+      hasRawAmount: true,
+      isFeeTooHigh: false,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when hasRawAmount is false even with both titles", () => {
+    const result = getAmountScreenMessage({
+      amountErrorTitle: "Amount too high",
+      amountWarningTitle: "Amount is high",
+      hasRawAmount: false,
+      isFeeTooHigh: false,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/amount.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/amount.ts
@@ -1,0 +1,5 @@
+import { BigNumber } from "bignumber.js";
+
+export function areAmountsEqual(a: BigNumber, b: BigNumber, tolerance: BigNumber): boolean {
+  return a.minus(b).abs().lte(tolerance);
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/amountInput.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/amountInput.ts
@@ -1,0 +1,103 @@
+import { BigNumber } from "bignumber.js";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
+import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/formatCurrencyUnit";
+import { sanitizeValueString } from "@ledgerhq/coin-framework/currencies/sanitizeValueString";
+import { clampDecimals, isOverDecimalLimit, trimTrailingZeros } from "./decimals";
+
+export type FormattedAmount = Readonly<{
+  display: string;
+  value: BigNumber;
+}>;
+
+export function formatAmountForInput(unit: Unit, amount: BigNumber, locale: string): string {
+  if (amount.isZero()) return "";
+
+  return formatCurrencyUnit(unit, amount, {
+    showCode: false,
+    disableRounding: true,
+    useGrouping: false,
+    locale,
+  });
+}
+
+export function formatFiatForInput(unit: Unit, amount: BigNumber, locale: string): string {
+  if (amount.isZero()) return "";
+
+  const formatted = formatCurrencyUnit(unit, amount, {
+    showCode: false,
+    disableRounding: true,
+    useGrouping: false,
+    locale,
+  });
+  const clamped = clampDecimals(formatted);
+  return trimTrailingZeros(clamped);
+}
+
+export function processRawInput(rawValue: string, unit: Unit, locale: string): FormattedAmount {
+  const sanitized = sanitizeValueString(unit, rawValue, locale);
+  const value = sanitized.value ? new BigNumber(sanitized.value) : new BigNumber(0);
+
+  return {
+    display: sanitized.display,
+    value: value.isFinite() && !value.isNaN() ? value : new BigNumber(0),
+  };
+}
+
+export function processFiatInput(
+  rawValue: string,
+  fiatUnit: Unit,
+  locale: string,
+): Readonly<{
+  display: string;
+  clampedDisplay: string;
+  value: BigNumber;
+  isOverLimit: boolean;
+}> {
+  const sanitized = sanitizeValueString(fiatUnit, rawValue, locale);
+  const clampedDisplay = clampDecimals(sanitized.display);
+  const nextSanitized = sanitizeValueString(fiatUnit, clampedDisplay, locale);
+  const value = nextSanitized.value ? new BigNumber(nextSanitized.value) : new BigNumber(0);
+  // Keep the same behavior as the hook did previously:
+  // - we clamp what is displayed,
+  // - and we avoid pushing transaction updates while the user is typing > 2 decimals.
+  const isOverLimit = isOverDecimalLimit(sanitized.display);
+
+  return {
+    display: sanitized.display,
+    clampedDisplay,
+    value,
+    isOverLimit,
+  };
+}
+
+export function calculateFiatEquivalent(params: {
+  amount: BigNumber;
+  lastTransactionAmount: BigNumber;
+  lastFiatAmount: BigNumber;
+  calculateFiatFromCrypto: (amount: BigNumber) => BigNumber | null | undefined;
+}): BigNumber | null {
+  const directFiat = params.calculateFiatFromCrypto(params.amount);
+
+  const ratioFiat =
+    params.lastTransactionAmount &&
+    !params.lastTransactionAmount.isZero() &&
+    params.lastFiatAmount &&
+    !params.lastFiatAmount.isZero()
+      ? params.lastFiatAmount.multipliedBy(params.amount).dividedBy(params.lastTransactionAmount)
+      : null;
+
+  return directFiat ?? ratioFiat;
+}
+
+export function shouldSyncInput(params: {
+  isQuickAction: boolean;
+  useAllAmountChanged: boolean;
+  isActiveInput: boolean;
+  hasInputValue: boolean;
+}): boolean {
+  return (
+    params.isQuickAction ||
+    params.useAllAmountChanged ||
+    !(params.isActiveInput && params.hasInputValue)
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/amountInputSync.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/amountInputSync.ts
@@ -1,0 +1,74 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { BigNumber } from "bignumber.js";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
+import { formatAmountForInput, formatFiatForInput, shouldSyncInput } from "./amountInput";
+
+export function syncAmountInputs(params: {
+  cryptoAmount: BigNumber;
+  fiatAmount: BigNumber;
+  transactionUseAllAmount: boolean;
+  inputMode: "fiat" | "crypto";
+  cryptoInputValue: string;
+  fiatInputValue: string;
+  locale: string;
+  accountUnit: Unit;
+  fiatUnit: Unit;
+  lastTransactionAmountRef: MutableRefObject<BigNumber>;
+  lastFiatAmountRef: MutableRefObject<BigNumber>;
+  lastUseAllAmountRef: MutableRefObject<boolean>;
+  lastUserInputTimeRef: MutableRefObject<number>;
+  setCryptoInputValue: Dispatch<SetStateAction<string>>;
+  setFiatInputValue: Dispatch<SetStateAction<string>>;
+}): void {
+  const useAllAmountChanged = params.transactionUseAllAmount !== params.lastUseAllAmountRef.current;
+  const cryptoAmountChanged =
+    !params.cryptoAmount.eq(params.lastTransactionAmountRef.current) || useAllAmountChanged;
+  const fiatAmountChanged = !params.fiatAmount.eq(params.lastFiatAmountRef.current);
+  const timeSinceUserInput = Date.now() - params.lastUserInputTimeRef.current;
+
+  // When useAllAmount is active and amount changes, always sync immediately
+  // This handles fee changes that affect the max amount (e.g., switching from medium to fast fees)
+  const isUseAllAmountActive = params.transactionUseAllAmount && cryptoAmountChanged;
+  const canSyncWithBridge = useAllAmountChanged || isUseAllAmountActive || timeSinceUserInput > 200;
+  const isQuickAction = params.lastUserInputTimeRef.current === 0;
+
+  if (cryptoAmountChanged && canSyncWithBridge) {
+    params.lastTransactionAmountRef.current = params.cryptoAmount;
+    if (useAllAmountChanged) {
+      params.lastUseAllAmountRef.current = params.transactionUseAllAmount;
+      params.lastUserInputTimeRef.current = 0;
+    }
+
+    const shouldSync = shouldSyncInput({
+      isQuickAction,
+      useAllAmountChanged,
+      isActiveInput: params.inputMode === "crypto",
+      hasInputValue: params.cryptoInputValue.length > 0,
+    });
+
+    if (shouldSync) {
+      const formatted = formatAmountForInput(
+        params.accountUnit,
+        params.cryptoAmount,
+        params.locale,
+      );
+      params.setCryptoInputValue(formatted);
+    }
+  }
+
+  if ((cryptoAmountChanged || fiatAmountChanged) && canSyncWithBridge) {
+    params.lastFiatAmountRef.current = params.fiatAmount;
+
+    const shouldSync = shouldSyncInput({
+      isQuickAction,
+      useAllAmountChanged,
+      isActiveInput: params.inputMode === "fiat",
+      hasInputValue: params.fiatInputValue.length > 0,
+    });
+
+    if (shouldSync) {
+      const formatted = formatFiatForInput(params.fiatUnit, params.fiatAmount, params.locale);
+      params.setFiatInputValue(formatted);
+    }
+  }
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/decimals.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/decimals.ts
@@ -1,0 +1,41 @@
+export function clampDecimals(display: string): string {
+  const dotIndex = display.lastIndexOf(".");
+  const commaIndex = display.lastIndexOf(",");
+  const sepIndex = Math.max(dotIndex, commaIndex);
+  if (sepIndex === -1) return display;
+
+  const integerPart = display.slice(0, sepIndex);
+  const sep = display[sepIndex];
+  const decimals = display.slice(sepIndex + 1);
+  if (decimals.length <= 2) return display;
+  return `${integerPart}${sep}${decimals.slice(0, 2)}`;
+}
+
+export function isOverDecimalLimit(display: string): boolean {
+  const dotIndex = display.lastIndexOf(".");
+  const commaIndex = display.lastIndexOf(",");
+  const sepIndex = Math.max(dotIndex, commaIndex);
+  if (sepIndex === -1) return false;
+  return display.length - sepIndex - 1 > 2;
+}
+
+export function trimTrailingZeros(display: string): string {
+  const dotIndex = display.lastIndexOf(".");
+  const commaIndex = display.lastIndexOf(",");
+  const sepIndex = Math.max(dotIndex, commaIndex);
+  if (sepIndex === -1) return display;
+
+  const integerPart = display.slice(0, sepIndex);
+  const sep = display[sepIndex];
+  let decimals = display.slice(sepIndex + 1);
+
+  // Remove trailing zeros
+  let endIndex = decimals.length;
+  while (endIndex > 0 && decimals[endIndex - 1] === "0") {
+    endIndex--;
+  }
+  decimals = decimals.slice(0, endIndex);
+
+  if (!decimals) return integerPart;
+  return `${integerPart}${sep}${decimals}`;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/errors.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/errors.ts
@@ -1,0 +1,24 @@
+import type { TransactionStatus } from "@ledgerhq/live-common/generated/types";
+
+export function getStatusError(
+  errors: TransactionStatus["errors"] | undefined,
+  key: string,
+): Error | undefined {
+  if (!errors) return undefined;
+  return errors[key];
+}
+
+export function pickBlockingError(
+  errors: TransactionStatus["errors"] | undefined,
+): Error | undefined {
+  if (!errors) return undefined;
+
+  // Prefer errors that are commonly tied to amount validity on UTXO chains.
+  const priorityKeys = ["dustLimit", "recipient", "fees", "transaction"] as const;
+  for (const key of priorityKeys) {
+    const err = errors[key];
+    if (err) return err;
+  }
+
+  return Object.values(errors).find(Boolean);
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/feeEstimation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/feeEstimation.ts
@@ -1,0 +1,24 @@
+import { BigNumber } from "bignumber.js";
+import type { FeePresetOption } from "../hooks/useFeePresetOptions";
+
+export function buildEstimationKey(params: {
+  mainAccountId: string;
+  recipient: string;
+  amount: BigNumber;
+  useAllAmount: boolean;
+  family: string;
+  feePresetOptions: readonly FeePresetOption[];
+  fallbackPresetIds?: readonly string[];
+}): string {
+  const optionsKey = params.feePresetOptions.map(o => `${o.id}:${o.amount.toString()}`).join("|");
+  const fallbackKey = params.fallbackPresetIds?.join("|") ?? "";
+  return [
+    params.mainAccountId,
+    params.recipient,
+    params.useAllAmount ? "1" : "0",
+    params.amount.toString(),
+    params.family,
+    optionsKey,
+    fallbackKey,
+  ].join("::");
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/gas.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/gas.ts
@@ -1,0 +1,32 @@
+import { BigNumber } from "bignumber.js";
+import type { FeePresetOption } from "../hooks/useFeePresetOptions";
+
+type GasOptionRecord = Record<string, unknown>;
+
+export function isGasOptionRecord(value: unknown): value is GasOptionRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function getGasOptionValue(option: unknown): BigNumber | null {
+  if (!isGasOptionRecord(option)) return null;
+  const maxFeePerGas = option.maxFeePerGas;
+  if (BigNumber.isBigNumber(maxFeePerGas)) return maxFeePerGas;
+  const gasPrice = option.gasPrice;
+  if (BigNumber.isBigNumber(gasPrice)) return gasPrice;
+  return null;
+}
+
+export function hasDistinctGasOptions(gasOptions: unknown): boolean {
+  if (!isGasOptionRecord(gasOptions)) return false;
+  const entries = ["slow", "medium", "fast"]
+    .map(key => getGasOptionValue(gasOptions[key]))
+    .filter((value): value is BigNumber => value !== null);
+  if (entries.length < 2) return false;
+  const first = entries[0];
+  return entries.some(value => !value.isEqualTo(first));
+}
+
+export function formatFeeRate(amount: FeePresetOption["amount"]): string {
+  if (!amount?.isFinite() || amount?.isNaN()) return "";
+  return amount.integerValue(BigNumber.ROUND_DOWN).toFixed(0);
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/isEvmTransaction.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/isEvmTransaction.ts
@@ -1,0 +1,20 @@
+import type { Transaction as LiveTransaction } from "@ledgerhq/live-common/generated/types";
+import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import { BigNumber } from "bignumber.js";
+
+function hasProp<K extends string>(obj: object, key: K): obj is Record<K, unknown> {
+  return key in obj;
+}
+
+export function isEvmTransaction(tx: LiveTransaction): tx is EvmTransaction {
+  if (tx.family !== "evm") return false;
+  if (typeof tx !== "object" || tx === null) return false;
+
+  if (!hasProp(tx, "type") || typeof tx.type !== "number") return false;
+  if (!hasProp(tx, "nonce") || typeof tx.nonce !== "number") return false;
+  if (!hasProp(tx, "chainId") || typeof tx.chainId !== "number") return false;
+  if (!hasProp(tx, "gasLimit") || !BigNumber.isBigNumber(tx.gasLimit)) return false;
+  if (!hasProp(tx, "mode") || typeof tx.mode !== "string") return false;
+
+  return true;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/messages.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/utils/messages.ts
@@ -1,0 +1,16 @@
+import { AmountScreenMessage } from "../types";
+
+export function getAmountScreenMessage(params: {
+  amountErrorTitle?: string;
+  amountWarningTitle?: string;
+  isFeeTooHigh: boolean;
+  hasRawAmount: boolean;
+}): AmountScreenMessage | null {
+  if (params.amountErrorTitle && params.hasRawAmount) {
+    return { type: "error", text: params.amountErrorTitle };
+  }
+  if (params.amountWarningTitle && params.hasRawAmount) {
+    return { type: params.isFeeTooHigh ? "info" : "warning", text: params.amountWarningTitle };
+  }
+  return null;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Create the Amount step of the send flow revamp
  - Creates / reinforces step presets descriptors to have a more generic approach (implying BTC Kaspa and EVM)


### 📝 Description

Complete redesign of the Amount screen in the Send flow, with descriptor-based fee preset system. This screen allows users to enter transaction amounts, select fee presets


https://github.com/user-attachments/assets/b7deb4f6-c467-4f2b-b04e-1238847fffc5


**Key Features:**

1. **Amount Input Section**
   - Dual input mode: toggle between crypto and fiat currency
   - Real-time validation with error/warning messages
   - Secondary value display (shows fiat when entering crypto, and vice versa)
   - Automatic decimal precision based on currency

2. **Quick Actions**
   - Percentage buttons (25%, 50%, 75%) for quick amount selection
   - "Max" button to use maximum available balance (accounting for fees)
   - Actions respect spendable balance and fee calculations

3. **Network Fees Management**
   - Fee preset selector (Slow/Medium/Fast) with individual fiat values
   - Bridge-based fee estimation for accurate preset costs
   - Support for custom fees and coin control (where applicable)
   - Tooltip explaining network fees

4. **Plugin System**
   - Extensible plugin architecture for coin-specific behaviors
   - EVM gas options sync plugin automatically updates transaction with latest gas prices

5. **Descriptor Integration**
   - Fee presets driven by coin descriptors (`getFeePresetOptions`, `shouldEstimateWithBridge`)
   - Coin-specific fee calculation logic centralized in descriptors
   - Support for fee rate legends (like "2 sat/vbyte" for Bitcoin)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-21024)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
