### PR TITLE
:sparkles: (LWM) lumen playground

### DIFF
--- a/.changeset/giant-apricots-jog.md
+++ b/.changeset/giant-apricots-jog.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add debug entry for lumen playground

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -27,6 +27,7 @@ import DebugInstallSetOfApps from "~/screens/Settings/Debug/Features/InstallSetO
 import DebugPerformance from "~/screens/Settings/Debug/Performance";
 import DebugLogs from "~/screens/Settings/Debug/Debugging/Logs";
 import DebugLottie from "~/screens/Settings/Debug/Features/Lottie";
+import DebugLumen from "~/screens/Settings/Debug/Debugging/Lumen";
 import DebugNetwork from "~/screens/Settings/Debug/Debugging/Network";
 import DebugCommandSender from "~/screens/Settings/Debug/Connectivity/CommandSender";
 import DebugPlayground from "~/screens/Settings/Debug/Playground";
@@ -296,6 +297,13 @@ export default function SettingsNavigator() {
         component={DebugPlayground}
         options={{
           title: "Playground",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugLumen}
+        component={DebugLumen}
+        options={{
+          title: "Lumen Debug",
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -64,6 +64,7 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.DebugHttpTransport]: undefined;
   [ScreenName.DebugLogs]: undefined;
   [ScreenName.DebugLottie]: undefined;
+  [ScreenName.DebugLumen]: undefined;
   [ScreenName.DebugPlayground]: undefined;
   [ScreenName.DebugBluetoothAndLocationServices]: undefined;
   [ScreenName.DebugStorageMigration]: undefined;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -51,6 +51,7 @@ export enum ScreenName {
   DebugPerformance = "DebugPerformance",
   DebugLogs = "DebugLogs",
   DebugLottie = "DebugLottie",
+  DebugLumen = "DebugLumen",
   DebugTermsOfUse = "DebugTermsOfUse",
   DebugVideos = "DebugVideos",
   DebugMockGenerateAccounts = "DebugMockGenerateAccounts",

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Lumen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Lumen.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from "react";
+import NavigationScrollView from "~/components/NavigationScrollView";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { Banner, TextInput } from "@ledgerhq/lumen-ui-rnative";
+import { View } from "react-native";
+
+export default function DebugLumen() {
+  const styles = useStyleSheet(
+    theme => ({
+      root: {
+        padding: theme.spacings.s16,
+        display: "flex",
+        flex: 1,
+        gap: theme.spacings.s16,
+      },
+    }),
+    [],
+  );
+
+  const [name, setName] = useState("");
+
+  return (
+    <NavigationScrollView>
+      <View style={styles.root}>
+        <Banner title="Lumen playground for testing Lumen components." />
+        <TextInput placeholder="Enter your name" value={name} onChangeText={setName} />
+      </View>
+    </NavigationScrollView>
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
@@ -65,6 +65,12 @@ export default function DebugSettings({
         iconLeft={<IconsLegacy.EmojiHappyMedium size={24} color="black" />}
         onPress={() => navigate(ScreenName.DebugPlayground)}
       />
+      <SettingsRow
+        title="Lumen Debug"
+        desc="Playground for testing Lumen components"
+        iconLeft={<IconsLegacy.PenMedium size={24} color="black" />}
+        onPress={() => navigate(ScreenName.DebugLumen)}
+      />
     </SettingsNavigationScrollView>
   );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - debug settings

### 📝 Description

Add a debug screen for Lumen so it can be used by Lumen team



https://github.com/user-attachments/assets/5ea919bb-6be7-44fc-b46f-2306713da299



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24989](https://ledgerhq.atlassian.net/browse/LIVE-24989)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24989]: https://ledgerhq.atlassian.net/browse/LIVE-24989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ