### PR TITLE
fix(swap): replace Changelly with generic swap provider wording

### DIFF
--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6365,7 +6365,7 @@
     },
     "TransactionCannotBeCreated": {
       "title": "Processing Error",
-      "description": "Changelly cannot process this transaction. Error code 8HBB-{{randomCode}}"
+      "description": "The swap provider cannot process this transaction. Error code 8HBB-{{randomCode}}"
     },
     "SwapQuoteLowLiquidity": {
       "title": "Partner unavailable",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8258,7 +8258,7 @@
     },
     "transactionCannotBeCreated": {
       "title": "Partner unavailable",
-      "description": "Changelly cannot process this transaction. Error code 8HBB-{{randomCode}}"
+      "description": "The swap provider cannot process this transaction. Error code 8HBB-{{randomCode}}"
     },
     "swapQuoteLowLiquidity": {
       "title": "Partner unavailable",


### PR DESCRIPTION
## Summary
Replace hardcoded "Changelly" with "The swap provider" in the `transactionCannotBeCreated` error message.

## Changes
- Updated English translations for both mobile and desktop:
  - `apps/ledger-live-mobile/src/locales/en/common.json`
  - `apps/ledger-live-desktop/static/i18n/en/app.json`

## Jira
[LIVE-24441](https://ledgerhq.atlassian.net/browse/LIVE-24441)

BEFORE
<img width="589" height="498" alt="image" src="https://github.com/user-attachments/assets/aa081941-ac3e-41f2-9212-3cfc95b3739d" />

AFTER
<img width="1286" height="822" alt="image" src="https://github.com/user-attachments/assets/acc83c12-f5dd-4814-8393-2cfa4ca533ba" />



[LIVE-24441]: https://ledgerhq.atlassian.net/browse/LIVE-24441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ