### PR TITLE
chore: adapt Secondary Action for Tile on Recipient Step

### DIFF
--- a/.changeset/nine-oranges-juggle.md
+++ b/.changeset/nine-oranges-juggle.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+chore: adapt Secondary Action for Tile on Recipient Step

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
@@ -5,6 +5,7 @@ import type { StepRegistry, StepRenderer } from "../../FlowWizard/types";
 import { FLOW_STATUS } from "../../FlowWizard/types";
 import type { SendFlowStep } from "../types";
 import { SendHeader } from "./SendHeader";
+import { cn } from "LLD/utils/cn";
 
 type SendFlowLayoutProps = Readonly<{
   stepRegistry: StepRegistry<SendFlowStep>;
@@ -32,22 +33,18 @@ export function SendFlowLayout({ stepRegistry, isOpen, onClose }: SendFlowLayout
 
   const dialogHeight = currentStepConfig?.height ?? "fixed";
 
-  const statusGradientClass = useMemo(() => {
-    if (state.flowStatus === FLOW_STATUS.ERROR) {
-      return "bg-gradient-error";
-    }
-    if (state.flowStatus === FLOW_STATUS.SUCCESS) {
-      return "bg-gradient-success";
-    }
-    return null;
-  }, [state.flowStatus]);
+  const shouldShowStatusGradient =
+    state.flowStatus === FLOW_STATUS.ERROR || state.flowStatus === FLOW_STATUS.SUCCESS;
 
   return (
     <Dialog height={dialogHeight} open={isOpen} onOpenChange={handleDialogOpenChange}>
       <DialogContent>
-        {statusGradientClass && (
+        {shouldShowStatusGradient && (
           <div
-            className={`pointer-events-none absolute inset-x-0 top-0 h-full ${statusGradientClass}`}
+            className={cn("pointer-events-none absolute inset-x-0 top-0 h-full", {
+              "bg-gradient-error": state.flowStatus === FLOW_STATUS.ERROR,
+              "bg-gradient-success": state.flowStatus === FLOW_STATUS.SUCCESS,
+            })}
           />
         )}
         <SendHeader />

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressListItem.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressListItem.tsx
@@ -12,6 +12,7 @@ import {
 import { Wallet, LedgerLogo, ChevronRight } from "@ledgerhq/lumen-ui-react/symbols";
 import { formatAddress } from "@ledgerhq/react-ui/pre-ldls/components/Address/formatAddress";
 import { formatRelativeDate } from "../utils/dateFormatter";
+import { cn } from "LLD/utils/cn";
 import type { AddressListItemProps } from "../types";
 
 export function AddressListItem({
@@ -41,12 +42,10 @@ export function AddressListItem({
   const trailingContent =
     balance && balanceFormatted ? (
       <div className="flex flex-col items-end">
-        <span className="truncate text-base body-2-semi-bold">{balanceFormatted}</span>
-        <span className="truncate text-muted body-3">{balance}</span>
+        <span className="truncate body-2-semi-bold text-base">{balanceFormatted}</span>
+        <span className="truncate body-3 text-muted">{balance}</span>
       </div>
     ) : undefined;
-
-  const className = disabled ? "mb-6 cursor-not-allowed opacity-50" : "mb-6";
 
   const title = showSendTo ? t("newSendFlow.sendTo", { address: displayName }) : displayName;
 
@@ -54,7 +53,9 @@ export function AddressListItem({
     <ListItem
       onClick={disabled ? undefined : onSelect}
       onContextMenu={onContextMenu}
-      className={className}
+      className={cn("mb-6", {
+        "cursor-not-allowed opacity-50": disabled,
+      })}
     >
       <ListItemLeading>
         <ListItemSpot appearance="icon" icon={icon} />

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecentAddressTile.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecentAddressTile.tsx
@@ -56,43 +56,9 @@ export function RecentAddressTile({ recentAddress, onSelect, onRemove }: RecentA
   };
 
   return (
-    <div className="w-[100px] pt-6">
-      {/* <Tile
-        leadingContent={<Spot appearance="icon" icon={icon} />}
-        title={displayName}
-        description={dateText}
-        onClick={onSelect}
-        secondaryAction={
-          <Menu>
-            <MenuTrigger asChild>
-              <InteractiveIcon
-                iconType="stroked"
-                aria-label="More actions"
-                onClick={handleStopPropagation}
-              >
-                <MoreVertical />
-              </InteractiveIcon>
-            </MenuTrigger>
-            <MenuContent>
-              <MenuItem onSelect={handleRemove}>
-                <Trash size={16} />
-                {t("newSendFlow.remove")}
-              </MenuItem>
-            </MenuContent>
-          </Menu>
-        }
-      />
-      */}
-
+    <div className="w-96 pt-6">
       <Tile onClick={onSelect}>
         <Menu>
-          {/*
-           * FIXME: MenuTrigger asChild requires TileSecondaryAction to use forwardRef.
-           * This is currently missing in @ledgerhq/lumen-ui-react but will be added soon
-           * as part of the Tailwind V4 upgrade. For now, this pattern is temporarily broken.
-           * No impact as this feature is not released yet.
-           * See: https://ledger.slack.com/archives/C089J9DLGJ3/p1768469178391389
-           */}
           <MenuTrigger asChild>
             <TileSecondaryAction
               icon={MoreVertical}
@@ -100,7 +66,7 @@ export function RecentAddressTile({ recentAddress, onSelect, onRemove }: RecentA
               onClick={handleStopPropagation}
             />
           </MenuTrigger>
-          <MenuContent>
+          <MenuContent onClick={handleStopPropagation} onPointerDown={handleStopPropagation}>
             <MenuItem onSelect={handleRemove}>
               <Trash size={16} />
               {t("newSendFlow.remove")}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 0.0.40
       version: 0.0.40
     '@ledgerhq/lumen-ui-react':
-      specifier: 0.0.64
-      version: 0.0.64
+      specifier: 0.0.65
+      version: 0.0.65
     '@ledgerhq/speculos-device-controller':
       specifier: 0.2.1
       version: 0.2.1
@@ -682,7 +682,7 @@ importers:
         version: 0.0.40
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.0.64(e17c1f4f71171860e7268885e247ad1a)
+        version: 0.0.65(e17c1f4f71171860e7268885e247ad1a)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -15398,8 +15398,8 @@ packages:
   '@ledgerhq/lumen-design-core@0.0.40':
     resolution: {integrity: sha512-/sa2Lnohy03hpNGUfNBfricilRYh7CMYvNHac8BR1Yp1OwIXR4UA9kN3oCJ1GxR8EnasyCcctJsH9G6BPLllYg==}
 
-  '@ledgerhq/lumen-ui-react@0.0.64':
-    resolution: {integrity: sha512-T090TRpIkYZtdkQ6begxYJ86Nn+5DoWS0xQofAefbHpjOmYOSfzwVt2hzfjBAcpAG1neAab5kzHIOadpxsJbFw==}
+  '@ledgerhq/lumen-ui-react@0.0.65':
+    resolution: {integrity: sha512-KdKjExRE9MxgRUgT7t23r0aKeJfD+gUBp6RR5hSVzmyOu2zbyhyS7t3ZsUkQGkociV7PGe/vJcu1BPWrAZ2ymg==}
     peerDependencies:
       '@radix-ui/react-checkbox': ^1.3.2
       '@radix-ui/react-dialog': ^1.1.15
@@ -45226,7 +45226,7 @@ snapshots:
       tailwindcss: 4.1.18
       tslib: 2.6.2
 
-  '@ledgerhq/lumen-ui-react@0.0.64(e17c1f4f71171860e7268885e247ad1a)':
+  '@ledgerhq/lumen-ui-react@0.0.65(e17c1f4f71171860e7268885e247ad1a)':
     dependencies:
       '@ledgerhq/lumen-utils-shared': 0.0.15(react@18.3.1)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@18.2.23(@types/react@18.2.73))(@types/react@18.2.73)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,7 +25,7 @@ catalog:
   "@ledgerhq/device-transport-kit-speculos": 1.1.2
   "@ledgerhq/device-transport-kit-web-hid": 1.2.2
   "@ledgerhq/lumen-design-core": 0.0.40
-  "@ledgerhq/lumen-ui-react": 0.0.64
+  "@ledgerhq/lumen-ui-react": 0.0.65
   "@ledgerhq/speculos-device-controller": 0.2.1
   "@react-native/assets-registry": 0.77.3
   "@react-native/babel-plugin-codegen": 0.77.3


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fixed the SecondaryAction of the Tile from Recent Account on the Recipient step of the new send flow.
Workaround to avoid a click-through on the Tile

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
