### PR TITLE
[QAA][E2E][CI] Fix iOS speculos cleanup

### DIFF
--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -14,6 +14,12 @@ import { waitForSpeculosReady } from "@ledgerhq/live-common/e2e/speculosCI";
 import { SettingsSetOverriddenFeatureFlagsPlayload } from "~/actions/types";
 import { sanitizeError } from "@ledgerhq/live-common/e2e/index";
 
+function checkTestFailed(): void {
+  if (globalThis.IS_FAILED) {
+    throw new Error("Test failed - aborting initialization to prevent orphaned Speculos instances");
+  }
+}
+
 type CliCommand = (
   userdataPath?: string,
   speculosAddress?: string,
@@ -65,6 +71,7 @@ async function executeCliCommand(
 async function launchSpeculosDevices(toStart: SpeculosAppType[]): Promise<Record<string, Entry>> {
   const entries: Entry[] = await Promise.all(
     toStart.map(async app => {
+      checkTestFailed();
       const proxyPort = await findFreePort();
       const device = await launchSpeculos(app.name);
 
@@ -100,6 +107,7 @@ async function executeCliCommandsOnApp(
     let lastError: unknown;
 
     while (attempt < maxRetries) {
+      checkTestFailed();
       attempt++;
 
       try {
@@ -126,6 +134,8 @@ async function executeCliCommandsOnApp(
         lastError = err;
 
         if (attempt < maxRetries) {
+          checkTestFailed();
+
           // Create fresh instance for next retry attempt
           await deleteSpeculos(entry.deviceId);
           const device = await launchSpeculos(app.name);
@@ -165,6 +175,7 @@ async function setupMainSpeculosApp(
   let lastError: unknown;
 
   while (attempt < maxRetries) {
+    checkTestFailed();
     attempt++;
 
     try {
@@ -183,6 +194,8 @@ async function setupMainSpeculosApp(
       lastError = err;
 
       if (attempt < maxRetries) {
+        checkTestFailed();
+
         log.info(`[${speculosApp.name}] Creating new main Speculos instance for retry`);
         await removeSpeculosAndDeregisterKnownSpeculos(main.deviceId);
         const device = await launchSpeculos(main.name);
@@ -218,6 +231,7 @@ async function executeCliCommands(
   let lastError: unknown;
 
   while (attempt < maxRetries) {
+    checkTestFailed();
     attempt++;
     log.info(`\n🔄 [Global CLI] Attempt ${attempt}/${maxRetries}`);
     try {
@@ -231,6 +245,8 @@ async function executeCliCommands(
       lastError = err;
 
       if (speculosApp && entryMap) {
+        checkTestFailed();
+
         const main = entryMap[speculosApp.name];
 
         await removeSpeculosAndDeregisterKnownSpeculos(main.deviceId);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Preventing async Speculos creation when test failed during init.

CI [execution](https://github.com/LedgerHQ/ledger-live/actions/runs/21052051441) with additional logs in artifacts.

Ex: **Shard 1:**
- Worker 1: 
{
    "totalOperations": 45,
    "created":  22,
    "released"23,
 },
- Worker 2: 
{
    "totalOperations": 45,
    "created":  22,
    "released"23,
 },
- Worker 3: 
{
    "totalOperations": 45,
    "created":  22,
    "released"23,
 },



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
