### PR TITLE
fix(theme): infinite rerender in some cases with the theme

### DIFF
--- a/.changeset/tame-camels-move.md
+++ b/.changeset/tame-camels-move.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update the way that we render the theme in the app to avoid multiple rerender crash


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - We have to try to change the theme and see if it works correctly 

### 📝 Description
We had a bug that introduced a rerender, causing a maximum depth exceeded. There is a fix inside the next Lumen release, but we could also update the way that we are reading this value and updating the theme in the app to not have this again.


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

