### PR TITLE
Feat/live-24550 fear and greed

### DIFF
--- a/.changeset/nasty-buckets-bathe.md
+++ b/.changeset/nasty-buckets-bathe.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): fear and greed tile in market banner

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/FearAndGreed.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/FearAndGreed.test.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { FearAndGreedView } from "../components/FearAndGreed";
+import { GradientMoodIndicator } from "../components/FearAndGreed/GradientMoodIndicator";
+
+describe("FearAndGreed", () => {
+  it("renders without crashing", () => {
+    const props = {
+      isLoading: false,
+      data: { value: 50, classification: "Neutral" },
+    };
+    render(<FearAndGreedView {...props} />);
+    expect(screen.getByTestId("fear-and-greed-card")).toBeVisible();
+  });
+
+  it("renders loading state", () => {
+    const props = {
+      isLoading: true,
+      data: undefined,
+    };
+    render(<FearAndGreedView {...props} />);
+    expect(screen.getByTestId("fear-and-greed-skeleton")).toBeVisible();
+  });
+
+  it("returns null when no data and not loading", () => {
+    const props = {
+      isLoading: false,
+      data: undefined,
+    };
+    const { container } = render(<FearAndGreedView {...props} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("GradientMoodIndicator", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("renders the SVG gradient arc", () => {
+    const { container } = render(<GradientMoodIndicator value={50} />);
+    const path = container.querySelector("path");
+    expect(path).toBeVisible();
+    expect(path?.getAttribute("stroke")).toBe("url(#paint0_linear_15877_11047)");
+  });
+
+  it("renders the white indicator circle", () => {
+    const { container } = render(<GradientMoodIndicator value={50} />);
+    const circle = container.querySelector("circle");
+    expect(circle).toBeVisible();
+    expect(circle?.getAttribute("fill")).toBe("white");
+  });
+
+  it("displays the initial value as 0", () => {
+    const { container } = render(<GradientMoodIndicator value={75} />);
+    const text = container.querySelector("text");
+    expect(text?.textContent).toBe("0");
+  });
+
+  it("animates to the target value", async () => {
+    const { container } = render(<GradientMoodIndicator value={75} />);
+    const text = container.querySelector("text");
+
+    // Fast-forward through animation
+    act(() => {
+      jest.advanceTimersByTime(1200);
+    });
+
+    await waitFor(() => {
+      expect(text?.textContent).toBe("75");
+    });
+  });
+
+  it("positions the circle at the left for value 0", () => {
+    const { container } = render(<GradientMoodIndicator value={0} />);
+
+    act(() => {
+      jest.advanceTimersByTime(1200);
+    });
+    const circle = container.querySelector("circle");
+    const cx = parseFloat(circle?.getAttribute("cx") || "0");
+
+    // At value 0, angle is 180°, so x should be near left side
+    expect(cx).toBeLessThan(21.5814);
+  });
+
+  it("positions the circle at the right for value 100", async () => {
+    const { container } = render(<GradientMoodIndicator value={100} />);
+
+    act(() => {
+      jest.advanceTimersByTime(1200);
+    });
+
+    await waitFor(() => {
+      const circle = container.querySelector("circle");
+      const cx = parseFloat(circle?.getAttribute("cx") || "0");
+
+      // At value 100, angle is 0°, so x should be near right side
+      expect(cx).toBeGreaterThan(21.5814);
+    });
+  });
+
+  it("positions the circle at the center for value 50", async () => {
+    const { container } = render(<GradientMoodIndicator value={50} />);
+
+    act(() => {
+      jest.advanceTimersByTime(1200);
+    });
+
+    await waitFor(() => {
+      const circle = container.querySelector("circle");
+      const cx = parseFloat(circle?.getAttribute("cx") || "0");
+
+      // At value 50, angle is 90°, so x should be near center
+      expect(cx).toBeCloseTo(21.5814, 1);
+    });
+  });
+
+  it("updates animation when value changes", async () => {
+    const { container, rerender } = render(<GradientMoodIndicator value={25} />);
+
+    act(() => {
+      jest.advanceTimersByTime(1200);
+    });
+
+    await waitFor(() => {
+      const text = container.querySelector("text");
+      expect(text?.textContent).toBe("25");
+    });
+
+    rerender(<GradientMoodIndicator value={75} />);
+
+    act(() => {
+      jest.advanceTimersByTime(1200);
+    });
+    await waitFor(() => {
+      const text = container.querySelector("text");
+      expect(text?.textContent).toBe("75");
+    });
+  });
+
+  it("displays rounded value during animation", async () => {
+    const { container } = render(<GradientMoodIndicator value={50} />);
+    const text = container.querySelector("text");
+
+    // Check intermediate values are integers
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    await waitFor(() => {
+      const value = parseInt(text?.textContent || "0", 10);
+      expect(Number.isInteger(value)).toBe(true);
+      expect(value).toBeGreaterThan(0);
+      expect(value).toBeLessThan(50);
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/AssetIcon.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/AssetIcon.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+
+export const AssetIcon = ({
+  item,
+  getCapitalizedTicker,
+}: {
+  item: MarketItemPerformer;
+  getCapitalizedTicker: (item: MarketItemPerformer) => string;
+}) => {
+  if (item.ledgerIds && item.ledgerIds.length > 0 && item.ticker) {
+    return <CryptoIcon ledgerId={item.ledgerIds[0]} ticker={item.ticker} size="48px" />;
+  }
+
+  return (
+    <img
+      width={48}
+      height={48}
+      className="overflow-hidden rounded-full"
+      src={item.image}
+      alt={`${getCapitalizedTicker(item)} logo`}
+    />
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/FearAndGreedTile.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/FearAndGreedTile.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import type { FearAndGreedIndex } from "@ledgerhq/live-common/cmc-client/state-manager/types";
+import {
+  getFearAndGreedColorKey,
+  getFearAndGreedTranslationKey,
+} from "@ledgerhq/live-common/cmc-client/utils/fearAndGreed";
+import { Tile, TileContent, TileTitle } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+import { GradientMoodIndicator } from "./GradientMoodIndicator";
+
+const COLOR_CLASS_MAP: Record<string, string> = {
+  error: "text-error",
+  warning: "text-warning",
+  success: "text-success",
+  muted: "text-muted",
+};
+
+export const FearAndGreedTile = ({ data }: { data: FearAndGreedIndex }) => {
+  const { t } = useTranslation();
+
+  const colorKey = getFearAndGreedColorKey(data.value);
+  const translationKey = getFearAndGreedTranslationKey(data.value);
+  const textColorClass = COLOR_CLASS_MAP[colorKey] || "text-muted";
+
+  return (
+    <Tile
+      appearance="card"
+      data-testid="fear-and-greed-card"
+      className="w-[98px] justify-center self-stretch"
+    >
+      <GradientMoodIndicator value={data.value} />
+      <TileContent>
+        <TileTitle>{t("marketBanner.fearAndGreed.title")}</TileTitle>
+      </TileContent>
+      <div className={`${textColorClass} body-2-semi-bold`}>{t(translationKey)}</div>
+    </Tile>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/GradientMoodIndicator.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/GradientMoodIndicator.tsx
@@ -1,0 +1,89 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useState, useEffect } from "react";
+
+const ANIMATION_DURATION = 1200;
+
+export const GradientMoodIndicator = ({ value }: { value: number }) => {
+  const [animatedValue, setAnimatedValue] = useState(0);
+  const [displayValue, setDisplayValue] = useState(0);
+
+  useEffect(() => {
+    const startValue = animatedValue;
+    const endValue = value;
+    const startTime = Date.now();
+    let frameId: number;
+
+    const animate = () => {
+      const elapsed = Date.now() - startTime;
+      const progress = Math.min(elapsed / ANIMATION_DURATION, 1);
+
+      // Cubic ease-out easing function
+      const eased = 1 - Math.pow(1 - progress, 3);
+
+      const currentValue = startValue + (endValue - startValue) * eased;
+      setAnimatedValue(currentValue);
+      setDisplayValue(Math.round(currentValue));
+
+      if (progress < 1) {
+        frameId = requestAnimationFrame(animate);
+      }
+    };
+
+    frameId = requestAnimationFrame(animate);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [value]);
+
+  // Calculate angle based on value (0-100)
+  // Arc goes from 180° (left) to 0° (right)
+  const angle = 180 - (animatedValue / 100) * 180;
+  const angleRad = (angle * Math.PI) / 180;
+
+  // Center point and radius of the arc
+  const centerX = 21.5814;
+  const centerY = 21.5814;
+  const radius = 19.5814; // Distance from center to the arc
+
+  // Calculate circle position
+  const circleX = centerX + radius * Math.cos(angleRad);
+  const circleY = centerY - radius * Math.sin(angleRad);
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 44 31" fill="none">
+      <path
+        d="M3.37572 28.8056C2.48799 26.5704 2 24.1329 2 21.5814C2 10.7669 10.7669 2 21.5814 2C32.396 2 41.1629 10.7669 41.1629 21.5814C41.1629 24.1323 40.6751 26.5693 39.7877 28.8041"
+        stroke="url(#paint0_linear_15877_11047)"
+        strokeWidth="4"
+        strokeLinecap="round"
+      />
+      {/* White indicator circle */}
+      <circle cx={circleX} cy={circleY} r="4" fill="white" stroke="#E0E0E0" strokeWidth="1" />
+      {/* Value text in the center */}
+      <text
+        x={centerX}
+        y={centerY + 2}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fill="currentColor"
+        className="body-2-semi-bold"
+      >
+        {displayValue}
+      </text>
+      <defs>
+        <linearGradient
+          id="paint0_linear_15877_11047"
+          x1="2"
+          y1="15.4028"
+          x2="41.1629"
+          y2="15.4028"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#F87274" />
+          <stop offset="1" stopColor="#6EC85C" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/LoadingTile.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/LoadingTile.tsx
@@ -1,0 +1,6 @@
+import { Skeleton } from "@ledgerhq/lumen-ui-react";
+import React from "react";
+
+export const LoadingTile = () => {
+  return <Skeleton component="tile" data-testid="fear-and-greed-skeleton" />;
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/index.tsx
@@ -1,0 +1,33 @@
+import React, { memo } from "react";
+import type { FearAndGreedIndex } from "@ledgerhq/live-common/cmc-client/state-manager/types";
+import { useFearAndGreedViewModel } from "../../hooks/useFearAndGreedViewModel";
+import { LoadingTile } from "./LoadingTile";
+import { FearAndGreedTile } from "./FearAndGreedTile";
+
+type FearAndGreedViewProps = {
+  readonly isLoading: boolean;
+  readonly data: FearAndGreedIndex | undefined;
+};
+
+const FearAndGreedView = memo(function FearAndGreedView({
+  isLoading,
+  data,
+}: FearAndGreedViewProps) {
+  let content: React.ReactNode = null;
+  if (isLoading) {
+    content = <LoadingTile />;
+  } else if (data) {
+    content = <FearAndGreedTile data={data} />;
+  }
+
+  return content;
+});
+
+const FearAndGreed = () => {
+  const { isLoading, data } = useFearAndGreedViewModel();
+
+  return <FearAndGreedView isLoading={isLoading} data={data} />;
+};
+
+export { FearAndGreedView };
+export default FearAndGreed;

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
@@ -4,7 +4,8 @@ import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
 import { PerformanceIndicator } from "./PerformanceIndicator";
 import { useNavigate } from "react-router";
 import { ViewAllTile } from "./ViewAllTile";
-import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import FearAndGreed from "./FearAndGreed";
+import { AssetIcon } from "./AssetIcon";
 
 type TrendingAssetsListProps = {
   readonly items: MarketItemPerformer[];
@@ -25,6 +26,7 @@ export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
   return (
     <div className="flex flex-col overflow-x-scroll" data-testid="trending-assets-list">
       <div className="flex items-center gap-8">
+        <FearAndGreed />
         {items.map(item => (
           <Tile
             className="w-[98px]"
@@ -34,19 +36,7 @@ export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
           >
             <TileSpot
               appearance="icon"
-              icon={() =>
-                item.ledgerIds && item.ledgerIds.length > 0 && item.ticker ? (
-                  <CryptoIcon ledgerId={item.ledgerIds[0]} ticker={item.ticker} size="48px" />
-                ) : (
-                  <img
-                    width={48}
-                    height={48}
-                    className="overflow-hidden rounded-full"
-                    src={item.image}
-                    alt={`${getCapitalizedTicker(item)} logo`}
-                  />
-                )
-              }
+              icon={() => <AssetIcon item={item} getCapitalizedTicker={getCapitalizedTicker} />}
             />
             <TileContent>
               <TileTitle>{getCapitalizedTicker(item)}</TileTitle>

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useFearAndGreedViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useFearAndGreedViewModel.ts
@@ -1,0 +1,12 @@
+import {
+  useGetFearAndGreedLatestQuery,
+  FIFTEEN_MINUTES_IN_MS,
+} from "@ledgerhq/live-common/cmc-client/state-manager/api";
+
+export const useFearAndGreedViewModel = () => {
+  const { data, isError, isLoading } = useGetFearAndGreedLatestQuery(undefined, {
+    pollingInterval: FIFTEEN_MINUTES_IN_MS,
+  });
+
+  return { data, isError, isLoading };
+};

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7857,7 +7857,19 @@
   "marketBanner": {
     "title": "Explore market",
     "genericError": "Connection failed",
-    "cta": "View all"
+    "cta": "View all",
+    "fearAndGreed": {
+      "title": "Mood"
+    }
+  },
+  "fearAndGreed": {
+    "levels": {
+      "extremeFear": "Fear+",
+      "fear": "Fear",
+      "neutral": "Neutral",
+      "greed": "Greed",
+      "extremeGreed": "Greed+"
+    }
   },
   "nftEntryPoint": {
     "title": "NFT (Non Fungible Tokens)",

--- a/apps/ledger-live-desktop/tests/handlers/fearAndGreed.ts
+++ b/apps/ledger-live-desktop/tests/handlers/fearAndGreed.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from "msw";
+import latestData from "./fixtures/fearAndGreed/latest.json";
+
+const BASE_URL = "https://proxycmc.api.live.ledger.com/v3";
+
+const handlers = [
+  http.get(`${BASE_URL}/fear-and-greed/latest`, () => {
+    return HttpResponse.json(latestData);
+  }),
+];
+
+export default handlers;

--- a/apps/ledger-live-desktop/tests/handlers/fixtures/fearAndGreed/latest.json
+++ b/apps/ledger-live-desktop/tests/handlers/fixtures/fearAndGreed/latest.json
@@ -1,0 +1,14 @@
+{
+  "status": {
+    "timestamp": "2026-01-20T10:00:00.000Z",
+    "error_code": 0,
+    "error_message": "",
+    "elapsed": 3,
+    "credit_count": 1
+  },
+  "data": {
+    "value": 65,
+    "value_classification": "Greed",
+    "update_time": "2026-01-20T00:00:00.000Z"
+  }
+}

--- a/apps/ledger-live-desktop/tests/handlers/index.ts
+++ b/apps/ledger-live-desktop/tests/handlers/index.ts
@@ -2,10 +2,12 @@ import MarketHandlers from "./market";
 import CryptoIconsHandlers from "./cryptoIcons";
 import CounterValuesHandlers from "./countervalues";
 import AssetsHandlers from "./assets";
+import FearAndGreedHandlers from "./fearAndGreed";
 
 export default [
   ...MarketHandlers,
   ...CryptoIconsHandlers,
   ...CounterValuesHandlers,
   ...AssetsHandlers,
+  ...FearAndGreedHandlers,
 ];


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a new "Fear and Greed" tile to the Market Banner feature in the desktop app. The implementation includes a dedicated component that displays the current market mood, with loading and error states, and integrates it into the trending assets list. Supporting hooks and translations are also added to fetch and display the index data.

### ❓ Context

[LIVE-24550](https://ledgerhq.atlassian.net/browse/LIVE-24550)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24550]: https://ledgerhq.atlassian.net/browse/LIVE-24550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ