### PR TITLE
:sparkles: (LWM) move portfolio banners under quick actions

### DIFF
--- a/.changeset/early-birds-check.md
+++ b/.changeset/early-birds-check.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Moove the quick actions above all the banners

--- a/apps/ledger-live-mobile/src/components/RecoverBanner/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RecoverBanner/index.tsx
@@ -18,7 +18,12 @@ enum LedgerRecoverSubscriptionStateEnum {
 
 const maxStepNumber = Object.keys(LedgerRecoverSubscriptionStateEnum).length;
 
-function RecoverBanner() {
+type Props = Readonly<{
+  mb?: number;
+  mt?: number;
+}>;
+
+function RecoverBanner({ mb, mt }: Props) {
   const [storageData, setStorageData] = useState<LedgerRecoverSubscriptionStateEnum>(
     LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
   );
@@ -101,7 +106,7 @@ function RecoverBanner() {
   const isWarning = stepNumber > 2;
 
   return (
-    <Flex justifyContent="center" position="relative" mt={3}>
+    <Flex justifyContent="center" position="relative" mt={mt} mb={mb}>
       <Flex
         position="relative"
         columnGap={12}

--- a/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioAssets.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioAssets.tsx
@@ -4,7 +4,7 @@ import { shallowEqual } from "react-redux";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { GestureResponderEvent } from "react-native";
 import { useNavigation } from "@react-navigation/native";
-import { Button, IconsLegacy, Box } from "@ledgerhq/native-ui";
+import { Box, Button, IconsLegacy } from "@ledgerhq/native-ui";
 import { useDistribution } from "~/actions/general";
 import { track, TrackScreen } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const";
@@ -15,7 +15,6 @@ import {
 } from "~/reducers/settings";
 import { setSelectedTabPortfolioAssets } from "~/actions/settings";
 import Assets from "./Assets";
-import PortfolioQuickActionsBar from "./PortfolioQuickActionsBar";
 import MarketBanner from "LLM/features/MarketBanner";
 import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import useListsAnimation, { type TabListType } from "./useListsAnimation";
@@ -140,9 +139,6 @@ const PortfolioAssets = ({ hideEmptyTokenAccount, openAddModal }: Props) => {
         accountsLength={distribution.list && distribution.list.length}
         discreet={discreetMode}
       />
-      <Box my={24}>
-        <PortfolioQuickActionsBar />
-      </Box>
       <MarketBanner />
 
       {shouldDisplayMarketBanner && __DEV__ && (

--- a/apps/ledger-live-mobile/src/screens/Portfolio/__integrations__/portfolioAssets.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/__integrations__/portfolioAssets.integration.test.tsx
@@ -20,7 +20,7 @@ const mockContentSizeChangeEvent = (width: number, height: number) => ({
 });
 
 describe("portfolioAssets", () => {
-  it("should render quick actions", async () => {
+  it("should display the market banner", async () => {
     const { getByText } = render(
       <TestNavigator>
         <PortfolioAssets hideEmptyTokenAccount={false} openAddModal={() => null} />
@@ -29,11 +29,24 @@ describe("portfolioAssets", () => {
         overrideInitialState: (state: State) => ({
           ...INITIAL_STATE.overrideInitialState(state),
           accounts: { ...state.accounts },
+          settings: {
+            ...state.settings,
+            overriddenFeatureFlags: {
+              llmAccountListUI: {
+                enabled: true,
+              },
+              lwmWallet40: {
+                enabled: true,
+                params: {
+                  marketBanner: true,
+                },
+              },
+            },
+          },
         }),
       },
     );
-    const quickActions = [/buy/i, /swap/i, /send/i, /receive/i];
-    quickActions.forEach(action => expect(getByText(action)).toBeVisible());
+    expect(getByText(/explore market/i)).toBeVisible();
   });
 
   it("should track click on tab account", async () => {

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -54,6 +54,7 @@ import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { PORTFOLIO_VIEW_ID, TOP_CHAINS } from "~/utils/constants";
 import { buildFeatureFlagTags } from "~/utils/datadogUtils";
 import { renderItem } from "LLM/utils/renderItem";
+import PortfolioQuickActionsBar from "./PortfolioQuickActionsBar";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<WalletTabNavigatorStackParamList, ScreenName.Portfolio>
@@ -174,12 +175,15 @@ function PortfolioScreen({ navigation }: NavigationProps) {
           key="PortfolioGraphCard"
           screenName={ScreenName.Portfolio}
         />
-        {isLNSUpsellBannerShown && <LNSUpsellBanner location="wallet" mx={6} mt={7} />}
+        <Box my={24} px={3}>
+          <PortfolioQuickActionsBar />
+        </Box>
+        {!isLNSUpsellBannerShown && <LNSUpsellBanner location="wallet" mx={6} mb={24} />}
         {!isLNSUpsellBannerShown && showAssets ? (
           <ContentCardsLocation
             key="contentCardsLocationPortfolio"
             locationId={ContentCardLocation.TopWallet}
-            mt="20px"
+            mb={24}
           />
         ) : null}
       </WalletTabSafeAreaView>,
@@ -187,7 +191,7 @@ function PortfolioScreen({ navigation }: NavigationProps) {
         isAccountListUIEnabled ? (
           <AnimatedContainer onHeightChange={handleHeightChange}>
             <Box background={colors.background.main} px={6} key="PortfolioAssets">
-              <RecoverBanner />
+              <RecoverBanner mb={24} />
               <PortfolioAssets
                 hideEmptyTokenAccount={hideEmptyTokenAccount}
                 openAddModal={openAddModal}
@@ -196,7 +200,7 @@ function PortfolioScreen({ navigation }: NavigationProps) {
           </AnimatedContainer>
         ) : (
           <Box background={colors.background.main} px={6} key="PortfolioAssets">
-            <RecoverBanner />
+            <RecoverBanner mb={24} />
             <PortfolioAssets
               hideEmptyTokenAccount={hideEmptyTokenAccount}
               openAddModal={openAddModal}
@@ -242,7 +246,7 @@ function PortfolioScreen({ navigation }: NavigationProps) {
         : [
             // If the user has no accounts we display an empty state
             <Flex flexDirection="column" mt={30} mx={6} key="PortfolioEmptyState">
-              <RecoverBanner />
+              <RecoverBanner mb={24} />
               <PortfolioEmptyState openAddAccountModal={openAddModal} />
             </Flex>,
           ]),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - main portfolio
  - all the banners position
  - quick actions position

### 📝 Description

Move all the banners (braze, recover, lns upsell) under the quick actions on the Portfolio
This is not under ff as we want it right now (confirmed by product)

the test in portfolioAssets has been updated as we don't display quick actions in this bloc anymore but the market. THe market banner is fully tested in another part of the code base so I simply check the render

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24605](https://ledgerhq.atlassian.net/browse/LIVE-24605) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24605]: https://ledgerhq.atlassian.net/browse/LIVE-24605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ