### PR TITLE
feat: wizard LWM

### DIFF
--- a/apps/ledger-live-mobile/src/newArch/features/FlowWizard/FlowWizardOrchestrator.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/FlowWizard/FlowWizardOrchestrator.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useMemo, useRef, type ComponentType, type ReactNode } from "react";
+import { Animated, type StyleProp, type ViewStyle, View } from "react-native";
+import { useFlowWizardNavigation } from "./hooks/useFlowWizardNavigation";
+import type {
+  FlowStep,
+  FlowConfig,
+  StepRegistry,
+  StepRenderer,
+  FlowNavigationDirection,
+  AnimationConfig,
+  FlowWizardContextValue,
+  FlowStepConfig,
+} from "./types";
+
+const DEFAULT_ANIMATION_CONFIG: AnimationConfig = {
+  forward: "animate-fade-in",
+  backward: "animate-fade-out",
+};
+
+type FlowWizardOrchestratorProps<
+  TStep extends FlowStep,
+  TContextValue,
+  TStepConfig extends FlowStepConfig<TStep> = FlowStepConfig<TStep>,
+> = Readonly<{
+  flowConfig: FlowConfig<TStep, TStepConfig>;
+  stepRegistry: StepRegistry<TStep>;
+  contextValue: TContextValue;
+  ContextProvider: ComponentType<{
+    value: FlowWizardContextValue<TStep, TContextValue, TStepConfig>;
+    children: ReactNode;
+  }>;
+  animationConfig?: AnimationConfig;
+  getContainerStyle?: (stepConfig: TStepConfig) => StyleProp<ViewStyle> | undefined;
+  children?: ReactNode;
+}>;
+
+function getAnimationClass(
+  direction: FlowNavigationDirection,
+  config: AnimationConfig,
+): string | undefined {
+  return direction === "FORWARD" ? config.forward : config.backward;
+}
+
+export function FlowWizardOrchestrator<
+  TStep extends FlowStep,
+  TContextValue,
+  TStepConfig extends FlowStepConfig<TStep> = FlowStepConfig<TStep>,
+>({
+  flowConfig,
+  stepRegistry,
+  contextValue,
+  ContextProvider,
+  animationConfig = DEFAULT_ANIMATION_CONFIG,
+  getContainerStyle,
+  children,
+}: FlowWizardOrchestratorProps<TStep, TContextValue, TStepConfig>) {
+  const { state, actions, currentStepConfig } = useFlowWizardNavigation<TStep, TStepConfig>({
+    flowConfig,
+  });
+
+  const enhancedContextValue = useMemo<FlowWizardContextValue<TStep, TContextValue, TStepConfig>>(
+    () => ({
+      ...contextValue,
+      navigation: actions,
+      currentStep: state.currentStep,
+      direction: state.direction,
+      currentStepConfig,
+    }),
+    [contextValue, actions, state.currentStep, state.direction, currentStepConfig],
+  );
+
+  const StepComponent = useMemo<StepRenderer | null>(() => {
+    return stepRegistry[state.currentStep] ?? null;
+  }, [state.currentStep, stepRegistry]);
+  const hasNavigated = state.stepHistory.length > 0 || state.direction === "BACKWARD";
+
+  // React Native: we don't use CSS classes. If the caller provided a non-empty animation config
+  // for the current direction, we apply a simple fade-in animation on step changes.
+  const shouldAnimate =
+    hasNavigated && Boolean(getAnimationClass(state.direction, animationConfig) ?? "");
+  const opacity = useRef(new Animated.Value(1)).current;
+  useEffect(() => {
+    if (!shouldAnimate) return;
+    opacity.setValue(0);
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 200,
+      useNativeDriver: true,
+    }).start();
+  }, [opacity, shouldAnimate, state.currentStep]);
+
+  const containerStyle = getContainerStyle ? getContainerStyle(currentStepConfig) : undefined;
+
+  return (
+    <ContextProvider value={enhancedContextValue}>
+      <View style={containerStyle}>
+        {children}
+        {StepComponent ? (
+          <Animated.View
+            // key forces a full remount on step change (same behavior as desktop)
+            key={state.currentStep}
+            style={{ flex: 1, opacity: shouldAnimate ? opacity : 1 }}
+          >
+            <StepComponent />
+          </Animated.View>
+        ) : null}
+      </View>
+    </ContextProvider>
+  );
+}
+
+export function createStepRegistry<TStep extends FlowStep>(
+  registry: StepRegistry<TStep>,
+): StepRegistry<TStep> {
+  return registry;
+}
+
+export default FlowWizardOrchestrator;

--- a/apps/ledger-live-mobile/src/newArch/features/FlowWizard/__tests__/FlowWizardOrchestrator.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/FlowWizard/__tests__/FlowWizardOrchestrator.test.tsx
@@ -1,0 +1,145 @@
+import React, { createContext, useContext } from "react";
+import { Text, TouchableOpacity, View } from "react-native";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { FlowWizardOrchestrator, createStepRegistry } from "../FlowWizardOrchestrator";
+import type { FlowConfig, FlowWizardContextValue } from "../types";
+
+const TEST_STEPS = {
+  FIRST: "FIRST",
+  SECOND: "SECOND",
+  THIRD: "THIRD",
+} as const;
+
+type TestStep = (typeof TEST_STEPS)[keyof typeof TEST_STEPS];
+
+type BaseContext = {
+  label: string;
+};
+
+type TestFlowContextValue = FlowWizardContextValue<TestStep, BaseContext>;
+
+const TestFlowContext = createContext<TestFlowContextValue | null>(null);
+
+const TestFlowProvider = ({
+  value,
+  children,
+}: {
+  value: TestFlowContextValue;
+  children: React.ReactNode;
+}) => <TestFlowContext.Provider value={value}>{children}</TestFlowContext.Provider>;
+
+function useTestFlowContext() {
+  const context = useContext(TestFlowContext);
+  if (!context) {
+    throw new Error("useTestFlowContext must be used within TestFlowProvider");
+  }
+  return context;
+}
+
+const StepOne = () => {
+  const { navigation, label, currentStep } = useTestFlowContext();
+
+  return (
+    <View testID="step-one">
+      <Text>Current: {currentStep}</Text>
+      <Text>Label: {label}</Text>
+      <TouchableOpacity onPress={navigation.goToNextStep}>
+        <Text>Next to Step Two</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={() => navigation.goToStep(TEST_STEPS.THIRD)}>
+        <Text>Skip to Step Three</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const StepTwo = () => {
+  const { navigation, currentStep } = useTestFlowContext();
+
+  return (
+    <View testID="step-two">
+      <Text>Current: {currentStep}</Text>
+      <TouchableOpacity onPress={navigation.goToPreviousStep}>
+        <Text>Back</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={navigation.goToNextStep}>
+        <Text>Next to Step Three</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const StepThree = () => {
+  const { navigation, currentStep } = useTestFlowContext();
+
+  return (
+    <View testID="step-three">
+      <Text>Current: {currentStep}</Text>
+      <TouchableOpacity onPress={navigation.goToPreviousStep}>
+        <Text>Back</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const stepRegistry = createStepRegistry<TestStep>({
+  [TEST_STEPS.FIRST]: StepOne,
+  [TEST_STEPS.SECOND]: StepTwo,
+  [TEST_STEPS.THIRD]: StepThree,
+});
+
+const flowConfig: FlowConfig<TestStep> = {
+  stepOrder: [TEST_STEPS.FIRST, TEST_STEPS.SECOND, TEST_STEPS.THIRD],
+  stepConfigs: {
+    [TEST_STEPS.FIRST]: { id: TEST_STEPS.FIRST, canGoBack: false },
+    [TEST_STEPS.SECOND]: { id: TEST_STEPS.SECOND, canGoBack: true },
+    [TEST_STEPS.THIRD]: { id: TEST_STEPS.THIRD, canGoBack: true },
+  },
+};
+
+function renderFlow(config: FlowConfig<TestStep> = flowConfig) {
+  return render(
+    <FlowWizardOrchestrator
+      flowConfig={config}
+      stepRegistry={stepRegistry}
+      contextValue={{ label: "test-flow" }}
+      ContextProvider={TestFlowProvider}
+    />,
+  );
+}
+
+describe("FlowWizardOrchestrator (mobile)", () => {
+  it("renders the initial step and merges base context", () => {
+    renderFlow();
+
+    expect(screen.getByTestId("step-one")).toBeTruthy();
+    expect(screen.getByText(/Label: test-flow/i)).toBeTruthy();
+  });
+
+  it("navigates forward and backward using the provided actions", () => {
+    renderFlow();
+
+    fireEvent.press(screen.getByText(/Next to Step Two/i));
+    expect(screen.getByTestId("step-two")).toBeTruthy();
+
+    fireEvent.press(screen.getByText(/^Back$/i));
+    expect(screen.getByTestId("step-one")).toBeTruthy();
+  });
+
+  it("supports jumping to any step", () => {
+    renderFlow();
+
+    fireEvent.press(screen.getByText(/Skip to Step Three/i));
+    expect(screen.getByTestId("step-three")).toBeTruthy();
+  });
+
+  it("respects custom initial step and history", () => {
+    renderFlow({
+      ...flowConfig,
+      initialStep: TEST_STEPS.SECOND,
+      initialHistory: [TEST_STEPS.FIRST],
+    });
+
+    expect(screen.getByTestId("step-two")).toBeTruthy();
+  });
+});

--- a/apps/ledger-live-mobile/src/newArch/features/FlowWizard/hooks/useFlowWizardNavigation.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/FlowWizard/hooks/useFlowWizardNavigation.ts
@@ -1,0 +1,157 @@
+import { useCallback, useMemo, useReducer } from "react";
+import {
+  FLOW_NAVIGATION_DIRECTION,
+  type FlowStep,
+  type FlowNavigationState,
+  type FlowNavigationActions,
+  type FlowStepConfig,
+  type UseFlowWizardNavigationParams,
+  type UseFlowWizardNavigationResult,
+  type FlowNavigationDirection,
+} from "../types";
+
+type NavigationAction<TStep extends FlowStep, TStepConfig extends FlowStepConfig<TStep>> =
+  | { type: "GO_TO_STEP"; step: TStep }
+  | { type: "GO_FORWARD"; stepOrder: readonly TStep[] }
+  | { type: "GO_BACKWARD"; stepConfigs: Record<TStep, TStepConfig> };
+
+function getStepIndex<TStep extends FlowStep>(step: TStep, stepOrder: readonly TStep[]): number {
+  return stepOrder.indexOf(step);
+}
+
+function getNextStep<TStep extends FlowStep>(
+  currentStep: TStep,
+  stepOrder: readonly TStep[],
+): TStep | null {
+  const currentIndex = getStepIndex(currentStep, stepOrder);
+  const nextIndex = currentIndex + 1;
+  return nextIndex < stepOrder.length ? stepOrder[nextIndex] : null;
+}
+
+function determineDirection<TStep extends FlowStep>(
+  currentStep: TStep,
+  targetStep: TStep,
+  stepOrder: readonly TStep[],
+): FlowNavigationDirection {
+  const currentIndex = getStepIndex(currentStep, stepOrder);
+  const targetIndex = getStepIndex(targetStep, stepOrder);
+  return targetIndex > currentIndex
+    ? FLOW_NAVIGATION_DIRECTION.FORWARD
+    : FLOW_NAVIGATION_DIRECTION.BACKWARD;
+}
+
+function createNavigationReducer<
+  TStep extends FlowStep,
+  TStepConfig extends FlowStepConfig<TStep> = FlowStepConfig<TStep>,
+>(stepOrder: readonly TStep[]) {
+  return function navigationReducer(
+    state: FlowNavigationState<TStep>,
+    action: NavigationAction<TStep, TStepConfig>,
+  ): FlowNavigationState<TStep> {
+    switch (action.type) {
+      case "GO_TO_STEP": {
+        if (action.step === state.currentStep) return state;
+        const direction = determineDirection(state.currentStep, action.step, stepOrder);
+        const newHistory =
+          direction === FLOW_NAVIGATION_DIRECTION.FORWARD
+            ? [...state.stepHistory, state.currentStep]
+            : state.stepHistory.slice(0, -1);
+        return { currentStep: action.step, direction, stepHistory: newHistory };
+      }
+
+      case "GO_FORWARD": {
+        const nextStep = getNextStep(state.currentStep, action.stepOrder);
+        if (!nextStep) return state;
+        return {
+          currentStep: nextStep,
+          direction: FLOW_NAVIGATION_DIRECTION.FORWARD,
+          stepHistory: [...state.stepHistory, state.currentStep],
+        };
+      }
+
+      case "GO_BACKWARD": {
+        const config = action.stepConfigs[state.currentStep];
+        if (!config?.canGoBack) return state;
+        const previousStep = state.stepHistory.at(-1);
+        if (!previousStep) return state;
+        return {
+          currentStep: previousStep,
+          direction: FLOW_NAVIGATION_DIRECTION.BACKWARD,
+          stepHistory: state.stepHistory.slice(0, -1),
+        };
+      }
+
+      default:
+        return state;
+    }
+  };
+}
+
+function createInitialState<TStep extends FlowStep>(
+  initialStep: TStep,
+  initialHistory: TStep[] = [],
+): FlowNavigationState<TStep> {
+  return {
+    currentStep: initialStep,
+    direction: FLOW_NAVIGATION_DIRECTION.FORWARD,
+    stepHistory: initialHistory,
+  };
+}
+
+export function useFlowWizardNavigation<
+  TStep extends FlowStep,
+  TStepConfig extends FlowStepConfig<TStep> = FlowStepConfig<TStep>,
+>({
+  flowConfig,
+}: UseFlowWizardNavigationParams<TStep, TStepConfig>): UseFlowWizardNavigationResult<
+  TStep,
+  TStepConfig
+> {
+  const { stepOrder, stepConfigs, initialStep, initialHistory } = flowConfig;
+
+  const computedInitialStep = useMemo(() => {
+    if (initialStep) return initialStep;
+    return stepOrder[0];
+  }, [initialStep, stepOrder]);
+
+  const reducer = useMemo(
+    () => createNavigationReducer<TStep, TStepConfig>(stepOrder),
+    [stepOrder],
+  );
+  const [state, dispatch] = useReducer(reducer, undefined, () =>
+    createInitialState(computedInitialStep, initialHistory),
+  );
+
+  const goToStep = useCallback((step: TStep) => {
+    dispatch({ type: "GO_TO_STEP", step });
+  }, []);
+
+  const goToNextStep = useCallback(() => {
+    dispatch({ type: "GO_FORWARD", stepOrder });
+  }, [stepOrder]);
+
+  const goToPreviousStep = useCallback(() => {
+    dispatch({ type: "GO_BACKWARD", stepConfigs });
+  }, [stepConfigs]);
+
+  const canGoBack = useCallback(() => {
+    const config = stepConfigs[state.currentStep];
+    return config?.canGoBack === true && state.stepHistory.length > 0;
+  }, [state.currentStep, state.stepHistory.length, stepConfigs]);
+
+  const canGoForward = useCallback(() => {
+    return getNextStep(state.currentStep, stepOrder) !== null;
+  }, [state.currentStep, stepOrder]);
+
+  const actions: FlowNavigationActions<TStep> = useMemo(
+    () => ({ goToStep, goToNextStep, goToPreviousStep, canGoBack, canGoForward }),
+    [goToStep, goToNextStep, goToPreviousStep, canGoBack, canGoForward],
+  );
+
+  const currentStepConfig = stepConfigs[state.currentStep];
+  const currentStepIndex = getStepIndex(state.currentStep, stepOrder);
+  const isFirstStep = currentStepIndex === 0;
+  const isLastStep = currentStepIndex === stepOrder.length - 1;
+
+  return { state, actions, currentStepConfig, isFirstStep, isLastStep };
+}

--- a/apps/ledger-live-mobile/src/newArch/features/FlowWizard/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/FlowWizard/types.ts
@@ -1,0 +1,99 @@
+import type { ComponentType } from "react";
+
+export type FlowStep = string;
+
+export const FLOW_NAVIGATION_DIRECTION = {
+  FORWARD: "FORWARD",
+  BACKWARD: "BACKWARD",
+};
+
+export type FlowNavigationDirection =
+  (typeof FLOW_NAVIGATION_DIRECTION)[keyof typeof FLOW_NAVIGATION_DIRECTION];
+
+export const FLOW_STATUS = {
+  IDLE: "IDLE",
+  ERROR: "ERROR",
+  SUCCESS: "SUCCESS",
+};
+
+export type FlowStatus = (typeof FLOW_STATUS)[keyof typeof FLOW_STATUS];
+
+export type FlowStepConfig<TStep extends FlowStep = FlowStep> = Readonly<{
+  id: TStep;
+  canGoBack: boolean;
+  showHeader?: boolean;
+}>;
+
+export type AnimationConfig = Readonly<{
+  forward?: string;
+  backward?: string;
+}>;
+
+export type FlowNavigationState<TStep extends FlowStep = FlowStep> = Readonly<{
+  currentStep: TStep;
+  direction: FlowNavigationDirection;
+  stepHistory: TStep[];
+}>;
+
+export type FlowNavigationActions<TStep extends FlowStep = FlowStep> = Readonly<{
+  goToStep: (step: TStep) => void;
+  goToNextStep: () => void;
+  goToPreviousStep: () => void;
+  canGoBack: () => boolean;
+  canGoForward: () => boolean;
+}>;
+
+export type FlowStatusActions = Readonly<{
+  setStatus: (status: FlowStatus) => void;
+  setError: () => void;
+  setSuccess: () => void;
+  resetStatus: () => void;
+}>;
+
+export type StepRenderer = ComponentType<unknown>;
+
+export type StepRegistry<TStep extends FlowStep = FlowStep> = Partial<Record<TStep, StepRenderer>>;
+
+export type FlowConfig<
+  TStep extends FlowStep = FlowStep,
+  TStepConfig extends FlowStepConfig<TStep> = FlowStepConfig<TStep>,
+> = Readonly<{
+  stepOrder: readonly TStep[];
+  stepConfigs: Record<TStep, TStepConfig>;
+  initialStep?: TStep;
+  initialHistory?: TStep[];
+}>;
+
+export type FlowWizardAugmentation<
+  TStep extends FlowStep = FlowStep,
+  TStepConfig extends FlowStepConfig<TStep> = FlowStepConfig<TStep>,
+> = Readonly<{
+  navigation: FlowNavigationActions<TStep>;
+  currentStep: TStep;
+  direction: FlowNavigationDirection;
+  currentStepConfig: TStepConfig;
+}>;
+
+export type FlowWizardContextValue<
+  TStep extends FlowStep,
+  TContextBase,
+  TStepConfig extends FlowStepConfig<TStep> = FlowStepConfig<TStep>,
+> = Readonly<TContextBase & FlowWizardAugmentation<TStep, TStepConfig>>;
+
+export type UseFlowWizardNavigationParams<
+  TStep extends FlowStep = FlowStep,
+  TStepConfig extends FlowStepConfig<TStep> = FlowStepConfig<TStep>,
+> = Readonly<{
+  flowConfig: FlowConfig<TStep, TStepConfig>;
+}>;
+
+export type UseFlowWizardNavigationResult<
+  TStep extends FlowStep = FlowStep,
+  TStepConfig extends FlowStepConfig<TStep> = FlowStepConfig<TStep>,
+> = Readonly<{
+  state: FlowNavigationState<TStep>;
+  actions: FlowNavigationActions<TStep>;
+  currentStepConfig: TStepConfig;
+  isFirstStep: boolean;
+  isLastStep: boolean;
+}>;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
