### PR TITLE
test(e2e): lwm swipe up modular drawer network selection

### DIFF
--- a/e2e/mobile/page/drawer/modular.drawer.ts
+++ b/e2e/mobile/page/drawer/modular.drawer.ts
@@ -80,12 +80,7 @@ export default class ModularDrawer {
   @Step("Select network in list if needed")
   async selectNetworkIfAsked(networkName: string): Promise<void> {
     if (await IsIdVisible(this.networkBasedTitleIdMAD)) {
-      const id = this.networkItemIdMAD(networkName);
-      if (!(await IsIdVisible(id))) {
-        await getElementById(this.networkBasedTitleIdMAD).swipe("up");
-        await scrollToId(id, this.networkSelectionScrollViewId);
-      }
-      await tapById(id, 0);
+      await this.selectNetwork(networkName);
     }
   }
 
@@ -93,6 +88,7 @@ export default class ModularDrawer {
   async selectNetwork(networkName: string): Promise<void> {
     const id = this.networkItemIdMAD(networkName);
     if (!(await IsIdVisible(id))) {
+      await getElementById(this.networkBasedTitleIdMAD).swipe("up");
       await scrollToId(id, this.networkSelectionScrollViewId);
     }
     await tapById(id, 0);
@@ -149,6 +145,7 @@ export default class ModularDrawer {
   async validateNetworksScreen(networks: string[]): Promise<void> {
     const modularDrawerAttributes = await getAttributesOfElement(this.modularDrawerFlowViewId, 0);
     jestExpect(modularDrawerAttributes.label).toMatch(/Select network.*/i);
+    await getElementById(this.networkBasedTitleIdMAD).swipe("up");
     for (const network of networks) {
       const networkItemId = this.networkItemIdMAD(network);
       await scrollToId(networkItemId, this.networkSelectionScrollViewId);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* To avoid flakiness, we needed to swipe up the modular drawer in case scroll is needed

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA**: [QAA-970](https://ledgerhq.atlassian.net/browse/QAA-970)
- [CI](https://github.com/LedgerHQ/ledger-live/actions/runs/21137846507/job/60789053879)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-970]: https://ledgerhq.atlassian.net/browse/QAA-970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ