### PR TITLE
refactor(llc): pass `bigint` inside Alpaca custom fees

### DIFF
--- a/.changeset/proud-points-scream.md
+++ b/.changeset/proud-points-scream.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/live-common": minor
+---
+
+refactor(llc): always pass `bigint` inside Alpaca custom fees

--- a/libs/coin-modules/coin-evm/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/estimateFees.test.ts
@@ -103,19 +103,19 @@ describe("estimateFees", () => {
           fast: {
             maxFeePerGas: null,
             maxPriorityFeePerGas: null,
-            gasPrice: new BigNumber("30000000000"),
+            gasPrice: 30000000000n,
             nextBaseFee: null,
           },
           medium: {
             maxFeePerGas: null,
             maxPriorityFeePerGas: null,
-            gasPrice: new BigNumber("20000000000"),
+            gasPrice: 20000000000n,
             nextBaseFee: null,
           },
           slow: {
             maxFeePerGas: null,
             maxPriorityFeePerGas: null,
-            gasPrice: new BigNumber("10000000000"),
+            gasPrice: 10000000000n,
             nextBaseFee: null,
           },
         },
@@ -282,7 +282,7 @@ describe("estimateFees", () => {
         data: { type: "buffer", value: Buffer.from([]) },
       } as SendTransactionIntent<MemoNotSupported, BufferTxData>,
       {
-        gasPrice: new BigNumber(60000),
+        gasPrice: 60000n,
       },
     );
 
@@ -527,7 +527,6 @@ describe("estimateFees", () => {
   });
 
   it("uses custom gas limit from customFeesParameters", async () => {
-    const customGasLimit = new BigNumber("50000");
     jest.mocked(getNodeApi).mockReturnValue(mockNodeApi as any);
     mockNodeApi.getFeeData.mockResolvedValue({
       gasPrice: new BigNumber("20000000000"),
@@ -550,8 +549,8 @@ describe("estimateFees", () => {
         data: { type: "buffer", value: Buffer.from([]) },
       } as SendTransactionIntent<MemoNotSupported, BufferTxData>,
       {
-        gasLimit: BigInt(customGasLimit.toFixed()),
-        gasPrice: new BigNumber(30000000000),
+        gasLimit: 50000n,
+        gasPrice: 30000000000n,
       },
     );
 

--- a/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
@@ -60,15 +60,21 @@ function extractFeeData(data: unknown): FeeData {
   }
 
   const gasPrice =
-    "gasPrice" in data && BigNumber.isBigNumber(data.gasPrice) ? data.gasPrice : null;
+    "gasPrice" in data && typeof data.gasPrice === "bigint"
+      ? new BigNumber(data.gasPrice.toString())
+      : null;
   const maxFeePerGas =
-    "maxFeePerGas" in data && BigNumber.isBigNumber(data.maxFeePerGas) ? data.maxFeePerGas : null;
+    "maxFeePerGas" in data && typeof data.maxFeePerGas === "bigint"
+      ? new BigNumber(data.maxFeePerGas.toString())
+      : null;
   const maxPriorityFeePerGas =
-    "maxPriorityFeePerGas" in data && BigNumber.isBigNumber(data.maxPriorityFeePerGas)
-      ? data.maxPriorityFeePerGas
+    "maxPriorityFeePerGas" in data && typeof data.maxPriorityFeePerGas === "bigint"
+      ? new BigNumber(data.maxPriorityFeePerGas.toString())
       : null;
   const nextBaseFee =
-    "nextBaseFee" in data && BigNumber.isBigNumber(data.nextBaseFee) ? data.nextBaseFee : null;
+    "nextBaseFee" in data && typeof data.nextBaseFee === "bigint"
+      ? new BigNumber(data.nextBaseFee.toString())
+      : null;
 
   return { gasPrice, maxFeePerGas, maxPriorityFeePerGas, nextBaseFee };
 }

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/estimateMaxSpendable.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/estimateMaxSpendable.ts
@@ -2,7 +2,7 @@ import { AccountBridge } from "@ledgerhq/types-live";
 import { getMainAccount } from "../../account";
 import { getAlpacaApi } from "./alpaca";
 import { createTransaction } from "./createTransaction";
-import { extractBalances, transactionToIntent } from "./utils";
+import { bigNumberToBigIntDeep, extractBalances, transactionToIntent } from "./utils";
 import BigNumber from "bignumber.js";
 import { GenericTransaction } from "./types";
 
@@ -35,7 +35,7 @@ export function genericEstimateMaxSpendable(
     const { amount } = await alpacaApi.validateIntent(
       transactionToIntent(account, { ...draftTransaction }, alpacaApi.computeIntentType),
       extractBalances(account, alpacaApi.getAssetFromToken),
-      { value: transaction?.fees ? BigInt(transaction.fees.toString()) : 0n },
+      bigNumberToBigIntDeep({ value: transaction?.fees ?? new BigNumber(0) }),
     );
     if (["stellar", "tezos", "evm"].includes(network)) {
       return amount > 0 ? new BigNumber(amount.toString()) : new BigNumber(0);

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/getTransactionStatus.ts
@@ -2,7 +2,12 @@ import { AccountBridge } from "@ledgerhq/types-live";
 import { AccountAwaitingSendPendingOperations } from "@ledgerhq/errors";
 import BigNumber from "bignumber.js";
 import { getAlpacaApi } from "./alpaca";
-import { extractBalances, applyMemoToIntent, transactionToIntent } from "./utils";
+import {
+  bigNumberToBigIntDeep,
+  extractBalances,
+  applyMemoToIntent,
+  transactionToIntent,
+} from "./utils";
 import { GenericTransaction } from "./types";
 
 // => alpaca validateIntent
@@ -38,29 +43,24 @@ export function genericGetTransactionStatus(
       }
     }
 
-    const fees = BigInt(transaction.fees?.toString() || "0");
-    const feesParameters = {
-      ...(transaction.gasLimit ? { gasLimit: BigInt(transaction.gasLimit.toFixed()) } : {}),
-      ...(transaction.gasPrice ? { gasPrice: BigInt(transaction.gasPrice.toFixed()) } : {}),
-      ...(transaction.maxFeePerGas
-        ? { maxFeePerGas: BigInt(transaction.maxFeePerGas.toFixed()) }
-        : {}),
-      ...(transaction.maxPriorityFeePerGas
-        ? { maxPriorityFeePerGas: BigInt(transaction.maxPriorityFeePerGas.toFixed()) }
-        : {}),
-      ...(transaction.additionalFees
-        ? { additionalFees: BigInt(transaction.additionalFees.toFixed()) }
-        : {}),
-    };
-
     let intent = transactionToIntent(account, draftTransaction, alpacaApi.computeIntentType);
     intent = applyMemoToIntent(intent, transaction);
 
+    const customFees = bigNumberToBigIntDeep({
+      value: transaction.fees ?? new BigNumber(0),
+      parameters: {
+        gasLimit: transaction.gasLimit,
+        gasPrice: transaction.gasPrice,
+        maxFeePerGas: transaction.maxFeePerGas,
+        maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
+        additionalFees: transaction.additionalFees,
+      },
+    });
     const { errors, warnings, estimatedFees, amount, totalSpent, totalFees } =
       await alpacaApi.validateIntent(
         intent,
         extractBalances(account, alpacaApi.getAssetFromToken),
-        { value: fees, parameters: feesParameters },
+        customFees,
       );
 
     return {

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/tests/prepareTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/tests/prepareTransaction.test.ts
@@ -11,6 +11,7 @@ jest.mock("../alpaca", () => ({
 }));
 
 jest.mock("../utils", () => ({
+  ...jest.requireActual("../utils"),
   transactionToIntent: jest.fn(),
   extractBalances: jest.fn(),
 }));

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/tests/signOperation.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/tests/signOperation.test.ts
@@ -9,14 +9,12 @@ jest.mock("../alpaca", () => ({
   getAlpacaApi: jest.fn(),
 }));
 
-jest.mock("../utils", () => {
-  const module = jest.requireActual("../utils");
-  return {
-    ...module,
-    buildOptimisticOperation: jest.fn(),
-    transactionToIntent: jest.fn(),
-  };
-});
+jest.mock("../utils", () => ({
+  ...jest.requireActual("../utils"),
+  buildOptimisticOperation: jest.fn(),
+  transactionToIntent: jest.fn(),
+}));
+
 describe("genericSignOperation", () => {
   const networks = ["xrp", "stellar", "tezos"];
   const kind = "local";

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/utils.test.ts
@@ -1,5 +1,6 @@
 import {
   adaptCoreOperationToLiveOperation,
+  bigNumberToBigIntDeep,
   buildOptimisticOperation,
   cleanedOperation,
   extractBalance,
@@ -13,6 +14,57 @@ import { Account } from "@ledgerhq/types-live";
 import { GenericTransaction, OperationCommon } from "./types";
 
 describe("Alpaca utils", () => {
+  describe("bigNumberToBigIntDeep", () => {
+    it.each([
+      [undefined, undefined],
+      [null, null],
+      ["", ""],
+      ["str", "str"],
+      [0, 0],
+      [1, 1],
+      [true, true],
+      [false, false],
+      [new BigNumber(0), 0n],
+      [new BigNumber(1), 1n],
+      [[], []],
+      [
+        ["str", 1],
+        ["str", 1],
+      ],
+      [
+        ["str", BigNumber(1)],
+        ["str", 1n],
+      ],
+      [
+        [new BigNumber(0), new BigNumber(1)],
+        [0n, 1n],
+      ],
+      [{}, {}],
+      [
+        { a: "str", b: 0, c: true },
+        { a: "str", b: 0, c: true },
+      ],
+      [
+        { a: "str", b: new BigNumber(1), c: true },
+        { a: "str", b: 1n, c: true },
+      ],
+      [
+        { a: "str", b: new BigNumber(1), c: { ca: new BigNumber(2), cb: 4 } },
+        { a: "str", b: 1n, c: { ca: 2n, cb: 4 } },
+      ],
+      [
+        { a: "str", b: new BigNumber(1), c: { ca: new BigNumber(2), cb: null } },
+        { a: "str", b: 1n, c: { ca: 2n, cb: null } },
+      ],
+      [
+        { a: "str", b: new BigNumber(1), c: { ca: new BigNumber(2), cb: undefined } },
+        { a: "str", b: 1n, c: { ca: 2n } },
+      ],
+    ])("replaces BigNumbers with BigInts (%j)", (input, output) => {
+      expect(bigNumberToBigIntDeep(input)).toStrictEqual(output);
+    });
+  });
+
   describe("buildOptimisticOperation", () => {
     it.each([
       [

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/utils.ts
@@ -22,6 +22,29 @@ import {
 } from "./types";
 import { StellarMemo } from "@ledgerhq/coin-stellar/types/bridge";
 
+type BigNumberToBigIntDeep<T> = T extends BigNumber
+  ? bigint
+  : T extends Array<infer U>
+    ? Array<BigNumberToBigIntDeep<U>>
+    : T extends object
+      ? { [K in keyof T]: BigNumberToBigIntDeep<Exclude<T[K], undefined>> }
+      : T;
+
+export function bigNumberToBigIntDeep<T>(obj: T): BigNumberToBigIntDeep<T> {
+  if (BigNumber.isBigNumber(obj)) return BigInt(obj.toFixed()) as BigNumberToBigIntDeep<T>;
+
+  if (Array.isArray(obj)) return obj.map(bigNumberToBigIntDeep) as BigNumberToBigIntDeep<T>;
+
+  if (!!obj && typeof obj === "object")
+    return Object.fromEntries(
+      Object.entries(obj)
+        .filter(([_, value]) => value !== undefined)
+        .map(([key, value]) => [key, bigNumberToBigIntDeep(value)]),
+    ) as BigNumberToBigIntDeep<T>;
+
+  return obj as BigNumberToBigIntDeep<T>;
+}
+
 export function findCryptoCurrencyByNetwork(network: string): CryptoCurrency | undefined {
   const networksRemap = {
     xrp: "ripple",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Framework type `FeeEstimation["parameters"]` must not be populated with `BigNumber`s since the Alpaca API promotes `BigInt`s.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
