### PR TITLE
:sparkles: (lwm/lwd) only show supported coin

### DIFF
--- a/.changeset/eight-tigers-tie.md
+++ b/.changeset/eight-tigers-tie.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Filter market data to show only supported currencies when lwdWallet40.params.marketBanner is enabled

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
@@ -1,4 +1,4 @@
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { MarketListRequestParams, Order } from "@ledgerhq/live-common/market/utils/types";
 import { rangeDataTable } from "@ledgerhq/live-common/market/utils/rangeDataTable";
 import {
@@ -42,7 +42,14 @@ export function useMarket() {
 
   const { supportedCounterCurrencies } = useMarketDataProvider();
 
-  const marketResult = useMarketDataHook(marketParams);
+  const { shouldDisplayMarketBanner: filterBySupported } = useWalletFeaturesConfig("desktop");
+
+  const shouldDisplayLiveCompatible = filterBySupported || marketParams.liveCompatible;
+
+  const marketResult = useMarketDataHook({
+    ...marketParams,
+    liveCompatible: shouldDisplayLiveCompatible,
+  });
 
   const timeRanges = useMemo(
     () =>

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketPerformanceWidget/useMarketPerformanceWidget.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketPerformanceWidget/useMarketPerformanceWidget.ts
@@ -16,6 +16,7 @@ import { useMarketPerformanceFeatureFlag } from "~/renderer/actions/marketperfor
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
 import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 const LIMIT_TO_DISPLAY = 5;
 
@@ -50,13 +51,17 @@ export function useMarketPerformanceWidget() {
   const timeRange = useSelector(selectedTimeRangeSelector);
   const countervalue = useSelector(counterValueCurrencySelector);
 
+  const { shouldDisplayMarketBanner: filterBySupported } = useWalletFeaturesConfig("desktop");
+
+  const shouldDisplaySupported = filterBySupported || supported;
+
   const { data, isError, isLoading } = useMarketPerformers({
     sort: order,
     counterCurrency: countervalue.ticker,
     range: timeRange,
     limit: enableNewFeature ? limit : LIMIT_TO_DISPLAY,
     top,
-    supported,
+    supported: shouldDisplaySupported,
     refreshRate,
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/useMarketListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/useMarketListViewModel.ts
@@ -12,6 +12,8 @@ import { getCurrentPage, isDataStale } from "../../utils";
 import { ViewToken } from "react-native";
 import { Order } from "@ledgerhq/live-common/market/utils/types";
 import { useQueryClient } from "@tanstack/react-query";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+
 type NavigationProps = BaseComposite<
   StackNavigatorProps<MarketNavigatorStackParamList, ScreenName.MarketList>
 >;
@@ -48,9 +50,14 @@ function useMarketListViewModel() {
 
   const { search, counterCurrency, range } = marketParams;
 
+  const { shouldDisplayMarketBanner: filterBySupported } = useWalletFeaturesConfig("mobile");
+
+  const shouldDisplayLiveCompatible = filterBySupported || marketParams.liveCompatible;
+
   const marketResult = useMarketDataHook({
     ...marketParams,
     starred: filterByStarredCurrencies ? starredMarketCoins : [],
+    liveCompatible: shouldDisplayLiveCompatible,
   });
 
   const baseData = filterByStarredCurrencies
@@ -68,10 +75,10 @@ function useMarketListViewModel() {
         starred: [],
         order: Order.MarketCapDesc,
         search: "",
-        liveCompatible: false,
+        liveCompatible: filterBySupported,
       });
     }
-  }, [initialTop100, updateMarketParams]);
+  }, [initialTop100, updateMarketParams, filterBySupported]);
 
   const onEndReached = useCallback(() => {
     dispatch(setMarketRequestParams({ page: (marketParams?.page || 1) + 1 }));


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - market list (filter under ff)

### 📝 Description

The goal of this PR is to unify the coins displayed on LWM and LWD depending on the market api. 
It will be filtered when we have the marketBanner ff ON

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25018](https://ledgerhq.atlassian.net/browse/LIVE-25018) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25018]: https://ledgerhq.atlassian.net/browse/LIVE-25018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ