### PR TITLE
feat: add transaction source tagging with headers for broadcast [LIVE-24876]

### DIFF
--- a/.changeset/mighty-planets-report.md
+++ b/.changeset/mighty-planets-report.md
@@ -1,0 +1,30 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/coin-bitcoin": minor
+"@ledgerhq/coin-evm": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: add transaction source tagging with headers for broadcast
+
+Add TransactionSource type and source field to BroadcastConfig to track
+transaction origins (dApp, live-app, coin-module, swap) and transmit them
+as X-Ledger-Source-Type and X-Ledger-Source-Name headers when broadcasting
+to blockchain explorers for Bitcoin and EVM.
+
+Changes:
+- Add TransactionSource type with type and name fields to types-live
+- Extend BroadcastConfig with optional source field
+- Thread source through Bitcoin broadcast chain (broadcast.ts → wallet.ts → xpub.ts → explorer)
+- Thread source through EVM broadcast in ledger node API
+- Update Desktop to pass source in:
+  - Live app broadcasts (LiveAppSDKLogic.ts)
+  - Swap flows (CompleteExchange Body.tsx)
+  - Native send flows (GenericStepConnectDevice.tsx)
+- Update Mobile to pass source in:
+  - Native transaction flows (screenTransactionHooks.ts)
+  - Platform exchange (CompleteExchange.tsx)
+  - Swap flows (Confirmation.tsx)
+- Update wallet-api integrations (react.ts, useDappLogic.ts)

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/LiveAppSDKLogic.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/LiveAppSDKLogic.ts
@@ -105,7 +105,10 @@ export const broadcastTransactionLogic = (
           optimisticOperation = await bridge.broadcast({
             account: mainAccount,
             signedOperation,
-            broadcastConfig: { mevProtected },
+            broadcastConfig: {
+              mevProtected,
+              source: { type: "live-app", name: manifest.id },
+            },
           });
           tracking.platformBroadcastSuccess(manifest);
         } catch (error) {

--- a/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
@@ -150,8 +150,12 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
 
   const mevProtected = useSelector(mevProtectionSelector);
   const broadcastConfig = useMemo(
-    () => ({ mevProtected, sponsored: !!sponsored }),
-    [mevProtected, sponsored],
+    () => ({
+      mevProtected,
+      sponsored: !!sponsored,
+      source: { type: "swap" as const, name: provider },
+    }),
+    [mevProtected, sponsored, provider],
   );
 
   const broadcast = useBroadcast({ account, parentAccount, broadcastConfig });

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
@@ -57,7 +57,13 @@ export default function StepConnectDevice({
 }) {
   const mevProtected = useSelector(mevProtectionSelector);
   const dispatch = useDispatch();
-  const broadcastConfig = useMemo(() => ({ mevProtected }), [mevProtected]);
+  const broadcastConfig = useMemo(
+    () => ({
+      mevProtected,
+      source: { type: "coin-module" as const, name: "ledger-live-desktop" },
+    }),
+    [mevProtected],
+  );
   const broadcast = useBroadcast({
     account,
     parentAccount,

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -124,7 +124,10 @@ export const useSignWithDevice = ({
                   .broadcast({
                     account: mainAccount,
                     signedOperation: (e as { signedOperation: SignedOperation }).signedOperation,
-                    broadcastConfig: { mevProtected },
+                    broadcastConfig: {
+                      mevProtected,
+                      source: { type: "coin-module", name: "ledger-live-mobile" },
+                    },
                   })
                   .then(operation => ({
                     type: "broadcasted",
@@ -269,7 +272,10 @@ export function useSignedTxHandler({
   const broadcast = useBroadcast({
     account,
     parentAccount,
-    broadcastConfig: { mevProtected },
+    broadcastConfig: {
+      mevProtected,
+      source: { type: "coin-module", name: "ledger-live-mobile" },
+    },
   });
   const dispatch = useDispatch();
   const mainAccount = getMainAccount(account, parentAccount);

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
@@ -35,7 +35,11 @@ const PlatformCompleteExchange: React.FC<Props> = ({
   const broadcast = useBroadcast({
     account,
     parentAccount,
-    broadcastConfig: { mevProtected, sponsored: request.sponsored },
+    broadcastConfig: {
+      mevProtected,
+      sponsored: request.sponsored,
+      source: { type: "swap", name: request.provider },
+    },
   });
   const [transaction, setTransaction] = useState<Transaction>();
   const [signedOperation, setSignedOperation] = useState<SignedOperation>();

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
@@ -103,7 +103,10 @@ export function Confirmation({
   const broadcast = useBroadcast({
     account: fromAccount,
     parentAccount: fromParentAccount,
-    broadcastConfig: { mevProtected },
+    broadcastConfig: {
+      mevProtected,
+      source: { type: "swap", name: provider },
+    },
   });
   const tokenCurrency =
     fromAccount && fromAccount.type === "TokenAccount" ? fromAccount.token : null;

--- a/libs/coin-modules/coin-bitcoin/src/broadcast.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/broadcast.test.ts
@@ -1,0 +1,119 @@
+import { broadcast } from "./broadcast";
+import wallet, { getWalletAccount } from "./wallet-btc";
+import { Account, SignedOperation } from "@ledgerhq/types-live";
+
+jest.mock("./wallet-btc");
+
+describe("broadcast", () => {
+  const mockAccount = {
+    id: "mock-account-id",
+    currency: { family: "bitcoin" },
+    bitcoinResources: {
+      utxos: [],
+    },
+  } as unknown as Account;
+
+  const mockWalletAccount = {
+    xpub: {
+      crypto: "bitcoin",
+      xpub: "mock-xpub",
+    },
+  };
+
+  const mockSignedOperation: SignedOperation = {
+    operation: {
+      id: "mock-operation-id",
+      hash: "",
+      type: "OUT",
+      value: "1000000",
+      fee: "1000",
+      blockHash: null,
+      blockHeight: null,
+      senders: ["sender-address"],
+      recipients: ["recipient-address"],
+      accountId: "mock-account-id",
+      date: new Date(),
+      extra: {},
+    },
+    signature: "mock-signature",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getWalletAccount as jest.Mock).mockReturnValue(mockWalletAccount);
+  });
+
+  it("should broadcast transaction without broadcastConfig", async () => {
+    const mockBroadcastTx = jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-tx-hash");
+
+    await broadcast({
+      account: mockAccount,
+      signedOperation: mockSignedOperation,
+    });
+
+    expect(mockBroadcastTx).toHaveBeenCalledWith(expect.any(Object), "mock-signature", undefined);
+  });
+
+  it("should broadcast transaction with broadcastConfig containing source", async () => {
+    const mockBroadcastTx = jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-tx-hash");
+
+    await broadcast({
+      account: mockAccount,
+      signedOperation: mockSignedOperation,
+      broadcastConfig: {
+        mevProtected: false,
+        source: { type: "live-app", name: "test-manifest" },
+      },
+    });
+
+    expect(mockBroadcastTx).toHaveBeenCalledWith(expect.any(Object), "mock-signature", {
+      mevProtected: false,
+      source: { type: "live-app", name: "test-manifest" },
+    });
+  });
+
+  it("should return operation with hash", async () => {
+    jest.spyOn(wallet, "broadcastTx").mockResolvedValue("broadcasted-hash");
+
+    const result = await broadcast({
+      account: mockAccount,
+      signedOperation: mockSignedOperation,
+      broadcastConfig: {
+        mevProtected: false,
+        source: { type: "swap", name: "provider-name" },
+      },
+    });
+
+    expect(result.hash).toBe("broadcasted-hash");
+    expect(result.id).toContain("broadcasted-hash");
+  });
+
+  it("should support all source types", async () => {
+    const mockBroadcastTx = jest.spyOn(wallet, "broadcastTx").mockResolvedValue("mock-hash");
+
+    const sourceTypes: Array<"live-app" | "dApp" | "coin-module" | "swap"> = [
+      "live-app",
+      "dApp",
+      "coin-module",
+      "swap",
+    ];
+
+    for (const type of sourceTypes) {
+      await broadcast({
+        account: mockAccount,
+        signedOperation: mockSignedOperation,
+        broadcastConfig: {
+          mevProtected: false,
+          source: { type, name: `test-${type}` },
+        },
+      });
+
+      expect(mockBroadcastTx).toHaveBeenCalledWith(expect.any(Object), "mock-signature", {
+        mevProtected: false,
+        source: { type, name: `test-${type}` },
+      });
+
+      mockBroadcastTx.mockClear();
+    }
+  });
+});

--- a/libs/coin-modules/coin-bitcoin/src/broadcast.ts
+++ b/libs/coin-modules/coin-bitcoin/src/broadcast.ts
@@ -10,10 +10,11 @@ import { Transaction } from "./types";
 export const broadcast: AccountBridge<Transaction>["broadcast"] = async ({
   account,
   signedOperation,
+  broadcastConfig,
 }) => {
   const { signature, operation } = signedOperation;
   const walletAccount = getWalletAccount(account);
-  const hash = await wallet.broadcastTx(walletAccount, signature);
+  const hash = await wallet.broadcastTx(walletAccount, signature, broadcastConfig);
   return patchOperationWithHash(operation, hash);
 };
 

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.explorer.unit.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.explorer.unit.test.ts
@@ -190,6 +190,42 @@ describe("BitcoinApi", () => {
         "f3a2aebc6cf6f27a04d95809a97b78e78a47b100672612eac07f17dd5ff56474",
       );
     });
+
+    it("broadcast api should include source headers when provided", async () => {
+      const mockNetwork = network as jest.MockedFunction<typeof network>;
+
+      await explorer.broadcast(
+        "02000000000101f3a2aebc6cf6f27a04d95809a97b78e78a47b100672612eac07f17dd5ff564740000000000ffffffff02a0860100000000001600141a1653e4395b75aa062bbe6a05c1bedc5f268d790000000000000",
+        { source: { type: "live-app", name: "test-app" } },
+      );
+
+      expect(mockNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: {
+            "X-Ledger-Source-Type": "live-app",
+            "X-Ledger-Source-Name": "test-app",
+          },
+        }),
+      );
+    });
+
+    it("broadcast api should not include headers when source is not provided", async () => {
+      const mockNetwork = network as jest.MockedFunction<typeof network>;
+
+      await explorer.broadcast(
+        "02000000000101f3a2aebc6cf6f27a04d95809a97b78e78a47b100672612eac07f17dd5ff564740000000000ffffffff02a0860100000000001600141a1653e4395b75aa062bbe6a05c1bedc5f268d790000000000000",
+      );
+
+      expect(mockNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "POST",
+          data: expect.any(Object),
+        }),
+      );
+
+      const callArgs = mockNetwork.mock.calls[mockNetwork.mock.calls.length - 1][0];
+      expect(callArgs.headers).toEqual({});
+    });
   });
 
   describe("hydrateTx unit test rbf", () => {

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/explorer/index.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/explorer/index.ts
@@ -1,3 +1,4 @@
+import type { BroadcastConfig } from "@ledgerhq/types-live";
 import { Address, Block, TX } from "../storage/types";
 import network from "@ledgerhq/live-network/network";
 import { IExplorer, NetworkInfoResponse } from "./types";
@@ -24,12 +25,21 @@ class BitcoinLikeExplorer implements IExplorer {
     this.baseUrl = forcedExplorerURI ? forcedExplorerURI : blockchainBaseURL(cryptoCurrency);
   }
 
-  async broadcast(tx: string): Promise<{ data: { result: string } }> {
+  async broadcast(
+    tx: string,
+    broadcastConfig?: Pick<BroadcastConfig, "source">,
+  ): Promise<{ data: { result: string } }> {
     const url = `${this.baseUrl}/tx/send`;
+    const headers: Record<string, string> = {};
+    if (broadcastConfig?.source) {
+      headers["X-Ledger-Source-Type"] = broadcastConfig.source.type;
+      headers["X-Ledger-Source-Name"] = broadcastConfig.source.name;
+    }
     const res = await network({
       method: "POST",
       url,
       data: { tx },
+      headers,
     });
     return res;
   }

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/explorer/types.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/explorer/types.ts
@@ -1,3 +1,4 @@
+import type { BroadcastConfig } from "@ledgerhq/types-live";
 import { TX, Address, Block } from "../storage/types";
 
 export type NetworkInfoResponse = {
@@ -9,7 +10,10 @@ export type NetworkInfoResponse = {
 // abstract explorer api used, abstract batching logic, pagination, and retries
 export interface IExplorer {
   baseUrl: string;
-  broadcast(tx: string): Promise<{ data: { result: string } }>;
+  broadcast(
+    tx: string,
+    broadcastConfig?: Pick<BroadcastConfig, "source">,
+  ): Promise<{ data: { result: string } }>;
   getTxHex(txId: string): Promise<string>;
   getFees(): Promise<{ [key: string]: number }>;
   getNetwork?(): Promise<NetworkInfoResponse>;

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/wallet.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/wallet.ts
@@ -3,6 +3,7 @@ import BigNumber from "bignumber.js";
 import { log } from "@ledgerhq/logs";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { BroadcastConfig } from "@ledgerhq/types-live";
 
 import { Currency } from "./crypto/types";
 import { TransactionInfo, DerivationModes } from "./types";
@@ -314,8 +315,12 @@ class BitcoinLikeWallet {
     return tx;
   }
 
-  async broadcastTx(fromAccount: Account, tx: string): Promise<string> {
-    const res = await fromAccount.xpub.broadcastTx(tx);
+  async broadcastTx(
+    fromAccount: Account,
+    tx: string,
+    broadcastConfig?: Pick<BroadcastConfig, "source">,
+  ): Promise<string> {
+    const res = await fromAccount.xpub.broadcastTx(tx, broadcastConfig);
     return res.data.result;
   }
 

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/xpub.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/xpub.ts
@@ -1,3 +1,4 @@
+import type { BroadcastConfig } from "@ledgerhq/types-live";
 import maxBy from "lodash/maxBy";
 import range from "lodash/range";
 import some from "lodash/some";
@@ -304,8 +305,11 @@ class Xpub {
     };
   }
 
-  async broadcastTx(rawTxHex: string): Promise<{ data: { result: string } }> {
-    return this.explorer.broadcast(rawTxHex);
+  async broadcastTx(
+    rawTxHex: string,
+    broadcastConfig?: Pick<BroadcastConfig, "source">,
+  ): Promise<{ data: { result: string } }> {
+    return this.explorer.broadcast(rawTxHex, broadcastConfig);
   }
 
   // internal

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/api/node/ledger.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/api/node/ledger.unit.test.ts
@@ -525,6 +525,50 @@ describe("EVM Family", () => {
 
         mockRequest.mockRestore();
       });
+
+      it("should include source headers when source is provided", async () => {
+        const mockRequest = jest.spyOn(axios, "request").mockImplementationOnce(async () => ({
+          data: {
+            result: "0xHash",
+          },
+        }));
+
+        await LEDGER_API.broadcastTransaction(currency, "0xSignedTx", {
+          mevProtected: false,
+          source: { type: "live-app", name: "test-manifest-id" },
+        });
+
+        expect(mockRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              "X-Ledger-Source-Type": "live-app",
+              "X-Ledger-Source-Name": "test-manifest-id",
+            }),
+          }),
+        );
+
+        mockRequest.mockRestore();
+      });
+
+      it("should not include source headers when source is not provided", async () => {
+        const mockRequest = jest.spyOn(axios, "request").mockImplementationOnce(async () => ({
+          data: {
+            result: "0xHash",
+          },
+        }));
+
+        await LEDGER_API.broadcastTransaction(currency, "0xSignedTx", { mevProtected: false });
+
+        expect(mockRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            headers: {
+              "X-Ledger-Client-Version": expect.any(String),
+            },
+          }),
+        );
+
+        mockRequest.mockRestore();
+      });
     });
 
     describe("getBlockByHeight", () => {

--- a/libs/coin-modules/coin-evm/src/logic/broadcastSource.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/broadcastSource.test.ts
@@ -1,0 +1,91 @@
+import { getNodeApi } from "../network/node/index";
+import { broadcast } from "./broadcast";
+
+jest.mock("../network/node/index", () => ({
+  getNodeApi: jest.fn(),
+}));
+
+const mockGetNodeApi = getNodeApi as jest.Mock;
+
+describe("EVM broadcast with source", () => {
+  const mockCurrency = { id: "ethereum" } as any;
+  const mockBroadcastTransaction = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetNodeApi.mockReturnValue({
+      broadcastTransaction: mockBroadcastTransaction,
+    });
+    mockBroadcastTransaction.mockResolvedValue("0xhash123");
+  });
+
+  it("should broadcast with source headers from broadcastConfig", async () => {
+    const result = await broadcast(mockCurrency, {
+      signature: "0xsignature",
+      broadcastConfig: {
+        mevProtected: true,
+        source: {
+          type: "live-app",
+          name: "test-manifest-id",
+        },
+      },
+    });
+
+    expect(mockBroadcastTransaction).toHaveBeenCalledWith(
+      mockCurrency,
+      "0xsignature",
+      expect.objectContaining({
+        mevProtected: true,
+        source: {
+          type: "live-app",
+          name: "test-manifest-id",
+        },
+      }),
+    );
+    expect(result).toBe("0xhash123");
+  });
+
+  it("should broadcast swap transaction with swap source", async () => {
+    const result = await broadcast(mockCurrency, {
+      signature: "0xsignature",
+      broadcastConfig: {
+        mevProtected: false,
+        sponsored: true,
+        source: {
+          type: "swap",
+          name: "1inch",
+        },
+      },
+    });
+
+    expect(mockBroadcastTransaction).toHaveBeenCalledWith(
+      mockCurrency,
+      "0xsignature",
+      expect.objectContaining({
+        source: {
+          type: "swap",
+          name: "1inch",
+        },
+      }),
+    );
+    expect(result).toBe("0xhash123");
+  });
+
+  it("should broadcast without source when not provided", async () => {
+    const result = await broadcast(mockCurrency, {
+      signature: "0xsignature",
+      broadcastConfig: {
+        mevProtected: false,
+      },
+    });
+
+    expect(mockBroadcastTransaction).toHaveBeenCalledWith(
+      mockCurrency,
+      "0xsignature",
+      expect.objectContaining({
+        mevProtected: false,
+      }),
+    );
+    expect(result).toBe("0xhash123");
+  });
+});

--- a/libs/coin-modules/coin-evm/src/network/node/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/ledger.ts
@@ -275,6 +275,12 @@ export const broadcastTransaction: NodeApi["broadcastTransaction"] = async (
     sponsored: Boolean(broadcastConfig?.sponsored),
   };
 
+  const headers: Record<string, string> = {};
+  if (broadcastConfig?.source) {
+    headers["X-Ledger-Source-Type"] = broadcastConfig.source.type;
+    headers["X-Ledger-Source-Name"] = broadcastConfig.source.name;
+  }
+
   const { result: hash } = await fetchWithRetries<{
     result: string;
   }>({
@@ -282,6 +288,7 @@ export const broadcastTransaction: NodeApi["broadcastTransaction"] = async (
     url: `${getEnv("EXPLORER")}/blockchain/v4/${node.explorerId}/tx/send`,
     data: { tx: signedTxHex },
     params,
+    headers,
   });
   return hash;
 };

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -855,7 +855,10 @@ export function useWalletAPIServer({
                   optimisticOperation = await bridge.broadcast({
                     account: mainAccount,
                     signedOperation,
-                    broadcastConfig: { mevProtected: !!config.mevProtected },
+                    broadcastConfig: {
+                      mevProtected: !!config.mevProtected,
+                      source: { type: "live-app", name: manifest.id },
+                    },
                   });
                   tracking.broadcastSuccess(manifest);
                 } catch (error) {
@@ -940,6 +943,7 @@ export function useWalletAPIServer({
                   broadcastConfig: {
                     mevProtected: !!config.mevProtected,
                     sponsored,
+                    source: { type: "live-app", name: manifest.id },
                   },
                 });
                 tracking.broadcastSuccess(manifest, isEmbeddedSwap, partner);

--- a/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
+++ b/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
@@ -547,7 +547,10 @@ export function useDappLogic({
                 optimisticOperation = await bridge.broadcast({
                   account: mainAccount,
                   signedOperation: signedTransaction,
-                  broadcastConfig: { mevProtected: !!mevProtected },
+                  broadcastConfig: {
+                    mevProtected: !!mevProtected,
+                    source: { type: "dApp", name: manifest.id },
+                  },
                 });
               }
 

--- a/libs/ledgerjs/packages/types-live/src/bridge.ts
+++ b/libs/ledgerjs/packages/types-live/src/bridge.ts
@@ -13,6 +13,7 @@ import type {
   SignedOperation,
   TransactionCommon,
   TransactionStatusCommon,
+  TransactionSource,
 } from "./transaction";
 import type { Operation, OperationExtra, OperationExtraRaw } from "./operation";
 import type { DerivationMode } from "./derivation";
@@ -46,6 +47,7 @@ export type PreloadStrategy = Partial<{
 export type BroadcastConfig = {
   mevProtected: boolean;
   sponsored?: boolean;
+  source?: TransactionSource;
 };
 
 /**

--- a/libs/ledgerjs/packages/types-live/src/transaction.ts
+++ b/libs/ledgerjs/packages/types-live/src/transaction.ts
@@ -4,6 +4,16 @@ import type { DomainServiceResolution } from "./domain";
 import type { Operation, OperationRaw } from "./operation";
 
 /**
+ * TransactionSource identifies the origin of a transaction
+ */
+export type TransactionSource = {
+  // Type of the transaction source
+  type: "dApp" | "live-app" | "coin-module" | "swap";
+  // Name/identifier of the source (e.g., manifestId, provider name)
+  name: string;
+};
+
+/**
  *
  */
 export type SignedOperation = {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Only adding headers to some network calls on most sign flows

### 📝 Description

Add TransactionSource type and source field to BroadcastConfig to track transaction origins (dApp, live-app, coin-module, swap) and transmit them as `X-Ledger-Source-Type` and `X-Ledger-Source-Name` headers when broadcasting to blockchain explorers for Bitcoin and EVM.

Changes:
- Add TransactionSource type with type and name fields to types-live
- Extend BroadcastConfig with optional source field
- Thread source through Bitcoin broadcast chain (broadcast.ts → wallet.ts → xpub.ts → explorer)
- Thread source through EVM broadcast in ledger node API
- Update Desktop to pass source in:
  - Live app broadcasts (LiveAppSDKLogic.ts)
  - Swap flows (CompleteExchange Body.tsx)
  - Native send flows (GenericStepConnectDevice.tsx)
- Update Mobile to pass source in:
  - Native transaction flows (screenTransactionHooks.ts)
  - Platform exchange (CompleteExchange.tsx)
  - Swap flows (Confirmation.tsx)
- Update wallet-api integrations (react.ts, useDappLogic.ts)
- Add test coverage:
  - Bitcoin broadcast tests
  - Bitcoin explorer tests
  - EVM broadcast source tests
  - EVM node API tests

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24876]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24876]: https://ledgerhq.atlassian.net/browse/LIVE-24876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ