### PR TITLE
fix (LIVE-24859): Fix canton error message on account creation refuse

### DIFF
--- a/.changeset/red-plants-heal.md
+++ b/.changeset/red-plants-heal.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix canton error message on account creation refuse

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/steps/__tests__/test-utils.ts
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/steps/__tests__/test-utils.ts
@@ -163,6 +163,20 @@ export const getMockReactI18next = () => ({
 export const getMockNativeUI = () => {
   const mockViewComponentFn = ({ children, testID, ...props }: any) =>
     React.createElement(View, { testID, ...props }, children);
+
+  const AlertComponent = Object.assign(
+    ({ children, testID, title, ...props }: any) =>
+      React.createElement(
+        View,
+        { testID, ...props },
+        title && React.createElement(View, {}, title),
+        children,
+      ),
+    {
+      UnderlinedText: mockViewComponentFn,
+    },
+  );
+
   return {
     Flex: mockViewComponentFn,
     Text: mockViewComponentFn,
@@ -176,7 +190,7 @@ export const getMockNativeUI = () => {
       React.createElement(TextInput, { testID, value: checked ? "checked" : "", ...props }),
     IconBox: ({ Icon, testID, ...props }: any) =>
       React.createElement(View, { testID, ...props }, React.createElement(Icon)),
-    Alert: mockViewComponentFn,
+    Alert: AlertComponent,
     IconsLegacy: {
       InfoMedium: () => React.createElement(View, { testID: "info-medium-icon" }, "InfoMedium"),
     },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - live-mobile

### 📝 Description

Fir for a wrong error message is displayed on canton account creation

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: 
- [LIVE-24859](https://ledgerhq.atlassian.net/browse/LIVE-24859)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24859]: https://ledgerhq.atlassian.net/browse/LIVE-24859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ