### PR TITLE
ci: add workflow to auto-update PR titles from labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,3 +32,7 @@ screenshots:
 coin-modules-api:
  - libs/coin-framework/src/api/**
  - libs/coin-modules/*/src/api/**
+
+coin-modules:
+ - libs/coin-framework/**/*
+ - libs/coin-modules/**/*

--- a/.github/workflows/pr-title-from-labels.yml
+++ b/.github/workflows/pr-title-from-labels.yml
@@ -1,0 +1,78 @@
+name: "[CI] - PR Title - Auto Update from Labels"
+run-name: "@PR • Title update triggered by ${{ github.actor }} ${{ format('on branch {0}', github.head_ref) }}"
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled]
+
+jobs:
+  update-title:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-22.04
+    steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+
+      - name: Update PR Title from Labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = pr.labels.map(l => l.name);
+
+            // Build prefix from labels
+            // If 'common' OR both 'desktop' + 'mobile' are present, use only LWDM
+            let prefixes = [];
+            const hasDesktop = labels.includes('desktop');
+            const hasMobile = labels.includes('mobile');
+            const hasCommon = labels.includes('common');
+            const hasCoinModules = labels.includes('coin-modules');
+            
+            if (hasCommon || (hasDesktop && hasMobile) || hasCoinModules) {
+              prefixes = ['LWDM'];
+            } else if (hasDesktop) {
+              prefixes = ['LWD'];
+            } else if (hasMobile) {
+              prefixes = ['LWM'];
+            }
+
+            // Remove existing prefixes from title (anything in brackets at start)
+            let cleanTitle = pr.title
+              .replace(/^(\[[^\]]+\]\s*)+/, '')
+              .trim();
+
+            // Build new title
+            let newTitle = cleanTitle;
+            if (prefixes.length > 0) {
+              newTitle = `[${prefixes.join('][')}] ${cleanTitle}`;
+            }
+
+            // Only update if changed
+            if (newTitle !== pr.title) {
+              try {
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  title: newTitle
+                });
+              } catch (error) {
+                if (core && typeof core.error === 'function') {
+                  core.error(`Failed to update PR title for #${pr.number}: ${error.message || error}`);
+                } else {
+                  console.error(`Failed to update PR title for #${pr.number}:`, error);
+                }
+                if (core && typeof core.setFailed === 'function') {
+                  core.setFailed(`Failed to update PR title for #${pr.number}`);
+                } else {
+                  throw error;
+                }
+              }
+            } 


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->

### Description
## What
Adds a GitHub Action that automatically prefixes PR titles based on applied labels.
## Why
Improves PR readability and helps quickly identify which areas of the codebase are affected (Desktop, Mobile, Common).
## How
When labels are added/removed or a PR is opened, the workflow updates the title with the corresponding prefix:

| Label | Prefix |
|-------|--------|
| `desktop` | `[LWD]` |
| `mobile` | `[LWM]` |
| `common` | `[LWDM]` |
| `desktop & mobile` | `[LWDM]` |

**Example:**
- Labels: `desktop`, `common`
- Title: `Fix sync issue` → `[LWDM] Fix sync issue`

## Notes

- Works alongside the existing `labeler.yml` workflow
- Uses the same GitHub App token for authentication
- Only updates title if a change is needed
