### PR TITLE
test(e2e): hedera send native

### DIFF
--- a/.changeset/grumpy-badgers-shave.md
+++ b/.changeset/grumpy-badgers-shave.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop-e2e-tests": minor
+"ledger-live-mobile-e2e-tests": minor
+---
+
+test: e2e send hbar

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -6,7 +6,10 @@ import { addBugLink, addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { CLI } from "tests/utils/cliUtils";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
-import { liveDataWithRecipientAddressCommand } from "tests/utils/cliCommandsUtils";
+import {
+  getAccountAddress,
+  liveDataWithRecipientAddressCommand,
+} from "tests/utils/cliCommandsUtils";
 import { Addresses } from "@ledgerhq/live-common/e2e/enum/Addresses";
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 
@@ -37,6 +40,11 @@ const transactionsAmountInvalid = [
     transaction: new Transaction(Account.ETH_1, Account.ETH_2, "100", Fee.MEDIUM),
     expectedErrorMessage: "Sorry, insufficient funds",
     xrayTicket: "B2CQA-2572",
+  },
+  {
+    transaction: new Transaction(Account.HEDERA_1, Account.HEDERA_2, "100000", undefined, "noTag"),
+    expectedErrorMessage: "Sorry, insufficient funds",
+    xrayTicket: "B2CQA-4281",
   },
 ];
 
@@ -70,6 +78,11 @@ const transactionsAddressInvalid = [
     address: undefined,
     expectedErrorMessage: "Recipient address is the same as the sender address",
     xrayTicket: "B2CQA-2713",
+  },
+  {
+    transaction: new Transaction(Account.HEDERA_1, Account.HEDERA_1, "0.00001", undefined, "noTag"),
+    expectedErrorMessage: "Recipient address is the same as the sender address",
+    xrayTicket: "B2CQA-4282",
   },
 ];
 
@@ -233,7 +246,17 @@ const transactionE2E = [
     transaction: new Transaction(Account.ZEC_1, Account.ZEC_2, "0.001"),
     xrayTicket: "B2CQA-4299",
   },
+  {
+    transaction: new Transaction(Account.HEDERA_1, Account.HEDERA_2, "0.00001", undefined, "noTag"),
+    xrayTicket: "B2CQA-4284",
+  },
 ];
+
+const LNS_UNSUPPORTED_CURRENCIES = new Set([Currency.SUI.id, Currency.VET.id, Currency.HBAR.id]);
+
+function shouldSkipLNSTag(currencyId: string): boolean {
+  return LNS_UNSUPPORTED_CURRENCIES.has(currencyId);
+}
 
 test.describe("Send flows", () => {
   for (const transaction of transactionE2E) {
@@ -251,10 +274,9 @@ test.describe("Send flows", () => {
         {
           tag: [
             "@NanoSP",
-            ...(transaction.transaction.accountToDebit.currency.id !== Currency.SUI.id &&
-            transaction.transaction.accountToDebit.currency.id !== Currency.VET.id
-              ? ["@LNS"]
-              : []),
+            ...(shouldSkipLNSTag(transaction.transaction.accountToDebit.currency.id)
+              ? []
+              : ["@LNS"]),
             "@NanoX",
             "@Stax",
             "@Flex",
@@ -310,7 +332,9 @@ test.describe("Send flows", () => {
         {
           tag: [
             "@NanoSP",
-            "@LNS",
+            ...(shouldSkipLNSTag(transaction.transaction.accountToDebit.currency.id)
+              ? []
+              : ["@LNS"]),
             "@NanoX",
             "@Stax",
             "@Flex",
@@ -358,7 +382,7 @@ test.describe("Send flows", () => {
       {
         tag: [
           "@NanoSP",
-          "@LNS",
+          ...(shouldSkipLNSTag(transactionInputValid.accountToDebit.currency.id) ? [] : ["@LNS"]),
           "@NanoX",
           "@Stax",
           "@Flex",
@@ -406,7 +430,9 @@ test.describe("Send flows", () => {
         {
           tag: [
             "@NanoSP",
-            "@LNS",
+            ...(shouldSkipLNSTag(transaction.transaction.accountToDebit.currency.id)
+              ? []
+              : ["@LNS"]),
             "@NanoX",
             "@Stax",
             "@Flex",
@@ -454,19 +480,19 @@ test.describe("Send flows", () => {
               add: true,
               appjson: appjsonPath,
             });
+
             if (
               transaction.transaction.accountToCredit !== Account.EMPTY &&
               transaction.transaction.accountToCredit !== Account.BTC_NATIVE_SEGWIT_1
             ) {
-              const receiveAddress = await CLI.getAddress({
-                currency: transaction.transaction.accountToCredit.currency.id,
-                path: transaction.transaction.accountToCredit.accountPath,
-                derivationMode: transaction.transaction.accountToCredit.derivationMode,
-              });
-              transaction.address = receiveAddress.address;
+              const receiveAddress = await getAccountAddress(
+                transaction.transaction.accountToCredit,
+              );
+              transaction.address = receiveAddress;
 
-              return receiveAddress.address;
+              return receiveAddress;
             }
+
             return transaction.address;
           },
         ],
@@ -479,7 +505,9 @@ test.describe("Send flows", () => {
         {
           tag: [
             "@NanoSP",
-            "@LNS",
+            ...(shouldSkipLNSTag(transaction.transaction.accountToDebit.currency.id)
+              ? []
+              : ["@LNS"]),
             "@NanoX",
             "@Stax",
             "@Flex",
@@ -536,7 +564,7 @@ test.describe("Send flows", () => {
       {
         tag: [
           "@NanoSP",
-          "@LNS",
+          ...(shouldSkipLNSTag(transactionEnsAddress.accountToDebit.currency.id) ? [] : ["@LNS"]),
           "@NanoX",
           "@Stax",
           "@Flex",

--- a/e2e/mobile/specs/send/sendHBAR.spec.ts
+++ b/e2e/mobile/specs/send/sendHBAR.spec.ts
@@ -1,0 +1,15 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSendTest } from "./send";
+
+const transaction = new Transaction(
+  Account.HEDERA_1,
+  Account.HEDERA_2,
+  "0.0001",
+  undefined,
+  "noTag",
+);
+runSendTest(
+  transaction,
+  ["B2CQA-4285"],
+  ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@hedera", "@family-hedera"],
+);

--- a/e2e/mobile/specs/send/sendInvalid/sendInvalidAddressHBAR.spec.ts
+++ b/e2e/mobile/specs/send/sendInvalid/sendInvalidAddressHBAR.spec.ts
@@ -1,0 +1,11 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSendInvalidAddressTest } from "../send";
+
+const transaction = new Transaction(Account.HEDERA_1, Account.HEDERA_1, "1", undefined, "noTag");
+runSendInvalidAddressTest(
+  transaction,
+  "Destination and source accounts must not be the same.",
+  undefined,
+  ["B2CQA-4286"],
+  ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@hedera", "@family-hedera"],
+);

--- a/e2e/mobile/specs/send/sendInvalid/sendInvalidAmountHBAR.spec.ts
+++ b/e2e/mobile/specs/send/sendInvalid/sendInvalidAmountHBAR.spec.ts
@@ -1,0 +1,16 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSendInvalidAmountTest } from "../send";
+
+const transaction = new Transaction(
+  Account.HEDERA_1,
+  Account.HEDERA_2,
+  "100000",
+  undefined,
+  "noTag",
+);
+runSendInvalidAmountTest(
+  transaction,
+  "Sorry, insufficient funds",
+  ["B2CQA-4287"],
+  ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@hedera", "@family-hedera"],
+);

--- a/e2e/mobile/utils/cliUtils.ts
+++ b/e2e/mobile/utils/cliUtils.ts
@@ -1,3 +1,4 @@
+import invariant from "invariant";
 import { getSdk } from "@ledgerhq/ledger-key-ring-protocol";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import { CloudSyncSDK, UpdateEvent } from "@ledgerhq/live-wallet/lib/cloudsync/index";
@@ -16,6 +17,7 @@ import {
 } from "@ledgerhq/live-dmk-speculos";
 import { isRemoteIos } from "../helpers/commonHelpers";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 
 export type LiveDataOpts = {
   currency: string;
@@ -265,6 +267,11 @@ export const CLI = {
     });
   },
   getAddressForAccount: async (account: Account) => {
+    if (account.currency.id === Currency.HBAR.id) {
+      invariant(account.address, "hedera: account address must be pre-set");
+      return account.address;
+    }
+
     const addressInfo = await CLI.getAddress({
       currency: account.currency.speculosApp.name,
       path: account.accountPath,

--- a/libs/ledger-live-common/src/e2e/enum/Account.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Account.ts
@@ -157,7 +157,29 @@ export class Account {
   static readonly ETH_3 = new Account(Currency.ETH, "Ethereum 3", 3, "44'/60'/2'/0/0");
   static readonly SANCTIONED_ETH = new Account(Currency.ETH, "Sanctioned Ethereum", 0, "");
 
-  static readonly HEDERA_1 = new Account(Currency.HBAR, "Hedera 1", 0, "44/3030");
+  // Hedera accounts use pre-configured addresses because account IDs cannot be derived from path
+  static readonly HEDERA_1 = new Account(
+    Currency.HBAR,
+    "Hedera 1",
+    0,
+    "44/3030",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    "0.0.10216539",
+  );
+  static readonly HEDERA_2 = new Account(
+    Currency.HBAR,
+    "Hedera 2",
+    1,
+    "44/3030",
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    "0.0.10219428",
+  );
 
   static readonly INJ_1 = new Account(Currency.INJ, "Injective 1", 0, "44'/60'/0'/0/0");
 

--- a/libs/ledger-live-common/src/e2e/families/hedera.ts
+++ b/libs/ledger-live-common/src/e2e/families/hedera.ts
@@ -1,10 +1,17 @@
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { pressUntilTextFound } from "../speculos";
+import { isTouchDevice } from "../speculosAppVersion";
 import { withDeviceController } from "../deviceInteraction/DeviceController";
+import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
 
 export const sendHedera = withDeviceController(({ getButtonsController }) => async () => {
   const buttons = getButtonsController();
 
-  await pressUntilTextFound(DeviceLabels.APPROVE);
-  await buttons.both();
+  if (isTouchDevice()) {
+    await pressUntilTextFound(DeviceLabels.HOLD_TO_SIGN);
+    await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
+  } else {
+    await pressUntilTextFound(DeviceLabels.CONFIRM);
+    await buttons.both();
+  }
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - changed generic getAddress logic to allow hardcoded addresses for Hedera
  - mobile e2e test for HBAR transfer
  - desktop e2e test for HBAR transfer

### 📝 Description

This PR adds end-to-end (e2e) test coverage for Hedera (HBAR) send transactions on both desktop and mobile. 
It also introduces pre-configured Hedera account addresses since account IDs cannot be derived from paths.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-24952


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
