### PR TITLE
feat: mood dialog

### DIFF
--- a/.changeset/stupid-parrots-leave.md
+++ b/.changeset/stupid-parrots-leave.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): mood index dialog

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/FearAndGreed.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/FearAndGreed.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor, act } from "tests/testSetup";
 import { FearAndGreedView } from "../components/FearAndGreed";
 import { GradientMoodIndicator } from "../components/FearAndGreed/GradientMoodIndicator";
 
@@ -29,6 +29,65 @@ describe("FearAndGreed", () => {
     };
     const { container } = render(<FearAndGreedView {...props} />);
     expect(container.firstChild).toBeNull();
+  });
+
+  describe("Dialog behavior", () => {
+    it("opens dialog when clicking on the tile", async () => {
+      const props = {
+        isLoading: false,
+        data: { value: 50, classification: "Neutral" },
+      };
+      const { user } = render(<FearAndGreedView {...props} />);
+
+      const moodTile = screen.getByTestId("fear-and-greed-card");
+      await user.click(moodTile);
+
+      expect(screen.getByTestId("mood-index-dialog-content")).toBeVisible();
+    });
+
+    it("closes dialog when clicking the close button", async () => {
+      const props = {
+        isLoading: false,
+        data: { value: 50, classification: "Neutral" },
+      };
+      const { user } = render(<FearAndGreedView {...props} />);
+
+      const moodTile = screen.getByTestId("fear-and-greed-card");
+      await user.click(moodTile);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("mood-index-dialog-content")).toBeVisible();
+      });
+
+      const closeButton = screen.getByRole("button", { name: /close/i });
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("mood-index-dialog-content")).not.toBeInTheDocument();
+      });
+    });
+
+    it("closes dialog when clicking the CTA button", async () => {
+      const props = {
+        isLoading: false,
+        data: { value: 50, classification: "Neutral" },
+      };
+      const { user } = render(<FearAndGreedView {...props} />);
+
+      const moodTile = screen.getByTestId("fear-and-greed-card");
+      await user.click(moodTile);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("mood-index-dialog-content")).toBeVisible();
+      });
+
+      const ctaButton = screen.getByTestId("mood-index-dialog-cta");
+      await user.click(ctaButton);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("mood-index-dialog-content")).not.toBeInTheDocument();
+      });
+    });
   });
 });
 
@@ -118,29 +177,6 @@ describe("GradientMoodIndicator", () => {
 
       // At value 50, angle is 90°, so x should be near center
       expect(cx).toBeCloseTo(21.5814, 1);
-    });
-  });
-
-  it("updates animation when value changes", async () => {
-    const { container, rerender } = render(<GradientMoodIndicator value={25} />);
-
-    act(() => {
-      jest.advanceTimersByTime(1200);
-    });
-
-    await waitFor(() => {
-      const text = container.querySelector("text");
-      expect(text?.textContent).toBe("25");
-    });
-
-    rerender(<GradientMoodIndicator value={75} />);
-
-    act(() => {
-      jest.advanceTimersByTime(1200);
-    });
-    await waitFor(() => {
-      const text = container.querySelector("text");
-      expect(text?.textContent).toBe("75");
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/FearAndGreedTile.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/FearAndGreedTile.tsx
@@ -7,6 +7,7 @@ import {
 import { Tile, TileContent, TileTitle } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
 import { GradientMoodIndicator } from "./GradientMoodIndicator";
+import { MoodIndexDialog } from "./MoodIndexDialog";
 
 const COLOR_CLASS_MAP: Record<string, string> = {
   error: "text-error",
@@ -23,16 +24,18 @@ export const FearAndGreedTile = ({ data }: { data: FearAndGreedIndex }) => {
   const textColorClass = COLOR_CLASS_MAP[colorKey] || "text-muted";
 
   return (
-    <Tile
-      appearance="card"
-      data-testid="fear-and-greed-card"
-      className="w-[98px] justify-center self-stretch"
-    >
-      <GradientMoodIndicator value={data.value} />
-      <TileContent>
-        <TileTitle>{t("marketBanner.fearAndGreed.title")}</TileTitle>
-      </TileContent>
-      <div className={`${textColorClass} body-2-semi-bold`}>{t(translationKey)}</div>
-    </Tile>
+    <MoodIndexDialog>
+      <Tile
+        appearance="card"
+        data-testid="fear-and-greed-card"
+        className="w-[98px] justify-center self-stretch"
+      >
+        <GradientMoodIndicator value={data.value} />
+        <TileContent>
+          <TileTitle>{t("marketBanner.fearAndGreed.title")}</TileTitle>
+        </TileContent>
+        <div className={`${textColorClass} body-2-semi-bold`}>{t(translationKey)}</div>
+      </Tile>
+    </MoodIndexDialog>
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/MoodIndexDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/MoodIndexDialog.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogHeader,
+  DialogFooter,
+  DialogContent,
+  DialogBody,
+  Button,
+} from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+
+export const MoodIndexDialog = ({ children }: { children: React.ReactNode }) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+
+      <DialogContent data-testid="mood-index-dialog-content">
+        <DialogHeader
+          appearance="extended"
+          title={t("fearAndGreed.dialog.title")}
+          onClose={() => setOpen(false)}
+        />
+        <DialogBody className="body-1 text-base">{t("fearAndGreed.dialog.content")}</DialogBody>
+        <DialogFooter className="justify-center">
+          <Button
+            className="w-full"
+            appearance="base"
+            size="lg"
+            onClick={() => setOpen(false)}
+            data-testid="mood-index-dialog-cta"
+          >
+            {t("fearAndGreed.dialog.cta")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7893,6 +7893,11 @@
       "neutral": "Neutral",
       "greed": "Greed",
       "extremeGreed": "Greed+"
+    },
+    "dialog": {
+      "title": "Mood index",
+      "content": "The mood index indicates the emotional state of the market. It ranges from 0 to 100, where a lower value indicates extreme fear, and a higher value indicates extreme greed.",
+      "cta": "Got it"
     }
   },
   "nftEntryPoint": {


### PR DESCRIPTION
Adds Fear and Greed index dialog


### ✅ Checklist
- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a new dialog feature to the Fear and Greed tile in the Market Banner, allowing users to view more information about the mood index when interacting with the tile. It also adds comprehensive tests for this dialog behavior and updates translations to support the new UI.

### ❓ Context
[LIVE-25095](https://ledgerhq.atlassian.net/browse/LIVE-25095)


### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25095]: https://ledgerhq.atlassian.net/browse/LIVE-25095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ