### PR TITLE
:bug: (mobile): prevent android crash on earn webview back navigation

### DIFF
--- a/.changeset/quiet-pumpkins-hang.md
+++ b/.changeset/quiet-pumpkins-hang.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Android crash when navigating back from Earn webview. The crash occurred when using hardware back button after navigating away from the webview screen and returning to another screen.


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Earn live app behavior after closing on Android
  - Hardware back button / back swipe navigation flow from Earn webview
  - Screen focus/blur lifecycle with webview refs

### 📝 Description

**Problem**: The app crashes on Android when users navigate back from the Earn webview using the hardware back button, navigate to another screen, and then press the hardware back button again.

**Root cause**: The `BackHandler` event listener remained active after the Earn webview screen lost focus. When the back button was pressed from a different screen, the stale listener attempted to access `webviewAPIRef.current` which no longer existed, causing a crash with the error "Ref objects doesn't have a current value".

**Solution**:
- Added ref existence checks (`if (!webviewAPIRef.current)`) before calling `safeGetRefValue()` to prevent accessing null refs
- Replaced `useEffect` with `useFocusEffect` for the Android `BackHandler` registration, ensuring the listener is automatically removed when the screen loses focus and re-attached when it regains focus
- Removed unused `navigation` dependency that was causing unnecessary re-registrations of the back handler

This ensures proper cleanup of event listeners tied to the component lifecycle and prevents crashes from stale references. 

I've made some global improvements for readability, too.

|before|after|
|---|---|
|<video src="https://github.com/user-attachments/assets/d698f975-4731-4d92-8bbf-85c5d1309236" />|<video src="https://github.com/user-attachments/assets/ff584334-086c-4bf9-ae7e-8c174daef9ce" />|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-25134](https://ledgerhq.atlassian.net/browse/LIVE-25134)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25134]: https://ledgerhq.atlassian.net/browse/LIVE-25134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ