### PR TITLE
fix(lwd): wrap RenderError in MemoryRouter in ThrowBlock

### DIFF
--- a/.changeset/famous-guests-lie.md
+++ b/.changeset/famous-guests-lie.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+wrap RenderError in MemoryRouter to fix useNavigate crash in error boundary

--- a/apps/ledger-live-desktop/src/renderer/components/ThrowBlock.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ThrowBlock.tsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from "react";
+import { MemoryRouter } from "react-router";
 import logger from "~/renderer/logger";
 import RenderError from "./RenderError";
 type Props = {
@@ -26,7 +27,14 @@ class ThrowBlock extends PureComponent<Props, State> {
   render() {
     const { error } = this.state;
     if (error) {
-      return <RenderError error={error} />;
+      // Wrap RenderError in MemoryRouter because RenderError uses TranslatedError
+      // which calls useNavigate() via useErrorLinks hook. ThrowBlock is positioned
+      // outside the main Router in App.tsx, so we need to provide a Router context.
+      return (
+        <MemoryRouter>
+          <RenderError error={error} />
+        </MemoryRouter>
+      );
     }
     return this.props.children;
   }


### PR DESCRIPTION
ThrowBlock is positioned outside the main Router in App.tsx. When it catches an error and renders RenderError, the TranslatedError component uses useErrorLinks hook which calls useNavigate(). This fails because there's no Router context available.

This fix wraps RenderError in MemoryRouter, matching the pattern already used in AppError.tsx for the same reason.

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

wrap RenderError in MemoryRouter in ThrowBlock

ThrowBlock is positioned outside the main Router in App.tsx. When it
catches an error and renders RenderError, the TranslatedError component
uses useErrorLinks hook which calls useNavigate(). This fails because
there's no Router context available.

This fix wraps RenderError in MemoryRouter, matching the pattern already
used in AppError.tsx for the same reason.



Component | Status
-- | --
ThrowBlock.tsx | ✅ Fixed (now has MemoryRouter)
AppError.tsx | ✅ Already has MemoryRouter
ReactRoot.tsx | ✅ OK - just renders String(error), no Router hooks
Unsafe (in RenderError.tsx) | ✅ OK - just returns null on error



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25153


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
