### PR TITLE
[LWM] :chart_with_upwards_trend: remove unwanted tracker

### DIFF
--- a/.changeset/rare-ravens-hear.md
+++ b/.changeset/rare-ravens-hear.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Remove unwanted tracker on the market banner

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerView/index.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useRef } from "react";
-import { FlatList, NativeSyntheticEvent, NativeScrollEvent } from "react-native";
+import React, { useCallback } from "react";
+import { FlatList } from "react-native";
 import {
   Subheader,
   SubheaderRow,
@@ -23,7 +23,6 @@ interface MarketBannerViewProps {
   onTilePress: (item: MarketItemPerformer) => void;
   onViewAllPress: () => void;
   onSectionTitlePress: () => void;
-  onSwipe: () => void;
   testID?: string;
 }
 
@@ -39,22 +38,9 @@ const MarketBannerView = ({
   onTilePress,
   onViewAllPress,
   onSectionTitlePress,
-  onSwipe,
   testID = "market-banner-container",
 }: MarketBannerViewProps) => {
   const { t } = useTranslation();
-  const hasTrackedSwipe = useRef(false);
-
-  const handleSwipe = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const { contentOffset } = event.nativeEvent;
-      if (contentOffset.x > 20 && !hasTrackedSwipe.current) {
-        hasTrackedSwipe.current = true;
-        onSwipe();
-      }
-    },
-    [onSwipe],
-  );
 
   const renderItem = useCallback(
     (props: { item: ListItem; index: number }) => (
@@ -90,8 +76,6 @@ const MarketBannerView = ({
           ListEmptyComponent={<SkeletonState />}
           horizontal
           showsHorizontalScrollIndicator={false}
-          onScroll={handleSwipe}
-          scrollEventThrottle={16}
           testID="market-banner-list"
           ListHeaderComponentStyle={{ marginRight: MARGIN_RIGHT }}
           contentContainerStyle={{ paddingHorizontal: PADDING_HORIZONTAL, height: HEIGHT }}

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
@@ -101,13 +101,6 @@ const useMarketBannerViewModel = (): UseMarketBannerViewModelResult => {
     navigateToMarket();
   }, [navigateToMarket]);
 
-  const onSwipe = useCallback(() => {
-    track("swipe", {
-      page: PAGE_NAME,
-      banner: BANNER_NAME,
-    });
-  }, []);
-
   return {
     items: filteredItems,
     isLoading,
@@ -117,7 +110,6 @@ const useMarketBannerViewModel = (): UseMarketBannerViewModelResult => {
     onTilePress,
     onViewAllPress,
     onSectionTitlePress,
-    onSwipe,
   };
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/index.tsx
@@ -4,16 +4,8 @@ import MarketBannerView from "./components/MarketBannerView";
 import { MarketBannerProps } from "./types";
 
 const MarketBanner = ({ testID }: MarketBannerProps) => {
-  const {
-    items,
-    isError,
-    isEnabled,
-    range,
-    onTilePress,
-    onViewAllPress,
-    onSectionTitlePress,
-    onSwipe,
-  } = useMarketBannerViewModel();
+  const { items, isError, isEnabled, range, onTilePress, onViewAllPress, onSectionTitlePress } =
+    useMarketBannerViewModel();
 
   if (!isEnabled) {
     return null;
@@ -27,7 +19,6 @@ const MarketBanner = ({ testID }: MarketBannerProps) => {
       onTilePress={onTilePress}
       onViewAllPress={onViewAllPress}
       onSectionTitlePress={onSectionTitlePress}
-      onSwipe={onSwipe}
       testID={testID}
     />
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/types.ts
@@ -29,5 +29,4 @@ export interface UseMarketBannerViewModelResult {
   onTilePress: (item: MarketItemPerformer) => void;
   onViewAllPress: () => void;
   onSectionTitlePress: () => void;
-  onSwipe: () => void;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - market banner not used analytics

### 📝 Description

Removal of a tracker on the market banner that wasn't working well. As the product team doesn't need it we can safely remove it

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25165](https://ledgerhq.atlassian.net/browse/LIVE-25165)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25165]: https://ledgerhq.atlassian.net/browse/LIVE-25165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ