### PR TITLE
feat: LIVE-24554 analytics

### DIFF
--- a/.changeset/orange-dolphins-cheer.md
+++ b/.changeset/orange-dolphins-cheer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): add tracking to market banner

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/FearAndGreedTile.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/FearAndGreed/FearAndGreedTile.tsx
@@ -8,6 +8,7 @@ import { Tile, TileContent, TileTitle } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
 import { GradientMoodIndicator } from "./GradientMoodIndicator";
 import { FearAndGreedDialog } from "./FearAndGreedDialog";
+import { track } from "~/renderer/analytics/segment";
 
 const COLOR_CLASS_MAP: Record<string, string> = {
   error: "text-error",
@@ -23,12 +24,19 @@ export const FearAndGreedTile = ({ data }: { data: FearAndGreedIndex }) => {
   const translationKey = getFearAndGreedTranslationKey(data.value);
   const textColorClass = COLOR_CLASS_MAP[colorKey] || "text-muted";
 
+  const onClick = () => {
+    track("button_clicked", {
+      button: "mood_index_definition",
+    });
+  };
+
   return (
     <FearAndGreedDialog>
       <Tile
         appearance="card"
         data-testid="fear-and-greed-card"
         className="w-[98px] justify-center self-stretch"
+        onClick={onClick}
       >
         <GradientMoodIndicator value={data.value} />
         <TileContent>

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
@@ -6,6 +6,8 @@ import { useNavigate } from "react-router";
 import { ViewAllTile } from "./ViewAllTile";
 import FearAndGreed from "./FearAndGreed";
 import { AssetIcon } from "./AssetIcon";
+import { track } from "~/renderer/analytics/segment";
+import { TRACKING_PAGE_NAME } from "../utils/constants";
 
 type TrendingAssetsListProps = {
   readonly items: MarketItemPerformer[];
@@ -16,6 +18,11 @@ export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
 
   const onAssetClick = useCallback(
     (id: string) => () => {
+      track("button_clicked", {
+        button: "Market Tile",
+        currency: id,
+        page: TRACKING_PAGE_NAME,
+      });
       navigate(`/market/${id}`);
     },
     [navigate],

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/index.tsx
@@ -6,6 +6,13 @@ import GenericError from "./components/GenericError";
 import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
 import { TrendingAssetsList } from "./components/TrendingAssetsList";
 import { MarketBannerHeader } from "./components/MarketBannerHeader";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import {
+  MARKET_BANNER_TOP,
+  MARKET_BANNER_DATA_SORT_ORDER,
+  TIME_RANGE,
+  TRACKING_PAGE_NAME,
+} from "./utils/constants";
 
 type MarketBannerViewProps = {
   readonly isLoading: boolean;
@@ -35,6 +42,12 @@ const MarketBannerView = memo(function MarketBannerView({
 
   return (
     <div className="flex flex-col gap-12">
+      <TrackPage
+        category={TRACKING_PAGE_NAME}
+        sort={MARKET_BANNER_DATA_SORT_ORDER}
+        timeframe={TIME_RANGE}
+        countervalue={MARKET_BANNER_TOP}
+      />
       <MarketBannerHeader onNavigate={goToMarket} />
       {content}
     </div>

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/utils/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/utils/constants.ts
@@ -8,3 +8,5 @@ export const MARKET_BANNER_REFRESH_RATE = 1000;
 export const MARKET_PERFORMERS_SUPPORTED = true;
 export const MARKET_BANNER_DATA_SORT_ORDER = Order.asc;
 export const TIME_RANGE = "day";
+
+export const TRACKING_PAGE_NAME = "Market Banner";


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces analytics tracking to the Market Banner feature in Ledger Live Desktop. The main focus is on capturing user interactions with key UI elements, such as the Fear and Greed index tile and trending asset tiles, and tracking page views for the Market Banner. Additionally, a new constant is introduced for consistent tracking of the page name.


### ❓ Context

[LIVE-24554](https://ledgerhq.atlassian.net/browse/LIVE-24554)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24554]: https://ledgerhq.atlassian.net/browse/LIVE-24554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ