### PR TITLE
fix(live-common): Close apps before onboarding

### DIFF
--- a/.changeset/tasty-mails-repeat.md
+++ b/.changeset/tasty-mails-repeat.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Close apps before onboarding


### PR DESCRIPTION
## Fix race condition in `getOnboardingStatePolling` when an app is open

When a Ledger app was open before onboarding polling started, `quitApp` and `getVersion` were executing simultaneously, causing an `INS_NOT_SUPPORTED (0x6d00)` error. `from(getVersion(...))` was creating a Promise that started executing immediately, racing with `quitApp`. 

### Changes:
- Wrapped `getVersion` call with `defer()` to lazily create the observable, ensuring it only executes when subscribed (after `quitApp` completes)
- Moved `hasQuitAppAlreadyRun = true` inside a `tap()` so the flag is set only after `quitApp` succeeds
- Added a 300ms delay after `quitApp` to let the device settle before calling `getVersion`

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1003](https://ledgerhq.atlassian.net/browse/DSDK-1003)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[DSDK-1003]: https://ledgerhq.atlassian.net/browse/DSDK-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ