### PR TITLE
fix: use tldts for subdomain-agnostic domain matching [LIVE-25164]

### DIFF
--- a/.changeset/mean-cherries-flash.md
+++ b/.changeset/mean-cherries-flash.md
@@ -1,0 +1,15 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix: use tldts for subdomain-agnostic domain matching
+
+- Use tldts library's getDomain function
+- Implement subdomain matching in isSameDomain (app.example.com now matches api.example.com)
+- Optimize URL parsing with shared parseUrl helper to create single URL object
+- Remove unused getDomain and getProtocol helper functions
+- Add test coverage for:
+  - Complex TLDs (.co.uk, etc.)
+  - Localhost and IP address edge cases
+  - Multiple subdomain levels
+  - Base domain to subdomain matching

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -267,6 +267,7 @@
     "rlp": "^3.0.0",
     "rxjs": "catalog:",
     "semver": "catalog:",
+    "tldts": "7.0.19",
     "triple-beam": "^1.3.0",
     "tsx": "^4.7.1",
     "usehooks-ts": "^2.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6317,6 +6317,9 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.7.3
+      tldts:
+        specifier: 7.0.19
+        version: 7.0.19
       triple-beam:
         specifier: ^1.3.0
         version: 1.4.1
@@ -34576,8 +34579,15 @@ packages:
   tldts-core@6.1.75:
     resolution: {integrity: sha512-AOvV5YYIAFFBfransBzSTyztkc3IMfz5Eq3YluaRiEu55nn43Fzaufx70UqEKYr8BoLCach4q8g/bg6e5+/aFw==}
 
+  tldts-core@7.0.19:
+    resolution: {integrity: sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==}
+
   tldts@6.1.75:
     resolution: {integrity: sha512-+lFzEXhpl7JXgWYaXcB6DqTYXbUArvrWAE/5ioq/X3CdWLbDjpPP4XTrQBmEJ91y3xbe4Fkw7Lxv4P3GWeJaNg==}
+    hasBin: true
+
+  tldts@7.0.19:
+    resolution: {integrity: sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==}
     hasBin: true
 
   tmp-promise@3.0.3:
@@ -72069,9 +72079,15 @@ snapshots:
 
   tldts-core@6.1.75: {}
 
+  tldts-core@7.0.19: {}
+
   tldts@6.1.75:
     dependencies:
       tldts-core: 6.1.75
+
+  tldts@7.0.19:
+    dependencies:
+      tldts-core: 7.0.19
 
   tmp-promise@3.0.3:
     dependencies:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Buy/sell and earn domain check logic

### 📝 Description

- Use tldts library's getDomain function
- Implement subdomain matching in isSameDomain (app.example.com now matches api.example.com)
- Optimize URL parsing with shared parseUrl helper to create single URL object
- Remove unused getDomain and getProtocol helper functions
- Add test coverage for:
  - Complex TLDs (.co.uk, etc.)
  - Localhost and IP address edge cases
  - Multiple subdomain levels
  - Base domain to subdomain matching

https://github.com/user-attachments/assets/167200ee-f339-499b-b739-fbc896144278

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25164]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25164]: https://ledgerhq.atlassian.net/browse/LIVE-25164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ