### PR TITLE
chore(desktop): introduce userData file cleanup mecanism at boot and cleanup unwanted app.json.* left over files

### DIFF
--- a/.changeset/famous-cooks-repair.md
+++ b/.changeset/famous-cooks-repair.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"ledger-live-desktop-e2e-tests": minor
+---
+
+introduce userData file cleanup mecanism at boot and cleanup unwanted app.json.\* left over files.

--- a/apps/ledger-live-desktop/src/main/cleanupUserData.test.ts
+++ b/apps/ledger-live-desktop/src/main/cleanupUserData.test.ts
@@ -1,0 +1,159 @@
+import * as path from "path";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { Dirent } from "fs";
+import type * as fsPromises from "node:fs/promises";
+import type { log as logType } from "@ledgerhq/logs";
+
+jest.mock("fs/promises", () => ({
+  readdir: jest.fn(),
+  unlink: jest.fn(),
+}));
+jest.mock("@ledgerhq/logs", () => ({
+  log: jest.fn(),
+}));
+
+let readdirMock: jest.MockedFunction<typeof fsPromises.readdir>;
+let unlinkMock: jest.MockedFunction<typeof fsPromises.unlink>;
+let UserDataCleanup: typeof import("./cleanupUserData").UserDataCleanup;
+let logMock: jest.MockedFunction<typeof logType>;
+
+class FakeDirent implements Dirent {
+  constructor(
+    public name: string,
+    private readonly file: boolean,
+  ) {}
+
+  public path = "";
+  public parentPath = "";
+
+  isFile() {
+    return this.file;
+  }
+
+  isDirectory() {
+    return !this.file;
+  }
+
+  isBlockDevice() {
+    return false;
+  }
+
+  isCharacterDevice() {
+    return false;
+  }
+
+  isFIFO() {
+    return false;
+  }
+
+  isSocket() {
+    return false;
+  }
+
+  isSymbolicLink() {
+    return false;
+  }
+}
+
+const fileEntry = (name: string) => new FakeDirent(name, true);
+
+const directoryEntry = (name: string) => new FakeDirent(name, false);
+
+describe("UserDataCleanup", () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    const fsPromisesMock = jest.requireMock("fs/promises") as {
+      readdir: jest.MockedFunction<typeof fsPromises.readdir>;
+      unlink: jest.MockedFunction<typeof fsPromises.unlink>;
+    };
+    readdirMock = fsPromisesMock.readdir;
+    unlinkMock = fsPromisesMock.unlink;
+    const logsMock = jest.requireMock("@ledgerhq/logs") as {
+      log: jest.MockedFunction<typeof logType>;
+    };
+    logMock = logsMock.log;
+    readdirMock.mockReset();
+    unlinkMock.mockReset();
+    logMock.mockReset();
+    UserDataCleanup = (await import("./cleanupUserData")).UserDataCleanup;
+  });
+
+  it("removes stale app.json.* files by default", async () => {
+    readdirMock.mockResolvedValue([
+      fileEntry("app.json.1"),
+      fileEntry("app.json"),
+      directoryEntry("nested"),
+      fileEntry("other.txt"),
+    ]);
+    unlinkMock.mockResolvedValue(undefined);
+
+    const cleanup = new UserDataCleanup("/tmp/userdata", {
+      patterns: [/^app\.json\..+$/],
+    });
+    await cleanup.cleanup();
+
+    expect(unlinkMock).toHaveBeenCalledTimes(1);
+    expect(unlinkMock).toHaveBeenCalledWith(path.join("/tmp/userdata", "app.json.1"));
+  });
+
+  it("supports custom regex patterns", async () => {
+    readdirMock.mockResolvedValue([fileEntry("keep.json"), fileEntry("extra.tmp")]);
+    unlinkMock.mockResolvedValue(undefined);
+
+    const cleanup = new UserDataCleanup("/data", { patterns: [/\.tmp$/] });
+    await cleanup.cleanup();
+
+    expect(unlinkMock).toHaveBeenCalledTimes(1);
+    expect(unlinkMock).toHaveBeenCalledWith(path.join("/data", "extra.tmp"));
+  });
+
+  it("does nothing when no files match", async () => {
+    readdirMock.mockResolvedValue([fileEntry("app.json"), fileEntry("keep.json")]);
+
+    const cleanup = new UserDataCleanup("/tmp/userdata", {
+      patterns: [/^app\.json\..+$/],
+    });
+    await cleanup.cleanup();
+
+    expect(unlinkMock).not.toHaveBeenCalled();
+    expect(logMock).not.toHaveBeenCalled();
+  });
+
+  it("logs failures when cleanup fails", async () => {
+    readdirMock.mockResolvedValue([fileEntry("app.json.1"), fileEntry("app.json.2")]);
+    unlinkMock.mockRejectedValueOnce(new Error("nope"));
+    unlinkMock.mockResolvedValueOnce(undefined);
+
+    const cleanup = new UserDataCleanup("/tmp/userdata", {
+      patterns: [/^app\.json\..+$/],
+    });
+    await cleanup.cleanup();
+
+    expect(logMock).toHaveBeenCalledWith("user-data", "cleanup failed for 1 file(s)");
+  });
+
+  it("silently handles ENOENT error when directory does not exist", async () => {
+    const enoentError = new Error("Directory not found") as NodeJS.ErrnoException;
+    enoentError.code = "ENOENT";
+    readdirMock.mockRejectedValue(enoentError);
+
+    const cleanup = new UserDataCleanup("/tmp/userdata", {
+      patterns: [/^app\.json\..+$/],
+    });
+    await cleanup.cleanup();
+
+    expect(logMock).not.toHaveBeenCalled();
+  });
+
+  it("logs error when readdir fails with non-ENOENT error", async () => {
+    const otherError = new Error("Permission denied");
+    readdirMock.mockRejectedValue(otherError);
+
+    const cleanup = new UserDataCleanup("/tmp/userdata", {
+      patterns: [/^app\.json\..+$/],
+    });
+    await cleanup.cleanup();
+
+    expect(logMock).toHaveBeenCalledWith("user-data", `cleanup failed: ${String(otherError)}`);
+  });
+});

--- a/apps/ledger-live-desktop/src/main/cleanupUserData.ts
+++ b/apps/ledger-live-desktop/src/main/cleanupUserData.ts
@@ -1,0 +1,50 @@
+import { log } from "@ledgerhq/logs";
+import * as fsPromises from "node:fs/promises";
+import * as path from "node:path";
+
+const isErrnoException = (error: unknown): error is NodeJS.ErrnoException =>
+  typeof error === "object" && error !== null && "code" in error;
+
+export type UserDataCleanupOptions = {
+  readonly patterns: RegExp[];
+};
+
+export class UserDataCleanup {
+  private readonly patterns: RegExp[];
+
+  constructor(
+    private readonly userDataPath: string,
+    options: UserDataCleanupOptions,
+  ) {
+    this.patterns = options.patterns;
+  }
+
+  private shouldCleanup(fileName: string) {
+    return this.patterns.some(matcher => matcher.test(fileName));
+  }
+
+  async cleanup(): Promise<void> {
+    try {
+      const entries = await fsPromises.readdir(this.userDataPath, { withFileTypes: true });
+      const staleFiles: string[] = [];
+      for (const entry of entries) {
+        if (entry.isFile() && this.shouldCleanup(entry.name)) {
+          staleFiles.push(path.join(this.userDataPath, entry.name));
+        }
+      }
+
+      if (!staleFiles.length) return;
+
+      const results = await Promise.allSettled(
+        staleFiles.map(filePath => fsPromises.unlink(filePath)),
+      );
+      const failures = results.filter(result => result.status === "rejected");
+      if (failures.length) {
+        log("user-data", `cleanup failed for ${failures.length} file(s)`);
+      }
+    } catch (error) {
+      if (isErrnoException(error) && error.code === "ENOENT") return;
+      log("user-data", `cleanup failed: ${String(error)}`);
+    }
+  }
+}

--- a/apps/ledger-live-desktop/src/main/index.ts
+++ b/apps/ledger-live-desktop/src/main/index.ts
@@ -23,6 +23,7 @@ import {
   loadWindow,
 } from "./window-lifecycle";
 import db from "./db";
+import { UserDataCleanup } from "./cleanupUserData";
 import debounce from "lodash/debounce";
 import sentry, { setTags } from "~/sentry/main";
 import type { SettingsState } from "~/renderer/reducers/settings";
@@ -105,6 +106,10 @@ app.on("ready", async () => {
   console.timeEnd("T-window");
 
   // Initialize database
+  const userDataCleanup = new UserDataCleanup(userDataDirectory, {
+    patterns: [/^app\.json\..+$/],
+  });
+  await userDataCleanup.cleanup();
   db.init(userDataDirectory);
 
   // Defer extension installation to not block startup

--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -23,6 +23,7 @@ type TestFixtures = {
   theme: "light" | "dark" | "no-preference" | undefined;
   speculosApp: AppInfos;
   userdata?: string;
+  extraUserdataFiles?: Record<string, string>;
   settings: Record<string, unknown>;
   userdataDestinationPath: string;
   userdataOriginalFile?: string;
@@ -62,6 +63,7 @@ export const test = base.extend<TestFixtures>({
   speculosApp: undefined,
   cliCommands: [],
   cliCommandsOnApp: [],
+  extraUserdataFiles: undefined,
 
   app: async ({ page, electronApp }, use) => {
     const app = new Application(page, electronApp);
@@ -92,6 +94,7 @@ export const test = base.extend<TestFixtures>({
       speculosApp,
       cliCommands,
       cliCommandsOnApp,
+      extraUserdataFiles,
     },
     use,
     testInfo,
@@ -105,6 +108,13 @@ export const test = base.extend<TestFixtures>({
 
     const userData = merge({ data: { settings } }, fileUserData);
     await writeFile(`${userdataDestinationPath}/app.json`, JSON.stringify(userData));
+    if (extraUserdataFiles) {
+      await Promise.all(
+        Object.entries(extraUserdataFiles).map(([name, contents]) =>
+          writeFile(path.join(userdataDestinationPath, name), contents),
+        ),
+      );
+    }
 
     let speculos: SpeculosDevice | undefined;
 

--- a/e2e/desktop/tests/specs/app.spec.ts
+++ b/e2e/desktop/tests/specs/app.spec.ts
@@ -1,0 +1,25 @@
+import { access } from "fs/promises";
+import * as path from "path";
+import { expect } from "@playwright/test";
+import test from "../fixtures/common";
+
+// These tests the general Ledger Waller app behavior
+
+test.use({
+  extraUserdataFiles: {
+    "app.json.123": "stale",
+  },
+});
+
+test(
+  "cleanup removes stale app.json.* files on boot",
+  {
+    tag: ["@NanoSP", "@NanoX", "@LNS"],
+  },
+  async ({ page, userdataDestinationPath }) => {
+    await page.title();
+
+    const staleFilePath = path.join(userdataDestinationPath, "app.json.123");
+    await expect(access(staleFilePath)).rejects.toThrow();
+  },
+);


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
  - unit tests
  - also e2e test https://github.com/LedgerHQ/ledger-live/actions/runs/21249772887/job/61148031020
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - desktop app
  - deletion of unwanted app.json.* files in user data folder

### 📝 Description

We add a pre‑DB startup cleanup that deletes stray `app.json.*` files left by interrupted write-file-atomic saves.

Also added unit/e2e coverage to ensure those leftovers are removed before app data is read.

### ❓ Context

- **JIRA or GitHub link**: LIVE-25196


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
