### PR TITLE
fix(mobile): fix touch events on newly added portfolio items

### DIFF
--- a/.changeset/plenty-tips-rest.md
+++ b/.changeset/plenty-tips-rest.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix touch events not working on newly added assets/accounts

--- a/apps/ledger-live-mobile/scripts/install-and-run-apk.sh
+++ b/apps/ledger-live-mobile/scripts/install-and-run-apk.sh
@@ -33,8 +33,14 @@ fi
 
 echo "Installing $APK"
 
-$ADB install -r $APK
+APP_ID=`"$APKANALYZER" manifest application-id "$APK"`
 
-APP_ID=`$APKANALYZER manifest application-id $APK`
+# Try to install with -r (replace) flag
+if ! "$ADB" install -r "$APK" 2>&1; then
+  echo "Installation failed, likely due to signature mismatch. Uninstalling existing app..."
+  "$ADB" uninstall "$APP_ID" || true
+  echo "Retrying installation..."
+  "$ADB" install "$APK"
+fi
 
-$ADB shell monkey -p $APP_ID 1 &> /dev/null
+"$ADB" shell monkey -p "$APP_ID" 1 &> /dev/null


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This is a workaround for a React Native Fabric bug that only manifests in release builds. Automated testing would require a release build environment which is not part of standard test suite._
- [x] **Impact of the changes:**
  - Portfolio tab: Adding accounts and switching between Assets/Accounts tabs
  - Touch responsiveness on all asset/account items after adding new ones
  - Test on both Android and iOS staging builds
  - Verify no visible UI glitches during normal usage

### 📝 Description

**Problem**: When assets or accounts are added while their Portfolio tab is hidden (e.g., adding accounts while on Assets tab), touch events don't work on the newly added items in staging/release builds. Users must manually switch tabs back and forth to make the items responsive.

**Root Cause**: React Native Fabric's hit testing system (TouchTargetHelper) caches view hierarchy and bounds. When items are added to a hidden tab, Fabric doesn't properly invalidate its layout measurement cache, causing touch events to not register on new items.

**Attempted unsuccesful fixes**:

- Classic remount `key` logic
- Cascadic remount `key` logic w/ FlashList `keyExtractor` updates to remount items
- Calling `view.requestLayout()` on native side
- Forcing synchronous layout with `view.measure() + view.layout()`
- Double `view.post()` to ensure layout completion
- Recursive layout forcing on entire view tree 
- React key changes with suppressed animations

None was able to invalidate the layout cache handled on the native side.

**Solution**: Implemented a workaround that briefly adjusts the container height by 1px after tab animations complete. This imperceptible change triggers a layout pass that forces Fabric to recalculate hit test bounds, making all items touchable.

**Reproduction Steps** (staging/release only):
1. Clear all accounts
2. Add first account (e.g. Bitcoin)
3. Stay on Assets tab
4. Switch to Accounts tab
5. Add new account (different asset, e.g. Ethereum)
6. Switch back to Assets tab
7. Try tapping the second asset item → BUG: nothing happens without the fix

**Technical Details**: 
- Added comprehensive documentation explaining the issue, attempted fixes, and the working solution
- Includes references to upstream React Native issues that should eventually fix this
- The fix is Android-specific in implementation but works on both platforms
- Also fixed the Android staging build script to handle signature mismatches automatically

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25195](https://ledgerhq.atlassian.net/browse/LIVE-25195)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25195]: https://ledgerhq.atlassian.net/browse/LIVE-25195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ