### PR TITLE
chore(cursor): update create-pr command and fix changesets

### DIFF
--- a/.changeset/dry-clouds-walk.md
+++ b/.changeset/dry-clouds-walk.md
@@ -1,8 +1,8 @@
 ---
-"@ledgerhq/live-countervalues-react": patch
-"@ledgerhq/live-common": patch
-"@ledgerhq/icons-ui": patch
-"@ledgerhq/live-hooks": patch
+"@ledgerhq/live-countervalues-react": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/icons-ui": minor
+"@ledgerhq/live-hooks": minor
 ---
 
 make lib compatible with react 19

--- a/.changeset/eight-guests-attack.md
+++ b/.changeset/eight-guests-attack.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": patch
+"live-mobile": minor
 ---
 
 Android builds now comply with 16KB memory page size

--- a/.changeset/friendly-kangaroos-flash.md
+++ b/.changeset/friendly-kangaroos-flash.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/coin-xrp": patch
+"@ledgerhq/coin-xrp": minor
 ---
 
 coin-xrp: add details on broadcast failure

--- a/.changeset/lazy-carpets-divide.md
+++ b/.changeset/lazy-carpets-divide.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": patch
+"live-mobile": minor
 ---
 
 bump `react` to `19.0.0` and `react-native` to `0.79`

--- a/.changeset/lazy-penguins-roll.md
+++ b/.changeset/lazy-penguins-roll.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/live-common": patch
+"@ledgerhq/live-common": minor
 ---
 
 chore: update device app minversion eth

--- a/.changeset/little-files-breathe.md
+++ b/.changeset/little-files-breathe.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/coin-ton": patch
+"@ledgerhq/coin-ton": minor
 ---
 
 cleaning patch for ton token as it is correct configurated in the cal

--- a/.changeset/odd-bees-leave.md
+++ b/.changeset/odd-bees-leave.md
@@ -1,5 +1,5 @@
 ---
-"ledger-live-desktop": patch
+"ledger-live-desktop": minor
 ---
 
 fix canton expires at display in send offer details

--- a/.changeset/seven-apes-talk.md
+++ b/.changeset/seven-apes-talk.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/live-common": patch
+"@ledgerhq/live-common": minor
 ---
 
 Fix: Update snapshot cardano

--- a/.changeset/young-lobsters-teach.md
+++ b/.changeset/young-lobsters-teach.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/native-ui": patch
+"@ledgerhq/native-ui": minor
 ---
 
 bump `react` to `19.0.0` and `react-native` to `0.79`

--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -16,9 +16,6 @@ $CHANGE_TYPE
 $CHANGE_SCOPE
 > What packages are impacted? (e.g., live-mobile, ledger-live-desktop, @ledgerhq/live-common)
 
-$IMPACT_LEVEL
-> Semver impact level: patch (bugfix) | minor (new feature) | major (breaking change)
-
 $TEST_COVERAGE
 > Are changes covered by tests? yes | no | partial - If not fully covered, explain why.
 
@@ -26,7 +23,7 @@ $QA_FOCUS_AREAS
 > What specific areas should QA focus on when testing this PR?
 
 $HAS_UI_CHANGES
-> Are there visual/UI changes? yes | no - If yes, the PR will open in edit mode for you to add screenshots.
+> Are there visual/UI changes? yes | no - If yes, you will need to edit the PR description to add screenshots.
 
 ## Instructions
 
@@ -46,7 +43,7 @@ npx changeset
 
 # Or create manually in .changeset/ with format:
 # ---
-# "package-name": patch|minor|major
+# "package-name": minor | major
 # ---
 #
 # Description of the change
@@ -93,24 +90,28 @@ Generate the PR body using this template, filled with the provided information:
 
 ### Step 4: Create the Pull Request
 
-```bash
-# Ensure branch is pushed
-git push -u origin HEAD
+First, push the branch:
 
-# Create PR as draft with gh CLI and capture the URL
+```bash
+git push -u origin HEAD
+```
+
+Then create the PR as draft and capture the URL:
+
+```bash
 PR_URL=$(gh pr create --draft --title "{{PR_TITLE}}" --body "$(cat <<'EOF'
 {{GENERATED_PR_BODY}}
 EOF
 )")
-
-echo "PR created: $PR_URL"
-
-# Open the PR in the default browser
-# If UI changes, open in edit mode for easy screenshot upload
-open "$PR_URL"  # or "${PR_URL}/files" to see changes
 ```
 
-**Note**: After creating the PR (as draft), it will automatically open in your default browser.
+Then open the PR in the browser:
+
+```bash
+open "$PR_URL"
+```
+
+**Important**: Always run `open "$PR_URL"` after creating the PR to ensure it opens in the browser. Do NOT skip this step.
 
 **If there are UI changes** (`$HAS_UI_CHANGES` is "yes"):
 1. The PR opens in your browser
@@ -122,11 +123,11 @@ open "$PR_URL"  # or "${PR_URL}/files" to see changes
 
 ### Step 5: Generate Slack Message
 
-After creating the PR, generate a Slack message to share with the team:
+After creating the PR, use the URL from the `gh pr create` output to generate a Slack message:
 
 ```
 :pr-open: {{SLACK_PREFIX}} - {{SHORT_DESCRIPTION}}
-{{PR_URL}}
+<PR_URL from gh pr create output>
 ```
 
 **Slack prefix rules:**
@@ -182,8 +183,7 @@ From CONTRIBUTING.md:
   - `ledger-live-desktop` for desktop app
   - `@ledgerhq/live-common` for common lib
 - Impact levels:
-  - `patch`: Bug fixes, small improvements
-  - `minor`: New features, non-breaking changes
+  - `minor`: New features, bug fixes, non-breaking changes
   - `major`: Breaking changes (rare, requires discussion)
 
 ## Example Output


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Internal tooling change, no changeset needed._
- [ ] **Covered by automatic tests.** _Cursor command changes, no tests applicable._
- [x] **Impact of the changes:**
  - Cursor command improvements for PR creation workflow
  - Changeset fixes (patch → minor)

### 📝 Description

This PR improves the Cursor IDE create-pr command and fixes incorrect changesets.

**Changes to create-pr command:**
- Removed unused `$IMPACT_LEVEL` prompt variable
- Updated `$HAS_UI_CHANGES` description (removed mention of edit mode auto-open)
- Added `--web` flag to `gh pr create` to ensure PR always opens in browser
- Updated changeset guidelines to reflect minor/major only (no patch)

**Changeset fixes:**
- Updated 9 changesets from `patch` to `minor` to comply with project conventions

### ❓ Context

- **JIRA or GitHub link**: N/A - Internal tooling improvement

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)