### PR TITLE
[LWD] fix(desktop): sync starred filter with starredMarketCoins in Market list

### DIFF
--- a/.changeset/late-items-repair.md
+++ b/.changeset/late-items-repair.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+sync starred filter with starredMarketCoins in Market list

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarket.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useMarket.test.ts
@@ -1,0 +1,156 @@
+import { act, renderHook, waitFor } from "tests/testSetup";
+import { Order } from "@ledgerhq/live-common/market/utils/types";
+import { useMarket } from "../useMarket";
+import { addStarredMarketCoins } from "~/renderer/actions/settings";
+import { INITIAL_STATE as SETTINGS_INITIAL_STATE } from "~/renderer/reducers/settings";
+
+jest.mock("@ledgerhq/live-common/market/hooks/useMarketDataProvider", () => ({
+  useMarketDataProvider: () => ({
+    supportedCounterCurrencies: ["usd", "eur"],
+  }),
+  useMarketData: () => ({
+    data: [],
+    isLoading: false,
+    cachedMetadataMap: new Map(),
+  }),
+}));
+
+jest.mock("~/renderer/hooks/useInitSupportedCounterValues", () => ({
+  useInitSupportedCounterValues: jest.fn(),
+}));
+
+const createMarketState = (starred: string[] = []) => ({
+  marketParams: {
+    starred,
+    range: "24h",
+    limit: 50,
+    order: Order.MarketCapDesc,
+    search: "",
+    liveCompatible: false,
+    page: 1,
+    counterCurrency: "USD",
+  },
+  currentPage: 1,
+});
+
+const createSettingsState = (starredMarketCoins: string[]) => ({
+  ...SETTINGS_INITIAL_STATE,
+  starredMarketCoins,
+  overriddenFeatureFlags: {
+    lldRefreshMarketData: { enabled: false },
+  },
+});
+
+describe("useMarket", () => {
+  describe("starred filter", () => {
+    it("uses starredMarketCoins when filter is active", () => {
+      const initialState = {
+        settings: createSettingsState(["bitcoin", "ethereum"]),
+        market: createMarketState(["bitcoin", "ethereum"]),
+      };
+
+      const { result } = renderHook(() => useMarket(), {
+        initialState,
+      });
+
+      expect(result.current.starFilterOn).toBe(true);
+      expect(result.current.starredMarketCoins).toEqual(["bitcoin", "ethereum"]);
+    });
+
+    it("starFilterOn is false when marketParams.starred is empty", () => {
+      const initialState = {
+        settings: createSettingsState(["bitcoin"]),
+        market: createMarketState([]),
+      };
+
+      const { result } = renderHook(() => useMarket(), {
+        initialState,
+      });
+
+      expect(result.current.starFilterOn).toBe(false);
+    });
+
+    it("updates starredMarketCoins when a coin is added", async () => {
+      const initialState = {
+        settings: createSettingsState(["bitcoin"]),
+        market: createMarketState(["bitcoin"]),
+      };
+
+      const { result, store } = renderHook(() => useMarket(), {
+        initialState,
+      });
+
+      expect(result.current.starredMarketCoins).toEqual(["bitcoin"]);
+
+      await act(async () => {
+        store.dispatch(addStarredMarketCoins("ethereum"));
+      });
+
+      await waitFor(() => {
+        expect(result.current.starredMarketCoins).toContain("ethereum");
+      });
+
+      expect(result.current.starredMarketCoins).toEqual(["bitcoin", "ethereum"]);
+    });
+
+    it("toggles starred filter on and off correctly", async () => {
+      const initialState = {
+        settings: createSettingsState(["bitcoin", "ethereum"]),
+        market: createMarketState([]),
+      };
+
+      const { result } = renderHook(() => useMarket(), {
+        initialState,
+      });
+
+      expect(result.current.starFilterOn).toBe(false);
+
+      await act(async () => {
+        result.current.toggleFilterByStarredAccounts();
+      });
+
+      await waitFor(() => {
+        expect(result.current.starFilterOn).toBe(true);
+      });
+
+      expect(result.current.marketParams.starred).toEqual(["bitcoin", "ethereum"]);
+
+      await act(async () => {
+        result.current.toggleFilterByStarredAccounts();
+      });
+
+      await waitFor(() => {
+        expect(result.current.starFilterOn).toBe(false);
+      });
+
+      expect(result.current.marketParams.starred).toEqual([]);
+    });
+
+    it("toggleStar adds and removes coins from starredMarketCoins", async () => {
+      const initialState = {
+        settings: createSettingsState(["bitcoin"]),
+        market: createMarketState([]),
+      };
+
+      const { result } = renderHook(() => useMarket(), {
+        initialState,
+      });
+
+      await act(async () => {
+        result.current.toggleStar("ethereum", false);
+      });
+
+      await waitFor(() => {
+        expect(result.current.starredMarketCoins).toContain("ethereum");
+      });
+
+      await act(async () => {
+        result.current.toggleStar("ethereum", true);
+      });
+
+      await waitFor(() => {
+        expect(result.current.starredMarketCoins).not.toContain("ethereum");
+      });
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarket.ts
@@ -48,6 +48,7 @@ export function useMarket() {
 
   const marketResult = useMarketDataHook({
     ...marketParams,
+    starred: starFilterOn ? starredMarketCoins : starred,
     liveCompatible: shouldDisplayLiveCompatible,
   });
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
sync starred filter with starredMarketCoins in Market list

When the starred filter is active and a user stars/unstars an asset from
another page (e.g., MarketCoin page), the filtered list now updates
automatically.


https://github.com/user-attachments/assets/5b4ec6c5-f2a9-4bce-8747-af8a768f55fb




### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25221


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
