### PR TITLE
fix(desktop): DesyncOverlay test flakiness

### DIFF
--- a/.changeset/fix-desync-overlay-test.md
+++ b/.changeset/fix-desync-overlay-test.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix DesyncOverlay test flakiness by using Jest fake timers

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__tests__/DesyncOverlay.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__tests__/DesyncOverlay.test.tsx
@@ -1,25 +1,35 @@
 import React from "react";
-import { render, screen, waitFor } from "tests/testSetup";
+import { render, screen, act } from "tests/testSetup";
 import { DesyncOverlay } from "../components/DesyncOverlay";
 
 describe("DesyncOverlay", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("should show desync overlay", async () => {
     render(<DesyncOverlay isOpen productName="stax" />);
 
-    await waitFor(() => expect(screen.getByTestId("onboarding-desync-overlay")).toBeVisible(), {
-      timeout: 1000,
+    await act(async () => {
+      jest.runOnlyPendingTimers();
     });
+
+    expect(screen.getByTestId("onboarding-desync-overlay")).toBeVisible();
   });
 
-  it("should wait for delay before displaying desync overly", async () => {
+  it("should wait for delay before displaying desync overlay", async () => {
     render(<DesyncOverlay isOpen productName="stax" delay={1000} />);
 
-    const overlay = screen.queryByTestId("onboarding-desync-overlay");
+    expect(screen.queryByTestId("onboarding-desync-overlay")).toBeNull();
 
-    expect(overlay).toBeNull();
-
-    await waitFor(() => expect(screen.queryByTestId("onboarding-desync-overlay")).toBeVisible(), {
-      timeout: 2000,
+    await act(async () => {
+      jest.runOnlyPendingTimers();
     });
+
+    expect(screen.getByTestId("onboarding-desync-overlay")).toBeVisible();
   });
 });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - DesyncOverlay test reliability
  - No production code changes

### 📝 Description

**Problem**: The DesyncOverlay tests were flaky and failing intermittently due to reliance on real timers. The test was using `waitFor` with timeouts, which can be unreliable in test environments.

**Solution**: Replaced real timer waits with Jest fake timers (`jest.useFakeTimers()` and `jest.advanceTimersByTime()`) to ensure deterministic test behavior. This approach:
- Eliminates timing-related flakiness
- Makes tests faster and more reliable
- Properly controls the component's `setTimeout` behavior

### ❓ Context

- **JIRA or GitHub link**: N/A - Test fix

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)