### PR TITLE
[LWD] test(desktop): use fake timers in DesyncOverlay tests

### DIFF
--- a/.changeset/test-desync-overlay-timers.md
+++ b/.changeset/test-desync-overlay-timers.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+test: use fake timers in DesyncOverlay tests

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__tests__/DesyncOverlay.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__tests__/DesyncOverlay.test.tsx
@@ -1,25 +1,35 @@
 import React from "react";
-import { render, screen, waitFor } from "tests/testSetup";
+import { render, screen, act } from "tests/testSetup";
 import { DesyncOverlay } from "../components/DesyncOverlay";
 
 describe("DesyncOverlay", () => {
-  it("should show desync overlay", async () => {
-    render(<DesyncOverlay isOpen productName="stax" />);
-
-    await waitFor(() => expect(screen.getByTestId("onboarding-desync-overlay")).toBeVisible(), {
-      timeout: 1000,
-    });
+  beforeEach(() => {
+    jest.useFakeTimers();
   });
 
-  it("should wait for delay before displaying desync overly", async () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should show desync overlay", () => {
+    render(<DesyncOverlay isOpen productName="stax" />);
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(screen.getByTestId("onboarding-desync-overlay")).toBeInTheDocument();
+  });
+
+  it("should wait for delay before displaying desync overly", () => {
     render(<DesyncOverlay isOpen productName="stax" delay={1000} />);
 
-    const overlay = screen.queryByTestId("onboarding-desync-overlay");
+    expect(screen.queryByTestId("onboarding-desync-overlay")).not.toBeInTheDocument();
 
-    expect(overlay).toBeNull();
-
-    await waitFor(() => expect(screen.queryByTestId("onboarding-desync-overlay")).toBeVisible(), {
-      timeout: 2000,
+    act(() => {
+      jest.runOnlyPendingTimers();
     });
+
+    expect(screen.getByTestId("onboarding-desync-overlay")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _Test refactoring itself_
- [x] **Impact of the changes:**
  - Test execution time and reliability
  - Better control over timer-based behavior in tests
  - More deterministic test outcomes

### 📝 Description

This PR refactors the `DesyncOverlay` component tests to use Jest's fake timers instead of `waitFor` with real timers.

**Problem**: Tests were using `waitFor` with real timeouts, making them slower and potentially flaky.

**Solution**: Implemented deterministic timer control using:
- `jest.useFakeTimers()` to control time in tests
- `jest.runOnlyPendingTimers()` wrapped in `act()` to advance timers synchronously
- Replaced `toBeVisible()` and `toBeNull()` with `toBeInTheDocument()` and `not.toBeInTheDocument()` for better semantics

##Context

- **JIRA or GitHub link**: N/A - Test improvement

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)