### PR TITLE
[LWD] feat: adds quick actions to portfolio

### DIFF
--- a/.changeset/stupid-foxes-collect.md
+++ b/.changeset/stupid-foxes-collect.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): adds quick actions to portfolio

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
@@ -10,6 +10,7 @@ import { PortfolioViewModelResult } from "./hooks/usePortfolioViewModel";
 import OperationsList from "~/renderer/components/OperationsList";
 import AssetDistribution from "~/renderer/screens/dashboard/AssetDistribution";
 import { Balance } from "./components/Balance";
+import QuickActions from "LLD/features/QuickActions";
 
 export const PortfolioView = memo(function PortfolioView({
   totalAccounts,
@@ -18,6 +19,7 @@ export const PortfolioView = memo(function PortfolioView({
   hasExchangeBannerCTA,
   shouldDisplayMarketBanner,
   shouldDisplayGraphRework,
+  shouldDisplayQuickActionCtas,
   shouldDisplaySwapWebView,
   accounts,
   filterOperations,
@@ -42,6 +44,7 @@ export const PortfolioView = memo(function PortfolioView({
           <div className="flex flex-col gap-24">
             <PageHeader title={t("portfolio.title")} />
             {shouldDisplayGraphRework && <Balance />}
+            {shouldDisplayQuickActionCtas && <QuickActions />}
             {shouldDisplayMarketBanner && <MarketBanner />}
           </div>
           {shouldDisplaySwapWebView && (

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -7,6 +7,8 @@ import { Portfolio } from "@ledgerhq/types-live";
 import { PortfolioView } from "../PortfolioView";
 import * as portfolioReact from "@ledgerhq/live-countervalues-react/portfolio";
 import { useNavigate } from "react-router";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import { ARB_ACCOUNT, BTC_ACCOUNT, HEDERA_ACCOUNT } from "../../__mocks__/accounts.mock";
 
 const MARKET_API_ENDPOINT = "https://countervalues.live.ledger.com/v3/markets";
 
@@ -74,6 +76,7 @@ describe("PortfolioView", () => {
     hasExchangeBannerCTA: true,
     shouldDisplayMarketBanner: true,
     shouldDisplayGraphRework: true,
+    shouldDisplayQuickActionCtas: true,
     shouldDisplaySwapWebView: true,
     filterOperations: () => true,
     accounts: [],
@@ -218,6 +221,29 @@ describe("PortfolioView", () => {
     it("should not render MarketBanner when shouldDisplayMarketBanner is false", () => {
       render(<PortfolioView {...defaultProps} shouldDisplayMarketBanner={false} />);
       expect(screen.queryByText("Explore market")).toBeNull();
+    });
+  });
+
+  describe("QuickActions", () => {
+    it("should render QuickActions when shouldDisplayQuickActionCtas is true", () => {
+      render(<PortfolioView {...defaultProps} shouldDisplayQuickActionCtas={true} />, {
+        ...INITIAL_STATE,
+        initialState: { accounts: [BTC_ACCOUNT, HEDERA_ACCOUNT, ARB_ACCOUNT] },
+      });
+      expect(screen.getByTestId("quick-actions-actions-list")).toBeVisible();
+    });
+
+    it("should not render QuickActions when user has no accounts", () => {
+      render(<PortfolioView {...defaultProps} shouldDisplayQuickActionCtas={true} />, {
+        ...INITIAL_STATE,
+        initialState: { accounts: [] },
+      });
+      expect(screen.queryByTestId("quick-actions-actions-list")).toBeNull();
+    });
+
+    it("should not render QuickActions when shouldDisplayQuickActionCtas is false", () => {
+      render(<PortfolioView {...defaultProps} shouldDisplayQuickActionCtas={false} />);
+      expect(screen.queryByTestId("quick-actions-actions-list")).toBeNull();
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/usePortfolioViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/usePortfolioViewModel.ts
@@ -16,6 +16,7 @@ export interface PortfolioViewModelResult {
   readonly hasExchangeBannerCTA: boolean;
   readonly shouldDisplayMarketBanner: boolean;
   readonly shouldDisplayGraphRework: boolean;
+  readonly shouldDisplayQuickActionCtas: boolean;
   readonly shouldDisplaySwapWebView: boolean;
   readonly filterOperations: (operation: Operation, account: AccountLike) => boolean;
   readonly accounts: AccountLike[];
@@ -25,7 +26,7 @@ export interface PortfolioViewModelResult {
 export const usePortfolioViewModel = (): PortfolioViewModelResult => {
   const accounts = useSelector(accountsSelector);
   const portfolioExchangeBanner = useFeature("portfolioExchangeBanner");
-  const { shouldDisplayMarketBanner, shouldDisplayGraphRework } =
+  const { shouldDisplayMarketBanner, shouldDisplayGraphRework, shouldDisplayQuickActionCtas } =
     useWalletFeaturesConfig("desktop");
   const ptxSwapLiveAppOnPortfolio = useFeature("ptxSwapLiveAppOnPortfolio");
   const { t } = useTranslation();
@@ -62,6 +63,7 @@ export const usePortfolioViewModel = (): PortfolioViewModelResult => {
     hasExchangeBannerCTA,
     shouldDisplayMarketBanner,
     shouldDisplayGraphRework,
+    shouldDisplayQuickActionCtas,
     shouldDisplaySwapWebView,
     filterOperations,
     accounts,

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/ActionsList.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/ActionsList.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { ActionsList } from "../components/ActionsList";
+import { QuickAction } from "../types";
+import { Plus } from "@ledgerhq/lumen-ui-react/symbols";
+
+jest.mock("../hooks/useQuickActions");
+
+describe("ActionsList", () => {
+  const mockHandlers = {
+    onReceive: jest.fn(),
+    onBuy: jest.fn(),
+  };
+  const mockActionsList: QuickAction[] = [
+    {
+      title: "receive",
+      onAction: mockHandlers.onReceive,
+      icon: Plus,
+      disabled: false,
+    },
+    {
+      title: "buy",
+      onAction: mockHandlers.onBuy,
+      icon: Plus,
+      disabled: true,
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders all actions", () => {
+    render(<ActionsList actionsList={mockActionsList} />);
+
+    expect(screen.getByRole("button", { name: /receive/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /buy/i })).toBeInTheDocument();
+  });
+
+  it("disables buttons correctly", () => {
+    render(<ActionsList actionsList={mockActionsList} />);
+
+    const receiveButton = screen.getByRole("button", { name: /receive/i });
+    const buyButton = screen.getByRole("button", { name: /buy/i });
+
+    expect(receiveButton).not.toBeDisabled();
+    expect(buyButton).toBeDisabled();
+  });
+
+  it("calls action when enabled button is clicked", async () => {
+    const { user } = render(<ActionsList actionsList={mockActionsList} />);
+
+    const receiveButton = screen.getByRole("button", { name: /receive/i });
+    await user.click(receiveButton);
+
+    expect(mockHandlers.onReceive).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call action when disabled button is clicked", async () => {
+    const { user } = render(<ActionsList actionsList={mockActionsList} />);
+
+    const buyButton = screen.getByRole("button", { name: /buy/i });
+    await user.click(buyButton);
+
+    expect(mockHandlers.onBuy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/QuickActionsView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/QuickActionsView.test.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { QuickActionsView } from "../index";
+
+describe("QuickActions", () => {
+  it("renders nothing when user has no accounts", () => {
+    const { container } = render(<QuickActionsView hasAccount={false} actionsList={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders ActionsList when user has accounts", () => {
+    render(<QuickActionsView hasAccount={true} actionsList={[]} />);
+    expect(screen.getByTestId("quick-actions-actions-list")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
@@ -1,0 +1,285 @@
+import { renderHook, act } from "tests/testSetup";
+import { useQuickActions } from "../hooks/useQuickActions";
+import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
+import { openModal } from "~/renderer/actions/modals";
+import { useNavigate, useLocation } from "react-router";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { ArrowDown, Plus, Minus, ArrowUp } from "@ledgerhq/lumen-ui-react/symbols";
+
+jest.mock("LLD/features/Send/hooks/useOpenSendFlow");
+jest.mock("~/renderer/actions/modals");
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(),
+  useLocation: jest.fn(),
+}));
+jest.mock("LLD/hooks/redux", () => ({
+  ...jest.requireActual("LLD/hooks/redux"),
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+const mockDispatch = jest.fn();
+const mockOpenSendFlow = jest.fn();
+
+const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
+const mockUseOpenSendFlow = useOpenSendFlow as jest.MockedFunction<typeof useOpenSendFlow>;
+const mockUseNavigate = useNavigate as jest.MockedFunction<typeof useNavigate>;
+const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+describe("useQuickActions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDispatch.mockReturnValue(mockDispatch);
+    mockUseOpenSendFlow.mockReturnValue(mockOpenSendFlow);
+    mockUseNavigate.mockReturnValue(mockNavigate);
+    mockUseLocation.mockReturnValue({
+      pathname: "/accounts",
+      state: undefined,
+      key: "",
+      search: "",
+      hash: "",
+    });
+    mockUseSelector.mockImplementation(() => false);
+  });
+
+  describe("actions structure", () => {
+    it("should return receive action with correct properties", () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      const receiveAction = result.current.actionsList[0];
+      expect(receiveAction.title).toBe("Receive");
+      expect(receiveAction.icon).toBe(ArrowDown);
+      expect(receiveAction.disabled).toBe(false);
+      expect(typeof receiveAction.onAction).toBe("function");
+    });
+
+    it("should return buy action with correct properties", () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      const buyAction = result.current.actionsList[1];
+      expect(buyAction.title).toBe("Buy");
+      expect(buyAction.icon).toBe(Plus);
+      expect(buyAction.disabled).toBe(false);
+      expect(typeof buyAction.onAction).toBe("function");
+    });
+
+    it("should return sell action with correct properties", () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      const sellAction = result.current.actionsList[2];
+      expect(sellAction.title).toBe("Sell");
+      expect(sellAction.icon).toBe(Minus);
+      expect(sellAction.disabled).toBe(false);
+      expect(typeof sellAction.onAction).toBe("function");
+    });
+
+    it("should return send action with correct properties", () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      const sendAction = result.current.actionsList[3];
+      expect(sendAction.title).toBe("Send");
+      expect(sendAction.icon).toBe(ArrowUp);
+      expect(sendAction.disabled).toBe(false);
+      expect(typeof sendAction.onAction).toBe("function");
+    });
+  });
+
+  describe("sell action disabled state", () => {
+    it("should enable sell action when accounts have funds", () => {
+      mockUseSelector.mockImplementation(() => false);
+
+      const { result } = renderHook(() => useQuickActions());
+
+      const sellAction = result.current.actionsList[2];
+      expect(sellAction.disabled).toBe(false);
+    });
+
+    it("should disable sell action when accounts are empty", () => {
+      mockUseSelector.mockImplementation(() => true);
+
+      const { result } = renderHook(() => useQuickActions());
+
+      const sellAction = result.current.actionsList[2];
+      expect(sellAction.disabled).toBe(true);
+    });
+  });
+
+  describe("onReceive action", () => {
+    it("should dispatch openModal with MODAL_RECEIVE when called", () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      act(() => {
+        result.current.actionsList[0].onAction();
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(openModal("MODAL_RECEIVE", undefined));
+    });
+
+    it("should not navigate when already on accounts page", () => {
+      mockUseLocation.mockReturnValue({
+        pathname: "/accounts",
+        state: undefined,
+        key: "",
+        search: "",
+        hash: "",
+      });
+
+      const { result } = renderHook(() => useQuickActions());
+
+      act(() => {
+        result.current.actionsList[0].onAction();
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalledWith("/accounts");
+    });
+
+    it("should navigate to accounts when on manager page", () => {
+      mockUseLocation.mockReturnValue({
+        pathname: "/manager",
+        state: undefined,
+        key: "",
+        search: "",
+        hash: "",
+      });
+
+      const { result } = renderHook(() => useQuickActions());
+
+      act(() => {
+        result.current.actionsList[0].onAction();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith("/accounts");
+      expect(mockDispatch).toHaveBeenCalledWith(openModal("MODAL_RECEIVE", undefined));
+    });
+  });
+
+  describe("onBuy action", () => {
+    it("should navigate to exchange with buy mode", () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      act(() => {
+        result.current.actionsList[1].onAction();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
+        state: {
+          mode: "buy",
+        },
+      });
+    });
+  });
+
+  describe("onSell action", () => {
+    it("should navigate to exchange with sell mode", () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      act(() => {
+        result.current.actionsList[2].onAction();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
+        state: {
+          mode: "sell",
+        },
+      });
+    });
+  });
+
+  describe("onSend action", () => {
+    it("should call openSendFlow when called", () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      act(() => {
+        result.current.actionsList[3].onAction();
+      });
+
+      expect(mockOpenSendFlow).toHaveBeenCalled();
+    });
+
+    it("should not navigate when already on accounts page", () => {
+      mockUseLocation.mockReturnValue({
+        pathname: "/accounts",
+        state: undefined,
+        key: "",
+        search: "",
+        hash: "",
+      });
+
+      const { result } = renderHook(() => useQuickActions());
+
+      act(() => {
+        result.current.actionsList[3].onAction();
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalledWith("/accounts");
+      expect(mockOpenSendFlow).toHaveBeenCalled();
+    });
+
+    it("should navigate to accounts when on manager page", () => {
+      mockUseLocation.mockReturnValue({
+        pathname: "/manager",
+        state: undefined,
+        key: "",
+        search: "",
+        hash: "",
+      });
+
+      const { result } = renderHook(() => useQuickActions());
+
+      act(() => {
+        result.current.actionsList[3].onAction();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith("/accounts");
+      expect(mockOpenSendFlow).toHaveBeenCalled();
+    });
+  });
+
+  describe("memoization", () => {
+    it("should return stable action callbacks when dependencies don't change", () => {
+      const { result, rerender } = renderHook(() => useQuickActions());
+
+      const firstReceiveAction = result.current.actionsList[0].onAction;
+      const firstSendAction = result.current.actionsList[3].onAction;
+
+      rerender();
+
+      const secondReceiveAction = result.current.actionsList[0].onAction;
+      const secondSendAction = result.current.actionsList[3].onAction;
+
+      expect(firstReceiveAction).toBe(secondReceiveAction);
+      expect(firstSendAction).toBe(secondSendAction);
+    });
+
+    it("should update callbacks when location changes", () => {
+      mockUseLocation.mockReturnValue({
+        pathname: "/accounts",
+        state: undefined,
+        key: "",
+        search: "",
+        hash: "",
+      });
+
+      const { result, rerender } = renderHook(() => useQuickActions());
+
+      const firstAction = result.current.actionsList[0].onAction;
+
+      mockUseLocation.mockReturnValue({
+        pathname: "/manager",
+        state: undefined,
+        key: "",
+        search: "",
+        hash: "",
+      });
+
+      rerender();
+
+      const secondAction = result.current.actionsList[0].onAction;
+
+      expect(firstAction).not.toBe(secondAction);
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/components/ActionsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/components/ActionsList.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { QuickAction } from "../types";
+
+interface ActionsListProps {
+  actionsList: QuickAction[];
+}
+
+export const ActionsList = ({ actionsList }: ActionsListProps) => {
+  return (
+    <div className="flex items-center gap-12" data-testid="quick-actions-actions-list">
+      {actionsList.map(({ title, onAction, icon, disabled, buttonAppearance }, index) => (
+        <Button
+          key={index}
+          appearance={buttonAppearance}
+          size="sm"
+          icon={icon}
+          onClick={onAction}
+          disabled={disabled}
+          data-testid={`quick-action-button-${title.replace(/\s+/g, "-").toLowerCase()}`}
+        >
+          {title}
+        </Button>
+      ))}
+    </div>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
@@ -1,0 +1,91 @@
+import { useCallback } from "react";
+import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
+import { openModal } from "~/renderer/actions/modals";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { useLocation, useNavigate } from "react-router";
+import { ArrowDown, Plus, Minus, ArrowUp } from "@ledgerhq/lumen-ui-react/symbols";
+import { useTranslation } from "react-i18next";
+import { areAccountsEmptySelector, hasAccountsSelector } from "~/renderer/reducers/accounts";
+import { QuickAction } from "../types";
+
+export const useQuickActions = (): { hasAccount: boolean; actionsList: QuickAction[] } => {
+  const openSendFlow = useOpenSendFlow();
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { t } = useTranslation();
+  const hasAccount = useSelector(hasAccountsSelector);
+  const hasFunds = !useSelector(areAccountsEmptySelector);
+
+  const push = useCallback(
+    (pathname: string) => {
+      if (location.pathname === pathname) return;
+      navigate(pathname);
+    },
+    [navigate, location.pathname],
+  );
+
+  const maybeRedirectToAccounts = useCallback(() => {
+    return location.pathname === "/manager" && push("/accounts");
+  }, [location.pathname, push]);
+
+  const onSend = useCallback(() => {
+    maybeRedirectToAccounts();
+    openSendFlow();
+  }, [maybeRedirectToAccounts, openSendFlow]);
+
+  const onReceive = useCallback(() => {
+    maybeRedirectToAccounts();
+    dispatch(openModal("MODAL_RECEIVE", undefined));
+  }, [dispatch, maybeRedirectToAccounts]);
+
+  const onBuy = useCallback(() => {
+    navigate("/exchange", {
+      state: {
+        mode: "buy",
+      },
+    });
+  }, [navigate]);
+
+  const onSell = useCallback(() => {
+    navigate("/exchange", {
+      state: {
+        mode: "sell",
+      },
+    });
+  }, [navigate]);
+
+  return {
+    hasAccount,
+    actionsList: [
+      {
+        title: t("quickActions.receive"),
+        onAction: onReceive,
+        icon: ArrowDown,
+        disabled: false,
+        buttonAppearance: "base",
+      },
+      {
+        title: t("quickActions.buy"),
+        onAction: onBuy,
+        icon: Plus,
+        disabled: false,
+        buttonAppearance: "transparent",
+      },
+      {
+        title: t("quickActions.sell"),
+        onAction: onSell,
+        icon: Minus,
+        disabled: !hasFunds,
+        buttonAppearance: "transparent",
+      },
+      {
+        title: t("quickActions.send"),
+        onAction: onSend,
+        icon: ArrowUp,
+        disabled: false,
+        buttonAppearance: "transparent",
+      },
+    ],
+  };
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/index.tsx
@@ -1,0 +1,29 @@
+import React, { memo } from "react";
+import { ActionsList } from "./components/ActionsList";
+import { useQuickActions } from "./hooks/useQuickActions";
+import { QuickAction } from "./types";
+
+interface QuickActionsProps {
+  hasAccount: boolean;
+  actionsList: QuickAction[];
+}
+
+const QuickActionsView = memo(function QuickActionsView({
+  hasAccount,
+  actionsList,
+}: QuickActionsProps) {
+  if (!hasAccount) {
+    // onboarding scenario
+    return null;
+  }
+
+  return <ActionsList actionsList={actionsList} />;
+});
+
+const QuickActions = () => {
+  const { hasAccount, actionsList } = useQuickActions();
+  return <QuickActionsView hasAccount={hasAccount} actionsList={actionsList} />;
+};
+
+export { QuickActionsView };
+export default QuickActions;

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/types.ts
@@ -1,0 +1,7 @@
+export type QuickAction = {
+  title: string;
+  onAction: () => void;
+  icon: React.ComponentType;
+  disabled: boolean;
+  buttonAppearance?: "base" | "transparent";
+};

--- a/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
@@ -249,7 +249,10 @@ const MainSideBar = () => {
   const recoverFeature = useFeature("protectServicesDesktop");
   const recoverHomePath = useAccountPath(recoverFeature);
 
-  const { shouldDisplayMarketBanner: isMarketBannerEnabled } = useWalletFeaturesConfig("desktop");
+  const {
+    shouldDisplayMarketBanner: isMarketBannerEnabled,
+    shouldDisplayQuickActionCtas: isQuickActionCtasEnabled,
+  } = useWalletFeaturesConfig("desktop");
 
   const handleCollapse = useCallback(() => {
     dispatch(setSidebarCollapsed(!collapsed));
@@ -426,24 +429,28 @@ const MainSideBar = () => {
                   disabled={noAccounts}
                   collapsed={secondAnim}
                 />
-                <SideBarListItem
-                  id={"send"}
-                  label={t("send.title")}
-                  icon={Icons.ArrowUp}
-                  iconActiveColor="wallet"
-                  onClick={handleOpenSendModal}
-                  disabled={noAccounts || navigationLocked}
-                  collapsed={secondAnim}
-                />
-                <SideBarListItem
-                  id={"receive"}
-                  label={t("receive.title")}
-                  icon={Icons.ArrowDown}
-                  iconActiveColor="wallet"
-                  onClick={handleOpenReceiveModal}
-                  disabled={noAccounts || navigationLocked}
-                  collapsed={secondAnim}
-                />
+                {!isQuickActionCtasEnabled && (
+                  <SideBarListItem
+                    id={"send"}
+                    label={t("send.title")}
+                    icon={Icons.ArrowUp}
+                    iconActiveColor="wallet"
+                    onClick={handleOpenSendModal}
+                    disabled={noAccounts || navigationLocked}
+                    collapsed={secondAnim}
+                  />
+                )}
+                {!isQuickActionCtasEnabled && (
+                  <SideBarListItem
+                    id={"receive"}
+                    label={t("receive.title")}
+                    icon={Icons.ArrowDown}
+                    iconActiveColor="wallet"
+                    onClick={handleOpenReceiveModal}
+                    disabled={noAccounts || navigationLocked}
+                    collapsed={secondAnim}
+                  />
+                )}
                 <SideBarListItem
                   id={"swap"}
                   label={t("sidebar.swap")}
@@ -463,16 +470,18 @@ const MainSideBar = () => {
                   isActive={location.pathname === "/earn"}
                   collapsed={secondAnim}
                 />
-                <SideBarListItem
-                  id={"exchange"}
-                  label={t("sidebar.exchange")}
-                  icon={Icons.Dollar}
-                  iconActiveColor="wallet"
-                  onClick={handleClickExchange}
-                  isActive={location.pathname === "/exchange"}
-                  disabled={noAccounts}
-                  collapsed={secondAnim}
-                />
+                {!isQuickActionCtasEnabled && (
+                  <SideBarListItem
+                    id={"exchange"}
+                    label={t("sidebar.exchange")}
+                    icon={Icons.Dollar}
+                    iconActiveColor="wallet"
+                    onClick={handleClickExchange}
+                    isActive={location.pathname === "/exchange"}
+                    disabled={noAccounts}
+                    collapsed={secondAnim}
+                  />
+                )}
                 <SideBarListItem
                   id={"catalog"}
                   label={t("sidebar.catalog")}

--- a/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
@@ -6,6 +6,7 @@ import {
   clearAccount,
   getAccountCurrency,
   isUpToDateAccount,
+  isAccountEmpty,
 } from "@ledgerhq/live-common/account/index";
 import { getEnv } from "@ledgerhq/live-env";
 import isEqual from "lodash/isEqual";
@@ -137,3 +138,8 @@ export const starredAccountsSelector = createSelector(
 export const isUpToDateAccountSelector = createSelector(accountSelector, isUpToDateAccount);
 
 export const flattenAccountsSelector = createSelector(accountsSelector, flattenAccounts);
+
+export const areAccountsEmptySelector = createSelector(
+  accountsSelector,
+  accounts => accounts.length > 0 && accounts.every(isAccountEmpty),
+);

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7874,6 +7874,14 @@
       "cta": "Got it"
     }
   },
+  "quickActions": {
+    "send": "Send",
+    "receive": "Receive",
+    "buy": "Buy",
+    "sell": "Sell",
+    "connect": "Connect",
+    "buyALedger": "Buy a Ledger"
+  },
   "nftEntryPoint": {
     "title": "NFT (Non Fungible Tokens)",
     "entry": {


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a new "Quick Actions" feature to the Ledger Live Desktop portfolio view, allowing users to easily access actions like Send, Receive, Buy, and Sell directly from the portfolio. The implementation includes new UI components, hooks, and comprehensive tests, as well as feature flag integration to control the display of these actions. Additionally, the sidebar is updated to conditionally hide redundant navigation items when Quick Actions are enabled.

### ❓ Context

[LIVE-24576 - quick actions with account and funds](https://ledgerhq.atlassian.net/browse/LIVE-24576)
[LIVE-24580 - quick actions with account and no funds](https://ledgerhq.atlassian.net/browse/LIVE-24580)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
