### PR TITLE
[LWM] feat: handle legacy users who have never seen the opt-in drawer

### DIFF
--- a/.changeset/serious-news-juggle.md
+++ b/.changeset/serious-news-juggle.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat: handle legacy users who have never seen the opt-in drawer and are opted out of app notifications


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

this handle an edge case where legacy users (before the feature is launched) THAT are opt out of app notifications (not os denied) AND have never dismissed the opt-in drawer, they will never be prompted the inactivity drawer unless they perform an action.

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-25286


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
