### PR TITLE
fix(back-10215,optimism): fetch blocks with more than 10 txs

### DIFF
--- a/.changeset/ten-wombats-swim.md
+++ b/.changeset/ten-wombats-swim.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+fix: Optimism can fetch blocks with more than 10 txs

--- a/libs/coin-modules/coin-evm/src/api/index.optimism.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.optimism.integ.test.ts
@@ -1,0 +1,49 @@
+import { Api, BufferTxData, MemoNotSupported } from "@ledgerhq/coin-framework/api/types";
+import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { EvmConfig } from "../config";
+import { createApi } from "./index";
+
+describe("EVM Optimism Network", () => {
+  let module: Api<MemoNotSupported, BufferTxData>;
+
+  beforeAll(() => {
+    setupCalClientStore();
+    const config = {
+      node: {
+        type: "external",
+        uri: "https://mainnet.optimism.io",
+      },
+      explorer: {
+        type: "none",
+      },
+    };
+    module = createApi(config as EvmConfig, "optimism");
+  });
+
+  describe("getBlock", () => {
+    it("returns block with more than 10 transactions for height 144931340", async () => {
+      const result = await module.getBlock(144931340);
+
+      // all the transactions are returned
+      expect(result.transactions.length).toBe(61);
+
+      // some other check but they are not the main concern of this test
+      expect(result).toMatchObject({
+        info: {
+          hash: "0x15d04d3a7ddc6ea7470f05b61e78dd2170ceb273e6659693d0b0370d12cd8d14",
+          height: 144931340,
+          time: expect.any(Date),
+        },
+        transactions: expect.arrayContaining([
+          expect.objectContaining({
+            hash: expect.any(String),
+            failed: expect.any(Boolean),
+            operations: expect.any(Array),
+            fees: expect.any(BigInt),
+            feesPayer: expect.any(String),
+          }),
+        ]),
+      });
+    });
+  });
+});

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.ts
@@ -1,5 +1,6 @@
 import type { Block, BlockInfo, BlockTransaction } from "@ledgerhq/coin-framework/api/index";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { promiseAllBatched } from "@ledgerhq/live-promise";
 import { getNodeApi } from "../network/node";
 import { rpcTransactionToBlockOperations } from "../adapters/blockOperations";
 
@@ -42,11 +43,20 @@ async function getTransactionsFromNode(
     return [];
   }
 
-  const transactionPromises = transactionHashes.map(async (txHash: string) => {
-    return await getTransactionFromHash(currency, txHash, nodeApi);
-  });
+  // some RPC nodes like the one on mainnet.optimism.io are limited to 10 concurrent calls
+  // given that the underlying nodeApi calls are doing 2 calls in parallel to fetch the transaction
+  // and given that we may have other concurrent calls to the nodeApi from other blocks or api
+  // and given that performance expectation is not critical for this api
+  // => concurrency of 2 will use 4 amongst the 10 concurrent calls allowed by the node
+  // => give good enough performance for the api
+  // Note: there is also a max number of calls per second limit on mainnet.optimism.io
+  const MAX_CONCURRENCY = 2;
+  const transactionResults = await promiseAllBatched(
+    MAX_CONCURRENCY,
+    transactionHashes,
+    (txHash: string) => getTransactionFromHash(currency, txHash, nodeApi),
+  );
 
-  const transactionResults = await Promise.all(transactionPromises);
   return transactionResults.filter((tx): tx is BlockTransaction => tx !== null);
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - bugfix in alpaca getBlock, no impact on LW AFAIK

### 📝 Description

This pull request fixes an issue (BACK-10215) where fetching blocks with more than 10 transactions would fail on certain RPC nodes that impose concurrent request limits. The fix implements batched promise execution to limit concurrent transaction fetches.

The solution favored robustness over speed

### ❓ Context
https://ledgerhq.atlassian.net/browse/BACK-10215


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
