### PR TITLE
[LWM] fix(mobile): keep portfolio title on one line

### DIFF
--- a/.changeset/fix-portfolio-title-wrap.md
+++ b/.changeset/fix-portfolio-title-wrap.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix portfolio header title to stay on one line

--- a/apps/ledger-live-mobile/src/screens/Portfolio/Header.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/Header.tsx
@@ -106,7 +106,7 @@ function PortfolioHeader({ hidePortfolio }: { hidePortfolio: boolean }) {
           flexShrink={1}
           textAlign="center"
           mr={3}
-          numberOfLines={2}
+          numberOfLines={1}
         >
           {t("tabs.portfolio")}
         </Text>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Not run since this will be replaced in V4._
- [x] **Impact of the changes:**
  - Portfolio header title layout on small screens/locales
  - Wallet tab header rendering

### 📝 Description

The portfolio header title can wrap to two lines, causing cramped header layout and inconsistent alignment.

This change forces the title to render on a single line. Before: the title could wrap to two lines. After: it stays on one line with truncation when needed.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24858](https://ledgerhq.atlassian.net/browse/LIVE-24858)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, n/a
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** n/a
- **Performance** n/a

[LIVE-24858]: https://ledgerhq.atlassian.net/browse/LIVE-24858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ