### PR TITLE
[LWDM] :sparkles: uniformize market banner config

### DIFF
--- a/.changeset/good-rats-hammer.md
+++ b/.changeset/good-rats-hammer.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Extract market banner top performer config in common to uniformize LWM and LWD

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
@@ -2,17 +2,17 @@ import { useMemo } from "react";
 import { useMarketPerformers } from "@ledgerhq/live-common/market/hooks/useMarketPerformers";
 import { useSelector } from "LLD/hooks/redux";
 import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
+import { MARKET_BANNER_ITEMS_COUNT } from "../utils/constants";
+import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
+import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
+import { filterMarketPerformersByAvailability } from "@ledgerhq/live-common/market/utils/index";
 import {
-  MARKET_BANNER_ITEMS_COUNT,
   MARKET_BANNER_TOP,
   MARKET_BANNER_DATA_SORT_ORDER,
   MARKET_BANNER_REFRESH_RATE,
   MARKET_PERFORMERS_SUPPORTED,
   TIME_RANGE,
-} from "../utils/constants";
-import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
-import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
-import { filterMarketPerformersByAvailability } from "@ledgerhq/live-common/market/utils/index";
+} from "@ledgerhq/live-common/market/constants";
 
 export const useMarketBannerViewModel = () => {
   const countervalue = useSelector(counterValueCurrencySelector);

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/index.tsx
@@ -7,12 +7,12 @@ import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
 import { TrendingAssetsList } from "./components/TrendingAssetsList";
 import { MarketBannerHeader } from "./components/MarketBannerHeader";
 import TrackPage from "~/renderer/analytics/TrackPage";
+import { TRACKING_PAGE_NAME } from "./utils/constants";
 import {
   MARKET_BANNER_TOP,
   MARKET_BANNER_DATA_SORT_ORDER,
   TIME_RANGE,
-  TRACKING_PAGE_NAME,
-} from "./utils/constants";
+} from "@ledgerhq/live-common/market/constants";
 import { track } from "~/renderer/analytics/segment";
 
 type MarketBannerViewProps = {

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/utils/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/utils/constants.ts
@@ -1,12 +1,3 @@
-enum Order {
-  asc = "asc",
-  desc = "desc",
-}
 export const MARKET_BANNER_ITEMS_COUNT = 11;
-export const MARKET_BANNER_TOP = 100;
-export const MARKET_BANNER_REFRESH_RATE = 1000;
-export const MARKET_PERFORMERS_SUPPORTED = true;
-export const MARKET_BANNER_DATA_SORT_ORDER = Order.asc;
-export const TIME_RANGE = "day";
 
 export const TRACKING_PAGE_NAME = "Market Banner";

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/constants.ts
@@ -1,7 +1,4 @@
 export const MARKET_BANNER_TILE_COUNT = 7;
-export const MARKET_BANNER_TOP = 50;
-// Refresh interval for fetching updated market data for the market banner, in seconds.
-export const REFRESH_RATE = 180;
 
 export const PAGE_NAME = "Wallet";
 export const BANNER_NAME = "Market Banner";

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
@@ -13,17 +13,16 @@ import { track } from "~/analytics";
 import { ScreenName } from "~/const";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
-import {
-  MARKET_BANNER_TILE_COUNT,
-  MARKET_BANNER_TOP,
-  REFRESH_RATE,
-  PAGE_NAME,
-  BANNER_NAME,
-} from "../constants";
+import { MARKET_BANNER_TILE_COUNT, PAGE_NAME, BANNER_NAME } from "../constants";
 import { UseMarketBannerViewModelResult } from "../types";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
-
-const TIME_RANGE = "day";
+import {
+  TIME_RANGE,
+  MARKET_BANNER_DATA_SORT_ORDER,
+  MARKET_BANNER_TOP,
+  MARKET_PERFORMERS_SUPPORTED,
+  MARKET_BANNER_REFRESH_RATE,
+} from "@ledgerhq/live-common/market/constants";
 
 const useMarketBannerViewModel = (): UseMarketBannerViewModelResult => {
   const baseNavigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
@@ -39,13 +38,13 @@ const useMarketBannerViewModel = (): UseMarketBannerViewModelResult => {
   );
 
   const { data, isLoading, isError } = useMarketPerformers({
-    sort: "asc",
+    sort: MARKET_BANNER_DATA_SORT_ORDER,
     counterCurrency: counterValueCurrency.ticker,
     range: TIME_RANGE,
     limit: MARKET_BANNER_TILE_COUNT * 2,
     top: MARKET_BANNER_TOP,
-    supported: true,
-    refreshRate: REFRESH_RATE,
+    supported: MARKET_PERFORMERS_SUPPORTED,
+    refreshRate: MARKET_BANNER_REFRESH_RATE,
   });
 
   const filteredItems = useMemo(() => {

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -244,6 +244,7 @@
     "src/manager/useDeviceHasUpdatesAvailable.ts",
     "src/market/utils/countervalueFormatter.ts",
     "src/market/utils/rangeDataTable.ts",
+    "src/market/constants.ts",
     "src/mock/account.ts",
     "src/mock/helpers.ts",
     "src/network-troubleshooting/index.ts",

--- a/libs/ledger-live-common/src/market/constants.ts
+++ b/libs/ledger-live-common/src/market/constants.ts
@@ -1,0 +1,9 @@
+declare enum Order {
+  asc = "asc",
+  desc = "desc",
+}
+export declare const MARKET_BANNER_TOP = 100;
+export declare const MARKET_BANNER_REFRESH_RATE = 1000;
+export declare const MARKET_PERFORMERS_SUPPORTED = true;
+export declare const MARKET_BANNER_DATA_SORT_ORDER = Order.asc;
+export declare const TIME_RANGE = "day";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - market banner

### 📝 Description

Extract config for market banner data fetching in common to uniformize mobile and desktop

This will be extracted in features/ folder in the future
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25351](https://ledgerhq.atlassian.net/browse/LIVE-25351) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25351]: https://ledgerhq.atlassian.net/browse/LIVE-25351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ