### PR TITLE
ci: temp move codecheck to larger runners

### DIFF
--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -138,7 +138,7 @@ jobs:
       FORCE_COLOR: 3
       CI_OS: ubuntu-22.04
 
-    runs-on: ubuntu-22.04
+    runs-on: ledger-live-4xlarge
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Temporarily move codecheck to larger runners due to linting issues

Green Run: https://github.com/LedgerHQ/ledger-live/actions/runs/21366643451/job/61500212330
Ticket: https://ledgerhq.atlassian.net/browse/LIVE-25363