### PR TITLE
[LWD] refactor(desktop): migrate PageHeader to design system NavBar

### DIFF
--- a/.changeset/migrate-page-header-navbar.md
+++ b/.changeset/migrate-page-header-navbar.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Migrate PageHeader component to use design system NavBar components

--- a/apps/ledger-live-desktop/src/mvvm/components/PageHeader/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/PageHeader/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { ArrowLeft } from "@ledgerhq/lumen-ui-react/symbols";
-import { cn } from "LLD/utils/cn";
+import { NavBar, NavBarBackButton, NavBarTitle } from "@ledgerhq/lumen-ui-react";
 
 type Props = Readonly<{
   title: string;
@@ -9,13 +8,9 @@ type Props = Readonly<{
 
 export default function PageHeader({ title, onBack }: Props) {
   return (
-    <div
-      onClick={onBack}
-      className={cn("flex items-center gap-4", onBack && "cursor-pointer")}
-      data-testid="page-header"
-    >
-      {onBack ? <ArrowLeft className={"m-10 text-base"} size={20} /> : null}
-      <span className="heading-3-semi-bold text-base">{title}</span>
-    </div>
+    <NavBar data-testid="page-header">
+      {onBack ? <NavBarBackButton onClick={onBack} /> : null}
+      <NavBarTitle className="text-base">{title}</NavBarTitle>
+    </NavBar>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
@@ -36,10 +36,10 @@ describe("Analytics", () => {
   it("should call navigateToDashboard when back button is clicked", async () => {
     const { user } = render(<Analytics />);
 
-    const pageHeader = screen.getByTestId("page-header");
-    expect(pageHeader).toBeInTheDocument();
+    const backButton = screen.getByRole("button");
+    expect(backButton).toBeInTheDocument();
 
-    await user.click(pageHeader);
+    await user.click(backButton);
 
     expect(mockNavigateToDashboard).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This is a refactor that replaces custom components with design system equivalents. The existing UI tests should cover this._
- [x] **Impact of the changes:**
      - PageHeader component rendering
      - Any screens using PageHeader with back navigation

### 📝 Description

**Problem**: The `PageHeader` component was using a custom implementation with `ArrowLeft` symbol and manual styling, duplicating patterns already available in the design system.

**Solution**: Migrated `PageHeader` to use the design system's `NavBar`, `NavBarBackButton`, and `NavBarTitle` components from `@ledgerhq/lumen-ui-react`. This:
- Reduces code duplication
- Ensures consistency with the design system
- Simplifies maintenance

### ❓ Context

- **JIRA or GitHub link**: N/A - Design system cleanup

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)