### PR TITLE
[LWD] refactor(desktop): add useBannersVisibility hook and conditional margin

### DIFF
--- a/.changeset/new-mails-hang.md
+++ b/.changeset/new-mails-hang.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add margin bottom under banner section on Wallet 4.0 portfolio

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
@@ -1,34 +1,57 @@
 import React from "react";
+import styled from "styled-components";
 
 import { Carousel } from "@ledgerhq/react-ui";
 import { track } from "~/renderer/analytics/segment";
 import { usePortfolioCards } from "../../hooks/usePortfolioCards";
 import Slide from "./Slide";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 export default PortfolioContentCards;
 
+// Wrapper with animated padding that grows on hover so the content area shrinks to reveal arrows (Wallet 4.0 only)
+const CarouselWrapper = styled.div<{ $isWallet40Enabled: boolean }>`
+  ${({ $isWallet40Enabled }) =>
+    $isWallet40Enabled &&
+    `
+    padding-left: 0;
+    padding-right: 0;
+    transition: padding 0.25s ease-in-out;
+
+    &:hover {
+      padding-left: 16px;
+      padding-right: 16px;
+    }
+  `}
+`;
+
 function PortfolioContentCards() {
   const { portfolioCards, logSlideClick, dismissCard } = usePortfolioCards();
+  const { isEnabled: isWallet40Enabled } = useWalletFeaturesConfig("desktop");
   const handlePrevButton = () => trackSlide("prev");
   const handleNextButton = () => trackSlide("next");
 
+  if (portfolioCards.length === 0) return null;
+
   return (
-    <Carousel
-      initialDelay={2500}
-      autoPlay={6000}
-      onPrev={handlePrevButton}
-      onNext={handleNextButton}
-    >
-      {portfolioCards.map((card, index) => (
-        <Slide
-          key={card.id}
-          {...card}
-          index={index}
-          logSlideClick={logSlideClick}
-          dismissCard={dismissCard}
-        />
-      ))}
-    </Carousel>
+    <CarouselWrapper $isWallet40Enabled={isWallet40Enabled}>
+      <Carousel
+        initialDelay={2500}
+        autoPlay={6000}
+        onPrev={handlePrevButton}
+        onNext={handleNextButton}
+      >
+        {portfolioCards.map((card, index) => (
+          <Slide
+            key={card.id}
+            {...card}
+            index={index}
+            logSlideClick={logSlideClick}
+            dismissCard={dismissCard}
+          />
+        ))}
+      </Carousel>
+    </CarouselWrapper>
   );
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
@@ -25,7 +25,7 @@ export const PortfolioView = memo(function PortfolioView({
 }: PortfolioViewModelResult) {
   return (
     <>
-      <BannerSection />
+      <BannerSection isWallet40Enabled={isWallet40Enabled} />
       <TrackPage
         category="Portfolio"
         totalAccounts={totalAccounts}

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBannersVisibility.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBannersVisibility.test.ts
@@ -1,0 +1,200 @@
+import { renderHook } from "tests/testSetup";
+import { usePostOnboardingEntryPointVisibleOnWallet } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { useLNSUpsellBannerState } from "LLD/features/LNSUpsell";
+import useActionCards from "~/renderer/hooks/useActionCards";
+import { useBannersVisibility } from "../useBannersVisibility";
+import { ActionContentCard } from "~/types/dynamicContent";
+import { LocationContentCard } from "~/types/dynamicContent";
+
+jest.mock("@ledgerhq/live-common/postOnboarding/hooks/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/postOnboarding/hooks/index"),
+  usePostOnboardingEntryPointVisibleOnWallet: jest.fn(),
+}));
+jest.mock("LLD/features/LNSUpsell", () => ({
+  ...jest.requireActual("LLD/features/LNSUpsell"),
+  useLNSUpsellBannerState: jest.fn(),
+}));
+jest.mock("~/renderer/hooks/useActionCards", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockUsePostOnboardingEntryPointVisibleOnWallet = jest.mocked(
+  usePostOnboardingEntryPointVisibleOnWallet,
+);
+const mockUseLNSUpsellBannerState = jest.mocked(useLNSUpsellBannerState);
+const mockUseActionCards = jest.mocked(useActionCards);
+
+const createMockActionCard = (overrides: Partial<ActionContentCard> = {}): ActionContentCard => ({
+  id: "card-1",
+  title: "Test Card",
+  description: "Test description",
+  location: LocationContentCard.Action,
+  created: null,
+  ...overrides,
+});
+
+const defaultInitialState = {
+  settings: {
+    showClearCacheBanner: false,
+    overriddenFeatureFlags: {
+      lldActionCarousel: { enabled: false },
+    },
+  },
+  dynamicContent: {
+    portfolioCards: [],
+  },
+};
+
+describe("useBannersVisibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePostOnboardingEntryPointVisibleOnWallet.mockReturnValue(false);
+    mockUseLNSUpsellBannerState.mockReturnValue({
+      isShown: false,
+      params: undefined,
+      tracking: "opted_out",
+    });
+    mockUseActionCards.mockReturnValue({
+      actionCards: [],
+      onClick: jest.fn(),
+      onDismiss: jest.fn(),
+    });
+  });
+
+  it("should return all banners hidden when no conditions are met", () => {
+    const { result } = renderHook(() => useBannersVisibility(), {
+      initialState: defaultInitialState,
+    });
+
+    expect(result.current.isClearCacheBannerVisible).toBe(false);
+    expect(result.current.isPostOnboardingBannerVisible).toBe(false);
+    expect(result.current.isActionCardsVisible).toBe(false);
+    expect(result.current.isLNSUpsellBannerVisible).toBe(false);
+    expect(result.current.isPortfolioContentCardsVisible).toBe(false);
+    expect(result.current.hasAnyBannerVisible).toBe(false);
+  });
+
+  it("should return true for isClearCacheBannerVisible when showClearCacheBanner is true", () => {
+    const { result } = renderHook(() => useBannersVisibility(), {
+      initialState: {
+        ...defaultInitialState,
+        settings: {
+          showClearCacheBanner: true,
+          overriddenFeatureFlags: {
+            lldActionCarousel: { enabled: false },
+          },
+        },
+      },
+    });
+
+    expect(result.current.isClearCacheBannerVisible).toBe(true);
+    expect(result.current.hasAnyBannerVisible).toBe(true);
+  });
+
+  it("should return true for isPostOnboardingBannerVisible when post-onboarding is visible", () => {
+    mockUsePostOnboardingEntryPointVisibleOnWallet.mockReturnValue(true);
+
+    const { result } = renderHook(() => useBannersVisibility(), {
+      initialState: defaultInitialState,
+    });
+
+    expect(result.current.isPostOnboardingBannerVisible).toBe(true);
+    expect(result.current.hasAnyBannerVisible).toBe(true);
+  });
+
+  it("should return true for isActionCardsVisible when action cards campaign is running and feature is enabled", () => {
+    mockUseActionCards.mockReturnValue({
+      actionCards: [createMockActionCard()],
+      onClick: jest.fn(),
+      onDismiss: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useBannersVisibility(), {
+      initialState: {
+        ...defaultInitialState,
+        settings: {
+          showClearCacheBanner: false,
+          overriddenFeatureFlags: {
+            lldActionCarousel: { enabled: true },
+          },
+        },
+      },
+    });
+
+    expect(result.current.isActionCardsVisible).toBe(true);
+    expect(result.current.hasAnyBannerVisible).toBe(true);
+  });
+
+  it("should return false for isActionCardsVisible when action cards exist but feature is disabled", () => {
+    mockUseActionCards.mockReturnValue({
+      actionCards: [createMockActionCard()],
+      onClick: jest.fn(),
+      onDismiss: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useBannersVisibility(), {
+      initialState: defaultInitialState,
+    });
+
+    expect(result.current.isActionCardsVisible).toBe(false);
+    expect(result.current.hasAnyBannerVisible).toBe(false);
+  });
+
+  it("should return true for isLNSUpsellBannerVisible when LNS upsell banner is shown", () => {
+    mockUseLNSUpsellBannerState.mockReturnValue({
+      isShown: true,
+      params: undefined,
+      tracking: "opted_in",
+    });
+
+    const { result } = renderHook(() => useBannersVisibility(), {
+      initialState: defaultInitialState,
+    });
+
+    expect(result.current.isLNSUpsellBannerVisible).toBe(true);
+    expect(result.current.hasAnyBannerVisible).toBe(true);
+  });
+
+  it("should return true for isPortfolioContentCardsVisible when portfolio cards exist", () => {
+    const { result } = renderHook(() => useBannersVisibility(), {
+      initialState: {
+        ...defaultInitialState,
+        dynamicContent: {
+          portfolioCards: [
+            { id: "card-1", title: "Test", location: LocationContentCard.Portfolio },
+          ],
+        },
+      },
+    });
+
+    expect(result.current.isPortfolioContentCardsVisible).toBe(true);
+    expect(result.current.hasAnyBannerVisible).toBe(true);
+  });
+
+  it("should return true for hasAnyBannerVisible when multiple banners are visible", () => {
+    mockUsePostOnboardingEntryPointVisibleOnWallet.mockReturnValue(true);
+    mockUseLNSUpsellBannerState.mockReturnValue({
+      isShown: true,
+      params: undefined,
+      tracking: "opted_in",
+    });
+
+    const { result } = renderHook(() => useBannersVisibility(), {
+      initialState: {
+        ...defaultInitialState,
+        settings: {
+          showClearCacheBanner: true,
+          overriddenFeatureFlags: {
+            lldActionCarousel: { enabled: false },
+          },
+        },
+      },
+    });
+
+    expect(result.current.isClearCacheBannerVisible).toBe(true);
+    expect(result.current.isPostOnboardingBannerVisible).toBe(true);
+    expect(result.current.isLNSUpsellBannerVisible).toBe(true);
+    expect(result.current.hasAnyBannerVisible).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBannersVisibility.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBannersVisibility.ts
@@ -1,0 +1,66 @@
+import { useSelector } from "LLD/hooks/redux";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { usePostOnboardingEntryPointVisibleOnWallet } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { showClearCacheBannerSelector } from "~/renderer/reducers/settings";
+import { portfolioContentCardSelector } from "~/renderer/reducers/dynamicContent";
+import { useLNSUpsellBannerState } from "LLD/features/LNSUpsell";
+import useActionCards from "~/renderer/hooks/useActionCards";
+
+interface BannerVisibilityState {
+  /** True if the clear cache banner is visible */
+  isClearCacheBannerVisible: boolean;
+  /** True if the post-onboarding banner is visible */
+  isPostOnboardingBannerVisible: boolean;
+  /** True if the action cards carousel is visible */
+  isActionCardsVisible: boolean;
+  /** True if the LNS upsell banner is visible */
+  isLNSUpsellBannerVisible: boolean;
+  /** True if portfolio content cards are visible */
+  isPortfolioContentCardsVisible: boolean;
+  /** True if at least one banner or content card is visible */
+  hasAnyBannerVisible: boolean;
+}
+
+/**
+ * Hook to determine the visibility state of portfolio banners.
+ * Returns individual banner visibility states and a combined flag
+ * indicating if at least one banner is displayed.
+ */
+export function useBannersVisibility(): BannerVisibilityState {
+  const lldActionCarousel = useFeature("lldActionCarousel");
+
+  // Clear cache banner
+  const isClearCacheBannerVisible: boolean = useSelector(showClearCacheBannerSelector);
+
+  // Post-onboarding banner
+  const isPostOnboardingBannerVisible = usePostOnboardingEntryPointVisibleOnWallet();
+
+  // Action cards carousel
+  const { actionCards } = useActionCards();
+  const isActionCardsCampaignRunning = actionCards.length > 0;
+  const isActionCardsVisible = isActionCardsCampaignRunning && Boolean(lldActionCarousel?.enabled);
+
+  // LNS upsell banner
+  const isLNSUpsellBannerVisible = useLNSUpsellBannerState("portfolio").isShown;
+
+  // Portfolio content cards (fallback carousel)
+  const portfolioCards = useSelector(portfolioContentCardSelector);
+  const isPortfolioContentCardsVisible = portfolioCards.length > 0;
+
+  // Combined check: at least one banner or content card is visible
+  const hasAnyBannerVisible =
+    isClearCacheBannerVisible ||
+    isPostOnboardingBannerVisible ||
+    isActionCardsVisible ||
+    isLNSUpsellBannerVisible ||
+    isPortfolioContentCardsVisible;
+
+  return {
+    isClearCacheBannerVisible,
+    isPostOnboardingBannerVisible,
+    isActionCardsVisible,
+    isLNSUpsellBannerVisible,
+    isPortfolioContentCardsVisible,
+    hasAnyBannerVisible,
+  };
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/BannerSection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/BannerSection.tsx
@@ -6,14 +6,12 @@ import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAle
 import { Box } from "@ledgerhq/react-ui/components/layout/index";
 import { currenciesSelector } from "~/renderer/reducers/accounts";
 import { useSelector } from "LLD/hooks/redux";
-import { usePostOnboardingEntryPointVisibleOnWallet } from "@ledgerhq/live-common/postOnboarding/hooks/index";
-import useActionCards from "~/renderer/hooks/useActionCards";
 import PostOnboardingHubBanner from "~/renderer/components/PostOnboardingHub/PostOnboardingHubBanner";
 import ActionContentCards from "~/renderer/screens/dashboard/ActionContentCards";
 import { ABTestingVariants } from "@ledgerhq/types-live";
-import { LNSUpsellBanner, useLNSUpsellBannerState } from "LLD/features/LNSUpsell";
+import { LNSUpsellBanner } from "LLD/features/LNSUpsell";
 import PortfolioContentCards from "LLD/features/DynamicContent/components/PortfolioContentCards";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useBannersVisibility } from "LLD/features/Portfolio/hooks/useBannersVisibility";
 
 // This forces only one visible top banner at a time
 export const TopBannerContainer = styled.div`
@@ -24,19 +22,22 @@ export const TopBannerContainer = styled.div`
   }
 `;
 
-export default function BannerSection() {
-  const lldActionCarousel = useFeature("lldActionCarousel");
+export default function BannerSection({
+  isWallet40Enabled = false,
+}: {
+  isWallet40Enabled?: boolean;
+}) {
   const currencies = useSelector(currenciesSelector);
 
-  const isPostOnboardingBannerVisible = usePostOnboardingEntryPointVisibleOnWallet();
-
-  const { actionCards } = useActionCards();
-  const isActionCardsCampainRunning = actionCards.length > 0;
-
-  const isLNSUpsellBannerShown = useLNSUpsellBannerState("portfolio").isShown;
+  const {
+    isPostOnboardingBannerVisible,
+    isActionCardsVisible,
+    isLNSUpsellBannerVisible,
+    hasAnyBannerVisible,
+  } = useBannersVisibility();
 
   return (
-    <section>
+    <section className={hasAnyBannerVisible && isWallet40Enabled ? "mb-32" : undefined}>
       <TopBannerContainer>
         <ClearCacheBanner />
         <CurrencyDownStatusAlert currencies={currencies} hideStatusIncidents />
@@ -46,9 +47,9 @@ export default function BannerSection() {
           <PostOnboardingHubBanner />
         ) : (
           <RecoverBanner>
-            {isActionCardsCampainRunning && lldActionCarousel?.enabled ? (
+            {isActionCardsVisible ? (
               <ActionContentCards variant={ABTestingVariants.variantA} />
-            ) : isLNSUpsellBannerShown ? (
+            ) : isLNSUpsellBannerVisible ? (
               <LNSUpsellBanner location="portfolio" />
             ) : (
               <PortfolioContentCards />


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio page layout spacing
      - Banner visibility logic centralized in a reusable hook

### 📝 Description

This PR introduces a `useBannersVisibility` hook that centralizes the logic for determining which banners are visible in the Portfolio view. It also applies a conditional `mb-32` margin to the banner section only when at least one banner is displayed.

**Changes:**
- Created `useBannersVisibility` hook in `src/mvvm/features/Portfolio/hooks/`
- Refactored `BannerSection` to use the new hook
- Added conditional margin class based on `hasAnyBannerVisible` state
- Added unit tests for the new hook

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25402

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)