### PR TITLE
[LWDM] PERF: cleanup old field from settings reducers

### DIFF
--- a/.changeset/tall-buckets-march.md
+++ b/.changeset/tall-buckets-march.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+cleanup old fields in settings reducers

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
@@ -12,6 +12,7 @@ import reducer, {
   localeSelector,
   INITIAL_STATE as SETTINGS_INITIAL_STATE,
   SettingsState,
+  filterValidSettings,
 } from "./settings";
 
 const invalidDeviceModelIds = ["nanoFTS", undefined, "whatever"];
@@ -167,5 +168,137 @@ describe("action: purgeAnonymousUserNotifications", () => {
     const newState = reducer(state, purgeExpiredAnonymousUserNotifications({ now }));
 
     expect(newState).toBe(state);
+  });
+});
+
+describe("filterValidSettings", () => {
+  it("should keep valid settings fields", () => {
+    const importedSettings: Partial<SettingsState> = {
+      counterValue: "EUR",
+      theme: "dark",
+      language: "en",
+      locale: "en-US",
+      hideEmptyTokenAccounts: true,
+    };
+
+    const filtered = filterValidSettings(importedSettings);
+
+    expect(filtered).toEqual(importedSettings);
+    expect(filtered.counterValue).toBe("EUR");
+    expect(filtered.theme).toBe("dark");
+    expect(filtered.language).toBe("en");
+    expect(filtered.locale).toBe("en-US");
+    expect(filtered.hideEmptyTokenAccounts).toBe(true);
+  });
+
+  it("should filter out unknown/obsolete fields like nftCollectionsStatusByNetwork", () => {
+    const importedSettings = {
+      counterValue: "USD",
+      theme: "light",
+      nftCollectionsStatusByNetwork: { ethereum: { someCollection: true } },
+      someOtherUnknownField: "should be filtered",
+    };
+
+    const filtered = filterValidSettings(importedSettings as Partial<SettingsState>);
+
+    expect(filtered.counterValue).toBe("USD");
+    expect(filtered.theme).toBe("light");
+    expect("nftCollectionsStatusByNetwork" in filtered).toBe(false);
+    expect("someOtherUnknownField" in filtered).toBe(false);
+  });
+
+  it("should handle empty object", () => {
+    const filtered = filterValidSettings({});
+
+    expect(filtered).toEqual({});
+  });
+
+  it("should handle mixed valid and invalid fields", () => {
+    const importedSettings = {
+      counterValue: "GBP",
+      obsoleteField1: "value1",
+      theme: "dark",
+      obsoleteField2: { nested: "value" },
+      language: "en",
+    };
+
+    const filtered = filterValidSettings(importedSettings as Partial<SettingsState>);
+
+    expect(filtered.counterValue).toBe("GBP");
+    expect(filtered.theme).toBe("dark");
+    expect(filtered.language).toBe("en");
+    expect("obsoleteField1" in filtered).toBe(false);
+    expect("obsoleteField2" in filtered).toBe(false);
+  });
+});
+
+describe("FETCH_SETTINGS action", () => {
+  it("should filter out unknown fields when fetching settings", () => {
+    const initialState = SETTINGS_INITIAL_STATE;
+    const importedSettings = {
+      ...SETTINGS_INITIAL_STATE,
+      counterValue: "JPY",
+      theme: "dark",
+      nftCollectionsStatusByNetwork: { ethereum: {} },
+      deprecatedField: "should be removed",
+    };
+
+    const action = {
+      type: "FETCH_SETTINGS" as const,
+      payload: importedSettings as Partial<SettingsState>,
+    };
+    const newState = reducer(initialState, action);
+
+    expect(newState.counterValue).toBe("JPY");
+    expect(newState.theme).toBe("dark");
+    expect(newState.loaded).toBe(true);
+    expect("nftCollectionsStatusByNetwork" in newState).toBe(false);
+    expect("deprecatedField" in newState).toBe(false);
+  });
+
+  it("should preserve valid settings and filter invalid ones", () => {
+    const initialState = SETTINGS_INITIAL_STATE;
+    const importedSettings = {
+      ...SETTINGS_INITIAL_STATE,
+      counterValue: "CHF",
+      language: "en",
+      locale: "en-GB",
+      oldField: "removed",
+      hideEmptyTokenAccounts: false,
+    };
+
+    const action = {
+      type: "FETCH_SETTINGS" as const,
+      payload: importedSettings as Partial<SettingsState>,
+    };
+    const newState = reducer(initialState, action);
+
+    expect(newState.counterValue).toBe("CHF");
+    expect(newState.language).toBe("en");
+    expect(newState.locale).toBe("en-GB");
+    expect(newState.hideEmptyTokenAccounts).toBe(false);
+    expect(newState.loaded).toBe(true);
+    expect("oldField" in newState).toBe(false);
+  });
+});
+
+describe("SAVE_SETTINGS action", () => {
+  it("should filter out unknown fields when saving settings", () => {
+    const initialState = SETTINGS_INITIAL_STATE;
+    const settingsToSave = {
+      counterValue: "AUD",
+      nftCollectionsStatusByNetwork: { polygon: {} },
+      theme: "light",
+    };
+
+    const action = {
+      type: "SAVE_SETTINGS" as const,
+      payload: settingsToSave as Partial<SettingsState>,
+    };
+    const newState = reducer(initialState, action);
+
+    expect(newState.counterValue).toBe("AUD");
+    expect(newState.theme).toBe("light");
+    expect("nftCollectionsStatusByNetwork" in newState).toBe(false);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -284,23 +284,45 @@ type HandlersPayloads = {
 };
 type SettingsHandlers<PreciseKey = true> = Handlers<SettingsState, HandlersPayloads, PreciseKey>;
 
+/**
+ * Filters imported settings to only include valid SettingsState keys.
+ * This prevents unknown/obsolete fields (like nftCollectionsStatusByNetwork) from being imported.
+ */
+function isValidSettingsKey(key: string): key is keyof SettingsState {
+  return key in INITIAL_STATE;
+}
+
+export function filterValidSettings(
+  importedSettings: Partial<SettingsState>,
+): Partial<SettingsState> {
+  const validKeys = new Set<string>(Object.keys(INITIAL_STATE));
+
+  return Object.fromEntries(
+    Object.entries(importedSettings).filter(
+      ([key]) => validKeys.has(key) && isValidSettingsKey(key),
+    ),
+  ) as Partial<SettingsState>;
+}
+
 const handlers: SettingsHandlers = {
   SAVE_SETTINGS: (state, { payload }) => {
     if (!payload) return state;
+    const filteredPayload = filterValidSettings(payload);
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const changed = (Object.keys(payload) as (keyof typeof payload)[]).some(
-      key => payload[key] !== state[key],
+    const changed = (Object.keys(filteredPayload) as (keyof typeof filteredPayload)[]).some(
+      key => filteredPayload[key] !== state[key],
     );
     if (!changed) return state;
     return {
       ...state,
-      ...payload,
+      ...filteredPayload,
     };
   },
   FETCH_SETTINGS: (state, { payload: settings }) => {
+    const filteredSettings = filterValidSettings(settings);
     return {
       ...state,
-      ...settings,
+      ...filteredSettings,
       loaded: true,
     };
   },

--- a/apps/ledger-live-mobile/src/reducers/settings.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.test.ts
@@ -4,9 +4,12 @@ import {
   lastSeenDeviceSelector,
   resolvedThemeSelector,
   INITIAL_STATE as SETTINGS_INITIAL_STATE,
+  filterValidSettings,
 } from "./settings";
-import { State, Theme } from "./types";
+import { State, Theme, SettingsState } from "./types";
 import { aDeviceInfoBuilder } from "@ledgerhq/live-common/mock/fixtures/aDeviceInfo";
+import reducer from "./settings";
+import { importSettings } from "../actions/settings";
 
 const invalidDeviceModelIds = ["nanoFTS", undefined, "whatever"];
 const validDeviceModelIds: DeviceModelId[] = Object.values(DeviceModelId);
@@ -131,5 +134,106 @@ describe("resolvedThemeSelector", () => {
       expect(resolvedThemeSelector(createState("system", null))).toBe("dark");
       expect(resolvedThemeSelector(createState("system", undefined))).toBe("dark");
     });
+  });
+});
+
+describe("filterValidSettings", () => {
+  it("should keep valid settings fields", () => {
+    const importedSettings: Partial<SettingsState> = {
+      counterValue: "EUR",
+      theme: "dark",
+      language: "fr",
+      locale: "fr-FR",
+      hideEmptyTokenAccounts: true,
+    };
+
+    const filtered = filterValidSettings(importedSettings);
+
+    expect(filtered).toEqual(importedSettings);
+    expect(filtered.counterValue).toBe("EUR");
+    expect(filtered.theme).toBe("dark");
+    expect(filtered.language).toBe("fr");
+    expect(filtered.locale).toBe("fr-FR");
+    expect(filtered.hideEmptyTokenAccounts).toBe(true);
+  });
+
+  it("should filter out unknown/obsolete fields like nftCollectionsStatusByNetwork", () => {
+    const importedSettings = {
+      counterValue: "USD",
+      theme: "light",
+      nftCollectionsStatusByNetwork: { ethereum: { someCollection: true } },
+      someOtherUnknownField: "should be filtered",
+    };
+
+    const filtered = filterValidSettings(importedSettings as Partial<SettingsState>);
+
+    expect(filtered.counterValue).toBe("USD");
+    expect(filtered.theme).toBe("light");
+    expect("nftCollectionsStatusByNetwork" in filtered).toBe(false);
+    expect("someOtherUnknownField" in filtered).toBe(false);
+  });
+
+  it("should handle empty object", () => {
+    const filtered = filterValidSettings({});
+
+    expect(filtered).toEqual({});
+  });
+
+  it("should handle mixed valid and invalid fields", () => {
+    const importedSettings = {
+      counterValue: "GBP",
+      obsoleteField1: "value1",
+      theme: "system",
+      obsoleteField2: { nested: "value" },
+      language: "en",
+    };
+
+    const filtered = filterValidSettings(importedSettings as Partial<SettingsState>);
+
+    expect(filtered.counterValue).toBe("GBP");
+    expect(filtered.theme).toBe("system");
+    expect(filtered.language).toBe("en");
+    expect("obsoleteField1" in filtered).toBe(false);
+    expect("obsoleteField2" in filtered).toBe(false);
+  });
+});
+
+describe("SETTINGS_IMPORT action", () => {
+  it("should filter out unknown fields when importing settings", () => {
+    const initialState = SETTINGS_INITIAL_STATE;
+    const importedSettings = {
+      counterValue: "JPY",
+      theme: "dark",
+      nftCollectionsStatusByNetwork: { ethereum: {} },
+      deprecatedField: "should be removed",
+    };
+
+    const action = importSettings(importedSettings as Partial<SettingsState>);
+    const newState = reducer(initialState, action);
+
+    expect(newState.counterValue).toBe("JPY");
+    expect(newState.theme).toBe("dark");
+    expect("nftCollectionsStatusByNetwork" in newState).toBe(false);
+    expect("deprecatedField" in newState).toBe(false);
+  });
+
+  it("should preserve valid settings and filter invalid ones", () => {
+    const initialState = SETTINGS_INITIAL_STATE;
+    const importedSettings = {
+      counterValue: "CHF",
+      language: "de",
+      locale: "de-DE",
+      oldField: "removed",
+      hideEmptyTokenAccounts: false,
+    };
+
+    const action = importSettings(importedSettings as Partial<SettingsState>);
+    const newState = reducer(initialState, action);
+
+    expect(newState.counterValue).toBe("CHF");
+    expect(newState.language).toBe("de");
+    expect(newState.locale).toBe("de-DE");
+    expect(newState.hideEmptyTokenAccounts).toBe(false);
+    expect("oldField" in newState).toBe(false);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - settings no longer "leak" old fields in the app.json

### 📝 Description

**Problem:**

When importing settings from app.json or the database, unknown/obsolete fields (e.g., nftCollectionsStatusByNetwork) were being imported into the state, contributing to overall app.json size.

**Solution:**

Added filterValidSettings() to filter imported settings and keep only valid SettingsState keys.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25404


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
