### PR TITLE
[LWDM] PERF: optimize countervalues export size dropping non observed datapoints

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/actions/general.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/general.ts
@@ -22,6 +22,7 @@ import { osDarkModeSelector } from "~/renderer/reducers/application";
 import {
   counterValueCurrencySelector,
   getOrderAccounts,
+  selectedTimeRangeSelector,
   userThemeSelector,
 } from "~/renderer/reducers/settings";
 import { walletSelector } from "../reducers/wallet";
@@ -107,6 +108,7 @@ export const themeSelector = createSelector(
 export function useCalculateCountervaluesUserSettings() {
   const dispatch = useDispatch();
   const countervalue = useSelector(counterValueCurrencySelector);
+  const selectedTimeRange = useSelector(selectedTimeRangeSelector);
 
   // countervalues for accounts
   const accounts = useSelector(accountsSelector);
@@ -126,6 +128,7 @@ export function useCalculateCountervaluesUserSettings() {
           hourly: Number(granularitiesRatesConfig.params?.hourly),
         }
       : undefined;
+
     dispatch(
       countervaluesActions.COUNTERVALUES_USER_SETTINGS_SET({
         trackingPairs,
@@ -135,7 +138,8 @@ export function useCalculateCountervaluesUserSettings() {
           "config_countervalues_marketCapBatchingAfterRank",
         ),
         granularitiesRates,
+        selectedTimeRange,
       }),
     );
-  }, [dispatch, granularitiesRatesConfig, extraSessionTrackingPairs, trPairs]);
+  }, [dispatch, granularitiesRatesConfig, extraSessionTrackingPairs, trPairs, selectedTimeRange]);
 }

--- a/apps/ledger-live-desktop/src/renderer/components/CountervaluesProvider.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CountervaluesProvider.tsx
@@ -79,7 +79,11 @@ function useCacheManager() {
   const state = useCountervaluesState();
   useEffect(() => {
     if (!Object.keys(state.status).length) return;
-    setKey("app", "countervalues", exportCountervalues(state, userSettings.trackingPairs));
+    setKey(
+      "app",
+      "countervalues",
+      exportCountervalues(state, userSettings.trackingPairs, userSettings.selectedTimeRange),
+    );
   }, [state, userSettings]);
 }
 

--- a/apps/ledger-live-mobile/src/actions/general.ts
+++ b/apps/ledger-live-mobile/src/actions/general.ts
@@ -15,7 +15,11 @@ import { useDistribution as useDistributionCommon } from "@ledgerhq/live-counter
 import { BehaviorSubject } from "rxjs";
 import { cleanCache, reorderAccounts } from "./accounts";
 import { accountsSelector } from "../reducers/accounts";
-import { counterValueCurrencySelector, orderAccountsSelector } from "../reducers/settings";
+import {
+  counterValueCurrencySelector,
+  orderAccountsSelector,
+  selectedTimeRangeSelector,
+} from "../reducers/settings";
 import { clearBridgeCache } from "../bridge/cache";
 import { flushAll } from "../components/DBSave";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
@@ -103,6 +107,7 @@ export function useCleanCache() {
 
 export function useUserSettings() {
   const trackingPairs = useTrackingPairs();
+  const selectedTimeRange = useSelector(selectedTimeRangeSelector);
 
   const granularitiesRatesConfig = useFeature("llCounterValueGranularitiesRates");
   const granularitiesRates = useMemo(
@@ -125,8 +130,9 @@ export function useUserSettings() {
         "config_countervalues_marketCapBatchingAfterRank",
       ),
       granularitiesRates,
+      selectedTimeRange,
     }),
-    [granularitiesRates, trackingPairs],
+    [granularitiesRates, trackingPairs, selectedTimeRange],
   );
 }
 

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -6,7 +6,7 @@ import isEqual from "lodash/isEqual";
 import throttleFn from "lodash/throttle";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useSelector } from "~/context/hooks";
-import { useTrackingPairs } from "~/actions/general";
+import { useTrackingPairs, useUserSettings } from "~/actions/general";
 import {
   saveAccounts,
   saveBle,
@@ -164,8 +164,12 @@ const extractIdentitiesForPersistence = (state: State) =>
 
 export const ConfigureDBSaveEffects = () => {
   const trackingPairs = useTrackingPairs();
+  const userSettings = useUserSettings();
   const state = useCountervaluesState();
-  const rawState = useMemo(() => exportCountervalues(state, trackingPairs), [state, trackingPairs]);
+  const rawState = useMemo(
+    () => exportCountervalues(state, trackingPairs, userSettings.selectedTimeRange),
+    [state, trackingPairs, userSettings.selectedTimeRange],
+  );
   const lastRawState = useRef(rawState);
   const countervaluesChangesStats = useCallback(() => {
     const changed = lastRawState.current !== rawState;

--- a/libs/live-countervalues/src/helpers.ts
+++ b/libs/live-countervalues/src/helpers.ts
@@ -1,5 +1,6 @@
 import { Currency } from "@ledgerhq/types-cryptoassets";
 import type { RateGranularity } from "./types";
+import type { PortfolioRange } from "@ledgerhq/types-live";
 
 export const inferCurrencyAPIID = (currency: Currency): string => {
   switch (currency.type) {
@@ -28,9 +29,25 @@ export const datapointLimits: Record<RateGranularity, number> = {
   hourly: 7 * DAY, // we fetch at MOST a week of hourly. after that there are too much data...
 };
 
-export const datapointRetention: Record<Extract<RateGranularity, "hourly">, number> = {
+export const datapointRetention: Record<RateGranularity, number> = {
   hourly: 7 * DAY, // we keep hourly data for 7 days
+  daily: 9999 * DAY, // we keep daily data for a very long time by default, can be overridden by user settings
 };
+
+export function portfolioRangeToDays(range: PortfolioRange): number | undefined {
+  switch (range) {
+    case "day":
+      return 1;
+    case "week":
+      return 7;
+    case "month":
+      return 30;
+    case "year":
+      return 365;
+    case "all":
+      return undefined;
+  }
+}
 
 /**
  * efficient implementation of YYYY-MM-DD formatter

--- a/libs/live-countervalues/src/types.ts
+++ b/libs/live-countervalues/src/types.ts
@@ -1,6 +1,7 @@
 // CountervaluesSettings is user config that drives the countervalues logic.
 
 import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { PortfolioRange } from "@ledgerhq/types-live";
 
 // we generally will just infer it from Accounts
 export type CountervaluesSettings = {
@@ -16,6 +17,7 @@ export type CountervaluesSettings = {
   disableAutoRecoverErrors?: boolean;
 
   granularitiesRates?: Record<RateGranularity, number>;
+  selectedTimeRange?: PortfolioRange;
 };
 // This is the internal state of countervalues.
 export type CounterValuesState = {


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - graph
  - historical countervalues

### 📝 Description

Optimize the countervalues exported in app.json to only select what user observes.

in our 16MB app.json dataset, we can drastically optimize; with all the other optimize:
in a **1 MONTH** time window, that optim on Daily alone moves me **from 3.4 MB to 0.8 MB**.


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25408


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
