### PR TITLE
ci: specify cross repo token scopes

### DIFF
--- a/.github/workflows/bot-nonreg-nitrogen.yml
+++ b/.github/workflows/bot-nonreg-nitrogen.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
       - name: Retrieving coin apps
         uses: actions/checkout@v4

--- a/.github/workflows/bot-nonreg-oxygen.yml
+++ b/.github/workflows/bot-nonreg-oxygen.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
       - name: Retrieving coin apps
         uses: actions/checkout@v4

--- a/.github/workflows/bot-portfolio-report.yml
+++ b/.github/workflows/bot-portfolio-report.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
       - name: Retrieving coin apps
         uses: actions/checkout@v4

--- a/.github/workflows/bot-staging-explorer-btc.yml
+++ b/.github/workflows/bot-staging-explorer-btc.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
         with:
           ref: main

--- a/.github/workflows/bot-staging-explorer-eth.yml
+++ b/.github/workflows/bot-staging-explorer-eth.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
         with:
           ref: main

--- a/.github/workflows/bot-testing-carbon.yml
+++ b/.github/workflows/bot-testing-carbon.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
       - name: Retrieving coin apps
         uses: actions/checkout@v4

--- a/.github/workflows/bot-testing-mere-denis.yml
+++ b/.github/workflows/bot-testing-mere-denis.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
       - name: Retrieving coin apps
         uses: actions/checkout@v4

--- a/.github/workflows/bot-testing-mooncake.yml
+++ b/.github/workflows/bot-testing-mooncake.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
       - name: Retrieving coin apps
         uses: actions/checkout@v4

--- a/.github/workflows/bot-testing-nitrogen.yml
+++ b/.github/workflows/bot-testing-nitrogen.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
       - name: Retrieving coin apps
         uses: actions/checkout@v4

--- a/.github/workflows/bot-testing-oxygen.yml
+++ b/.github/workflows/bot-testing-oxygen.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
       - name: Retrieving coin apps
         uses: actions/checkout@v4

--- a/.github/workflows/bot-testing-phosphore.yml
+++ b/.github/workflows/bot-testing-phosphore.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
       - name: Retrieving coin apps
         uses: actions/checkout@v4

--- a/.github/workflows/bot-testing-silicium.yml
+++ b/.github/workflows/bot-testing-silicium.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
       - name: Retrieving coin apps
         uses: actions/checkout@v4

--- a/.github/workflows/bot-transfer.yml
+++ b/.github/workflows/bot-transfer.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
       - name: Retrieving coin apps
         uses: actions/checkout@v4

--- a/.github/workflows/release-final-nightly.yml
+++ b/.github/workflows/release-final-nightly.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            ledger-live
+            ledger-live-build
 
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -42,7 +42,10 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
-          
+          repositories: |
+            ledger-live
+            ledger-live-build
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            ledger-live
+            ledger-live-build
       - uses: actions/checkout@v4
         if: ${{ github.event_name == 'push' }}
         with:

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -143,6 +143,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -131,6 +131,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            coin-apps
+            ledger-live
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### 📝 Description

The replacement of the bot token results in the tokens being scoped to just the current repository. This PR specifies the correct repo's to appropriately scope the tokens

Test run: 
LL -> LLB https://github.com/LedgerHQ/ledger-live/actions/runs/21416050754
LL -> Coin https://github.com/LedgerHQ/ledger-live/actions/runs/21416573906