### PR TITLE
[LWM] 💄 change network crypto icons border radius to match LWD

### DIFF
--- a/.changeset/plenty-candles-swim.md
+++ b/.changeset/plenty-candles-swim.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": patch
+---
+
+Change network crypto icons border radius to match LWD

--- a/libs/ui/packages/native/src/pre-ldls/components/NetworkItem/NetworkItem.tsx
+++ b/libs/ui/packages/native/src/pre-ldls/components/NetworkItem/NetworkItem.tsx
@@ -70,7 +70,7 @@ export const NetworkItem = ({
       })}
       testID={`network-item-${name}`}
     >
-      <CryptoIcon size={48} ledgerId={id} ticker={ticker} />
+      <CryptoIcon size={48} overridesRadius={12} ledgerId={id} ticker={ticker} />
       <InfoWrapper tokens={tokens}>
         <Text
           variant="largeLineHeight"


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Network icons visual consistency between LWD and LWM

### 📝 Description

**Problem**: Network crypto icons had different border radius between Ledger Live Desktop and Ledger Live Mobile, causing visual inconsistency across platforms.

**Solution**: Updated the `NetworkItem` component to use `overridesRadius={12}` on the `CryptoIcon`, matching the 12px border radius used in LWD (25% of 48px icon size).

**Changes**:
- Modified `@ledgerhq/native-ui` NetworkItem component
- Added `overridesRadius={12}` prop to CryptoIcon in NetworkItem

| Before | After |
| ------ | ----- |
| <img width="200" height="2868" alt="image" src="https://github.com/user-attachments/assets/e1be3201-7d48-4eb7-baac-9f2d31befffa" /> | <img width="200" height="2868" alt="image" src="https://github.com/user-attachments/assets/39ab1bae-8e03-4d4c-9f69-3b816cc8936c" /> |

### ❓ Context

- **JIRA link**: [LIVE-25426](https://ledgerhq.atlassian.net/browse/LIVE-25426)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA issue.
- **The PR description clearly documents the changes** made and explains the technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-25426]: https://ledgerhq.atlassian.net/browse/LIVE-25426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ