### PR TITLE
test(e2e): add Market page E2E tests for filters behavior

### DIFF
--- a/.changeset/add-market-e2e-tests.md
+++ b/.changeset/add-market-e2e-tests.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+Add E2E tests for Market page filters behavior

--- a/e2e/desktop/tests/page/market.page.ts
+++ b/e2e/desktop/tests/page/market.page.ts
@@ -1,5 +1,6 @@
 import { AppPage } from "./abstractClasses";
 import { step } from "../misc/reporters/step";
+import { expect } from "@playwright/test";
 
 export class MarketPage extends AppPage {
   private searchInput = this.page.getByTestId("market-search-input");
@@ -12,9 +13,20 @@ export class MarketPage extends AppPage {
   private stakeButton = (ticker: string) => this.page.getByTestId(`market-${ticker}-stake-button`);
   private swapButtonOnAsset = this.page.getByTestId("market-coin-swap-button");
 
+  // Filter controls - using text selector because react-select doesn't forward data-testid
+  private filterDropdown = this.page.getByText("Show").first();
+  private starButton = (ticker: string) => this.page.getByTestId(`market-${ticker}-star-button`);
+  private starredOptionFilter = this.page.getByRole("option", { name: "Starred Assets" });
+
   @step("Search for $0")
   async search(query: string) {
     await this.searchInput.fill(query);
+  }
+
+  @step("Validate Market List")
+  async validateMarketList() {
+    await this.coinRow("btc").waitFor({ state: "visible" });
+    await this.coinRow("eth").waitFor({ state: "visible" });
   }
 
   @step("Open coin page for $0")
@@ -42,5 +54,31 @@ export class MarketPage extends AppPage {
   @step("Click on stake button for $0")
   async stakeButtonClick(ticker: string) {
     await this.stakeButton(ticker.toLowerCase()).click();
+  }
+
+  @step("Expect filter dropdown to be visible")
+  async expectFilterDropdownToBeVisible() {
+    await expect(this.filterDropdown).toBeVisible();
+  }
+
+  @step("Open filter dropdown and select Starred Assets")
+  async selectStarredAssetsFilter() {
+    await this.filterDropdown.click();
+    await this.starredOptionFilter.click();
+  }
+
+  @step("Star coin $0")
+  async starCoin(ticker: string) {
+    await this.starButton(ticker).click();
+  }
+
+  @step("Expect coin $0 to be visible")
+  async expectCoinToBeVisible(ticker: string) {
+    await expect(this.coinRow(ticker)).toBeVisible();
+  }
+
+  @step("Expect coin $0 to not be visible")
+  async expectCoinToNotBeVisible(ticker: string) {
+    await expect(this.coinRow(ticker)).not.toBeVisible();
   }
 }

--- a/e2e/desktop/tests/specs/market.spec.ts
+++ b/e2e/desktop/tests/specs/market.spec.ts
@@ -1,0 +1,59 @@
+import { test } from "tests/fixtures/common";
+import { addTmsLink } from "tests/utils/allureUtils";
+import { getDescription } from "tests/utils/customJsonReporter";
+
+test.describe("Market", () => {
+  test.use({
+    //todo:  remove feature flag when market banner is enabled for all users
+    userdata: "speculos-tests-app",
+    featureFlags: {
+      lwdWallet40: {
+        enabled: true,
+        params: {
+          marketBanner: true,
+        },
+      },
+    },
+  });
+
+  test(
+    "Market list content",
+    {
+      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+      annotation: {
+        type: "TMS",
+        description: "B2CQA-4316",
+      },
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+      await app.marketBanner.clickExploreMarketHeader();
+      await app.market.validateMarketList();
+    },
+  );
+
+  test.only(
+    "Filters behavior",
+    {
+      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+      annotation: {
+        type: "TMS",
+        description: "B2CQA-4315",
+      },
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+      await app.marketBanner.clickExploreMarketHeader();
+
+      await app.market.validateMarketList();
+
+      await app.market.starCoin("btc");
+      await app.market.expectFilterDropdownToBeVisible();
+      await app.market.selectStarredAssetsFilter();
+      await app.market.expectCoinToBeVisible("btc");
+      await app.market.expectCoinToNotBeVisible("eth");
+    },
+  );
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Market page E2E test suite
      - Filter dropdown interaction tests
      - Star/favorite coin functionality tests

### 📝 Description

This PR adds new E2E tests for the Market page, specifically covering the filters behavior functionality.

**Changes:**
- Added new `market.spec.ts` with tests for:
  - **B2CQA-4316**: Market list content verification (BTC and ETH visible)
  - **B2CQA-4315**: Filters behavior - starring Bitcoin, selecting "Starred Assets" filter, and verifying only starred coins are displayed
  
- Extended `market.page.ts` with new methods:
  - `expectFilterDropdownToBeVisible()` - Verifies the "Show" filter dropdown is visible
  - `selectStarredAssetsFilter()` - Opens filter and selects "Starred Assets"
  - `starCoin(ticker)` - Stars a coin in the market list
  - `expectCoinToBeVisible(ticker)` / `expectCoinToNotBeVisible(ticker)` - Visibility assertions

### ❓ Context

- **JIRA or GitHub link**: N/A - Test coverage improvement

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.