### PR TITLE
feat(mobile): add tap to toggle discreet mode on portfolio balance

### DIFF
--- a/.changeset/toggle-discreet-mode-balance.md
+++ b/.changeset/toggle-discreet-mode-balance.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add tap to toggle discreet mode on portfolio balance

--- a/apps/ledger-live-mobile/src/components/DiscreetModeButton.tsx
+++ b/apps/ledger-live-mobile/src/components/DiscreetModeButton.tsx
@@ -1,24 +1,13 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { TouchableOpacity, StyleSheet } from "react-native";
-import { useSelector, useDispatch } from "~/context/hooks";
 import { EyeMedium, EyeNoneMedium } from "@ledgerhq/native-ui/assets/icons";
-import { discreetModeSelector } from "~/reducers/settings";
-import { setDiscreetMode } from "~/actions/settings";
-import { track } from "~/analytics";
+import { useToggleDiscreetMode } from "~/hooks/useToggleDiscreetMode";
 
 export default function DiscreetModeButton({ size = 24 }: { size?: number }) {
-  const discreetMode = useSelector(discreetModeSelector);
-  const dispatch = useDispatch();
-  const onPress = useCallback(() => {
-    track("button_clicked", {
-      button: "Discreet mode",
-      toggle: !discreetMode ? "ON" : "OFF",
-    });
-    dispatch(setDiscreetMode(!discreetMode));
-  }, [discreetMode, dispatch]);
+  const { discreetMode, toggleDiscreetMode } = useToggleDiscreetMode();
 
   return (
-    <TouchableOpacity onPress={onPress} style={styles.root}>
+    <TouchableOpacity onPress={toggleDiscreetMode} style={styles.root}>
       {discreetMode ? (
         <EyeNoneMedium size={size} color={"neutral.c100"} />
       ) : (

--- a/apps/ledger-live-mobile/src/hooks/__tests__/useToggleDiscreetMode.test.ts
+++ b/apps/ledger-live-mobile/src/hooks/__tests__/useToggleDiscreetMode.test.ts
@@ -1,0 +1,22 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { useToggleDiscreetMode } from "../useToggleDiscreetMode";
+
+describe("useToggleDiscreetMode", () => {
+  it("should toggle discreet mode", () => {
+    const { result, store } = renderHook(() => useToggleDiscreetMode());
+
+    expect(result.current.discreetMode).toBe(false);
+
+    act(() => {
+      result.current.toggleDiscreetMode();
+    });
+
+    expect(store.getState().settings.discreetMode).toBe(true);
+
+    act(() => {
+      result.current.toggleDiscreetMode();
+    });
+
+    expect(store.getState().settings.discreetMode).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/hooks/useToggleDiscreetMode.ts
+++ b/apps/ledger-live-mobile/src/hooks/useToggleDiscreetMode.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { useSelector, useDispatch } from "~/context/hooks";
+import { discreetModeSelector } from "~/reducers/settings";
+import { setDiscreetMode } from "~/actions/settings";
+import { track } from "~/analytics";
+
+interface UseToggleDiscreetModeResult {
+  readonly discreetMode: boolean;
+  readonly toggleDiscreetMode: () => void;
+}
+
+export function useToggleDiscreetMode(): UseToggleDiscreetModeResult {
+  const discreetMode = useSelector(discreetModeSelector);
+  const dispatch = useDispatch();
+
+  const toggleDiscreetMode = useCallback(() => {
+    track("button_clicked", {
+      button: "Discreet mode",
+      toggle: discreetMode ? "OFF" : "ON",
+    });
+    dispatch(setDiscreetMode(!discreetMode));
+  }, [discreetMode, dispatch]);
+
+  return {
+    discreetMode,
+    toggleDiscreetMode,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { InfiniteLoader } from "@ledgerhq/native-ui";
-import { AmountDisplay, Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { AmountDisplay, Box, Pressable, Text } from "@ledgerhq/lumen-ui-rnative";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
@@ -29,6 +29,7 @@ export const PortfolioBalanceSectionView = ({
   countervalueChange,
   unit,
   isBalanceAvailable,
+  onToggleDiscreetMode,
 }: PortfolioBalanceSectionViewProps) => {
   const { t } = useTranslation();
   const { locale } = useLocale();
@@ -72,13 +73,15 @@ export const PortfolioBalanceSectionView = ({
       lx={{ ...containerStyle, paddingBottom: "s64" }}
       testID={isBalanceAvailable ? "portfolio-balance-normal" : "portfolio-balance-loading"}
     >
-      <AmountDisplay
-        key={unit.code}
-        value={isBalanceAvailable ? balance : 0}
-        formatter={formatter}
-        hidden={!isBalanceAvailable || discreet}
-        testID="portfolio-balance-amount"
-      />
+      <Pressable onPress={onToggleDiscreetMode} testID="portfolio-balance-toggle">
+        <AmountDisplay
+          key={unit.code}
+          value={isBalanceAvailable ? balance : 0}
+          formatter={formatter}
+          hidden={!isBalanceAvailable || discreet}
+          testID="portfolio-balance-amount"
+        />
+      </Pressable>
       <Box lx={{ ...rowStyle, ...(!isBalanceAvailable && { minHeight: "s24" }) }}>
         {getBalanceIndicator()}
       </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/index.tsx
@@ -7,7 +7,7 @@ export const PortfolioBalanceSection = ({
   showAssets,
   isReadOnlyMode = false,
 }: PortfolioBalanceSectionProps) => {
-  const { state, balance, countervalueChange, unit, isBalanceAvailable } =
+  const { state, balance, countervalueChange, unit, isBalanceAvailable, onToggleDiscreetMode } =
     usePortfolioBalanceSectionViewModel({
       showAssets,
       isReadOnlyMode,
@@ -20,6 +20,7 @@ export const PortfolioBalanceSection = ({
       countervalueChange={countervalueChange}
       unit={unit}
       isBalanceAvailable={isBalanceAvailable}
+      onToggleDiscreetMode={onToggleDiscreetMode}
     />
   );
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/types.ts
@@ -14,6 +14,7 @@ export interface PortfolioBalanceSectionViewProps {
   readonly countervalueChange: ValueChange;
   readonly unit: Unit;
   readonly isBalanceAvailable: boolean;
+  readonly onToggleDiscreetMode: () => void;
 }
 
 export type UsePortfolioBalanceSectionViewModelResult = PortfolioBalanceSectionViewProps;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useSelector } from "~/context/hooks";
 import { usePortfolioAllAccounts } from "~/hooks/portfolio";
+import { useToggleDiscreetMode } from "~/hooks/useToggleDiscreetMode";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import {
   PortfolioBalanceState,
@@ -13,6 +14,7 @@ export const usePortfolioBalanceSectionViewModel = ({
   isReadOnlyMode,
 }: PortfolioBalanceSectionProps): UsePortfolioBalanceSectionViewModelResult => {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const { toggleDiscreetMode } = useToggleDiscreetMode();
   const portfolio = usePortfolioAllAccounts();
 
   const { countervalueChange, balanceHistory, balanceAvailable } = portfolio;
@@ -36,5 +38,6 @@ export const usePortfolioBalanceSectionViewModel = ({
     countervalueChange,
     unit,
     isBalanceAvailable: balanceAvailable,
+    onToggleDiscreetMode: toggleDiscreetMode,
   };
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio balance section tap interaction
      - Discreet mode toggle behavior across the app
      - Analytics tracking for discreet mode usage

### 📝 Description

**Problem**: Users have no quick way to hide their balance while viewing the portfolio. The only way to toggle discreet mode is through the settings or using the eye icon in the header.

**Solution**: Added the ability to tap directly on the portfolio balance to toggle discreet mode. This provides a more intuitive and quicker way for users to hide/show their balance.

**Changes**:
- Created a reusable `useToggleDiscreetMode` hook that encapsulates the toggle logic and analytics tracking
- Refactored `DiscreetModeButton` to use the new shared hook
- Made the portfolio balance tappable using `Pressable` from lumen-ui-rnative
- Analytics automatically tracks the page context via the existing `track` function

### ❓ Context

https://github.com/user-attachments/assets/f44c937a-145d-4599-a403-f88e37ac8c23



- **JIRA or GitHub link**: [LIVE-25461](https://ledgerhq.atlassian.net/browse/LIVE-25461)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25461]: https://ledgerhq.atlassian.net/browse/LIVE-25461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ