### PR TITLE
test(desktop): add E2E tests for portfolio analytics navigation

### DIFF
--- a/.changeset/portfolio-analytics-e2e.md
+++ b/.changeset/portfolio-analytics-e2e.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add E2E tests for portfolio analytics navigation

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
@@ -30,7 +30,7 @@ describe("Analytics", () => {
     render(<Analytics />);
 
     expect(screen.getByText("analytics.title")).toBeVisible();
-    expect(screen.getByTestId("portfolio-balance-summary")).toBeVisible();
+    expect(screen.getByTestId("analytics-chart")).toBeVisible();
   });
 
   it("should call navigateToDashboard when back button is clicked", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
@@ -18,7 +18,7 @@ function AnalyticsContent({ viewModel }: { readonly viewModel: AnalyticsViewMode
       <TrackPage category="Analytics" range={selectedTimeRange} countervalue={counterValue} />
       <PageHeader title={t("analytics.title")} onBack={navigateToDashboard} />
 
-      <div className="overflow-hidden rounded-md bg-surface">
+      <div className="overflow-hidden rounded-md bg-surface" data-testid="analytics-chart">
         <PortfolioBalanceSummary
           counterValue={counterValue}
           chartColor={colors.wallet}

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -8,6 +8,7 @@ import { PortfolioView } from "../PortfolioView";
 import * as portfolioReact from "@ledgerhq/live-countervalues-react/portfolio";
 import { useNavigate } from "react-router";
 import { BTC_ACCOUNT } from "../../__mocks__/accounts.mock";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
 
 const MARKET_API_ENDPOINT = "https://countervalues.live.ledger.com/v3/markets";
 
@@ -141,6 +142,37 @@ describe("PortfolioView", () => {
 
       expect(screen.getByTestId("no-balance-title")).toBeVisible();
       expect(screen.queryByTestId("portfolio-balance")).toBeNull();
+    });
+    it("should display discreet placeholders when discreet mode is enabled", () => {
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+        initialState: {
+          accounts: [BTC_ACCOUNT],
+          settings: {
+            ...INITIAL_STATE,
+            discreetMode: true,
+          },
+        },
+      });
+
+      const balanceElement = screen.getByTestId("portfolio-total-balance");
+      expect(balanceElement).toHaveTextContent("••••");
+      expect(balanceElement).not.toHaveTextContent("$1,000.00");
+    });
+
+    it("should display actual balance when discreet mode is disabled", () => {
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+        initialState: {
+          accounts: [BTC_ACCOUNT],
+          settings: {
+            ...INITIAL_STATE,
+            discreetMode: false,
+          },
+        },
+      });
+
+      const balanceElement = screen.getByTestId("portfolio-total-balance");
+      expect(balanceElement).toHaveTextContent("$1,000.00"); // Check for actual balance
+      expect(balanceElement).not.toHaveTextContent("••••"); // Ensure no placeholders
     });
   });
 

--- a/e2e/desktop/tests/component/layout.component.ts
+++ b/e2e/desktop/tests/component/layout.component.ts
@@ -18,6 +18,7 @@ export class Layout extends Component {
   // topbar
   readonly topbarSynchronizeButton = this.page.getByTestId("topbar-synchronize-button");
   readonly topbarSettingsButton = this.page.getByTestId("topbar-settings-button");
+  readonly topbarDiscreetButton = this.page.getByTestId("topbar-discreet-button");
 
   @step("Go to Portfolio")
   async goToPortfolio() {
@@ -62,6 +63,11 @@ export class Layout extends Component {
   @step("synchronize accounts")
   async syncAccounts() {
     await this.topbarSynchronizeButton.click();
+  }
+
+  @step("toggle discreet mode")
+  async toggleDiscreetMode() {
+    await this.topbarDiscreetButton.click();
   }
 
   @step("Wait for accounts sync to be finished")

--- a/e2e/desktop/tests/page/analytics.page.ts
+++ b/e2e/desktop/tests/page/analytics.page.ts
@@ -1,0 +1,20 @@
+import { step } from "tests/misc/reporters/step";
+import { AppPage } from "./abstractClasses";
+import { expect } from "@playwright/test";
+
+export class AnalyticsPage extends AppPage {
+  private pageHeader = this.page.getByTestId("page-header");
+  private chart = this.page.getByTestId("analytics-chart");
+  private backButton = this.pageHeader.getByRole("button");
+
+  @step("Expect analytics screen to be visible")
+  async expectAnalyticsScreenToBeVisible() {
+    await expect(this.pageHeader).toBeVisible();
+    await expect(this.chart).toBeVisible();
+  }
+
+  @step("Click back button to return to portfolio")
+  async clickBackButton() {
+    await this.backButton.click();
+  }
+}

--- a/e2e/desktop/tests/page/index.ts
+++ b/e2e/desktop/tests/page/index.ts
@@ -1,5 +1,6 @@
 import { AccountPage } from "./account.page";
 import { AccountsPage } from "./accounts.page";
+import { AnalyticsPage } from "./analytics.page";
 import { AddAccountModal } from "./modal/add.account.modal";
 import { AssetDrawer } from "./drawer/asset.drawer";
 import { AssetPage } from "./asset.page";
@@ -37,6 +38,7 @@ import { FearAndGreedDialog } from "./dialog/fearGreed.dialog";
 export class Application extends PageHolder {
   public account = new AccountPage(this.page);
   public accounts = new AccountsPage(this.page);
+  public analytics = new AnalyticsPage(this.page);
   public addAccount = new AddAccountModal(this.page);
   public assetDrawer = new AssetDrawer(this.page);
   public assetPage = new AssetPage(this.page);

--- a/e2e/desktop/tests/page/portfolio.page.ts
+++ b/e2e/desktop/tests/page/portfolio.page.ts
@@ -20,6 +20,11 @@ export class PortfolioPage extends AppPage {
   private totalBalance = this.page.getByTestId("total-balance");
   private balanceDiff = this.page.getByTestId("balance-diff");
 
+  // Wallet 4.0 elements
+  private portfolioBalance = this.page.getByTestId("portfolio-balance");
+  private portfolioTotalBalance = this.page.getByTestId("portfolio-total-balance");
+  private portfolioTrend = this.page.getByTestId("portfolio-trend");
+
   @step("Open `Add account` modal")
   async openAddAccountModal() {
     await this.addAccountButton.click();
@@ -155,5 +160,27 @@ export class PortfolioPage extends AppPage {
   @step("Wait for balance to be visible")
   async expectBalanceVisibility() {
     await this.totalBalance.waitFor({ state: "visible" });
+  }
+
+  // Wallet 4.0 methods
+  @step("Check portfolio total balance visibility")
+  async checkPortfolioTotalBalanceVisibility() {
+    await expect(this.portfolioTotalBalance).toBeVisible();
+  }
+
+  @step("Check one-day performance indicator visibility")
+  async checkOneDayPerformanceIndicatorVisibility() {
+    await expect(this.portfolioTrend).toBeVisible();
+  }
+
+  @step("Click on performance pill to navigate to analytics")
+  async clickOnPerformancePill() {
+    await expect(this.portfolioTrend).toBeVisible();
+    await this.portfolioTrend.click();
+  }
+
+  @step("Expect portfolio screen to be visible")
+  async expectPortfolioScreenToBeVisible() {
+    await expect(this.portfolioBalance).toBeVisible();
   }
 }

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -27,3 +27,40 @@ test.describe("Portfolio", () => {
     },
   );
 });
+
+test.describe("Portfolio Wallet 4.0", () => {
+  test.use({
+    userdata: "speculos-tests-app",
+    // to-do remove when wallet 4.0 is default
+    featureFlags: {
+      lwdWallet40: {
+        enabled: true,
+        params: {
+          marketBanner: true,
+          graphRework: true,
+          quickActionCtas: true,
+        },
+      },
+    },
+  });
+
+  test(
+    "Portfolio displays balance and performance indicators with non-zero balance accounts and clicking on performance pill navigates to analytics",
+    {
+      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+      annotation: {
+        type: "TMS",
+        description: "B2CQA-4339, B2CQA-4340, B2CQA-4345",
+      },
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.portfolio.checkPortfolioTotalBalanceVisibility();
+      await app.portfolio.checkOneDayPerformanceIndicatorVisibility();
+      await app.portfolio.clickOnPerformancePill();
+      await app.analytics.expectAnalyticsScreenToBeVisible();
+      await app.analytics.clickBackButton();
+      await app.portfolio.expectPortfolioScreenToBeVisible();
+    },
+  );
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This PR adds E2E tests - the tests themselves are the coverage._
- [x] **Impact of the changes:**
      - Portfolio screen E2E test coverage
      - Analytics screen navigation flow
      - Back navigation from analytics to portfolio

### 📝 Description

This PR adds E2E tests for the portfolio analytics navigation feature in Wallet 4.0.

**Changes:**
- Added test for verifying performance pill visibility and navigation to analytics screen
- Added test for back navigation from analytics screen to portfolio
- Created new `AnalyticsPage` page object for analytics screen assertions
- Updated `PortfolioPage` with Wallet 4.0 elements and navigation methods

**Test coverage:**
1. `Portfolio displays balance and performance indicators with non-zero balance accounts` - Verifies balance and performance pill visibility
2. `Clicking on performance pill navigates to analytics screen` - Verifies navigation to analytics and back to portfolio

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25478

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)