### PR TITLE
chore(coin-evm): embed etherscan message within `InvalidExplorerResponse`

### DIFF
--- a/.changeset/tiny-tables-run.md
+++ b/.changeset/tiny-tables-run.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+chore(coin-evm): embed etherscan message within `InvalidExplorerResponse`

--- a/libs/coin-modules/coin-evm/src/network/explorer/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/etherscan.ts
@@ -412,10 +412,18 @@ export const getLastOperations = makeLRUCache<
       };
     } catch (err) {
       log("EVM getLastOperations", "Error while fetching data from Etherscan like API", err);
-      throw new InvalidExplorerResponse("", { currencyName: currency.name });
+      const message =
+        typeof err === "string"
+          ? err
+          : err instanceof Error
+            ? `${err.name} - ${err.message}`
+            : JSON.stringify(err);
+      throw new InvalidExplorerResponse(`${currency.name} - ${message}`, {
+        currencyName: currency.name,
+      });
     }
   },
-  (currency, address, accountId, fromBlock, toBlock) => accountId + fromBlock + toBlock,
+  (_currency, _address, accountId, fromBlock, toBlock) => accountId + fromBlock + toBlock,
   { ttl: ETHERSCAN_TIMEOUT },
 );
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - No impact on Ledger Wallet, just adding more context while throwing etherscan error

### 📝 Description

Add context while throwing `InvalidExplorerResponse` for easier debug on Sentry

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
