### PR TITLE
feat: lwm - add content drawer debug screen and wallet v4 tour state

### DIFF
--- a/.changeset/perfect-clocks-peel.md
+++ b/.changeset/perfect-clocks-peel.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: ContentDrawer - add tour parameter to lwmWallet40 ff, new hasSeenWalletV4Tour flag, add debug row

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -66,6 +66,7 @@ import {
   SettingsIsOnboardingFlowPayload,
   SettingsIsOnboardingFlowReceiveSuccessPayload,
   SettingsIsPostOnboardingFlowPayload,
+  SettingsSetHasSeenWalletV4TourPayload,
 } from "./types";
 import { ImageType } from "~/components/CustomImage/types";
 
@@ -288,6 +289,10 @@ export const setSelectedTabPortfolioAssets =
   createAction<SettingsSetSelectedTabPortfolioAssetsPayload>(
     SettingsActionTypes.SET_SELECTED_TAB_PORTFOLIO_ASSETS,
   );
+
+export const setHasSeenWalletV4Tour = createAction<SettingsSetHasSeenWalletV4TourPayload>(
+  SettingsActionTypes.SET_HAS_SEEN_WALLET_V4_TOUR,
+);
 
 type PortfolioRangeOption = {
   key: PortfolioRange;

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -303,6 +303,7 @@ export enum SettingsActionTypes {
 
   ADD_STARRED_MARKET_COINS = "ADD_STARRED_MARKET_COINS",
   REMOVE_STARRED_MARKET_COINS = "REMOVE_STARRED_MARKET_COINS",
+  SET_HAS_SEEN_WALLET_V4_TOUR = "SET_HAS_SEEN_WALLET_V4_TOUR",
 }
 
 export type SettingsImportPayload = Partial<SettingsState>;
@@ -390,6 +391,7 @@ export type SettingsSetGeneralTermsVersionAccepted = SettingsState["generalTerms
 export type SettingsSetUserNps = number;
 export type SettingsSetSupportedCounterValues = SettingsState["supportedCounterValues"];
 export type SettingsSetHasSeenAnalyticsOptInPrompt = SettingsState["hasSeenAnalyticsOptInPrompt"];
+export type SettingsSetHasSeenWalletV4TourPayload = SettingsState["hasSeenWalletV4Tour"];
 export type SettingsSetDismissedContentCardsPayload = SettingsState["dismissedContentCards"];
 export type SettingsClearDismissedContentCardsPayload = string[];
 export type SettingsSetFromLedgerSyncOnboardingPayload = boolean;
@@ -456,7 +458,8 @@ export type SettingsPayload =
   | SettingsSetMevProtectionPayload
   | SettingsSetSelectedTabPortfolioAssetsPayload
   | SettingsAddStarredMarketcoinsPayload
-  | SettingsRemoveStarredMarketcoinsPayload;
+  | SettingsRemoveStarredMarketcoinsPayload
+  | SettingsSetHasSeenWalletV4TourPayload;
 
 // === WALLET CONNECT ACTIONS ===
 export enum WalletConnectActionTypes {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -76,6 +76,7 @@ import SwiperScreenDebug from "~/screens/Settings/Debug/Features/SwiperScreenDeb
 import { DebugStorageMigration } from "~/screens/Settings/Debug/Debugging/StorageMigration";
 import CustomCALRefInput from "~/screens/Settings/Developer/CustomCALRefInput";
 import ModularDrawerScreenDebug from "LLM/features/ModularDrawer/Debug";
+import WalletV4TourScreenDebug from "LLM/features/WalletV4Tour/Debug";
 import { UnmountOnBlur } from "./utils/UnmountOnBlur";
 
 const Stack = createNativeStackNavigator<SettingsNavigatorStackParamList>();
@@ -519,6 +520,13 @@ export default function SettingsNavigator() {
         component={ModularDrawerScreenDebug}
         options={{
           title: "ModularAssetDrawer Screen Debug",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugWalletV4Tour}
+        component={WalletV4TourScreenDebug}
+        options={{
+          title: "Wallet V4 Tour",
         }}
       />
     </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -83,4 +83,5 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.DebugSwipe]: undefined;
   [ScreenName.DebugModularAssetDrawer]: undefined;
   [ScreenName.DebugTooltip]: undefined;
+  [ScreenName.DebugWalletV4Tour]: undefined;
 };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -52,6 +52,7 @@ export enum ScreenName {
   DebugLottie = "DebugLottie",
   DebugLumen = "DebugLumen",
   DebugWallet40 = "DebugWallet40",
+  DebugWalletV4Tour = "DebugWalletV4Tour",
   DebugTermsOfUse = "DebugTermsOfUse",
   DebugVideos = "DebugVideos",
   DebugMockGenerateAccounts = "DebugMockGenerateAccounts",

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Debug/components/SectionCard.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Debug/components/SectionCard.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Flex, Text } from "@ledgerhq/native-ui";
+
+interface SectionCardProps {
+  children: React.ReactNode;
+  title?: string;
+}
+
+export const SectionCard = ({ children, title }: SectionCardProps) => (
+  <Flex p={5} backgroundColor="neutral.c40" borderRadius={12} mb={4}>
+    {title && (
+      <Text variant="h3Inter" color="neutral.c100" fontWeight="semiBold" mb={4}>
+        {title}
+      </Text>
+    )}
+    {children}
+  </Flex>
+);

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Debug/components/ToggleRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Debug/components/ToggleRow.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Flex, Switch, Text } from "@ledgerhq/native-ui";
+
+interface ToggleRowProps {
+  label: string;
+  value: boolean;
+  onChange: (value: boolean) => void;
+  description?: string;
+}
+
+export const ToggleRow = ({ label, value, onChange, description }: ToggleRowProps) => (
+  <Flex flexDirection="row" alignItems="center" justifyContent="space-between" py={2}>
+    <Flex flex={1} mr={4}>
+      <Text variant="body" fontWeight="medium" color="neutral.c100">
+        {label}
+      </Text>
+      {description && (
+        <Text variant="small" color="neutral.c70" mt={1}>
+          {description}
+        </Text>
+      )}
+    </Flex>
+    <Switch checked={value} onChange={onChange} />
+  </Flex>
+);

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Debug/components/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Debug/components/index.ts
@@ -1,0 +1,2 @@
+export { SectionCard } from "./SectionCard";
+export { ToggleRow } from "./ToggleRow";

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Debug/index.tsx
@@ -1,0 +1,80 @@
+import React, { useCallback } from "react";
+import { Flex, Text, Button } from "@ledgerhq/native-ui";
+import { ScrollView } from "react-native-gesture-handler";
+import { useTheme } from "styled-components/native";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { setHasSeenWalletV4Tour } from "~/actions/settings";
+import { hasSeenWalletV4TourSelector } from "~/reducers/settings";
+import { SectionCard, ToggleRow } from "./components";
+
+function WalletV4TourScreenDebug() {
+  const { colors } = useTheme();
+  const dispatch = useDispatch();
+
+  const hasSeenTour = useSelector(hasSeenWalletV4TourSelector);
+
+  const handleToggleHasSeenTour = useCallback(() => {
+    dispatch(setHasSeenWalletV4Tour(!hasSeenTour));
+  }, [dispatch, hasSeenTour]);
+
+  const handleOpenDrawer = useCallback(() => {
+    // TODO: Implement drawer opening
+  }, []);
+
+  return (
+    <Flex flex={1}>
+      <ScrollView
+        style={{ flex: 1, paddingHorizontal: 16, paddingVertical: 16 }}
+        contentContainerStyle={{ paddingBottom: 16 }}
+      >
+        <SectionCard>
+          <Text variant="body" color="neutral.c80" lineHeight="20px">
+            {
+              "Allows you to test the UI of the different drawer (Tour carrousel, Feature intro, prompt...)"
+            }
+          </Text>
+        </SectionCard>
+
+        <SectionCard title="Tour State">
+          <ToggleRow
+            label="Has Seen Wallet V4 Tour"
+            value={hasSeenTour}
+            onChange={handleToggleHasSeenTour}
+            description={
+              hasSeenTour
+                ? "User has already seen the tour. Toggle to reset."
+                : "User has not seen the tour yet."
+            }
+          />
+        </SectionCard>
+
+        <SectionCard title="Current Configuration">
+          <Text variant="body" color="neutral.c80">
+            <Text fontWeight="semiBold">{"Tour State: "}</Text>
+            {hasSeenTour ? "Completed" : "Not seen"}
+          </Text>
+        </SectionCard>
+      </ScrollView>
+
+      <Flex
+        px={4}
+        pb={16}
+        pt={2}
+        backgroundColor="background.main"
+        style={{
+          shadowColor: colors.neutral.c100,
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.25,
+          shadowRadius: 3.84,
+          elevation: 5,
+        }}
+      >
+        <Button size="large" type="main" onPress={handleOpenDrawer}>
+          {"Open Drawer"}
+        </Button>
+      </Flex>
+    </Flex>
+  );
+}
+
+export default WalletV4TourScreenDebug;

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -76,6 +76,7 @@ import type {
   SettingsIsOnboardingFlowPayload,
   SettingsIsOnboardingFlowReceiveSuccessPayload,
   SettingsIsPostOnboardingFlowPayload,
+  SettingsSetHasSeenWalletV4TourPayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -167,6 +168,7 @@ export const INITIAL_STATE: SettingsState = {
   isOnboardingFlow: false,
   isOnboardingFlowReceiveSuccess: false,
   isPostOnboardingFlow: false,
+  hasSeenWalletV4Tour: false,
 };
 
 const pairHash = (from: { ticker: string }, to: { ticker: string }) =>
@@ -615,6 +617,11 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     selectedTabPortfolioAssets: (action as Action<SettingsSetSelectedTabPortfolioAssetsPayload>)
       .payload,
   }),
+
+  [SettingsActionTypes.SET_HAS_SEEN_WALLET_V4_TOUR]: (state, action) => ({
+    ...state,
+    hasSeenWalletV4Tour: (action as Action<SettingsSetHasSeenWalletV4TourPayload>).payload,
+  }),
 };
 
 export default handleActions<SettingsState, SettingsPayload>(handlers, INITIAL_STATE);
@@ -841,3 +848,4 @@ export const starredMarketCoinsSelector = (state: State) => state.settings.starr
 export const mevProtectionSelector = (state: State) => state.settings.mevProtection;
 export const selectedTabPortfolioAssetsSelector = (state: State) =>
   state.settings.selectedTabPortfolioAssets;
+export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasSeenWalletV4Tour;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -282,6 +282,7 @@ export type SettingsState = {
   fromLedgerSyncOnboarding: boolean;
   mevProtection: boolean;
   selectedTabPortfolioAssets: TabPortfolioAssetsType;
+  hasSeenWalletV4Tour: boolean;
 };
 
 export type NotificationsSettings = {

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/index.tsx
@@ -1,9 +1,16 @@
 import React from "react";
 import { ScrollView, StyleSheet } from "react-native";
 import { Box, Text, Switch, Button, Tag, Divider } from "@ledgerhq/lumen-ui-rnative";
+import { IconsLegacy } from "@ledgerhq/native-ui";
+import { useNavigation } from "@react-navigation/native";
+import { ScreenName } from "~/const";
+import { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
+import { SettingsNavigatorStackParamList } from "~/components/RootNavigator/types/SettingsNavigator";
+import SettingsRow from "~/components/SettingsRow";
 import { useWallet40ViewModel, WALLET_40_PARAMS } from "./useWallet40ViewModel";
 
 export default function DebugWallet40() {
+  const navigation = useNavigation<StackNavigatorNavigation<SettingsNavigatorStackParamList>>();
   const { isEnabled, params, allEnabled, handleToggleEnabled, handleToggleParam, handleToggleAll } =
     useWallet40ViewModel();
 
@@ -96,6 +103,21 @@ export default function DebugWallet40() {
             );
           })}
         </Box>
+
+        <Box lx={{ marginTop: "s24", marginBottom: "s16" }}>
+          <Text typography="body2SemiBold" lx={{ color: "muted", marginBottom: "s8" }}>
+            FEATURES
+          </Text>
+          <Divider />
+        </Box>
+
+        <SettingsRow
+          title="Wallet V4 Tour"
+          desc="Test tour drawer"
+          iconLeft={<IconsLegacy.NewsMedium size={24} color="black" />}
+          arrowRight
+          onPress={() => navigation.navigate(ScreenName.DebugWalletV4Tour)}
+        />
       </Box>
     </ScrollView>
   );

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
@@ -7,6 +7,7 @@ export const WALLET_40_PARAMS = [
   { key: "marketBanner", label: "Market Banner" },
   { key: "graphRework", label: "Graph & Balance Rework" },
   { key: "quickActionCtas", label: "Quick Action CTAs" },
+  { key: "tour", label: "Tour" },
 ] as const;
 
 type WalletFeatureParamKey = (typeof WALLET_40_PARAMS)[number]["key"];

--- a/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
+++ b/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
@@ -20,5 +20,6 @@ export const getWallet40Attributes = (
     marketBanner: wallet40FeatureFlag?.params?.marketBanner ?? false,
     graphRework: wallet40FeatureFlag?.params?.graphRework ?? false,
     quickActionCtas: wallet40FeatureFlag?.params?.quickActionCtas ?? false,
+    tour: wallet40FeatureFlag?.params?.tour ?? false,
   };
 };

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -770,6 +770,7 @@ export const DEFAULT_FEATURES: Features = {
       marketBanner: true,
       graphRework: true,
       quickActionCtas: true,
+      tour: true,
     },
   },
   lwdWallet40: {

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -796,18 +796,15 @@ type Feature_Wallet40_Params = {
   marketBanner: boolean;
   graphRework: boolean;
   quickActionCtas: boolean;
+  tour?: boolean;
 };
 
 export type Feature_LwmWallet40 = Feature<
   {
-    // Add specific LWM params
+    tour: boolean;
   } & Feature_Wallet40_Params
 >;
-export type Feature_LwdWallet40 = Feature<
-  {
-    //  Add specific LWD params
-  } & Feature_Wallet40_Params
->;
+export type Feature_LwdWallet40 = Feature<Feature_Wallet40_Params>;
 export type Feature_LwmNewWordingOptInNotificationsDrawer = Feature<{
   variant: ABTestingVariants;
 }>;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Add tour parameter to lwmWallet40 feature flag for controlling wallet v4 tour visibility (also in firebase)
- Add hasSeenWalletV4Tour persistent state in Redux/MMKV to track tour completion
- Create "Content drawer" debug screen under Settings > Debug > Features for testing drawer UIs (tour carousel, feature intro, prompts)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25530] [LIVE-25317]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->






https://github.com/user-attachments/assets/fd91827f-d63f-436b-a317-98d9d8bafe6a







---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25530]: https://ledgerhq.atlassian.net/browse/LIVE-25530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ