### PR TITLE
feat(recover): pass hasConnectedNanoS and countryCode to Recover webapp

### DIFF
--- a/.changeset/recover-pass-device-country-params.md
+++ b/.changeset/recover-pass-device-country-params.md
@@ -1,0 +1,11 @@
+---
+"@ledgerhq/live-common": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+feat(recover): pass hasConnectedNanoS and countryCode params to Recover webapp
+
+- Add new `getCountryCodeFromLocale` utility in `@ledgerhq/live-common/locale`
+- Pass `hasConnectedNanoS` boolean to indicate if user has ever connected a Nano S
+- Pass `countryCode` (ISO 3166-1 alpha-2, lowercase) extracted from user's locale setting

--- a/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
@@ -7,7 +7,9 @@ import { OnboardingStep } from "@ledgerhq/live-common/hw/extractOnboardingState"
 import {
   counterValueCurrencySelector,
   developerModeSelector,
+  devicesModelListSelector,
   languageSelector,
+  localeSelector,
 } from "~/renderer/reducers/settings";
 import WebRecoverPlayer from "~/renderer/components/WebRecoverPlayer";
 import useTheme from "~/renderer/hooks/useTheme";
@@ -16,6 +18,8 @@ import styled from "styled-components";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import { SeedOriginType } from "@ledgerhq/types-live";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { getCountryCodeFromLocale } from "@ledgerhq/live-common/locale/index";
 
 const pollingPeriodMs = 1000;
 
@@ -49,7 +53,14 @@ export default function RecoverPlayer() {
   const navigate = useNavigate();
   const queryParams = useMemo(() => Object.fromEntries(new URLSearchParams(search)), [search]);
   const locale = useSelector(languageSelector);
+  const userLocale = useSelector(localeSelector);
+  const devicesModelList = useSelector(devicesModelListSelector);
   const currencySettings = useSelector(counterValueCurrencySelector);
+  const hasConnectedNanoS = useMemo(
+    () => devicesModelList.includes(DeviceModelId.nanoS),
+    [devicesModelList],
+  );
+  const countryCode = useMemo(() => getCountryCodeFromLocale(userLocale), [userLocale]);
   const localManifest = useLocalLiveAppManifest(params.appId || "");
   const remoteManifest = useRemoteLiveAppManifest(params.appId || "");
   const manifest = localManifest || remoteManifest;
@@ -88,6 +99,8 @@ export default function RecoverPlayer() {
       deviceModelId: device?.modelId,
       devModeEnabled,
       currency,
+      hasConnectedNanoS,
+      countryCode,
       ...params,
       ...queryParams,
     }),
@@ -97,7 +110,17 @@ export default function RecoverPlayer() {
      * This is to ensure the WebRecoverPlayer is not reloaded given the user disconnects their cable.
      */
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [theme, locale, availableOnDesktop, state?.deviceId, currency, params, queryParams],
+    [
+      theme,
+      locale,
+      availableOnDesktop,
+      state?.deviceId,
+      currency,
+      hasConnectedNanoS,
+      countryCode,
+      params,
+      queryParams,
+    ],
   );
 
   return manifest ? (

--- a/apps/ledger-live-mobile/src/screens/Protect/Player.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/Player.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import {
   useRemoteLiveAppContext,
@@ -16,7 +16,12 @@ import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/Ba
 import { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { NavigatorName, ScreenName } from "~/const";
 import { DeviceModelId } from "@ledgerhq/devices";
-import { counterValueCurrencySelector } from "~/reducers/settings";
+import { getCountryCodeFromLocale } from "@ledgerhq/live-common/locale/index";
+import {
+  counterValueCurrencySelector,
+  knownDeviceModelIdsSelector,
+  localeSelector,
+} from "~/reducers/settings";
 import { useSelector } from "~/context/hooks";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 
@@ -40,6 +45,10 @@ export function RecoverPlayer({ navigation, route }: Props) {
   const currencySettings = useSelector(counterValueCurrencySelector);
   const currency = currencySettings.ticker;
   const manifest = localManifest || remoteManifest;
+  const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
+  const hasConnectedNanoS = knownDeviceModelIds.nanoS;
+  const userLocale = useSelector(localeSelector);
+  const countryCode = useMemo(() => getCountryCodeFromLocale(userLocale), [userLocale]);
 
   const { onboardingState } = useOnboardingStatePolling({
     device: device || null,
@@ -91,6 +100,8 @@ export function RecoverPlayer({ navigation, route }: Props) {
           currency,
           deviceId: device?.deviceId,
           deviceModelId: device?.modelId,
+          hasConnectedNanoS: hasConnectedNanoS.toString(),
+          countryCode,
           ...params,
         }}
       />

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -234,6 +234,7 @@
     "src/icons/providers/providers.ts",
     "src/icons/providers/sizes.ts",
     "src/load/speculos.ts",
+    "src/locale/index.ts",
     "src/logs/simple.ts",
     "src/manager/api.ts",
     "src/manager/hooks.ts",

--- a/libs/ledger-live-common/src/locale/index.test.ts
+++ b/libs/ledger-live-common/src/locale/index.test.ts
@@ -1,0 +1,26 @@
+import { getCountryCodeFromLocale } from "./index";
+
+describe("getCountryCodeFromLocale", () => {
+  it("should extract country code from standard locale strings", () => {
+    expect(getCountryCodeFromLocale("fr-FR")).toBe("fr");
+    expect(getCountryCodeFromLocale("en-US")).toBe("us");
+    expect(getCountryCodeFromLocale("de-DE")).toBe("de");
+    expect(getCountryCodeFromLocale("es-ES")).toBe("es");
+    expect(getCountryCodeFromLocale("pt-BR")).toBe("br");
+  });
+
+  it("should handle uppercase country codes by lowercasing them", () => {
+    expect(getCountryCodeFromLocale("en-US")).toBe("us");
+    expect(getCountryCodeFromLocale("fr-FR")).toBe("fr");
+  });
+
+  it("should return undefined for language-only locale strings", () => {
+    expect(getCountryCodeFromLocale("en")).toBeUndefined();
+    expect(getCountryCodeFromLocale("fr")).toBeUndefined();
+    expect(getCountryCodeFromLocale("de")).toBeUndefined();
+  });
+
+  it("should handle empty string", () => {
+    expect(getCountryCodeFromLocale("")).toBeUndefined();
+  });
+});

--- a/libs/ledger-live-common/src/locale/index.ts
+++ b/libs/ledger-live-common/src/locale/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Locale utility functions for parsing and extracting information from BCP 47 locale strings.
+ */
+
+/**
+ * Extracts the ISO 3166-1 alpha-2 country code from a BCP 47 locale string.
+ *
+ * @param locale - A BCP 47 locale string (e.g., "fr-FR", "en-US", "de-DE")
+ * @returns The lowercase country code (e.g., "fr", "us", "de") or undefined if not present
+ *
+ * @example
+ * getCountryCodeFromLocale("fr-FR") // "fr"
+ * getCountryCodeFromLocale("en-US") // "us"
+ * getCountryCodeFromLocale("en")    // undefined
+ */
+export function getCountryCodeFromLocale(locale: string): string | undefined {
+  const parts = locale.split("-");
+  return parts.length > 1 ? parts[1].toLowerCase() : undefined;
+}


### PR DESCRIPTION
- Add getCountryCodeFromLocale utility in @ledgerhq/live-common/locale
- Pass hasConnectedNanoS boolean from knownDeviceModelIds (mobile) / devicesModelList (desktop)
- Pass countryCode extracted from user's locale setting (ISO 3166-1 alpha-2, lowercase)

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Recover Mobile
  - Recover Desktop

### 📝 Description

Recover needs info from the Wallet in order to optimize its Backup funnel

### ❓ Context

[LIVE-25074](https://ledgerhq.atlassian.net/browse/LIVE-25074)
[LIVE-25422](https://ledgerhq.atlassian.net/browse/LIVE-25422)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25074]: https://ledgerhq.atlassian.net/browse/LIVE-25074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ