### PR TITLE
fix(desktop): correct grammar in Ledger Sync copy

### DIFF
--- a/.changeset/calm-boats-wave.md
+++ b/.changeset/calm-boats-wave.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix grammar in Ledger Sync copy: "use a phone" → "using a phone"

--- a/apps/ledger-live-desktop/src/mvvm/features/LedgerSyncEntryPoints/__tests__/LedgerSyncEntryPoint.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LedgerSyncEntryPoints/__tests__/LedgerSyncEntryPoint.test.tsx
@@ -221,7 +221,7 @@ describe("LedgerSyncEntryPoint", () => {
       expect(bannerTitle).toBeVisible();
 
       const bannerDescription = screen.getByText(
-        /Keep your portfolio up to date when switching computers or use a phone/,
+        /Keep your portfolio up to date when switching computers or using a phone/,
       );
       expect(bannerDescription).toBeVisible();
 
@@ -246,7 +246,7 @@ describe("LedgerSyncEntryPoint", () => {
       expect(bannerTitle).toBeVisible();
 
       const bannerDescription = screen.getByText(
-        /Keep your portfolio up to date when switching computers or use a phone/,
+        /Keep your portfolio up to date when switching computers or using a phone/,
       );
       expect(bannerDescription).toBeVisible();
 
@@ -271,7 +271,7 @@ describe("LedgerSyncEntryPoint", () => {
       expect(bannerTitle).toBeVisible();
 
       const bannerDescription = screen.getByText(
-        /Keep your portfolio up to date when switching computers or use a phone/,
+        /Keep your portfolio up to date when switching computers or using a phone/,
       );
       expect(bannerDescription).toBeVisible();
 

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4455,7 +4455,7 @@
       "stockDesc": "Choose Western to display market increases in blue or Eastern to display them in red.",
       "walletSync": "Ledger Sync",
       "walletSyncDesc": "Sync your Ledger Wallet crypto accounts across different phones and computers.",
-      "walletSyncDescription": "Keep your portfolio up to date when switching computers or use a phone",
+      "walletSyncDescription": "Keep your portfolio up to date when switching computers or using a phone",
       "mevProtection": "MEV Protection",
       "mevProtectionDesc": "Enable MEV Protection for more reliable transactions on Ethereum.",
       "mevProtectionLearnMore": "Privacy notice"
@@ -7576,7 +7576,7 @@
     "close": "Close",
     "banner": {
       "title": "Your wallet isn't synced",
-      "description": "Keep your portfolio up to date when switching computers or use a phone",
+      "description": "Keep your portfolio up to date when switching computers or using a phone",
       "cta": "Sync my wallet"
     },
     "activate": {
@@ -7586,7 +7586,7 @@
       "alreadySync": "I already turned it on",
       "learnMore": "How does Ledger Sync work?",
       "titleModal": "Sync your wallet",
-      "descriptionModal": "Keep your portfolio up to date when switching computers or use a phone — all secured by your Ledger device.",
+      "descriptionModal": "Keep your portfolio up to date when switching computers or using a phone — all secured by your Ledger device.",
       "ctaModal": "Continue"
     },
     "entryPoints": {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Copy/translation changes do not require code tests._
- [x] **Impact of the changes:**
      - Ledger Sync settings description text
      - Ledger Sync banner description
      - Ledger Sync activation modal description

### 📝 Description

**Problem**: The Ledger Sync copy contains a grammatical inconsistency where "use a phone" should be "using a phone" for proper parallel construction.

**Solution**: Updated 3 translation strings in `app.json` to correct the grammar:
- `settings.display.walletSyncDescription`
- `walletSync.banner.description`
- `walletSync.activate.descriptionModal`

Changed: "Keep your portfolio up to date when switching computers or use a phone" → "Keep your portfolio up to date when switching computers or using a phone"

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25145](https://ledgerhq.atlassian.net/browse/LIVE-25145)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25145]: https://ledgerhq.atlassian.net/browse/LIVE-25145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ