### PR TITLE
feat: adds no balance state to portfolio view

### DIFF
--- a/.changeset/tall-shrimps-stare.md
+++ b/.changeset/tall-shrimps-stare.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): add no balance case scenario to portfolio view

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -7,6 +7,7 @@ import { Portfolio } from "@ledgerhq/types-live";
 import { PortfolioView } from "../PortfolioView";
 import * as portfolioReact from "@ledgerhq/live-countervalues-react/portfolio";
 import { useNavigate } from "react-router";
+import { BTC_ACCOUNT } from "../../__mocks__/accounts.mock";
 
 const MARKET_API_ENDPOINT = "https://countervalues.live.ledger.com/v3/markets";
 
@@ -104,7 +105,11 @@ describe("PortfolioView", () => {
 
   describe("Balance", () => {
     it("should render Balance with total balance when shouldDisplayGraphRework is true", () => {
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />);
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+        initialState: {
+          accounts: [BTC_ACCOUNT],
+        },
+      });
 
       expect(screen.getByTestId("portfolio-balance")).toBeVisible();
       expect(screen.getByTestId("portfolio-total-balance")).toBeVisible();
@@ -116,11 +121,26 @@ describe("PortfolioView", () => {
     });
 
     it("should navigate to analytics when clicking on balance", async () => {
-      const { user } = render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />);
+      const { user } = render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
+        initialState: {
+          accounts: [BTC_ACCOUNT],
+        },
+      });
 
       await user.click(screen.getByTestId("portfolio-balance"));
 
       expect(mockNavigate).toHaveBeenCalledWith("/analytics");
+    });
+
+    it("should render NoBalanceView when user has no accounts", () => {
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+        initialState: {
+          accounts: [],
+        },
+      });
+
+      expect(screen.getByTestId("no-balance-title")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-balance")).toBeNull();
     });
   });
 
@@ -128,7 +148,11 @@ describe("PortfolioView", () => {
     it("should render Trend with positive percentage and display separator with Today label", () => {
       mockUsePortfolio.mockReturnValue(createPortfolioMock({ percentage: 0.0542, value: 5000 }));
 
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />);
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
+        initialState: {
+          accounts: [BTC_ACCOUNT],
+        },
+      });
 
       expect(screen.getByTestId("portfolio-trend")).toBeVisible();
       expect(screen.getByText("+5.42%")).toBeVisible();
@@ -138,7 +162,11 @@ describe("PortfolioView", () => {
     it("should render Trend with negative percentage", () => {
       mockUsePortfolio.mockReturnValue(createPortfolioMock({ percentage: -0.0315, value: -3000 }));
 
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />);
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
+        initialState: {
+          accounts: [BTC_ACCOUNT],
+        },
+      });
 
       expect(screen.getByTestId("portfolio-trend")).toBeVisible();
       expect(screen.getByText("-3.15%")).toBeVisible();
@@ -147,7 +175,11 @@ describe("PortfolioView", () => {
     it("should show 0% when percentage is zero", () => {
       mockUsePortfolio.mockReturnValue(createPortfolioMock({ percentage: 0, value: 0 }));
 
-      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />);
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
+        initialState: {
+          accounts: [BTC_ACCOUNT],
+        },
+      });
 
       expect(screen.getByTestId("portfolio-trend")).toBeVisible();
       expect(screen.getByTestId("portfolio-trend-percentage")).toBeVisible();

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/NoBalanceView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/NoBalanceView.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+export const NoBalanceView = () => {
+  const { t } = useTranslation();
+  return (
+    <span data-testid="no-balance-title" className="heading-1-semi-bold text-base">
+      {t("portfolio.noBalanceTitle")}
+    </span>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/index.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useBalanceViewModel } from "../../hooks/useBalanceViewModel";
 import { BalanceView } from "./BalanceView";
+import { NoBalanceView } from "./NoBalanceView";
 
 export const Balance = () => {
-  const viewModel = useBalanceViewModel();
+  const { hasFunds, ...viewModel } = useBalanceViewModel();
 
-  return <BalanceView {...viewModel} />;
+  return hasFunds ? <BalanceView {...viewModel} /> : <NoBalanceView />;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
@@ -11,4 +11,6 @@ export interface BalanceViewProps {
   readonly handleKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 }
 
-export type BalanceViewModelResult = BalanceViewProps;
+export type BalanceViewModelResult = BalanceViewProps & {
+  readonly hasFunds: boolean;
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -8,6 +8,7 @@ import {
   discreetModeSelector,
 } from "~/renderer/reducers/settings";
 import { accountsSelector } from "~/renderer/reducers/accounts";
+import { useAccountStatus } from "LLD/hooks/useAccountStatus";
 import { BalanceViewModelResult } from "../components/Balance/types";
 import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
@@ -30,6 +31,7 @@ export const useBalanceViewModel = (
   const selectedTimeRange = useSelector(selectedTimeRangeSelector);
   const locale = useSelector(localeSelector);
   const discreet = useSelector(discreetModeSelector);
+  const { hasFunds } = useAccountStatus();
 
   const range = useLegacyRange ? selectedTimeRange : NEW_FLOW_RANGE;
 
@@ -74,5 +76,6 @@ export const useBalanceViewModel = (
     isAvailable,
     navigateToAnalytics,
     handleKeyDown,
+    hasFunds,
   };
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
@@ -1,11 +1,11 @@
 import { useCallback } from "react";
 import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
 import { openModal } from "~/renderer/actions/modals";
-import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { useDispatch } from "LLD/hooks/redux";
 import { useLocation, useNavigate } from "react-router";
 import { ArrowDown, Plus, Minus, ArrowUp } from "@ledgerhq/lumen-ui-react/symbols";
 import { useTranslation } from "react-i18next";
-import { areAccountsEmptySelector, hasAccountsSelector } from "~/renderer/reducers/accounts";
+import { useAccountStatus } from "LLD/hooks/useAccountStatus";
 import { QuickAction } from "../types";
 
 export const useQuickActions = (): { actionsList: QuickAction[] } => {
@@ -14,8 +14,7 @@ export const useQuickActions = (): { actionsList: QuickAction[] } => {
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
-  const hasAccount = useSelector(hasAccountsSelector);
-  const hasFunds = !useSelector(areAccountsEmptySelector) && hasAccount;
+  const { hasAccount, hasFunds } = useAccountStatus();
 
   const push = useCallback(
     (pathname: string) => {

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useAccountStatus.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useAccountStatus.ts
@@ -1,0 +1,17 @@
+import { useSelector } from "./redux";
+import { areAccountsEmptySelector, hasAccountsSelector } from "~/renderer/reducers/accounts";
+
+/**
+ * Hook to determine the status of user accounts and funds.
+ * @returns Object containing `hasAccount` (whether accounts exist) and `hasFunds` (whether accounts exist and have funds)
+ */
+export const useAccountStatus = () => {
+  const hasAccount = useSelector(hasAccountsSelector);
+  const areAccountsEmpty = useSelector(areAccountsEmptySelector);
+  const hasFunds = !areAccountsEmpty && hasAccount;
+
+  return {
+    hasAccount,
+    hasFunds,
+  };
+};

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7852,7 +7852,8 @@
   "portfolio": {
     "title": "Home",
     "today": "Today",
-    "addAccountCta": "Add crypto account"
+    "addAccountCta": "Add crypto account",
+    "noBalanceTitle": "Secure your crypto"
   },
   "marketBanner": {
     "title": "Explore market",


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a new "no balance" scenario to the portfolio view in Ledger Live Desktop. When a user has no accounts or all accounts have zero balance, the UI now displays a dedicated message instead of the standard balance components. The implementation includes a new `NoBalanceView` component, updates to the balance rendering logic, and corresponding test coverage.

<img width="593" height="291" alt="Screenshot 2026-01-28 at 16 07 35" src="https://github.com/user-attachments/assets/13d2803b-cdd2-4e53-9f00-629b8172278d" />

### ❓ Context

[LIVE-24578](https://ledgerhq.atlassian.net/browse/LIVE-24578)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24578]: https://ledgerhq.atlassian.net/browse/LIVE-24578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ