### PR TITLE
ci(renovate): remove block with no matchers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -102,8 +102,7 @@
     },
     {
       "extends": ["monorepo:expo"],
-      "groupName": null,
-      "minimumReleaseAge": "2 days"
+      "groupName": null
     }
   ],
   "prConcurrentLimit": 10,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR fixes the Renovate configuration so Renovate can resume operating by removing an invalid package rule that had no matchers.

Changes:
- Removed a packageRules entry that defined only minimumReleaseAge without any match* fields, which Renovate flags as invalid.
- Left all other Renovate settings and package rules unchanged.



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://github.com/LedgerHQ/ledger-live/issues/14053


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
