### PR TITLE
PERF: chore(cryptoassets): only save persisted state if changed

### DIFF
--- a/.changeset/two-kids-shake.md
+++ b/.changeset/two-kids-shake.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/cryptoassets": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Optimize cryptoAssets persisted save refresh

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -18,7 +18,11 @@ import {
   trustchainStoreActionTypePrefix,
   trustchainStoreSelector,
 } from "@ledgerhq/ledger-key-ring-protocol/store";
-import { extractPersistedCALFromState } from "@ledgerhq/cryptoassets/cal-client/persistence";
+import {
+  extractPersistedCALFromState,
+  persistedCALContentEqual,
+  type PersistedCAL,
+} from "@ledgerhq/cryptoassets/cal-client/persistence";
 
 import { marketStoreSelector } from "../reducers/market";
 import { exportIdentitiesForPersistence } from "@ledgerhq/client-ids/store";
@@ -43,11 +47,17 @@ function accountsExportSelector(state: State) {
 }
 
 // Throttled save for crypto assets cache (save at most once per 5 seconds)
+// Only write when content actually changed to avoid redundant app.json resaves
+let lastPersistedCryptoAssets: PersistedCAL | null = null;
 const saveCryptoAssetsCache = throttle((state: State) => {
   try {
     const persistedData = extractPersistedCALFromState(state);
-    if (persistedData.tokens.length > 0) {
+    if (
+      persistedData.tokens.length > 0 &&
+      !persistedCALContentEqual(lastPersistedCryptoAssets, persistedData)
+    ) {
       setKey("app", "cryptoAssets", persistedData);
+      lastPersistedCryptoAssets = persistedData;
     }
   } catch (error) {
     console.error("Failed to save crypto assets cache:", error);

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -29,7 +29,10 @@ import { settingsStoreSelector } from "~/reducers/settings";
 import type { State } from "~/reducers/types";
 import { walletSelector } from "~/reducers/wallet";
 import { Maybe } from "../types/helpers";
-import { extractPersistedCALFromState } from "@ledgerhq/cryptoassets/cal-client/persistence";
+import {
+  extractPersistedCALFromState,
+  persistedCALContentEqual,
+} from "@ledgerhq/cryptoassets/cal-client/persistence";
 import { exportIdentitiesForPersistence } from "@ledgerhq/client-ids/store";
 import { exportCountervalues } from "@ledgerhq/live-countervalues/logic";
 
@@ -150,10 +153,8 @@ const compareWalletState = (a: State, b: State) =>
   walletStateExportShouldDiffer(a.wallet, b.wallet);
 const largeMoverNotEquals = (a: State, b: State) => a.largeMover !== b.largeMover;
 
-const cryptoAssetsNotEquals = (a: State, b: State) => {
-  // Compare RTK Query state reference
-  return a.cryptoAssetsApi !== b.cryptoAssetsApi;
-};
+const cryptoAssetsNotEquals = (a: State, b: State) =>
+  !persistedCALContentEqual(extractPersistedCALFromState(a), extractPersistedCALFromState(b));
 const identitiesNotEquals = (a: State, b: State) => a.identities !== b.identities;
 
 const extractIdentitiesForPersistence = (state: State) =>

--- a/libs/ledgerjs/packages/cryptoassets/package.json
+++ b/libs/ledgerjs/packages/cryptoassets/package.json
@@ -40,7 +40,8 @@
     "@ledgerhq/errors": "workspace:^",
     "@reduxjs/toolkit": "catalog:",
     "invariant": "2",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@ledgerhq/types-cryptoassets": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6700,6 +6700,9 @@ importers:
       invariant:
         specifier: '2'
         version: 2.2.4
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       zod:
         specifier: ^3.22.4
         version: 3.25.76


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - desktop and mobile

### 📝 Description

We introduce a predicate `persistedCALContentEqual ` which allows to know if there is a new persisted state to save or not for cryptoassets store.

- Before the change, `cryptoAssets` frequently gets re-saved

<img width="855" height="714" alt="Screenshot 2026-01-29 at 11 52 02" src="https://github.com/user-attachments/assets/f5df32f7-641e-4e87-9f6f-d6cfef32f0d9" />

- After the change, `cryptoAssets` always never need to be re-saved (nb: this screenshot includes all other optims)

<img width="931" height="267" alt="Screenshot 2026-01-29 at 11 51 11" src="https://github.com/user-attachments/assets/6abfb173-8c46-49e2-80a0-94507511d664" />



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25540


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
