### PR TITLE
feat(mobile): update market banner tiles to use lumen TileSpot component

### DIFF
--- a/.changeset/empty-otters-end.md
+++ b/.changeset/empty-otters-end.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Adjust market banner tiles to match design

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketTile/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketTile/index.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useMemo } from "react";
-import { Tile, TileContent, TileTitle, TileDescription, Text } from "@ledgerhq/lumen-ui-rnative";
+import {
+  Tile,
+  TileContent,
+  TileTitle,
+  TileDescription,
+  Text,
+  TileSpot,
+} from "@ledgerhq/lumen-ui-rnative";
 import { useTranslation } from "~/context/Locale";
 import { getChangePercentage } from "@ledgerhq/live-common/market/utils/index";
 import { MarketTileProps } from "../../types";
@@ -13,6 +20,11 @@ const MarketTile = ({ item, index, range, onPress }: MarketTileProps) => {
   }, [item, onPress]);
 
   const priceChange = useMemo(() => getChangePercentage(item, range), [item, range]);
+
+  const renderIcon = useCallback(
+    () => <MarketTileIcon ledgerIds={item.ledgerIds} ticker={item.ticker} image={item.image} />,
+    [item.ledgerIds, item.ticker, item.image],
+  );
 
   const isPositive = priceChange >= 0;
   const changeSign = isPositive ? "+" : "";
@@ -34,7 +46,7 @@ const MarketTile = ({ item, index, range, onPress }: MarketTileProps) => {
       accessibilityHint={t("marketBanner.tile.accessibilityHint")}
       accessibilityRole="button"
     >
-      <MarketTileIcon ledgerIds={item.ledgerIds} ticker={item.ticker} image={item.image} />
+      <TileSpot size={40} appearance="icon" icon={renderIcon} />
       <TileContent>
         <TileTitle>{capitalizedTicker}</TileTitle>
         <TileDescription>

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketTileIcon/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketTileIcon/index.tsx
@@ -10,11 +10,11 @@ interface MarketTileIconProps {
 
 const MarketTileIcon = ({ ticker, ledgerIds, image }: MarketTileIconProps) => {
   return ledgerIds && ledgerIds.length > 0 && ticker ? (
-    <Icon ledgerId={ledgerIds?.[0]} ticker={ticker} size={32} />
+    <Icon ledgerId={ledgerIds?.[0]} ticker={ticker} size={40} />
   ) : (
     <Image
       source={{ uri: image }}
-      style={{ width: 32, height: 32, borderRadius: 16 }}
+      style={{ width: 40, height: 40, borderRadius: 20 }}
       resizeMode="cover"
     />
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/ViewAllTile/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/ViewAllTile/index.tsx
@@ -16,7 +16,7 @@ const ViewAllTile = ({ onPress }: ViewAllTileProps) => {
       accessibilityLabel={t("marketBanner.viewAll")}
       accessibilityHint={t("marketBanner.viewAllAccessibilityHint")}
     >
-      <TileSpot appearance="icon" icon={ChevronRight} />
+      <TileSpot size={40} appearance="icon" icon={ChevronRight} />
       <TileContent>
         <TileTitle>{t("marketBanner.viewAll")}</TileTitle>
       </TileContent>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Market banner tile rendering and icon display
  - Visual consistency with Lumen design system
  - Component performance optimizations

### 📝 Description

This PR updates the Market Banner tiles to utilize the latest `TileSpot` component from Lumen UI, ensuring visual consistency across the application.

**Changes:**
- Wrapped `MarketTileIcon` with `TileSpot` component for proper visual hierarchy
- Updated icon sizes from 32px to 40px for better visual balance
- Added explicit `size` prop to `TileSpot` across all market banner tiles
- Optimized icon rendering with `useCallback` to prevent unnecessary re-renders

**Before/After:**

| Before | After |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/37f9c94d-4c9a-43b8-bb1b-4b1b5c126cf4" />|<video src="https://github.com/user-attachments/assets/f4b22513-2942-440e-8fee-bdb3aff743af" />|


**Comparison (I switch between my branch and develop):**

<video src="https://github.com/user-attachments/assets/52ec4224-0b5b-41cc-bd9d-ecb61574a667" />




### ❓ Context

- **JIRA or GitHub link**: [LIVE-25534](https://ledgerhq.atlassian.net/browse/LIVE-25534)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25534]: https://ledgerhq.atlassian.net/browse/LIVE-25534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ