### PR TITLE
[LWM] :bug: build time

### DIFF
--- a/apps/ledger-live-mobile/babel.config.js
+++ b/apps/ledger-live-mobile/babel.config.js
@@ -15,17 +15,6 @@ module.exports = {
     "@babel/plugin-transform-flow-strip-types",
     ["@babel/plugin-transform-private-methods", { loose: true }],
     "babel-plugin-transform-inline-environment-variables",
-    [
-      "babel-plugin-styled-components",
-      {
-        ssr: false,
-        displayName: process.env.NODE_ENV === "development",
-        fileName: process.env.NODE_ENV === "production",
-        minify: process.env.NODE_ENV === "production",
-        transpileTemplateLiterals: true,
-        pure: true,
-      },
-    ],
     // only inject collapsable={false} for builds running Detox tests
     process.env.DETOX === "1" || process.env.DETOX === "true"
       ? "./babel-plugin-inject-collapsable.js"

--- a/apps/ledger-live-mobile/e2e/babel.config.detox.js
+++ b/apps/ledger-live-mobile/e2e/babel.config.detox.js
@@ -4,17 +4,6 @@ module.exports = {
     "@babel/plugin-transform-named-capturing-groups-regex",
     "@babel/plugin-transform-export-namespace-from",
     ["@babel/plugin-transform-class-properties", { loose: true }],
-    [
-      "babel-plugin-styled-components",
-      {
-        ssr: false,
-        displayName: true,
-        fileName: true,
-        minify: true,
-        transpileTemplateLiterals: true,
-        pure: true,
-      },
-    ],
     "react-native-reanimated/plugin",
   ],
 };

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -271,7 +271,6 @@
     "@types/uuid": "8.3.4",
     "@types/ws": "8.5.10",
     "babel-jest": "catalog:",
-    "babel-plugin-styled-components": "2.1.4",
     "babel-plugin-transform-inline-environment-variables": "0.4.4",
     "detox": "20.46.0",
     "detox-allure2-adapter": "1.0.0-alpha.42",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1915,9 +1915,6 @@ importers:
       babel-jest:
         specifier: 'catalog:'
         version: 30.2.0(@babel/core@7.28.5)
-      babel-plugin-styled-components:
-        specifier: 2.1.4
-        version: 2.1.4(@babel/core@7.28.5)(styled-components@6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react@19.0.0))
       babel-plugin-transform-inline-environment-variables:
         specifier: 0.4.4
         version: 0.4.4
@@ -50879,18 +50876,6 @@ snapshots:
       lodash: 4.17.21
       picomatch: 2.3.1
       styled-components: 5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  babel-plugin-styled-components@2.1.4(@babel/core@7.28.5)(styled-components@6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react@19.0.0)):
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      lodash: 4.17.21
-      picomatch: 2.3.1
-      styled-components: 6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react@19.0.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Removal of useless styled babel plugin
It was slowing down the js bundle process

see ticket for more context

The plugin is still present in the lock file because of styled v5 in some parts of the codebase

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25546](https://ledgerhq.atlassian.net/browse/LIVE-25546)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25546]: https://ledgerhq.atlassian.net/browse/LIVE-25546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ