### PR TITLE
refactor(desktop): use CSS Grid for Wallet 4.0 layout

### DIFF
--- a/.changeset/wallet40-grid-layout.md
+++ b/.changeset/wallet40-grid-layout.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Refactor Wallet 4.0 layout to use CSS Grid for better responsiveness and add tests for QuickActions openAssetFlow

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/components/Wallet40Layout.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/components/Wallet40Layout.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from "react";
-import { cn } from "LLD/utils/cn";
+import { RIGHT_PANEL_WIDTH } from "LLD/components/Page/constants";
 
 interface Wallet40LayoutProps {
   readonly children: React.ReactNode;
@@ -18,8 +18,11 @@ export const Wallet40Layout = memo(function Wallet40Layout({
   rightPanel,
 }: Wallet40LayoutProps) {
   return (
-    <div className={cn("flex flex-1 gap-32 overflow-hidden px-32")}>
-      <div id="scroll-area" className="relative flex flex-1 flex-col overflow-hidden">
+    <div
+      className="grid flex-1 gap-32 overflow-hidden px-32"
+      style={rightPanel ? { gridTemplateColumns: `1fr ${RIGHT_PANEL_WIDTH}px` } : undefined}
+    >
+      <div id="scroll-area" className="relative flex min-w-0 flex-col overflow-hidden">
         <div
           id="page-scroller"
           ref={scrollerRef}

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/RightPanelView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/RightPanelView.tsx
@@ -1,7 +1,6 @@
 import React, { memo } from "react";
 import SwapWebViewEmbedded from "~/renderer/screens/dashboard/components/SwapWebViewEmbedded";
 import { RightPanelViewModelResult } from "./useRightPanelViewModel";
-import { RIGHT_PANEL_WIDTH } from "LLD/components/Page/constants";
 
 type RightPanelViewProps = RightPanelViewModelResult;
 
@@ -15,7 +14,7 @@ export const RightPanelView = memo(function RightPanelView({ shouldDisplay }: Ri
   }
 
   return (
-    <div className="flex h-full shrink-0 flex-col py-32" style={{ width: RIGHT_PANEL_WIDTH }}>
+    <div className="flex h-full flex-col py-32">
       <SwapWebViewEmbedded height="100%" isWallet40 />
     </div>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/AddAccount/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/AddAccount/index.tsx
@@ -1,15 +1,18 @@
 import React from "react";
 import { Button } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
-import { useDispatch } from "LLD/hooks/redux";
-import { openModal } from "~/renderer/actions/modals";
+import { useOpenAssetFlow } from "LLD/features/ModularDialog/hooks/useOpenAssetFlow";
+import { ModularDrawerLocation } from "LLD/features/ModularDrawer";
 
 export const AddAccount = () => {
   const { t } = useTranslation();
-  const dispatch = useDispatch();
+  const { openAssetFlow } = useOpenAssetFlow(
+    { location: ModularDrawerLocation.ADD_ACCOUNT },
+    "portfolio_add_account",
+  );
 
   const onAction = () => {
-    dispatch(openModal("MODAL_ADD_ACCOUNTS", undefined));
+    openAssetFlow();
   };
 
   return (

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from "tests/testSetup";
 import { useQuickActions } from "../hooks/useQuickActions";
 import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
+import { useOpenAssetFlow } from "LLD/features/ModularDialog/hooks/useOpenAssetFlow";
 import { useNavigate, useLocation } from "react-router";
 import { ArrowDown, Plus, Minus, ArrowUp } from "@ledgerhq/lumen-ui-react/symbols";
 import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
@@ -9,6 +10,7 @@ import BigNumber from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 
 jest.mock("LLD/features/Send/hooks/useOpenSendFlow");
+jest.mock("LLD/features/ModularDialog/hooks/useOpenAssetFlow");
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
   useNavigate: jest.fn(),
@@ -17,8 +19,11 @@ jest.mock("react-router", () => ({
 
 const mockNavigate = jest.fn();
 const mockOpenSendFlow = jest.fn();
+const mockOpenAssetFlow = jest.fn();
+const mockOpenAddAccountFlow = jest.fn();
 
 const mockUseOpenSendFlow = useOpenSendFlow as jest.MockedFunction<typeof useOpenSendFlow>;
+const mockUseOpenAssetFlow = useOpenAssetFlow as jest.MockedFunction<typeof useOpenAssetFlow>;
 const mockUseNavigate = useNavigate as jest.MockedFunction<typeof useNavigate>;
 const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
 
@@ -53,6 +58,10 @@ describe("useQuickActions", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseOpenSendFlow.mockReturnValue(mockOpenSendFlow);
+    mockUseOpenAssetFlow.mockReturnValue({
+      openAssetFlow: mockOpenAssetFlow,
+      openAddAccountFlow: mockOpenAddAccountFlow,
+    });
     mockUseNavigate.mockReturnValue(mockNavigate);
     mockUseLocation.mockReturnValue(createLocation("/accounts"));
   });
@@ -155,7 +164,19 @@ describe("useQuickActions", () => {
       });
     });
 
-    it("should open add accounts modal when user has no accounts", () => {
+    it("should call openAssetFlow when user has no accounts", () => {
+      const { result } = renderHook(() => useQuickActions(), {
+        initialState: { accounts: [] },
+      });
+
+      act(() => {
+        result.current.actionsList[0].onAction();
+      });
+
+      expect(mockOpenAssetFlow).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not open receive modal when user has no accounts", () => {
       const { result, store } = renderHook(() => useQuickActions(), {
         initialState: { accounts: [] },
       });
@@ -164,9 +185,7 @@ describe("useQuickActions", () => {
         result.current.actionsList[0].onAction();
       });
 
-      expect(store.getState().modals).toMatchObject({
-        MODAL_ADD_ACCOUNTS: { isOpened: true },
-      });
+      expect(store.getState().modals.MODAL_RECEIVE?.isOpened).toBeFalsy();
     });
 
     it("should not navigate when already on accounts page", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
@@ -7,6 +7,8 @@ import { ArrowDown, Plus, Minus, ArrowUp } from "@ledgerhq/lumen-ui-react/symbol
 import { useTranslation } from "react-i18next";
 import { areAccountsEmptySelector, hasAccountsSelector } from "~/renderer/reducers/accounts";
 import { QuickAction } from "../types";
+import { useOpenAssetFlow } from "../../ModularDialog/hooks/useOpenAssetFlow";
+import { ModularDrawerLocation } from "../../ModularDrawer";
 
 export const useQuickActions = (): { actionsList: QuickAction[] } => {
   const openSendFlow = useOpenSendFlow();
@@ -16,6 +18,12 @@ export const useQuickActions = (): { actionsList: QuickAction[] } => {
   const { t } = useTranslation();
   const hasAccount = useSelector(hasAccountsSelector);
   const hasFunds = !useSelector(areAccountsEmptySelector) && hasAccount;
+
+  const { openAssetFlow } = useOpenAssetFlow(
+    { location: ModularDrawerLocation.ADD_ACCOUNT },
+    "quick_actions_receive",
+    "MODAL_RECEIVE",
+  );
 
   const push = useCallback(
     (pathname: string) => {
@@ -38,12 +46,12 @@ export const useQuickActions = (): { actionsList: QuickAction[] } => {
     maybeRedirectToAccounts();
 
     if (!hasAccount) {
-      dispatch(openModal("MODAL_ADD_ACCOUNTS", undefined));
+      openAssetFlow();
       return;
     }
 
     dispatch(openModal("MODAL_RECEIVE", undefined));
-  }, [dispatch, maybeRedirectToAccounts, hasAccount]);
+  }, [maybeRedirectToAccounts, hasAccount, dispatch, openAssetFlow]);
 
   const onBuy = useCallback(() => {
     navigate("/exchange", {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio/Wallet 4.0 layout rendering
  - Right panel positioning and width
  - QuickActions receive flow when no accounts exist

### 📝 Description

**Problem**: The Wallet 4.0 layout was using Flexbox which provided less explicit control over column widths and responsiveness.

**Solution**: 
- Replaced Flexbox with CSS Grid in `Wallet40Layout` for better two-column layout control
- The main content area uses `1fr` (flexible) while the right panel has a fixed width of `375px`
- Used `RIGHT_PANEL_WIDTH` constant as single source of truth
- Grid template is conditionally applied only when `rightPanel` is present
- Removed redundant inline width styling from `RightPanelView` (now controlled by Grid parent)
- Added missing test coverage for `openAssetFlow` in `useQuickActions` hook

### 🎬 Demo



https://github.com/user-attachments/assets/9dc7761f-c70c-4661-8b5b-1f01022f5153


### ❓ Context

- **JIRA or GitHub link**: N/A - Technical improvement

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)