### PR TITLE
fix: disables send action when no accounts exist

### DIFF
--- a/.changeset/fresh-pigs-camp.md
+++ b/.changeset/fresh-pigs-camp.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(lwd): disabled send when no accounts or funds

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
@@ -291,5 +291,23 @@ describe("useQuickActions", () => {
       expect(mockNavigate).toHaveBeenCalledWith("/accounts");
       expect(mockOpenSendFlow).toHaveBeenCalledTimes(1);
     });
+
+    it("should disable send action when no accounts exist", () => {
+      const { result } = renderHook(() => useQuickActions(), {
+        initialState: { accounts: [] },
+      });
+
+      const sendAction = result.current.actionsList[3];
+      expect(sendAction.disabled).toBe(true);
+    });
+
+    it("should enable send action when all accounts are empty", () => {
+      const { result } = renderHook(() => useQuickActions(), {
+        initialState: { accounts: [createEmptyAccount()] },
+      });
+
+      const sendAction = result.current.actionsList[3];
+      expect(sendAction.disabled).toBe(false);
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
@@ -95,7 +95,7 @@ export const useQuickActions = (): { actionsList: QuickAction[] } => {
         title: t("quickActions.send"),
         onAction: onSend,
         icon: ArrowUp,
-        disabled: false,
+        disabled: !hasAccount,
         buttonAppearance: "transparent",
       },
     ],


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a minor update to `ledger-live-desktop` that improves user experience by disabling the "Send" action when there are no accounts. The update includes both the implementation and corresponding tests to ensure correct behavior.

<img width="804" height="392" alt="Screenshot 2026-01-29 at 12 40 02" src="https://github.com/user-attachments/assets/4a3c1d8a-b403-45e4-bce7-da22ec18769d" />


### ❓ Context

[LIVE-25519](https://ledgerhq.atlassian.net/browse/LIVE-25519)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25519]: https://ledgerhq.atlassian.net/browse/LIVE-25519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ