### PR TITLE
fix(desktop): fix portfolio layout issues in Wallet 4.0

### DIFF
--- a/.changeset/red-purple-oats.md
+++ b/.changeset/red-purple-oats.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix portfolio layout issues: prevent horizontal scroll with multiple content cards, fix empty right panel causing 2-grid layout, and add border-radius to carousel slides in Wallet 4.0

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/PageView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/PageView.tsx
@@ -4,7 +4,6 @@ import ActionContentCards from "~/renderer/screens/dashboard/ActionContentCards"
 import { ABTestingVariants } from "@ledgerhq/types-live";
 import { PageViewModelResult } from "./usePageViewModel";
 import { ClassicLayout, Wallet40Layout, ScrollUpButton } from "./components";
-import { shouldDisplayRightPanel } from "./utils";
 import RightPanel from "LLD/components/RightPanel";
 
 type PageViewProps = PageViewModelResult & {
@@ -24,16 +23,15 @@ export const PageView = memo(function PageView({
   isWallet40Enabled,
   pathname,
   onClickScrollUp,
+  shouldRenderRightPanel,
 }: PageViewProps) {
-  const shouldShowRightPanel = shouldDisplayRightPanel(pathname);
-
   return (
     <div className="relative flex flex-1 flex-col">
       <TopBar />
       {isWallet40Enabled ? (
         <Wallet40Layout
           scrollerRef={pageScrollerRef}
-          rightPanel={shouldShowRightPanel ? <RightPanel /> : undefined}
+          rightPanel={shouldRenderRightPanel ? <RightPanel /> : undefined}
         >
           {children}
         </Wallet40Layout>

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/usePageViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/usePageViewModel.ts
@@ -2,6 +2,8 @@ import { useCallback, useLayoutEffect, useState } from "react";
 import { useLocation } from "react-router";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { SCROLL_UP_BUTTON_THRESHOLD } from "./constants";
+import { shouldDisplayRightPanel as isRightPanelPage } from "./utils";
+import { useRightPanelViewModel } from "LLD/components/RightPanel/useRightPanelViewModel";
 
 export interface PageViewModelResult {
   readonly pageScrollerRef: (node: HTMLDivElement | null) => void;
@@ -10,6 +12,7 @@ export interface PageViewModelResult {
   readonly isWallet40Enabled: boolean;
   readonly pathname: string;
   readonly onClickScrollUp: () => void;
+  readonly shouldRenderRightPanel: boolean;
 }
 
 export const usePageViewModel = (): PageViewModelResult => {
@@ -18,6 +21,9 @@ export const usePageViewModel = (): PageViewModelResult => {
   const [isScrollAtUpperBound, setScrollAtUpperBound] = useState(true);
   const { pathname } = useLocation();
   const { isEnabled: isWallet40Enabled } = useWalletFeaturesConfig("desktop");
+  const { shouldDisplay: isRightPanelEnabled } = useRightPanelViewModel();
+
+  const shouldRenderRightPanel = isRightPanelPage(pathname) && isRightPanelEnabled;
 
   // Callback ref to capture the scroller element
   const pageScrollerRef = useCallback((node: HTMLDivElement | null) => {
@@ -69,5 +75,6 @@ export const usePageViewModel = (): PageViewModelResult => {
     isWallet40Enabled,
     pathname,
     onClickScrollUp,
+    shouldRenderRightPanel,
   };
 };

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/RightPanelView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/RightPanelView.tsx
@@ -1,18 +1,12 @@
 import React, { memo } from "react";
 import SwapWebViewEmbedded from "~/renderer/screens/dashboard/components/SwapWebViewEmbedded";
-import { RightPanelViewModelResult } from "./useRightPanelViewModel";
-
-type RightPanelViewProps = RightPanelViewModelResult;
 
 /**
  * RightPanelView
  * Displays the swap sidebar in Wallet 4.0 layout
+ * Note: Visibility is controlled by PageView, this component always renders when mounted
  */
-export const RightPanelView = memo(function RightPanelView({ shouldDisplay }: RightPanelViewProps) {
-  if (!shouldDisplay) {
-    return null;
-  }
-
+export const RightPanelView = memo(function RightPanelView() {
   return (
     <div className="flex h-full flex-col py-32">
       <SwapWebViewEmbedded height="100%" isWallet40 />

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/index.tsx
@@ -1,17 +1,14 @@
 import React from "react";
-import { useRightPanelViewModel } from "./useRightPanelViewModel";
 import { RightPanelView } from "./RightPanelView";
 
 /**
  * RightPanel component - Sidebar panel on the right side of the app
  * Displays the SwapWebView when enabled on supported pages (Portfolio, Market, Analytics)
  *
- * Follows MVVM pattern: Container → ViewModel → View
+ * Note: Visibility is controlled by PageView using useRightPanelViewModel
  */
 const RightPanel = () => {
-  const viewModel = useRightPanelViewModel();
-
-  return <RightPanelView {...viewModel} />;
+  return <RightPanelView />;
 };
 
 export default RightPanel;

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/Slide.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/Slide.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from "react";
 import { useNavigate } from "react-router";
+import styled from "styled-components";
 
 import { PortfolioContentCard as Card } from "@ledgerhq/react-ui";
 import { openURL } from "~/renderer/linking";
@@ -9,7 +10,20 @@ import LogContentCardWrapper from "../LogContentCardWrapper";
 
 export default memo(Slide);
 
-type Props = PortfolioContentCard & CarouselActions & { index: number };
+const SlideContainer = styled.div<{ $isWallet40Enabled: boolean }>`
+  ${({ $isWallet40Enabled }) =>
+    $isWallet40Enabled &&
+    `
+    border-radius: 12px;
+    overflow: hidden;
+  `}
+`;
+
+type Props = PortfolioContentCard &
+  CarouselActions & {
+    index: number;
+    isWallet40Enabled: boolean;
+  };
 
 function Slide({
   id,
@@ -24,6 +38,7 @@ function Slide({
   location,
   logSlideClick,
   dismissCard,
+  isWallet40Enabled,
 }: Props) {
   const navigate = useNavigate();
 
@@ -38,16 +53,18 @@ function Slide({
   };
 
   return (
-    <LogContentCardWrapper id={id} location={location}>
-      <Card
-        title={title}
-        cta={cta}
-        description={description}
-        tag={tag}
-        image={image}
-        onClick={handleClick}
-        onClose={handleClose}
-      />
-    </LogContentCardWrapper>
+    <SlideContainer $isWallet40Enabled={isWallet40Enabled}>
+      <LogContentCardWrapper id={id} location={location}>
+        <Card
+          title={title}
+          cta={cta}
+          description={description}
+          tag={tag}
+          image={image}
+          onClick={handleClick}
+          onClose={handleClose}
+        />
+      </LogContentCardWrapper>
+    </SlideContainer>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
@@ -11,6 +11,8 @@ export default PortfolioContentCards;
 
 // Wrapper with animated padding that grows on hover so the content area shrinks to reveal arrows (Wallet 4.0 only)
 const CarouselWrapper = styled.div<{ $isWallet40Enabled: boolean }>`
+  overflow: hidden;
+
   ${({ $isWallet40Enabled }) =>
     $isWallet40Enabled &&
     `
@@ -48,6 +50,7 @@ function PortfolioContentCards() {
             index={index}
             logSlideClick={logSlideClick}
             dismissCard={dismissCard}
+            isWallet40Enabled={isWallet40Enabled}
           />
         ))}
       </Carousel>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _CSS/UI fixes only - visual verification required_
- [x] **Impact of the changes:**
  - Portfolio page horizontal scrolling behavior
  - Right panel grid layout when feature flag is disabled
  - Carousel slides border-radius in Wallet 4.0

### 📝 Description

**Problem**: Multiple layout issues in the Portfolio page for Wallet 4.0:
1. When multiple PortfolioContentCards are displayed, the page allows horizontal scrolling which shouldn't happen
2. When the right panel feature flag is disabled, the 2-grid layout is still applied causing empty space on the right
3. Carousel slides don't have rounded corners when hovering in Wallet 4.0

**Solution**:
- Added `overflow: hidden` to the CarouselWrapper to prevent horizontal scroll
- Moved the right panel visibility check from RightPanelView to usePageViewModel, ensuring the grid layout only applies when the panel should actually render
- Added conditional `border-radius` and `overflow: hidden` to Slide component for Wallet 4.0

:pr-open: LWD - Fix portfolio layout issues in Wallet 4.0
https://github.com/LedgerHQ/ledger-live/pull/14084
<img width="1912" height="805" alt="Screenshot 2026-01-29 at 14 46 46" src="https://github.com/user-attachments/assets/1bbaede7-81ac-4dba-9906-4a9b85dc11d9" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25554](https://ledgerhq.atlassian.net/browse/LIVE-25554)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25554]: https://ledgerhq.atlassian.net/browse/LIVE-25554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ