### PR TITLE
PERF: optimize accounts persistence to only save on significant changes

### DIFF
--- a/.changeset/stupid-oranges-peel.md
+++ b/.changeset/stupid-oranges-peel.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/types-live": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/coin-framework": minor
+---
+
+Stop persisting Account#lastSyncDate to optimize need to resave accounts

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -31,6 +31,7 @@ import { walletSelector } from "~/reducers/wallet";
 import { Maybe } from "../types/helpers";
 import { extractPersistedCALFromState } from "@ledgerhq/cryptoassets/cal-client/persistence";
 import { exportIdentitiesForPersistence } from "@ledgerhq/client-ids/store";
+import { accountPersistedStateChanged } from "@ledgerhq/live-common/account/index";
 import { exportCountervalues } from "@ledgerhq/live-countervalues/logic";
 
 type MaybeState = Maybe<State>;
@@ -128,11 +129,12 @@ const getAccountsChanged = (
   | null
   | undefined => {
   if (oldState.accounts !== newState.accounts) {
+    const oldById = new Map(oldState.accounts.active.map(a => [a.id, a] as const));
     return {
       changed: newState.accounts.active
         .filter(a => {
-          const old = oldState.accounts.active.find(b => a.id === b.id);
-          return !old || old !== a;
+          const old = oldById.get(a.id);
+          return !old || accountPersistedStateChanged(old, a);
         })
         .map(a => a.id),
     };

--- a/libs/coin-framework/src/serialization/account.ts
+++ b/libs/coin-framework/src/serialization/account.ts
@@ -176,7 +176,6 @@ export function toAccountRaw(account: Account, toFamilyRaw?: ToFamiliyRaw): Acco
     operationsCount,
     operations,
     pendingOperations,
-    lastSyncDate,
     balance,
     balanceHistoryCache,
     spendableBalance,
@@ -204,7 +203,6 @@ export function toAccountRaw(account: Account, toFamilyRaw?: ToFamiliyRaw): Acco
     operations: operations.map(convertOperation),
     pendingOperations: pendingOperations.map(convertOperation),
     currencyId: currency.id,
-    lastSyncDate: lastSyncDate.toISOString(),
     balance: balance.toFixed(),
     spendableBalance: spendableBalance.toFixed(),
   };

--- a/libs/ledger-live-common/src/account/index.ts
+++ b/libs/ledger-live-common/src/account/index.ts
@@ -14,6 +14,7 @@ export {
 } from "@ledgerhq/coin-framework/account/index";
 export * from "./formatters";
 export * from "./helpers";
+export { accountPersistedStateChanged, accountsPersistedStateChanged } from "./persistence";
 export * from "./serialization";
 export * from "./support";
 export {

--- a/libs/ledger-live-common/src/account/persistence.test.ts
+++ b/libs/ledger-live-common/src/account/persistence.test.ts
@@ -1,0 +1,98 @@
+import { getCryptoCurrencyById, setSupportedCurrencies } from "../currencies";
+import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
+import { accountPersistedStateChanged, accountsPersistedStateChanged } from "./persistence";
+
+setSupportedCurrencies(["ethereum"]);
+
+const Ethereum = getCryptoCurrencyById("ethereum");
+
+describe("account persistence predicates", () => {
+  describe("accountPersistedStateChanged", () => {
+    it("returns false when only lastSyncDate changed", () => {
+      const account = genAccount("seed", { currency: Ethereum });
+      const sameWithNewLastSync = {
+        ...account,
+        lastSyncDate: new Date(account.lastSyncDate.getTime() + 60000),
+      };
+      expect(accountPersistedStateChanged(account, sameWithNewLastSync)).toBe(false);
+    });
+
+    it("returns true when balance changed", () => {
+      const account = genAccount("seed", { currency: Ethereum });
+      const withDifferentBalance = {
+        ...account,
+        balance: account.balance.plus(1),
+        spendableBalance: account.spendableBalance.plus(1),
+      };
+      expect(accountPersistedStateChanged(account, withDifferentBalance)).toBe(true);
+    });
+
+    it("returns true when operationsCount changed", () => {
+      const account = genAccount("seed", { currency: Ethereum, operationsSize: 2 });
+      const withDifferentOpsCount = { ...account, operationsCount: account.operationsCount + 1 };
+      expect(accountPersistedStateChanged(account, withDifferentOpsCount)).toBe(true);
+    });
+
+    it("returns false when only blockHeight changed (not a persistence trigger)", () => {
+      const account = genAccount("seed", { currency: Ethereum });
+      const withDifferentBlockHeight = { ...account, blockHeight: account.blockHeight + 1 };
+      expect(accountPersistedStateChanged(account, withDifferentBlockHeight)).toBe(false);
+    });
+
+    it("returns true when subAccounts length changed", () => {
+      const account = genAccount("seed", { currency: Ethereum, subAccountsCount: 0 });
+      const withOneSub = { ...account, subAccounts: account.subAccounts ?? [] };
+      const withExtraSub = {
+        ...account,
+        subAccounts: [...(account.subAccounts ?? []), { ...account, id: account.id + "+token" }],
+      };
+      expect(accountPersistedStateChanged(withOneSub, withExtraSub)).toBe(true);
+    });
+
+    it("returns false when same account (reference equality)", () => {
+      const account = genAccount("seed", { currency: Ethereum });
+      expect(accountPersistedStateChanged(account, account)).toBe(false);
+    });
+
+    it("returns true when ids differ (different accounts)", () => {
+      const a = genAccount("seed1", { currency: Ethereum });
+      const b = genAccount("seed2", { currency: Ethereum });
+      expect(accountPersistedStateChanged(a, b)).toBe(true);
+    });
+  });
+
+  describe("accountsPersistedStateChanged", () => {
+    it("returns false when lists are same and no persisted state changed", () => {
+      const account = genAccount("seed", { currency: Ethereum });
+      const list = [account];
+      const sameList = [{ ...account, lastSyncDate: new Date() }];
+      expect(accountsPersistedStateChanged(list, sameList)).toBe(false);
+    });
+
+    it("returns true when list length differs (new account)", () => {
+      const a = genAccount("seed1", { currency: Ethereum });
+      const b = genAccount("seed2", { currency: Ethereum });
+      expect(accountsPersistedStateChanged([a], [a, b])).toBe(true);
+    });
+
+    it("returns true when list length differs (removed account)", () => {
+      const a = genAccount("seed1", { currency: Ethereum });
+      const b = genAccount("seed2", { currency: Ethereum });
+      expect(accountsPersistedStateChanged([a, b], [a])).toBe(true);
+    });
+
+    it("returns true when an account has persisted state changed", () => {
+      const a = genAccount("seed1", { currency: Ethereum });
+      const b = genAccount("seed2", { currency: Ethereum });
+      const bWithNewBalance = { ...b, balance: b.balance.plus(1) };
+      expect(accountsPersistedStateChanged([a, b], [a, bWithNewBalance])).toBe(true);
+    });
+
+    it("returns true when account id is new (not in old list)", () => {
+      const a = genAccount("seed1", { currency: Ethereum });
+      const b = genAccount("seed2", { currency: Ethereum });
+      const c = genAccount("seed3", { currency: Ethereum });
+      expect(accountsPersistedStateChanged([a, b], [a, c])).toBe(true);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/account/persistence.ts
+++ b/libs/ledger-live-common/src/account/persistence.ts
@@ -1,0 +1,66 @@
+import type { Account, TokenAccount } from "@ledgerhq/types-live";
+
+/**
+ * Returns true when something that is persisted and user-visible (or structurally
+ * relevant) changed between prev and next. Used to decide if an account is worth
+ * re-saving to app.json / mmkv. Ignores lastSyncDate and other in-memory-only fields.
+ */
+export function accountPersistedStateChanged(prev: Account, next: Account): boolean {
+  // critical fields that reflect changes
+  if (prev.id !== next.id) return true;
+  if (prev.syncHash !== next.syncHash) return true;
+
+  // balances
+  if (!prev.balance.eq(next.balance) || !prev.spendableBalance.eq(next.spendableBalance)) {
+    return true;
+  }
+
+  // operations
+  if (
+    prev.operationsCount !== next.operationsCount ||
+    prev.operations.length !== next.operations.length ||
+    prev.pendingOperations.length !== next.pendingOperations.length
+  ) {
+    return true;
+  }
+
+  // swap history
+  if ((prev.swapHistory?.length ?? 0) !== (next.swapHistory?.length ?? 0)) return true;
+
+  // sub accounts
+  if ((prev.subAccounts?.length ?? 0) !== (next.subAccounts?.length ?? 0)) return true;
+  const prevSubs = prev.subAccounts ?? [];
+  const nextSubs = next.subAccounts ?? [];
+  for (let i = 0; i < prevSubs.length; i++) {
+    const p = prevSubs[i];
+    const n = nextSubs[i];
+    if (!n || n.type !== "TokenAccount") return true;
+    if (tokenAccountPersistedStateChanged(p, n)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if the list of accounts has a change that is worth re-saving
+ * (new/removed account or any account with persisted state changed).
+ * Compares by index, like subAccounts.
+ */
+export function accountsPersistedStateChanged(
+  oldAccounts: Account[],
+  newAccounts: Account[],
+): boolean {
+  if (oldAccounts.length !== newAccounts.length) return true;
+  for (let i = 0; i < newAccounts.length; i++) {
+    if (accountPersistedStateChanged(oldAccounts[i], newAccounts[i])) return true;
+  }
+  return false;
+}
+
+function tokenAccountPersistedStateChanged(prev: TokenAccount, next: TokenAccount): boolean {
+  return (
+    prev.id !== next.id ||
+    !prev.balance.eq(next.balance) ||
+    prev.operationsCount !== next.operationsCount
+  );
+}

--- a/libs/ledgerjs/packages/types-live/src/account.ts
+++ b/libs/ledgerjs/packages/types-live/src/account.ts
@@ -193,7 +193,8 @@ export type AccountRaw = {
   feesCurrencyId?: string;
   operations: OperationRaw[];
   pendingOperations: OperationRaw[];
-  lastSyncDate: string;
+  /** Not persisted; kept optional for backward compat when reading old data */
+  lastSyncDate?: string;
   subAccounts?: TokenAccountRaw[];
   balanceHistoryCache?: BalanceHistoryCache;
   swapHistory?: SwapOperationRaw[];


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - mobile and desktop

### 📝 Description

Don’t persist `lastSyncDate` and only re-save when account data actually changes in the user's eye.

- `Account#lastSyncDate` is no longer stored in app.json / MMKV. A predicate decides when an account is “worth re-saving” (balance, ops count, subAccounts, etc.; not `lastSyncDate` or `blockHeight`).
- `AccountRaw.lastSyncDate` optional; `toAccountRaw` omits it; `fromAccountRaw` still reads it (default `new Date(0)`). New helpers in live-common: `accountPersistedStateChanged`, `accountsPersistedStateChanged` (compare by index).
- **Mobile:** Only accounts that pass the predicate are written (unchanged: still per-account writes).
- **Desktop:** Accounts are written only when `accountsPersistedStateChanged(old, new)` is true.
- **Compatibility:** Old payloads with `lastSyncDate` still load; new ones don’t include it. No migration.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25545

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
