### PR TITLE
support(mobile): realign fear and greed tile with other tiles

### DIFF
--- a/.changeset/forty-timers-lay.md
+++ b/.changeset/forty-timers-lay.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Realign fear and greed tile with the other tiles

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8384,7 +8384,8 @@
       "neutral": "Neutral",
       "greed": "Greed",
       "extremeGreed": "Greed+"
-    }
+    },
+    "tileTitle": "Mood"
   },
   "analyticsAllocation": {
     "header": {

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedCard/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/components/FearAndGreedCard/index.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from "react";
-import { Tile, TileContent, TileTitle, TileDescription } from "@ledgerhq/lumen-ui-rnative";
+import { Tile, TileContent, TileTitle, TileDescription, Box } from "@ledgerhq/lumen-ui-rnative";
 import { useTranslation } from "~/context/Locale";
 import {
   getFearAndGreedColorKey,
@@ -18,9 +18,11 @@ function FearAndGreedCard({ data, onPress }: FearAndGreedCardProps) {
 
   return (
     <Tile appearance="card" lx={{ width: "s96", flexGrow: 1 }} onPress={onPress}>
-      <FearAndGreedArc value={value} />
+      <Box lx={{ height: "s40", justifyContent: "center", alignItems: "center" }}>
+        <FearAndGreedArc value={value} />
+      </Box>
       <TileContent>
-        <TileTitle>{t("fearAndGreed.title")}</TileTitle>
+        <TileTitle>{t("fearAndGreed.tileTitle")}</TileTitle>
         <TileDescription
           style={{
             // will be fixed with the new folder structure

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerView/index.tsx
@@ -26,7 +26,7 @@ interface MarketBannerViewProps {
   testID?: string;
 }
 
-const HEIGHT = 102;
+const HEIGHT = 108;
 const MARGIN_RIGHT = 8;
 const PADDING_HORIZONTAL = 16;
 const MARGIN_HORIZONTAL = -16;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _UI alignment changes are difficult to test automatically. Should be verified visually by QA._
- [x] **Impact of the changes:**
  - Fear and Greed tile visual alignment and consistency
  - Tile title text and translation
  - Arc indicator vertical centering and spacing

### 📝 Description

This PR realigns the Fear and Greed tile to match the visual consistency and layout of other tiles in the application, following the latest Lumen UI design system updates.

**Changes made:**

- Wrapped the `FearAndGreedArc` component in a `Box` with a fixed height (`s40`) to ensure consistent vertical alignment across tiles
- Added proper centering for the arc indicator using flexbox properties
- Updated the tile title translation key from `"fearAndGreed.title"` to `"fearAndGreed.tileTitle"` which now displays "Mood" instead of the previous title for better consistency
- Ensured the tile matches the height and spacing of other dashboard tiles

**Before/After:**

| Before | After |
| ------ | ----- |
| <img width="331" height="719" alt="image" src="https://github.com/user-attachments/assets/6c31fb38-4054-4bb4-b319-80bcc7ed9263" />| <img width="331" height="2868" alt="image" src="https://github.com/user-attachments/assets/c06b1208-950f-4768-a75b-adea7c516e16" /> |

### ❓ Context

- **JIRA link**: [LIVE-25565](https://ledgerhq.atlassian.net/browse/LIVE-25565)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25565]: https://ledgerhq.atlassian.net/browse/LIVE-25565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ