### PR TITLE
PERF: feat(lwm): stop the incessant re-saving of countervalues

### DIFF
--- a/.changeset/khaki-goats-check.md
+++ b/.changeset/khaki-goats-check.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Stop the incessant re-saving of countervalues

--- a/apps/ledger-live-mobile/src/db.ts
+++ b/apps/ledger-live-mobile/src/db.ts
@@ -74,11 +74,7 @@ async function getKeys(prefix: string) {
   return (await storage.keys()).filter(k => k.indexOf(prefix) === 0);
 }
 
-async function unsafeSaveCountervalues(
-  state: CounterValuesStateRaw,
-  { changed }: { changed: boolean },
-): Promise<void> {
-  if (!changed) return;
+async function unsafeSaveCountervalues(state: CounterValuesStateRaw): Promise<void> {
   const data = Object.entries(state).map<[string, RateMapRaw | CounterValuesStatus]>(
     ([key, val]) => [`${COUNTERVALUES_DB_PREFIX}${key}`, val],
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Should greatly improve the general uses perfs on LWM

### 📝 Description

Before this LWM was trying to save the countervalues on every Redux store update. Thankfully the actual saving is throttled to every 2 seconds. But since the countervalues data are pretty huge it still potentially resulted in a lot of data re-written all the time and for a user with many accounts the saving process itself could take more than a second.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25589] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25589]: https://ledgerhq.atlassian.net/browse/LIVE-25589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ