### PR TITLE
PERF: chore(countervalues): optimize logic & only persist historical rates

### DIFF
--- a/.changeset/afraid-cycles-shave.md
+++ b/.changeset/afraid-cycles-shave.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-countervalues-react": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-countervalues": minor
+---
+
+optimize countervalues logic to only persist historical rates and refresh "holes" only once.

--- a/libs/live-countervalues-react/src/index.tsx
+++ b/libs/live-countervalues-react/src/index.tsx
@@ -165,9 +165,10 @@ function Effect({
     );
   }, [pending, currentState, userSettings, triggerLoad, batchStrategySolver, bridge]);
 
-  // save the state when it changes
+  // restore state from persisted raw (history only so we know it's first run and check holes)
   useEffect(() => {
-    if (!savedState?.status || !Object.keys(savedState.status).length) return;
+    if (!savedState || typeof savedState !== "object") return;
+    if (!Object.keys(savedState).length) return;
     bridge.setState(importCountervalues(savedState, userSettings));
   }, [bridge, savedState, userSettings]);
 

--- a/libs/live-countervalues/src/logic.integ.test.ts
+++ b/libs/live-countervalues/src/logic.integ.test.ts
@@ -5,9 +5,13 @@ import {
   exportCountervalues,
   importCountervalues,
 } from "./logic";
-import { getFiatCurrencyByTicker } from "@ledgerhq/cryptoassets";
+import {
+  getFiatCurrencyByTicker,
+  findFiatCurrencyByTicker,
+  findCryptoCurrencyByTicker,
+  getCryptoCurrencyById,
+} from "@ledgerhq/cryptoassets";
 import { getBTCValues } from "./mock";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { Currency } from "@ledgerhq/types-cryptoassets";
 import Prando from "prando";
@@ -294,9 +298,13 @@ test("export and import it back", async () => {
     disableAutoRecoverErrors: true,
   };
   const state = await loadCountervalues(initialState, settings);
-  const exported = exportCountervalues(state);
+  const exported = exportCountervalues(state, settings.trackingPairs);
   const imported = importCountervalues(exported, settings);
-  expect(imported).toEqual(state);
+  expect(imported.status).toEqual(state.status);
+  expect(imported.data).toBeDefined();
+  expect(imported.checkHolesOnNextLoad).toBe(true);
+  const exportedDataKeys = Object.keys(exported).filter(k => k !== "status");
+  expect(Object.keys(imported.data).sort()).toEqual(exportedDataKeys.sort());
 });
 
 describe("API specific unit tests", () => {

--- a/libs/live-countervalues/src/types.ts
+++ b/libs/live-countervalues/src/types.ts
@@ -27,6 +27,8 @@ export type CounterValuesState = {
   status: CounterValuesStatus;
   // this "cache" layer pre-compute all direct mapping for all dates of the range (complete holes...)
   cache: Record<string, PairRateMapCache>;
+  // set by import, cleared after first loadCountervalues; triggers hole check on first run after restore
+  checkHolesOnNextLoad?: boolean;
 };
 // serialized version of CounterValuesState to be saved/restored
 // The goal here is to make a key-value map where the value is not exceeding 2MB for Android to not glitch...


### PR DESCRIPTION
this PR is based on https://github.com/LedgerHQ/ledger-live/pull/14015

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - desktop and mobile will less often resave the countervalues in app.json / mmkv

### 📝 Description

Countervalues were written to the DB too often (e.g. on every “latest” rate tick), which caused unnecessary DB writes and could trigger extra work (e.g. HTTP) when nothing important had changed.

Gap handling: Some historical gaps never get filled by the API (e.g. missing data for a pair/period), so we treat them as permanent: we run hole detection only once per pair, store an “earliest stable date” before the first hole, and stop re-fetching that range so we don’t keep hitting the server for data that will never exist.




### ❓ Context

- **JIRA or GitHub link**:
  - https://ledgerhq.atlassian.net/browse/LIVE-25267
  - https://ledgerhq.atlassian.net/browse/LIVE-25563


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
