### PR TITLE
fix(desktop): prevent auto-expand of MainSideBar

### DIFF
--- a/.changeset/olive-seals-tell.md
+++ b/.changeset/olive-seals-tell.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix auto-collapse MainSideBar

--- a/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
@@ -257,8 +257,9 @@ const MainSideBar = () => {
   } = useWalletFeaturesConfig("desktop");
 
   /**
-   * Auto-collapse/expand sidebar when wallet40 is enabled based on window width.
+   * Auto-collapse sidebar when wallet40 is enabled and window width becomes narrow.
    * Uses the same threshold as the AssetDistribution responsive layout.
+   * Note: Does not auto-expand when window becomes wider; user must manually reopen.
    */
   const wasNarrowRef = useRef<boolean | null>(null);
 
@@ -270,7 +271,9 @@ const MainSideBar = () => {
 
       if (wasNarrowRef.current !== isNarrow) {
         wasNarrowRef.current = isNarrow;
-        dispatch(setSidebarCollapsed(isNarrow));
+        if (isNarrow) {
+          dispatch(setSidebarCollapsed(true));
+        }
       }
     };
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Main sidebar auto-collapse behavior
  - Window resize responsiveness
  - User experience consistency

### 📝 Description

**Problem**: The MainSideBar was automatically expanding when the window became wider, which could be disruptive to user experience.

**Solution**: 
- Modified the auto-collapse logic to only collapse the sidebar when the window becomes narrow
- Removed automatic expansion when the window becomes wider
- Users must now manually reopen a collapsed sidebar
- This maintains a more predictable and consistent sidebar state

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25581](https://ledgerhq.atlassian.net/browse/LIVE-25581)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25581]: https://ledgerhq.atlassian.net/browse/LIVE-25581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ