### PR TITLE
Make the Export Operations feature waiting all accounts to be synchronised so users don't miss operations

### DIFF
--- a/.changeset/curvy-shoes-explain.md
+++ b/.changeset/curvy-shoes-explain.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Export Operations to trigger sync and wait Accounts to have all operations


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - desktop : export operations

### 📝 Description


with the incoming evolution of https://github.com/LedgerHQ/ledger-live/pull/14001 , there is a risk to use the Export Operations feature without accounts having fetched all the necessary operations yet. what we can do is to trigger a sync and wait all accounts to be synced during the operations export flow before the export happens.

Here is the currently implemented user experience: the button possibly turns as a loading on the action.

https://github.com/user-attachments/assets/9127dc1d-0fab-4222-96f0-94717acb06ce


### ❓ Context

- **JIRA or GitHub link**: LIVE-25580


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
