### PR TITLE
fix: Corrects hover state on error

### DIFF
--- a/.changeset/tough-mayflies-jog.md
+++ b/.changeset/tough-mayflies-jog.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(lwd): market banner hover on error state

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/GenericError.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/GenericError.tsx
@@ -1,18 +1,16 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Tile, TileSpot, TileContent, TileTitle } from "@ledgerhq/lumen-ui-react";
+import { Spot } from "@ledgerhq/lumen-ui-react";
 import { Warning } from "@ledgerhq/lumen-ui-react/symbols";
 
 const GenericError = () => {
   const { t } = useTranslation();
 
   return (
-    <Tile data-testid="generic-error">
-      <TileSpot appearance="icon" icon={Warning} />
-      <TileContent>
-        <TileTitle>{t("marketBanner.genericError")}</TileTitle>
-      </TileContent>
-    </Tile>
+    <div className="flex flex-col items-center justify-center gap-8" data-testid="generic-error">
+      <Spot appearance="icon" icon={Warning} />
+      <span className="body-2-semi-bold text-base">{t("marketBanner.genericError")}</span>
+    </div>
   );
 };
 


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a minor update to the market banner error state in Ledger Live Desktop, improving its visual consistency and user experience. The main change refactors the error component to use updated UI primitives and styling, so to avoid a hover on the error tile.

https://github.com/user-attachments/assets/83f01208-4387-41c9-9ef5-c42cd3a05c2e


### ❓ Context

[LIVE-25541](https://ledgerhq.atlassian.net/browse/LIVE-25541)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25541]: https://ledgerhq.atlassian.net/browse/LIVE-25541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ