### PR TITLE
chore(mobile): disable JS minification for Hermes compatibility in E2E

### DIFF
--- a/.github/workflows/test-mobile-build-android-reusable.yml
+++ b/.github/workflows/test-mobile-build-android-reusable.yml
@@ -226,10 +226,14 @@ jobs:
       - name: Build JS Bundle app for Detox test run
         run: pnpm mobile e2e:ci -p android --bundle
 
+      - name: Build minified JS Bundle for size analysis
+        run: pnpm mobile e2e:ci -p android --bundle-size
+
       - name: Output bundle size for analysis
         id: output-js-bundle-size
         run: |
-          echo size=`ls -l ${{ env.ANDROID_JSBUNDLE_PATH }}  | cut -d " " -f5` >> $GITHUB_OUTPUT
+          # Report the minified bundle size for comparison with other branches
+          echo size=`ls -l apps/ledger-live-mobile/main.jsbundle.minified | cut -d " " -f5` >> $GITHUB_OUTPUT
 
       - name: Upload Detox JS Build
         uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop

--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -242,9 +242,14 @@ jobs:
       - name: Build JS Bundle app for Detox test run
         run: pnpm mobile e2e:ci -p ios --bundle
 
+      - name: Build minified JS Bundle for size analysis
+        run: pnpm mobile e2e:ci -p ios --bundle-size
+
       - name: Output bundle size for analysis
         id: output-js-bundle-size
-        run: echo size=`ls -l ${{ github.workspace }}/apps/ledger-live-mobile/main.jsbundle  | cut -d " " -f5` >> $GITHUB_OUTPUT
+        run: |
+          # Report the minified bundle size for comparison with other branches
+          echo size=`ls -l ${{ github.workspace }}/apps/ledger-live-mobile/main.jsbundle.minified | cut -d " " -f5` >> $GITHUB_OUTPUT
 
       - name: Upload Detox JS Build
         uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** E2E tests validate this fix.
- [x] **Impact of the changes:**
  - E2E test bundle generation for iOS and Android
  - Bundle size reporting (now uses separate minified bundle)

### 📝 Description

**Problem**: When using Repack bundler, minified JS bundles cause Hermes parsing errors ("non-terminated string") in CI E2E tests. The issue occurs because CI injects raw JS into the APK, while local Gradle builds compile JS to Hermes bytecode.

**Solution**: 
- Disable JS minification for E2E bundles (`--minify false`), matching React Native's native build behavior when Hermes is enabled
- Add `--bundle-size` flag to generate a separate minified bundle for size reporting, preserving the ability to compare bundle sizes across branches

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-24694

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.