### PR TITLE
fix(BACK-10510): fix wrong amounts on ERC-20 transfer operations

### DIFF
--- a/.changeset/nine-dolphins-taste.md
+++ b/.changeset/nine-dolphins-taste.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/coin-tester": minor
+---
+
+fix(BACK-10510): fix wrong amounts on ERC-20 transfer operations

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.test.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.test.ts
@@ -66,7 +66,7 @@ describe("EVM Family", () => {
             blockHeight: 14923692,
             recipients: [""],
             senders: ["0x9AA99C23F67c81701C772B106b4F83f6e858dd2E"],
-            value: new BigNumber("7175807958762144"),
+            value: new BigNumber("0"),
             fee: new BigNumber("7175807958762144"),
             date: new Date("2022-06-08T00:02:50.000Z"),
             transactionSequenceNumber: new BigNumber(7),
@@ -124,7 +124,7 @@ describe("EVM Family", () => {
             blockHeight: 14923692,
             recipients: ["0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC"],
             senders: ["0x9AA99C23F67c81701C772B106b4F83f6e858dd2E"],
-            value: new BigNumber("7175807958762144"),
+            value: new BigNumber("0"),
             fee: new BigNumber("7175807958762144"),
             date: new Date("2022-06-08T00:02:50.000Z"),
             transactionSequenceNumber: new BigNumber(7),
@@ -181,7 +181,7 @@ describe("EVM Family", () => {
             blockHeight: 13807766,
             recipients: ["0x26E3fd2dEc89bF645BA7b41c4DdFad8454Ee6245"],
             senders: ["0x829BD824B016326A401d083B33D092293333A830"],
-            value: new BigNumber("143141441418750645").plus("1435640675553000"),
+            value: new BigNumber("143141441418750645"),
             fee: new BigNumber("1435640675553000"),
             date: new Date("2021-12-15T05:08:46.000Z"),
             transactionSequenceNumber: new BigNumber(11898499),
@@ -372,7 +372,7 @@ describe("EVM Family", () => {
               blockHeight: 14923692,
               recipients: ["0x9AA99C23F67c81701C772B106b4F83f6e858dd2E"],
               senders: ["0x9AA99C23F67c81701C772B106b4F83f6e858dd2E"],
-              value: new BigNumber("7175807958763144"),
+              value: new BigNumber("1000"),
               fee: new BigNumber("7175807958762144"),
               date: new Date("2022-06-08T00:02:50.000Z"),
               transactionSequenceNumber: new BigNumber(7),
@@ -423,17 +423,15 @@ describe("EVM Family", () => {
             functionName: "transfer(address _to, uint256 _value)",
           };
 
-          // Successful Op
+          // Successful Op (value = transferred only; fee is separate; Ledger Wallet adds fee in bridge)
           expect(etherscanOperationToOperations(accountId, etherscanOpFees)[0].value).toEqual(
-            new BigNumber(etherscanOpFees.value).plus(
-              new BigNumber(etherscanOpFees.gasPrice).times(etherscanOpFees.gasUsed),
-            ),
+            new BigNumber(etherscanOpFees.value),
           );
-          // Failing Op
+          // Failing Op (value = tx value, same as success)
           expect(
             etherscanOperationToOperations(accountId, { ...etherscanOpFees, isError: "1" })[0]
               .value,
-          ).toEqual(new BigNumber(etherscanOpFees.gasPrice).times(etherscanOpFees.gasUsed));
+          ).toEqual(new BigNumber(etherscanOpFees.value));
 
           const etherscanOpOut: EtherscanOperation = {
             blockNumber: "13807766",
@@ -458,16 +456,14 @@ describe("EVM Family", () => {
             functionName: "",
           };
 
-          // Successful Op
+          // Successful Op (value = transferred only; fee is separate; Ledger Wallet adds fee in bridge)
           expect(etherscanOperationToOperations(accountId, etherscanOpOut)[0].value).toEqual(
-            new BigNumber(etherscanOpOut.value).plus(
-              new BigNumber(etherscanOpOut.gasPrice).times(etherscanOpOut.gasUsed),
-            ),
+            new BigNumber(etherscanOpOut.value),
           );
-          // Failing Op
+          // Failing Op (value = tx value, same as success)
           expect(
             etherscanOperationToOperations(accountId, { ...etherscanOpOut, isError: "1" })[0].value,
-          ).toEqual(new BigNumber(etherscanOpOut.gasPrice).times(etherscanOpOut.gasUsed));
+          ).toEqual(new BigNumber(etherscanOpOut.value));
 
           const etherscanOpIn: EtherscanOperation = {
             blockNumber: "13807766",
@@ -1517,7 +1513,7 @@ describe("EVM Family", () => {
             blockHeight: 12345678,
             recipients: ["0x0000000000000000000000000000000000001005"],
             senders: ["0x9AA99C23F67c81701C772B106b4F83f6e858dd2E"],
-            value: new BigNumber("7175807958762144"),
+            value: new BigNumber("0"),
             fee: new BigNumber("7175807958762144"),
             date: new Date(1694851200 * 1000), // timestamp in ms
             transactionSequenceNumber: new BigNumber(7),
@@ -1575,7 +1571,7 @@ describe("EVM Family", () => {
             blockHeight: 12345678,
             recipients: ["0x0000000000000000000000000000000000001005"],
             senders: ["0x9AA99C23F67c81701C772B106b4F83f6e858dd2E"],
-            value: new BigNumber("7175807958762144"),
+            value: new BigNumber("0"),
             fee: new BigNumber("7175807958762144"),
             date: new Date(1694851200 * 1000), // timestamp in ms
             transactionSequenceNumber: new BigNumber(7),
@@ -1631,7 +1627,7 @@ describe("EVM Family", () => {
             blockHeight: 12345678,
             recipients: ["0x0000000000000000000000000000000000001005"],
             senders: ["0x9AA99C23F67c81701C772B106b4F83f6e858dd2E"],
-            value: new BigNumber("7175807958762144"),
+            value: new BigNumber("0"),
             fee: new BigNumber("7175807958762144"),
             date: new Date(1694851200 * 1000), // timestamp in ms
             transactionSequenceNumber: new BigNumber(7),

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
@@ -67,37 +67,29 @@ export const etherscanOperationToOperations = (
     types.push("NONE");
   }
 
-  const valueIncludesFees = ["OUT", "FEES", "DELEGATE", "UNDELEGATE", "REDELEGATE"];
-
-  return types.map(type => {
-    let operationValue: BigNumber = value;
-
-    if (valueIncludesFees.includes(type) && hasFailed) {
-      operationValue = fee;
-    } else if (valueIncludesFees.includes(type)) {
-      operationValue = value.plus(fee);
-    }
-
-    return {
-      id: encodeOperationId(accountId, etherscanOp.hash, type),
-      hash: etherscanOp.hash,
-      type,
-      value: operationValue,
-      fee,
-      senders: [from],
-      recipients: [to],
-      blockHeight: Number.parseInt(etherscanOp.blockNumber, 10),
-      blockHash: etherscanOp.blockHash,
-      transactionSequenceNumber: new BigNumber(etherscanOp.nonce),
-      accountId: accountId,
-      date: new Date(Number.parseInt(etherscanOp.timeStamp, 10) * 1000),
-      subOperations: [],
-      nftOperations: [],
-      internalOperations: [],
-      hasFailed,
-      extra: {},
-    } as Operation;
-  });
+  // Value = transferred amount only (same whether tx failed or not); fee is separate. Ledger Wallet contract is applied by generic-alpaca bridge.
+  return types.map(
+    type =>
+      ({
+        id: encodeOperationId(accountId, etherscanOp.hash, type),
+        hash: etherscanOp.hash,
+        type,
+        value,
+        fee,
+        senders: [from],
+        recipients: [to],
+        blockHeight: Number.parseInt(etherscanOp.blockNumber, 10),
+        blockHash: etherscanOp.blockHash,
+        transactionSequenceNumber: new BigNumber(etherscanOp.nonce),
+        accountId: accountId,
+        date: new Date(Number.parseInt(etherscanOp.timeStamp, 10) * 1000),
+        subOperations: [],
+        nftOperations: [],
+        internalOperations: [],
+        hasFailed,
+        extra: {},
+      }) as Operation,
+  );
 };
 
 /**

--- a/libs/coin-modules/coin-evm/src/adapters/ledger.test.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/ledger.test.ts
@@ -32,7 +32,7 @@ const coinOperation: Operation = {
   blockHeight: 38476740,
   recipients: ["0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"],
   senders: ["0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d"],
-  value: new BigNumber("4254163264389158"),
+  value: new BigNumber("0"), // FEES op: transferred amount only
   fee: new BigNumber("4254163264389158"),
   date: new Date("2023-01-24T17:11:45Z"),
   transactionSequenceNumber: new BigNumber(75),
@@ -165,7 +165,7 @@ describe("EVM Family", () => {
             blockHeight: 38476740,
             recipients: ["0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"],
             senders: ["0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d"],
-            value: new BigNumber("4254163264389158"),
+            value: new BigNumber("0"),
             fee: new BigNumber("4254163264389158"),
             date: new Date("2023-01-24T17:11:45Z"),
             transactionSequenceNumber: new BigNumber(75),
@@ -228,7 +228,7 @@ describe("EVM Family", () => {
             blockHeight: 38476740,
             recipients: ["0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"],
             senders: ["0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d"],
-            value: new BigNumber("4254163264389159"),
+            value: new BigNumber("1"),
             fee: new BigNumber("4254163264389158"),
             date: new Date("2023-01-24T17:11:45Z"),
             transactionSequenceNumber: new BigNumber(75),
@@ -504,7 +504,7 @@ describe("EVM Family", () => {
             blockHeight: 38476740,
             recipients: ["0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d"],
             senders: ["0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d"],
-            value: new BigNumber("4254163264389159"),
+            value: new BigNumber("1"),
             fee: new BigNumber("4254163264389158"),
             date: new Date("2023-01-24T17:11:45Z"),
             transactionSequenceNumber: new BigNumber(75),
@@ -617,18 +617,14 @@ describe("EVM Family", () => {
             },
           };
 
-          // Successful Op
+          // Successful Op (value = transferred only; fee is separate; Ledger Wallet adds fee in bridge)
           expect(ledgerOperationToOperations(accountId, ledgerExplorerFeesOp)[0].value).toEqual(
-            new BigNumber(ledgerExplorerFeesOp.value).plus(
-              new BigNumber(ledgerExplorerFeesOp.gas_price).times(ledgerExplorerFeesOp.gas_used),
-            ),
+            new BigNumber(ledgerExplorerFeesOp.value),
           );
-          // Failing Op
+          // Failing Op (value = tx value, same as success)
           expect(
             ledgerOperationToOperations(accountId, { ...ledgerExplorerFeesOp, status: 0 })[0].value,
-          ).toEqual(
-            new BigNumber(ledgerExplorerFeesOp.gas_price).times(ledgerExplorerFeesOp.gas_used),
-          );
+          ).toEqual(new BigNumber(ledgerExplorerFeesOp.value));
 
           const ledgerOperationOut: LedgerExplorerOperation = {
             hash: "0xf350d4f8e910419e2d5cec294d44e69af8c6185b7089061d33bb4fc246cefb79",
@@ -667,16 +663,14 @@ describe("EVM Family", () => {
             },
           };
 
-          // Successful Op
+          // Successful Op (value = transferred only; fee is separate; Ledger Wallet adds fee in bridge)
           expect(ledgerOperationToOperations(accountId, ledgerOperationOut)[0].value).toEqual(
-            new BigNumber(ledgerOperationOut.value).plus(
-              new BigNumber(ledgerOperationOut.gas_price).times(ledgerOperationOut.gas_used),
-            ),
+            new BigNumber(ledgerOperationOut.value),
           );
-          // Failing Op
+          // Failing Op (value = tx value, same as success)
           expect(
             ledgerOperationToOperations(accountId, { ...ledgerOperationOut, status: 0 })[0].value,
-          ).toEqual(new BigNumber(ledgerOperationOut.gas_price).times(ledgerOperationOut.gas_used));
+          ).toEqual(new BigNumber(ledgerOperationOut.value));
 
           const ledgerOperationIn: LedgerExplorerOperation = {
             hash: "0xf350d4f8e910419e2d5cec294d44e69af8c6185b7089061d33bb4fc246cefb79",
@@ -1331,11 +1325,12 @@ describe("EVM Family", () => {
             type: "IN" as const,
           };
 
+          // Action value must match coin op value (transferred amount) for deduplication
           const ledgerActionOutOrFees: LedgerExplorerInternalTransaction = {
             from: coinOperationFees.senders[0],
             to: coinOperationFees.recipients[0],
             input: null,
-            value: coinOperationFees.value.minus(coinOperationFees.fee).toFixed(),
+            value: coinOperationFees.value.toFixed(),
             gas: "57090",
             gas_used: "27485",
             error: null,
@@ -1358,6 +1353,43 @@ describe("EVM Family", () => {
           expect(ledgerInternalTransactionToOperations(coinOperationIn, ledgerActionIn)).toEqual(
             [],
           );
+        });
+
+        it("should emit internal op when action has same from/to but value differs from coin op value", () => {
+          // Deduplication only when action.value === coinOperation.value (transferred amount)
+          const coinOpOutWithTransfer = {
+            ...coinOperation,
+            type: "OUT" as const,
+            value: new BigNumber("10000000000000000"),
+          };
+          const actionSameFromToDifferentValue: LedgerExplorerInternalTransaction = {
+            from: coinOpOutWithTransfer.senders[0],
+            to: coinOpOutWithTransfer.recipients[0],
+            input: null,
+            value: "10000000000000000",
+            gas: "57090",
+            gas_used: "27485",
+            error: null,
+          };
+          // Value matches → filtered
+          expect(
+            ledgerInternalTransactionToOperations(
+              coinOpOutWithTransfer,
+              actionSameFromToDifferentValue,
+            ),
+          ).toEqual([]);
+
+          const actionDifferentValue: LedgerExplorerInternalTransaction = {
+            ...actionSameFromToDifferentValue,
+            value: "1",
+          };
+          // Value differs → internal op emitted
+          const result = ledgerInternalTransactionToOperations(
+            coinOpOutWithTransfer,
+            actionDifferentValue,
+          );
+          expect(result).toHaveLength(1);
+          expect(result[0].value.toFixed()).toBe("1");
         });
 
         it("should convert a ledger explorer none action to a Ledger Live Operation", () => {

--- a/libs/coin-modules/coin-evm/src/adapters/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/ledger.ts
@@ -50,13 +50,14 @@ export const ledgerOperationToOperations = (
     types.push("NONE");
   }
 
+  // Value = transferred amount only (same whether tx failed or not); fee is separate. Ledger Wallet contract is applied by generic-alpaca bridge.
   return types.map(
     type =>
       ({
         id: encodeOperationId(accountId, ledgerOp.hash, type),
         hash: ledgerOp.hash,
         type: type,
-        value: type === "OUT" || type === "FEES" ? (hasFailed ? fee : value.plus(fee)) : value,
+        value,
         fee,
         senders: [from],
         recipients: [to],
@@ -252,21 +253,13 @@ export const ledgerInternalTransactionToOperations = (
   // Ledger explorers are indexing the first `CALL` opcode of a smart contract transaction as an
   // internal transaction which is wrong. Only children `CALL` opcode should be indexed,
   // therefore we need to filter those "actions" to prevent duplicating ops.
-  if (from === coinOperation.senders[0] && to === coinOperation.recipients[0]) {
-    const coinOpValueWithoutFees = coinOperation.value.minus(coinOperation.fee);
-    const coinOpValueWithFees = coinOperation.value;
-    const coinTypeOutOrFees = coinOperation.type === "OUT" || coinOperation.type === "FEES";
-    const coinTypeIn = coinOperation.type === "IN";
-
-    // Detecting if an action value is identical to its coin op value
-    // (which is modified in the live depending on its type)
-    // in order to ignore the action completely
-    if (
-      (coinTypeOutOrFees && value.isEqualTo(coinOpValueWithoutFees)) ||
-      (coinTypeIn && value.isEqualTo(coinOpValueWithFees))
-    ) {
-      return [];
-    }
+  // coinOperation.value is the transferred amount only (same for OUT/FEES/IN); compare directly.
+  if (
+    from === coinOperation.senders[0] &&
+    to === coinOperation.recipients[0] &&
+    value.isEqualTo(coinOperation.value)
+  ) {
+    return [];
   }
 
   if (to === checksummedAddress) {

--- a/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
@@ -529,6 +529,187 @@ describe.each([
         }
       });
     });
+
+    describe("transactions non-regression", () => {
+      const opsForTx = (items: Operation[], txHash: string) =>
+        items.filter(op => op.tx.hash.toLowerCase() === txHash.toLowerCase());
+
+      const expectAddressEq = (actual: string, expected: string) =>
+        expect(actual.toLowerCase()).toBe(expected.toLowerCase());
+
+      it("simple native transfer between EOAs", async () => {
+        const txHash = "0x9f555da0bb8d9ff99ced6db6e5f966699f8df849f4887c80ed44ffb101f7d252";
+        const blockHeight = 24600494;
+        const sender = "0x12644b85A2F20F39Ade7543FBA1C0C9DFE289580";
+        const recipient = "0xD017e1a34648521E7959F0AfDb5d359c979f5E2f";
+
+        const { items: senderOps } = await module.listOperations(sender, {
+          minHeight: blockHeight,
+          order: "asc",
+          limit: 50,
+        });
+        const { items: recipientOps } = await module.listOperations(recipient, {
+          minHeight: blockHeight,
+          order: "asc",
+          limit: 50,
+        });
+
+        const senderTxOps = opsForTx(senderOps, txHash);
+        const recipientTxOps = opsForTx(recipientOps, txHash);
+
+        expect(senderTxOps).toHaveLength(1);
+        expect(senderTxOps[0]).toMatchObject({
+          type: "OUT",
+          asset: { type: "native" },
+          tx: { feesPayer: expect.any(String) },
+        });
+        expectAddressEq(senderTxOps[0].senders[0], sender);
+        expectAddressEq(senderTxOps[0].recipients[0], recipient);
+        expectAddressEq(senderTxOps[0].tx.feesPayer!, sender);
+        expect(senderTxOps[0].value).toBeGreaterThan(0n);
+        expect(senderTxOps[0].tx.fees).toBeGreaterThan(0n);
+
+        expect(recipientTxOps).toHaveLength(1);
+        expect(recipientTxOps[0]).toMatchObject({
+          type: "IN",
+          asset: { type: "native" },
+          tx: { feesPayer: expect.any(String) },
+        });
+        expectAddressEq(recipientTxOps[0].senders[0], sender);
+        expectAddressEq(recipientTxOps[0].recipients[0], recipient);
+        expectAddressEq(recipientTxOps[0].tx.feesPayer!, sender);
+        expect(recipientTxOps[0].value).toBe(senderTxOps[0].value);
+      });
+
+      it("simple ERC20 transfer between EOAs", async () => {
+        const txHash = "0xbbe8faac0666fb9741c536a1fcb184dc81884c95a38dcff899328a3c6c7c05b9";
+        const blockHeight = 24676233;
+        const sender = "0xf764Af5afc8dbfa0e698aBB8Eeb3E5a79c0cE4B5";
+        const recipient = "0x1f2F2d487C79822dc59550d87Bd5B32234F6F387";
+        const contract = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+
+        const { items: senderOps } = await module.listOperations(sender, {
+          minHeight: blockHeight,
+          order: "asc",
+          limit: 50,
+        });
+        const { items: recipientOps } = await module.listOperations(recipient, {
+          minHeight: blockHeight,
+          order: "asc",
+          limit: 50,
+        });
+
+        const senderTxOps = opsForTx(senderOps, txHash);
+        const recipientTxOps = opsForTx(recipientOps, txHash);
+
+        expect(senderTxOps).toHaveLength(1);
+        expect(senderTxOps[0]).toMatchObject({
+          type: "OUT",
+          asset: { type: "erc20" },
+          tx: { feesPayer: expect.any(String) },
+        });
+        const senderAsset = senderTxOps[0].asset as {
+          assetReference?: string;
+          assetOwner?: string;
+        };
+        expect(senderAsset.assetReference?.toLowerCase()).toBe(contract.toLowerCase());
+        expectAddressEq(senderTxOps[0].senders[0], sender);
+        expectAddressEq(senderTxOps[0].recipients[0], recipient);
+        expectAddressEq(senderAsset.assetOwner!, sender);
+        expectAddressEq(senderTxOps[0].tx.feesPayer!, sender);
+        expect(senderTxOps[0].value).toBeGreaterThan(0n);
+
+        expect(recipientTxOps).toHaveLength(1);
+        expect(recipientTxOps[0]).toMatchObject({
+          type: "IN",
+          asset: { type: "erc20" },
+        });
+        const recipientAsset = recipientTxOps[0].asset as {
+          assetReference?: string;
+          assetOwner?: string;
+        };
+        expect(recipientAsset.assetReference?.toLowerCase()).toBe(contract.toLowerCase());
+        expectAddressEq(recipientTxOps[0].senders[0], sender);
+        expectAddressEq(recipientTxOps[0].recipients[0], recipient);
+        expectAddressEq(recipientAsset.assetOwner!, recipient);
+        expect(recipientTxOps[0].value).toBe(senderTxOps[0].value);
+      });
+
+      it("Lido deposit (ETH to contract + STETH mint to sender)", async () => {
+        const txHash = "0x5b4fc90367ca30d5c790ae394d9d177db4f91cfb52d627e8fa94379c16ac5724";
+        const blockHeight = 24535189;
+        const sender = "0xf88e9863b2c157cdeaab3e3401be6b2d583bdfbd";
+        const lidoContract = "0xae7ab96520de3a18e5e111b5eaab095312d7fe84";
+        const zeroAddress = "0x0000000000000000000000000000000000000000";
+
+        const { items } = await module.listOperations(sender, {
+          minHeight: blockHeight,
+          order: "asc",
+          limit: 50,
+        });
+        const txOps = opsForTx(items, txHash);
+
+        expect(txOps.length).toBeGreaterThanOrEqual(2);
+        const nativeOp = txOps.find(op => op.asset.type === "native");
+        const tokenOp = txOps.find(
+          op =>
+            op.asset.type === "erc20" &&
+            op.asset.assetReference?.toLowerCase() === lidoContract.toLowerCase(),
+        );
+
+        expect(nativeOp).toMatchObject({
+          type: "OUT",
+          asset: { type: "native" },
+          tx: { feesPayer: expect.any(String) },
+        });
+        expectAddressEq(nativeOp!.senders[0], sender);
+        expectAddressEq(nativeOp!.recipients[0], lidoContract);
+        expectAddressEq(nativeOp!.tx.feesPayer!, sender);
+        expect(nativeOp!.value).toBeGreaterThan(0n);
+
+        expect(tokenOp).toMatchObject({
+          type: "IN",
+          asset: { type: "erc20", assetOwner: expect.any(String) },
+          tx: { feesPayer: expect.any(String) },
+        });
+        const tokenOpAsset = tokenOp!.asset as { assetReference?: string; assetOwner?: string };
+        expect(tokenOpAsset.assetReference?.toLowerCase()).toBe(lidoContract.toLowerCase());
+        expectAddressEq(tokenOpAsset.assetOwner!, sender);
+        expect(tokenOp!.senders[0].toLowerCase()).toBe(zeroAddress.toLowerCase());
+        expectAddressEq(tokenOp!.recipients[0], sender);
+        expectAddressEq(tokenOp!.tx.feesPayer!, sender);
+        expect(tokenOp!.value).toBeGreaterThan(0n);
+      });
+
+      it("Spoofed NFT transfer through smart contract", async () => {
+        const txHash = "0x61adea29cbf2e50f9ab975636af9a624620589c2cca9b8dc82ccccaefeb9c6ad";
+        const blockHeight = 21348730;
+        const caller = "0x6b2ae7cc19eda092476f32cced9311da568a823c";
+        const spoofedSender = "0x7d75Acd9B52e01B149557ed230717ECd088b898a";
+
+        const { items: spoofedSenderOps } = await module.listOperations(spoofedSender, {
+          minHeight: blockHeight,
+          order: "asc",
+          limit: 50,
+        });
+        const txOpsSpoofedSender = opsForTx(spoofedSenderOps, txHash);
+
+        expect(txOpsSpoofedSender).toHaveLength(1);
+        expect(txOpsSpoofedSender[0]).toMatchObject({
+          type: "NFT_OUT",
+          senders: expect.any(Array),
+          recipients: expect.any(Array),
+          asset: { type: "erc1155" },
+        });
+        expectAddressEq(txOpsSpoofedSender[0].senders[0], spoofedSender);
+        // feesPayer is caller when the explorer returns the parent coin op; undefined when it does not (e.g. Ledger when querying by spoofed sender).
+        const feesPayer = txOpsSpoofedSender[0].tx.feesPayer;
+        if (feesPayer !== undefined) {
+          expectAddressEq(feesPayer, caller);
+        }
+        expect(txOpsSpoofedSender[0].value).toBeGreaterThan(0n);
+      });
+    });
   });
 
   describe.each([

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
@@ -10,9 +10,11 @@ import { listOperations } from "./listOperations";
 describe("listOperations", () => {
   const currency = {} as CryptoCurrency;
   const address = "address";
+
   afterEach(() => {
     jest.clearAllMocks();
   });
+
   const buildOperationsSpy = (explorer: ExplorerApi) =>
     jest.spyOn(explorer, "getOperations").mockResolvedValue({
       lastCoinOperations: [
@@ -218,6 +220,7 @@ describe("listOperations", () => {
       ],
       nextPagingToken: "",
     });
+
   it.each([
     ["an etherscan explorer", { type: "etherscan" }, etherscanExplorer.explorerApi],
     [
@@ -268,7 +271,7 @@ describe("listOperations", () => {
             type: "OUT",
             senders: ["address"],
             recipients: ["address2"],
-            value: 8n,
+            value: 28n,
             asset: { type: "native" },
             tx: {
               hash: "coin-op-2-tx-hash",
@@ -286,7 +289,7 @@ describe("listOperations", () => {
           },
           {
             id: "coin-op-6",
-            type: "NONE",
+            type: "IN",
             senders: ["contract-address"],
             recipients: ["address"],
             value: 0n,
@@ -307,10 +310,10 @@ describe("listOperations", () => {
           },
           {
             id: "token-op-1",
-            type: "FEES",
+            type: "OUT",
             senders: ["address"],
             recipients: ["address1"],
-            value: 0n,
+            value: 1n,
             asset: { type: "erc20", assetReference: "contract-address", assetOwner: "address" },
             tx: {
               hash: "token-op-1-tx-hash",
@@ -336,10 +339,10 @@ describe("listOperations", () => {
           },
           {
             id: "token-op-2",
-            type: "NONE",
+            type: "OUT",
             senders: ["address"],
             recipients: ["address2"],
-            value: 0n,
+            value: 2n,
             asset: {
               assetOwner: "address",
               assetReference: "contract-address",
@@ -359,7 +362,7 @@ describe("listOperations", () => {
             },
             details: {
               assetAmount: "2",
-              ledgerOpType: "IN",
+              ledgerOpType: "OUT",
               assetSenders: ["address"],
               assetRecipients: ["address2"],
               parentSenders: ["address1"],
@@ -369,10 +372,10 @@ describe("listOperations", () => {
           },
           {
             id: "token-op-3",
-            type: "FEES",
+            type: "OUT",
             senders: ["address"],
             recipients: ["address1"],
-            value: 0n,
+            value: 1n,
             asset: { type: "erc20", assetReference: "contract-address", assetOwner: "address" },
             tx: {
               hash: "token-op-3-tx-hash",
@@ -491,6 +494,352 @@ describe("listOperations", () => {
     });
   });
 
+  it("filters out operations where the requested address is not involved (case insensitive)", async () => {
+    setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+    const address = "address";
+    // Explorer returns: one native op for "address", and one internal op (same tx) where
+    // senders/recipients and parent senders/recipients do NOT include "address"
+    jest.spyOn(ledgerExplorer, "getOperations").mockResolvedValue({
+      lastCoinOperations: [
+        {
+          id: "coin-op-for-address",
+          accountId: "",
+          type: "OUT",
+          senders: [address.toUpperCase()],
+          recipients: ["address2"],
+          value: new BigNumber(100),
+          hash: "0xTxForAddress",
+          blockHeight: 100,
+          blockHash: "0xBlockHash",
+          fee: new BigNumber(10),
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(1),
+          extra: {},
+        },
+        {
+          id: "coin-op-unrelated",
+          accountId: "",
+          type: "OUT",
+          senders: ["0xOtherA"],
+          recipients: ["0xOtherB"],
+          value: new BigNumber(0),
+          hash: "0xTxUnrelated",
+          blockHeight: 101,
+          blockHash: "0xBlockHash2",
+          fee: new BigNumber(10),
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(2),
+          extra: {},
+        },
+      ],
+      lastTokenOperations: [],
+      lastNftOperations: [],
+      lastInternalOperations: [
+        {
+          id: "internal-op-unrelated",
+          accountId: "",
+          type: "IN",
+          senders: ["0xOtherA"],
+          recipients: ["0xOtherB"],
+          value: new BigNumber(50),
+          hash: "0xTxUnrelated",
+          blockHeight: 101,
+          blockHash: "0xBlockHash2",
+          fee: new BigNumber(0),
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(2),
+          extra: {},
+        },
+      ],
+      nextPagingToken: "",
+    });
+
+    expect(
+      await listOperations({} as CryptoCurrency, address.toLowerCase(), {
+        minHeight: 1,
+        order: "asc",
+      }),
+    ).toEqual({
+      items: [
+        {
+          id: "coin-op-for-address",
+          type: "OUT",
+          senders: [address.toUpperCase()],
+          recipients: ["address2"],
+          value: 100n,
+          asset: { type: "native" },
+          tx: {
+            hash: "0xTxForAddress",
+            block: {
+              height: 100,
+              hash: "0xBlockHash",
+              time: new Date("2025-02-20"),
+            },
+            fees: 10n,
+            feesPayer: "ADDRESS",
+            date: new Date("2025-02-20"),
+            failed: false,
+          },
+          details: { sequence: BigNumber(1) },
+        },
+      ],
+      next: "",
+    });
+  });
+
+  it("should use token transfer value for ERC20 operations, not parent native value", async () => {
+    setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+
+    const erc20TransferValue = new BigNumber("666"); // The actual ERC20 amount
+    const parentNativeValue = new BigNumber("0"); // No native ETH transferred
+    const txFee = new BigNumber("21000000000000"); // Tx fees
+
+    jest.spyOn(ledgerExplorer, "getOperations").mockResolvedValue({
+      lastCoinOperations: [
+        {
+          id: "coin-op-erc20-tx",
+          accountId: "",
+          type: "FEES", // FEES type because it's a pure ERC20 transfer
+          senders: ["address1"],
+          recipients: ["address2"], // contract address
+          value: parentNativeValue,
+          hash: "0x4235dc16c74aecb248ad1005f3a0c82582a25afe797e62ecc8f4eed86ca628a1",
+          blockHeight: 279040,
+          blockHash: "0x172b9bcb8f7d598227ab5f7f0ce",
+          fee: txFee,
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(1),
+          extra: {},
+        },
+      ],
+      lastTokenOperations: [
+        {
+          id: "token-op-erc20",
+          accountId: "",
+          type: "OUT",
+          senders: ["address1"],
+          recipients: ["0xD656ab767968Fb3954cb1a16D525B540e1AfA00d"],
+          contract: "address2",
+          value: erc20TransferValue, // The actual ERC20 transfer amount
+          hash: "0x4235dc16c74aecb248ad1005f3a0c82582a25afe797e62ecc8f4eed86ca628a1",
+          blockHeight: 279040,
+          blockHash: "0x172b9bcb8f7d598227ab5f7f0ce",
+          fee: txFee,
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(1),
+          extra: {},
+        },
+      ],
+      lastNftOperations: [],
+      lastInternalOperations: [],
+      nextPagingToken: "",
+    });
+
+    expect(
+      await listOperations({} as CryptoCurrency, "address1", { minHeight: 1, order: "asc" }),
+    ).toEqual({
+      items: [
+        {
+          id: "token-op-erc20",
+          type: "OUT",
+          senders: ["address1"],
+          recipients: ["0xD656ab767968Fb3954cb1a16D525B540e1AfA00d"],
+          value: 666n,
+          asset: { type: "erc20", assetReference: "address2", assetOwner: "address1" },
+          tx: {
+            hash: "0x4235dc16c74aecb248ad1005f3a0c82582a25afe797e62ecc8f4eed86ca628a1",
+            block: {
+              height: 279040,
+              hash: "0x172b9bcb8f7d598227ab5f7f0ce",
+              time: new Date("2025-02-20"),
+            },
+            fees: 21000000000000n,
+            feesPayer: "address1",
+            date: new Date("2025-02-20"),
+            failed: false,
+          },
+          details: {
+            ledgerOpType: "OUT",
+            assetAmount: "666",
+            assetSenders: ["address1"],
+            assetRecipients: ["0xD656ab767968Fb3954cb1a16D525B540e1AfA00d"],
+            parentSenders: ["address1"],
+            parentRecipients: ["address2"],
+            sequence: BigNumber(1),
+          },
+        },
+      ],
+      next: "",
+    });
+  });
+
+  it("leaves feesPayer undefined when token op has no parent coin op (no reference operation)", async () => {
+    setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+
+    const recipient = "0xrecipient";
+    const sender = "0xsender";
+    const txHash = "0xTokenTxNoParent";
+    jest.spyOn(ledgerExplorer, "getOperations").mockResolvedValue({
+      lastCoinOperations: [
+        {
+          id: "coin-op-other-tx",
+          accountId: "",
+          type: "OUT",
+          senders: [recipient],
+          recipients: ["0xOther"],
+          value: new BigNumber(0),
+          hash: "0xOtherTxHash",
+          blockHeight: 100,
+          blockHash: "0xBlockHash",
+          fee: new BigNumber(1),
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(1),
+          extra: {},
+        },
+      ],
+      lastTokenOperations: [
+        {
+          id: "token-op-in",
+          accountId: "",
+          type: "IN",
+          senders: [sender],
+          recipients: [recipient],
+          contract: "0xUSDT",
+          value: new BigNumber(100),
+          hash: txHash,
+          blockHeight: 101,
+          blockHash: "0xBlockHash2",
+          fee: new BigNumber(0),
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(2),
+          extra: {},
+        },
+      ],
+      lastNftOperations: [],
+      lastInternalOperations: [],
+      nextPagingToken: "",
+    });
+
+    const { items } = await listOperations({} as CryptoCurrency, recipient, {
+      minHeight: 1,
+      order: "asc",
+    });
+    const tokenInOp = items.find(op => op.tx.hash === txHash && op.asset.type === "erc20");
+    expect(tokenInOp!.type).toBe("IN");
+    expect(tokenInOp!.tx.feesPayer).toBeUndefined();
+  });
+
+  it("should emit both native and token operations when tx has native value > 0 and token transfers", async () => {
+    setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+
+    const nativeTransferValue = new BigNumber("1000000000000000000"); // 1 ETH
+    const erc20TransferValue = new BigNumber("500000000"); // 500 USDC
+    const txFee = new BigNumber("21000000000000"); // Tx fees
+
+    jest.spyOn(ledgerExplorer, "getOperations").mockResolvedValue({
+      lastCoinOperations: [
+        {
+          id: "coin-op-mixed-tx",
+          accountId: "",
+          type: "OUT", // OUT type because native ETH is transferred
+          senders: ["address1"],
+          recipients: ["address2"],
+          value: nativeTransferValue, // Native ETH transferred
+          hash: "0xMixedTransactionHash",
+          blockHeight: 100,
+          blockHash: "0xBlockHash",
+          fee: txFee,
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(1),
+          extra: {},
+        },
+      ],
+      lastTokenOperations: [
+        {
+          id: "token-op-mixed-tx",
+          accountId: "",
+          type: "OUT",
+          senders: ["address1"],
+          recipients: ["address3"],
+          contract: "0xUSDCContract",
+          value: erc20TransferValue,
+          hash: "0xMixedTransactionHash", // Same tx hash
+          blockHeight: 100,
+          blockHash: "0xBlockHash",
+          fee: txFee,
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(1),
+          extra: {},
+        },
+      ],
+      lastNftOperations: [],
+      lastInternalOperations: [],
+      nextPagingToken: "",
+    });
+
+    expect(
+      await listOperations({} as CryptoCurrency, "address1", { minHeight: 1, order: "asc" }),
+    ).toEqual({
+      items: [
+        {
+          id: "coin-op-mixed-tx",
+          type: "OUT",
+          senders: ["address1"],
+          recipients: ["address2"],
+          value: 1000000000000000000n,
+          asset: { type: "native" },
+          tx: {
+            hash: "0xMixedTransactionHash",
+            block: {
+              height: 100,
+              hash: "0xBlockHash",
+              time: new Date("2025-02-20"),
+            },
+            fees: 21000000000000n,
+            feesPayer: "address1",
+            date: new Date("2025-02-20"),
+            failed: false,
+          },
+          details: { sequence: BigNumber(1) },
+        },
+        {
+          id: "token-op-mixed-tx",
+          type: "OUT",
+          senders: ["address1"],
+          recipients: ["address3"],
+          value: 500000000n,
+          asset: {
+            type: "erc20",
+            assetReference: "0xUSDCContract",
+            assetOwner: "address1",
+          },
+          tx: {
+            hash: "0xMixedTransactionHash",
+            block: {
+              height: 100,
+              hash: "0xBlockHash",
+              time: new Date("2025-02-20"),
+            },
+            fees: 21000000000000n,
+            feesPayer: "address1",
+            date: new Date("2025-02-20"),
+            failed: false,
+          },
+          details: {
+            ledgerOpType: "OUT",
+            assetAmount: "500000000",
+            assetSenders: ["address1"],
+            assetRecipients: ["address3"],
+            parentSenders: ["address1"],
+            parentRecipients: ["address2"],
+            sequence: BigNumber(1),
+          },
+        },
+      ],
+      next: "",
+    });
+  });
+
   // here is the table of behavior for pagination:
   const paginationBehaviors: {
     limit: number | undefined;
@@ -601,9 +950,847 @@ describe("listOperations", () => {
       order: "asc",
     });
     expect(result.map(op => ({ id: op.id, tx: { feesPayer: op.tx.feesPayer } }))).toEqual([
-      // { id: "coin-op-1", tx: { feesPayer: undefined } }, // should be returned with BACK-10510
+      { id: "coin-op-1", tx: { feesPayer: undefined } },
       { id: "token-op-1", tx: { feesPayer: undefined } },
       { id: "internal-op-1", tx: { feesPayer: undefined } },
     ]);
+  });
+
+  it("preserves semantic operation types (DELEGATE, NFT_*, etc.) instead of mapping to IN/OUT", async () => {
+    const address = "0xdelegator";
+    const stakingContract = "0xstaking";
+    setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+    jest.spyOn(ledgerExplorer, "getOperations").mockResolvedValue({
+      lastCoinOperations: [
+        {
+          id: "delegate-op",
+          accountId: "",
+          type: "DELEGATE",
+          senders: [address],
+          recipients: [stakingContract],
+          value: new BigNumber(100),
+          hash: "0xdelegate-tx",
+          blockHeight: 100,
+          blockHash: "0xblock",
+          fee: new BigNumber(1),
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(1),
+          hasFailed: false,
+          extra: {},
+        },
+      ],
+      lastTokenOperations: [],
+      lastNftOperations: [],
+      lastInternalOperations: [],
+      nextPagingToken: "",
+    });
+
+    const { items } = await listOperations({} as CryptoCurrency, address, {
+      minHeight: 0,
+      order: "asc",
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0].type).toBe("DELEGATE");
+    expect(items[0].senders[0]).toBe(address);
+    expect(items[0].recipients[0]).toBe(stakingContract);
+  });
+
+  describe("Transaction to operation mapping should match the specification", () => {
+    const blockHeight = 100;
+    const blockHash = "0xblock";
+    const date = new Date("2025-02-20");
+
+    function mockGetOperations(
+      response: {
+        lastCoinOperations?: Array<{
+          type: string;
+          senders: string[];
+          recipients: string[];
+          value: number | string;
+          fee: number | string;
+          id?: string;
+          hash?: string;
+        }>;
+        lastTokenOperations?: Array<{
+          type: string;
+          senders: string[];
+          recipients: string[];
+          value: number | string;
+          contract: string;
+          fee: number | string;
+          id?: string;
+          hash?: string;
+        }>;
+        lastInternalOperations?: Array<{
+          type: string;
+          senders: string[];
+          recipients: string[];
+          value: number | string;
+          fee: number | string;
+          id?: string;
+          hash?: string;
+        }>;
+      },
+      sharedHash?: string,
+    ) {
+      const operationTxHash = sharedHash ?? "0xsingle";
+      const toBigNumber = (value: number | string) => new BigNumber(value);
+      const coinOps = (response.lastCoinOperations ?? []).map((op, i) => ({
+        id: `coin-op-${i}`,
+        accountId: "",
+        type: op.type,
+        senders: op.senders,
+        recipients: op.recipients,
+        value: toBigNumber(op.value),
+        hash: op.hash ?? operationTxHash,
+        blockHeight,
+        blockHash,
+        fee: toBigNumber(op.fee),
+        date,
+        transactionSequenceNumber: new BigNumber(1),
+        hasFailed: false,
+        extra: {},
+      }));
+      const tokenOps = (response.lastTokenOperations ?? []).map((op, i) => ({
+        id: `token-op-${i}`,
+        accountId: "",
+        type: op.type,
+        senders: op.senders,
+        recipients: op.recipients,
+        contract: op.contract,
+        value: toBigNumber(op.value),
+        hash: op.hash ?? operationTxHash,
+        blockHeight,
+        blockHash,
+        fee: toBigNumber(op.fee),
+        date,
+        transactionSequenceNumber: new BigNumber(1),
+        extra: {},
+      }));
+      const internalOps = (response.lastInternalOperations ?? []).map((op, i) => ({
+        id: `internal-op-${i}`,
+        accountId: "",
+        type: op.type,
+        senders: op.senders,
+        recipients: op.recipients,
+        value: toBigNumber(op.value),
+        hash: op.hash ?? operationTxHash,
+        blockHeight,
+        blockHash,
+        fee: toBigNumber(op.fee),
+        date,
+        transactionSequenceNumber: new BigNumber(1),
+        extra: {},
+      }));
+      return jest.spyOn(ledgerExplorer, "getOperations").mockResolvedValue({
+        lastCoinOperations: coinOps as Operation[],
+        lastTokenOperations: tokenOps as Operation[],
+        lastNftOperations: [],
+        lastInternalOperations: internalOps as Operation[],
+        nextPagingToken: "",
+      });
+    }
+
+    it("Case 1: simple native transfer between EOAs", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      mockGetOperations({
+        lastCoinOperations: [
+          {
+            type: "OUT",
+            senders: ["address1"],
+            recipients: ["address2"],
+            value: 2,
+            fee: 1,
+          },
+        ],
+      });
+
+      const address1Result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+      const address2Result = await listOperations({} as CryptoCurrency, "address2", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: address1 sees 1 op: sender=address1, recipient=address2, amount=2, asset=native, fee=1, feePayer=address1
+      expect(address1Result.items).toHaveLength(1);
+      expect(address1Result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["address2"],
+        value: 2n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+
+      // Spec: address2 sees 1 op: sender=address1, recipient=address2, amount=2, fee=1, feePayer=address1
+      expect(address2Result.items).toHaveLength(1);
+      expect(address2Result.items[0]).toMatchObject({
+        type: "IN",
+        senders: ["address1"],
+        recipients: ["address2"],
+        value: 2n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
+
+    it("Case 2: native self send from EOA", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      mockGetOperations({
+        lastCoinOperations: [
+          {
+            type: "OUT",
+            senders: ["address1"],
+            recipients: ["address1"],
+            value: 2,
+            fee: 1,
+          },
+        ],
+      });
+
+      const result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: always 2 ops (OUT, IN, order not specified) for self-sends.
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: 2n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+      expect(result.items[1]).toMatchObject({
+        type: "IN",
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: 2n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
+
+    it("Case 2: when explorer returns IN+OUT for self-send, still 2 ops", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            { type: "IN", senders: ["address1"], recipients: ["address1"], value: 2, fee: 1 },
+            { type: "OUT", senders: ["address1"], recipients: ["address1"], value: 2, fee: 1 },
+          ],
+        },
+        "0xselfsend",
+      );
+
+      const result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].type).toBe("IN");
+      expect(result.items[1].type).toBe("OUT");
+      expect(result.items[0]).toMatchObject({
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: 2n,
+      });
+      expect(result.items[1]).toMatchObject({
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: 2n,
+      });
+    });
+
+    it("Case 3: simple ERC20 transfer between EOAs", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      const sharedTxHash = "0xcase3";
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "FEES",
+              senders: ["address1"],
+              recipients: ["0xUSDTContract"],
+              value: 0,
+              fee: 1,
+            },
+          ],
+          lastTokenOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["address2"],
+              value: 2,
+              contract: "0xUSDTContract",
+              fee: 1,
+            },
+          ],
+        },
+        sharedTxHash,
+      );
+
+      const address1Result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+      const address2Result = await listOperations({} as CryptoCurrency, "address2", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: address1 sees 1 op type=OUT, sender=address1, recipient=address2, amount=2, asset=USDT, fee=1, feePayer=address1
+      expect(address1Result.items).toHaveLength(1);
+      expect(address1Result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["address2"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xUSDTContract", assetOwner: "address1" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+
+      // Spec: address2 sees 1 op type=IN, sender=address1, recipient=address2, amount=2, asset=USDT, fee=1, feePayer=address1
+      expect(address2Result.items).toHaveLength(1);
+      expect(address2Result.items[0]).toMatchObject({
+        type: "IN",
+        senders: ["address1"],
+        recipients: ["address2"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xUSDTContract", assetOwner: "address2" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
+
+    it("Case 4: ERC20 self send from EOA", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "FEES",
+              senders: ["address1"],
+              recipients: ["0xUSDTContract"],
+              value: 0,
+              fee: 1,
+            },
+          ],
+          lastTokenOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["address1"],
+              value: 2,
+              contract: "0xUSDTContract",
+              fee: 1,
+            },
+          ],
+        },
+        "0xcase4",
+      );
+
+      const result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: always 2 ops (OUT, IN, order not specified) for token self-send.
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xUSDTContract", assetOwner: "address1" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+      expect(result.items[1]).toMatchObject({
+        type: "IN",
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xUSDTContract", assetOwner: "address1" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
+
+    it("Case 5: ETH transfer from smart contract", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      const sharedTxHash = "0xcase5";
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["contract1"],
+              value: 0,
+              fee: 1,
+            },
+          ],
+          lastInternalOperations: [
+            {
+              type: "IN",
+              senders: ["contract1"],
+              recipients: ["address2"],
+              value: 2,
+              fee: 1,
+            },
+          ],
+        },
+        sharedTxHash,
+      );
+
+      const address1Result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+      const address2Result = await listOperations({} as CryptoCurrency, "address2", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: address1 → 1 op type=OUT, sender=address1, recipient=contract1, amount=0, asset=native, fee=1, feePayer=address1
+      expect(address1Result.items).toHaveLength(1);
+      expect(address1Result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["contract1"],
+        value: 0n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+
+      // Spec: address2 → 1 op type=IN, sender=contract1, recipient=address2, amount=2, asset=native, fee=1, feePayer=address1
+      expect(address2Result.items).toHaveLength(1);
+      expect(address2Result.items[0]).toMatchObject({
+        type: "IN",
+        senders: ["contract1"],
+        recipients: ["address2"],
+        value: 2n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
+
+    it("Case 6: ERC20 transfer from smart contract", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      const sharedTxHash = "0xcase6";
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["contract1"],
+              value: 0,
+              fee: 1,
+            },
+          ],
+          lastTokenOperations: [
+            {
+              type: "OUT",
+              senders: ["address3"],
+              recipients: ["address2"],
+              value: 2,
+              contract: "0xUSDTContract",
+              fee: 1,
+            },
+          ],
+        },
+        sharedTxHash,
+      );
+
+      const address1Result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+      const address2Result = await listOperations({} as CryptoCurrency, "address2", {
+        minHeight: 0,
+        order: "asc",
+      });
+      const address3Result = await listOperations({} as CryptoCurrency, "address3", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: address1 → 1 op type=OUT, sender=address1, recipient=contract1, amount=0, asset=native, fee=1, feePayer=address1
+      expect(address1Result.items).toHaveLength(1);
+      expect(address1Result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["contract1"],
+        value: 0n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+
+      // Spec: address2 → 1 op type=IN, sender=address3, recipient=address2, amount=2, asset=USDT, fee=1, feePayer=address1
+      expect(address2Result.items).toHaveLength(1);
+      expect(address2Result.items[0]).toMatchObject({
+        type: "IN",
+        senders: ["address3"],
+        recipients: ["address2"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xUSDTContract", assetOwner: "address2" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+
+      // Spec: address3 → 1 op type=OUT, sender=address3, recipient=address2, amount=2, asset=USDT, fee=1, feePayer=address1
+      expect(address3Result.items).toHaveLength(1);
+      expect(address3Result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address3"],
+        recipients: ["address2"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xUSDTContract", assetOwner: "address3" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
+
+    it("Case 7: ETH transfer to smart contract", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      mockGetOperations({
+        lastCoinOperations: [
+          {
+            type: "OUT",
+            senders: ["address1"],
+            recipients: ["contract1"],
+            value: 2,
+            fee: 1,
+          },
+        ],
+      });
+
+      const result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: 1 op type=OUT, sender=address1, recipient=contract1, amount=2, asset=native, fee=1, feePayer=address1
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["contract1"],
+        value: 2n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
+
+    it("Case 8: ERC20 transfer to smart contract", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "FEES",
+              senders: ["address1"],
+              recipients: ["contract1"],
+              value: 0,
+              fee: 1,
+            },
+          ],
+          lastTokenOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["contract1"],
+              value: 2,
+              contract: "0xUSDTContract",
+              fee: 1,
+            },
+          ],
+        },
+        "0xcase8",
+      );
+
+      const result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: 1 op type=OUT, sender=address1, recipient=contract1, amount=2, asset=USDT, fee=1, feePayer=address1
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["contract1"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xUSDTContract", assetOwner: "address1" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
+
+    it("Case 9: ETH transfer through smart contract", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      const sharedTxHash = "0xcase9";
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["contract1"],
+              value: 2,
+              fee: 1,
+            },
+          ],
+          lastInternalOperations: [
+            {
+              type: "IN",
+              senders: ["contract1"],
+              recipients: ["address2"],
+              value: 2,
+              fee: 1,
+            },
+          ],
+        },
+        sharedTxHash,
+      );
+
+      const address1Result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+      const address2Result = await listOperations({} as CryptoCurrency, "address2", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: address1 → 1 op type=OUT, sender=address1, recipient=contract1, amount=2, asset=ETH, fee=1, feePayer=address1
+      expect(address1Result.items).toHaveLength(1);
+      expect(address1Result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["contract1"],
+        value: 2n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+
+      // Spec: address2 → 1 op type=IN, sender=contract1, recipient=address2, amount=2, asset=ETH, fee=1, feePayer=address1
+      expect(address2Result.items).toHaveLength(1);
+      expect(address2Result.items[0]).toMatchObject({
+        type: "IN",
+        senders: ["contract1"],
+        recipients: ["address2"],
+        value: 2n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
+
+    it("Case 10: mixed assets smart contract interaction", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      const sharedTxHash = "0xcase10";
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["contract1"],
+              value: 1,
+              fee: 1,
+            },
+          ],
+          lastTokenOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["address2"],
+              value: 2,
+              contract: "0xUSDTContract",
+              fee: 1,
+            },
+          ],
+        },
+        sharedTxHash,
+      );
+
+      const address1Result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+      const address2Result = await listOperations({} as CryptoCurrency, "address2", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: address1 → 2 ops: (1) type=OUT address1→contract1, 1 ETH, fee=1; (2) type=OUT address1→address2, 2 USDT, fee=1, feePayer=address1
+      expect(address1Result.items).toHaveLength(2);
+      const nativeOp = address1Result.items.find(op => op.asset.type === "native");
+      const tokenOp = address1Result.items.find(op => op.asset.type === "erc20");
+      expect(nativeOp).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["contract1"],
+        value: 1n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+      expect(tokenOp).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["address2"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xUSDTContract", assetOwner: "address1" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+
+      // Spec: address2 → 1 op type=IN, sender=address1, recipient=address2, amount=2, asset=USDT, fee=1, feePayer=address1
+      expect(address2Result.items).toHaveLength(1);
+      expect(address2Result.items[0]).toMatchObject({
+        type: "IN",
+        senders: ["address1"],
+        recipients: ["address2"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xUSDTContract", assetOwner: "address2" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
+
+    it("Case 11: Spoofed token transfer through smart contract", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      const sharedTxHash = "0xcase11";
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "FEES",
+              senders: ["address1"],
+              recipients: ["contract1"],
+              value: 0,
+              fee: 1,
+            },
+          ],
+          lastTokenOperations: [
+            {
+              type: "OUT",
+              senders: ["address2"],
+              recipients: ["address3"],
+              value: 2,
+              contract: "0xSCAMCOINContract",
+              fee: 1,
+            },
+          ],
+        },
+        sharedTxHash,
+      );
+
+      const address1Result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+      const address2Result = await listOperations({} as CryptoCurrency, "address2", {
+        minHeight: 0,
+        order: "asc",
+      });
+      const address3Result = await listOperations({} as CryptoCurrency, "address3", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: address1 → 1 or 2 ops (OUT and/or FEES), sender=address1, recipient=contract1, amount=0, fee=1
+      expect(address1Result.items.length).toBeGreaterThanOrEqual(1);
+      expect(address1Result.items.length).toBeLessThanOrEqual(2);
+      const addr1Op = address1Result.items.find(
+        o => o.senders[0] === "address1" && o.recipients[0] === "contract1",
+      );
+      expect(addr1Op).toMatchObject({
+        senders: ["address1"],
+        recipients: ["contract1"],
+        value: 0n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+      expect(["OUT", "FEES"]).toContain(addr1Op!.type);
+
+      // Spec (spam not detected): address2 → 1 op type=OUT, sender=address2, recipient=address3, amount=2, asset=SCAMCOIN, fee=1, feePayer=address1
+      expect(address2Result.items).toHaveLength(1);
+      expect(address2Result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address2"],
+        recipients: ["address3"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xSCAMCOINContract", assetOwner: "address2" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+
+      // Spec (spam not detected): address3 → 1 op type=IN, sender=address2, recipient=address3, amount=2, asset=SCAMCOIN, fee=1, feePayer=address1
+      expect(address3Result.items).toHaveLength(1);
+      expect(address3Result.items[0]).toMatchObject({
+        type: "IN",
+        senders: ["address2"],
+        recipients: ["address3"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xSCAMCOINContract", assetOwner: "address3" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
+
+    it("Case 12: Smart contract token minting", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      const sharedTxHash = "0xcase12";
+      const zeroAddress = "0x0000000000000000000000000000000000000000";
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["contract1"],
+              value: 1,
+              fee: 1,
+            },
+          ],
+          lastTokenOperations: [
+            {
+              type: "IN",
+              senders: [zeroAddress],
+              recipients: ["address1"],
+              value: 2,
+              contract: "0xSTETHContract",
+              fee: 1,
+            },
+          ],
+        },
+        sharedTxHash,
+      );
+
+      const result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Spec: address1 → 2 ops: (1) type=OUT address1→contract1, 1 ETH, fee=1; (2) type=IN 0x0→address1, 2 STETH, fee=1, feePayer=address1
+      expect(result.items).toHaveLength(2);
+      const nativeOp = result.items.find(op => op.asset.type === "native");
+      const tokenOp = result.items.find(op => op.asset.type === "erc20");
+      expect(nativeOp).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["contract1"],
+        value: 1n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+      expect(tokenOp).toMatchObject({
+        type: "IN",
+        senders: [zeroAddress],
+        recipients: ["address1"],
+        value: 2n,
+        asset: { type: "erc20", assetReference: "0xSTETHContract", assetOwner: "address1" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+    });
   });
 });

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.ts
@@ -21,20 +21,37 @@ function extractStandard(op: LiveOperation): string {
   return "token"; // NOTE: old default
 }
 
-function extractType(asset: AssetConfig, op: LiveOperation): OperationType {
-  if (asset.type === "native") return op.type;
-  return asset.parent?.type || "NONE";
+/** Operation types that carry semantic meaning and must not be overridden with generic IN/OUT. */
+const SEMANTIC_OP_TYPES: Set<OperationType> = new Set([
+  "DELEGATE",
+  "UNDELEGATE",
+  "REDELEGATE",
+  "NFT_IN",
+  "NFT_OUT",
+]);
+
+/**
+ * Type from the perspective of the requested address (IN when they receive, OUT when they send).
+ * Only overrides for generic types (e.g. NONE, FEES); preserves semantic types (DELEGATE, NFT_*, etc.)
+ * so that staking and NFT operations are not shown as plain IN/OUT in history.
+ */
+function typeFromAddressPerspective(
+  senders: string[],
+  recipients: string[],
+  requestedAddress: string,
+  rawType: OperationType,
+): OperationType {
+  if (SEMANTIC_OP_TYPES.has(rawType)) return rawType;
+  const addressLower = requestedAddress.toLowerCase();
+  const inSenders = senders.some(s => s.toLowerCase() === addressLower);
+  const inRecipients = recipients.some(r => r.toLowerCase() === addressLower);
+  if (inRecipients && !inSenders) return "IN";
+  if (inSenders && !inRecipients) return "OUT";
+  return rawType;
 }
 
-function computeValue(asset: AssetConfig, op: LiveOperation): bigint {
-  if (asset.type === "native" && ["OUT", "FEES"].includes(op.type)) {
-    return BigInt(op.value.toFixed(0)) - BigInt(op.fee.toFixed(0));
-  }
-
-  if (asset.type === "token" && asset.parent) {
-    return BigInt(asset.parent.value.toFixed(0));
-  }
-
+function computeValue(op: LiveOperation): bigint {
+  // amount = amount effectively transferred, fees are reported separately in tx.fees.
   return BigInt(op.value.toFixed(0));
 }
 
@@ -46,13 +63,12 @@ function computeFailed(asset: AssetConfig, op: LiveOperation): boolean {
   return op.hasFailed ?? false;
 }
 
-const unambiguousSender = (referenceOperation: LiveOperation | undefined): string | undefined =>
-  referenceOperation?.senders?.length === 1 ? referenceOperation?.senders[0] : undefined;
-
 function computeFeesPayer(asset: AssetConfig, op: LiveOperation): string | undefined {
+  // Important: do not use the op sender as fee payer by default, it may be wrong or ambiguous for token operations.
+  // We prefer leaving fee payer unset if unknown.
   const isTokenOrInternal = asset.type === "token" || (asset.type === "native" && asset.internal);
   const referenceOperation = isTokenOrInternal ? asset.parent : op;
-  return unambiguousSender(referenceOperation);
+  return referenceOperation?.senders?.length === 1 ? referenceOperation?.senders[0] : undefined;
 }
 
 function toOperation(
@@ -80,8 +96,8 @@ function toOperation(
     assetInfo.type = extractStandard(op);
   }
 
-  const type = extractType(asset, op);
-  const value = computeValue(asset, op);
+  const type = typeFromAddressPerspective(op.senders, op.recipients, address, op.type);
+  const value = computeValue(op);
   const failed = computeFailed(asset, op);
   const feesPayer = computeFeesPayer(asset, op);
 
@@ -90,7 +106,7 @@ function toOperation(
   const tokenOpDetail =
     asset.type === "token"
       ? {
-          ledgerOpType: op.type,
+          ledgerOpType: type,
           assetAmount: op.value.toFixed(0),
           assetSenders: op.senders,
           assetRecipients: op.recipients,
@@ -156,22 +172,37 @@ export async function listOperations(
     explorerOrder,
   );
 
-  const isNativeOperation = (coinOperation: LiveOperation): boolean =>
-    ![...lastTokenOperations, ...lastNftOperations].map(op => op.hash).includes(coinOperation.hash);
-  const isTokenOrInternalOperation = (coinOperation: LiveOperation): boolean =>
-    [...lastTokenOperations, ...lastNftOperations, ...lastInternalOperations]
-      .map(op => op.hash)
-      .includes(coinOperation.hash);
+  const tokenOrNftHashes = new Set(
+    [...lastTokenOperations, ...lastNftOperations].map(op => op.hash),
+  );
+  const tokenNftOrInternalHashes = new Set(
+    [...lastTokenOperations, ...lastNftOperations, ...lastInternalOperations].map(op => op.hash),
+  );
+
+  const addressLower = address.toLowerCase();
+  const isAddressInOp = (op: LiveOperation): boolean =>
+    op.senders.some(s => s.toLowerCase() === addressLower) ||
+    op.recipients.some(r => r.toLowerCase() === addressLower);
+  const tokenOpHashesWhereAddressInvolved = new Set(
+    [...lastTokenOperations, ...lastNftOperations].filter(isAddressInOp).map(op => op.hash),
+  );
 
   const parents: Record<string, LiveOperation> = {};
   const nativeOperations: Operation<MemoNotSupported>[] = [];
 
   for (const coinOperation of lastCoinOperations) {
-    if (isTokenOrInternalOperation(coinOperation)) {
+    // Store parent reference for token/NFT/internal operations
+    if (tokenNftOrInternalHashes.has(coinOperation.hash)) {
       parents[coinOperation.hash] = coinOperation;
     }
 
-    if (isNativeOperation(coinOperation)) {
+    // Emit native operation so the fee-payer and any native transfer are represented.
+    // Skip FEES-only (value 0) when the same tx has a token/NFT op for this address to avoid duplicate.
+    const isFeesOnlyWithTokenOpForAddress =
+      coinOperation.value.isZero() &&
+      tokenOrNftHashes.has(coinOperation.hash) &&
+      tokenOpHashesWhereAddressInvolved.has(coinOperation.hash);
+    if (!isFeesOnlyWithTokenOpForAddress) {
       nativeOperations.push(toOperation(currency.id, address, { type: "native" }, coinOperation));
     }
   }
@@ -214,15 +245,80 @@ export async function listOperations(
       "NFT_OUT",
     ].includes(operation.type);
 
-  const operations = nativeOperations
-    .concat(tokenOperations)
+  const isAddressInvolved = (op: Operation<MemoNotSupported>): boolean => {
+    // some explorers return addresses with uppercase letters (eg eip-55 encoded addresses)
+    const addressLower = address.toLowerCase();
+    const isIncluded = (list: string[]): boolean =>
+      list.some(item => item.toLowerCase() === addressLower);
+    return isIncluded(op.senders) || isIncluded(op.recipients);
+  };
+
+  /** Always output 2 ops (OUT, IN) for self-sends. Expand single op to two when needed. */
+  function expandSelfSendToTwoOps(
+    ops: Operation<MemoNotSupported>[],
+    address: string,
+  ): Operation<MemoNotSupported>[] {
+    const groupKey = (op: Operation<MemoNotSupported>): string => {
+      if (op.asset.type === "native") return `${op.tx.hash}\t${op.asset.type}`;
+      const ref = ("assetReference" in op.asset ? op.asset.assetReference : undefined) ?? "";
+      return `${op.tx.hash}\t${op.asset.type}\t${ref}`;
+    };
+
+    const addr = address.toLowerCase();
+
+    const byKey = new Map<string, Operation<MemoNotSupported>[]>();
+    for (const op of ops) {
+      const k = groupKey(op);
+      const list = byKey.get(k) ?? [];
+      list.push(op);
+      byKey.set(k, list);
+    }
+
+    const isSelfSend = (op: Operation<MemoNotSupported>): boolean =>
+      op.senders?.length === 1 &&
+      op.recipients?.length === 1 &&
+      op.senders[0]?.toLowerCase() === addr &&
+      op.recipients[0]?.toLowerCase() === addr;
+
+    const asType = (
+      op: Operation<MemoNotSupported>,
+      type: OperationType,
+    ): Operation<MemoNotSupported> =>
+      op.type === type
+        ? op
+        : {
+            ...op,
+            id: `${op.id}_${type}`,
+            type,
+            details: { ...op.details, ledgerOpType: type },
+          };
+
+    const result: Operation<MemoNotSupported>[] = [];
+    for (const [, group] of byKey) {
+      if (group.every(isSelfSend) && group.length === 1) {
+        const op = group[0];
+        result.push(asType(op, "OUT"), asType(op, "IN"));
+      } else {
+        for (const op of group) result.push(op);
+      }
+    }
+    return result;
+  }
+
+  const nativeExpanded = expandSelfSendToTwoOps(nativeOperations, address);
+  const tokenExpanded = expandSelfSendToTwoOps(tokenOperations, address);
+
+  const operations = nativeExpanded
+    .concat(tokenExpanded)
     .concat(internalOperations)
     .filter(hasValidType)
-    .sort((a, b) =>
-      options.order === "asc"
-        ? a.tx.date.getTime() - b.tx.date.getTime()
-        : b.tx.date.getTime() - a.tx.date.getTime(),
-    );
+    .filter(isAddressInvolved);
+
+  operations.sort((a, b) =>
+    options.order === "asc"
+      ? a.tx.date.getTime() - b.tx.date.getTime()
+      : b.tx.date.getTime() - a.tx.date.getTime(),
+  );
 
   return { items: operations, next: nextPagingToken };
 }

--- a/libs/coin-modules/coin-evm/src/network/explorer/ledger.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/ledger.test.ts
@@ -270,9 +270,7 @@ describe("EVM Family", () => {
               senders: [eip55.encode(coinOperation1.from)],
               transactionSequenceNumber: new BigNumber(coinOperation1.nonce_value),
               type: "FEES",
-              value: new BigNumber(coinOperation1.value).plus(
-                new BigNumber(coinOperation1.gas_used).times(coinOperation1.gas_price),
-              ),
+              value: new BigNumber(coinOperation1.value),
             },
             {
               id: "js:2:ethereum:0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d:-0xf350d4f8e910419e2d5cec294d44e69af8c6185b7089061d33bb4fc246cefb79-OUT",
@@ -291,9 +289,7 @@ describe("EVM Family", () => {
               senders: [eip55.encode(coinOperation2.from)],
               transactionSequenceNumber: new BigNumber(coinOperation2.nonce_value),
               type: "OUT",
-              value: new BigNumber(coinOperation2.value).plus(
-                new BigNumber(coinOperation2.gas_used).times(coinOperation2.gas_price),
-              ),
+              value: new BigNumber(coinOperation2.value),
             },
             {
               id: "js:2:ethereum:0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d:-0xf350d4f8e910419e2d5cec294d44e69af8c6185b7089061d33bb4fc246cefb79-IN",

--- a/libs/coin-tester-modules/coin-tester-evm/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/helpers.ts
@@ -23,6 +23,14 @@ export const ERC721Interface = new ethers.Interface(ERC721_ABI);
 export const ERC1155Interface = new ethers.Interface(ERC1155_ABI);
 export const VITALIK = "0x6bfD74C0996F269Bcece59191EFf667b3dFD73b9";
 
+/** Asserts that an address appears in a list (case-insensitive, for EIP-55 robustness). Skips when list is missing or empty. */
+export function expectAddressInList(list: string[] | undefined, address: string): void {
+  if (!list || list.length === 0) return;
+  const normalizedAddress = address?.toLowerCase() ?? "";
+  const found = list.some(a => (a ?? "").toLowerCase() === normalizedAddress);
+  expect(found).toBe(true);
+}
+
 export async function getBridges(signer: Signer): Promise<{
   currencyBridge: CurrencyBridge;
   accountBridge: AccountBridge<GenericTransaction>;

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/blast.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/blast.ts
@@ -6,7 +6,7 @@ import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account/
 import { resetIndexer, setBlock, indexBlocks, initMswHandlers } from "../indexer";
 import { getCoinConfig, setCoinConfig } from "@ledgerhq/coin-evm/config";
 import { makeAccount } from "../fixtures";
-import { blast, callMyDealer, getBridges, VITALIK } from "../helpers";
+import { blast, callMyDealer, expectAddressInList, getBridges, VITALIK } from "../helpers";
 import { killAnvil, spawnAnvil } from "../anvil";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { MIM_ON_BLAST } from "../tokenFixtures";
@@ -48,6 +48,11 @@ const makeScenarioTransactions = ({ address }: { address: string }): BlastScenar
       expect(currentAccount.subAccounts?.[0].balance.toFixed()).toBe(
         ethers.parseUnits("20", MIM_ON_BLAST.units[0].magnitude).toString(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, MIM_ON_BLAST.contractAddress);
+      const subOp = latestOperation.subOperations?.[0];
+      expectAddressInList(subOp?.senders, currentAccount.freshAddress);
+      expectAddressInList(subOp?.recipients, VITALIK);
     },
   };
 
@@ -62,6 +67,8 @@ const makeScenarioTransactions = ({ address }: { address: string }): BlastScenar
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, VITALIK);
     },
   };
 

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/bnb.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/bnb.ts
@@ -6,7 +6,7 @@ import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account/
 import { resetIndexer, setBlock, indexBlocks, initMswHandlers } from "../indexer";
 import { getCoinConfig, setCoinConfig } from "@ledgerhq/coin-evm/config";
 import { makeAccount } from "../fixtures";
-import { callMyDealer, getBridges, bnb, VITALIK } from "../helpers";
+import { callMyDealer, expectAddressInList, getBridges, bnb, VITALIK } from "../helpers";
 import { killAnvil, spawnAnvil } from "../anvil";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { USDT_ON_BNB } from "../tokenFixtures";
@@ -28,6 +28,8 @@ const makeScenarioTransactions = ({ address }: { address: string }): BnbScenario
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, VITALIK);
     },
   };
 
@@ -48,6 +50,11 @@ const makeScenarioTransactions = ({ address }: { address: string }): BnbScenario
       expect(currentAccount.subAccounts?.[0].balance.toFixed()).toBe(
         ethers.parseUnits("20", USDT_ON_BNB.units[0].magnitude).toString(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, USDT_ON_BNB.contractAddress);
+      const subOp = latestOperation.subOperations?.[0];
+      expectAddressInList(subOp?.senders, currentAccount.freshAddress);
+      expectAddressInList(subOp?.recipients, VITALIK);
     },
   };
 
@@ -62,6 +69,8 @@ const makeScenarioTransactions = ({ address }: { address: string }): BnbScenario
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, VITALIK);
     },
   };
 

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/core.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/core.ts
@@ -7,7 +7,7 @@ import { Account } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { ethers } from "ethers";
 import { killAnvil, spawnAnvil } from "../anvil";
-import { VITALIK, core, getBridges } from "../helpers";
+import { VITALIK, core, expectAddressInList, getBridges } from "../helpers";
 import { indexBlocks, initMswHandlers, resetIndexer, setBlock } from "../indexer";
 import { STCORE_ON_CORE } from "../tokenFixtures";
 import { buildSigner } from "../signer";
@@ -28,6 +28,8 @@ const makeScenarioTransactions = ({ address }: { address: string }): CoreScenari
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, VITALIK);
     },
   };
 
@@ -49,6 +51,11 @@ const makeScenarioTransactions = ({ address }: { address: string }): CoreScenari
       expect(currentAccount.subAccounts?.[0].balance.toFixed()).toBe(
         ethers.parseUnits("20", STCORE_ON_CORE.units[0].magnitude).toString(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, STCORE_ON_CORE.contractAddress);
+      const subOp = latestOperation.subOperations?.[0];
+      expectAddressInList(subOp?.senders, currentAccount.freshAddress);
+      expectAddressInList(subOp?.recipients, VITALIK);
     },
   };
 
@@ -63,6 +70,8 @@ const makeScenarioTransactions = ({ address }: { address: string }): CoreScenari
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, VITALIK);
     },
   };
 

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/ethereum.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/ethereum.ts
@@ -6,7 +6,7 @@ import { ethers } from "ethers";
 import { makeAccount } from "../fixtures";
 import { getCoinConfig, setCoinConfig } from "@ledgerhq/coin-evm/config";
 import { killAnvil, spawnAnvil } from "../anvil";
-import { callMyDealer, ethereum, VITALIK, getBridges } from "../helpers";
+import { callMyDealer, ethereum, expectAddressInList, getBridges, VITALIK } from "../helpers";
 import { indexBlocks, initMswHandlers, resetIndexer, setBlock } from "../indexer";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { USDC_ON_ETHEREUM } from "../tokenFixtures";
@@ -32,6 +32,8 @@ const makeScenarioTransactions = ({
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, VITALIK);
     },
   };
 
@@ -52,6 +54,11 @@ const makeScenarioTransactions = ({
       expect(currentAccount.subAccounts?.[0].balance.toFixed()).toBe(
         ethers.parseUnits("20", USDC_ON_ETHEREUM.units[0].magnitude).toString(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, USDC_ON_ETHEREUM.contractAddress);
+      const subOp = latestOperation.subOperations?.[0];
+      expectAddressInList(subOp?.senders, currentAccount.freshAddress);
+      expectAddressInList(subOp?.recipients, VITALIK);
     },
   };
 
@@ -66,6 +73,8 @@ const makeScenarioTransactions = ({
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, VITALIK);
     },
   };
 

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/polygon.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/polygon.ts
@@ -6,7 +6,7 @@ import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account/
 import { resetIndexer, initMswHandlers, setBlock, indexBlocks } from "../indexer";
 import { getCoinConfig, setCoinConfig } from "@ledgerhq/coin-evm/config";
 import { makeAccount } from "../fixtures";
-import { callMyDealer, getBridges, polygon, VITALIK } from "../helpers";
+import { callMyDealer, expectAddressInList, getBridges, polygon, VITALIK } from "../helpers";
 import { killAnvil, spawnAnvil } from "../anvil";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { USDC_ON_POLYGON } from "../tokenFixtures";
@@ -30,9 +30,6 @@ const makeScenarioTransactions = ({ address }: { address: string }) => {
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
-      expect(currentAccount.balance.toFixed()).toBe(
-        previousAccount.balance.minus(latestOperation.value).toFixed(),
-      );
     },
   };
 
@@ -45,10 +42,16 @@ const makeScenarioTransactions = ({ address }: { address: string }) => {
       const [latestOperation] = currentAccount.operations;
       expect(currentAccount.operations.length - previousAccount.operations.length).toBe(1);
       expect(latestOperation.type).toBe("FEES");
+      expect(latestOperation.value.toFixed()).toBe(latestOperation.fee.toFixed());
       expect(latestOperation.subOperations?.[0].type).toBe("OUT");
       expect(latestOperation.subOperations?.[0].value.toFixed()).toBe(
         ethers.parseUnits("80", USDC_ON_POLYGON.units[0].magnitude).toString(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, USDC_ON_POLYGON.contractAddress);
+      const subOp = latestOperation.subOperations?.[0];
+      expectAddressInList(subOp?.senders, currentAccount.freshAddress);
+      expectAddressInList(subOp?.recipients, VITALIK);
     },
   };
 
@@ -63,6 +66,8 @@ const makeScenarioTransactions = ({ address }: { address: string }) => {
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, VITALIK);
     },
   };
 

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/scroll.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/scroll.ts
@@ -6,7 +6,7 @@ import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account/
 import { resetIndexer, setBlock, indexBlocks, initMswHandlers } from "../indexer";
 import { getCoinConfig, setCoinConfig } from "@ledgerhq/coin-evm/config";
 import { makeAccount } from "../fixtures";
-import { callMyDealer, getBridges, scroll, VITALIK } from "../helpers";
+import { callMyDealer, expectAddressInList, getBridges, scroll, VITALIK } from "../helpers";
 import { killAnvil, spawnAnvil } from "../anvil";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { USDC_ON_SCROLL } from "../tokenFixtures";
@@ -32,6 +32,8 @@ const makeScenarioTransactions = ({
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, VITALIK);
     },
   };
 
@@ -52,6 +54,11 @@ const makeScenarioTransactions = ({
       expect(currentAccount.subAccounts?.[0].balance.toFixed()).toBe(
         ethers.parseUnits("20", USDC_ON_SCROLL.units[0].magnitude).toString(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, USDC_ON_SCROLL.contractAddress);
+      const subOp = latestOperation.subOperations?.[0];
+      expectAddressInList(subOp?.senders, currentAccount.freshAddress);
+      expectAddressInList(subOp?.recipients, VITALIK);
     },
   };
 
@@ -66,6 +73,8 @@ const makeScenarioTransactions = ({
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, VITALIK);
     },
   };
 

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/sonic.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/sonic.ts
@@ -6,7 +6,7 @@ import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
 import { resetIndexer, indexBlocks, initMswHandlers, setBlock } from "../indexer";
 import { getCoinConfig, setCoinConfig } from "@ledgerhq/coin-evm/config";
 import { makeAccount } from "../fixtures";
-import { VITALIK, callMyDealer, getBridges, sonic } from "../helpers";
+import { VITALIK, callMyDealer, expectAddressInList, getBridges, sonic } from "../helpers";
 import { killAnvil, spawnAnvil } from "../anvil";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { BRIDGED_USDC_ON_SONIC as USDC_ON_SONIC } from "../tokenFixtures";
@@ -48,6 +48,11 @@ const makeScenarioTransactions = ({ address }: { address: string }): SonicScenar
       expect(currentAccount.subAccounts?.[0].balance.toFixed()).toBe(
         ethers.parseUnits("20", USDC_ON_SONIC.units[0].magnitude).toString(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, USDC_ON_SONIC.contractAddress);
+      const subOp = latestOperation.subOperations?.[0];
+      expectAddressInList(subOp?.senders, currentAccount.freshAddress);
+      expectAddressInList(subOp?.recipients, VITALIK);
     },
   };
 
@@ -62,6 +67,8 @@ const makeScenarioTransactions = ({ address }: { address: string }): SonicScenar
       expect(currentAccount.balance.toFixed()).toBe(
         previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
+      expectAddressInList(latestOperation.senders, currentAccount.freshAddress);
+      expectAddressInList(latestOperation.recipients, VITALIK);
     },
   };
 

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/getAccountShape.ts
@@ -2,13 +2,14 @@ import { encodeAccountId, getSyncHash } from "@ledgerhq/ledger-wallet-framework/
 import { GetAccountShape, mergeOps } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import BigNumber from "bignumber.js";
+import groupBy from "lodash/groupBy";
 import { getAlpacaApi } from "./alpaca";
 import { adaptCoreOperationToLiveOperation, cleanedOperation, extractBalance } from "./utils";
 import { inferSubOperations } from "@ledgerhq/ledger-wallet-framework/serialization";
 import { buildSubAccounts, mergeSubAccounts } from "./buildSubAccounts";
 import type { Operation } from "@ledgerhq/coin-framework/api/types";
 import type { OperationCommon } from "./types";
-import type { Account } from "@ledgerhq/types-live";
+import type { Account, TokenAccount } from "@ledgerhq/types-live";
 
 function isNftCoreOp(operation: Operation): boolean {
   return (
@@ -28,6 +29,250 @@ function isIncomingCoreOp(operation: Operation): boolean {
 
 function isInternalLiveOp(operation: OperationCommon): boolean {
   return !!operation.extra?.internal;
+}
+
+/** True when the op is a main-account (native) op, not a token/sub-account op */
+function isNativeLiveOp(operation: OperationCommon): boolean {
+  const assetReference = operation.extra?.assetReference;
+  const assetOwner = operation.extra?.assetOwner;
+  const hasAssetReference = typeof assetReference === "string" && assetReference.length > 0;
+  const hasAssetOwner = typeof assetOwner === "string" && assetOwner.length > 0;
+
+  // Native ops are those that do not have a non-empty asset reference/owner
+  return !(hasAssetReference || hasAssetOwner);
+}
+
+/**
+ * Parent recipients for token-only ops: use the token contract (assetReference), not the token transfer recipient.
+ */
+function getTokenContract(op: OperationCommon): string | undefined {
+  const ref = op.extra?.assetReference;
+  return typeof ref === "string" && ref.length > 0 ? ref : undefined;
+}
+
+/** Get the fee payer for this tx from the op (from API/extra). */
+function getFeePayer(op: OperationCommon): string | undefined {
+  const fp = op.extra?.feePayer;
+  return typeof fp === "string" && fp.length > 0 ? fp : undefined;
+}
+
+/** Compare two addresses for equality, ignoring case. */
+function isSameAddress(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+/** True when the native op is outbound with value equal to fee (fees-only). */
+function isFeesOnlyNativeOp(op: OperationCommon): boolean {
+  return op.type === "OUT" && op.value !== null && op.fee != null && op.value.eq(op.fee);
+}
+
+/** Emit one parent op per native op: FEES when fees-only, otherwise passthrough. */
+function parentOpsFromNativeOps(
+  nativeOps: OperationCommon[],
+  accountId: string,
+  subOperations: OperationCommon[],
+  internalOperations: OperationCommon[],
+): OperationCommon[] {
+  const out: OperationCommon[] = [];
+  for (const nativeOp of nativeOps) {
+    // Native outgoing operation with value 0 (only fees) => output as single FEES op
+    if (isFeesOnlyNativeOp(nativeOp)) {
+      out.push(
+        cleanedOperation({
+          id: encodeOperationId(accountId, nativeOp.hash, "FEES"),
+          hash: nativeOp.hash,
+          accountId,
+          type: "FEES",
+          value: nativeOp.fee,
+          fee: nativeOp.fee,
+          blockHash: nativeOp.blockHash,
+          blockHeight: nativeOp.blockHeight,
+          senders: nativeOp.senders,
+          recipients: nativeOp.recipients,
+          date: nativeOp.date,
+          transactionSequenceNumber: nativeOp.transactionSequenceNumber,
+          hasFailed: nativeOp.hasFailed,
+          extra: nativeOp.extra,
+          subOperations,
+          internalOperations,
+        }),
+      );
+    }
+    // Otherwise, don't transform the operation
+    else {
+      out.push(
+        cleanedOperation({
+          ...nativeOp,
+          subOperations,
+          internalOperations,
+        }),
+      );
+    }
+  }
+  return out;
+}
+
+/** One synthetic FEES or NONE parent when the tx has no native ops (e.g. token-only). */
+function syntheticParentForTokenOnlyTx(
+  referenceOp: OperationCommon,
+  accountId: string,
+  address: string,
+  subOperations: OperationCommon[],
+  internalOperations: OperationCommon[],
+): OperationCommon {
+  // Parent operation is of type FEES if account has paid fees for the transaction, NONE otherwise.
+  const feePayer = getFeePayer(referenceOp);
+  const isFeePayer = feePayer !== undefined && isSameAddress(address, feePayer);
+  const parentType = isFeePayer ? "FEES" : "NONE";
+  const parentValue = isFeePayer ? referenceOp.fee : new BigNumber(0);
+  // In the case of smart contract interaction, the contract must be the recipient of the parent operation => this
+  // is why we need to extract this information from the operation details.
+  const contract = getTokenContract(referenceOp);
+  const parentRecipients = contract !== undefined ? [contract] : referenceOp.recipients ?? [];
+  const parentSenders = referenceOp.senders ?? [];
+  return cleanedOperation({
+    id: encodeOperationId(accountId, referenceOp.hash, parentType),
+    hash: referenceOp.hash,
+    accountId,
+    type: parentType,
+    value: parentValue,
+    fee: referenceOp.fee,
+    blockHash: referenceOp.blockHash,
+    blockHeight: referenceOp.blockHeight,
+    senders: parentSenders,
+    recipients: parentRecipients,
+    date: referenceOp.date,
+    transactionSequenceNumber: referenceOp.transactionSequenceNumber,
+    hasFailed: referenceOp.hasFailed,
+    extra: referenceOp.extra,
+    subOperations,
+    internalOperations,
+  });
+}
+
+/** Parent op(s) for a tx that has non-internal ops (native and/or token). */
+function parentOpsForTxWithNonInternalOperations(
+  hash: string,
+  transactionOps: OperationCommon[],
+  internalOperations: OperationCommon[],
+  newSubAccounts: TokenAccount[],
+  accountId: string,
+  address: string,
+): OperationCommon[] {
+  const nativeOps = transactionOps.filter(isNativeLiveOp);
+  // inferSubOperations returns types-live Operation[]; we use OperationCommon in this bridge
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- framework type vs bridge type
+  const subOperations = inferSubOperations(hash, newSubAccounts) as OperationCommon[];
+
+  // If transaction has native ops, use them as parents
+  if (nativeOps.length > 0)
+    return parentOpsFromNativeOps(nativeOps, accountId, subOperations, internalOperations);
+
+  // If transaction has no native ops, create a synthetic parent
+  const firstOp = transactionOps[0];
+  return [
+    syntheticParentForTokenOnlyTx(firstOp, accountId, address, subOperations, internalOperations),
+  ];
+}
+
+/**
+ * Parent + internal ops for a tx that has only internal ops (e.g. contract transfer from B to C).
+ * This case happens when an address A calls a smart contract, that performs a transfer from B to C, seen from B or
+ * C's perspective. In this case, the parent operation must be of type NONE, with A as the sender and the contract
+ * as the recipient => the sender of the internal operation is used as the recipient of the synthetic parent operation.
+ */
+function parentOpsForTxWithOnlyInternalOperations(
+  hash: string,
+  internalOperations: OperationCommon[],
+  newSubAccounts: TokenAccount[],
+  accountId: string,
+): OperationCommon[] {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- framework type vs bridge type
+  const subOperations = inferSubOperations(hash, newSubAccounts) as OperationCommon[];
+  const firstInternal = internalOperations[0];
+  if (!firstInternal) return [];
+
+  const out: OperationCommon[] = [];
+  const feePayer = getFeePayer(firstInternal);
+  if (feePayer != null) {
+    out.push(
+      cleanedOperation({
+        id: encodeOperationId(accountId, hash, "NONE"),
+        hash,
+        accountId,
+        type: "NONE",
+        value: new BigNumber(0),
+        fee: firstInternal.fee,
+        blockHash: firstInternal.blockHash,
+        blockHeight: firstInternal.blockHeight,
+        senders: [feePayer],
+        recipients: firstInternal.senders,
+        date: firstInternal.date,
+        transactionSequenceNumber: firstInternal.transactionSequenceNumber,
+        hasFailed: firstInternal.hasFailed,
+        extra: firstInternal.extra,
+        subOperations,
+        internalOperations,
+      }),
+    );
+  }
+  for (const internalOp of internalOperations) {
+    out.push(
+      cleanedOperation({
+        ...internalOp,
+        subOperations,
+        internalOperations,
+      }),
+    );
+  }
+  return out;
+}
+
+/**
+ * Emit parent operations per tx hash so the account has one top-level operation per transaction for normal transactions,
+ * and two for self-sends (IN + OUT) or internal-only (NONE + IN).
+ */
+function buildParentOperations(
+  newSubAccounts: TokenAccount[],
+  newNonInternalOperations: OperationCommon[],
+  newInternalOperations: OperationCommon[],
+  accountId: string,
+  address: string,
+): OperationCommon[] {
+  const nonInternalByHash = groupBy(newNonInternalOperations, "hash");
+  const internalByHash = groupBy(newInternalOperations, "hash");
+
+  const result: OperationCommon[] = [];
+
+  // Inspect non-internal ops first to create parent ops
+  for (const [hash, transactionOps] of Object.entries(nonInternalByHash)) {
+    const internalOperations = internalByHash[hash] ?? [];
+    result.push(
+      ...parentOpsForTxWithNonInternalOperations(
+        hash,
+        transactionOps,
+        internalOperations,
+        newSubAccounts,
+        accountId,
+        address,
+      ),
+    );
+  }
+
+  // If transaction only has internal ops, we must create a synthetic parent op as well
+  for (const [hash, internalOperations] of Object.entries(internalByHash)) {
+    if (hash in nonInternalByHash) continue;
+    result.push(
+      ...parentOpsForTxWithOnlyInternalOperations(
+        hash,
+        internalOperations,
+        newSubAccounts,
+        accountId,
+      ),
+    );
+  }
+
+  return result;
 }
 
 export function genericGetAccountShape(network: string, kind: string): GetAccountShape {
@@ -88,7 +333,14 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
         operation?.extra?.assetOwner &&
         !["OPT_IN", "OPT_OUT"].includes(operation.type),
     );
-    const newInternalOperations = newOps.filter(isInternalLiveOp);
+
+    const newInternalOperations: OperationCommon[] = [];
+    const newNonInternalOperations: OperationCommon[] = [];
+    for (const op of newOps) {
+      if (isInternalLiveOp(op)) newInternalOperations.push(op);
+      else newNonInternalOperations.push(op);
+    }
+
     const newSubAccounts = await buildSubAccounts({
       accountId,
       allTokenAssetsBalances,
@@ -100,18 +352,13 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       ? newSubAccounts
       : mergeSubAccounts(initialAccount?.subAccounts ?? [], newSubAccounts);
 
-    const newOpsWithSubs = newOps
-      .filter(operation => !isInternalLiveOp(operation))
-      .map(op => {
-        const subOperations = inferSubOperations(op.hash, newSubAccounts);
-        const internalOperations = newInternalOperations.filter(it => it.hash === op.hash);
-
-        return cleanedOperation({
-          ...op,
-          subOperations,
-          internalOperations,
-        });
-      });
+    const newOpsWithSubs = buildParentOperations(
+      newSubAccounts,
+      newNonInternalOperations,
+      newInternalOperations,
+      accountId,
+      address,
+    );
     // Try to refresh known pending and broadcasted operations (if not already updated)
     // Useful for integrations without explorers
     const operationsToRefresh = initialAccount?.pendingOperations.filter(

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/tests/getAccountShape.test.ts
@@ -85,7 +85,7 @@ describe("genericGetAccountShape", () => {
             type: "OUT",
             blockHeight: 12,
             subOperations: [{ id: `${currency.id}_subOp1` }],
-            extra: { assetReference: "ar2", assetOwner: "ow2" },
+            extra: {},
           },
           {
             blockHeight: 16,
@@ -118,7 +118,7 @@ describe("genericGetAccountShape", () => {
             type: "OUT",
             blockHeight: 12,
             subOperations: [{ id: `${currency.id}_subOp1` }],
-            extra: { assetReference: "ar2", assetOwner: "ow2" },
+            extra: {},
           },
           {
             blockHeight: 16,
@@ -163,6 +163,7 @@ describe("genericGetAccountShape", () => {
         listOperationsMock.mockResolvedValue({
           items: [
             { hash: "h2", type: "OUT", height: 12 },
+            { hash: "h2", type: "OUT", height: 12, _token: true },
             { hash: "h3", type: "IN", tx: { failed: true }, height: 14 }, // won't appear in final shape
             { hash: "h4", type: "IN", tx: { failed: false }, height: 16 },
           ],
@@ -176,12 +177,15 @@ describe("genericGetAccountShape", () => {
           return [];
         });
 
-        adaptCoreOperationToLiveOperationMock.mockImplementation((_accId, op) => ({
-          hash: op.hash,
-          type: op.type,
-          blockHeight: op.height,
-          extra: { assetReference: "ar2", assetOwner: "ow2" },
-        }));
+        adaptCoreOperationToLiveOperationMock.mockImplementation((_accId, op: any) => {
+          const isTokenOp = op._token === true;
+          return {
+            hash: op.hash,
+            type: op.type,
+            blockHeight: op.height,
+            extra: isTokenOp ? { assetReference: "ar2", assetOwner: "ow2" } : {},
+          };
+        });
 
         mergeOpsMock.mockImplementation((oldOps, newOps) => [...newOps, ...oldOps]);
         cleanedOperationMock.mockImplementation(operation => operation);
@@ -235,15 +239,6 @@ describe("genericGetAccountShape", () => {
             },
             hash: "h2",
             type: "OUT",
-          },
-          {
-            blockHeight: 16,
-            extra: {
-              assetOwner: "ow2",
-              assetReference: "ar2",
-            },
-            hash: "h4",
-            type: "IN",
           },
         ]);
 
@@ -340,7 +335,24 @@ describe("genericGetAccountShape", () => {
         },
       };
 
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 0n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 0n, locked: 0n });
       listOperationsMock.mockResolvedValue({ items: [txWithLedgerOpTypes], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      adaptCoreOperationToLiveOperationMock.mockImplementation((_accId, op: any) => ({
+        hash: op.hash,
+        type: op.type,
+        blockHeight: 1,
+        extra: {
+          assetReference: op.details?.assetReference,
+          assetOwner: op.details?.assetOwner,
+          feePayer: `${currency.id}_addr2`,
+        },
+      }));
+      cleanedOperationMock.mockImplementation((o: any) => o);
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps);
+      inferSubOperationsMock.mockReturnValue([]);
 
       const getShape = genericGetAccountShape(network, currency.id);
       const result = await getShape(
@@ -355,7 +367,292 @@ describe("genericGetAccountShape", () => {
 
       const operation = result.operations?.[0];
       expect(operation?.hash).toBe(txWithLedgerOpTypes.hash);
-      expect(operation?.type).toBe(txWithLedgerOpTypes.type);
+      // Token-only op becomes a synthetic FEES parent (one parent per hash)
+      expect(operation?.type).toBe("FEES");
+    });
+
+    test("buildOneParentOpPerHash: token-only hash produces one synthetic FEES parent with subOperations", async () => {
+      const txHash = "pure-erc20-hash";
+      const tokenOpFromList = { hash: txHash, type: "OUT", height: 20, tx: { failed: false } };
+
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 1000n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 1000n, locked: 0n });
+      listOperationsMock.mockResolvedValue({ items: [tokenOpFromList] });
+      lastBlockMock.mockResolvedValue({ height: 100 });
+
+      adaptCoreOperationToLiveOperationMock.mockImplementation((_accId, op) => ({
+        hash: op.hash,
+        type: op.type,
+        blockHeight: op.height,
+        blockHash: "0xblock",
+        fee: new BigNumber(21000),
+        value: new BigNumber("8000000"),
+        senders: ["0xabc"],
+        recipients: ["0xdef"],
+        date: new Date("2024-01-15"),
+        extra: {
+          assetReference: "0xusdc",
+          assetOwner: "accId",
+          feePayer: `${currency.id}_addr_pure_token`,
+        },
+      }));
+
+      buildSubAccountsMock.mockReturnValue([
+        {
+          id: `${currency.id}_tokenAcc1`,
+          type: "TokenAccount",
+          operations: [
+            {
+              hash: txHash,
+              type: "OUT",
+              accountId: `${currency.id}_tokenAcc1`,
+              id: `accId_${txHash}_OUT`,
+              value: new BigNumber("8000000"),
+              fee: new BigNumber(0),
+            },
+          ],
+        },
+      ]);
+      inferSubOperationsMock.mockImplementation((hash: string) =>
+        hash === txHash
+          ? [
+              {
+                hash: txHash,
+                type: "OUT",
+                accountId: `${currency.id}_tokenAcc1`,
+                id: `accId_${txHash}_OUT`,
+                value: new BigNumber("8000000"),
+                fee: new BigNumber(0),
+              },
+            ]
+          : [],
+      );
+      cleanedOperationMock.mockImplementation((op: any) => op);
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps);
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address: `${currency.id}_addr_pure_token`,
+          initialAccount: undefined,
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(result.operations).toHaveLength(1);
+      const topOp = result.operations?.[0];
+      expect(topOp?.hash).toBe(txHash);
+      expect(topOp?.type).toBe("FEES");
+      expect(topOp?.value?.toFixed()).toBe("21000");
+      expect(topOp?.fee?.toFixed()).toBe("21000");
+      expect(topOp?.subOperations).toHaveLength(1);
+      expect(topOp?.subOperations?.[0]?.type).toBe("OUT");
+      expect(topOp?.subOperations?.[0]?.value?.toFixed()).toBe("8000000");
+    });
+
+    test("buildOneParentOpPerHash: native op with same hash as token uses native as parent with subOperations", async () => {
+      const txHash = "native-and-token-hash";
+      const nativeOpFromList = { hash: txHash, type: "OUT", height: 18, tx: { failed: false } };
+      const tokenOpFromList = { hash: txHash, type: "OUT", height: 18, tx: { failed: false } };
+
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 1000n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 1000n, locked: 0n });
+      listOperationsMock.mockResolvedValue({ items: [nativeOpFromList, tokenOpFromList] });
+      lastBlockMock.mockResolvedValue({ height: 100 });
+
+      adaptCoreOperationToLiveOperationMock.mockImplementation((_accId, op) => {
+        if (op === tokenOpFromList) {
+          return {
+            hash: op.hash,
+            type: op.type,
+            blockHeight: op.height,
+            blockHash: "0xblock",
+            fee: new BigNumber(21000),
+            value: new BigNumber("1000000"),
+            senders: ["0xabc"],
+            recipients: ["0xdef"],
+            date: new Date("2024-01-15"),
+            extra: { assetReference: "0xusdc", assetOwner: "accId" },
+          };
+        }
+        return {
+          hash: op.hash,
+          type: op.type,
+          blockHeight: op.height,
+          blockHash: "0xblock",
+          fee: new BigNumber(21000),
+          value: new BigNumber(1e18),
+          senders: ["0xabc"],
+          recipients: ["0xdef"],
+          date: new Date("2024-01-15"),
+          extra: {},
+        };
+      });
+
+      buildSubAccountsMock.mockReturnValue([
+        {
+          id: `${currency.id}_tokenAcc1`,
+          type: "TokenAccount",
+          operations: [
+            {
+              hash: txHash,
+              type: "OUT",
+              accountId: `${currency.id}_tokenAcc1`,
+              id: `accId_${txHash}_OUT`,
+              value: new BigNumber("1000000"),
+              fee: new BigNumber(0),
+            },
+          ],
+        },
+      ]);
+      inferSubOperationsMock.mockImplementation((hash: string) =>
+        hash === txHash
+          ? [
+              {
+                hash: txHash,
+                type: "OUT",
+                accountId: `${currency.id}_tokenAcc1`,
+                id: `accId_${txHash}_OUT`,
+                value: new BigNumber("1000000"),
+                fee: new BigNumber(0),
+              },
+            ]
+          : [],
+      );
+      cleanedOperationMock.mockImplementation((op: any) => op);
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps);
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address: `${currency.id}_addr_native_token`,
+          initialAccount: undefined,
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(result.operations).toHaveLength(1);
+      const topOp = result.operations?.[0];
+      expect(topOp?.hash).toBe(txHash);
+      expect(topOp?.type).toBe("OUT");
+      expect(topOp?.value?.toFixed()).toBe((1e18).toString());
+      expect(topOp?.subOperations).toHaveLength(1);
+      expect(topOp?.subOperations?.[0]?.value?.toFixed()).toBe("1000000");
+    });
+
+    test("buildOneParentOpPerHash: self-send (same hash IN + OUT) emits 2 parent operations", async () => {
+      const txHash = "self-send-hash";
+      const inOpFromList = { hash: txHash, type: "IN", height: 20, tx: { failed: false } };
+      const outOpFromList = { hash: txHash, type: "OUT", height: 20, tx: { failed: false } };
+
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 1000n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 1000n, locked: 0n });
+      listOperationsMock.mockResolvedValue({ items: [inOpFromList, outOpFromList] });
+      lastBlockMock.mockResolvedValue({ height: 100 });
+
+      adaptCoreOperationToLiveOperationMock.mockImplementation((_accId, op: any) => {
+        return {
+          hash: op.hash,
+          type: op.type,
+          blockHeight: op.height,
+          blockHash: "0xblock",
+          fee: new BigNumber(21000),
+          value: new BigNumber("1"),
+          senders: ["0xabc"],
+          recipients: ["0xabc"],
+          date: new Date("2024-01-15"),
+          extra: {},
+        };
+      });
+
+      buildSubAccountsMock.mockReturnValue([]);
+      inferSubOperationsMock.mockReturnValue([]);
+      cleanedOperationMock.mockImplementation((op: any) => op);
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps);
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address: `${currency.id}_addr_self_send`,
+          initialAccount: undefined,
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(result.operations).toHaveLength(2);
+      const types = result.operations?.map(o => o.type) ?? [];
+      expect(types).toContain("IN");
+      expect(types).toContain("OUT");
+      expect(result.operations?.[0]?.hash).toBe(txHash);
+      expect(result.operations?.[1]?.hash).toBe(txHash);
+    });
+
+    test("internal vs non-internal ops are partitioned and internal attached to correct parent", async () => {
+      const parentHash = "parent-h";
+      const nativeOp = {
+        hash: parentHash,
+        type: "OUT",
+        height: 10,
+        tx: { failed: false },
+      };
+      const internalOp = {
+        hash: parentHash,
+        type: "IN",
+        height: 10,
+        tx: { failed: false },
+        details: { ledgerOpType: "IN" },
+      };
+
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 1000n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 1000n, locked: 0n });
+      listOperationsMock.mockResolvedValue({ items: [nativeOp, internalOp] });
+      buildSubAccountsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 100 });
+
+      adaptCoreOperationToLiveOperationMock.mockImplementation((_accId, op: any) => {
+        if (op.hash === parentHash && op.type === "IN") {
+          return {
+            hash: op.hash,
+            type: op.type,
+            blockHeight: op.height,
+            extra: { internal: true },
+          };
+        }
+        return {
+          hash: op.hash,
+          type: op.type,
+          blockHeight: op.height,
+          extra: {},
+        };
+      });
+
+      cleanedOperationMock.mockImplementation((op: any) => op);
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps);
+      inferSubOperationsMock.mockReturnValue([]);
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address: `${currency.id}_addr_partition`,
+          initialAccount: undefined,
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(result.operations).toHaveLength(1);
+      expect(result.operations?.[0]?.internalOperations).toHaveLength(1);
+      expect(result.operations?.[0]?.internalOperations?.[0]?.extra).toHaveProperty(
+        "internal",
+        true,
+      );
     });
 
     test("internal operations are correctly attached to parent operations with matching hash", async () => {
@@ -426,6 +723,915 @@ describe("genericGetAccountShape", () => {
       expect(attachedInternalOp?.hash).toBe(parentOpHash);
       expect(attachedInternalOp?.type).toBe("IN");
       expect((attachedInternalOp as any)?.extra?.internal).toBe(true);
+    });
+  });
+
+  describe("evm", () => {
+    const network = "mainnet";
+    const currency = { id: "evm", name: "EVM" };
+    const txHash = "0xspec";
+
+    const realAdaptCoreOp = (
+      jest.requireActual("../utils") as {
+        adaptCoreOperationToLiveOperation: (a: string, o: unknown) => unknown;
+      }
+    ).adaptCoreOperationToLiveOperation;
+
+    function toCoreOp(op: {
+      type: string;
+      senders: string[];
+      recipients: string[];
+      value: number | string;
+      fee: number | string;
+      asset?: { type: "native" } | { type: string; assetReference?: string; assetOwner?: string };
+      feesPayer?: string;
+      internal?: boolean;
+    }) {
+      const details =
+        op.asset?.type !== "native" && op.asset && "assetReference" in op.asset
+          ? {
+              assetAmount: String(op.value),
+              ledgerOpType: op.type,
+              assetSenders: op.senders,
+              assetRecipients: op.recipients,
+              ...(op.internal ? { internal: true } : {}),
+            }
+          : op.internal
+            ? { internal: true }
+            : undefined;
+      return {
+        type: op.type,
+        senders: op.senders,
+        recipients: op.recipients,
+        value: BigInt(op.value),
+        asset: op.asset ?? { type: "native" },
+        tx: {
+          hash: txHash,
+          fees: BigInt(op.fee),
+          feesPayer: op.feesPayer,
+          failed: false,
+          block: { hash: "0xblock", height: 100 },
+          date: new Date("2025-02-20"),
+        },
+        ...(details ? { details } : {}),
+      };
+    }
+
+    function setupSpecTest() {
+      getSyncHashMock.mockReturnValue("sync-hash");
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 0n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 0n, locked: 0n });
+      lastBlockMock.mockResolvedValue({ height: 100 });
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps);
+      cleanedOperationMock.mockImplementation((op: any) => op);
+      mergeSubAccountsMock.mockImplementation((_old: any[], newSub: any[]) => newSub);
+      chainSpecificGetAccountShapeMock.mockImplementation(() => {});
+      adaptCoreOperationToLiveOperationMock.mockImplementation(
+        realAdaptCoreOp as typeof adaptCoreOperationToLiveOperationMock,
+      );
+    }
+
+    function createGetShape() {
+      return genericGetAccountShape(network, currency.id);
+    }
+
+    async function runGetShape(address: string) {
+      const getShape = createGetShape();
+      return getShape({ address, initialAccount: undefined, currency, derivationMode: "" } as any, {
+        paginationConfig: {} as any,
+      });
+    }
+
+    function mockNoSubAccounts() {
+      buildSubAccountsMock.mockReturnValue([]);
+    }
+
+    function mockNoInferSubOps() {
+      inferSubOperationsMock.mockReturnValue([]);
+    }
+
+    function mockInferSubOpsByHash() {
+      inferSubOperationsMock.mockImplementation((hash: string, subAccounts: any[]) =>
+        (subAccounts?.[0]?.operations ?? []).filter((o: any) => o.hash === hash),
+      );
+    }
+
+    function mockErc20SubAccounts(
+      contractAddress: string,
+      opMap?: (ops: any[], owner: string) => any[],
+    ) {
+      buildSubAccountsMock.mockImplementation((_ctx: any) => {
+        const ops = _ctx.operations as any[];
+        if (!ops?.length) return [];
+        const owner = ops[0].extra?.assetOwner ?? "";
+        const tokenAccId = `accId_${owner}_${contractAddress}`;
+        const defaultOps = ops.map((o: any) => ({
+          ...o,
+          accountId: tokenAccId,
+          value: new BigNumber(o.value?.toString() ?? o.extra?.assetAmount ?? 0),
+          type: o.extra?.ledgerOpType ?? o.type,
+        }));
+        return [
+          {
+            id: tokenAccId,
+            type: "TokenAccount",
+            parentId: "accId",
+            token: { contractAddress },
+            operations: opMap ? opMap(ops, owner) : defaultOps,
+          } as any,
+        ];
+      });
+    }
+
+    test("Case 1: simple native transfer between EOAs", async () => {
+      setupSpecTest();
+      const alpacaAddress1 = toCoreOp({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["address2"],
+        value: 2,
+        fee: 1,
+        feesPayer: "address1",
+      });
+      const alpacaAddress2 = toCoreOp({
+        type: "IN",
+        senders: ["address1"],
+        recipients: ["address2"],
+        value: 2,
+        fee: 1,
+        feesPayer: "address1",
+      });
+      listOperationsMock.mockImplementation((addr: string) => {
+        const items = addr === "address1" ? [alpacaAddress1] : [alpacaAddress2];
+        return Promise.resolve({ items, next: undefined });
+      });
+      mockNoSubAccounts();
+      mockNoInferSubOps();
+
+      const result1 = await runGetShape("address1");
+      expect(result1).toMatchObject({
+        operations: [
+          {
+            type: "OUT",
+            senders: ["address1"],
+            recipients: ["address2"],
+            value: new BigNumber(3),
+            fee: new BigNumber(1),
+          },
+        ],
+      });
+
+      const result2 = await runGetShape("address2");
+      expect(result2).toMatchObject({
+        operations: [
+          {
+            type: "IN",
+            senders: ["address1"],
+            recipients: ["address2"],
+            value: new BigNumber(2),
+            fee: new BigNumber(1),
+          },
+        ],
+      });
+    });
+
+    test("Case 2: native self send from EOA", async () => {
+      setupSpecTest();
+      // AlpacaApi returns 2 ops (OUT, IN) for self-sends per spec. getAccountShape uses them as-is.
+      const outOp = toCoreOp({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: 2,
+        fee: 1,
+        feesPayer: "address1",
+      });
+      const inOp = toCoreOp({
+        type: "IN",
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: 2,
+        fee: 1,
+        feesPayer: "address1",
+      });
+      listOperationsMock.mockResolvedValue({ items: [outOp, inOp], next: undefined });
+      mockNoSubAccounts();
+      mockNoInferSubOps();
+
+      const result = await runGetShape("address1");
+      expect(result.operations).toHaveLength(2);
+      const out = result.operations?.find(o => o.type === "OUT");
+      const in_ = result.operations?.find(o => o.type === "IN");
+      expect(out).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: new BigNumber(3),
+        fee: new BigNumber(1),
+      });
+      expect(in_).toMatchObject({
+        type: "IN",
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: new BigNumber(2),
+        fee: new BigNumber(1),
+      });
+    });
+
+    test("Case 3: simple ERC20 transfer between EOAs", async () => {
+      setupSpecTest();
+      const usdtContract = "0xUSDTContract";
+      const alpacaAddr1 = toCoreOp({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["address2"],
+        value: 2,
+        fee: 1,
+        feesPayer: "address1",
+        asset: { type: "erc20", assetReference: usdtContract, assetOwner: "address1" },
+      });
+      const alpacaAddr2 = toCoreOp({
+        type: "IN",
+        senders: ["address1"],
+        recipients: ["address2"],
+        value: 2,
+        fee: 1,
+        feesPayer: "address1",
+        asset: { type: "erc20", assetReference: usdtContract, assetOwner: "address2" },
+      });
+      listOperationsMock.mockImplementation((addr: string) => {
+        const items = addr === "address1" ? [alpacaAddr1] : [alpacaAddr2];
+        return Promise.resolve({ items, next: undefined });
+      });
+      mockErc20SubAccounts(usdtContract);
+      mockInferSubOpsByHash();
+
+      const result1 = await runGetShape("address1");
+      expect(result1).toMatchObject({
+        operations: [
+          {
+            type: "FEES",
+            value: new BigNumber(1),
+            senders: ["address1"],
+            recipients: [usdtContract],
+          },
+        ],
+        subAccounts: [
+          {
+            operations: [
+              {
+                type: "OUT",
+                senders: ["address1"],
+                recipients: ["address2"],
+                value: new BigNumber(2),
+              },
+            ],
+          },
+        ],
+      });
+
+      const result2 = await runGetShape("address2");
+      expect(result2).toMatchObject({
+        operations: [
+          {
+            type: "NONE",
+            senders: ["address1"],
+            recipients: [usdtContract],
+            value: new BigNumber(0),
+            fee: new BigNumber(1),
+          },
+        ],
+        subAccounts: [
+          {
+            operations: [
+              {
+                type: "IN",
+                senders: ["address1"],
+                recipients: ["address2"],
+                value: new BigNumber(2),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    test("Case 4: ERC20 self send from EOA", async () => {
+      setupSpecTest();
+      const usdtContract = "0xUSDTContract";
+      // AlpacaApi returns 2 ops (OUT, IN) for self-sends per spec.
+      const outOp = toCoreOp({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: 2,
+        fee: 1,
+        feesPayer: "address1",
+        asset: { type: "erc20", assetReference: usdtContract, assetOwner: "address1" },
+      });
+      const inOp = toCoreOp({
+        type: "IN",
+        senders: ["address1"],
+        recipients: ["address1"],
+        value: 2,
+        fee: 1,
+        feesPayer: "address1",
+        asset: { type: "erc20", assetReference: usdtContract, assetOwner: "address1" },
+      });
+      listOperationsMock.mockResolvedValue({ items: [outOp, inOp], next: undefined });
+      mockErc20SubAccounts(usdtContract);
+      mockInferSubOpsByHash();
+
+      const result = await runGetShape("address1");
+      expect(result.operations).toHaveLength(1);
+      expect(result.operations?.[0]).toMatchObject({ type: "FEES", value: new BigNumber(1) });
+      expect(result.subAccounts).toHaveLength(1);
+      expect(result.subAccounts?.[0].operations).toHaveLength(2);
+      const outSub = result.subAccounts?.[0].operations?.find(
+        (o: { type: string }) => o.type === "OUT",
+      );
+      const inSub = result.subAccounts?.[0].operations?.find(
+        (o: { type: string }) => o.type === "IN",
+      );
+      expect(outSub?.value?.toFixed()).toBe("2");
+      expect(inSub?.value?.toFixed()).toBe("2");
+    });
+
+    test("Case 5: ETH transfer from smart contract", async () => {
+      setupSpecTest();
+      const alpacaAddr1 = toCoreOp({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["contract1"],
+        value: 0,
+        fee: 1,
+        feesPayer: "address1",
+      });
+      const alpacaAddr2Internal = toCoreOp({
+        type: "IN",
+        senders: ["contract1"],
+        recipients: ["address2"],
+        value: 2,
+        fee: 1,
+        feesPayer: "address1",
+        internal: true,
+      });
+      listOperationsMock.mockImplementation((addr: string) => {
+        const items = addr === "address1" ? [alpacaAddr1] : [alpacaAddr2Internal];
+        return Promise.resolve({ items, next: undefined });
+      });
+      mockNoSubAccounts();
+      mockNoInferSubOps();
+
+      const result1 = await runGetShape("address1");
+      expect(result1).toMatchObject({
+        operations: [
+          {
+            type: "FEES",
+            senders: ["address1"],
+            recipients: ["contract1"],
+            value: new BigNumber(1),
+            fee: new BigNumber(1),
+          },
+        ],
+      });
+
+      const result2 = await runGetShape("address2");
+      expect(result2.operations).toHaveLength(2);
+      const noneOp = result2.operations?.find(o => o.type === "NONE");
+      const inOp = result2.operations?.find(o => o.type === "IN");
+      expect(noneOp).toMatchObject({
+        type: "NONE",
+        senders: ["address1"],
+        recipients: ["contract1"],
+        value: new BigNumber(0),
+        fee: new BigNumber(1),
+      });
+      expect(inOp).toMatchObject({
+        type: "IN",
+        senders: ["contract1"],
+        recipients: ["address2"],
+        value: new BigNumber(2),
+        fee: new BigNumber(1),
+      });
+    });
+
+    test("Case 6: ERC20 transfer from smart contract", async () => {
+      setupSpecTest();
+      const usdtContract = "0xUSDTContract";
+      listOperationsMock.mockImplementation((addr: string) => {
+        let items: ReturnType<typeof toCoreOp>[];
+        switch (addr) {
+          case "address1":
+            items = [
+              toCoreOp({
+                type: "OUT",
+                senders: ["address1"],
+                recipients: ["contract1"],
+                value: 0,
+                fee: 1,
+                feesPayer: "address1",
+              }),
+            ];
+            break;
+          case "address2":
+            items = [
+              toCoreOp({
+                type: "IN",
+                senders: ["address3"],
+                recipients: ["address2"],
+                value: 2,
+                fee: 1,
+                feesPayer: "address1",
+                asset: { type: "erc20", assetReference: usdtContract, assetOwner: "address2" },
+              }),
+            ];
+            break;
+          default:
+            items = [
+              toCoreOp({
+                type: "OUT",
+                senders: ["address3"],
+                recipients: ["address2"],
+                value: 2,
+                fee: 1,
+                feesPayer: "address1",
+                asset: { type: "erc20", assetReference: usdtContract, assetOwner: "address3" },
+              }),
+            ];
+        }
+        return Promise.resolve({ items, next: undefined });
+      });
+      mockErc20SubAccounts(usdtContract);
+      mockInferSubOpsByHash();
+
+      const result1 = await runGetShape("address1");
+      expect(result1).toMatchObject({
+        operations: [
+          {
+            type: "FEES",
+            value: new BigNumber(1),
+            senders: ["address1"],
+            recipients: ["contract1"],
+          },
+        ],
+      });
+
+      const result2 = await runGetShape("address2");
+      expect(result2).toMatchObject({
+        operations: [
+          {
+            type: "NONE",
+            senders: ["address3"],
+            recipients: [usdtContract],
+            value: new BigNumber(0),
+            fee: new BigNumber(1),
+          },
+        ],
+        subAccounts: [
+          {
+            operations: [
+              {
+                type: "IN",
+                senders: ["address3"],
+                recipients: ["address2"],
+                value: new BigNumber(2),
+              },
+            ],
+          },
+        ],
+      });
+
+      const result3 = await runGetShape("address3");
+      expect(result3).toMatchObject({
+        operations: [
+          {
+            type: "NONE",
+            senders: ["address3"],
+            recipients: [usdtContract],
+            value: new BigNumber(0),
+            fee: new BigNumber(1),
+          },
+        ],
+        subAccounts: [
+          {
+            operations: [
+              {
+                type: "OUT",
+                senders: ["address3"],
+                recipients: ["address2"],
+                value: new BigNumber(2),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    test("Case 7: ETH transfer to smart contract", async () => {
+      setupSpecTest();
+      listOperationsMock.mockResolvedValue({
+        items: [
+          toCoreOp({
+            type: "OUT",
+            senders: ["address1"],
+            recipients: ["contract1"],
+            value: 2,
+            fee: 1,
+            feesPayer: "address1",
+          }),
+        ],
+        next: undefined,
+      });
+      mockNoSubAccounts();
+      mockNoInferSubOps();
+
+      const result = await runGetShape("address1");
+      expect(result).toMatchObject({
+        operations: [
+          {
+            type: "OUT",
+            senders: ["address1"],
+            recipients: ["contract1"],
+            value: new BigNumber(3),
+            fee: new BigNumber(1),
+          },
+        ],
+      });
+    });
+
+    test("Case 8: ERC20 transfer to smart contract", async () => {
+      setupSpecTest();
+      const usdtContract = "0xUSDTContract";
+      listOperationsMock.mockResolvedValue({
+        items: [
+          toCoreOp({
+            type: "OUT",
+            senders: ["address1"],
+            recipients: ["contract1"],
+            value: 2,
+            fee: 1,
+            feesPayer: "address1",
+            asset: { type: "erc20", assetReference: usdtContract, assetOwner: "address1" },
+          }),
+        ],
+        next: undefined,
+      });
+      mockErc20SubAccounts(usdtContract, (ops, owner) =>
+        ops.map((o: any) => ({
+          ...o,
+          accountId: `accId_${owner}_${usdtContract}`,
+          value: new BigNumber(o.value?.toString() ?? 0),
+        })),
+      );
+      mockInferSubOpsByHash();
+
+      const result = await runGetShape("address1");
+      expect(result).toMatchObject({
+        operations: [
+          {
+            type: "FEES",
+            value: new BigNumber(1),
+            senders: ["address1"],
+            recipients: [usdtContract],
+          },
+        ],
+        subAccounts: [
+          {
+            operations: [
+              {
+                type: "OUT",
+                senders: ["address1"],
+                recipients: ["contract1"],
+                value: new BigNumber(2),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    test("Case 9: ETH transfer through smart contract", async () => {
+      setupSpecTest();
+      listOperationsMock.mockImplementation((addr: string) => {
+        let items: ReturnType<typeof toCoreOp>[];
+        switch (addr) {
+          case "address1":
+            items = [
+              toCoreOp({
+                type: "OUT",
+                senders: ["address1"],
+                recipients: ["contract1"],
+                value: 2,
+                fee: 1,
+                feesPayer: "address1",
+              }),
+            ];
+            break;
+          default:
+            items = [
+              toCoreOp({
+                type: "IN",
+                senders: ["contract1"],
+                recipients: ["address2"],
+                value: 2,
+                fee: 1,
+                feesPayer: "address1",
+              }),
+            ];
+        }
+        return Promise.resolve({ items, next: undefined });
+      });
+      mockNoSubAccounts();
+      mockNoInferSubOps();
+
+      const result1 = await runGetShape("address1");
+      expect(result1).toMatchObject({
+        operations: [
+          {
+            type: "OUT",
+            senders: ["address1"],
+            recipients: ["contract1"],
+            value: new BigNumber(3),
+            fee: new BigNumber(1),
+          },
+        ],
+      });
+
+      const result2 = await runGetShape("address2");
+      expect(result2).toMatchObject({
+        operations: [
+          {
+            type: "IN",
+            senders: ["contract1"],
+            recipients: ["address2"],
+            value: new BigNumber(2),
+            fee: new BigNumber(1),
+          },
+        ],
+      });
+    });
+
+    test("Case 10: mixed assets smart contract interaction", async () => {
+      setupSpecTest();
+      const usdtContract = "0xUSDTContract";
+      listOperationsMock.mockImplementation((addr: string) => {
+        let items: ReturnType<typeof toCoreOp>[];
+        switch (addr) {
+          case "address1":
+            items = [
+              toCoreOp({
+                type: "OUT",
+                senders: ["address1"],
+                recipients: ["contract1"],
+                value: 1,
+                fee: 1,
+                feesPayer: "address1",
+              }),
+              toCoreOp({
+                type: "OUT",
+                senders: ["address1"],
+                recipients: ["address2"],
+                value: 2,
+                fee: 1,
+                feesPayer: "address1",
+                asset: { type: "erc20", assetReference: usdtContract, assetOwner: "address1" },
+              }),
+            ];
+            break;
+          default:
+            items = [
+              toCoreOp({
+                type: "IN",
+                senders: ["address1"],
+                recipients: ["address2"],
+                value: 2,
+                fee: 1,
+                feesPayer: "address1",
+                asset: { type: "erc20", assetReference: usdtContract, assetOwner: "address2" },
+              }),
+            ];
+        }
+        return Promise.resolve({ items, next: undefined });
+      });
+      mockErc20SubAccounts(usdtContract);
+      mockInferSubOpsByHash();
+
+      const result1 = await runGetShape("address1");
+      expect(result1).toMatchObject({
+        operations: [
+          {
+            type: "OUT",
+            value: new BigNumber(2),
+            senders: ["address1"],
+            recipients: ["contract1"],
+          },
+        ],
+        subAccounts: [
+          {
+            operations: [
+              {
+                type: "OUT",
+                senders: ["address1"],
+                recipients: ["address2"],
+                value: new BigNumber(2),
+              },
+            ],
+          },
+        ],
+      });
+
+      const result2 = await runGetShape("address2");
+      expect(result2).toMatchObject({
+        operations: [
+          {
+            type: "NONE",
+            senders: ["address1"],
+            recipients: [usdtContract],
+            value: new BigNumber(0),
+            fee: new BigNumber(1),
+          },
+        ],
+        subAccounts: [
+          {
+            operations: [
+              {
+                type: "IN",
+                senders: ["address1"],
+                recipients: ["address2"],
+                value: new BigNumber(2),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    test("Case 11: Spoofed ERC20 transfer through smart contract", async () => {
+      setupSpecTest();
+      const scamContract = "0xSCAMCOINContract";
+      listOperationsMock.mockImplementation((addr: string) => {
+        let items: ReturnType<typeof toCoreOp>[];
+        switch (addr) {
+          case "address1":
+            items = [
+              toCoreOp({
+                type: "OUT",
+                senders: ["address1"],
+                recipients: ["contract1"],
+                value: 0,
+                fee: 1,
+                feesPayer: "address1",
+              }),
+            ];
+            break;
+          case "address2":
+            items = [
+              toCoreOp({
+                type: "OUT",
+                senders: ["address2"],
+                recipients: ["address3"],
+                value: 2,
+                fee: 1,
+                feesPayer: "address1",
+                asset: { type: "erc20", assetReference: scamContract, assetOwner: "address2" },
+              }),
+            ];
+            break;
+          default:
+            items = [
+              toCoreOp({
+                type: "IN",
+                senders: ["address2"],
+                recipients: ["address3"],
+                value: 2,
+                fee: 1,
+                feesPayer: "address1",
+                asset: { type: "erc20", assetReference: scamContract, assetOwner: "address3" },
+              }),
+            ];
+        }
+        return Promise.resolve({ items, next: undefined });
+      });
+      mockErc20SubAccounts(scamContract);
+      mockInferSubOpsByHash();
+
+      const result1 = await runGetShape("address1");
+      expect(result1).toMatchObject({
+        operations: [
+          {
+            type: "FEES",
+            value: new BigNumber(1),
+            senders: ["address1"],
+            recipients: ["contract1"],
+          },
+        ],
+      });
+
+      const result2 = await runGetShape("address2");
+      expect(result2).toMatchObject({
+        operations: [
+          {
+            type: "NONE",
+            senders: ["address2"],
+            recipients: [scamContract],
+            value: new BigNumber(0),
+            fee: new BigNumber(1),
+          },
+        ],
+        subAccounts: [
+          {
+            operations: [
+              {
+                type: "OUT",
+                senders: ["address2"],
+                recipients: ["address3"],
+                value: new BigNumber(2),
+              },
+            ],
+          },
+        ],
+      });
+
+      const result3 = await runGetShape("address3");
+      expect(result3).toMatchObject({
+        operations: [
+          {
+            type: "NONE",
+            senders: ["address2"],
+            recipients: [scamContract],
+            value: new BigNumber(0),
+            fee: new BigNumber(1),
+          },
+        ],
+        subAccounts: [
+          {
+            operations: [
+              {
+                type: "IN",
+                senders: ["address2"],
+                recipients: ["address3"],
+                value: new BigNumber(2),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    test("Case 12: Smart contract token minting", async () => {
+      setupSpecTest();
+      const stethContract = "0xSTETHContract";
+      const zeroAddress = "0x0000000000000000000000000000000000000000";
+      listOperationsMock.mockResolvedValue({
+        items: [
+          toCoreOp({
+            type: "OUT",
+            senders: ["address1"],
+            recipients: ["contract1"],
+            value: 1,
+            fee: 1,
+            feesPayer: "address1",
+          }),
+          toCoreOp({
+            type: "IN",
+            senders: [zeroAddress],
+            recipients: ["address1"],
+            value: 2,
+            fee: 1,
+            feesPayer: "address1",
+            asset: { type: "erc20", assetReference: stethContract, assetOwner: "address1" },
+          }),
+        ],
+        next: undefined,
+      });
+      mockErc20SubAccounts(stethContract);
+      mockInferSubOpsByHash();
+
+      const result = await runGetShape("address1");
+      expect(result).toMatchObject({
+        operations: [
+          {
+            type: "OUT",
+            senders: ["address1"],
+            recipients: ["contract1"],
+            value: new BigNumber(2),
+            fee: new BigNumber(1),
+          },
+        ],
+        subAccounts: [
+          {
+            operations: [
+              {
+                type: "IN",
+                senders: [zeroAddress],
+                recipients: ["address1"],
+                value: new BigNumber(2),
+              },
+            ],
+          },
+        ],
+      });
     });
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/utils.ts
@@ -127,6 +127,7 @@ export function adaptCoreOperationToLiveOperation(accountId: string, op: CoreOpe
     ledgerOpType?: string | undefined;
     memo?: string | undefined;
     internal?: boolean;
+    feePayer?: string;
   } = {};
 
   if (op.details?.ledgerOpType !== undefined) {
@@ -164,6 +165,10 @@ export function adaptCoreOperationToLiveOperation(accountId: string, op: CoreOpe
 
   if (op.details?.internal === true) {
     extra.internal = op.details?.internal;
+  }
+
+  if (typeof op.tx.feesPayer === "string") {
+    extra.feePayer = op.tx.feesPayer;
   }
 
   const bnFees = new BigNumber(op.tx.fees.toString());


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - coin-evm

### 📝 Description

This fixes several cases where `listOperations` returns operations with `amount` not matching `asset`, or amount in one currency (eg: ETH) are added to amounts in another one (eg: an ERC20).

All cases have been described in [Coin modules - ADR-016 - EVM transactions to operations mapping](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/6790873440/Coin+modules+-+ADR-016+-+EVM+transactions+to+operations+mapping).

> [!WARNING]
> This PR changes the number of output operations per input operations in `AlpacaApi.listOperations` in some cases.

Also: improved `coin-tester` to show failing asserts, and assert on more fields.

### ❓ Context

- https://ledgerhq.atlassian.net/browse/BACK-10515
- https://ledgerhq.atlassian.net/browse/BACK-10512
- https://ledgerhq.atlassian.net/browse/BACK-10510


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
