### PR TITLE
feat(mobile): hide bank transfer in transfer drawer when Noah flag is disabled

### DIFF
--- a/.changeset/tidy-jokes-pay.md
+++ b/.changeset/tidy-jokes-pay.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Hide bank transfer option in transfer drawer when Noah feature flag is disabled

--- a/apps/ledger-live-mobile/src/mvvm/features/Noah/shouldShowNoahMenu.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Noah/shouldShowNoahMenu.ts
@@ -1,17 +1,19 @@
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 
-export type NoahParams = {
-  fromMenu?: boolean;
-  currency?: string | CryptoOrTokenCurrency;
-};
+export type NoahParams =
+  | {
+      fromMenu?: boolean;
+      currency?: string | CryptoOrTokenCurrency;
+    }
+  | undefined;
 
 export function shouldShowNoahMenu(
   params: NoahParams,
   noahFlagEnabled: boolean,
   activeCurrencyIds: string[],
 ) {
-  const fromMenu = params.fromMenu;
-  const currency = params.currency;
+  const fromMenu = params?.fromMenu;
+  const currency = params?.currency;
   let hasValidCurrency = true;
 
   if (currency) {

--- a/apps/ledger-live-mobile/src/mvvm/features/Noah/useNoahEntryPoint.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Noah/useNoahEntryPoint.ts
@@ -5,7 +5,7 @@ import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
  * Check if the noah menu should be shown based on the feature flag and the route
  */
 
-export const useReceiveNoahEntry = (params: NoahParams) => {
+export const useReceiveNoahEntry = (params?: NoahParams) => {
   const noah = useFeature("noah");
   const showMenu = shouldShowNoahMenu(
     params,

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/__integrations__/QuickActionsCtas.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/__integrations__/QuickActionsCtas.integration.test.tsx
@@ -8,6 +8,7 @@ import {
   getCtaButtons,
 } from "./shared";
 import { QUICK_ACTIONS_TEST_IDS } from "../testIds";
+import { State } from "~/reducers/types";
 
 const { transferDrawer } = QUICK_ACTIONS_TEST_IDS;
 
@@ -97,6 +98,26 @@ describe("QuickActionsCtas Integration Tests", () => {
       expect(transferButton).toBeDisabled();
       expect(swapButton).toBeDisabled();
       expect(buyButton).toBeDisabled();
+    });
+
+    it("should not display bank transfer option in transfer drawer when noah feature flag is disabled", async () => {
+      const { user } = render(<TestQuickActionsWrapper />, {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            overriddenFeatureFlags: {
+              ...state.settings.overriddenFeatureFlags,
+              noah: { enabled: false },
+            },
+          },
+        }),
+      });
+
+      const { transferButton } = await getCtaButtons();
+      await user.press(transferButton);
+
+      expect(screen.queryByTestId(transferDrawer.bankTransfer)).not.toBeVisible();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/__integrations__/shared.tsx
@@ -51,6 +51,7 @@ export const overrideStateWithFunds = (state: State): State => {
       readOnlyModeEnabled: false,
       overriddenFeatureFlags: {
         ptxServiceCtaExchangeDrawer: { enabled: true },
+        noah: { enabled: true },
       },
     },
   };
@@ -67,6 +68,7 @@ export const overrideStateWithoutFunds = (state: State): State => ({
     readOnlyModeEnabled: false,
     overriddenFeatureFlags: {
       ptxServiceCtaExchangeDrawer: { enabled: true },
+      noah: { enabled: true },
     },
   },
 });
@@ -85,6 +87,7 @@ export const overrideStateReadOnly = (state: State): State => {
       readOnlyModeEnabled: true,
       overriddenFeatureFlags: {
         ptxServiceCtaExchangeDrawer: { enabled: true },
+        noah: { enabled: true },
       },
     },
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -13,6 +13,7 @@ import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import { TransferAction } from "../../types";
 import { QUICK_ACTIONS_TEST_IDS } from "../../testIds";
 import { useTranslation } from "~/context/Locale";
+import { useReceiveNoahEntry } from "LLM/features/Noah/useNoahEntryPoint";
 
 interface TransferDrawerViewModel {
   isOpen: boolean;
@@ -33,7 +34,10 @@ export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
     sourceScreenName,
+    fromMenu: true,
   });
+
+  const { showNoahMenu: showNoahOption } = useReceiveNoahEntry();
 
   const handleReceivePress = useCallback(() => {
     track("button_clicked", {
@@ -90,22 +94,27 @@ export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
         onPress: handleSendPress,
         testID: QUICK_ACTIONS_TEST_IDS.transferDrawer.send,
       },
-      {
-        id: "bank_transfer",
-        title: t("portfolio.quickActionsCtas.transferDrawer.bankTransfer"),
-        description: t("portfolio.quickActionsCtas.transferDrawer.bankTransferDescription"),
-        icon: Bank,
-        disabled: readOnlyModeEnabled,
-        onPress: handleBankTransferPress,
-        testID: QUICK_ACTIONS_TEST_IDS.transferDrawer.bankTransfer,
-      },
+      ...(showNoahOption
+        ? [
+            {
+              id: "bank_transfer" as const,
+              title: t("portfolio.quickActionsCtas.transferDrawer.bankTransfer"),
+              description: t("portfolio.quickActionsCtas.transferDrawer.bankTransferDescription"),
+              icon: Bank,
+              disabled: readOnlyModeEnabled,
+              onPress: handleBankTransferPress,
+              testID: QUICK_ACTIONS_TEST_IDS.transferDrawer.bankTransfer,
+            },
+          ]
+        : []),
     ],
     [
       t,
       readOnlyModeEnabled,
-      hasFunds,
       handleReceivePress,
+      hasFunds,
       handleSendPress,
+      showNoahOption,
       handleBankTransferPress,
     ],
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Integration test added: bank transfer option is not displayed in transfer drawer when Noah feature flag is disabled.
- [x] **Impact of the changes:**
  - Transfer drawer: bank transfer option visibility when Noah feature flag is on/off
  - Quick Actions CTAs and transfer drawer behavior
  - Noah entry point: optional params and safe handling when params are undefined

### 📝 Description

**Problem:** The bank transfer option in the transfer drawer was always shown, regardless of the Noah feature flag. When Noah is disabled, users should not see the bank transfer entry point. We also need to remove it when we do a receive as it's prompted earlier in the flow

**Solution:**
- **Transfer drawer:** The bank transfer action is now included only when `showNoahOption` is true (from `useReceiveNoahEntry()`). When the Noah feature flag is disabled, the transfer drawer shows only Receive and Send.
- **Noah entry point:** `useReceiveNoahEntry` and `shouldShowNoahMenu` accept optional params (`params?: NoahParams`) and use optional chaining so callers can pass no arguments (e.g. from the transfer drawer).
- **Types:** Bank transfer action uses `id: "bank_transfer" as const` and includes `testID` so it satisfies `TransferAction`.
- **Tests:** Integration test verifies that with Noah flag disabled, the bank transfer option is not visible in the transfer drawer. Shared test state overrides include `noah: { enabled: true }` where relevant.

https://github.com/user-attachments/assets/29fa32ff-1499-40fb-97fe-b659e32814ea

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25652](https://ledgerhq.atlassian.net/browse/LIVE-25652)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25652]: https://ledgerhq.atlassian.net/browse/LIVE-25652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ