### PR TITLE
ci: Revert ci: skip pnpm caching due to github issues

### DIFF
--- a/.github/workflows/test-mobile-build-android-reusable.yml
+++ b/.github/workflows/test-mobile-build-android-reusable.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           install-proto: true
           skip-turbo-cache: "false"
-          skip-pnpm-cache: "true"
+          skip-pnpm-cache: "false"
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
@@ -200,7 +200,7 @@ jobs:
           install-proto: "true"
           skip-pod-cache: "true"
           skip-turbo-cache: "false"
-          skip-pnpm-cache: "true"
+          skip-pnpm-cache: "false"
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}

--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           skip-pod-cache: "true"
           skip-turbo-cache: "false"
-          skip-pnpm-cache: "true"
+          skip-pnpm-cache: "false"
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
@@ -216,7 +216,7 @@ jobs:
           install-proto: "true"
           skip-pod-cache: "true"
           skip-turbo-cache: "false"
-          skip-pnpm-cache: "true"
+          skip-pnpm-cache: "false"
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -645,7 +645,7 @@ jobs:
         id: setup-caches
         with:
           install-proto: true
-          skip-pnpm-cache: "true"
+          skip-pnpm-cache: "false"
           skip-turbo-cache: "false"
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -447,7 +447,7 @@ jobs:
         id: setup-caches
         with:
           install-proto: true
-          skip-pnpm-cache: "true"
+          skip-pnpm-cache: "false"
           skip-turbo-cache: "false"
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}


### PR DESCRIPTION
Reverts LedgerHQ/ledger-live#12818

Caching was removed due to networking issues affecting cache speed.

This should now be resolved for larger runners, so reverting and monitoring the situation

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-23068