### PR TITLE
feat(desktop): new Receive options dialog (Lumen) behind W4.0 flag

### DIFF
--- a/.changeset/ninety-melons-tan.md
+++ b/.changeset/ninety-melons-tan.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+Revamp Receive StepOptions for W40

--- a/apps/ledger-live-desktop/src/mvvm/features/Receive/__integrations__/Receive.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Receive/__integrations__/Receive.integration.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { render, screen, waitFor } from "tests/testSetup";
+import { ReceiveOptionsDialog } from "../screens/ReceiveOptions";
+import { useNavigate } from "react-router";
+import { track } from "~/renderer/analytics/segment";
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+const mockUseNavigate = useNavigate as jest.MockedFunction<typeof useNavigate>;
+
+describe("Receive feature integration", () => {
+  const onClose = jest.fn();
+  const onGoToAccount = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+  });
+
+  describe("ReceiveOptionsDialog", () => {
+    it("renders dialog with Receive title and both options", () => {
+      render(<ReceiveOptionsDialog onClose={onClose} onGoToAccount={onGoToAccount} />);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByTestId("receive-step-options")).toBeInTheDocument();
+      expect(screen.getByTestId("receive-step-options-crypto")).toBeInTheDocument();
+      expect(screen.getByTestId("receive-step-options-bank")).toBeInTheDocument();
+    });
+
+    it("calls onGoToAccount when user clicks crypto option", async () => {
+      const { user } = render(
+        <ReceiveOptionsDialog onClose={onClose} onGoToAccount={onGoToAccount} />,
+      );
+
+      await user.click(screen.getByTestId("receive-step-options-crypto"));
+
+      expect(onGoToAccount).toHaveBeenCalledTimes(1);
+      expect(onClose).not.toHaveBeenCalled();
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "crypto",
+        page: "receive_drawer",
+      });
+    });
+
+    it("calls onClose and navigates to /bank when user clicks bank option", async () => {
+      const { user } = render(
+        <ReceiveOptionsDialog onClose={onClose} onGoToAccount={onGoToAccount} />,
+      );
+
+      await user.click(screen.getByTestId("receive-step-options-bank"));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith("/bank");
+      expect(onGoToAccount).not.toHaveBeenCalled();
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "fiat",
+        page: "receive_drawer",
+      });
+    });
+
+    it("calls onClose when user clicks close button", async () => {
+      const { user } = render(
+        <ReceiveOptionsDialog onClose={onClose} onGoToAccount={onGoToAccount} />,
+      );
+
+      const closeButton = screen.getByRole("button", { name: /close/i });
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Receive/hooks/useReceiveOptionsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Receive/hooks/useReceiveOptionsViewModel.ts
@@ -1,0 +1,34 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router";
+import { track } from "~/renderer/analytics/segment";
+
+export type UseReceiveOptionsViewModelArgs = Readonly<{
+  onClose: () => void;
+  onGoToAccount: () => void;
+}>;
+
+export function useReceiveOptionsViewModel({
+  onClose,
+  onGoToAccount,
+}: UseReceiveOptionsViewModelArgs) {
+  const navigate = useNavigate();
+
+  const handleGoToBank = useCallback(() => {
+    track("button_clicked", {
+      button: "fiat",
+      page: "receive_drawer",
+    });
+    onClose();
+    navigate("/bank");
+  }, [onClose, navigate]);
+
+  const handleGoToCrypto = useCallback(() => {
+    track("button_clicked", {
+      button: "crypto",
+      page: "receive_drawer",
+    });
+    onGoToAccount();
+  }, [onGoToAccount]);
+
+  return { handleGoToBank, handleGoToCrypto };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Receive/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Receive/index.ts
@@ -1,0 +1,2 @@
+export { ReceiveOptionsDialog } from "./screens/ReceiveOptions";
+export type { ReceiveOptionsDialogProps } from "./types";

--- a/apps/ledger-live-desktop/src/mvvm/features/Receive/screens/ReceiveOptions/ReceiveOptionsDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Receive/screens/ReceiveOptions/ReceiveOptionsDialog.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogContent, DialogHeader, DialogBody } from "@ledgerhq/lumen-ui-react";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { useReceiveOptionsViewModel } from "../../hooks/useReceiveOptionsViewModel";
+import { ReceiveOptionsView } from "./ReceiveOptionsView";
+import type { ReceiveOptionsDialogProps } from "../../types";
+
+export function ReceiveOptionsDialog({ onClose, onGoToAccount }: ReceiveOptionsDialogProps) {
+  const { t } = useTranslation();
+  const { handleGoToBank, handleGoToCrypto } = useReceiveOptionsViewModel({
+    onClose,
+    onGoToAccount,
+  });
+
+  return (
+    <Dialog open onOpenChange={open => !open && onClose()}>
+      <DialogContent>
+        <TrackPage category="receive_drawer" type="drawer" />
+        <DialogHeader appearance="extended" title={t("receive.title")} onClose={onClose} />
+        <DialogBody className="px-16! pt-12">
+          <ReceiveOptionsView onGoToBank={handleGoToBank} onGoToCrypto={handleGoToCrypto} />
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Receive/screens/ReceiveOptions/ReceiveOptionsView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Receive/screens/ReceiveOptions/ReceiveOptionsView.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import {
+  ListItemTitle,
+  ListItemDescription,
+  ListItemContent,
+  ListItem,
+  ListItemLeading,
+  Spot,
+} from "@ledgerhq/lumen-ui-react";
+import { Bank, QrCode } from "@ledgerhq/lumen-ui-react/symbols";
+
+export type ReceiveOptionsViewProps = Readonly<{
+  onGoToBank: () => void;
+  onGoToCrypto: () => void;
+}>;
+
+export function ReceiveOptionsView({ onGoToBank, onGoToCrypto }: ReceiveOptionsViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col gap-8" data-testid="receive-step-options">
+      <ListItem onClick={onGoToCrypto} data-testid="receive-step-options-crypto">
+        <ListItemLeading>
+          <Spot appearance="icon" icon={QrCode} />
+          <ListItemContent>
+            <ListItemTitle>{t("newReceive.steps.options.fromCrypto.title")}</ListItemTitle>
+          </ListItemContent>
+        </ListItemLeading>
+      </ListItem>
+      <ListItem onClick={onGoToBank} data-testid="receive-step-options-bank">
+        <ListItemLeading>
+          <Spot appearance="icon" icon={Bank} />
+          <ListItemContent>
+            <ListItemTitle>{t("newReceive.steps.options.fromBank.title")}</ListItemTitle>
+            <ListItemDescription>
+              {t("newReceive.steps.options.fromBank.description")}
+            </ListItemDescription>
+          </ListItemContent>
+        </ListItemLeading>
+      </ListItem>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Receive/screens/ReceiveOptions/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Receive/screens/ReceiveOptions/index.tsx
@@ -1,0 +1,2 @@
+export { ReceiveOptionsDialog } from "./ReceiveOptionsDialog";
+export { ReceiveOptionsView } from "./ReceiveOptionsView";

--- a/apps/ledger-live-desktop/src/mvvm/features/Receive/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Receive/types.ts
@@ -1,0 +1,4 @@
+export type ReceiveOptionsDialogProps = Readonly<{
+  onClose: () => void;
+  onGoToAccount: () => void;
+}>;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2206,6 +2206,19 @@
       "description": "You might need a <0>Tag/Memo</0> for receiving this asset from an exchange. You can use any combination of numbers like 1234."
     }
   },
+  "newReceive": {
+    "steps": {
+      "options": {
+        "fromBank": {
+          "title": "Bank transfer",
+          "description": "Receive stablecoin by sending cash"
+        },
+        "fromCrypto": {
+          "title": "Receive crypto"
+        }
+      }
+    }
+  },
   "send": {
     "title": "Send",
     "totalSpent": "Total to debit",

--- a/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
+++ b/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
@@ -22,5 +22,6 @@ export const getWallet40Attributes = (
     quickActionCtas: wallet40FeatureFlag?.params?.quickActionCtas ?? false,
     tour: wallet40FeatureFlag?.params?.tour ?? false,
     mainNavigation: wallet40FeatureFlag?.params?.mainNavigation ?? false,
+    newReceiveDialog: wallet40FeatureFlag?.params?.newReceiveDialog ?? false,
   };
 };

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
@@ -4,6 +4,7 @@ export type Wallet40Params = {
   readonly marketBanner?: boolean;
   readonly graphRework?: boolean;
   readonly quickActionCtas?: boolean;
+  readonly newReceiveDialog?: boolean;
 };
 
 export const FEATURE_FLAG_KEYS = {
@@ -21,4 +22,6 @@ export interface WalletFeaturesConfig {
   readonly shouldDisplayGraphRework: boolean;
   /** Whether to show quick action CTAs */
   readonly shouldDisplayQuickActionCtas: boolean;
+  /** Whether to show the new receive options dialog (Lumen) */
+  readonly shouldDisplayNewReceiveDialog: boolean;
 }

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
@@ -36,6 +36,7 @@ const DISABLED_CONFIG: WalletFeaturesConfig = {
   shouldDisplayMarketBanner: false,
   shouldDisplayGraphRework: false,
   shouldDisplayQuickActionCtas: false,
+  shouldDisplayNewReceiveDialog: false,
 };
 
 const ENABLED_NO_PARAMS_CONFIG: WalletFeaturesConfig = {
@@ -43,6 +44,7 @@ const ENABLED_NO_PARAMS_CONFIG: WalletFeaturesConfig = {
   shouldDisplayMarketBanner: false,
   shouldDisplayGraphRework: false,
   shouldDisplayQuickActionCtas: false,
+  shouldDisplayNewReceiveDialog: false,
 };
 
 const ALL_ENABLED_CONFIG: WalletFeaturesConfig = {
@@ -50,12 +52,14 @@ const ALL_ENABLED_CONFIG: WalletFeaturesConfig = {
   shouldDisplayMarketBanner: true,
   shouldDisplayGraphRework: true,
   shouldDisplayQuickActionCtas: true,
+  shouldDisplayNewReceiveDialog: true,
 };
 
 const ALL_PARAMS_ENABLED: Wallet40Params = {
   marketBanner: true,
   graphRework: true,
   quickActionCtas: true,
+  newReceiveDialog: true,
 };
 
 describe("useWalletFeaturesConfig hook", () => {
@@ -98,6 +102,7 @@ describe("useWalletFeaturesConfig hook", () => {
         ["marketBanner", { marketBanner: true }, { shouldDisplayMarketBanner: true }],
         ["graphRework", { graphRework: true }, { shouldDisplayGraphRework: true }],
         ["quickActionCtas", { quickActionCtas: true }, { shouldDisplayQuickActionCtas: true }],
+        ["newReceiveDialog", { newReceiveDialog: true }, { shouldDisplayNewReceiveDialog: true }],
       ])("should return correct config when only %s is enabled", (_, params, expectedOverrides) => {
         const { result } = renderWalletFeaturesConfig(platform, {
           [flagKey]: createFeatureFlag(true, params),

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
@@ -35,6 +35,7 @@ export const useWalletFeaturesConfig = (platform: WalletPlatform): WalletFeature
       shouldDisplayMarketBanner: isEnabled && Boolean(params?.marketBanner),
       shouldDisplayGraphRework: isEnabled && Boolean(params?.graphRework),
       shouldDisplayQuickActionCtas: isEnabled && Boolean(params?.quickActionCtas),
+      shouldDisplayNewReceiveDialog: isEnabled && Boolean(params?.newReceiveDialog),
     };
   }, [walletFeatureFlag]);
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Receive modal: when "Receive" is opened with Noah + new dialog flag, the options step (Bank / Crypto) uses the new Lumen dialog
  - Legacy Receive flow unchanged when flag is off; Stepper still includes legacy StepOptions
  - Wallet 4.0 config: new `shouldDisplayNewReceiveDialog` (lwdWallet40 params)

### 📝 Description

**Problem:** The Receive modal’s “options” step (choose Bank or Crypto) uses the legacy UI (styled-components, old Modal). We want a Lumen-based step for Wallet 4.0 and a clear path to migrate the rest of the flow later.

**Solution:**

- **New Receive feature in mvvm** (`LLD/features/Receive`): `ReceiveOptionsDialog` (Lumen `Dialog` + `DialogHeader` + `DialogBody`) and `ReceiveOptionsView` (Lumen `ListItem` for Bank/Crypto), with `useReceiveOptionsViewModel` for tracking, close, and navigation.
- **Feature flag:** `shouldDisplayNewReceiveDialog` from `useWalletFeaturesConfig("desktop")` (lwdWallet40 params). When **true**: the options step is rendered as the new Lumen dialog only (no legacy Modal chrome). When **false**: legacy Modal + Stepper with legacy StepOptions.
- **Two modals in one flow:** For the options step we render either the Lumen dialog or the legacy Stepper; “Crypto” goes to the account step (legacy Modal), “Bank” closes and navigates to `/bank`. Close and onboarding state are handled by a single `handleClose(success?)` in the Receive modal index.
- **live-common:** `WalletFeaturesConfig` and `Wallet40Params` extended with `shouldDisplayNewReceiveDialog` / `newReceiveDialog`; `useWalletFeaturesConfig` returns it; tests updated.
- **i18n:** New keys under `newReceive.steps.options` for the Lumen step labels.


<img width="835" height="71" alt="Screenshot 2026-02-02 at 16 45 11" src="https://github.com/user-attachments/assets/02a4b8db-b7f6-4725-bc4a-54dc80ab37d6" />

https://github.com/user-attachments/assets/ac2a94b7-8574-45fc-a4d7-0d896645afaa



### ❓ Context

- **JIRA or GitHub link**: [LIVE-25672](https://ledgerhq.atlassian.net/browse/LIVE-25672)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25672]: https://ledgerhq.atlassian.net/browse/LIVE-25672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ