### PR TITLE
fix(mobile): show refresh indicator when market banner is enabled

### DIFF
--- a/.changeset/silly-phones-sniff.md
+++ b/.changeset/silly-phones-sniff.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add missing refresh indicator in the market list page

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/index.tsx
@@ -164,6 +164,7 @@ function View({
         colors={[colors.primary.c80]}
         tintColor={colors.primary.c80}
         onRefresh={handlePullToRefresh}
+        progressViewOffset={isMarketBannerEnabled ? headerSpacerHeight : undefined}
       />
     ),
   };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new tests; change is a layout/visibility fix for RefreshControl._
- [x] **Impact of the changes:**
  - Market list pull-to-refresh when marketBanner is ON
  - Visibility of refresh indicator below transparent nav header (Android)

### 📝 Description

When the market banner feature flag is enabled, the Market list is shown in standalone mode with a transparent navigation header. The list header includes a spacer (`headerSpacerHeight`) so content sits below the nav bar. The `RefreshControl` was still anchored at the top of the scroll content, so the refresh indicator was drawn **behind** the status bar / nav bar and was not visible when pulling to refresh.

**Solution:** When `marketBanner` is enabled, pass `progressViewOffset={headerSpacerHeight}` to `RefreshControl` so the indicator is offset and appears below the transparent header.

ON Android, there is no change as the loader is not on the same layer as the rest of the layout

| Before | After |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/492678dd-de67-4f0f-8e3e-3801349bf3fb" />|<video src="https://github.com/user-attachments/assets/1c9858ed-531c-45c7-bb36-0ca7855b0b48" />|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-25530](https://ledgerhq.atlassian.net/browse/LIVE-25530)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25530]: https://ledgerhq.atlassian.net/browse/LIVE-25530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ