### PR TITLE
[LWM] fix: save swap to history

### DIFF
--- a/.changeset/twenty-readers-pump.md
+++ b/.changeset/twenty-readers-pump.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix lvm save to history


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Move the save to history functionality into the "combinedSwap" flow. When saving to history on android we would loose the wallet context whilst we were progressing through combined swap which meant when we then try and action another custom module it would never resolve.

This saves this history as part of the combinedSwap flow instead of as an extra step. Something desktop was already doing.

**Note:** It took me too long to find but this method is already being used within the desktop flow:
https://github.com/LedgerHQ/ledger-live/blob/develop/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx#L208
Which is why that is working

### ❓ Context

- [[LIVE-24933](https://ledgerhq.atlassian.net/browse/LIVE-24933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)](https://ledgerhq.atlassian.net/browse/LIVE-24933)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24933]: https://ledgerhq.atlassian.net/browse/LIVE-24933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ