### PR TITLE
fix(desktop): allow ledgerlive/ledgerwallet in urlSafety for portfolio content cards deeplinks

### DIFF
--- a/.changeset/witty-coats-speak.md
+++ b/.changeset/witty-coats-speak.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Allow ledgerlive: and ledgerwallet: in urlSafety for portfolio content cards deeplinks

--- a/apps/ledger-live-desktop/src/helpers/urlSafety.test.ts
+++ b/apps/ledger-live-desktop/src/helpers/urlSafety.test.ts
@@ -13,6 +13,18 @@ describe("isUrlSafe", () => {
       expect(isUrlSafe("https://ledger.com/support")).toBe(true);
       expect(isUrlSafe("https://api.example.com/v1/data?query=test")).toBe(true);
     });
+
+    it("should return true for ledgerlive: URLs", () => {
+      expect(isUrlSafe("ledgerlive://")).toBe(true);
+      expect(isUrlSafe("ledgerlive://some-path")).toBe(true);
+      expect(isUrlSafe("ledgerlive://request?params=value")).toBe(true);
+    });
+
+    it("should return true for ledgerwallet: URLs", () => {
+      expect(isUrlSafe("ledgerwallet://")).toBe(true);
+      expect(isUrlSafe("ledgerwallet://some-path")).toBe(true);
+      expect(isUrlSafe("ledgerwallet://request?params=value")).toBe(true);
+    });
   });
 
   describe("blocked protocols (RCE prevention)", () => {

--- a/apps/ledger-live-desktop/src/helpers/urlSafety.ts
+++ b/apps/ledger-live-desktop/src/helpers/urlSafety.ts
@@ -1,7 +1,7 @@
-const ALLOWED_PROTOCOLS = ["http:", "https:"];
+const ALLOWED_PROTOCOLS = ["http:", "https:", "ledgerlive:", "ledgerwallet:"];
 
 /**
- * Validates that a URL uses a safe protocol (http or https only).
+ * Validates that a URL uses a safe protocol (http or https only) or LW deeplink protocols.
  * This prevents RCE attacks via dangerous protocols like file://, smb://, etc.
  * @see https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-openexternal-with-untrusted-content
  */


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - URL/link opening from Portfolio content cards (carousel + action cards)
  - In-app deeplinks (`ledgerlive://`, `ledgerwallet://`) opened via content cards
  - External link safety (http/https) unchanged

### 📝 Description

**Problem**: On certain in-app deeplinks used via **portfolio content cards** (carousel and action cards on the Portfolio screen), URLs with the `ledgerlive://` and `ledgerwallet://` protocols were rejected by `isUrlSafe`. They were therefore not opened and a warning was logged ("Blocked potentially unsafe URL"), even though they are legitimate Ledger Live internal links.

**Solution**: Extend the list of allowed protocols in `isUrlSafe` to include `ledgerlive:` and `ledgerwallet:`, in addition to `http:` and `https:`. Validation still blocks dangerous protocols (file://, smb://, javascript:, etc.) to prevent RCE attacks, in line with Electron security recommendations.

- **Before**: only `http:` and `https:` were allowed → content card deeplinks were blocked.
- **After**: `http:`, `https:`, `ledgerlive:` and `ledgerwallet:` are allowed → in-app links from portfolio content cards open correctly.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25685

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
