### PR TITLE
feat: create wallet v4 tour drawer viewmodel & shell

### DIFF
--- a/.changeset/shy-plums-sell.md
+++ b/.changeset/shy-plums-sell.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat: Create Wallet V4 Tour Drawer ViewModel & Shell

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Debug/index.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "styled-components/native";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { setHasSeenWalletV4Tour } from "~/actions/settings";
 import { hasSeenWalletV4TourSelector } from "~/reducers/settings";
+import { useWalletV4TourDrawer, WalletV4TourDrawer } from "../Drawer";
 import { SectionCard, ToggleRow } from "./components";
 
 function WalletV4TourScreenDebug() {
@@ -12,14 +13,11 @@ function WalletV4TourScreenDebug() {
   const dispatch = useDispatch();
 
   const hasSeenTour = useSelector(hasSeenWalletV4TourSelector);
+  const { isDrawerOpen, handleOpenDrawer, handleCloseDrawer } = useWalletV4TourDrawer();
 
   const handleToggleHasSeenTour = useCallback(() => {
     dispatch(setHasSeenWalletV4Tour(!hasSeenTour));
   }, [dispatch, hasSeenTour]);
-
-  const handleOpenDrawer = useCallback(() => {
-    // TODO: Implement drawer opening
-  }, []);
 
   return (
     <Flex flex={1}>
@@ -73,6 +71,7 @@ function WalletV4TourScreenDebug() {
           {"Open Drawer"}
         </Button>
       </Flex>
+      <WalletV4TourDrawer isDrawerOpen={isDrawerOpen} handleCloseDrawer={handleCloseDrawer} />
     </Flex>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Drawer/__integrations__/walletV4TourDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Drawer/__integrations__/walletV4TourDrawer.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Button } from "react-native";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import { useWalletV4TourDrawer, WalletV4TourDrawer } from "../index";
+
+const TestComponent = () => {
+  const { isDrawerOpen, handleOpenDrawer, handleCloseDrawer } = useWalletV4TourDrawer();
+  return (
+    <>
+      <Button onPress={handleOpenDrawer} title="Open Drawer" />
+      <WalletV4TourDrawer isDrawerOpen={isDrawerOpen} handleCloseDrawer={handleCloseDrawer} />
+    </>
+  );
+};
+
+describe("WalletV4TourDrawer integration", () => {
+  it("should persist seen state when closed", async () => {
+    const { store, user } = render(<TestComponent />, {
+      overrideInitialState: state => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          hasSeenWalletV4Tour: false,
+        },
+      }),
+    });
+
+    await user.press(screen.getByText("Open Drawer"));
+
+    const closeButton = await screen.findByTestId("drawer-close-button");
+    await user.press(closeButton);
+
+    await waitFor(() => expect(store.getState().settings.hasSeenWalletV4Tour).toBe(true));
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Drawer/hooks/useWalletV4TourDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Drawer/hooks/useWalletV4TourDrawerViewModel.ts
@@ -1,0 +1,29 @@
+import { useState, useCallback } from "react";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { setHasSeenWalletV4Tour } from "~/actions/settings";
+import { hasSeenWalletV4TourSelector } from "~/reducers/settings";
+import type { WalletV4TourDrawerViewModel } from "../types";
+
+export const useWalletV4TourDrawerViewModel = (): WalletV4TourDrawerViewModel => {
+  const dispatch = useDispatch();
+  const hasSeenTour = useSelector(hasSeenWalletV4TourSelector);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  const handleOpenDrawer = useCallback(() => {
+    if (hasSeenTour) return;
+    setIsDrawerOpen(true);
+  }, [hasSeenTour]);
+
+  const handleCloseDrawer = useCallback(() => {
+    setIsDrawerOpen(false);
+    if (!hasSeenTour) {
+      dispatch(setHasSeenWalletV4Tour(true));
+    }
+  }, [dispatch, hasSeenTour]);
+
+  return {
+    isDrawerOpen,
+    handleOpenDrawer,
+    handleCloseDrawer,
+  };
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Drawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Drawer/index.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Flex } from "@ledgerhq/native-ui";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import QueuedDrawerGorhom from "../../../components/QueuedDrawer/temp/QueuedDrawerGorhom";
+import { useWalletV4TourDrawerViewModel } from "./hooks/useWalletV4TourDrawerViewModel";
+
+export const useWalletV4TourDrawer = () => {
+  return useWalletV4TourDrawerViewModel();
+};
+
+export const WalletV4TourDrawer = ({
+  isDrawerOpen,
+  handleCloseDrawer,
+}: {
+  isDrawerOpen: boolean;
+  handleCloseDrawer: () => void;
+}) => {
+  const { bottom: bottomInset } = useSafeAreaInsets();
+
+  return (
+    <QueuedDrawerGorhom
+      isRequestingToBeOpened={isDrawerOpen}
+      onClose={handleCloseDrawer}
+      snapPoints={["92%"]}
+      noCloseButton={false}
+    >
+      <Flex flex={1} style={{ paddingBottom: bottomInset }}>
+        {/* add the slides here */}
+      </Flex>
+    </QueuedDrawerGorhom>
+  );
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Drawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Drawer/types.ts
@@ -1,0 +1,5 @@
+export interface WalletV4TourDrawerViewModel {
+  readonly isDrawerOpen: boolean;
+  readonly handleOpenDrawer: () => void;
+  readonly handleCloseDrawer: () => void;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Add Wallet V4 Tour drawer shell (local state, MVVM) with 90% height and close persistence (hasSeenWalletV4Tour).
- Wire debug entry point to open/close the drawer.
- Add integration test for open → close → persistence.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25318]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


https://github.com/user-attachments/assets/ccdc0ca0-7dea-41d8-98ad-d50f7f80ceec


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25318]: https://ledgerhq.atlassian.net/browse/LIVE-25318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ