### PR TITLE
fix(LIVE-25564): correct sync backup deletion copy

### DIFF
--- a/.changeset/selfish-mugs-compete.md
+++ b/.changeset/selfish-mugs-compete.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: correct the sync backup deletion copy

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/BackupDeleted.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/BackupDeleted.test.tsx
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import BackupDeleted from "../screens/ManageBackup/02-FinalStep";
+
+describe("BackupDeleted", () => {
+  it("should show delete backup success message, not Sync complete", () => {
+    render(<BackupDeleted isSuccessful />);
+
+    expect(screen.getByText("Your Ledger Wallet apps are no longer synced")).toBeInTheDocument();
+    expect(screen.getByText("You can turn on sync anytime")).toBeInTheDocument();
+    expect(screen.queryByText("Sync complete")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/screens/ManageBackup/02-FinalStep.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/screens/ManageBackup/02-FinalStep.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Success } from "../../components/Success";
+import { GenericStatusDisplay } from "../../components/GenericStatusDisplay";
 import { useTranslation } from "react-i18next";
 import { Flex } from "@ledgerhq/react-ui";
 import { Error } from "../../components/Error";
@@ -26,12 +26,13 @@ export default function BackupDeleted({ isSuccessful }: BackupDeletedProps) {
   return (
     <Flex flexDirection="column" alignItems="center" justifyContent="center" height="100%">
       {isSuccessful ? (
-        <Success
+        <GenericStatusDisplay
           title={t("walletSync.manageBackup.deleteBackupSuccess.title")}
           description={t("walletSync.manageBackup.deleteBackupSuccess.description")}
           withClose
           onClose={onClose}
           analyticsPage={AnalyticsPage.BackupDeleted}
+          type="success"
           testId="walletsync-delete-backup-success-title"
         />
       ) : (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**

### 📝 Description

**Problem:** With lwdLedgerSyncOptimisation enabled, the Ledger Sync success screen always showed "Sync complete, from now on your portfolio will automatically stay synced across all your devices" after deleting a backup, instead of the correct copy.

**Solution:** Use GenericStatusDisplay directly in BackupDeleted (ManageBackup 02-FinalStep) so they always show the right title/description. No changes to Success; the correct message is chosen at the call site.

Before | After
-- | --
<img width="425" height="296" alt="Screenshot 2026-02-03 at 12 12 55" src="https://github.com/user-attachments/assets/154b875c-bc96-4632-a8fc-3ce6e8291979" /> | <img width="433" height="341" alt="Screenshot 2026-02-03 at 12 12 35" src="https://github.com/user-attachments/assets/f15fe12f-bc9a-49a6-94b7-54daf44428b9" />


### ❓ Context

JIRA or GitHub link: [LIVE-25564](https://ledgerhq.atlassian.net/browse/LIVE-25564)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25564]: https://ledgerhq.atlassian.net/browse/LIVE-25564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ