### PR TITLE
fix term of use drawer

### DIFF
--- a/.changeset/hungry-cats-rescue.md
+++ b/.changeset/hungry-cats-rescue.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-wallet": minor
+---
+
+fix term of use drawer

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -168,6 +168,7 @@ export const INITIAL_STATE: SettingsState = {
   isOnboardingFlow: false,
   isOnboardingFlowReceiveSuccess: false,
   isPostOnboardingFlow: false,
+  generalTermsVersionAccepted: undefined,
   hasSeenWalletV4Tour: false,
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Cause
generalTermsVersionAccepted wasn’t part of INITIAL_STATE, so it got filtered out during importSettings and lost on every app start — the Terms of Use drawer kept reopening.
Fix
Add generalTermsVersionAccepted: undefined to INITIAL_STATE so the persisted value is kept and the drawer no longer appears on each launch.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25743]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


https://github.com/user-attachments/assets/014930e1-d2cf-43dd-9b66-4214c0f66f57


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25743]: https://ledgerhq.atlassian.net/browse/LIVE-25743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ