### PR TITLE
fix(desktop): Expose DMK context in renderer for E2E tests

### DIFF
--- a/.changeset/light-falcons-repeat.md
+++ b/.changeset/light-falcons-repeat.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-dmk-speculos": patch
+---
+
+Expose DMK context in renderer for E2E


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Enables DMK-based signers to work in Speculos E2E tests by exposing the DMK context directly in the renderer process.

**Problem:** E2E tests previously routed Speculos through IPC to the main process, which only forwarded APDU exchanges without exposing dmk and sessionId properties. 

**Solution:** Added a direct `DeviceManagementKitTransportSpeculos` path in the renderer when `SPECULOS_API_PORT` is set, making DMK properties accessible to signers. 



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
