### PR TITLE
Feat/live 24578 n ledger

### DIFF
--- a/.changeset/fluffy-zoos-joke.md
+++ b/.changeset/fluffy-zoos-joke.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): quick actions with no ledger device

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -116,6 +116,10 @@ describe("PortfolioView", () => {
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+          },
         },
       });
 
@@ -132,6 +136,10 @@ describe("PortfolioView", () => {
       const { user } = render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+          },
         },
       });
 
@@ -144,11 +152,31 @@ describe("PortfolioView", () => {
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
         initialState: {
           accounts: [],
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+          },
         },
       });
 
       expect(screen.getByTestId("no-balance-title")).toBeVisible();
       expect(screen.queryByTestId("portfolio-balance")).toBeNull();
+    });
+
+    it("should render NoDeviceView when user has not completed onboarding", () => {
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+        initialState: {
+          accounts: [],
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: false,
+          },
+        },
+      });
+
+      expect(screen.getByTestId("no-device-title")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-balance")).toBeNull();
+      expect(screen.queryByTestId("no-balance-title")).toBeNull();
     });
     it("should display discreet placeholders when discreet mode is enabled", () => {
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
@@ -156,6 +184,7 @@ describe("PortfolioView", () => {
           accounts: [BTC_ACCOUNT],
           settings: {
             ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
             discreetMode: true,
           },
         },
@@ -172,6 +201,7 @@ describe("PortfolioView", () => {
           accounts: [BTC_ACCOUNT],
           settings: {
             ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
             discreetMode: false,
           },
         },
@@ -190,6 +220,10 @@ describe("PortfolioView", () => {
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+          },
         },
       });
 
@@ -204,6 +238,10 @@ describe("PortfolioView", () => {
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+          },
         },
       });
 
@@ -217,6 +255,10 @@ describe("PortfolioView", () => {
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+          },
         },
       });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/NoDeviceView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/NoDeviceView.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+export const NoDeviceView = () => {
+  const { t } = useTranslation();
+  return (
+    <span data-testid="no-device-title" className="heading-1-semi-bold text-base">
+      {t("portfolio.noDeviceTitle")}
+    </span>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/index.tsx
@@ -2,9 +2,18 @@ import React from "react";
 import { useBalanceViewModel } from "../../hooks/useBalanceViewModel";
 import { BalanceView } from "./BalanceView";
 import { NoBalanceView } from "./NoBalanceView";
+import { NoDeviceView } from "./NoDeviceView";
 
 export const Balance = () => {
-  const { hasFunds, ...viewModel } = useBalanceViewModel();
+  const { hasFunds, hasCompletedOnboarding, ...viewModel } = useBalanceViewModel();
 
-  return hasFunds ? <BalanceView {...viewModel} /> : <NoBalanceView />;
+  if (!hasCompletedOnboarding) {
+    return <NoDeviceView />;
+  }
+
+  if (!hasFunds) {
+    return <NoBalanceView />;
+  }
+
+  return <BalanceView {...viewModel} />;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
@@ -13,4 +13,5 @@ export interface BalanceViewProps {
 
 export type BalanceViewModelResult = BalanceViewProps & {
   readonly hasFunds: boolean;
+  readonly hasCompletedOnboarding: boolean;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -6,6 +6,7 @@ import {
   selectedTimeRangeSelector,
   localeSelector,
   discreetModeSelector,
+  hasCompletedOnboardingSelector,
 } from "~/renderer/reducers/settings";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { useAccountStatus } from "LLD/hooks/useAccountStatus";
@@ -35,6 +36,7 @@ export const useBalanceViewModel = (
   const locale = useSelector(localeSelector);
   const discreet = useSelector(discreetModeSelector);
   const { hasFunds } = useAccountStatus();
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
 
   const range = useLegacyRange ? selectedTimeRange : NEW_FLOW_RANGE;
 
@@ -88,5 +90,6 @@ export const useBalanceViewModel = (
     navigateToAnalytics,
     handleKeyDown,
     hasFunds,
+    hasCompletedOnboarding,
   };
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
@@ -8,9 +8,14 @@ import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import BigNumber from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
+import { urls } from "~/config/urls";
+import { openURL } from "~/renderer/linking";
 
 jest.mock("LLD/features/Send/hooks/useOpenSendFlow");
 jest.mock("LLD/features/ModularDialog/hooks/useOpenAssetFlow");
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
+}));
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
   useNavigate: jest.fn(),
@@ -22,6 +27,7 @@ const mockOpenSendFlow = jest.fn();
 const mockOpenAssetFlow = jest.fn();
 const mockOpenAddAccountFlow = jest.fn();
 
+const mockOpenURL = openURL as jest.MockedFunction<typeof openURL>;
 const mockUseOpenSendFlow = useOpenSendFlow as jest.MockedFunction<typeof useOpenSendFlow>;
 const mockUseOpenAssetFlow = useOpenAssetFlow as jest.MockedFunction<typeof useOpenAssetFlow>;
 const mockUseNavigate = useNavigate as jest.MockedFunction<typeof useNavigate>;
@@ -71,7 +77,10 @@ describe("useQuickActions", () => {
   describe("actions structure", () => {
     it("should return receive action with ArrowDown icon", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       const receiveAction = result.current.actionsList[0];
@@ -82,7 +91,10 @@ describe("useQuickActions", () => {
 
     it("should return buy action with Plus icon", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       const buyAction = result.current.actionsList[1];
@@ -93,7 +105,10 @@ describe("useQuickActions", () => {
 
     it("should return sell action with Minus icon", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       const sellAction = result.current.actionsList[2];
@@ -103,7 +118,10 @@ describe("useQuickActions", () => {
 
     it("should return send action with ArrowUp icon", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       const sendAction = result.current.actionsList[3];
@@ -116,7 +134,10 @@ describe("useQuickActions", () => {
   describe("sell action disabled state", () => {
     it("should disable sell action when no accounts exist", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [] },
+        initialState: {
+          accounts: [],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       const sellAction = result.current.actionsList[2];
@@ -125,7 +146,10 @@ describe("useQuickActions", () => {
 
     it("should disable sell action when all accounts are empty", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createEmptyAccount()] },
+        initialState: {
+          accounts: [createEmptyAccount()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       const sellAction = result.current.actionsList[2];
@@ -134,7 +158,10 @@ describe("useQuickActions", () => {
 
     it("should enable sell action when accounts have funds", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       const sellAction = result.current.actionsList[2];
@@ -143,7 +170,10 @@ describe("useQuickActions", () => {
 
     it("should enable sell action when at least one account has funds", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createEmptyAccount(), createAccountWithFunds()] },
+        initialState: {
+          accounts: [createEmptyAccount(), createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       const sellAction = result.current.actionsList[2];
@@ -154,7 +184,10 @@ describe("useQuickActions", () => {
   describe("onReceive action", () => {
     it("should open receive modal when user has accounts", () => {
       const { result, store } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       act(() => {
@@ -168,7 +201,10 @@ describe("useQuickActions", () => {
 
     it("should call openAssetFlow when user has no accounts", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [] },
+        initialState: {
+          accounts: [],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       act(() => {
@@ -180,7 +216,10 @@ describe("useQuickActions", () => {
 
     it("should not open receive modal when user has no accounts", () => {
       const { result, store } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [] },
+        initialState: {
+          accounts: [],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       act(() => {
@@ -194,7 +233,10 @@ describe("useQuickActions", () => {
       mockUseLocation.mockReturnValue(createLocation("/accounts"));
 
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       act(() => {
@@ -208,7 +250,10 @@ describe("useQuickActions", () => {
       mockUseLocation.mockReturnValue(createLocation("/manager"));
 
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       act(() => {
@@ -222,7 +267,10 @@ describe("useQuickActions", () => {
   describe("onBuy action", () => {
     it("should navigate to exchange with buy mode", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       act(() => {
@@ -238,7 +286,10 @@ describe("useQuickActions", () => {
   describe("onSell action", () => {
     it("should navigate to exchange with sell mode", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       act(() => {
@@ -254,7 +305,10 @@ describe("useQuickActions", () => {
   describe("onSend action", () => {
     it("should open send flow when triggered", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       act(() => {
@@ -268,7 +322,10 @@ describe("useQuickActions", () => {
       mockUseLocation.mockReturnValue(createLocation("/accounts"));
 
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       act(() => {
@@ -283,7 +340,10 @@ describe("useQuickActions", () => {
       mockUseLocation.mockReturnValue(createLocation("/manager"));
 
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createAccountWithFunds()] },
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       act(() => {
@@ -296,7 +356,10 @@ describe("useQuickActions", () => {
 
     it("should disable send action when no accounts exist", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [] },
+        initialState: {
+          accounts: [],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       const sendAction = result.current.actionsList[3];
@@ -305,11 +368,62 @@ describe("useQuickActions", () => {
 
     it("should enable send action when all accounts are empty", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
-        initialState: { accounts: [createEmptyAccount()] },
+        initialState: {
+          accounts: [createEmptyAccount()],
+          settings: { hasCompletedOnboarding: true },
+        },
       });
 
       const sendAction = result.current.actionsList[3];
       expect(sendAction.disabled).toBe(false);
+    });
+  });
+
+  describe("when onboarding is not completed", () => {
+    it("should return only connect and buy a ledger actions", () => {
+      const { result } = renderHook(() => useQuickActions(trackingPageName), {
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: false },
+        },
+      });
+
+      const actionTitles = result.current.actionsList.map(action => action.title);
+      expect(actionTitles).toHaveLength(2);
+      expect(actionTitles).toContain("Connect");
+      expect(actionTitles).toContain("Buy a Ledger");
+    });
+
+    it("should open connect device modal when connect action is triggered", () => {
+      const { result, store } = renderHook(() => useQuickActions(trackingPageName), {
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: false },
+        },
+      });
+
+      act(() => {
+        result.current.actionsList[0].onAction();
+      });
+
+      expect(store.getState().modals).toMatchObject({
+        MODAL_CONNECT_DEVICE: { isOpened: true },
+      });
+    });
+
+    it("should open ledger shop when buy a ledger action is triggered", () => {
+      const { result } = renderHook(() => useQuickActions(trackingPageName), {
+        initialState: {
+          accounts: [createAccountWithFunds()],
+          settings: { hasCompletedOnboarding: false },
+        },
+      });
+
+      act(() => {
+        result.current.actionsList[1].onAction();
+      });
+
+      expect(mockOpenURL).toHaveBeenCalledWith(urls.ledgerShop);
     });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
@@ -1,15 +1,26 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
 import { openModal } from "~/renderer/actions/modals";
-import { useDispatch } from "LLD/hooks/redux";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useLocation, useNavigate } from "react-router";
-import { ArrowDown, Plus, Minus, ArrowUp } from "@ledgerhq/lumen-ui-react/symbols";
+import {
+  ArrowDown,
+  Plus,
+  Minus,
+  ArrowUp,
+  LedgerLogo,
+  Cart,
+} from "@ledgerhq/lumen-ui-react/symbols";
 import { useTranslation } from "react-i18next";
 import { useAccountStatus } from "LLD/hooks/useAccountStatus";
 import { QuickAction } from "../types";
 import { useOpenAssetFlow } from "../../ModularDialog/hooks/useOpenAssetFlow";
 import { ModularDrawerLocation } from "../../ModularDrawer";
 import { track } from "~/renderer/analytics/segment";
+import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
+import { urls } from "~/config/urls";
+import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
+import { openURL } from "~/renderer/linking";
 
 export const useQuickActions = (trackingPageName: string): { actionsList: QuickAction[] } => {
   const openSendFlow = useOpenSendFlow();
@@ -18,6 +29,9 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
   const location = useLocation();
   const { t } = useTranslation();
   const { hasAccount, hasFunds } = useAccountStatus();
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const urlLedgerShop = useLocalizedUrl(urls.ledgerShop);
+  const openLedgerShop = useCallback(() => openURL(urlLedgerShop), [urlLedgerShop]);
 
   const { openAssetFlow } = useOpenAssetFlow(
     { location: ModularDrawerLocation.ADD_ACCOUNT },
@@ -89,8 +103,46 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
     });
   }, [navigate, trackingPageName]);
 
-  return {
-    actionsList: [
+  const onConnect = useCallback(() => {
+    track("button_clicked", {
+      button: "quick_action",
+      flow: "connect",
+      page: trackingPageName,
+    });
+
+    dispatch(openModal("MODAL_CONNECT_DEVICE", { onResult: () => {} }));
+  }, [dispatch, trackingPageName]);
+
+  const onBuyALedger = useCallback(() => {
+    track("button_clicked", {
+      button: "quick_action",
+      flow: "buy_ledger",
+      page: trackingPageName,
+    });
+    openLedgerShop();
+  }, [trackingPageName, openLedgerShop]);
+
+  const actionsList = useMemo((): QuickAction[] => {
+    if (!hasCompletedOnboarding) {
+      return [
+        {
+          title: t("quickActions.connect"),
+          onAction: onConnect,
+          icon: LedgerLogo,
+          disabled: false,
+          buttonAppearance: "base",
+        },
+        {
+          title: t("quickActions.buyALedger"),
+          onAction: onBuyALedger,
+          icon: Cart,
+          disabled: false,
+          buttonAppearance: "transparent",
+        },
+      ];
+    }
+
+    return [
       {
         title: t("quickActions.receive"),
         onAction: onReceive,
@@ -119,6 +171,9 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
         disabled: !hasAccount,
         buttonAppearance: "transparent",
       },
-    ],
-  };
+    ];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasCompletedOnboarding, hasFunds, hasAccount]);
+
+  return { actionsList };
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/types.ts
@@ -1,7 +1,25 @@
+import type {
+  ArrowDown,
+  Plus,
+  Minus,
+  ArrowUp,
+  LedgerLogo,
+  Cart,
+} from "@ledgerhq/lumen-ui-react/symbols";
+
+// Use the actual type from lumen-ui-react symbols
+export type IconComponent =
+  | typeof ArrowDown
+  | typeof Plus
+  | typeof Minus
+  | typeof ArrowUp
+  | typeof LedgerLogo
+  | typeof Cart;
+
 export type QuickAction = {
   title: string;
   onAction: () => void;
-  icon: React.ComponentType;
+  icon: IconComponent;
   disabled: boolean;
   buttonAppearance?: "base" | "transparent";
 };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7873,7 +7873,8 @@
     "title": "Home",
     "today": "Today",
     "addAccountCta": "Add crypto account",
-    "noBalanceTitle": "Secure your crypto"
+    "noBalanceTitle": "Secure your crypto",
+    "noDeviceTitle": "The most secure wallet"
   },
   "marketBanner": {
     "title": "Explore market",


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a new "No Device" view and updates the logic for displaying balance and quick actions in the portfolio, especially for users who have not completed onboarding (i.e., have not set up a Ledger device). It also ensures that tests and view models correctly handle the onboarding state throughout the portfolio and quick actions features.

https://github.com/user-attachments/assets/d4ce556c-325c-41f8-9d77-41106d1b2c7a


### ❓ Context

[LIVE-24578](https://ledgerhq.atlassian.net/browse/LIVE-24578)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
