### PR TITLE
ci: pin prototools version

### DIFF
--- a/tools/actions/composites/setup-caches/action.yml
+++ b/tools/actions/composites/setup-caches/action.yml
@@ -47,6 +47,8 @@ runs:
     - name: Setup proto
       if: inputs.install-proto == 'true'
       uses: moonrepo/setup-toolchain@v0
+      with:
+        proto-version: "0.55.2"
 
     - name: Update proto
       if: inputs.upgrade-proto == 'true'


### PR DESCRIPTION
Pin prototools to stable version for github hosted runners

Green run: https://github.com/LedgerHQ/ledger-live/actions/runs/21667802231/job/62467663763