### PR TITLE
test(e2e): lwm update deeplink tests

### DIFF
--- a/apps/ledger-live-mobile/src/icons/ArrowLeft.tsx
+++ b/apps/ledger-live-mobile/src/icons/ArrowLeft.tsx
@@ -4,10 +4,11 @@ import Svg, { Path } from "react-native-svg";
 type Props = {
   size: number;
   color: string;
+  testID?: string;
 };
-export default function ArrowLeft({ size = 16, color }: Props) {
+export default function ArrowLeft({ size = 16, color, testID }: Props) {
   return (
-    <Svg viewBox="0 0 16 16" width={size} height={size}>
+    <Svg viewBox="0 0 16 16" width={size} height={size} testID={testID}>
       <Path
         fill={color}
         d="M3.117 7.913l4.529 4.528a.913.913 0 0 1-1.292 1.292L.267 7.646a.913.913 0 0 1 0-1.292L6.354.267A.913.913 0 1 1 7.646 1.56L3.117 6.087h9.97a.913.913 0 1 1 0 1.826h-9.97z"

--- a/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/AppCard.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/AppCard.tsx
@@ -122,7 +122,10 @@ export const AppCard = memo(({ manifest, onPress }: Props) => {
           ]}
         >
           <AppIcon isDisabled={isDisabled} size={52} name={manifest.name} icon={manifest.icon} />
-          <View style={styles.content}>
+          <View
+            style={styles.content}
+            testID={`catalog-app-card-${manifest.name.trim().toLowerCase()}`}
+          >
             <View style={styles.header}>
               <LText
                 variant="h3"

--- a/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/Search/SearchBar.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/Search/SearchBar.tsx
@@ -18,7 +18,7 @@ export function SearchBar({
             flexGrow: 1,
             width: 100,
           }}
-          data-testid="platform-catalog-search-input"
+          testID="platform-catalog-search-input"
           ref={inputRef}
           value={input}
           onChange={onChange}

--- a/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/Search/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/Search/index.tsx
@@ -84,7 +84,7 @@ export function Search({ title, disclaimer, search }: Props) {
             style={{ paddingVertical: 16 }}
             onPress={search.onCancel}
           >
-            <ArrowLeft size={18} color={colors.neutral.c100} />
+            <ArrowLeft size={18} color={colors.neutral.c100} testID="catalog-search-arrow-left" />
           </TouchableOpacity>
         }
         searchContent={<SearchBar search={search} />}

--- a/e2e/mobile/page/discover/discover.page.ts
+++ b/e2e/mobile/page/discover/discover.page.ts
@@ -2,50 +2,68 @@ import { Step } from "jest-allure2-reporter/api";
 import { log } from "detox";
 import { openDeeplink } from "../../helpers/commonHelpers";
 
+const discoverApps = [
+  { name: "MoonPay", url: "https://www.moonpay.com/" },
+  { name: "Ramp", url: "https://rampnetwork.com/buy-crypto" },
+  { name: "Kiln", url: "https://kiln.fi" },
+  { name: "Lido", url: "https://lido.fi/" },
+  // { name: "1inch", url: "https://1inch.com/" }, // QAA-997
+  { name: "Zerion", url: "https://zerion.io/" },
+  { name: "Transak", url: "https://transak.com" },
+] as const;
+
+export type DiscoverAppName = (typeof discoverApps)[number]["name"];
+
 export default class DiscoverPage {
-  discoverApps = [
-    // for some reason there is a space before the URL so this is required
-    { name: "MoonPay", url: " https://www.moonpay.com/" },
-    { name: "Ramp", url: " https://ramp.network/buy" },
-    { name: "ParaSwap", url: " https://paraswap.io" },
-    { name: "Kiln", url: " https://kiln.fi" },
-    { name: "Lido", url: " https://lido.fi/" },
-    { name: "1inch", url: " https://1inch.com/" },
-    { name: "BTCDirect", url: " https://btcdirect.eu/" },
-    { name: "Banxa", url: " https://banxa.com/" },
-    { name: "Bitrefill", url: " https://bitrefill.com" },
-    { name: "Zerion", url: " https://zerion.io/" },
-    { name: "Yearn", url: " https://beta.yearn.fi" },
-    { name: "Transak", url: " https://transak.com" },
-  ];
+  discoverApps = discoverApps;
   baseLink = "discover/";
   discoverPageHeader = () => getElementById("discover-banner");
   liveAppTitle = () => getElementById("live-app-title");
+  catalogSearchArrowLeft = () => getElementById("catalog-search-arrow-left");
+  catalogSearchBar = () => getElementById("platform-catalog-search-input");
+  catalogAppCard = (appName: DiscoverAppName) =>
+    getElementById(new RegExp(`catalog-app-card-${appName.trim().toLowerCase()}.*`));
 
   @Step("Get live App")
-  getRandomLiveApp() {
+  getRandomLiveApp(): DiscoverAppName {
     const app = this.discoverApps[Math.floor(Math.random() * this.discoverApps.length)].name;
     log.info(`Selected Live app: ${app}`);
     return app;
   }
 
   @Step("Open discover page via deeplink")
-  async openViaDeeplink(discoverApps = "") {
-    await openDeeplink(this.baseLink + discoverApps);
+  async openViaDeeplink(appName?: DiscoverAppName) {
+    await openDeeplink(this.baseLink + (appName ?? ""));
   }
 
-  getAppUrl(name: string) {
-    const app = this.discoverApps.find(app => app.name === name);
-    return app ? app.url : "App not found";
+  getAppUrl(name: DiscoverAppName) {
+    const app = this.discoverApps.find(app => app.name === name)!;
+    return app.url;
   }
 
   @Step("Expect live app title")
-  async expectApp(app: string) {
-    await detoxExpect(this.liveAppTitle()).toHaveText(this.getAppUrl(app));
+  async expectApp(app: DiscoverAppName) {
+    // space is required as it is part of the element text
+    await detoxExpect(this.liveAppTitle()).toHaveText(` ${this.getAppUrl(app)}`);
   }
 
   @Step("Expect discover page")
   async expectDiscoverPage() {
     await detoxExpect(this.discoverPageHeader()).toBeVisible();
+  }
+
+  @Step("Type in catalog search bar")
+  async typeInCatalogSearchBar(text: string) {
+    await typeTextByElement(this.catalogSearchBar(), text);
+  }
+
+  @Step("Go back from catalog search")
+  async goBackFromCatalogSearch() {
+    await tapByElement(this.catalogSearchArrowLeft());
+  }
+
+  @Step("Expect catalog app card")
+  async expectCatalogAppCard(appName: DiscoverAppName) {
+    await detoxExpect(this.catalogAppCard(appName)).toBeVisible();
   }
 }

--- a/e2e/mobile/specs/deeplinks.spec.ts
+++ b/e2e/mobile/specs/deeplinks.spec.ts
@@ -10,6 +10,7 @@ describe("DeepLinks Tests", () => {
   const nanoApp = AppInfos.ETHEREUM;
   const ethereumLong = "ethereum";
   const bitcoinLong = "bitcoin";
+  const randomLiveApp = app.discover.getRandomLiveApp();
 
   beforeAll(async () => {
     await app.init({
@@ -69,17 +70,24 @@ describe("DeepLinks Tests", () => {
     await app.customLockscreen.expectCustomLockscreenPage();
   });
 
-  (isSmokeTestRun ? it.skip : it)("should open the Discover page", async () => {
-    await app.discover.openViaDeeplink();
-    await app.discover.expectDiscoverPage();
-  });
+  (isSmokeTestRun ? it.skip : it)(
+    `should open the Discover page and search for ${randomLiveApp}`,
+    async () => {
+      await app.discover.openViaDeeplink();
+      await app.discover.typeInCatalogSearchBar(randomLiveApp);
+      await app.discover.expectCatalogAppCard(randomLiveApp);
+      await app.discover.goBackFromCatalogSearch();
+      await app.discover.expectDiscoverPage();
+    },
+  );
 
-  (isSmokeTestRun ? it.skip : it)(`should open discovery to random live App`, async () => {
-    // Opening only one random liveApp to avoid flakiness
-    const randomLiveApp = app.discover.getRandomLiveApp();
-    await app.discover.openViaDeeplink(randomLiveApp);
-    await app.discover.expectApp(randomLiveApp);
-  });
+  (isSmokeTestRun ? it.skip : it)(
+    `should open discovery to ${randomLiveApp} live App`,
+    async () => {
+      await app.discover.openViaDeeplink(randomLiveApp);
+      await app.discover.expectApp(randomLiveApp);
+    },
+  );
 
   (isSmokeTestRun ? it.skip : it)("should open Swap Form page", async () => {
     await app.swap.openViaDeeplink();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* Yearn app is not listed anymore
* Other removed apps are crashing when opened on Android, discussed with Gabriel and we do not need to validate those
* 1inch is also crashing but it is important to test so I opened QAA-997 to investigate
* On Android, when opening via Deeplink, the discovery app screen opens with focus on search field, causing a different UI and failing, as a solution I performed a search and click back to do the validation This added about 3 more seconds to the test

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [QAA-995](https://ledgerhq.atlassian.net/browse/QAA-995)
- [CI](https://github.com/LedgerHQ/ledger-live/actions/runs/21708959475)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
