### PR TITLE
feat(desktop): show portfolio balance when user has accounts with zero balance

### DIFF
--- a/.changeset/rotten-scissors-brush.md
+++ b/.changeset/rotten-scissors-brush.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Show portfolio balance (0,00) when user has accounts with zero balance

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -7,7 +7,7 @@ import { Portfolio } from "@ledgerhq/types-live";
 import { PortfolioView } from "../PortfolioView";
 import * as portfolioReact from "@ledgerhq/live-countervalues-react/portfolio";
 import { useNavigate } from "react-router";
-import { BTC_ACCOUNT } from "../../__mocks__/accounts.mock";
+import { BTC_ACCOUNT, EMPTY_BTC_ACCOUNT } from "../../__mocks__/accounts.mock";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
 
 const MARKET_API_ENDPOINT = "https://countervalues.live.ledger.com/v3/markets";
@@ -161,6 +161,20 @@ describe("PortfolioView", () => {
 
       expect(screen.getByTestId("no-balance-title")).toBeVisible();
       expect(screen.queryByTestId("portfolio-balance")).toBeNull();
+    });
+
+    it("should render BalanceView when user has accounts but no funds", () => {
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+        initialState: {
+          accounts: [EMPTY_BTC_ACCOUNT],
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+          },
+        },
+      });
+
+      expect(screen.queryByTestId("portfolio-balance")).toBeVisible();
     });
 
     it("should render NoDeviceView when user has not completed onboarding", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/index.tsx
@@ -5,13 +5,13 @@ import { NoBalanceView } from "./NoBalanceView";
 import { NoDeviceView } from "./NoDeviceView";
 
 export const Balance = () => {
-  const { hasFunds, hasCompletedOnboarding, ...viewModel } = useBalanceViewModel();
+  const { hasFunds, hasCompletedOnboarding, hasAccount, ...viewModel } = useBalanceViewModel();
 
   if (!hasCompletedOnboarding) {
     return <NoDeviceView />;
   }
 
-  if (!hasFunds) {
+  if (!hasAccount) {
     return <NoBalanceView />;
   }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
@@ -13,5 +13,6 @@ export interface BalanceViewProps {
 
 export type BalanceViewModelResult = BalanceViewProps & {
   readonly hasFunds: boolean;
+  readonly hasAccount: boolean;
   readonly hasCompletedOnboarding: boolean;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -35,7 +35,7 @@ export const useBalanceViewModel = (
   const selectedTimeRange = useSelector(selectedTimeRangeSelector);
   const locale = useSelector(localeSelector);
   const discreet = useSelector(discreetModeSelector);
-  const { hasFunds } = useAccountStatus();
+  const { hasFunds, hasAccount } = useAccountStatus();
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
 
   const range = useLegacyRange ? selectedTimeRange : NEW_FLOW_RANGE;
@@ -90,6 +90,7 @@ export const useBalanceViewModel = (
     navigateToAnalytics,
     handleKeyDown,
     hasFunds,
+    hasAccount,
     hasCompletedOnboarding,
   };
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/__mocks__/accounts.mock.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/__mocks__/accounts.mock.ts
@@ -71,6 +71,12 @@ export const ETH_ACCOUNT_2 = genAccount("ethereum-2", {
 export const BTC_ACCOUNT = genAccount("bitcoin-1", {
   currency: bitcoinCurrency,
 });
+
+export const EMPTY_BTC_ACCOUNT = genAccount("bitcoin-empty", {
+  currency: bitcoinCurrency,
+  operationsSize: 0,
+});
+
 export const ARB_ACCOUNT = genAccount("arbitrum-1", {
   currency: arbitrumCurrency,
   tokenIds: ["arbitrum/erc20/arbitrum"],


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio balance section rendering
  - Behavior with no accounts vs accounts with zero balance
  - Onboarding / no-device states

### 📝 Description

**Problem:** When users had at least one account but all accounts had zero balance, the portfolio could show the "no balance" empty state instead of the actual total balance (0,00).

**Solution:** The Balance component now uses `hasAccount` from the viewModel so that:
- **No accounts** → `NoBalanceView` (unchanged)
- **Has accounts (including zero balance)** → `BalanceView` with the total balance, showing 0,00 when all accounts are empty

Implementation details:
- `useBalanceViewModel` exposes `hasAccount` (from `useAccountStatus`) in addition to `hasFunds` and `hasCompletedOnboarding`
- Balance container shows `NoBalanceView` only when `!hasAccount`; when the user has at least one account, `BalanceView` is always shown so the balance (including 0,00) is displayed
- Added `EMPTY_BTC_ACCOUNT` fixture (`genAccount` with `operationsSize: 0`) and an integration test that asserts BalanceView is visible when the user has accounts but no funds

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25833](https://ledgerhq.atlassian.net/browse/LIVE-25833)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
