### PR TITLE
fix(desktop): disable Send quick action when user has no funds

### DIFF
--- a/.changeset/violet-geckos-invent.md
+++ b/.changeset/violet-geckos-invent.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Send button is not greyed when accounts with no funds

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
@@ -366,10 +366,22 @@ describe("useQuickActions", () => {
       expect(sendAction.disabled).toBe(true);
     });
 
-    it("should enable send action when all accounts are empty", () => {
+    it("should disable send action when user has no funds", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createEmptyAccount()],
+          settings: { hasCompletedOnboarding: true },
+        },
+      });
+
+      const sendAction = result.current.actionsList[3];
+      expect(sendAction.disabled).toBe(true);
+    });
+
+    it("should enable send action when user has at least one account with funds", () => {
+      const { result } = renderHook(() => useQuickActions(trackingPageName), {
+        initialState: {
+          accounts: [createEmptyAccount(), createAccountWithFunds()],
           settings: { hasCompletedOnboarding: true },
         },
       });

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
@@ -168,7 +168,7 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
         title: t("quickActions.send"),
         onAction: onSend,
         icon: ArrowUp,
-        disabled: !hasAccount,
+        disabled: !hasFunds,
         buttonAppearance: "transparent",
       },
     ];


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Quick Actions Send button state (enabled/disabled)
  - Behavior when user has accounts but no funds vs has funds

### 📝 Description

**Problem:** The Send button in the dashboard Quick Actions stayed enabled when the user had at least one account but all accounts had zero balance. Users could click Send and hit a no-funds flow instead of seeing the button greyed out.

**Solution:** The Send quick action is now disabled based on `hasFunds` instead of `hasAccount`:
- **No funds** (no accounts or all accounts empty) → Send button disabled
- **Has funds** (at least one account with balance > 0) → Send button enabled

Implementation:
- In `useQuickActions`, the Send action uses `disabled: !hasFunds` (from `useAccountStatus`) instead of `disabled: !hasAccount`.
- Tests updated: "should disable send action when user has no funds" (with empty account only) and "should enable send action when user has at least one account with funds" (with mixed empty + funded accounts).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25764](https://ledgerhq.atlassian.net/browse/LIVE-25764)
https://ledgerhq.atlassian.net/browse/LIVE-25764

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
