### PR TITLE
feat(desktop): add analytics for Card page

### DIFF
--- a/.changeset/rare-squids-exist.md
+++ b/.changeset/rare-squids-exist.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add analytics for Card page (page view and button clicks)

--- a/apps/ledger-live-desktop/src/mvvm/features/Card/CardView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Card/CardView.tsx
@@ -12,6 +12,8 @@ import {
   CARD_IMAGE_WIDTH_VIEWPORT_RATIO,
   CARD_SUBTITLE_MAX_WIDTH_PX,
 } from "./constants";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { CARD_TRACKING_PAGE_NAME } from "./constants";
 
 const imageStyle = {
   maxHeight: `min(${CARD_IMAGE_MAX_HEIGHT_PX}px, ${MIN_HEIGHT * CARD_IMAGE_HEIGHT_VIEWPORT_RATIO}px)`,
@@ -31,6 +33,7 @@ export const CardView = memo(function CardView({
 
   return (
     <>
+      <TrackPage category={CARD_TRACKING_PAGE_NAME} />
       <PageHeader title={t("card.title")} />
 
       <div className="my-24 flex flex-col gap-12">

--- a/apps/ledger-live-desktop/src/mvvm/features/Card/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Card/constants.ts
@@ -12,3 +12,4 @@ export const CARD_IMAGE_WIDTH_VIEWPORT_RATIO = 0.45;
 
 /** Max width of the subtitle text block in pixels */
 export const CARD_SUBTITLE_MAX_WIDTH_PX = 330;
+export const CARD_TRACKING_PAGE_NAME = "Card";

--- a/apps/ledger-live-desktop/src/mvvm/features/Card/hooks/useCardViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Card/hooks/useCardViewModel.ts
@@ -1,5 +1,7 @@
 import { useCallback } from "react";
 import { useNavigate } from "react-router";
+import { track } from "~/renderer/analytics/segment";
+import { CARD_TRACKING_PAGE_NAME } from "../constants";
 
 const CARD_APP_ID = "card-program";
 const CL_CARD_APP_ID = "cl-card";
@@ -10,12 +12,20 @@ export const useCardViewModel = () => {
   const navigate = useNavigate();
 
   const goToExploreCards = useCallback(() => {
+    track("button_clicked", {
+      button: "explore cards",
+      page: CARD_TRACKING_PAGE_NAME,
+    });
     navigate(`/card/${CARD_APP_ID}?path=${encodeURIComponent(CARD_PROGRAM_PATH_PROVIDERS_LIST)}`, {
       state: { fromCardLanding: true },
     });
   }, [navigate]);
 
   const goToIHaveACard = useCallback(() => {
+    track("button_clicked", {
+      button: "I have a card",
+      page: CARD_TRACKING_PAGE_NAME,
+    });
     navigate(`/card/${CL_CARD_APP_ID}`, {
       state: { fromCardLanding: true },
     });

--- a/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
@@ -349,7 +349,7 @@ const MainSideBar = () => {
   }, [push, trackEntry]);
   const handleClickCardWallet = useCallback(() => {
     push("/card-new-wallet");
-    trackEntry("card-new-wallet");
+    trackEntry("card");
   }, [push, trackEntry]);
   const handleClickRefer = useCallback(() => {
     if (referralProgramConfig?.enabled && referralProgramConfig?.params?.path) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing Card integration tests cover navigation; analytics (TrackPage, track) are not asserted._
- [x] **Impact of the changes:**
  - Card page: page view tracking and button click events
  - Sidebar: Card entry tracking name aligned to "card"

### 📝 Description

**Problem:** The new Card page had no analytics, so product could not measure page visits or user actions (Explore Cards / I already have a card).

**Solution:** Add analytics for the Card feature:

- **Page view:** `TrackPage` with category `"Page Card"` so the Card landing page is tracked when users open it.
- **Button clicks:** `track("button_clicked", { button, page: "card" })` for:
  - "Explore Cards" → `button: "explore cards"`
  - "I already have a card" → `button: "I have a card"`
- **Sidebar:** `trackEntry` for the Card sidebar item updated from `"card-new-wallet"` to `"card"` for consistent naming.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25834](https://ledgerhq.atlassian.net/browse/LIVE-25834)
https://ledgerhq.atlassian.net/browse/LIVE-25834
---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
