### PR TITLE
fix(desktop): simplify db middleware to also fix bugs

### DIFF
--- a/.changeset/tidy-hounds-chew.md
+++ b/.changeset/tidy-hounds-chew.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Simplify db middleware and fix accounts resave to trigger on an add account flow

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import BigNumber from "bignumber.js";
 import { render, screen } from "tests/testSetup";
 import userEvent from "@testing-library/user-event";
 import TopBar from "../index";
@@ -14,6 +15,27 @@ jest.mock("@braze/web-sdk", () => ({
   logCardDismissal: () => {},
   logContentCardClick: () => {},
 }));
+
+const mockBalance = new BigNumber(0);
+
+const mockAccount = {
+  id: "account1",
+  balance: mockBalance,
+  spendableBalance: mockBalance,
+  swapHistory: [],
+  operations: [],
+  operationsCount: 0,
+  pendingOperations: [],
+  lastSyncDate: new Date(),
+  currency: {
+    id: "bitcoin",
+    type: "CryptoCurrency",
+    ticker: "BTC",
+    name: "Bitcoin",
+    family: "bitcoin",
+    blockAvgTime: 10 * 60,
+  },
+};
 
 describe("TopBar", () => {
   const getDefaultInitialState = (overrides = {}) => ({
@@ -38,22 +60,7 @@ describe("TopBar", () => {
   it("renders ActivityIndicator when hasAccounts is true", () => {
     render(<TopBar />, {
       initialState: getDefaultInitialState({
-        accounts: [
-          {
-            id: "account1",
-            balance: { toString: () => "0" },
-            swapHistory: [],
-            lastSyncDate: new Date(),
-            currency: {
-              id: "bitcoin",
-              type: "CryptoCurrency",
-              ticker: "BTC",
-              name: "Bitcoin",
-              family: "bitcoin",
-              blockAvgTime: 10 * 60,
-            },
-          },
-        ],
+        accounts: [mockAccount],
       }),
     });
 
@@ -90,22 +97,7 @@ describe("TopBar", () => {
     render(<TopBar />, {
       initialState: getDefaultInitialState({
         application: { hasPassword: true },
-        accounts: [
-          {
-            id: "account1",
-            balance: { toString: () => "0" },
-            swapHistory: [],
-            lastSyncDate: new Date(),
-            currency: {
-              id: "bitcoin",
-              type: "CryptoCurrency",
-              ticker: "BTC",
-              name: "Bitcoin",
-              family: "bitcoin",
-              blockAvgTime: 10 * 60,
-            },
-          },
-        ],
+        accounts: [mockAccount],
       }),
     });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__tests__/addAccountFlow.test.tsx
@@ -36,6 +36,12 @@ jest.mock("~/renderer/hooks/useConnectAppAction", () => ({
 let triggerNext: (accounts: Account[]) => void = () => null;
 let triggerComplete: () => void = () => null;
 
+const mockAccountBridge = {
+  assignToAccountRaw: () => {},
+  assignToTokenAccountRaw: () => {},
+  toOperationExtraRaw: (extra: unknown) => extra,
+};
+
 jest.mock("@ledgerhq/live-common/bridge/index", () => ({
   __esModule: true,
   getCurrencyBridge: () => ({
@@ -56,6 +62,7 @@ jest.mock("@ledgerhq/live-common/bridge/index", () => ({
     preload: () => true,
     hydrate: () => true,
   }),
+  getAccountBridge: () => mockAccountBridge,
 }));
 
 const mockScanAccountsSubscription = async (accounts: Account[]) => {

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -66,7 +66,7 @@ async function save(
     dispatch(setNonImportedAccounts(newLocalState.accounts.nonImportedAccountInfos));
     dispatch(setAccountNames(newLocalState.accountNames));
     dispatch(updateRecentAddresses(newLocalState.recentAddresses));
-    dispatch(replaceAccounts(newLocalState.accounts.list)); // IMPORTANT: keep this one last, it's doing the DB:* trigger to save the data
+    dispatch(replaceAccounts(newLocalState.accounts.list)); // triggers db middleware to persist accounts
   }
 }
 

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
@@ -6,7 +6,7 @@ import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import { ThunkResult } from "./types";
 
 export const removeAccount = (payload: Account) => ({
-  type: "DB:REMOVE_ACCOUNT",
+  type: "REMOVE_ACCOUNT",
   payload,
 });
 
@@ -25,7 +25,7 @@ export const initAccounts = (data: [Account, AccountUserData][]) => {
 };
 
 export const replaceAccounts = (accounts: Account[]) => ({
-  type: "DB:REPLACE_ACCOUNTS",
+  type: "REPLACE_ACCOUNTS",
   payload: accounts,
 });
 
@@ -33,7 +33,7 @@ export const reorderAccounts =
   (comparator: AccountComparator): ThunkResult =>
   (dispatch, _getState, _extra) =>
     dispatch({
-      type: "DB:REORDER_ACCOUNTS",
+      type: "REORDER_ACCOUNTS",
       payload: { comparator },
     });
 
@@ -55,17 +55,17 @@ export type UpdateAccountWithUpdater = (
 ) => UpdateAccountAction;
 
 export const updateAccountWithUpdater: UpdateAccountWithUpdater = (accountId, updater) => ({
-  type: "DB:UPDATE_ACCOUNT",
+  type: "UPDATE_ACCOUNT",
   payload: { accountId, updater },
 });
 
 export type UpdateAccount = (account: Partial<Account>) => UpdateAccountAction;
 export const updateAccount: UpdateAccount = payload => ({
-  type: "DB:UPDATE_ACCOUNT",
+  type: "UPDATE_ACCOUNT",
   payload: {
     updater: (account: Account) => ({ ...account, ...payload }),
     accountId: payload.id,
   },
 });
 
-export const cleanAccountsCache = () => ({ type: "DB:CLEAN_ACCOUNTS_CACHE" });
+export const cleanAccountsCache = () => ({ type: "CLEAN_ACCOUNTS_CACHE" });

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -34,7 +34,7 @@ export type SaveSettings = (a: Partial<Settings>) => {
   payload: Partial<Settings>;
 };
 export const saveSettings: SaveSettings = payload => ({
-  type: "DB:SAVE_SETTINGS",
+  type: "SAVE_SETTINGS",
   payload,
 });
 export const setCountervalueFirst = (countervalueFirst: boolean) =>

--- a/apps/ledger-live-desktop/src/renderer/actions/wallet.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/wallet.ts
@@ -3,9 +3,7 @@ import { getKey } from "../storage";
 import { ThunkResult } from "./types";
 
 export const toggleStarAction = (id: string, value: boolean) => {
-  const action = setAccountStarred(id, value);
-  action.type = "DB:" + action.type;
-  return action;
+  return setAccountStarred(id, value);
 };
 
 export const fetchWallet =

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/CustomHandlers.ts
@@ -137,7 +137,7 @@ export function useACRECustomHandlers(manifest: WebviewProps["manifest"], accoun
             onError,
           }) => {
             try {
-              // Desktop: Limitation, can't add one single account, only REPLACE_ACCOUNT redux store action has 'DB:' prefix and make the storage
+              // Desktop: add account via replaceAccounts so the db middleware persists to storage
               dispatch(replaceAccounts([parentAccount, ...existingAccounts]));
               dispatch(setAccountName(parentAccount.id, accountName));
               onSuccess();

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/useDeepLinkHandler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/useDeepLinkHandler.test.ts
@@ -96,12 +96,20 @@ jest.mock("../utils", () => ({
 
 const createMockAccount = (currencyId: string): Account => {
   const currency = getCryptoCurrencyById(currencyId);
+  const zero = new BigNumber(0);
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return {
     id: `${currencyId}-account-1`,
     type: "Account" as const,
     name: `${currency.name} 1`,
     currency,
+    balance: zero,
+    spendableBalance: zero,
+    operations: [],
+    operationsCount: 0,
+    pendingOperations: [],
+    lastSyncDate: new Date(),
+    swapHistory: [],
   } as unknown as Account;
 };
 
@@ -112,6 +120,8 @@ const createMockTokenAccount = (parentId: string, tokenId: string): TokenAccount
     type: "TokenAccount" as const,
     parentId,
     token: { id: tokenId },
+    balance: new BigNumber(0),
+    operationsCount: 0,
   }) as unknown as TokenAccount;
 
 describe("useDeepLinkHandler", () => {

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -30,7 +30,7 @@ import { accountsPersistedStateChanged } from "@ledgerhq/live-common/account/ind
 
 let DB_MIDDLEWARE_ENABLED = true;
 
-// ability to temporary disable the db middleware from outside
+/** Used during hard reset (reset.ts): disable persist so we don't re-write app.json while clearing. */
 export const disable = (ms = 1000) => {
   DB_MIDDLEWARE_ENABLED = false;
   setTimeout(() => (DB_MIDDLEWARE_ENABLED = true), ms);
@@ -70,57 +70,63 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
     return next(action);
   }
 
-  if (DB_MIDDLEWARE_ENABLED && action.type.startsWith("DB:")) {
-    const oldState = store.getState();
-    const [, type] = action.type.split(":");
-    store.dispatch({
-      type,
-      payload: action.payload,
-    });
-    const newState = store.getState();
-    if (accountsPersistedStateChanged(oldState.accounts, newState.accounts)) {
-      setKey("app", "accounts", accountsExportSelector(newState));
-    }
-  } else if (DB_MIDDLEWARE_ENABLED && action.type.startsWith(postOnboardingActionTypePrefix)) {
-    next(action);
+  if (!DB_MIDDLEWARE_ENABLED) {
+    return next(action);
+  }
+
+  if (action.type.startsWith(postOnboardingActionTypePrefix)) {
+    const res = next(action);
     const state = store.getState();
     setKey("app", "postOnboarding", postOnboardingSelector(state));
-  } else if (DB_MIDDLEWARE_ENABLED && action.type.startsWith(trustchainStoreActionTypePrefix)) {
-    next(action);
+    return res;
+  }
+
+  if (action.type.startsWith(trustchainStoreActionTypePrefix)) {
+    const res = next(action);
     const state = store.getState();
     setKey("app", "trustchain", trustchainStoreSelector(state));
-  } else if (DB_MIDDLEWARE_ENABLED && action.type.startsWith("MARKET")) {
-    next(action);
+    return res;
+  }
+
+  if (action.type.startsWith("MARKET")) {
+    const res = next(action);
     const state = store.getState();
     setKey("app", "market", marketStoreSelector(state));
-  } else if (DB_MIDDLEWARE_ENABLED && action.type.startsWith("cryptoAssetsApi/")) {
-    // Handle RTK Query crypto assets actions (throttled save)
+    return res;
+  }
+
+  if (action.type.startsWith("cryptoAssetsApi/")) {
     const res = next(action);
     const state = store.getState();
     saveCryptoAssetsCache(state);
     return res;
-  } else {
-    const oldState = store.getState();
-    const res = next(action);
-    const newState = store.getState();
-    // NB Prevent write attempts when the app is locked.
-    if (!oldState.application.isLocked || action.type === "APPLICATION_SET_DATA") {
-      if (areSettingsLoaded(newState) && oldState.settings !== newState.settings) {
-        setKey("app", "settings", settingsStoreSelector(newState));
-      }
-    }
-
-    if (walletStateExportShouldDiffer(oldState.wallet, newState.wallet)) {
-      setKey("app", "wallet", exportWalletState(newState.wallet));
-    }
-
-    // Save identities if state changed
-    if (oldState.identities !== newState.identities) {
-      const persisted = exportIdentitiesForPersistence(newState.identities);
-      setKey("app", "identities", persisted);
-    }
-    return res;
   }
+
+  const oldState = store.getState();
+  const res = next(action);
+  const newState = store.getState();
+
+  // NB Prevent write attempts when the app is locked.
+  if (!oldState.application.isLocked || action.type === "APPLICATION_SET_DATA") {
+    if (areSettingsLoaded(newState) && oldState.settings !== newState.settings) {
+      setKey("app", "settings", settingsStoreSelector(newState));
+    }
+  }
+
+  if (walletStateExportShouldDiffer(oldState.wallet, newState.wallet)) {
+    setKey("app", "wallet", exportWalletState(newState.wallet));
+  }
+
+  if (accountsPersistedStateChanged(oldState.accounts, newState.accounts)) {
+    setKey("app", "accounts", accountsExportSelector(newState));
+  }
+
+  if (oldState.identities !== newState.identities) {
+    const persisted = exportIdentitiesForPersistence(newState.identities);
+    setKey("app", "identities", persisted);
+  }
+
+  return res;
 };
 
 export default DBMiddleware;


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**  :
  - https://github.com/LedgerHQ/ledger-live/pull/14271 reveals the bug on develop
  - i confirm it pass via https://github.com/LedgerHQ/ledger-live/actions/runs/21747668021

<img width="1236" height="622" alt="Screenshot 2026-02-06 at 13 55 13" src="https://github.com/user-attachments/assets/411a8b16-906e-43ee-aade-758a67dbb577" />


- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

  - desktop

### 📝 Description

This db middleware rework simplify the "hack" that existed in Ledger Wallet Desktop only that consisted of prefixing `"DB:"` in actions in order to save data (and only in that case, we were going through the accounts saves)

After the optimisation done in https://github.com/LedgerHQ/ledger-live/pull/14086 , it was possible that the accountsExportSelector were not called during two successive updates which created a scenario where the app.json were not resaved with new added accounts.

By reworking this, we have a more common approach with mobile, that said we'll still have to converge to same codebase in future. I'm not sure if doing this at middleware level is the best approach, but at least we harmonize it with the rest of the code here, allowing us to drop the last case of `"DB:"`. 

the following code was moved outside of the "if actions is a `DB:` action" which due to this condition, was bailing out some legit cases of saving again the action: I believe that there are part of our codebase where we weren't using `DB:` anymore, preventing us to save the account at case it actually should.
```ts
  if (accountsPersistedStateChanged(oldState.accounts, newState.accounts)) {
    setKey("app", "accounts", accountsExportSelector(newState));
  }
```

There were also a bug where the middleware were not properly stopped during a Reset app action, which could have created case where Reset don't properly reset the data.


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25871


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
