### PR TITLE
fix: display 0 if unavailable balance

### DIFF
--- a/.changeset/hot-dolls-invite.md
+++ b/.changeset/hot-dolls-invite.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(lwd): display 0 for unavailable balance

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/BalanceView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/BalanceView.tsx
@@ -8,14 +8,9 @@ export const BalanceView = ({
   formatter,
   discreet,
   valueChange,
-  isAvailable,
   navigateToAnalytics,
   handleKeyDown,
 }: BalanceViewProps) => {
-  if (!isAvailable) {
-    return null;
-  }
-
   return (
     <div
       className="flex cursor-pointer items-baseline gap-12"

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/index.tsx
@@ -5,7 +5,7 @@ import { NoBalanceView } from "./NoBalanceView";
 import { NoDeviceView } from "./NoDeviceView";
 
 export const Balance = () => {
-  const { hasFunds, hasCompletedOnboarding, hasAccount, ...viewModel } = useBalanceViewModel();
+  const { hasCompletedOnboarding, hasAccount, ...viewModel } = useBalanceViewModel();
 
   if (!hasCompletedOnboarding) {
     return <NoDeviceView />;

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
@@ -6,13 +6,11 @@ export interface BalanceViewProps {
   readonly formatter: (value: number) => FormattedValue;
   readonly discreet: boolean;
   readonly valueChange: ValueChange;
-  readonly isAvailable: boolean;
   readonly navigateToAnalytics: () => void;
   readonly handleKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 }
 
 export type BalanceViewModelResult = BalanceViewProps & {
-  readonly hasFunds: boolean;
   readonly hasAccount: boolean;
   readonly hasCompletedOnboarding: boolean;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
@@ -48,7 +48,6 @@ describe("useBalanceViewModel", () => {
     expect(result.current.balance).toBe(1500);
     const formatted = result.current.formatter(result.current.balance);
     expect(formatted.integerPart).toContain("15");
-    expect(result.current.isAvailable).toBe(true);
     expect(result.current.valueChange).toEqual(mockPortfolio.countervalueChange);
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -35,7 +35,7 @@ export const useBalanceViewModel = (
   const selectedTimeRange = useSelector(selectedTimeRangeSelector);
   const locale = useSelector(localeSelector);
   const discreet = useSelector(discreetModeSelector);
-  const { hasFunds, hasAccount } = useAccountStatus();
+  const { hasAccount } = useAccountStatus();
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
 
   const range = useLegacyRange ? selectedTimeRange : NEW_FLOW_RANGE;
@@ -49,7 +49,6 @@ export const useBalanceViewModel = (
   const latestBalanceValue =
     portfolio.balanceHistory[portfolio.balanceHistory.length - 1]?.value ?? 0;
   const unit = counterValue.units[0];
-  const isAvailable = portfolio.balanceAvailable;
   const valueChange = portfolio.countervalueChange;
 
   const navigateToAnalytics = useCallback(() => {
@@ -86,10 +85,8 @@ export const useBalanceViewModel = (
     formatter,
     discreet,
     valueChange,
-    isAvailable,
     navigateToAnalytics,
     handleKeyDown,
-    hasFunds,
     hasAccount,
     hasCompletedOnboarding,
   };


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request simplifies the balance display logic in the portfolio feature of `ledger-live-desktop`. It removes the `isAvailable` and `hasFunds` checks and ensures that a zero balance is displayed when the balance is unavailable, rather than hiding the balance component. This improves the user experience by always showing a balance value, even if it's zero.

https://github.com/user-attachments/assets/dd2cbf68-9709-4d0e-b426-ef4aa0b503d8


### ❓ Context

[LIVE-25876](https://ledgerhq.atlassian.net/browse/LIVE-25876)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
