### PR TITLE
🐛 fix(mobile): redirect bank transfer to Noah fiat provider

### DIFF
--- a/.changeset/thin-moles-nail.md
+++ b/.changeset/thin-moles-nail.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix bank transfer navigation in TransferDrawer to use Noah fiat provider

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
@@ -1,0 +1,96 @@
+import { renderHook } from "@tests/test-renderer";
+import { useTransferDrawerViewModel } from "../useTransferDrawerViewModel";
+import { NavigatorName, ScreenName } from "~/const";
+import { track } from "~/analytics";
+import { overrideStateWithFunds } from "LLM/features/QuickActions/__integrations__/shared";
+import { State } from "~/reducers/types";
+
+const mockNavigate = jest.fn();
+const mockHandleOpenReceiveDrawer = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock("LLM/features/Receive", () => ({
+  useOpenReceiveDrawer: () => ({ handleOpenReceiveDrawer: mockHandleOpenReceiveDrawer }),
+}));
+
+jest.mock("LLM/features/Noah/useNoahEntryPoint", () => ({
+  useReceiveNoahEntry: () => ({ showNoahMenu: true }),
+}));
+
+const SOURCE_SCREEN = "Portfolio";
+
+const overrideWithOpenDrawer = (state: State): State => {
+  const base = overrideStateWithFunds(state);
+  return {
+    ...base,
+    transferDrawer: {
+      isOpen: true,
+      sourceScreenName: SOURCE_SCREEN,
+    },
+  };
+};
+
+describe("TransferDrawer Navigation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderViewModel = () =>
+    renderHook(() => useTransferDrawerViewModel(), {
+      overrideInitialState: overrideWithOpenDrawer,
+    });
+
+  const findAction = (
+    result: { current: ReturnType<typeof useTransferDrawerViewModel> },
+    id: string,
+  ) => result.current.actions.find(a => a.id === id)!;
+
+  it("send navigates to SendFunds/SendCoin and tracks", () => {
+    const { result } = renderViewModel();
+
+    findAction(result, "send").onPress();
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+      screen: ScreenName.SendCoin,
+    });
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "quick_action_transfer",
+      flow: "send",
+      page: SOURCE_SCREEN,
+    });
+  });
+
+  it("bank_transfer navigates to ReceiveFunds/ReceiveProvider with noah manifest and tracks", () => {
+    const { result } = renderViewModel();
+
+    findAction(result, "bank_transfer").onPress();
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.ReceiveFunds, {
+      screen: ScreenName.ReceiveProvider,
+      params: { manifestId: "noah" },
+    });
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "quick_action_transfer",
+      flow: "bank_transfer",
+      page: SOURCE_SCREEN,
+    });
+  });
+
+  it("receive opens receive drawer and tracks", () => {
+    const { result } = renderViewModel();
+
+    findAction(result, "receive").onPress();
+
+    expect(mockHandleOpenReceiveDrawer).toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "quick_action_transfer",
+      flow: "receive",
+      page: SOURCE_SCREEN,
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -15,6 +15,11 @@ import { QUICK_ACTIONS_TEST_IDS } from "../../testIds";
 import { useTranslation } from "~/context/Locale";
 import { useReceiveNoahEntry } from "LLM/features/Noah/useNoahEntryPoint";
 
+// Fiat provider manifest ID for Noah integration
+const FIAT_PROVIDER_MANIFEST_ID = "noah";
+
+const BUTTON_ID = "quick_action_transfer";
+
 interface TransferDrawerViewModel {
   isOpen: boolean;
   actions: readonly TransferAction[];
@@ -41,7 +46,7 @@ export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
 
   const handleReceivePress = useCallback(() => {
     track("button_clicked", {
-      button: "quick_action_transfer",
+      button: BUTTON_ID,
       flow: "receive",
       page: sourceScreenName,
     });
@@ -51,7 +56,7 @@ export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
 
   const handleSendPress = useCallback(() => {
     track("button_clicked", {
-      button: "quick_action_transfer",
+      button: BUTTON_ID,
       flow: "send",
       page: sourceScreenName,
     });
@@ -63,15 +68,15 @@ export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
 
   const handleBankTransferPress = useCallback(() => {
     track("button_clicked", {
-      button: "quick_action_transfer",
+      button: BUTTON_ID,
       flow: "bank_transfer",
       page: sourceScreenName,
     });
     closeDrawer();
-    navigation.navigate(NavigatorName.Exchange, {
-      screen: ScreenName.ExchangeBuy,
+    navigation.navigate(NavigatorName.ReceiveFunds, {
+      screen: ScreenName.ReceiveProvider,
       params: {
-        mode: "onRamp",
+        manifestId: FIAT_PROVIDER_MANIFEST_ID,
       },
     });
   }, [closeDrawer, navigation, sourceScreenName]);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - All three transfer drawer actions (receive, send, bank transfer)
      - Bank transfer now navigates to `ReceiveFunds/ReceiveProvider` with `manifestId: "noah"` instead of `Exchange/ExchangeBuy`

### 📝 Description

The bank transfer action in the TransferDrawer was incorrectly navigating to `Exchange/ExchangeBuy` with `mode: "onRamp"`. This didn't match the expected Noah fiat provider integration flow.

**Fix:** Updated the bank transfer navigation to route to `ReceiveFunds/ReceiveProvider` with `manifestId: "noah"`, consistent with the Noah integration pattern already used in `useReceiveFundsOptionsViewModel`.

Also added integration tests covering navigation and analytics tracking for all three TransferDrawer actions (send, receive, bank transfer).



https://github.com/user-attachments/assets/44fb6fa6-1c89-4c90-9129-ba80d5ac56cf



### ❓ Context

- **JIRA or GitHub link**: [LIVE-25893](https://ledgerhq.atlassian.net/browse/LIVE-25893)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)