### PR TITLE
🐛 fix(mobile): reduce analytics pill height from s48 to s40

### DIFF
--- a/.changeset/plenty-rings-ring.md
+++ b/.changeset/plenty-rings-ring.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Reduce analytics pill height to 40

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/AnalyticPill.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/AnalyticPill.tsx
@@ -67,7 +67,7 @@ const PressableStyle: LumenViewStyle = {
   flexDirection: "row",
   alignItems: "center",
   justifyContent: "center",
-  height: "s48",
+  height: "s40",
   borderRadius: "full",
   paddingHorizontal: "s16",
   gap: "s2",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _UI-only spacing change, no logic affected._
- [x] **Impact of the changes:**
      - Portfolio screen: AnalyticPill component height reduced from `s48` to `s40`
      - Verify the pill looks visually correct and aligned on Portfolio screen

### 📝 Description

The analytics pill on the Portfolio balance section had an incorrect height of `s48`, causing it to appear too tall relative to the surrounding UI elements.

Reduced the `height` from `s48` to `s40` on the `AnalyticPill` pressable container to match the expected design specification.


Before

<img width="200" height="2868" alt="before" src="https://github.com/user-attachments/assets/c6fb2830-1cc9-446c-a836-12df5f4f8270" />

After 

<img width="200" height="2868" alt="after" src="https://github.com/user-attachments/assets/cf42db03-0b96-44d4-bc35-f476d926fe34" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-25894](https://ledgerhq.atlassian.net/browse/LIVE-25894)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
