### PR TITLE
🐛 fix(mobile): adjust DiscreetModeIcon position in portfolio balance

### DIFF
--- a/.changeset/rude-bugs-wave.md
+++ b/.changeset/rude-bugs-wave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Change DiscreetModeIcon position

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
@@ -64,7 +64,7 @@ export const PortfolioBalanceSectionView = ({
     return (
       <>
         <Pressable onPress={onToggleDiscreetMode} testID="portfolio-balance-toggle">
-          <Box lx={{ flexDirection: "row", alignItems: "baseline", gap: "s4" }}>
+          <Box lx={{ flexDirection: "row", alignItems: "baseline", gap: "s14" }}>
             <AmountDisplay
               key={unit.code}
               value={isBalanceAvailable ? balance : 0}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _UI spacing fix — visual change only, no logic affected._
- [x] **Impact of the changes:**
      - Portfolio balance section layout on mobile
      - Gap between the balance amount and the discreet mode icon

### 📝 Description

The DiscreetModeIcon was positioned too close to the balance amount in the portfolio section, causing a visual inconsistency.

Fixed by adjusting the `gap` property from `s4` to `s14` in the `PortfolioBalanceSectionView` component, giving proper spacing between the amount display and the discreet mode icon.

| Before | After |
| ------ | ----- |
| <img width="1320" alt="image" src="https://github.com/user-attachments/assets/0f5f83ac-c1bd-4c5a-8650-2a3d4472747b" /> | <img width="1320"  alt="image" src="https://github.com/user-attachments/assets/46bb122c-0a59-4b25-90af-46c832913371" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25895](https://ledgerhq.atlassian.net/browse/LIVE-25895)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)