### PR TITLE
🐛 fix(settings): set default selectedTimeRange to day

### DIFF
--- a/.changeset/heavy-jars-doubt.md
+++ b/.changeset/heavy-jars-doubt.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Set the selectedTimeRange to "day" by default

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -160,7 +160,7 @@ export const INITIAL_STATE: SettingsState = {
   orderAccounts: "balance|desc",
   countervalueFirst: false,
   autoLockTimeout: 10,
-  selectedTimeRange: "month",
+  selectedTimeRange: "day",
   currenciesSettings: {},
   pairExchanges: {},
   developerMode: !!process.env.__DEV__,

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -93,7 +93,7 @@ export const INITIAL_STATE: SettingsState = {
   personalizedRecommendationsEnabled: true,
   currenciesSettings: {},
   pairExchanges: {},
-  selectedTimeRange: "month",
+  selectedTimeRange: "day",
   orderAccounts: "balance|desc",
   hasCompletedCustomImageFlow: false,
   hasCompletedOnboarding: false,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No test changes needed — this is a default value change in the initial state._
- [x] **Impact of the changes:**
  - Portfolio chart default time range on both Desktop and Mobile
  - First-time users and users who never changed the time range setting will now see the "day" view by default

### 📝 Description

**Problem**: The default `selectedTimeRange` in the portfolio settings was set to `"month"`, which did not match the expected default behavior.

**Solution**: Changed the `INITIAL_STATE.selectedTimeRange` from `"month"` to `"day"` in both `ledger-live-desktop` and `ledger-live-mobile` settings reducers so users see the daily view by default.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25889](https://ledgerhq.atlassian.net/browse/LIVE-25889)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
