### PR TITLE
[LWM] :white_check_mark: add portfolio states e2e

### DIFF
--- a/.changeset/stupid-tables-deliver.md
+++ b/.changeset/stupid-tables-deliver.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+e2e portfolio wallet 4.0

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2690,7 +2690,7 @@
     "walletBalance": "Wallet balance",
     "balance": {
       "noSigner": "The most secure\nwallet",
-      "noFund": "Secure your\ncrypto"
+      "noAccounts": "Secure your\ncrypto"
     },
     "seeAllAssets": "See all assets",
     "seeAllAccounts": "See all accounts",

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/portfolio.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/portfolio.integration.test.tsx
@@ -49,7 +49,7 @@ describe("Portfolio Screen", () => {
 
       await screen.findByTestId("PortfolioEmptyList");
 
-      expect(await screen.findByTestId("portfolio-balance-noFund")).toBeVisible();
+      expect(await screen.findByTestId("portfolio-balance-noAccounts")).toBeVisible();
     });
 
     it("should display noSigner state when graphRework is enabled and user is in readOnly mode", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
@@ -41,14 +41,14 @@ export const PortfolioBalanceSectionView = ({
   );
 
   const getTestId = (): string => {
-    if (state === "noSigner" || state === "noFund") {
+    if (state === "noSigner" || state === "noAccounts") {
       return `portfolio-balance-${state}`;
     }
     return isBalanceAvailable ? "portfolio-balance-normal" : "portfolio-balance-loading";
   };
 
   const renderContent = () => {
-    if (state === "noSigner" || state === "noFund") {
+    if (state === "noSigner" || state === "noAccounts") {
       return (
         <Text
           typography="heading1SemiBold"

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
@@ -14,7 +14,7 @@ describe("usePortfolioBalanceSectionViewModel", () => {
       expect(result.current.state).toBe("noSigner");
     });
 
-    it("should return 'noFund' state when isReadOnlyMode is false and showAssets is false", () => {
+    it("should return 'noAccounts' state when isReadOnlyMode is false and showAssets is false", () => {
       const { result } = renderHook(() =>
         usePortfolioBalanceSectionViewModel({
           showAssets: false,
@@ -22,7 +22,7 @@ describe("usePortfolioBalanceSectionViewModel", () => {
         }),
       );
 
-      expect(result.current.state).toBe("noFund");
+      expect(result.current.state).toBe("noAccounts");
     });
 
     it("should return 'normal' state when isReadOnlyMode is false and showAssets is true", () => {
@@ -36,7 +36,7 @@ describe("usePortfolioBalanceSectionViewModel", () => {
       expect(result.current.state).toBe("normal");
     });
 
-    it("should prioritize noSigner over noFund when both conditions are met", () => {
+    it("should prioritize noSigner over noAccounts when both conditions are met", () => {
       const { result } = renderHook(() =>
         usePortfolioBalanceSectionViewModel({
           showAssets: false,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/types.ts
@@ -1,7 +1,7 @@
 import { Unit } from "@ledgerhq/types-cryptoassets";
 import { ValueChange } from "@ledgerhq/types-live";
 
-export type PortfolioBalanceState = "noSigner" | "noFund" | "normal";
+export type PortfolioBalanceState = "noSigner" | "noAccounts" | "normal";
 
 export interface PortfolioBalanceSectionProps {
   readonly showAssets: boolean;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
@@ -29,7 +29,7 @@ export const usePortfolioBalanceSectionViewModel = ({
       return "noSigner";
     }
     if (!showAssets) {
-      return "noFund";
+      return "noAccounts";
     }
     return "normal";
   }, [isReadOnlyMode, showAssets]);

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoAccountsContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoAccountsContent.tsx
@@ -28,7 +28,13 @@ const PortfolioNoAccountsContent = ({
       <TransferDrawer />
       <PortfolioBannersSection isFirst={true} isLNSUpsellBannerShown={isLNSUpsellBannerShown} />
       <MarketBanner />
-      <Button appearance="gray" size="lg" lx={{ width: "full" }} onPress={openAddModal}>
+      <Button
+        appearance="gray"
+        size="lg"
+        lx={{ width: "full" }}
+        onPress={openAddModal}
+        testID="add-account-cta"
+      >
         {t("account.emptyState.addCryptoAccount")}
       </Button>
       <AddAccountDrawer isOpened={isAddModalOpened} onClose={closeAddModal} doesNotHaveAccount />

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -17,7 +17,7 @@ export default class CommonPage {
   deviceItem = (deviceId: string): string => `device-item-${deviceId}`;
   deviceItemRegex = /device-item-.*/;
   walletApiWebview = "wallet-api-webview";
-
+  closeWithConfirmationButtonId = "button-close-add-account";
   errorPage = new ErrorPage();
 
   searchBar = () => getElementById(this.searchBarId);
@@ -80,6 +80,12 @@ export default class CommonPage {
   async goToAccount(accountId: string) {
     await scrollToId(this.accountItemRegExp(accountId), this.assetScreenFlatlistId);
     await tapByElement(this.accountItem(accountId));
+  }
+
+  @Step("Tap on close with confirmation button")
+  async tapCloseWithConfirmationButton() {
+    await waitForElementById(this.closeWithConfirmationButtonId);
+    await tapById(this.closeWithConfirmationButtonId);
   }
 
   @Step("Check number of account rows")

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -1,5 +1,7 @@
 import { Step } from "jest-allure2-reporter/api";
 import { openDeeplink } from "../../helpers/commonHelpers";
+import { getFlags } from "../../bridge/server";
+import { Feature_Noah } from "@ledgerhq/types-live";
 
 export default class PortfolioPage {
   addNewOrExistingAccount = "add-new-account-button";
@@ -42,6 +44,15 @@ export default class PortfolioPage {
   bottomSheetCloseButton = "drawer-close-button";
   accountsList = "portfolio-assets-layout";
   marketBannerTitle = "market-banner-title";
+  quickActionTransferButtonV4 = "quick-action-transfer";
+  quickActionSwapButtonV4 = "quick-action-swap";
+  quickActionBuyButtonV4 = "quick-action-buy";
+  portfolioBalanceNoAccount = "portfolio-balance-noAccounts";
+  portfolioBalanceNormal = "portfolio-balance-normal";
+  portfolioBalanceAnalyticsPill = "portfolio-balance-analytics-pill";
+  transferBottomSheetReceiveButton = "transfer-action-receive";
+  transferBottomSheetSendButton = "transfer-action-send";
+  transferBottomSheetBankTransferButton = "transfer-action-bank-transfer";
 
   portfolioSettingsButton = async () => getElementById(this.portfolioSettingsButtonId);
   assetItemId = (currencyName: string) => `${this.baseAssetItem}${currencyName}`;
@@ -51,6 +62,17 @@ export default class PortfolioPage {
     getElementById(`${this.walletTabSelectorBase}${id}`);
   operationByType = (operationType?: string) =>
     getElementByIdAndText(this.operationRowDate, new RegExp(`.*${operationType ?? ""}.*`, "i"));
+
+  private flags: Feature_Noah | null = null;
+
+  private async loadFlags(): Promise<void> {
+    this.flags ??= JSON.parse(await getFlags()).noah;
+  }
+
+  async isNoahEnabled(): Promise<boolean> {
+    await this.loadFlags();
+    return this.flags!.enabled;
+  }
 
   @Step("Navigate to Settings")
   async navigateToSettings() {
@@ -81,6 +103,11 @@ export default class PortfolioPage {
     await this.expectAssetRowToBeVisible(asset);
     const text = await getTextOfElement(this.assetItemBalanceId(asset));
     jestExpect(text).toContain(counterValue);
+  }
+
+  @Step("Expect chart to be visible")
+  async expectBalanceToBeVisible() {
+    await detoxExpect(getElementById(this.graphCardBalanceId)).toBeVisible();
   }
 
   @Step("Expect total balance value")
@@ -305,5 +332,84 @@ export default class PortfolioPage {
   @Step("Swipe market banner to view all")
   async swipeMarketBannerToViewAll() {
     await scrollToId(this.marketBannerViewAll, this.marketBannerList, 1000, "right");
+  }
+
+  @Step("Check quick action transfer button visibility")
+  async checkQuickActionTransferButtonVisibility() {
+    await detoxExpect(getElementById(this.quickActionTransferButtonV4)).toBeVisible();
+  }
+
+  @Step("Check quick action swap button visibility")
+  async checkQuickActionSwapButtonVisibility() {
+    await detoxExpect(getElementById(this.quickActionSwapButtonV4)).toBeVisible();
+  }
+
+  @Step("Check quick action buy button visibility")
+  async checkQuickActionBuyButtonVisibility() {
+    await detoxExpect(getElementById(this.quickActionBuyButtonV4)).toBeVisible();
+  }
+
+  @Step("Press quick action buy button")
+  async pressQuickActionBuyButton() {
+    await tapById(this.quickActionBuyButtonV4);
+  }
+
+  @Step("Press quick action swap button")
+  async pressQuickActionSwapButton() {
+    await tapById(this.quickActionSwapButtonV4);
+  }
+
+  @Step("Press quick action transfer button")
+  async pressQuickActionTransferButton() {
+    await tapById(this.quickActionTransferButtonV4);
+  }
+  @Step("Check no balance title visibility")
+  async checkNoBalanceTitleVisibility() {
+    await detoxExpect(getElementById(this.portfolioBalanceNoAccount)).toBeVisible();
+  }
+
+  @Step("Check normal balance title visibility")
+  async checkNormalBalanceTitleVisibility() {
+    await detoxExpect(getElementById(this.portfolioBalanceNormal)).toBeVisible();
+  }
+
+  @Step("Check portfolio balance analytics pill visibility")
+  async checkPortfolioBalanceAnalyticsPillVisibility() {
+    await detoxExpect(getElementById(this.portfolioBalanceAnalyticsPill)).toBeVisible();
+  }
+
+  @Step("Tap on portfolio balance analytics pill")
+  async tapPortfolioBalanceAnalyticsPill() {
+    await tapById(this.portfolioBalanceAnalyticsPill);
+  }
+
+  @Step("Check transfer bottom sheet receive button visibility")
+  async checkTransferBottomSheetReceiveButtonVisibility() {
+    await detoxExpect(getElementById(this.transferBottomSheetReceiveButton)).toBeVisible();
+  }
+
+  @Step("Check transfer bottom sheet send button visibility")
+  async checkTransferBottomSheetSendButtonVisibility() {
+    await detoxExpect(getElementById(this.transferBottomSheetSendButton)).toBeVisible();
+  }
+
+  @Step("Check transfer bottom sheet bank transfer button visibility")
+  async checkTransferBottomSheetBankTransferButtonVisibility() {
+    await detoxExpect(getElementById(this.transferBottomSheetBankTransferButton)).toBeVisible();
+  }
+
+  @Step("Press transfer bottom sheet receive button")
+  async pressTransferBottomSheetReceiveButton() {
+    await tapById(this.transferBottomSheetReceiveButton);
+  }
+
+  @Step("Press transfer bottom sheet send button")
+  async pressTransferBottomSheetSendButton() {
+    await tapById(this.transferBottomSheetSendButton);
+  }
+
+  @Step("Press transfer bottom sheet bank transfer button")
+  async pressTransferBottomSheetBankTransferButton() {
+    await tapById(this.transferBottomSheetBankTransferButton);
   }
 }

--- a/e2e/mobile/specs/portfolio/portfolio.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolio.spec.ts
@@ -1,0 +1,95 @@
+const testConfig = {
+  tmsLinks: ["B2CQA-4345", "B2CQA-4339", "B2CQA-4346", "B2CQA-4343", "B2CQA-4341", "B2CQA-4340"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+};
+
+const ACCOUNT = Account.INJ_1;
+const CURRENCY = ACCOUNT.currency;
+const TICKER = CURRENCY.ticker;
+
+describe("Wallet 4.0 - Portfolio", () => {
+  beforeAll(async () => {
+    await app.init({
+      userdata: "skip-onboarding",
+      speculosApp: CURRENCY.speculosApp,
+      // to-do remove when wallet 4.0 is default
+      featureFlags: {
+        lwmWallet40: {
+          enabled: true,
+          params: { marketBanner: true, graphRework: true, quickActionCtas: true },
+        },
+        llmAccountListUI: {
+          enabled: true,
+        },
+      },
+    });
+    await app.portfolio.waitForPortfolioPageToLoad();
+  });
+
+  testConfig.tmsLinks.forEach(link => $TmsLink(link));
+  testConfig.tags.forEach(tag => $Tag(tag));
+
+  it("is the zero balance portfolio state", async () => {
+    await app.portfolio.checkQuickActionTransferButtonVisibility();
+    await app.portfolio.checkQuickActionSwapButtonVisibility();
+    await app.portfolio.checkQuickActionBuyButtonVisibility();
+    // check that the quick action swap button is disabled by pressing it and checking the no balance title visibility
+    await app.portfolio.pressQuickActionSwapButton();
+    await app.portfolio.checkNoBalanceTitleVisibility();
+  });
+
+  it("adds an account and change the app state", async () => {
+    await app.portfolio.addAccount();
+    await app.addAccount.importWithYourLedger();
+    await app.modularDrawer.performSearchByTicker(TICKER);
+    await app.modularDrawer.selectCurrencyByTicker(TICKER);
+    await app.modularDrawer.selectNetwork(CURRENCY.name);
+    await app.addAccount.addAccountAtIndex(ACCOUNT.accountName, CURRENCY.id, ACCOUNT.index);
+    await app.common.tapCloseWithConfirmationButton();
+  });
+
+  it("is the funded portfolio state", async () => {
+    await app.portfolio.checkQuickActionTransferButtonVisibility();
+    await app.portfolio.checkQuickActionSwapButtonVisibility();
+    await app.portfolio.checkQuickActionBuyButtonVisibility();
+    await app.portfolio.checkNormalBalanceTitleVisibility();
+    await app.portfolio.checkPortfolioBalanceAnalyticsPillVisibility();
+  });
+
+  it("navigates to the analytics screen", async () => {
+    await app.portfolio.tapPortfolioBalanceAnalyticsPill();
+    await app.portfolio.expectBalanceToBeVisible();
+    await app.common.goToPreviousPage();
+  });
+
+  it("navigates to the buy screen", async () => {
+    await app.portfolio.pressQuickActionBuyButton();
+    await app.buySell.expectBuySellScreenToBeVisible("Buy");
+  });
+
+  it("navigates to the swap screen", async () => {
+    await app.portfolio.openViaDeeplink();
+    await app.portfolio.waitForPortfolioPageToLoad();
+
+    await app.portfolio.pressQuickActionSwapButton();
+    await app.swapLiveApp.expectSwapLiveApp();
+  });
+
+  it("performs the transfer bottom sheet actions", async () => {
+    await app.portfolio.openViaDeeplink();
+    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.portfolio.pressQuickActionTransferButton();
+    await app.portfolio.checkTransferBottomSheetReceiveButtonVisibility();
+    await app.portfolio.checkTransferBottomSheetSendButtonVisibility();
+    if (await app.portfolio.isNoahEnabled()) {
+      await app.portfolio.checkTransferBottomSheetBankTransferButtonVisibility();
+    }
+    await app.portfolio.pressTransferBottomSheetReceiveButton();
+    await app.modularDrawer.checkSelectAssetPage();
+    await app.portfolio.closeBottomSheet();
+
+    await app.portfolio.pressQuickActionTransferButton();
+    await app.portfolio.pressTransferBottomSheetSendButton();
+    await app.send.expectFirstStep();
+  });
+});

--- a/e2e/mobile/userdata/skip-onboarding.json
+++ b/e2e/mobile/userdata/skip-onboarding.json
@@ -15,7 +15,6 @@
       "orderAccounts": "balance|desc",
       "countervalueFirst": false,
       "autoLockTimeout": 10,
-      "selectedTimeRange": "month",
       "marketIndicator": "western",
       "currenciesSettings": {},
       "pairExchanges": {},


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - New E2E test covering the Wallet 4.0 portfolio happy path on mobile
  - Rename `noFund` state to `noAccounts` across the portfolio balance section (type, view model, view, tests, integration tests, translations)
  - Add `testID` to the "Add crypto account" CTA button in `PortfolioNoAccountsContent`
  - Rename `NavigationHeaderClose` to `NavigationHeaderCloseButton` in Swap header navigation
  - Remove hardcoded `selectedTimeRange` from skip-onboarding userdata fixture
  - Add new page object methods for portfolio quick actions, transfer bottom sheet, and balance states

### 📝 Description

This PR adds comprehensive E2E coverage for the **Wallet 4.0 portfolio** feature on mobile and includes several minor fixes to support test reliability.

**E2E test (`portfolio.spec.ts`):**
- Validates the zero-balance state (quick actions visible, swap disabled without accounts)
- Adds an account (INJ) via the add account flow and verifies the portfolio transitions to the normal balance state
- Checks balance analytics pill visibility and interaction
- Validates quick action CTAs: **Buy** navigates to the Buy/Sell screen, **Swap** navigates to the Swap Live App, **Transfer** opens the bottom sheet with Receive/Send/Bank Transfer options
- Verifies the transfer bottom sheet actions (Receive opens asset selector, Send opens first step)
- Conditionally checks bank transfer visibility based on the Noah feature flag

**Portfolio page object (`portfolio.page.ts`):**
- Added selectors and methods for quick action buttons (Transfer, Swap, Buy)
- Added selectors and methods for transfer bottom sheet actions (Receive, Send, Bank Transfer)
- Added balance state checks (`noAccounts`, `normal`, analytics pill)
- Added Noah feature flag helper to conditionally assert bank transfer availability

**Rename `noFund` → `noAccounts`:**
- Updated the `PortfolioBalanceState` type, view model, view component, unit tests, integration test, and translation key to use `noAccounts` instead of `noFund` for better semantic clarity

**Other changes:**
- Added `testID="add-account-cta"` to the add account button in `PortfolioNoAccountsContent`
- Renamed `NavigationHeaderClose` → `NavigationHeaderCloseButton` test ID in Swap navigation
- Added `tapCloseWithConfirmationButton` helper to `common.page.ts`
- Removed `selectedTimeRange: "month"` from `skip-onboarding.json` fixture to use the default value

<img width="1072" height="73" alt="image" src="https://github.com/user-attachments/assets/3328d5a3-69b7-4a6b-9012-1c64f4608418" />

e2e run: https://github.com/LedgerHQ/ledger-live/actions/runs/22039884377

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24651](https://ledgerhq.atlassian.net/browse/LIVE-24651)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-24651]: https://ledgerhq.atlassian.net/browse/LIVE-24651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ