### PR TITLE
fix(lwm): avoid dismissing the keyboard when drawer closes (memo input)

### DIFF
--- a/.changeset/mighty-hairs-rule.md
+++ b/.changeset/mighty-hairs-rule.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix(lwm): avoid dismissing keyboard when drawer closes (memo)

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/index.tsx
@@ -28,6 +28,7 @@ export type Props = {
   onClose?: () => void;
   onModalHide?: () => void;
   preventBackdropClick?: boolean;
+  preventKeyboardDismissOnClose?: boolean;
   style?: StyleProp<ViewStyle>;
   containerStyle?: StyleProp<ViewStyle>;
   children?: React.ReactNode;
@@ -49,6 +50,7 @@ const QueuedDrawerNative = ({
   noCloseButton,
   hasBackButton,
   preventBackdropClick,
+  preventKeyboardDismissOnClose,
   style,
   containerStyle,
   children,
@@ -79,6 +81,7 @@ const QueuedDrawerNative = ({
     onBack,
     onModalHide,
     preventBackdropClick,
+    preventKeyboardDismissOnClose,
   });
 
   const translateY = useSharedValue(1000);

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/useQueuedDrawerNative.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/useQueuedDrawerNative.ts
@@ -13,6 +13,7 @@ interface UseQueuedDrawerNativeProps {
   onBack?: () => void;
   onModalHide?: () => void;
   preventBackdropClick?: boolean;
+  preventKeyboardDismissOnClose?: boolean;
 }
 
 const useQueuedDrawerNative = ({
@@ -22,6 +23,7 @@ const useQueuedDrawerNative = ({
   onBack,
   onModalHide,
   preventBackdropClick,
+  preventKeyboardDismissOnClose = false,
 }: UseQueuedDrawerNativeProps) => {
   const { addDrawerToQueue } = useQueuedDrawerContext();
   const drawerInQueueRef = useRef<DrawerInQueue | undefined>(undefined);
@@ -76,10 +78,12 @@ const useQueuedDrawerNative = ({
 
   const handleDismiss = useCallback(() => {
     logDrawer("Native modal dismissed");
-    Keyboard.dismiss();
+    if (!preventKeyboardDismissOnClose) {
+      Keyboard.dismiss();
+    }
     handleClose();
     onModalHideRef.current?.();
-  }, [handleClose]);
+  }, [handleClose, preventKeyboardDismissOnClose]);
 
   // Queue management effect
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/MemoTag/components/MemoTagDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MemoTag/components/MemoTagDrawer.tsx
@@ -20,7 +20,12 @@ export const MemoTagDrawer = memo(({ open, onClose, onNext, onModalHide }: Props
   const { t } = useTranslation();
 
   return (
-    <QueuedDrawer isRequestingToBeOpened={open} onClose={onClose} onModalHide={onModalHide}>
+    <QueuedDrawer
+      isRequestingToBeOpened={open}
+      onClose={onClose}
+      onModalHide={onModalHide}
+      preventKeyboardDismissOnClose
+    >
       <Flex alignItems="center" mb={7}>
         <Circle size={72} bg={colors.opacityDefault.c05}>
           <Icons.InformationFill size="L" color="primary.c80" />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Adds a `preventKeyboardDismissOnClose` prop to `QueuedDrawer` so callers can avoid dismissing the keyboard when the drawer closes. `MemoTagDrawer` use this so that when the users close the memo tag info drawer after viewing it, the keyboard stays open and they can continue typing in the memo field without reapplying focus.

https://github.com/user-attachments/assets/5ba8ffa5-bb9d-483f-ba49-cb039d944d73



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-22997)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->https://ledgerhq.atlassian.net/browse/LIVE-25850


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
