### PR TITLE
fix(live-mobile): tighten test-renderer typing

### DIFF
--- a/.changeset/yellow-kings-nail.md
+++ b/.changeset/yellow-kings-nail.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix typing issue in test-renderer

--- a/apps/ledger-live-mobile/__tests__/test-renderer.tsx
+++ b/apps/ledger-live-mobile/__tests__/test-renderer.tsx
@@ -88,6 +88,10 @@ enum RenderType {
   HOOK = "hook",
 }
 
+type NavigationChildren = React.ComponentProps<typeof NavigationContainer>["children"];
+type CountervaluesChildren = React.ComponentProps<typeof CountervaluesProvider>["children"];
+type WrapperProps = { children?: NavigationChildren };
+
 function createStore({ overrideInitialState }: { overrideInitialState: (state: State) => State }) {
   return configureStore({
     reducer: reducers,
@@ -106,7 +110,7 @@ function CountervaluesProviders({
   children,
   store,
 }: {
-  children: React.ReactNode;
+  children: CountervaluesChildren;
   store: ReduxStore;
 }): React.JSX.Element {
   // TODO This interim bridge is only a stop-gap. We’ll remove it once we either:
@@ -156,7 +160,7 @@ function Providers({
   withLiveApp = false,
   renderType = RenderType.DEFAULT,
 }: {
-  children: React.ReactNode;
+  children: NavigationChildren;
   store: ReduxStore;
   withReactQuery?: boolean;
   withLiveApp?: boolean;
@@ -208,7 +212,7 @@ function Providers({
 }
 
 const customRender = (
-  ui: React.ReactElement,
+  ui: Parameters<typeof rntlRender>[0],
   {
     overrideInitialState: overrideInitialState = state => state,
     userEventOptions = {},
@@ -219,7 +223,7 @@ const customRender = (
     overrideInitialState,
   });
 
-  const ProvidersWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const ProvidersWrapper = ({ children }: WrapperProps): React.JSX.Element => {
     return <Providers store={store}>{children}</Providers>;
   };
 
@@ -231,7 +235,7 @@ const customRender = (
 };
 
 const renderWithReactQuery = (
-  ui: React.ReactElement,
+  ui: Parameters<typeof rntlRender>[0],
   {
     overrideInitialState: overrideInitialState = state => state,
     userEventOptions = {},
@@ -242,7 +246,7 @@ const renderWithReactQuery = (
     overrideInitialState,
   });
 
-  const ProvidersWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const ProvidersWrapper = ({ children }: WrapperProps): React.JSX.Element => {
     return (
       <Providers store={store} withReactQuery>
         {children}
@@ -267,7 +271,7 @@ const customRenderHook = <Result,>(
   const store = createStore({
     overrideInitialState,
   });
-  const ProvidersWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const ProvidersWrapper = ({ children }: WrapperProps): React.JSX.Element => {
     return (
       <Providers store={store} renderType={RenderType.HOOK}>
         {children}
@@ -289,7 +293,7 @@ const customRenderHookWithLiveAppProvider = <Result,>(
     overrideInitialState,
   });
 
-  const ProvidersWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const ProvidersWrapper = ({ children }: WrapperProps): React.JSX.Element => {
     return (
       <Providers store={store} renderType={RenderType.HOOK} withLiveApp>
         {children}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Not run locally for this PR; change is limited to test utility typings._
- [x] **Impact of the changes:**
  - Mobile test renderer typing surface (`__tests__/test-renderer.tsx`)
  - Type compatibility with `NavigationContainer`, `CountervaluesProvider`, and RNTL render signatures
  - No runtime/app UI behavior impact

### 📝 Description

This PR fixes typing friction in the mobile test renderer helper, where broad React types caused incompatibilities and weaker type guarantees in test wrappers.

The update introduces narrower, source-derived types for provider children and render inputs, and replaces broad `React.ReactElement`/`React.ReactNode` usages with signatures inferred from React Navigation and RNTL helpers. A `live-mobile` changeset is included for release notes.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26010

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)