### PR TITLE
feat(mobile): add Lumen TabBar as main navigation behind lwmWallet40 feature flag

### DIFF
--- a/.changeset/lumen-main-tab-bar.md
+++ b/.changeset/lumen-main-tab-bar.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Lumen TabBar as the main navigation bar behind the lwmWallet40 feature flag

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/MainTabBarView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/MainTabBarView.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import Animated, { FadeInDown, FadeOutDown } from "react-native-reanimated";
+import { TabBar, TabBarItem } from "@ledgerhq/lumen-ui-rnative";
+import type { MainTabBarViewProps } from "./types";
+
+export const MainTabBarView: React.FC<MainTabBarViewProps> = ({
+  activeRouteName,
+  tabItems,
+  onTabPress,
+  hideTabBar,
+  bottomInset,
+  bottomOffset,
+}) => {
+  if (hideTabBar) {
+    return null;
+  }
+
+  return (
+    <Animated.View
+      entering={FadeInDown}
+      exiting={FadeOutDown}
+      style={{
+        position: "absolute",
+        bottom: bottomOffset,
+        left: 0,
+        right: 0,
+        paddingBottom: bottomInset,
+      }}
+    >
+      <TabBar active={activeRouteName} onTabPress={onTabPress} lx={{ marginHorizontal: "s16" }}>
+        {tabItems.map(item => (
+          <TabBarItem
+            key={item.value}
+            value={item.value}
+            label={item.label}
+            icon={item.icon}
+            activeIcon={item.activeIcon}
+          />
+        ))}
+      </TabBar>
+    </Animated.View>
+  );
+};

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/__integrations__/MainTabBar.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/__integrations__/MainTabBar.integration.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { render, screen } from "@tests/test-renderer";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { NavigatorName, ScreenName } from "~/const";
+import { MainTabBar } from "../index";
+import type { MainTabBarProps } from "../types";
+
+const Tab = createBottomTabNavigator();
+
+function StubScreen({ label }: { readonly label: string }) {
+  return (
+    <View>
+      <Text>{label}</Text>
+    </View>
+  );
+}
+
+const PortfolioScreen = () => <StubScreen label="Portfolio Content" />;
+const EarnScreen = () => <StubScreen label="Earn Content" />;
+const TransferScreen = () => <StubScreen label="Transfer Content" />;
+const DiscoverScreen = () => <StubScreen label="Discover Content" />;
+const MyLedgerScreen = () => <StubScreen label="My Ledger Content" />;
+
+function TestNavigator() {
+  return (
+    <Tab.Navigator
+      tabBar={props => <MainTabBar {...(props as MainTabBarProps)} />}
+      screenOptions={{ headerShown: false }}
+    >
+      <Tab.Screen name={NavigatorName.Portfolio} component={PortfolioScreen} />
+      <Tab.Screen name={NavigatorName.Earn} component={EarnScreen} />
+      <Tab.Screen name={ScreenName.Transfer} component={TransferScreen} />
+      <Tab.Screen name={NavigatorName.Discover} component={DiscoverScreen} />
+      <Tab.Screen name={NavigatorName.MyLedger} component={MyLedgerScreen} />
+    </Tab.Navigator>
+  );
+}
+
+describe("MainTabBar Integration", () => {
+  it("should render all tab labels", () => {
+    render(<TestNavigator />);
+
+    ["Home", "Earn", "Transfer", "Discover", "Ledger"].forEach(name =>
+      expect(screen.getByRole("tab", { name })).toBeVisible(),
+    );
+  });
+
+  it("should render the first tab screen by default", () => {
+    render(<TestNavigator />);
+
+    expect(screen.getByText("Portfolio Content")).toBeVisible();
+  });
+
+  it("should navigate to tab when pressed", async () => {
+    const { user } = render(<TestNavigator />);
+
+    const cases = [
+      { tab: "Earn", content: "Earn Content" },
+      { tab: "Transfer", content: "Transfer Content" },
+      { tab: "Discover", content: "Discover Content" },
+      { tab: "Ledger", content: "My Ledger Content" },
+    ];
+
+    for (const { tab, content } of cases) {
+      await user.press(screen.getByRole("tab", { name: tab }));
+      expect(screen.getByText(content)).toBeVisible();
+    }
+  });
+
+  it("should mark the active tab as selected", () => {
+    render(<TestNavigator />);
+
+    const homeTab = screen.getByRole("tab", { name: "Home" });
+    expect(homeTab).toHaveProp("accessibilityState", { selected: true });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/index.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Platform } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useKeyboardVisible } from "~/logic/keyboardVisible";
+import { useMainTabBarViewModel } from "./useMainTabBarViewModel";
+import { MainTabBarView } from "./MainTabBarView";
+import type { MainTabBarProps } from "./types";
+
+export function MainTabBar({
+  state,
+  navigation,
+  hideTabBar = false,
+}: MainTabBarProps): React.JSX.Element {
+  const { bottom } = useSafeAreaInsets();
+  const { keyboardHeight } = useKeyboardVisible();
+  const viewModel = useMainTabBarViewModel({ state, navigation });
+
+  // On Android 35+ the keyboard overlaps the tab bar because it is absolutely
+  // positioned. Shift the whole bar upward by the keyboard height so it stays
+  // visible, matching the behaviour of the legacy CustomTabBar.
+  const bottomOffset = Platform.OS === "android" && Platform.Version >= 35 ? keyboardHeight : 0;
+
+  return (
+    <MainTabBarView
+      {...viewModel}
+      hideTabBar={hideTabBar}
+      bottomInset={bottom}
+      bottomOffset={bottomOffset}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/types.ts
@@ -1,0 +1,17 @@
+import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import type { TabBarItemProps } from "@ledgerhq/lumen-ui-rnative";
+
+export type TabItemConfig = Pick<TabBarItemProps, "value" | "label" | "icon" | "activeIcon">;
+
+export interface MainTabBarViewProps {
+  readonly activeRouteName: string;
+  readonly tabItems: readonly TabItemConfig[];
+  readonly onTabPress: (value: string) => void;
+  readonly hideTabBar: boolean;
+  readonly bottomInset: number;
+  readonly bottomOffset: number;
+}
+
+export interface MainTabBarProps extends BottomTabBarProps {
+  readonly hideTabBar?: boolean;
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
@@ -1,0 +1,79 @@
+import { useCallback, useMemo } from "react";
+import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import {
+  Home,
+  HomeFill,
+  Chart5,
+  Exchange,
+  ExchangeFill,
+  Compass,
+  LedgerDevices,
+} from "@ledgerhq/lumen-ui-rnative/symbols";
+import { NavigatorName, ScreenName } from "~/const";
+import type { TabItemConfig, MainTabBarViewProps } from "./types";
+
+type UseMainTabBarViewModelParams = Pick<BottomTabBarProps, "state" | "navigation">;
+
+type UseMainTabBarViewModelReturn = Pick<
+  MainTabBarViewProps,
+  "activeRouteName" | "tabItems" | "onTabPress"
+>;
+
+type TabIconConfig = { icon: TabItemConfig["icon"]; activeIcon?: TabItemConfig["activeIcon"] };
+
+const TAB_ICONS: Partial<Record<string, TabIconConfig>> = {
+  [NavigatorName.Portfolio]: { icon: Home, activeIcon: HomeFill },
+  [NavigatorName.Earn]: { icon: Chart5 },
+  [ScreenName.Transfer]: { icon: Exchange, activeIcon: ExchangeFill },
+  [NavigatorName.Discover]: { icon: Compass },
+  [NavigatorName.Web3HubTab]: { icon: Compass },
+  [NavigatorName.MyLedger]: { icon: LedgerDevices },
+};
+
+const LABEL_MAP: Partial<Record<string, string>> = {
+  [NavigatorName.Portfolio]: "Home",
+  [NavigatorName.Earn]: "Earn",
+  [ScreenName.Transfer]: "Transfer",
+  [NavigatorName.Discover]: "Discover",
+  [NavigatorName.Web3HubTab]: "Discover",
+  [NavigatorName.MyLedger]: "Ledger",
+};
+
+export const useMainTabBarViewModel = ({
+  state,
+  navigation,
+}: UseMainTabBarViewModelParams): UseMainTabBarViewModelReturn => {
+  const activeRouteName = state.routes[state.index].name;
+
+  const tabItems: readonly TabItemConfig[] = useMemo(
+    () =>
+      state.routes.map(route => ({
+        value: route.name,
+        label: LABEL_MAP[route.name] ?? route.name,
+        ...TAB_ICONS[route.name],
+      })),
+    [state.routes],
+  );
+
+  const onTabPress = useCallback(
+    (value: string) => {
+      const targetRoute = state.routes.find(route => route.name === value);
+      if (!targetRoute) return;
+
+      const event = navigation.emit({
+        type: "tabPress",
+        target: targetRoute.key,
+        canPreventDefault: true,
+      });
+
+      const isFocused = activeRouteName === value;
+
+      if (!isFocused && !event.defaultPrevented) {
+        navigation.navigate(value);
+      }
+    },
+    [state.routes, navigation, activeRouteName],
+  );
+
+  return { activeRouteName, tabItems, onTabPress };
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Bottom tab bar rendering when `lwmWallet40` feature flag is enabled
      - Navigation between all main tabs (Home, Earn, Transfer, Discover, Ledger)
      - Transfer tab opening the bottom sheet drawer instead of navigating to a blank screen
      - Existing navbar remains fully functional when feature flag is disabled

### 📝 Description

**Problem**: The current mobile navigation bar uses a custom implementation with SVG shapes and a floating Transfer action button. As part of the Wallet 4.0 initiative, we need to adopt the new Lumen design system `TabBar` component for a cleaner, more consistent UI.

**Solution**: Introduced a new `MainTabBar` MVVM component that uses Lumen's `TabBar` and `TabBarItem`, conditionally rendered behind the `lwmWallet40` feature flag via `useWalletFeaturesConfig("mobile").shouldDisplayWallet40MainNav`.

Key changes:
- **`MainTabBar` (Container)** — Wires `useSafeAreaInsets` and ViewModel, passes everything as props to the View.
- **`useMainTabBarViewModel`** — Maps React Navigation state to Lumen TabBar props (icons, labels, active state, tab press handling with event emission).
- **`MainTabBarView`** — Pure rendering component using Lumen `TabBar`/`TabBarItem` with Reanimated fade animations.
- **`MainNavigator`** — Conditionally renders `MainTabBar` or the existing `customTabBar` based on the feature flag. Added `tabPress` listener on the Transfer tab to intercept navigation and open the Redux-controlled transfer drawer.
- **Icons** — Uses Lumen symbols (`Home`/`HomeFill`, `Chart2`, `Exchange`/`ExchangeFill`, `Planet`, `LedgerDevices`) with `activeIcon` variants where available.
- **Integration tests** — 4 tests covering tab rendering, default screen, navigation, and active state selection.

<img width="300" height="750" alt="simulator_screenshot_6778B4C0-D62F-444E-96F4-1F7B0C6B8039" src="https://github.com/user-attachments/assets/ba19816e-56e6-433a-b79c-179f5a02ccfd" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24664](https://ledgerhq.atlassian.net/browse/LIVE-24664)
---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)