### PR TITLE
support: optimize Cursor rules context usage

### DIFF
--- a/.cursor/rules/client-ids.mdc
+++ b/.cursor/rules/client-ids.mdc
@@ -1,3 +1,8 @@
+---
+description: Privacy-protected ID management with @ledgerhq/client-ids — DeviceId, UserId, DatadogId, export-rules.json
+alwaysApply: false
+---
+
 # Client IDs Library (`@ledgerhq/client-ids`)
 
 ## Purpose

--- a/.cursor/rules/cursor-rules.mdc
+++ b/.cursor/rules/cursor-rules.mdc
@@ -1,0 +1,32 @@
+---
+globs: ["**/.cursor/rules/**"]
+description: Guidelines for authoring and configuring .cursor/rules — activation modes, frontmatter, best practices
+alwaysApply: false
+---
+
+# Cursor Rule Authoring
+
+Reference: https://cursor.com/docs/context/rules#rule-file-format
+
+## Rule Activation Modes
+
+Rules activate based on the combination of `description`, `globs`, and `alwaysApply` in their frontmatter:
+
+| Rule Type               | Frontmatter                                 | Behavior                           |
+| ----------------------- | ------------------------------------------- | ---------------------------------- |
+| Always Apply            | `alwaysApply: true`                         | Injected into every conversation   |
+| Apply Intelligently     | `description` + `alwaysApply: false`        | Agent decides based on description |
+| Apply to Specific Files | `globs` + `alwaysApply: false`              | Auto-activates on matching files   |
+| Apply Manually          | `alwaysApply: false` (no description/globs) | Only when @-mentioned in chat      |
+
+A `description` can be combined with `globs` — the description serves as documentation for human readers and also enables agent-decided activation when no matching file is open. The `description` field is always recommended.
+
+## Rules
+
+- **Avoid `alwaysApply: true`** — it clogs the context window by injecting the rule into every conversation unconditionally.
+- **Always add a `description`** — it documents the rule's purpose for human readers and enables intelligent agent-decided activation.
+- **Prefer smart activation (`description`) over `globs`** — the agent can judge relevance from conversation context better than broad file patterns. Add `globs` only when activation must be strictly tied to specific file types (e.g., test files, `.tsx` components).
+- **Never combine `alwaysApply: true` with `description` or `globs`** — it makes the other fields useless since the rule is always injected regardless.
+- If using `globs`, ensure patterns are precise (avoid overly broad patterns like `**/*`).
+- Keep rules under 500 lines. Split large rules into composable pieces.
+- Reference files with `@path` instead of copying their contents.

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -1,7 +1,6 @@
 ---
 description: Git workflow and commit conventions for Ledger Wallet
-globs: ["**/*"]
-alwaysApply: true
+alwaysApply: false
 ---
 
 # Git Workflow & Commit Conventions

--- a/.cursor/rules/ldls.mdc
+++ b/.cursor/rules/ldls.mdc
@@ -1,7 +1,6 @@
 ---
-description: LDLS UI React design system rules
-globs: ["**/*.tsx", "**/*.jsx"]
-alwaysApply: true
+description: LDLS UI React design system rules (@ledgerhq/lumen-ui-react)
+alwaysApply: false
 ---
 
 @node_modules/@ledgerhq/lumen-ui-react/ai-rules/RULES.md

--- a/.cursor/rules/react-general.mdc
+++ b/.cursor/rules/react-general.mdc
@@ -1,7 +1,7 @@
 ---
-alwaysApply: true
 description: General React and React Native engineering rules for Ledger Live
 globs: ["**/*.{ts,tsx}"]
+alwaysApply: false
 ---
 
 # General React & React Native Patterns

--- a/.cursor/rules/react-mvvm.mdc
+++ b/.cursor/rules/react-mvvm.mdc
@@ -1,7 +1,7 @@
 ---
-alwaysApply: true
 description: React MVVM Architecture engineering rules (mvvm) for Ledger Wallet
 globs: ["**/*.ts", "**/*.tsx"]
+alwaysApply: false
 ---
 
 # React MVVM Architecture (`mvvm`)

--- a/.cursor/rules/redux-slice.mdc
+++ b/.cursor/rules/redux-slice.mdc
@@ -1,6 +1,6 @@
 ---
 description: Redux Toolkit createSlice best practices
-alwaysApply: true
+alwaysApply: false
 ---
 
 # Redux Toolkit - createSlice

--- a/.cursor/rules/rtk-query-api.mdc
+++ b/.cursor/rules/rtk-query-api.mdc
@@ -1,6 +1,6 @@
 ---
 description: RTK Query createApi best practices
-alwaysApply: true
+alwaysApply: false
 ---
 
 # RTK Query - createApi

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,7 +1,7 @@
 ---
-globs: ["*.test.*", "*.spec.*", "**/tests/**", "**/__tests__/**"]
 description: General, Desktop, and Mobile testing patterns for Ledger Wallet
-alwaysApply: true
+globs: ["*.test.*", "*.spec.*", "**/tests/**", "**/__tests__/**"]
+alwaysApply: false
 ---
 
 # Testing Rules

--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -1,7 +1,7 @@
 ---
-alwaysApply: true
-globs: ["**/*.ts", "**/*.tsx"]
 description: React and React Native development patterns for Ledger Wallet
+globs: ["**/*.ts", "**/*.tsx"]
+alwaysApply: false
 ---
 
 ## **Components**

--- a/.cursor/rules/zod-schemas.mdc
+++ b/.cursor/rules/zod-schemas.mdc
@@ -1,6 +1,6 @@
 ---
 description: Zod schema validation patterns for API types
-alwaysApply: true
+alwaysApply: false
 ---
 
 # Zod Schema Validation


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _N/A — tooling config only, no runtime code changed._
- [x] **Impact of the changes:**
  - Cursor AI context window usage when working in this repo
  - No impact on build, CI, or runtime behavior

### 📝 Description

**Problem**: All 10 Cursor AI rules (`.cursor/rules/*.mdc`) had `alwaysApply: true`, injecting ~7,500–8,000 tokens of instructions into every conversation unconditionally — even when irrelevant (e.g., Lumen UI design tokens during a git operation, Zod schema patterns when editing a README).

**Solution**: Set `alwaysApply: false` on all rules so they activate conditionally via their existing `description` (agent-decided) and/or `globs` (file-matched) fields instead. All original descriptions and globs are preserved. Also adds missing YAML frontmatter to `client-ids.mdc` and a new `cursor-rules.mdc` authoring guide.

**How Cursor rule activation works** (from [the docs](https://cursor.com/docs/context/rules#rule-file-format)):

> If alwaysApply is true, the rule will be applied to every chat session. Otherwise, the description of the rule will be presented to the Cursor Agent to decide if it should be applied.

| Rule Type | Frontmatter | Behavior |
|---|---|---|
| Always Apply | `alwaysApply: true` | Injected into every conversation |
| Apply Intelligently | `description` + `alwaysApply: false` | Agent decides based on description |
| Apply to Specific Files | `globs` + `alwaysApply: false` | Auto-activates on matching files |
| Apply Manually | `alwaysApply: false` (no description/globs) | Only when @-mentioned |

A `description` can be combined with `globs` — the description serves as documentation and enables agent-decided activation even when no matching file is open. Only `alwaysApply: true` should never be combined with other fields.

### ⚠️ Follow-up: `typescript.mdc` likely duplicates `react-general.mdc`

Despite its name, `typescript.mdc` is not about TypeScript-specific patterns — its description is _"React and React Native development patterns for Ledger Wallet"_ and its content covers React components, props, hooks, memoization, and performance. This overlaps significantly with `react-general.mdc` which covers the same topics (functional components, state management, memoization, `useMemo`/`useCallback`/`React.memo`, etc.).

This means both rules can be activated simultaneously on `.ts`/`.tsx` files, injecting redundant instructions. A follow-up should either:
- **Merge** the two rules into one (keeping unique content from each)
- **Rename and refocus** `typescript.mdc` to cover only TS-specific patterns (type utilities, generics, `as const`, discriminated unions, error classes) and remove the React overlap

### ❓ Context

- **Reference**: [Cursor Rules documentation — Rule file format](https://cursor.com/docs/context/rules#rule-file-format)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)