### PR TITLE
fix: call update identify after analytics prompt action

### DIFF
--- a/.changeset/tender-dolls-check.md
+++ b/.changeset/tender-dolls-check.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix call update identify after analytics prompt action

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
@@ -11,7 +11,7 @@ import { ABTestingVariants } from "@ledgerhq/types-live";
 import { urls } from "~/config/urls";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { openURL } from "~/renderer/linking";
-import { track } from "~/renderer/analytics/segment";
+import { track, updateIdentify } from "~/renderer/analytics/segment";
 
 const trackingKeysByFlow: Record<EntryPoint, string> = {
   onboarding: "consent onboarding",
@@ -70,9 +70,14 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
     ],
   );
 
-  const onSubmit = () => {
+  const onSubmit = async () => {
     setIsAnalyticsOptInPromptOpened(false);
     dispatch(setHasSeenAnalyticsOptInPrompt(true));
+    try {
+      await updateIdentify({ force: true });
+    } catch (error) {
+      console.error("Failed to update analytics identify", error);
+    }
     if (entryPoint === EntryPoint.onboarding) {
       nextStep?.();
       setNextStep(null);

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -399,8 +399,17 @@ const confidentialityFilter = (properties?: Record<string, unknown> | null) => {
   };
 };
 
-export const updateIdentify = async () => {
-  if (!storeInstance || !trackingEnabledSelector(storeInstance.getState())) return;
+export interface UpdateIdentifyOptions {
+  /** When true, send identify even when both analytics opt-ins are false (e.g. after analytics prompt "Refuse all"). */
+  force?: boolean;
+}
+
+export const updateIdentify = async ({ force }: UpdateIdentifyOptions = { force: false }) => {
+  if (!storeInstance) return;
+
+  const canTrack = force || trackingEnabledSelector(storeInstance.getState());
+  if (!canTrack) return;
+
   const analytics = getAnalytics();
   if (!analytics) return;
   const { id } = await user();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. 
- [ ] **Covered by automatic tests.** _No dedicated automated test added for this small analytics flow fix._
- [x] **Impact of the changes:**
  - Analytics opt-in prompt flow on Desktop
  - Segment identify update timing after user action
  - User analytics properties consistency after opt-in/interaction

### 📝 Description

This PR fixes an analytics sequencing issue where user identify data was not reliably refreshed after interacting with the analytics opt-in prompt.

The fix updates the Desktop analytics flow so `updateIdentify` is called after the user action in the prompt path, ensuring Segment receives up-to-date identify traits and keeping analytics state consistent.

### ❓ Context

- **JIRA link**: [LIVE-26042](https://ledgerhq.atlassian.net/browse/LIVE-26042)
- **JIRA link**: [LIVE-26044](https://ledgerhq.atlassian.net/browse/LIVE-26044)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)