### PR TITLE
🐛 Fix(market): LIVE-25552 Fix "internet down" reconnection behaviour

### DIFF
--- a/.changeset/fix-live-25552-reconnection-test.md
+++ b/.changeset/fix-live-25552-reconnection-test.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Enable refetching market data on network reconnection (LIVE-25552)

--- a/apps/ledger-live-mobile/__tests__/handlers/market.ts
+++ b/apps/ledger-live-mobile/__tests__/handlers/market.ts
@@ -28,6 +28,9 @@ const handlers = [
 
     return HttpResponse.json(paginatedData);
   }),
+  http.get("https://countervalues.live.ledger.com/v3/supported/fiat", () => {
+    return HttpResponse.json(["usd", "eur", "gbp"]);
+  }),
   http.get("https://proxycg.api.live.ledger.com/api/v3/coins/:coin/market_chart", ({ params }) => {
     return HttpResponse.json(marketsMock.find(({ id }) => id === params.coin));
   }),

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -3,6 +3,7 @@ require("./promise-polyfill");
 import "./polyfill";
 import "./live-common-setup";
 import "./iosWebsocketFix";
+import "./utils/tanstack-setup";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import React, { Component, useMemo, useEffect, useRef } from "react";
 import { StyleSheet, LogBox, Appearance, AppState, View } from "react-native";

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/__tests__/MarketListLayout.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/__tests__/MarketListLayout.test.tsx
@@ -3,9 +3,23 @@ import { renderWithReactQuery, screen, waitFor } from "@tests/test-renderer";
 import { server, http, HttpResponse } from "@tests/server";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { MOCK_MARKET_PERFORMERS } from "@ledgerhq/live-common/market/utils/fixtures";
+import { useNetInfo, type NetInfoState } from "@react-native-community/netinfo";
 import MarketList from "../index";
 import { ScreenName } from "~/const";
 import { State } from "~/reducers/types";
+
+jest.mock("@react-native-community/netinfo", () => {
+  return {
+    __esModule: true,
+    default: { addEventListener: jest.fn },
+    useNetInfo: jest.fn(() => ({ isConnected: true })),
+  };
+});
+
+const setNetInfoState = (state: { isConnected: boolean }) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  jest.mocked(useNetInfo).mockReturnValue(state as NetInfoState);
+};
 
 const COUNTERVALUES_API = "https://countervalues.live.ledger.com";
 
@@ -23,11 +37,9 @@ const MarketListTest = () => (
 
 describe("MarketList Layout based on Feature Flag", () => {
   beforeEach(() => {
+    setNetInfoState({ isConnected: true });
     server.use(
       http.get(`${COUNTERVALUES_API}/v3/markets`, () => HttpResponse.json(MOCK_MARKET_PERFORMERS)),
-      http.get(`${COUNTERVALUES_API}/v3/supported/fiat`, () =>
-        HttpResponse.json(["usd", "eur", "gbp"]),
-      ),
     );
   });
 
@@ -136,6 +148,35 @@ describe("MarketList Layout based on Feature Flag", () => {
 
       // Should use default tabs mode layout
       expect(screen.getByTestId("search-box")).toBeVisible();
+    });
+  });
+
+  describe("When internet seems to be down", () => {
+    it("should display empty market list and 'internet down' message", async () => {
+      setNetInfoState({ isConnected: false });
+      server.use(http.get(`${COUNTERVALUES_API}/v3/markets`, () => HttpResponse.json([])));
+
+      renderWithReactQuery(<MarketListTest />, {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            overriddenFeatureFlags: {
+              lwmWallet40: { enabled: true, params: { marketBanner: true } },
+            },
+          },
+        }),
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("market-list")).toBeVisible();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Sorry, internet seems to be down/i)).toBeVisible();
+      });
+
+      expect(screen.getByText(/Please check your internet connection\./i)).toBeVisible();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/utils/tanstack-setup.ts
+++ b/apps/ledger-live-mobile/src/utils/tanstack-setup.ts
@@ -1,0 +1,8 @@
+import NetInfo from "@react-native-community/netinfo";
+import { onlineManager } from "@tanstack/react-query";
+
+onlineManager.setEventListener(setOnline =>
+  NetInfo.addEventListener(state => {
+    setOnline(!!state.isConnected);
+  }),
+);

--- a/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
+++ b/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
@@ -78,7 +78,7 @@ export function useMarketData(props: MarketListRequestParams): MarketListRequest
         page,
       }),
       refetchOnMount: false,
-      refetchOnReconnect: false,
+      refetchOnReconnect: true,
       refetchOnWindowFocus: false,
     })),
     combine: combineMarketData,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new unit tests — the fix relies on RTK Query's built-in `refetchOnReconnect` mechanism which is well-tested upstream. Manual QA is recommended._
- [x] **Impact of the changes:**
      - Reconnecting to internet replaces Market list with refetched data
      - Tanstack Query refetch listeners are now active globally (setupListeners)

### 📝 Description

**Problem**: If Ledger Wallet is opened without internet the market list shows an error state. This error persists even after the internet connection is restored — the user has to restart the app to see the market list content.

**Solution**: Enabled Tanstack Query's built-in network reconnection detection:
- Set event listeners for Tanstack query in **LWM** initialization to respond to NetInfo state
- Set `refetchOnReconnect: true` for `useMarketData` hook


### ❓ Context

- **JIRA or GitHub link**: [LIVE-25552](https://ledgerhq.atlassian.net/browse/LIVE-25552)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25552]: https://ledgerhq.atlassian.net/browse/LIVE-25552