### PR TITLE
✨ feat(mobile): add TopBar as shared header for Wallet 4.0 main nav

### DIFF
--- a/.changeset/nasty-donuts-build.md
+++ b/.changeset/nasty-donuts-build.md
@@ -1,0 +1,8 @@
+---
+"live-mobile": minor
+---
+
+Add TopBar as shared header for Wallet 4.0 main navigation (LIVE-25994)
+
+- TopBar component (mvvm/components/TopBar): four icon buttons
+- Lumen UI, MainNavigator header, WalletTabHeader, Analytics, Tests

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
@@ -4,8 +4,8 @@ import { IconsLegacy } from "@ledgerhq/native-ui";
 import { BottomTabBarProps, createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { useSelector } from "~/context/hooks";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useWalletFeaturesConfig, useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import Web3HubTabNavigator from "LLM/features/Web3Hub/TabNavigator";
-import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useManagerNavLockCallback } from "./CustomBlockRouterNavigator";
 import { ScreenName, NavigatorName } from "~/const";
 import { PortfolioTabIcon } from "~/screens/Portfolio";
@@ -22,6 +22,7 @@ import { isMainNavigatorVisibleSelector } from "~/reducers/appstate";
 import EarnLiveAppNavigator from "./EarnLiveAppNavigator";
 import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
 import { useRebornFlow } from "LLM/features/Reborn/hooks/useRebornFlow";
+import { MainNavigatorTopBarHeader } from "./MainNavigatorTopBarHeader";
 import { useTransferDrawerController } from "LLM/features/QuickActions";
 
 const Tab = createBottomTabNavigator<MainNavigatorParamList>();
@@ -64,38 +65,46 @@ export default function MainNavigator() {
     (callback: () => void) => {
       // NB This is conditionally going to show the confirmation modal from the manager
       // in the event of having ongoing installs/uninstalls.
-      managerNavLockCallback ? managerNavLockCallback(() => callback) : callback();
+      if (managerNavLockCallback) {
+        managerNavLockCallback(() => callback());
+      } else {
+        callback();
+      }
     },
     [managerNavLockCallback],
   );
 
+  const screenOptions = useMemo(
+    () => ({
+      sceneStyle: { backgroundColor: colors.background.main },
+      tabBarStyle: [
+        {
+          height: 300,
+          borderTopColor: colors.neutral.c30,
+          borderTopWidth: 1,
+          elevation: 5,
+          shadowColor: colors.neutral.c30,
+          backgroundColor: colors.opacityDefault.c10,
+        },
+      ],
+      tabBarShowLabel: false,
+      tabBarActiveTintColor: colors.primary.c80,
+      tabBarInactiveTintColor: colors.neutral.c70,
+      headerShown: shouldDisplayWallet40MainNav,
+      headerTransparent: shouldDisplayWallet40MainNav,
+      header: shouldDisplayWallet40MainNav ? () => <MainNavigatorTopBarHeader /> : undefined,
+      popToTopOnBlur: true,
+    }),
+    [colors, shouldDisplayWallet40MainNav],
+  );
+
   return (
-    <Tab.Navigator
-      tabBar={tabBar}
-      screenOptions={{
-        sceneStyle: { backgroundColor: colors.background.main },
-        tabBarStyle: [
-          {
-            height: 300,
-            borderTopColor: colors.neutral.c30,
-            borderTopWidth: 1,
-            elevation: 5,
-            shadowColor: colors.neutral.c30,
-            backgroundColor: colors.opacityDefault.c10,
-          },
-        ],
-        tabBarShowLabel: false,
-        tabBarActiveTintColor: colors.primary.c80,
-        tabBarInactiveTintColor: colors.neutral.c70,
-        headerShown: false,
-        popToTopOnBlur: true,
-      }}
-    >
+    <Tab.Navigator tabBar={tabBar} screenOptions={screenOptions}>
       <Tab.Screen
         name={NavigatorName.Portfolio}
         component={PortfolioNavigator}
         options={{
-          headerShown: false,
+          ...(!shouldDisplayWallet40MainNav && { headerShown: false }),
           tabBarIcon: props => <PortfolioTabIcon {...props} />,
         }}
         listeners={({ navigation }) => ({
@@ -114,7 +123,7 @@ export default function MainNavigator() {
         component={EarnLiveAppNavigator}
         options={{
           freezeOnBlur: true,
-          headerShown: false,
+          ...(!shouldDisplayWallet40MainNav && { headerShown: false }),
           tabBarIcon: props => (
             <TabIcon
               Icon={IconsLegacy.LendMedium}
@@ -149,7 +158,7 @@ export default function MainNavigator() {
         name={ScreenName.Transfer}
         component={Transfer}
         options={{
-          headerShown: false,
+          ...(!shouldDisplayWallet40MainNav && { headerShown: false }),
           tabBarIcon: () => <TransferTabIcon />,
         }}
         listeners={() => ({
@@ -164,7 +173,7 @@ export default function MainNavigator() {
           name={NavigatorName.Web3HubTab}
           component={Web3HubTabNavigator}
           options={{
-            headerShown: false,
+            ...(!shouldDisplayWallet40MainNav && { headerShown: false }),
             tabBarIcon: props => (
               <TabIcon Icon={IconsLegacy.PlanetMedium} i18nKey="tabs.discover" {...props} />
             ),
@@ -183,7 +192,7 @@ export default function MainNavigator() {
           name={NavigatorName.Discover}
           component={DiscoverNavigator}
           options={{
-            headerShown: false,
+            ...(!shouldDisplayWallet40MainNav && { headerShown: false }),
             tabBarIcon: props => (
               <TabIcon Icon={IconsLegacy.PlanetMedium} i18nKey="tabs.discover" {...props} />
             ),
@@ -204,6 +213,7 @@ export default function MainNavigator() {
         name={NavigatorName.MyLedger}
         component={MyLedgerNavigator}
         options={{
+          ...(!shouldDisplayWallet40MainNav && { headerShown: false }),
           tabBarIcon: props => <ManagerTabIcon {...props} />,
           tabBarButtonTestID: "TabBarManager",
         }}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigatorTopBarHeader.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigatorTopBarHeader.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { View } from "react-native";
+import { useRoute } from "@react-navigation/native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { TopBar } from "LLM/components/TopBar";
+
+export function MainNavigatorTopBarHeader() {
+  const route = useRoute();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View
+      style={{
+        marginTop: insets.top,
+        paddingHorizontal: 16,
+        paddingBottom: 12,
+        backgroundColor: "transparent",
+        height: 48,
+      }}
+    >
+      <TopBar screenName={route.name} />
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/WalletTabNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/WalletTabNavigator.tsx
@@ -53,8 +53,11 @@ export default function WalletTabNavigator() {
   const { t } = useTranslation();
   const [currentRouteName, setCurrentRouteName] = useState<string | undefined>();
 
-  const { shouldDisplayMarketBanner: shouldHideTabs, isEnabled: isNewPortfolioEnabled } =
-    useWalletFeaturesConfig("mobile");
+  const {
+    shouldDisplayMarketBanner: shouldHideTabs,
+    isEnabled: isNewPortfolioEnabled,
+    shouldDisplayWallet40MainNav: shouldDisplayWallet40TopBar,
+  } = useWalletFeaturesConfig("mobile");
   const { backgroundColor } = useWallet40Theme("mobile");
 
   const PortfolioComponent = useMemo(() => {
@@ -115,7 +118,7 @@ export default function WalletTabNavigator() {
             />
           )}
         </WalletTab.Navigator>
-        <WalletTabHeader hidePortfolio={false} />
+        <WalletTabHeader hidePortfolio={false} useWallet40TopBar={shouldDisplayWallet40TopBar} />
       </Box>
     </WalletTabNavigatorScrollManager>
   );

--- a/apps/ledger-live-mobile/src/components/WalletTab/WalletTabHeader.tsx
+++ b/apps/ledger-live-mobile/src/components/WalletTab/WalletTabHeader.tsx
@@ -11,11 +11,20 @@ const AnimatedFlex = Animated.createAnimatedComponent(Flex);
 function WalletTabHeader({
   hidePortfolio,
   animated,
+  useWallet40TopBar = false,
 }: {
   hidePortfolio: boolean;
   animated?: boolean;
+  useWallet40TopBar?: boolean;
 }) {
   const { scrollY, headerHeight } = useContext(WalletTabNavigatorScrollContext);
+  const insets = useSafeAreaInsets();
+  const hasExperimentalHeader = useExperimental();
+
+  if (useWallet40TopBar) {
+    return null;
+  }
+
   const y = animated
     ? 0
     : scrollY.interpolate({
@@ -30,9 +39,6 @@ function WalletTabHeader({
         outputRange: [1, 0],
         extrapolateRight: "clamp",
       });
-
-  const insets = useSafeAreaInsets();
-  const hasExperimentalHeader = useExperimental();
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView.tsx
@@ -1,0 +1,120 @@
+import React, { useCallback } from "react";
+import { Box, IconButton } from "@ledgerhq/lumen-ui-rnative";
+import { type LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import {
+  Stax,
+  Compass,
+  Bell,
+  BellNotification,
+  Settings,
+  Apex,
+  Flex,
+  Nano,
+} from "@ledgerhq/lumen-ui-rnative/symbols";
+import { lastConnectedDeviceSelector } from "~/reducers/settings";
+import { useSelector } from "~/context/hooks";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { ICON_SIZE } from "./const";
+
+type TopBarViewProps = {
+  onMyLedgerPress: () => void;
+  onDiscoverPress: () => void;
+  onNotificationsPress: () => void;
+  onSettingsPress: () => void;
+  hasUnreadNotifications: boolean;
+};
+
+type IconComponent = NonNullable<React.ComponentProps<typeof IconButton>["icon"]>;
+
+export function TopBarView({
+  onMyLedgerPress,
+  onDiscoverPress,
+  onNotificationsPress,
+  onSettingsPress,
+  hasUnreadNotifications,
+}: Readonly<TopBarViewProps>) {
+  const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+
+  const deviceIcon: IconComponent = useCallback(
+    ({ size, style }) => {
+      switch (lastConnectedDevice?.modelId) {
+        case DeviceModelId.nanoS:
+        case DeviceModelId.nanoSP:
+        case DeviceModelId.nanoX:
+          return <Nano size={size ?? ICON_SIZE} style={style} color="base" />;
+        case DeviceModelId.europa:
+          return <Flex size={size ?? ICON_SIZE} style={style} color="base" />;
+        case DeviceModelId.apex:
+          return <Apex size={size ?? ICON_SIZE} style={style} color="base" />;
+        case DeviceModelId.stax:
+        default:
+          return <Stax size={size ?? ICON_SIZE} style={style} color="base" />;
+      }
+    },
+    [lastConnectedDevice?.modelId],
+  );
+
+  const notificationIcon: IconComponent = useCallback(
+    ({ size, style }) => {
+      return hasUnreadNotifications ? (
+        <BellNotification size={size ?? ICON_SIZE} style={style} color="base" />
+      ) : (
+        <Bell size={size ?? ICON_SIZE} style={style} color="base" />
+      );
+    },
+    [hasUnreadNotifications],
+  );
+
+  return (
+    <Box lx={rowLx}>
+      <IconButton
+        onPress={onMyLedgerPress}
+        testID="topbar-myledger"
+        accessibilityLabel="My Ledger"
+        appearance="transparent"
+        icon={deviceIcon}
+        size="md"
+      />
+
+      <Box lx={rightGroupLx}>
+        <IconButton
+          onPress={onDiscoverPress}
+          testID="topbar-discover"
+          accessibilityLabel="Discover"
+          appearance="transparent"
+          icon={Compass}
+          size="md"
+        />
+        <IconButton
+          onPress={onNotificationsPress}
+          testID="topbar-notifications"
+          accessibilityLabel="Notifications"
+          appearance="transparent"
+          icon={notificationIcon}
+          size="md"
+        />
+        <IconButton
+          onPress={onSettingsPress}
+          testID="topbar-settings"
+          accessibilityLabel="Settings"
+          appearance="transparent"
+          icon={Settings}
+          size="md"
+        />
+      </Box>
+    </Box>
+  );
+}
+
+const rowLx: LumenViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  width: "full",
+  justifyContent: "space-between",
+};
+
+const rightGroupLx: LumenViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  gap: "s8",
+};

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { renderWithReactQuery } from "@tests/test-renderer";
+import { expectedNavigationParams } from "../const";
+import { TopBar } from "../index";
+import { track } from "~/analytics";
+import { ScreenName } from "~/const/navigation";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+describe("TopBar navigation", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it("should navigate to MyLedger with expected params when myLedger button is pressed", async () => {
+    const { user, getByTestId } = renderWithReactQuery(<TopBar />);
+
+    await user.press(getByTestId("topbar-myledger"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expectedNavigationParams.myLedger.name,
+      expectedNavigationParams.myLedger.params,
+    );
+
+    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+      button: "MyLedger",
+      page: ScreenName.Portfolio,
+    });
+  });
+
+  it("should navigate to Discover with expected params when discover button is pressed", async () => {
+    const { user, getByTestId } = renderWithReactQuery(<TopBar />);
+
+    await user.press(getByTestId("topbar-discover"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expectedNavigationParams.discover.name,
+      expectedNavigationParams.discover.params,
+    );
+
+    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+      button: "Discover",
+      page: ScreenName.Portfolio,
+    });
+  });
+
+  it("should navigate to NotificationCenter with expected params when notifications button is pressed", async () => {
+    const { user, getByTestId } = renderWithReactQuery(<TopBar />);
+
+    await user.press(getByTestId("topbar-notifications"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expectedNavigationParams.notifications.name,
+      expectedNavigationParams.notifications.params,
+    );
+
+    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+      button: "Notifications",
+      page: ScreenName.Portfolio,
+    });
+  });
+
+  it("should navigate to Settings with expected params when settings button is pressed", async () => {
+    const { user, getByTestId } = renderWithReactQuery(<TopBar />);
+
+    await user.press(getByTestId("topbar-settings"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(expectedNavigationParams.settings.name);
+
+    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+      button: "Settings",
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
@@ -1,0 +1,71 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { expectedNavigationParams } from "../const";
+import { useTopBarViewModel } from "../useTopBarViewModel";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const mockNavigation = { navigate: mockNavigate };
+
+describe("useTopBarViewModel", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it("should call navigate with expected params when onMyLedgerPress is invoked", () => {
+    const { result } = renderHook(() => useTopBarViewModel(mockNavigation as never));
+
+    act(() => {
+      result.current.onMyLedgerPress();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expectedNavigationParams.myLedger.name,
+      expectedNavigationParams.myLedger.params,
+    );
+  });
+
+  it("should call navigate with expected params when onDiscoverPress is invoked", () => {
+    const { result } = renderHook(() => useTopBarViewModel(mockNavigation as never));
+
+    act(() => {
+      result.current.onDiscoverPress();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expectedNavigationParams.discover.name,
+      expectedNavigationParams.discover.params,
+    );
+  });
+
+  it("should call navigate with expected params when onNotificationsPress is invoked", () => {
+    const { result } = renderHook(() => useTopBarViewModel(mockNavigation as never));
+
+    act(() => {
+      result.current.onNotificationsPress();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expectedNavigationParams.notifications.name,
+      expectedNavigationParams.notifications.params,
+    );
+  });
+
+  it("should call navigate with expected params when onSettingsPress is invoked", () => {
+    const { result } = renderHook(() => useTopBarViewModel(mockNavigation as never));
+
+    act(() => {
+      result.current.onSettingsPress();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(expectedNavigationParams.settings.name);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/const.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/const.ts
@@ -1,0 +1,25 @@
+import { NavigatorName, ScreenName } from "~/const";
+import type { TopBarNavigationParams } from "./types";
+
+export const ICON_SIZE = 24;
+
+export const expectedNavigationParams: TopBarNavigationParams = {
+  myLedger: {
+    name: NavigatorName.MyLedger,
+    params: {
+      screen: ScreenName.MyLedgerChooseDevice,
+      params: { tab: undefined, searchQuery: undefined, updateModalOpened: undefined },
+    },
+  },
+  discover: {
+    name: NavigatorName.Discover,
+    params: { screen: ScreenName.DiscoverScreen },
+  },
+  notifications: {
+    name: NavigatorName.NotificationCenter,
+    params: { screen: ScreenName.NotificationCenter },
+  },
+  settings: {
+    name: NavigatorName.Settings,
+  },
+};

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/index.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { useTopBarViewModel } from "./useTopBarViewModel";
+import { TopBarView } from "./TopBarView";
+
+type TopBarProps = {
+  screenName?: string;
+};
+
+export function TopBar({ screenName }: Readonly<TopBarProps>) {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<{ [key: string]: object | undefined }>>();
+  const {
+    onMyLedgerPress,
+    onDiscoverPress,
+    onNotificationsPress,
+    onSettingsPress,
+    hasUnreadNotifications,
+  } = useTopBarViewModel(navigation, screenName);
+
+  return (
+    <TopBarView
+      onMyLedgerPress={onMyLedgerPress}
+      onDiscoverPress={onDiscoverPress}
+      onNotificationsPress={onNotificationsPress}
+      onSettingsPress={onSettingsPress}
+      hasUnreadNotifications={hasUnreadNotifications}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/types.ts
@@ -1,0 +1,6 @@
+export type TopBarNavigationParams = {
+  myLedger: { name: string; params: { screen: string; params?: object } };
+  discover: { name: string; params: { screen: string } };
+  notifications: { name: string; params: { screen: string } };
+  settings: { name: string };
+};

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
@@ -1,0 +1,57 @@
+import { useCallback, useMemo } from "react";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { NavigatorName, ScreenName } from "~/const";
+import useDynamicContent from "~/dynamicContent/useDynamicContent";
+import { track } from "~/analytics";
+
+export function useTopBarViewModel(
+  navigation: NativeStackNavigationProp<{ [key: string]: object | undefined }>,
+  screenName?: string,
+) {
+  const { notificationCards } = useDynamicContent();
+  const page = screenName ?? ScreenName.Portfolio;
+
+  const hasUnreadNotifications = useMemo(
+    () => notificationCards.some(n => !n.viewed),
+    [notificationCards],
+  );
+
+  const onMyLedgerPress = useCallback(() => {
+    track("menuentry_clicked", { button: "MyLedger", page });
+    navigation.navigate(NavigatorName.MyLedger, {
+      screen: ScreenName.MyLedgerChooseDevice,
+      params: {
+        tab: undefined,
+        searchQuery: undefined,
+        updateModalOpened: undefined,
+      },
+    });
+  }, [navigation, page]);
+
+  const onDiscoverPress = useCallback(() => {
+    track("menuentry_clicked", { button: "Discover", page });
+    navigation.navigate(NavigatorName.Discover, {
+      screen: ScreenName.DiscoverScreen,
+    });
+  }, [navigation, page]);
+
+  const onNotificationsPress = useCallback(() => {
+    track("menuentry_clicked", { button: "Notifications", page });
+    navigation.navigate(NavigatorName.NotificationCenter, {
+      screen: ScreenName.NotificationCenter,
+    });
+  }, [navigation, page]);
+
+  const onSettingsPress = useCallback(() => {
+    track("menuentry_clicked", { button: "Settings" });
+    navigation.navigate(NavigatorName.Settings);
+  }, [navigation]);
+
+  return {
+    onMyLedgerPress,
+    onDiscoverPress,
+    onNotificationsPress,
+    onSettingsPress,
+    hasUnreadNotifications,
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - TopBar visibility when Wallet 4.0 main nav is enabled
  - Navigation from TopBar to My Ledger, Discover, Notifications, Settings
  - Main navigator header and Wallet tab header behavior
  - Feature flag `shouldDisplayWallet40MainNav`

### 📝 Description

**Problem**: With Wallet 4.0 main nav, having both a bottom tab bar and a top header led to a redundant double navigation (bottom + top), hurting UX.

**Solution**: Add a shared TopBar as the single top navigation when Wallet 4.0 main nav is enabled. This change is **behind the feature flag** `shouldDisplayWallet40MainNav`:
- **TopBar** (mvvm/components/TopBar): 4 icon buttons (device, Discover, Notifications, Settings), Lumen UI, MVVM
- **MainNavigatorTopBarHeader**: uses TopBar as the shared header for all tab screens
- **WalletTabHeader**: returns `null` when the Wallet 4.0 TopBar is used to avoid duplicate top + bottom nav
- Types and constants extracted (`types.ts`, `const.ts`), exports cleaned up
- Analytics on button clicks, unit and integration tests
- We use the last seen device to render the correct icon: Stax, Flex, Gen5 (Apex), Nanos. By default we display the stax

**Note**: This is an intentional transitional state to keep this PR scope manageable. The implementation will be refined incrementally in follow-up tasks. 


**Demo**

https://github.com/user-attachments/assets/a7edaaa7-ac24-4547-9c13-bc5053b15ebe


### ❓ Context

- **JIRA**: [LIVE-25994](https://ledgerhq.atlassian.net/browse/LIVE-25994)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
