### PR TITLE
💄 style(mobile): [LIVE-25277] Less intrusive OS update banner

### DIFF
--- a/.changeset/weak-planets-compete.md
+++ b/.changeset/weak-planets-compete.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Replace OS update banner with a less intrusive entry point

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -5044,6 +5044,14 @@
   },
   "FirmwareUpdate": {
     "banner": {
+      "wallet40": {
+          "title": {
+            "default": "OS update available",
+            "manager": "Ledger OS update available"
+          },
+          "version": "Version {{firmwareVersion}}",
+          "cta": "Update"
+        },
       "title": "OS update available",
       "descriptionDeviceName": "Tap to update “{{deviceName}}” to OS version {{firmwareVersion}}.",
       "descriptionProductName": "Tap to update your {{productName}} to OS version {{firmwareVersion}}."

--- a/apps/ledger-live-mobile/src/mvvm/components/CustomTopBar/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/CustomTopBar/index.tsx
@@ -1,13 +1,9 @@
 import React, { useCallback } from "react";
 import { Box, IconButton } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
-import { Stax, Apex, Flex, Nano } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { lastConnectedDeviceSelector } from "~/reducers/settings";
 import { useSelector } from "~/context/hooks";
-import { DeviceModelId } from "@ledgerhq/types-devices";
-import { ICON_SIZE } from "LLM/components/TopBar/const";
-
-type IconComponent = NonNullable<React.ComponentProps<typeof IconButton>["icon"]>;
+import { getDeviceIcon, IconComponent } from "LLM/utils/getDeviceIcon";
 
 export type TopBarActionIcon = {
   id: string;
@@ -26,22 +22,8 @@ export function CustomTopBar({ onMyLedgerPress, customIcons }: Readonly<CustomTo
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
 
   const deviceIcon: IconComponent = useCallback(
-    ({ size, style }) => {
-      switch (lastConnectedDevice?.modelId) {
-        case DeviceModelId.nanoS:
-        case DeviceModelId.nanoSP:
-        case DeviceModelId.nanoX:
-          return <Nano size={size ?? ICON_SIZE} style={style} color="base" />;
-        case DeviceModelId.europa:
-          return <Flex size={size ?? ICON_SIZE} style={style} color="base" />;
-        case DeviceModelId.apex:
-          return <Apex size={size ?? ICON_SIZE} style={style} color="base" />;
-        case DeviceModelId.stax:
-        default:
-          return <Stax size={size ?? ICON_SIZE} style={style} color="base" />;
-      }
-    },
-    [lastConnectedDevice?.modelId],
+    ({ size, style }) => getDeviceIcon(lastConnectedDevice, size, style),
+    [lastConnectedDevice],
   );
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/LegacyBanner.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/LegacyBanner.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Pressable } from "react-native";
+import { Text, Flex } from "@ledgerhq/native-ui";
+import { useTranslation } from "~/context/Locale";
+import { getDeviceIcon } from "LLM/utils/getDeviceIcon";
+import type { ViewProps, DrawerProps } from "./ViewProps";
+import UnsupportedUpdateDrawer from "./UnsupportedUpdateDrawer";
+
+type LegacyBannerProps = {
+  lastConnectedDevice: ViewProps["lastConnectedDevice"];
+  deviceName: string | undefined;
+  productName: string | undefined;
+  version: string;
+  onClickUpdate: () => void;
+  drawerProps: DrawerProps;
+};
+
+const LegacyBanner = ({
+  lastConnectedDevice,
+  deviceName,
+  productName,
+  version,
+  onClickUpdate,
+  drawerProps,
+}: LegacyBannerProps) => {
+  const { t } = useTranslation();
+  const description = deviceName
+    ? t("FirmwareUpdate.banner.descriptionDeviceName", { deviceName, firmwareVersion: version })
+    : t("FirmwareUpdate.banner.descriptionProductName", { productName, firmwareVersion: version });
+
+  return (
+    <>
+      <Pressable onPress={onClickUpdate} testID="fw-update-banner">
+        <Flex
+          flexDirection="row"
+          alignItems="flex-start"
+          backgroundColor="opacityDefault.c05"
+          borderRadius={12}
+          p={7}
+          pl={5}
+        >
+          <Flex flexDirection="row" alignItems="center" mb={5} mr={4}>
+            {getDeviceIcon(lastConnectedDevice)}
+          </Flex>
+          <Flex flexDirection="column" alignItems={"flex-start"} flexShrink={1}>
+            <Text variant="h5" fontWeight="semiBold" pb={4}>
+              {t("FirmwareUpdate.banner.title")}
+            </Text>
+            <Text variant="paragraph" fontWeight="medium" color="opacityDefault.c70">
+              {description}
+            </Text>
+          </Flex>
+        </Flex>
+      </Pressable>
+      <UnsupportedUpdateDrawer
+        isOpen={drawerProps.unsupportedUpdateDrawerOpened}
+        onClose={drawerProps.closeUnsupportedUpdateDrawer}
+        isUsbRequired={drawerProps.isUpdateSupportedButDeviceNotWired}
+        productName={drawerProps.productName}
+        noCloseButton
+      />
+    </>
+  );
+};
+
+export default LegacyBanner;

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/UnsupportedUpdateDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/UnsupportedUpdateDrawer.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { DownloadMedium, UsbMedium } from "@ledgerhq/native-ui/assets/icons";
+import { Button, Box, Text, BottomSheetView, BottomSheetHeader } from "@ledgerhq/lumen-ui-rnative";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { useTranslation } from "~/context/Locale";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+type UnsupportedUpdateDrawerProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  isUsbRequired: boolean;
+  productName: string | undefined;
+  noCloseButton?: boolean;
+};
+
+const UnsupportedUpdateDrawer = ({
+  isOpen,
+  onClose,
+  isUsbRequired,
+  productName,
+  noCloseButton,
+}: UnsupportedUpdateDrawerProps) => {
+  const { t } = useTranslation();
+  const { bottom: bottomInset } = useSafeAreaInsets();
+
+  const Icon = isUsbRequired ? UsbMedium : DownloadMedium;
+  const title = isUsbRequired
+    ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbTitle")
+    : t("FirmwareUpdate.drawerUpdate.title");
+  const description = isUsbRequired
+    ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbDescription", {
+        deviceName: productName,
+      })
+    : t("FirmwareUpdate.drawerUpdate.description");
+
+  return (
+    <QueuedDrawerBottomSheet
+      isRequestingToBeOpened={isOpen}
+      onClose={onClose}
+      noCloseButton={noCloseButton}
+      enableDynamicSizing
+    >
+      <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
+        <BottomSheetHeader />
+        <Box lx={{ alignItems: "center", gap: "s16", paddingHorizontal: "s16" }}>
+          <Icon size={48} />
+          <Text typography="heading5SemiBold" lx={{ textAlign: "center" }}>
+            {title}
+          </Text>
+          <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+            {description}
+          </Text>
+        </Box>
+        <Box lx={{ paddingHorizontal: "s16", paddingTop: "s24" }}>
+          <Button
+            appearance="base"
+            size="lg"
+            onPress={onClose}
+            testID="fw-update-drawer-unsupported-close-btn"
+          >
+            {t("common.close")}
+          </Button>
+        </Box>
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
+};
+
+export default UnsupportedUpdateDrawer;

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/UpdateBanner.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/UpdateBanner.test.tsx
@@ -6,11 +6,12 @@ import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
 import UpdateBanner from ".";
 import { makeOverrideInitialState } from "./__mocks__/makeOverrideInitialState";
 
-// Mock react-navigation's useRoute and useNavigation
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useRoute: jest.fn().mockReturnValue({ params: {} }),
   useNavigation: jest.fn().mockReturnValue({ navigate: jest.fn() }),
+  useIsFocused: jest.fn().mockReturnValue(true),
+  useFocusEffect: jest.fn().mockImplementation((cb: () => void) => cb()),
 }));
 
 // Mock useLatestFirmware
@@ -90,8 +91,10 @@ const newUpdateFlowSupportedDataSet: Array<{
   { ...NANO_SP_DATA, version: "1.0.0", fwVersion: "1.1.0", wired: true },
   { ...NANO_S_DATA, version: "1.6.1", fwVersion: "1.7.2", wired: true },
 ];
-
-describe("<UpdateBanner />", () => {
+describe.each([
+  { lwmWallet40: { enabled: true, params: { mainNavigation: true } } },
+  { lwmWallet40: { enabled: false, params: { mainNavigation: false } } },
+])("<UpdateBanner /> when lwmWallet40 is $lwmWallet40", ({ lwmWallet40 }) => {
   let PlatformSpy: jest.SpyInstance;
   beforeEach(() => {
     // Use clearAllMocks instead of restoreAllMocks to avoid restoring global mocks
@@ -104,13 +107,19 @@ describe("<UpdateBanner />", () => {
     PlatformSpy?.mockRestore();
   });
 
+  const makeOverride = (args: Parameters<typeof makeOverrideInitialState>[0]) =>
+    makeOverrideInitialState({
+      ...args,
+      lwmWallet40: { enabled: lwmWallet40.enabled, params: lwmWallet40.params },
+    });
+
   it("should not display the firmware update banner if there is no update", async () => {
     useLatestFirmware.mockReturnValue(null);
 
     const mockDeviceModelId = DeviceModelId.nanoS;
     const mockDeviceVersion = "2.0.0";
     render(<UpdateBanner onBackFromUpdate={() => {}} />, {
-      overrideInitialState: makeOverrideInitialState({
+      overrideInitialState: makeOverride({
         deviceModelId: mockDeviceModelId,
         version: mockDeviceVersion,
         hasCompletedOnboarding: true,
@@ -135,7 +144,7 @@ describe("<UpdateBanner />", () => {
     const mockDeviceModelId = DeviceModelId.nanoS;
     const mockDeviceVersion = "2.0.0";
     render(<UpdateBanner onBackFromUpdate={() => {}} />, {
-      overrideInitialState: makeOverrideInitialState({
+      overrideInitialState: makeOverride({
         deviceModelId: mockDeviceModelId,
         version: mockDeviceVersion,
         hasCompletedOnboarding: false, // Onboarding has not been completed
@@ -160,7 +169,7 @@ describe("<UpdateBanner />", () => {
     const mockDeviceModelId = DeviceModelId.nanoS;
     const mockDeviceVersion = "2.0.0";
     render(<UpdateBanner onBackFromUpdate={() => {}} />, {
-      overrideInitialState: makeOverrideInitialState({
+      overrideInitialState: makeOverride({
         deviceModelId: mockDeviceModelId,
         version: mockDeviceVersion,
         hasCompletedOnboarding: true,
@@ -186,7 +195,7 @@ describe("<UpdateBanner />", () => {
     const mockDeviceModelId = DeviceModelId.nanoX;
     const mockDeviceVersion = "2.0.0";
     const { user } = render(<UpdateBanner onBackFromUpdate={() => {}} />, {
-      overrideInitialState: makeOverrideInitialState({
+      overrideInitialState: makeOverride({
         deviceModelId: mockDeviceModelId,
         version: mockDeviceVersion,
         hasCompletedOnboarding: true,
@@ -197,9 +206,11 @@ describe("<UpdateBanner />", () => {
 
     // Check that the banner is displayed with the correct wording
     expect(await screen.findByText("OS update available")).toBeOnTheScreen();
-    expect(
-      await screen.findByText("Tap to update your Ledger Nano X to OS version mockVersion."),
-    ).toBeOnTheScreen();
+    if (!lwmWallet40.enabled) {
+      expect(
+        await screen.findByText("Tap to update your Ledger Nano X to OS version mockVersion."),
+      ).toBeOnTheScreen();
+    }
 
     // Press the banner
     await user.press(screen.getByTestId("fw-update-banner"));
@@ -227,16 +238,18 @@ describe("<UpdateBanner />", () => {
     });
 
     const { user } = render(<UpdateBanner onBackFromUpdate={() => {}} />, {
-      overrideInitialState: makeOverrideInitialState({
+      overrideInitialState: makeOverride({
         ...nanoX,
       }),
     });
 
     // Check that the banner is displayed with the correct wording
     expect(await screen.findByText("OS update available")).toBeOnTheScreen();
-    expect(
-      await screen.findByText("Tap to update your Ledger Nano X to OS version mockVersion."),
-    ).toBeOnTheScreen();
+    if (!lwmWallet40.enabled) {
+      expect(
+        await screen.findByText("Tap to update your Ledger Nano X to OS version mockVersion."),
+      ).toBeOnTheScreen();
+    }
 
     // Press the banner
     await user.press(screen.getByTestId("fw-update-banner"));
@@ -264,16 +277,18 @@ describe("<UpdateBanner />", () => {
     });
 
     const { user } = render(<UpdateBanner onBackFromUpdate={() => {}} />, {
-      overrideInitialState: makeOverrideInitialState({
+      overrideInitialState: makeOverride({
         ...nanoX,
       }),
     });
 
     // Check that the banner is displayed with the correct wording
     expect(await screen.findByText("OS update available")).toBeOnTheScreen();
-    expect(
-      await screen.findByText("Tap to update your Ledger Nano X to OS version mockVersion."),
-    ).toBeOnTheScreen();
+    if (!lwmWallet40.enabled) {
+      expect(
+        await screen.findByText("Tap to update your Ledger Nano X to OS version mockVersion."),
+      ).toBeOnTheScreen();
+    }
 
     // Press the banner
     await user.press(screen.getByTestId("fw-update-banner"));
@@ -302,7 +317,7 @@ describe("<UpdateBanner />", () => {
     const mockDeviceModelId = DeviceModelId.nanoS;
     const mockDeviceVersion = "2.0.0";
     const { user } = render(<UpdateBanner onBackFromUpdate={() => {}} />, {
-      overrideInitialState: makeOverrideInitialState({
+      overrideInitialState: makeOverride({
         deviceModelId: mockDeviceModelId,
         version: mockDeviceVersion,
         hasCompletedOnboarding: true,
@@ -313,9 +328,11 @@ describe("<UpdateBanner />", () => {
 
     // Check that the banner is displayed with the correct wording
     expect(await screen.findByText("OS update available")).toBeOnTheScreen();
-    expect(
-      await screen.findByText("Tap to update your Ledger Nano S to OS version mockVersion."),
-    ).toBeOnTheScreen();
+    if (!lwmWallet40.enabled) {
+      expect(
+        await screen.findByText("Tap to update your Ledger Nano S to OS version mockVersion."),
+      ).toBeOnTheScreen();
+    }
 
     // Press the banner
     await user.press(screen.getByTestId("fw-update-banner"));
@@ -342,7 +359,7 @@ describe("<UpdateBanner />", () => {
       });
 
       const { user } = render(<UpdateBanner onBackFromUpdate={() => {}} />, {
-        overrideInitialState: makeOverrideInitialState({
+        overrideInitialState: makeOverride({
           deviceModelId,
           version,
           hasCompletedOnboarding: true,
@@ -353,9 +370,11 @@ describe("<UpdateBanner />", () => {
 
       // Check that the banner is displayed with the correct wording
       expect(await screen.findByText("OS update available")).toBeOnTheScreen();
-      expect(
-        await screen.findByText(`Tap to update your ${productName} to OS version mockVersion.`),
-      ).toBeOnTheScreen();
+      if (!lwmWallet40.enabled) {
+        expect(
+          await screen.findByText(`Tap to update your ${productName} to OS version mockVersion.`),
+        ).toBeOnTheScreen();
+      }
 
       // Press the banner
       await user.press(screen.getByTestId("fw-update-banner"));
@@ -385,7 +404,7 @@ describe("<UpdateBanner />", () => {
         });
 
         const { user } = render(<UpdateBanner onBackFromUpdate={() => {}} />, {
-          overrideInitialState: makeOverrideInitialState({
+          overrideInitialState: makeOverride({
             deviceModelId,
             version,
             hasCompletedOnboarding: true,
@@ -396,9 +415,11 @@ describe("<UpdateBanner />", () => {
 
         // Check that the banner is displayed with the correct wording
         expect(await screen.findByText("OS update available")).toBeOnTheScreen();
-        expect(
-          await screen.findByText(`Tap to update your ${productName} to OS version mockVersion.`),
-        ).toBeOnTheScreen();
+        if (!lwmWallet40.enabled) {
+          expect(
+            await screen.findByText(`Tap to update your ${productName} to OS version mockVersion.`),
+          ).toBeOnTheScreen();
+        }
 
         // Press the banner and check that the entrypoint to the new update flow is called
         await user.press(screen.getByTestId("fw-update-banner"));

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/ViewProps.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/ViewProps.tsx
@@ -8,4 +8,16 @@ export interface ViewProps {
   unsupportedUpdateDrawerOpened: boolean;
   closeUnsupportedUpdateDrawer(): void;
   isUpdateSupportedButDeviceNotWired: boolean;
+  shouldDisplayWallet40MainNav: boolean;
+  isInMyLedgerDeviceScreen: boolean;
 }
+
+export type DrawerProps = Pick<
+  ViewProps,
+  | "unsupportedUpdateDrawerOpened"
+  | "closeUnsupportedUpdateDrawer"
+  | "isUpdateSupportedButDeviceNotWired"
+> & {
+  productName: string | undefined;
+  noCloseButton?: boolean;
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/Wallet40MyLedgerBanner.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/Wallet40MyLedgerBanner.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Button, Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+import type { DrawerProps } from "./ViewProps";
+import UnsupportedUpdateDrawer from "./UnsupportedUpdateDrawer";
+
+type Wallet40MyLedgerBannerProps = {
+  productName: string | undefined;
+  version: string;
+  onClickUpdate: () => void;
+  drawerProps: DrawerProps;
+};
+
+const Wallet40MyLedgerBanner = ({
+  productName,
+  version,
+  onClickUpdate,
+  drawerProps,
+}: Wallet40MyLedgerBannerProps) => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Box
+        lx={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          backgroundColor: "accent",
+          borderRadius: "md",
+          padding: "s16",
+        }}
+      >
+        <Box lx={{ flexDirection: "column", alignItems: "flex-start", flexShrink: 1 }}>
+          <Text typography="heading5SemiBold" lx={{ color: "black" }}>
+            {t("FirmwareUpdate.banner.wallet40.title.manager")}
+          </Text>
+          <Text typography="body2" lx={{ color: "black" }}>
+            {t("FirmwareUpdate.banner.wallet40.version", {
+              productName,
+              firmwareVersion: version,
+            })}
+          </Text>
+        </Box>
+        <Box>
+          <Button appearance="gray" size="sm" onPress={onClickUpdate}>
+            {t("FirmwareUpdate.banner.wallet40.cta", {
+              productName,
+              firmwareVersion: version,
+            })}
+          </Button>
+        </Box>
+      </Box>
+      <UnsupportedUpdateDrawer
+        isOpen={drawerProps.unsupportedUpdateDrawerOpened}
+        onClose={drawerProps.closeUnsupportedUpdateDrawer}
+        isUsbRequired={drawerProps.isUpdateSupportedButDeviceNotWired}
+        productName={drawerProps.productName}
+        noCloseButton
+      />
+    </>
+  );
+};
+
+export default Wallet40MyLedgerBanner;

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/Wallet40PortfolioBanner.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/Wallet40PortfolioBanner.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Button, Box } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+import type { DrawerProps } from "./ViewProps";
+import type { IconComponent } from "LLM/utils/getDeviceIcon";
+import UnsupportedUpdateDrawer from "./UnsupportedUpdateDrawer";
+
+type Wallet40PortfolioBannerProps = {
+  deviceIcon: IconComponent;
+  onClickUpdate: () => void;
+  drawerProps: DrawerProps;
+};
+
+const Wallet40PortfolioBanner = ({
+  deviceIcon,
+  onClickUpdate,
+  drawerProps,
+}: Wallet40PortfolioBannerProps) => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <Box lx={{ alignItems: "center", paddingTop: "s16", gap: "s10" }}>
+        <Button
+          appearance="transparent"
+          size="sm"
+          icon={deviceIcon}
+          onPress={onClickUpdate}
+          testID="fw-update-banner"
+        >
+          {t("FirmwareUpdate.banner.wallet40.title.default")}
+        </Button>
+      </Box>
+      <UnsupportedUpdateDrawer
+        isOpen={drawerProps.unsupportedUpdateDrawerOpened}
+        onClose={drawerProps.closeUnsupportedUpdateDrawer}
+        isUsbRequired={drawerProps.isUpdateSupportedButDeviceNotWired}
+        productName={drawerProps.productName}
+      />
+    </>
+  );
+};
+
+export default Wallet40PortfolioBanner;

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/__mocks__/makeOverrideInitialState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/__mocks__/makeOverrideInitialState.tsx
@@ -1,6 +1,7 @@
 import { DeviceModelId } from "@ledgerhq/devices";
 import { State } from "~/reducers/types";
 import { aDeviceInfoBuilder } from "@ledgerhq/live-common/mock/fixtures/aDeviceInfo";
+import { Feature_LwmWallet40 } from "@ledgerhq/types-live";
 
 function makeMockSettings({
   modelId,
@@ -43,6 +44,7 @@ export function makeOverrideInitialState(args: {
   hasCompletedOnboarding: boolean;
   wired: boolean;
   hasConnectedDevice: boolean;
+  lwmWallet40?: { enabled: boolean; params: Partial<Feature_LwmWallet40["params"]> };
 }) {
   return (state: State): State => ({
     ...state,
@@ -53,6 +55,12 @@ export function makeOverrideInitialState(args: {
         version: args.version,
         hasCompletedOnboarding: args.hasCompletedOnboarding,
         wired: args.wired,
+      }),
+      ...(args.lwmWallet40 !== undefined && {
+        overriddenFeatureFlags: {
+          ...state.settings.overriddenFeatureFlags,
+          lwmWallet40: { enabled: args.lwmWallet40.enabled, params: args.lwmWallet40.params },
+        },
       }),
     },
     appstate: {

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/index.tsx
@@ -1,34 +1,18 @@
 import React, { memo } from "react";
-import { Pressable } from "react-native";
-import { useTranslation } from "~/context/Locale";
-import { Text, Flex, Icons } from "@ledgerhq/native-ui";
-import { DownloadMedium, UsbMedium } from "@ledgerhq/native-ui/assets/icons";
-import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
-
-import Button from "~/components/Button";
-import QueuedDrawer from "~/components/QueuedDrawer";
+import { getDeviceModel } from "@ledgerhq/devices";
 import { UpdateStep } from "~/screens/FirmwareUpdate";
 import { useUpdateBannerViewModel } from "./useUpdateBannerViewModel";
-import type { ViewProps } from "./ViewProps";
+import type { ViewProps, DrawerProps } from "./ViewProps";
+import { getDeviceSymbol } from "LLM/utils/getDeviceIcon";
+import Wallet40PortfolioBanner from "./Wallet40PortfolioBanner";
+import Wallet40MyLedgerBanner from "./Wallet40MyLedgerBanner";
+import LegacyBanner from "./LegacyBanner";
 
 export type FirmwareUpdateBannerProps = {
   onBackFromUpdate: (updateState: UpdateStep) => void;
 };
 
-const DeviceIcon = ({ deviceModelId }: { deviceModelId: DeviceModelId | undefined }) => {
-  switch (deviceModelId) {
-    case DeviceModelId.stax:
-      return <Icons.Stax color="primary.c80" size="M" />;
-    case DeviceModelId.europa:
-      return <Icons.Flex color="primary.c80" size="M" />;
-    case DeviceModelId.apex:
-      return <Icons.Apex color="primary.c80" size="M" />;
-    default:
-      return <Icons.Nano color="primary.c80" size="M" />;
-  }
-};
-
-const UpdateBanner = ({
+const UpdateBannerView = ({
   bannerVisible,
   lastConnectedDevice,
   version,
@@ -36,76 +20,55 @@ const UpdateBanner = ({
   unsupportedUpdateDrawerOpened,
   closeUnsupportedUpdateDrawer,
   isUpdateSupportedButDeviceNotWired,
+  shouldDisplayWallet40MainNav,
+  isInMyLedgerDeviceScreen,
 }: ViewProps) => {
-  const { t } = useTranslation();
+  if (!bannerVisible) return null;
+
   const productName = lastConnectedDevice
     ? getDeviceModel(lastConnectedDevice.modelId).productName
     : undefined;
 
-  const deviceName = lastConnectedDevice?.deviceName;
+  const drawerProps: DrawerProps = {
+    unsupportedUpdateDrawerOpened,
+    closeUnsupportedUpdateDrawer,
+    isUpdateSupportedButDeviceNotWired,
+    productName,
+  };
 
-  return bannerVisible ? (
-    <>
-      <Pressable onPress={onClickUpdate} testID="fw-update-banner">
-        <Flex
-          flexDirection="row"
-          alignItems="flex-start"
-          backgroundColor="opacityDefault.c05"
-          borderRadius={12}
-          p={7}
-          pl={5}
-        >
-          <Flex flexDirection="row" alignItems="center" mb={5} mr={4}>
-            <DeviceIcon deviceModelId={lastConnectedDevice?.modelId} />
-          </Flex>
-          <Flex flexDirection="column" alignItems={"flex-start"} flexShrink={1}>
-            <Text variant="h5" fontWeight="semiBold" pb={4}>
-              {t("FirmwareUpdate.banner.title")}
-            </Text>
-            <Text variant="paragraph" fontWeight="medium" color="opacityDefault.c70">
-              {deviceName
-                ? t("FirmwareUpdate.banner.descriptionDeviceName", {
-                    deviceName,
-                    firmwareVersion: version,
-                  })
-                : t("FirmwareUpdate.banner.descriptionProductName", {
-                    productName,
-                    firmwareVersion: version,
-                  })}
-            </Text>
-          </Flex>
-        </Flex>
-      </Pressable>
+  if (shouldDisplayWallet40MainNav && !isInMyLedgerDeviceScreen) {
+    return (
+      <Wallet40PortfolioBanner
+        deviceIcon={getDeviceSymbol(lastConnectedDevice)}
+        onClickUpdate={onClickUpdate}
+        drawerProps={drawerProps}
+      />
+    );
+  }
 
-      <QueuedDrawer
-        isRequestingToBeOpened={unsupportedUpdateDrawerOpened}
-        onClose={closeUnsupportedUpdateDrawer}
-        Icon={isUpdateSupportedButDeviceNotWired ? UsbMedium : DownloadMedium}
-        title={
-          isUpdateSupportedButDeviceNotWired
-            ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbTitle")
-            : t("FirmwareUpdate.drawerUpdate.title")
-        }
-        description={
-          isUpdateSupportedButDeviceNotWired
-            ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbDescription", {
-                deviceName: productName,
-              })
-            : t("FirmwareUpdate.drawerUpdate.description")
-        }
-        noCloseButton
-      >
-        <Button
-          testID="fw-update-drawer-unsupported-close-btn"
-          type="primary"
-          title={t("common.close")}
-          onPress={closeUnsupportedUpdateDrawer}
-        />
-      </QueuedDrawer>
-    </>
-  ) : null;
+  if (shouldDisplayWallet40MainNav && isInMyLedgerDeviceScreen) {
+    return (
+      <Wallet40MyLedgerBanner
+        productName={productName}
+        version={version}
+        onClickUpdate={onClickUpdate}
+        drawerProps={drawerProps}
+      />
+    );
+  }
+
+  return (
+    <LegacyBanner
+      lastConnectedDevice={lastConnectedDevice}
+      deviceName={lastConnectedDevice?.deviceName ?? undefined}
+      productName={productName}
+      version={version}
+      onClickUpdate={onClickUpdate}
+      drawerProps={drawerProps}
+    />
+  );
 };
 
 export default memo((props: FirmwareUpdateBannerProps) => (
-  <UpdateBanner {...useUpdateBannerViewModel(props)} />
+  <UpdateBannerView {...useUpdateBannerViewModel(props)} />
 ));

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/useUpdateBannerViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/useUpdateBannerViewModel.test.tsx
@@ -1,46 +1,25 @@
 import ReactNative from "react-native";
-import { act, renderHook } from "@testing-library/react-native";
+import { act, renderHook } from "@tests/test-renderer";
 import { useUpdateBannerViewModel } from "./useUpdateBannerViewModel";
-
-/** Brace yourselves for the mocks ... */
+import { State } from "~/reducers/types";
 
 // Mock react-navigation
+const mockUseRoute = jest.fn();
+const mockUseNavigation = jest.fn();
+const mockUseFocusEffect = jest.fn();
+
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
-  useRoute: jest.fn(),
-  useNavigation: jest.fn(),
+  useRoute: (...args: unknown[]) => mockUseRoute(...args),
+  useNavigation: (...args: unknown[]) => mockUseNavigation(...args),
+  useFocusEffect: (...args: unknown[]) => mockUseFocusEffect(...args),
 }));
 
-jest.mock("react-redux", () => {
-  const actual = jest.requireActual("react-redux");
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  const mockUseSelector = jest
-    .fn()
-    .mockImplementation((selector: () => unknown) => selector()) as jest.Mock & {
-    withTypes: () => jest.Mock;
-  };
-  mockUseSelector.withTypes = () => mockUseSelector;
-  return {
-    ...actual,
-    useSelector: mockUseSelector,
-  };
-});
-
-// Mock the selectors
-jest.mock("~/reducers/settings", () => ({
-  ...jest.requireActual("~/reducers/settings"),
-  lastSeenDeviceSelector: jest.fn(),
-  lastConnectedDeviceSelector: jest.fn(),
-  hasCompletedOnboardingSelector: jest.fn(),
+// Mock analytics
+const mockTrack = jest.fn();
+jest.mock("~/analytics", () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
 }));
-const { lastConnectedDeviceSelector, hasCompletedOnboardingSelector, lastSeenDeviceSelector } =
-  jest.requireMock("~/reducers/settings");
-
-jest.mock("~/reducers/appstate", () => ({
-  ...jest.requireActual("~/reducers/appstate"),
-  hasConnectedDeviceSelector: jest.fn(),
-}));
-const { hasConnectedDeviceSelector } = jest.requireMock("~/reducers/appstate");
 
 // Mock useLatestFirmware
 jest.mock("@ledgerhq/live-common/device/hooks/useLatestFirmware", () => ({
@@ -67,28 +46,68 @@ jest.mock("../../utils/navigateToNewUpdateFlow", () => ({
 }));
 const { navigateToNewUpdateFlow } = jest.requireMock("../../utils/navigateToNewUpdateFlow");
 
-/** TESTS */
+function withState(overrides: {
+  hasConnectedDevice?: boolean;
+  hasCompletedOnboarding?: boolean;
+  lastConnectedDevice?: Record<string, unknown> | null;
+  seenDevices?: Record<string, unknown>[];
+  withWallet40MainNav?: boolean;
+}) {
+  return {
+    overrideInitialState: (state: State): State => ({
+      ...state,
+      settings: {
+        ...state.settings,
+        ...(overrides.hasCompletedOnboarding !== undefined && {
+          hasCompletedOnboarding: overrides.hasCompletedOnboarding,
+        }),
+        ...(overrides.lastConnectedDevice !== undefined && {
+          lastConnectedDevice:
+            overrides.lastConnectedDevice as State["settings"]["lastConnectedDevice"],
+        }),
+        ...(overrides.seenDevices !== undefined && {
+          seenDevices: overrides.seenDevices as State["settings"]["seenDevices"],
+        }),
+        ...(overrides.withWallet40MainNav && {
+          overriddenFeatureFlags: {
+            ...state.settings.overriddenFeatureFlags,
+            lwmWallet40: { enabled: true, params: { mainNavigation: true } },
+          },
+        }),
+      },
+      appstate: {
+        ...state.appstate,
+        ...(overrides.hasConnectedDevice !== undefined && {
+          hasConnectedDevice: overrides.hasConnectedDevice,
+        }),
+      },
+    }),
+  };
+}
 
 describe("useUpdateBannerViewModel", () => {
   let PlatformSpy: jest.SpyInstance;
   beforeEach(() => {
     jest.clearAllMocks();
     PlatformSpy = jest.spyOn(ReactNative, "Platform", "get");
+    mockUseRoute.mockReturnValue({ name: "Portfolio" });
+    mockUseNavigation.mockReturnValue({ navigate: jest.fn() });
+    mockUseFocusEffect.mockImplementation((cb: () => void) => cb());
   });
   afterEach(() => {
     PlatformSpy?.mockRestore();
   });
 
   it("should return bannerVisible: true if conditions are fulfilled", () => {
-    const lastConnectedDevice = { modelId: "mockModelId" };
-    lastConnectedDeviceSelector.mockReturnValue(lastConnectedDevice);
-    hasConnectedDeviceSelector.mockReturnValue(true);
-    hasCompletedOnboardingSelector.mockReturnValue(true);
+    const lastConnectedDevice = { modelId: "nanoX" };
     useLatestFirmware.mockReturnValue({ final: { name: "mockVersion", version: "1.0.0" } });
 
-    const { result } = renderHook(() =>
-      useUpdateBannerViewModel({
-        onBackFromUpdate: jest.fn(),
+    const { result } = renderHook(
+      () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+      withState({
+        hasConnectedDevice: true,
+        hasCompletedOnboarding: true,
+        lastConnectedDevice,
       }),
     );
 
@@ -98,13 +117,13 @@ describe("useUpdateBannerViewModel", () => {
   });
 
   it("should return bannerVisible: false if there is no update", () => {
-    hasConnectedDeviceSelector.mockReturnValue(true);
-    hasCompletedOnboardingSelector.mockReturnValue(true);
     useLatestFirmware.mockReturnValue(null);
 
-    const { result } = renderHook(() =>
-      useUpdateBannerViewModel({
-        onBackFromUpdate: jest.fn(),
+    const { result } = renderHook(
+      () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+      withState({
+        hasConnectedDevice: true,
+        hasCompletedOnboarding: true,
       }),
     );
 
@@ -112,13 +131,13 @@ describe("useUpdateBannerViewModel", () => {
   });
 
   it("should return bannerVisible: false if onboarding has not been completed", () => {
-    hasConnectedDeviceSelector.mockReturnValue(true);
-    hasCompletedOnboardingSelector.mockReturnValue(false);
     useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
 
-    const { result } = renderHook(() =>
-      useUpdateBannerViewModel({
-        onBackFromUpdate: jest.fn(),
+    const { result } = renderHook(
+      () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+      withState({
+        hasConnectedDevice: true,
+        hasCompletedOnboarding: false,
       }),
     );
 
@@ -126,13 +145,13 @@ describe("useUpdateBannerViewModel", () => {
   });
 
   it("should return bannerVisible: false if there is no connected device", () => {
-    hasConnectedDeviceSelector.mockReturnValue(false);
-    hasCompletedOnboardingSelector.mockReturnValue(true);
     useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
 
-    const { result } = renderHook(() =>
-      useUpdateBannerViewModel({
-        onBackFromUpdate: jest.fn(),
+    const { result } = renderHook(
+      () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+      withState({
+        hasConnectedDevice: false,
+        hasCompletedOnboarding: true,
       }),
     );
 
@@ -140,17 +159,17 @@ describe("useUpdateBannerViewModel", () => {
   });
 
   it("should return isUpdateSupportedButDeviceNotWired: true if the update is supported only on USB and the device is not wired, on iOS", () => {
-    hasConnectedDeviceSelector.mockReturnValue(true);
-    hasCompletedOnboardingSelector.mockReturnValue(true);
     useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
-    lastConnectedDeviceSelector.mockReturnValue({ modelId: "nanoX", wired: false });
     isNewFirmwareUpdateUxSupported.mockReturnValue(true);
     isBleUpdateSupported.mockReturnValue(false);
     PlatformSpy.mockReturnValue({ ...ReactNative.Platform, OS: "ios" });
 
-    const { result } = renderHook(() =>
-      useUpdateBannerViewModel({
-        onBackFromUpdate: jest.fn(),
+    const { result } = renderHook(
+      () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+      withState({
+        hasConnectedDevice: true,
+        hasCompletedOnboarding: true,
+        lastConnectedDevice: { modelId: "nanoX", wired: false },
       }),
     );
 
@@ -159,17 +178,17 @@ describe("useUpdateBannerViewModel", () => {
   });
 
   it("should return isUpdateSupportedButDeviceNotWired: true if the update is supported only on USB and the device is not wired, on Android", () => {
-    hasConnectedDeviceSelector.mockReturnValue(true);
-    hasCompletedOnboardingSelector.mockReturnValue(true);
     useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
-    lastConnectedDeviceSelector.mockReturnValue({ modelId: "nanoX", wired: false });
     isNewFirmwareUpdateUxSupported.mockReturnValue(true);
     isBleUpdateSupported.mockReturnValue(false);
     PlatformSpy.mockReturnValue({ ...ReactNative.Platform, OS: "android" });
 
-    const { result } = renderHook(() =>
-      useUpdateBannerViewModel({
-        onBackFromUpdate: jest.fn(),
+    const { result } = renderHook(
+      () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+      withState({
+        hasConnectedDevice: true,
+        hasCompletedOnboarding: true,
+        lastConnectedDevice: { modelId: "nanoX", wired: false },
       }),
     );
 
@@ -178,15 +197,14 @@ describe("useUpdateBannerViewModel", () => {
   });
 
   it("should not call startFirmwareUpdateFlow when onClickUpdate is called if update flow is not supported", () => {
-    hasConnectedDeviceSelector.mockReturnValue(true);
-    hasCompletedOnboardingSelector.mockReturnValue(true);
     useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
-
     isNewFirmwareUpdateUxSupported.mockReturnValue(false);
 
-    const { result } = renderHook(() =>
-      useUpdateBannerViewModel({
-        onBackFromUpdate: jest.fn(),
+    const { result } = renderHook(
+      () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+      withState({
+        hasConnectedDevice: true,
+        hasCompletedOnboarding: true,
       }),
     );
 
@@ -199,17 +217,16 @@ describe("useUpdateBannerViewModel", () => {
   });
 
   it("should not call startFirmwareUpdateFlow when onClickUpdate is called for a bluetooth Nano X update with version < 2.4.0", () => {
-    hasConnectedDeviceSelector.mockReturnValue(true);
-    hasCompletedOnboardingSelector.mockReturnValue(true);
     useLatestFirmware.mockReturnValue({ final: { name: "mockVersion", version: "2.4.0" } });
-    lastConnectedDeviceSelector.mockReturnValue({ modelId: "nanoX", wired: false });
-    lastSeenDeviceSelector.mockReturnValue({ modelId: "nanoX", deviceInfo: { version: "2.3.9" } });
-
     isNewFirmwareUpdateUxSupported.mockReturnValue(true);
 
-    const { result } = renderHook(() =>
-      useUpdateBannerViewModel({
-        onBackFromUpdate: jest.fn(),
+    const { result } = renderHook(
+      () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+      withState({
+        hasConnectedDevice: true,
+        hasCompletedOnboarding: true,
+        lastConnectedDevice: { modelId: "nanoX", wired: false },
+        seenDevices: [{ modelId: "nanoX", deviceInfo: { version: "2.3.9" } }],
       }),
     );
 
@@ -219,17 +236,16 @@ describe("useUpdateBannerViewModel", () => {
   });
 
   it("should call startFirmwareUpdateFlow when onClickUpdate is called if new update flow is supported", () => {
-    hasConnectedDeviceSelector.mockReturnValue(true);
-    hasCompletedOnboardingSelector.mockReturnValue(true);
     useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
-    lastSeenDeviceSelector.mockReturnValue({ modelId: "mockId", deviceInfo: { version: "3.0.0" } });
-
     isNewFirmwareUpdateUxSupported.mockReturnValue(true);
     isBleUpdateSupported.mockReturnValue(true);
 
-    const { result } = renderHook(() =>
-      useUpdateBannerViewModel({
-        onBackFromUpdate: jest.fn(),
+    const { result } = renderHook(
+      () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+      withState({
+        hasConnectedDevice: true,
+        hasCompletedOnboarding: true,
+        seenDevices: [{ modelId: "nanoX", deviceInfo: { version: "3.0.0" } }],
       }),
     );
 
@@ -240,21 +256,17 @@ describe("useUpdateBannerViewModel", () => {
   });
 
   it("should call startFirmwareUpdateFlow when onClickUpdate is called for a bluetooth Nano X update with version >= 2.4.0", () => {
-    hasConnectedDeviceSelector.mockReturnValue(true);
-    hasCompletedOnboardingSelector.mockReturnValue(true);
     useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
-    lastConnectedDeviceSelector.mockReturnValue({
-      modelId: "nanoX",
-      wired: false,
-    });
-    lastSeenDeviceSelector.mockReturnValue({ modelId: "nanoX", deviceInfo: { version: "2.4.0" } });
-
     isBleUpdateSupported.mockReturnValue(true);
     isNewFirmwareUpdateUxSupported.mockReturnValue(true);
 
-    const { result } = renderHook(() =>
-      useUpdateBannerViewModel({
-        onBackFromUpdate: jest.fn(),
+    const { result } = renderHook(
+      () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+      withState({
+        hasConnectedDevice: true,
+        hasCompletedOnboarding: true,
+        lastConnectedDevice: { modelId: "nanoX", wired: false },
+        seenDevices: [{ modelId: "nanoX", deviceInfo: { version: "2.4.0" } }],
       }),
     );
 
@@ -262,5 +274,139 @@ describe("useUpdateBannerViewModel", () => {
 
     expect(result.current.unsupportedUpdateDrawerOpened).toBe(false);
     expect(navigateToNewUpdateFlow).toHaveBeenCalled();
+  });
+
+  describe("analytics", () => {
+    it("should track banner impression when shouldDisplayWallet40MainNav is true and screen is focused", () => {
+      useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
+
+      renderHook(
+        () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+        withState({
+          hasConnectedDevice: true,
+          hasCompletedOnboarding: true,
+          withWallet40MainNav: true,
+        }),
+      );
+
+      expect(mockTrack).toHaveBeenCalledWith("banner_impression", {
+        banner: "OS update",
+        page: "portfolio",
+      });
+    });
+
+    it("should track banner impression with 'my ledger' page when on MyLedgerDevice screen", () => {
+      mockUseRoute.mockReturnValue({ name: "MyLedgerDevice" });
+      useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
+
+      renderHook(
+        () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+        withState({
+          hasConnectedDevice: true,
+          hasCompletedOnboarding: true,
+          withWallet40MainNav: true,
+        }),
+      );
+
+      expect(mockTrack).toHaveBeenCalledWith("banner_impression", {
+        banner: "OS update",
+        page: "my ledger",
+      });
+    });
+
+    it("should not track banner impression when shouldDisplayWallet40MainNav is false", () => {
+      useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
+
+      renderHook(
+        () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+        withState({
+          hasConnectedDevice: true,
+          hasCompletedOnboarding: true,
+        }),
+      );
+
+      expect(mockTrack).not.toHaveBeenCalledWith("banner_impression", expect.anything());
+    });
+
+    it("should not track banner impression when screen is not focused", () => {
+      mockUseFocusEffect.mockImplementation(() => {});
+      useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
+
+      renderHook(
+        () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+        withState({
+          hasConnectedDevice: true,
+          hasCompletedOnboarding: true,
+          withWallet40MainNav: true,
+        }),
+      );
+
+      expect(mockTrack).not.toHaveBeenCalledWith("banner_impression", expect.anything());
+    });
+
+    it("should track impression only once even if re-rendered", () => {
+      useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
+
+      const { rerender } = renderHook(
+        () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+        withState({
+          hasConnectedDevice: true,
+          hasCompletedOnboarding: true,
+          withWallet40MainNav: true,
+        }),
+      );
+
+      rerender({});
+
+      const impressionCalls = mockTrack.mock.calls.filter(
+        ([event]: [string]) => event === "banner_impression",
+      );
+      expect(impressionCalls).toHaveLength(1);
+    });
+
+    it("should track button_clicked when onClickUpdate is called", () => {
+      useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
+      isNewFirmwareUpdateUxSupported.mockReturnValue(false);
+
+      const { result } = renderHook(
+        () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+        withState({
+          hasConnectedDevice: true,
+          hasCompletedOnboarding: true,
+          withWallet40MainNav: true,
+        }),
+      );
+
+      act(() => result.current.onClickUpdate());
+
+      expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
+        page: "portfolio",
+        banner: "OS update",
+        button: "click(update)",
+      });
+    });
+
+    it("should track button_clicked with 'my ledger' page when on MyLedgerDevice screen", () => {
+      mockUseRoute.mockReturnValue({ name: "MyLedgerDevice" });
+      useLatestFirmware.mockReturnValue({ final: { name: "mockVersion" } });
+      isNewFirmwareUpdateUxSupported.mockReturnValue(false);
+
+      const { result } = renderHook(
+        () => useUpdateBannerViewModel({ onBackFromUpdate: jest.fn() }),
+        withState({
+          hasConnectedDevice: true,
+          hasCompletedOnboarding: true,
+          withWallet40MainNav: true,
+        }),
+      );
+
+      act(() => result.current.onClickUpdate());
+
+      expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
+        page: "my ledger",
+        banner: "OS update",
+        button: "click(update)",
+      });
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/useUpdateBannerViewModel.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/useUpdateBannerViewModel.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { Platform } from "react-native";
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute, useFocusEffect } from "@react-navigation/native";
 import { useSelector } from "~/context/hooks";
 import { useLatestFirmware } from "@ledgerhq/live-common/device/hooks/useLatestFirmware";
 import {
@@ -17,6 +17,9 @@ import {
 } from "../../utils/isFirmwareUpdateSupported";
 import { navigateToNewUpdateFlow } from "../../utils/navigateToNewUpdateFlow";
 import { BaseNavigation } from "~/components/RootNavigator/types/helpers";
+import { ScreenName } from "~/const";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { track } from "~/analytics";
 
 export function useUpdateBannerViewModel({
   onBackFromUpdate,
@@ -46,7 +49,31 @@ export function useUpdateBannerViewModel({
     setUnsupportedUpdateDrawerOpened(false);
   }, []);
 
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
+  const route = useRoute();
+  const isInMyLedgerDeviceScreen = route.name === ScreenName.MyLedgerDevice;
+
+  const impressionTracked = useRef(false);
+  useFocusEffect(
+    useCallback(() => {
+      if (!shouldDisplayWallet40MainNav || impressionTracked.current) return;
+      impressionTracked.current = true;
+      track("banner_impression", {
+        banner: "OS update",
+        page: isInMyLedgerDeviceScreen ? "my ledger" : "portfolio",
+      });
+    }, [shouldDisplayWallet40MainNav, isInMyLedgerDeviceScreen]),
+  );
+
   const onClickUpdate = useCallback(() => {
+    if (shouldDisplayWallet40MainNav) {
+      track("button_clicked", {
+        page: isInMyLedgerDeviceScreen ? "my ledger" : "portfolio",
+        banner: "OS update",
+        button: "click(update)",
+      });
+    }
+
     if (isNewUxSupported) {
       if (connectionType === "bluetooth" && !bleUpdateSupported) {
         setUnsupportedUpdateDrawerOpened(true);
@@ -64,6 +91,7 @@ export function useUpdateBannerViewModel({
     }
   }, [
     isNewUxSupported,
+    isInMyLedgerDeviceScreen,
     lastConnectedDevice,
     lastSeenDeviceModelInfo,
     latestFirmware,
@@ -71,6 +99,7 @@ export function useUpdateBannerViewModel({
     onBackFromUpdate,
     bleUpdateSupported,
     connectionType,
+    shouldDisplayWallet40MainNav,
   ]);
 
   return {
@@ -82,5 +111,7 @@ export function useUpdateBannerViewModel({
     closeUnsupportedUpdateDrawer,
     isUpdateSupportedButDeviceNotWired:
       Platform.OS === "android" && isNewUxSupported && !bleUpdateSupported,
+    shouldDisplayWallet40MainNav,
+    isInMyLedgerDeviceScreen,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/utils/getDeviceIcon.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/utils/getDeviceIcon.tsx
@@ -1,0 +1,45 @@
+import React, { ComponentType } from "react";
+import { Stax, Apex, Flex, Nano } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { IconButton, IconSize } from "@ledgerhq/lumen-ui-rnative";
+import { Device, DeviceModelId } from "@ledgerhq/types-devices";
+import { ICON_SIZE } from "../components/TopBar/const";
+import { StyleProp, ViewStyle } from "react-native";
+
+type SymbolProps = { size?: IconSize; style?: StyleProp<ViewStyle> };
+
+export function getDeviceSymbol(
+  lastConnectedDevice: Device | undefined,
+): ComponentType<SymbolProps> {
+  switch (lastConnectedDevice?.modelId) {
+    case DeviceModelId.europa:
+      return Flex;
+    case DeviceModelId.apex:
+      return Apex;
+    case DeviceModelId.stax:
+      return Stax;
+    default:
+      return Nano;
+  }
+}
+
+export type IconComponent = NonNullable<React.ComponentProps<typeof IconButton>["icon"]>;
+
+export function getDeviceIcon(
+  lastConnectedDevice: Device | undefined,
+  size?: IconSize,
+  style?: StyleProp<ViewStyle>,
+): React.JSX.Element {
+  switch (lastConnectedDevice?.modelId) {
+    case DeviceModelId.nanoS:
+    case DeviceModelId.nanoSP:
+    case DeviceModelId.nanoX:
+      return <Nano size={size ?? ICON_SIZE} style={style} color="base" />;
+    case DeviceModelId.europa:
+      return <Flex size={size ?? ICON_SIZE} style={style} color="base" />;
+    case DeviceModelId.apex:
+      return <Apex size={size ?? ICON_SIZE} style={style} color="base" />;
+    case DeviceModelId.stax:
+    default:
+      return <Stax size={size ?? ICON_SIZE} style={style} color="base" />;
+  }
+}

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/AppsScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/AppsScreen.tsx
@@ -51,6 +51,7 @@ import { getEnv } from "@ledgerhq/live-env";
 import LedgerSyncEntryPoint from "LLM/features/LedgerSyncEntryPoint";
 import { EntryPoint } from "LLM/features/LedgerSyncEntryPoint/types";
 import { LNSUpsellBanner } from "LLM/features/LNSUpsell";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 type Props = {
   state: State;
@@ -191,6 +192,8 @@ const AppsScreen = ({
     [scrollOffset],
   );
 
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
+
   const scrollToSearchBar = useCallback(() => {
     const minScrollOffset = headerLayoutRef.current?.height ?? 0;
     if (scrollOffset.current > minScrollOffset) return; // avoid scrolling past the search bar if it's already visible
@@ -211,6 +214,11 @@ const AppsScreen = ({
   const listHeader = useMemo(
     () => (
       <Flex pt={4} pb={8} onLayout={onHeaderLayout} backgroundColor="background.main">
+        {showFwUpdateBanner && shouldDisplayWallet40MainNav ? (
+          <Flex pb={16} testID="wallet40-firmware-update-banner">
+            <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
+          </Flex>
+        ) : null}
         <DeviceCard
           distribution={distribution}
           state={state}
@@ -224,8 +232,8 @@ const AppsScreen = ({
           appList={deviceApps}
           onLanguageChange={onLanguageChange}
         >
-          {showFwUpdateBanner ? (
-            <Flex p={6} pb={0}>
+          {showFwUpdateBanner && !shouldDisplayWallet40MainNav ? (
+            <Flex p={6} pb={0} testID="firmware-update-banner">
               <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
             </Flex>
           ) : null}
@@ -266,6 +274,7 @@ const AppsScreen = ({
       showFwUpdateBanner,
       state,
       updateModalOpened,
+      shouldDisplayWallet40MainNav,
     ],
   );
 

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/index.tsx
@@ -25,6 +25,7 @@ import {
 } from "~/components/RootNavigator/types/helpers";
 import { lastConnectedDeviceSelector } from "~/reducers/settings";
 import { UpdateStep } from "../FirmwareUpdate";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import {
   AppWithDependencies,
   AppWithDependents,
@@ -52,6 +53,7 @@ const MyLedgerDevice = ({ navigation, route }: NavigationProps) => {
   const reduxDispatch = useDispatch();
   const baseNavigation = useNavigation<BaseNavigation>();
 
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
   useEffect(() => {
     // refresh the manager if an USB device gets plugged while we're on a bluetooth connection
@@ -136,31 +138,38 @@ const MyLedgerDevice = ({ navigation, route }: NavigationProps) => {
 
   const onBackFromNewUpdateUx = useCallback(
     (updateState: UpdateStep) => {
-      baseNavigation.reset({
-        index: 0,
+      const myLedgerState = {
         routes: [
           {
-            name: NavigatorName.Main,
-            state: {
-              routes: [
-                {
-                  name: NavigatorName.MyLedger,
-                  state: {
-                    routes: [
-                      {
-                        name: ScreenName.MyLedgerChooseDevice,
-                        params: ["start", "completed"].includes(updateState) ? { device } : {},
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
+            name: ScreenName.MyLedgerChooseDevice,
+            params: ["start", "completed"].includes(updateState) ? { device } : {},
           },
         ],
-      });
+      };
+
+      if (shouldDisplayWallet40MainNav) {
+        baseNavigation.reset({
+          index: 1,
+          routes: [
+            { name: NavigatorName.Main },
+            { name: NavigatorName.MyLedger, state: myLedgerState },
+          ],
+        });
+      } else {
+        baseNavigation.reset({
+          index: 0,
+          routes: [
+            {
+              name: NavigatorName.Main,
+              state: {
+                routes: [{ name: NavigatorName.MyLedger, state: myLedgerState }],
+              },
+            },
+          ],
+        });
+      }
     },
-    [device, baseNavigation],
+    [device, baseNavigation, shouldDisplayWallet40MainNav],
   );
 
   const appsInstallUninstallWithDependenciesContextValue = useMemo(

--- a/apps/ledger-live-mobile/src/screens/__tests__/AppsScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/__tests__/AppsScreen.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { screen } from "@testing-library/react-native";
+import { render } from "@tests/test-renderer";
+import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
+import { aDeviceInfoBuilder } from "@ledgerhq/live-common/mock/fixtures/aDeviceInfo";
+import AppsScreen from "../MyLedgerDevice/AppsScreen";
+import { makeOverrideInitialState } from "LLM/features/FirmwareUpdate/components/UpdateBanner/__mocks__/makeOverrideInitialState";
+import { ListAppsResult, State } from "@ledgerhq/live-common/apps/types";
+import { getProductName } from "LLM/utils/getProductName";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+
+jest.mock("react-native-image-picker", () => ({}));
+jest.mock("expo-keep-awake", () => ({}));
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useRoute: jest.fn().mockReturnValue({ name: "MyLedgerDevice", params: {} }),
+  useIsFocused: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock("@ledgerhq/live-common/device/hooks/useLatestFirmware", () => ({
+  useLatestFirmware: jest.fn(),
+}));
+const { useLatestFirmware } = jest.requireMock(
+  "@ledgerhq/live-common/device/hooks/useLatestFirmware",
+);
+
+describe("<AppsScreen />", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useLatestFirmware.mockReturnValue({
+      final: { name: "mockVersion", version: "3.0.0" },
+    });
+  });
+
+  describe.each([
+    { wallet40Enabled: true, mainNavigation: true },
+    { wallet40Enabled: false, mainNavigation: false },
+  ])("when wallet40Enabled is $wallet40Enabled", ({ wallet40Enabled, mainNavigation }) => {
+    const deviceInfo = aDeviceInfoBuilder({
+      version: "2.0.0",
+      isOSU: false,
+    });
+
+    const state = makeOverrideInitialState({
+      deviceModelId: DeviceModelId.nanoS,
+      version: "2.0.0",
+      hasCompletedOnboarding: true,
+      wired: true,
+      hasConnectedDevice: true,
+      lwmWallet40: {
+        enabled: wallet40Enabled,
+        params: { mainNavigation },
+      },
+    });
+    const dispatch = jest.fn();
+    const deviceId = DeviceModelId.nanoS;
+    const initialDeviceName = getProductName(deviceId);
+    const device = {
+      deviceId: DeviceModelId.nanoS,
+      deviceName: initialDeviceName,
+      modelId: DeviceModelId.nanoS,
+      wired: true,
+    } as Device;
+
+    it("should show firmware update banner when update is available", () => {
+      const appState = {
+        installQueue: ["Bitcoin"],
+        install: [{ name: "Bitcoin", version: "1.0.0" }],
+        uninstallQueue: [],
+        updateAllQueue: [],
+        recentlyInstalledApps: [],
+        installed: [],
+        apps: [],
+        deviceInfo,
+        deviceModel: getDeviceModel(DeviceModelId.nanoS),
+      } as unknown as State;
+
+      render(
+        <AppsScreen
+          state={appState}
+          dispatch={dispatch}
+          setStorageWarning={() => {}}
+          deviceId={deviceId}
+          initialDeviceName={initialDeviceName}
+          pendingInstalls={false}
+          deviceInfo={deviceInfo}
+          device={device}
+          tab={"INSTALLED_APPS"}
+          optimisticState={appState}
+          result={{} as ListAppsResult}
+          onLanguageChange={() => {}}
+          onBackFromUpdate={() => {}}
+        />,
+        {
+          overrideInitialState: state,
+        },
+      );
+
+      if (wallet40Enabled) {
+        expect(screen.getByTestId("wallet40-firmware-update-banner")).toBeOnTheScreen();
+      } else {
+        expect(screen.getByTestId("firmware-update-banner")).toBeOnTheScreen();
+      }
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:**
  - **Firmware / My Ledger:** OS update entry point is now a compact transparent button instead of a large banner card. QA should check visibility and tap behavior on Portfolio (centered, non–full width) and on Manager/Apps screen (full width).
  - **Analytics:** New `banner_impression` event for "OS update" on portfolio page; confirm it fires when the banner is shown.
  
### 📝 Description

**Problem:** The OS update banner was a large card (background, padding, two text lines including device name and version). It took a lot of space and felt intrusive on Portfolio and Manager.

**Solution:** Replace it with a **less intrusive** entry point:

- **UI:** A single transparent `LumenButton` (small, with device icon) showing only the title "OS update available". No background card, no description line, no version in the banner.
- **Layout:** On Portfolio the button is centered; on Manager/Apps screen it uses the new `fullWidth` prop so the button spans the row.
- **Data:** The `version` prop is removed from the banner (and from ViewProps/ViewModel); the unsupported-update drawer is unchanged and still explains the context when opened.
- **Analytics:** First time the banner is visible, we track `banner_impression` with `banner: "OS update"` and `page: "portfolio"`.

Behavior (navigate to update flow or open unsupported drawer) is unchanged; only the banner’s size and content are reduced.


| Before        | After         |
| ------------- | ------------- |
| <img width="175" alt="Screenshot_20260211-082709~2" src="https://github.com/user-attachments/assets/e82d8952-a949-43fe-bcaf-218f347f315e" /> <img width="175" alt="Screenshot_20260211-082746~2" src="https://github.com/user-attachments/assets/b0fbaf70-1816-4ab0-8927-9bdd1b246b62" /> | <img width="175" alt="Screenshot_20260211-082248" src="https://github.com/user-attachments/assets/ac3a2d25-b409-4cec-a647-217872648057" /> <img width="175" alt="Screenshot_20260211-082318" src="https://github.com/user-attachments/assets/b7145302-3d96-4251-800f-0294565bd3ed" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25277](https://ledgerhq.atlassian.net/browse/LIVE-25277)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25277]: https://ledgerhq.atlassian.net/browse/LIVE-25277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ