### PR TITLE
🐛 fix(desktop,mobile): default time range to 1D when Wallet 40 FF is on

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -40,7 +40,7 @@ import {
 } from "../actions/constants";
 import { OnboardingUseCase } from "../components/Onboarding/OnboardingUseCase";
 import { Handlers } from "./types";
-import { getFeature } from "@ledgerhq/live-common/featureFlags/firebaseFeatureFlags";
+
 /* Initial state */
 
 export type VaultSigner = {
@@ -307,8 +307,6 @@ export function filterValidSettings(
   ) as Partial<SettingsState>;
 }
 
-const LWD_WALLET_40: FeatureId = "lwdWallet40";
-
 const handlers: SettingsHandlers = {
   SAVE_SETTINGS: (state, { payload }) => {
     if (!payload) return state;
@@ -325,17 +323,10 @@ const handlers: SettingsHandlers = {
   },
   FETCH_SETTINGS: (state, { payload: settings }) => {
     const filteredSettings = filterValidSettings(settings);
-    const wallet40FF = getFeature({
-      key: LWD_WALLET_40,
-      localOverrides: filteredSettings.overriddenFeatureFlags,
-    });
-    const isWallet40Enabled = wallet40FF?.enabled === true;
-
     return {
       ...state,
       ...filteredSettings,
       loaded: true,
-      ...(isWallet40Enabled && { selectedTimeRange: "day" }),
     };
   },
   SETTINGS_DISMISS_BANNER: (state, { payload: bannerId }) => ({

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -207,11 +207,13 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
       localOverrides: filteredPayload.overriddenFeatureFlags,
     });
     const isWallet40Enabled = wallet40FF?.enabled === true;
+    const isWallet40GraphReworkEnabled =
+      wallet40FF?.params?.graphRework === true && isWallet40Enabled;
     return {
       ...state,
       ...filteredPayload,
       locale: filteredPayload.locale ?? state.locale ?? getDefaultLocale(),
-      ...(isWallet40Enabled && { selectedTimeRange: "day" }),
+      ...(isWallet40GraphReworkEnabled && { selectedTimeRange: "day" }),
     };
   },
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - default timerange

### 📝 Description

When Wallet 4.0 is enabled, the portfolio time range is reset to **1D on every app relaunch**. During a session the user can still switch to other ranges (1W, 1M, etc.); the reset only happens on cold start.

**Why desktop and mobile implement this differently:**

- **Mobile — logic in the settings reducer (`SETTINGS_IMPORT`):** Settings are loaded by dispatching `importSettings(settingsData)`. By then LiveConfig/remote config is already available, so we can call `getFeature({ key: "lwmWallet40", localOverrides })` inside the reducer and force `selectedTimeRange: "day"` when the flag is on.

- **Desktop — logic in a `useEffect` in `FirebaseFeatureFlagsProvider`:** `FETCH_SETTINGS` runs during `init()` before the React tree mounts. Firebase remote config is loaded later when `FirebaseRemoteConfigProvider` mounts, so when the reducer runs `LiveConfig.instance?.provider` is not set and `getFeature()` returns `null`. The fix is to run the check after config is ready: a one-time `useEffect` in `FirebaseFeatureFlagsProvider` (which only mounts once Firebase has loaded), where we call `getFeature` and dispatch `setSelectedTimeRange("day")` when the lwdWallet40 flag is enabled.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25889](https://ledgerhq.atlassian.net/browse/LIVE-25889)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
