### PR TITLE
bugfix: track changes of analytics optin

### DIFF
--- a/.changeset/dry-drinks-warn.md
+++ b/.changeset/dry-drinks-warn.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+update calls to updateIdentify to force tracking of analytics optin changes

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -410,8 +410,15 @@ export const updateIdentify = async ({ force }: UpdateIdentifyOptions = { force:
   const canTrack = force || trackingEnabledSelector(storeInstance.getState());
   if (!canTrack) return;
 
-  const analytics = getAnalytics();
-  if (!analytics) return;
+  let analytics = getAnalytics();
+  if (!analytics) {
+    initializeSegment();
+    analytics = getAnalytics();
+
+    // Unlikely scenario where we are unable to initialise the analytics instance
+    if (!analytics) return;
+  }
+
   const { id } = await user();
 
   const allProperties = {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ShareAnalyticsButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ShareAnalyticsButton.tsx
@@ -16,7 +16,7 @@ const ShareAnalyticsButton = () => {
   const toggleShareAnalytics = async (value: boolean) => {
     dispatch(setShareAnalytics(value));
     dispatch(setSharePersonalizedRecommendations(value));
-    await updateIdentify();
+    await updateIdentify({ force: true });
   };
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ShareAnalyticsButtonFF.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ShareAnalyticsButtonFF.tsx
@@ -11,7 +11,7 @@ const ShareAnalyticsButtonFF = () => {
 
   const toggleShareAnalytics = async (value: boolean) => {
     dispatch(setShareAnalytics(value));
-    await updateIdentify();
+    await updateIdentify({ force: true });
     track(
       "toggle_clicked",
       {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/SharePersonalRecoButtonFF.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/SharePersonalRecoButtonFF.tsx
@@ -11,7 +11,7 @@ const SharePersonnalRecoButtonFF = () => {
 
   const toggleSharePersonalizedRecommendations = async (value: boolean) => {
     dispatch(setSharePersonalizedRecommendations(value));
-    await updateIdentify();
+    await updateIdentify({ force: true });
     track(
       "toggle_clicked",
       {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Updates to analytics sharing were not registering in the updateIdentify call when the the fields were previously all off as the event would not fire, and when the application booted with both analytics sharing fields off the segment instance was not initiated and was not subsequently reinitialised if the user changed the setting to allow sharing via either analytics sharing toggle.


https://github.com/user-attachments/assets/b3007b6d-5bab-4f1e-834c-0743e6a17e5f



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26050


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
