### PR TITLE
LIVE-25792: Skip device onboarding from analytics opt in

### DIFF
--- a/.changeset/green-spies-sip.md
+++ b/.changeset/green-spies-sip.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: skip device onboarding from analytics opt in

--- a/apps/ledger-live-mobile/src/hooks/analyticsOptInPrompt/useAnalyticsOptInPromptLogic.ts
+++ b/apps/ledger-live-mobile/src/hooks/analyticsOptInPrompt/useAnalyticsOptInPromptLogic.ts
@@ -1,5 +1,11 @@
 import { useSelector, useDispatch } from "~/context/hooks";
-import { setHasSeenAnalyticsOptInPrompt } from "~/actions/settings";
+import {
+  completeOnboarding,
+  setHasSeenAnalyticsOptInPrompt,
+  setIsReborn,
+  setOnboardingHasDevice,
+  setReadOnlyMode,
+} from "~/actions/settings";
 import { useNavigation } from "@react-navigation/native";
 import { NavigatorName, ScreenName } from "~/const";
 import {
@@ -14,6 +20,8 @@ import { track, updateIdentify } from "~/analytics";
 import { hasSeenAnalyticsOptInPromptSelector, trackingEnabledSelector } from "~/reducers/settings";
 import { EntryPoint } from "~/components/RootNavigator/types/AnalyticsOptInPromptNavigator";
 import { ABTestingVariants } from "@ledgerhq/types-live";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { useNotifications } from "LLM/features/NotificationsPrompt";
 
 const trackingKeysByFlow: Record<EntryPoint, string> = {
   Onboarding: "consent onboarding",
@@ -35,6 +43,8 @@ const useAnalyticsOptInPromptLogic = ({ entryPoint, variant }: Props) => {
   const isTrackingEnabled = useSelector(trackingEnabledSelector);
   const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
   const shouldWeTrack = isTrackingEnabled || !hasSeenAnalyticsOptInPrompt;
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("mobile");
+  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
   const flow = trackingKeysByFlow?.[entryPoint];
 
   const privacyPolicyUrl =
@@ -46,6 +56,30 @@ const useAnalyticsOptInPromptLogic = ({ entryPoint, variant }: Props) => {
   const urlByVariant = {
     [ABTestingVariants.variantA]: trackingPolicyUrl,
     [ABTestingVariants.variantB]: privacyPolicyUrl,
+  };
+
+  const enableRebornState = () => {
+    dispatch(setReadOnlyMode(true));
+    dispatch(setIsReborn(true));
+  };
+
+  const skipDeviceOnboarding = () => {
+    dispatch(completeOnboarding());
+    dispatch(setOnboardingHasDevice(false));
+
+    enableRebornState();
+
+    navigation.navigate(NavigatorName.Base, {
+      screen: NavigatorName.Main,
+      params: {
+        screen: NavigatorName.Portfolio,
+        params: {
+          screen: NavigatorName.WalletTab,
+        },
+      },
+    });
+
+    tryTriggerPushNotificationDrawerAfterAction("onboarding");
   };
 
   const continueOnboarding = () => {
@@ -64,15 +98,19 @@ const useAnalyticsOptInPromptLogic = ({ entryPoint, variant }: Props) => {
         });
         break;
       case "Onboarding":
-        navigation.navigate(NavigatorName.BaseOnboarding, {
-          screen: NavigatorName.Onboarding,
-          params: {
-            screen: ScreenName.OnboardingPostWelcomeSelection,
+        if (shouldUseLazyOnboarding) {
+          skipDeviceOnboarding();
+        } else {
+          navigation.navigate(NavigatorName.BaseOnboarding, {
+            screen: NavigatorName.Onboarding,
             params: {
-              userHasDevice: true,
+              screen: ScreenName.OnboardingPostWelcomeSelection,
+              params: {
+                userHasDevice: true,
+              },
             },
-          },
-        });
+          });
+        }
         break;
     }
     updateIdentify(undefined, shouldWeTrack);

--- a/apps/ledger-live-mobile/src/screens/AnalyticsOptInPrompt/__tests__/AnalyticsOptInPrompt.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/AnalyticsOptInPrompt/__tests__/AnalyticsOptInPrompt.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { useNavigation } from "@react-navigation/native";
+import AnalyticsOptInPromptMain from "~/screens/AnalyticsOptInPrompt/variantA/Main";
+import { NavigatorName, ScreenName } from "~/const";
+import { State } from "~/reducers/types";
+
+jest.mock("@react-navigation/native", () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  return {
+    ...actual,
+    useNavigation: jest.fn(),
+  };
+});
+
+const mockedUseNavigation = jest.mocked(useNavigation);
+
+const mockNavigate = jest.fn();
+const mockAddListener = jest.fn();
+
+const renderAnalyticsOptInMain = ({
+  wallet40Enabled,
+  lazyOnboarding,
+}: {
+  wallet40Enabled: boolean;
+  lazyOnboarding?: boolean;
+}) =>
+  render(
+    <AnalyticsOptInPromptMain
+      route={{ params: { entryPoint: "Onboarding" } } as never}
+      navigation={{ addListener: mockAddListener } as never}
+    />,
+    {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          overriddenFeatureFlags: {
+            ...state.settings.overriddenFeatureFlags,
+            lwmWallet40: {
+              enabled: wallet40Enabled,
+              params: {
+                lazyOnboarding,
+              },
+            },
+          },
+        },
+      }),
+    },
+  );
+
+describe("AnalyticsOptInPrompt", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedUseNavigation.mockReturnValue({ navigate: mockNavigate });
+  });
+
+  it("navigates to onboarding device selection when lazy onboarding is disabled", async () => {
+    const { user } = renderAnalyticsOptInMain({ wallet40Enabled: true, lazyOnboarding: false });
+
+    await user.press(screen.getByTestId("accept-analytics-button"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.BaseOnboarding, {
+      screen: NavigatorName.Onboarding,
+      params: {
+        screen: ScreenName.OnboardingPostWelcomeSelection,
+        params: {
+          userHasDevice: true,
+        },
+      },
+    });
+  });
+
+  it("navigates to portfolio when lazy onboarding is enabled", async () => {
+    const { user } = await renderAnalyticsOptInMain({
+      wallet40Enabled: true,
+      lazyOnboarding: true,
+    });
+
+    await user.press(screen.getByTestId("accept-analytics-button"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Base, {
+      screen: NavigatorName.Main,
+      params: {
+        screen: NavigatorName.Portfolio,
+        params: {
+          screen: NavigatorName.WalletTab,
+        },
+      },
+    });
+  });
+
+  it("keeps onboarding path when Wallet40 is disabled even with lazyOnboarding enabled", async () => {
+    const { user } = await renderAnalyticsOptInMain({
+      wallet40Enabled: false,
+      lazyOnboarding: true,
+    });
+
+    await user.press(screen.getByTestId("accept-analytics-button"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.BaseOnboarding, {
+      screen: NavigatorName.Onboarding,
+      params: {
+        screen: ScreenName.OnboardingPostWelcomeSelection,
+        params: {
+          userHasDevice: true,
+        },
+      },
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
@@ -9,6 +9,7 @@ export const WALLET_40_PARAMS = [
   { key: "quickActionCtas", label: "Quick Action CTAs" },
   { key: "tour", label: "Tour" },
   { key: "mainNavigation", label: "Main Navigation" },
+  { key: "lazyOnboarding", label: "Lazy Onboarding" },
 ] as const;
 
 type WalletFeatureParamKey = (typeof WALLET_40_PARAMS)[number]["key"];

--- a/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
+++ b/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
@@ -23,5 +23,6 @@ export const getWallet40Attributes = (
     tour: wallet40FeatureFlag?.params?.tour ?? false,
     mainNavigation: wallet40FeatureFlag?.params?.mainNavigation ?? false,
     newReceiveDialog: wallet40FeatureFlag?.params?.newReceiveDialog ?? false,
+    lazyOnboarding: wallet40FeatureFlag?.params?.lazyOnboarding ?? false,
   };
 };

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -785,6 +785,7 @@ export const DEFAULT_FEATURES: Features = {
       quickActionCtas: true,
       tour: true,
       mainNavigation: true,
+      lazyOnboarding: true,
     },
   },
   lwdWallet40: {
@@ -795,6 +796,7 @@ export const DEFAULT_FEATURES: Features = {
       quickActionCtas: true,
       mainNavigation: true,
       tour: true,
+      lazyOnboarding: true,
       newReceiveDialog: true,
     },
   },

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
@@ -6,6 +6,7 @@ export type Wallet40Params = {
   readonly quickActionCtas?: boolean;
   readonly newReceiveDialog?: boolean;
   readonly mainNavigation?: boolean;
+  readonly lazyOnboarding?: boolean;
 };
 
 export const FEATURE_FLAG_KEYS = {
@@ -27,4 +28,6 @@ export interface WalletFeaturesConfig {
   readonly shouldDisplayNewReceiveDialog: boolean;
   /** Whether to show the wallet 4.0 main navigation */
   readonly shouldDisplayWallet40MainNav: boolean;
+  /** Whether onboarding should skip device setup and open portfolio in read-only mode */
+  readonly shouldUseLazyOnboarding: boolean;
 }

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
@@ -38,6 +38,7 @@ const DISABLED_CONFIG: WalletFeaturesConfig = {
   shouldDisplayQuickActionCtas: false,
   shouldDisplayNewReceiveDialog: false,
   shouldDisplayWallet40MainNav: false,
+  shouldUseLazyOnboarding: false,
 };
 
 const ENABLED_NO_PARAMS_CONFIG: WalletFeaturesConfig = {
@@ -47,6 +48,7 @@ const ENABLED_NO_PARAMS_CONFIG: WalletFeaturesConfig = {
   shouldDisplayQuickActionCtas: false,
   shouldDisplayNewReceiveDialog: false,
   shouldDisplayWallet40MainNav: false,
+  shouldUseLazyOnboarding: false,
 };
 
 const ALL_ENABLED_CONFIG: WalletFeaturesConfig = {
@@ -56,6 +58,7 @@ const ALL_ENABLED_CONFIG: WalletFeaturesConfig = {
   shouldDisplayQuickActionCtas: true,
   shouldDisplayNewReceiveDialog: true,
   shouldDisplayWallet40MainNav: true,
+  shouldUseLazyOnboarding: true,
 };
 
 const ALL_PARAMS_ENABLED: Wallet40Params = {
@@ -64,6 +67,7 @@ const ALL_PARAMS_ENABLED: Wallet40Params = {
   quickActionCtas: true,
   newReceiveDialog: true,
   mainNavigation: true,
+  lazyOnboarding: true,
 };
 
 describe("useWalletFeaturesConfig hook", () => {
@@ -108,6 +112,7 @@ describe("useWalletFeaturesConfig hook", () => {
         ["quickActionCtas", { quickActionCtas: true }, { shouldDisplayQuickActionCtas: true }],
         ["newReceiveDialog", { newReceiveDialog: true }, { shouldDisplayNewReceiveDialog: true }],
         ["mainNavigation", { mainNavigation: true }, { shouldDisplayWallet40MainNav: true }],
+        ["lazyOnboarding", { lazyOnboarding: true }, { shouldUseLazyOnboarding: true }],
       ])("should return correct config when only %s is enabled", (_, params, expectedOverrides) => {
         const { result } = renderWalletFeaturesConfig(platform, {
           [flagKey]: createFeatureFlag(true, params),

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
@@ -37,6 +37,7 @@ export const useWalletFeaturesConfig = (platform: WalletPlatform): WalletFeature
       shouldDisplayQuickActionCtas: isEnabled && Boolean(params?.quickActionCtas),
       shouldDisplayNewReceiveDialog: isEnabled && Boolean(params?.newReceiveDialog),
       shouldDisplayWallet40MainNav: isEnabled && Boolean(params?.mainNavigation),
+      shouldUseLazyOnboarding: isEnabled && Boolean(params?.lazyOnboarding),
     };
   }, [walletFeatureFlag]);
 };

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -808,6 +808,7 @@ type Feature_Wallet40_Params = {
   quickActionCtas: boolean;
   mainNavigation: boolean;
   tour: boolean;
+  lazyOnboarding: boolean;
 
   //Specifics
   newReceiveDialog?: boolean;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

#### Summary
When Wallet40 lazyOnboarding is enabled on mobile, continuing from the Analytics Opt-In prompt skips device onboarding and goes straight to Portfolio in read-only mode.

#### What changed
* Added Wallet40 param lazyOnboarding (types + feature flag config) and exposed shouldUseLazyOnboarding.
* Updated analytics opt-in onboarding flow to:
  * mark onboarding complete + set read-only / reborn state
  * navigate directly to Portfolio
  * trigger notifications drawer after onboarding
* Added debug toggle + unit tests, and a changeset for types-live, live-common, and live-mobile.

| Before        | After         |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/75bc8235-924b-4c45-a34e-953a21fdd3c8" /> | <video src="https://github.com/user-attachments/assets/209d782c-7602-4a1d-82c8-b1fca10d1566" /> |

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25792

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
