### PR TITLE
feat(LIVE-24446): aleo view key resolver

### DIFF
--- a/.changeset/chatty-emus-sing.md
+++ b/.changeset/chatty-emus-sing.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aleo": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: aleo view key resolver

--- a/libs/coin-modules/coin-aleo/src/bridge/index.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/index.ts
@@ -4,7 +4,8 @@ import {
   makeAccountBridgeReceive,
   makeScanAccounts,
 } from "@ledgerhq/coin-framework/bridge/jsHelpers";
-import { SignerContext } from "@ledgerhq/coin-framework/signer";
+import type { SignerContext } from "@ledgerhq/coin-framework/signer";
+import type { CoinConfig } from "@ledgerhq/coin-framework/config";
 import type {
   AccountBridge,
   Bridge,
@@ -13,6 +14,7 @@ import type {
 } from "@ledgerhq/types-live";
 import getAddressWrapper from "@ledgerhq/coin-framework/bridge/getAddressWrapper";
 import type { Observable } from "rxjs";
+import aleoCoinConfig, { type AleoCoinConfig } from "../config";
 import type { Transaction as AleoTransaction } from "../types/index";
 import type { AleoSigner } from "../types/signer";
 import resolver from "../signer/getAddress";
@@ -66,7 +68,12 @@ export function buildAccountBridge(
   };
 }
 
-export function createBridges(signerContext: SignerContext<AleoSigner>): Bridge<AleoTransaction> {
+export function createBridges(
+  signerContext: SignerContext<AleoSigner>,
+  coinConfig: CoinConfig<AleoCoinConfig>,
+): Bridge<AleoTransaction> {
+  aleoCoinConfig.setCoinConfig(coinConfig);
+
   return {
     currencyBridge: buildCurrencyBridge(signerContext),
     accountBridge: buildAccountBridge(signerContext),

--- a/libs/coin-modules/coin-aleo/src/signer/getViewKey.test.ts
+++ b/libs/coin-modules/coin-aleo/src/signer/getViewKey.test.ts
@@ -1,0 +1,54 @@
+import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
+import getViewKeyResolver from "./getViewKey";
+
+describe("getViewKey", () => {
+  const mockCurrency = getMockedCurrency();
+  const mockDeviceId = "mock-device-id";
+  const mockPath = "44'/683'/0";
+  const mockViewKey = Buffer.from("viewkey123");
+
+  const mockSigner = {
+    getViewKey: jest.fn().mockResolvedValue(mockViewKey),
+  };
+
+  const mockSignerContext = jest
+    .fn()
+    .mockImplementation((_deviceId, callback) => callback(mockSigner));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should successfully resolve a view key", async () => {
+    const getViewKey = getViewKeyResolver(mockSignerContext);
+
+    const result = await getViewKey(mockDeviceId, {
+      currency: mockCurrency,
+      path: mockPath,
+    });
+
+    expect(mockSigner.getViewKey).toHaveBeenCalledWith(mockPath);
+    expect(result).toEqual({
+      viewKey: mockViewKey.toString(),
+      path: mockPath,
+    });
+  });
+
+  it("should handle errors from signer", async () => {
+    const errorSigner = {
+      getViewKey: jest.fn().mockRejectedValue(new Error("Device error")),
+    };
+    const errorSignerContext = jest
+      .fn()
+      .mockImplementation((_deviceId, callback) => callback(errorSigner));
+
+    const getViewKey = getViewKeyResolver(errorSignerContext);
+
+    await expect(
+      getViewKey(mockDeviceId, {
+        currency: mockCurrency,
+        path: mockPath,
+      }),
+    ).rejects.toThrow("Device error");
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/signer/getViewKey.ts
+++ b/libs/coin-modules/coin-aleo/src/signer/getViewKey.ts
@@ -1,0 +1,26 @@
+import type { GetAddressOptions } from "@ledgerhq/coin-framework/derivation";
+import type { SignerContext } from "@ledgerhq/coin-framework/signer";
+import type { AleoSigner } from "../types";
+
+export type GetViewKeyOptions = Pick<GetAddressOptions, "path" | "currency">;
+export type GetViewKeyResult = {
+  path: string;
+  viewKey: string;
+};
+export type GetViewKeyFn = (
+  deviceId: string,
+  viewKeyOpt: GetViewKeyOptions,
+) => Promise<GetViewKeyResult>;
+
+const getViewKey = (signerContext: SignerContext<AleoSigner>): GetViewKeyFn => {
+  return async (deviceId: string, opts: GetViewKeyOptions) => {
+    const viewKey = await signerContext(deviceId, signer => signer.getViewKey(opts.path));
+
+    return {
+      path: opts.path,
+      viewKey: viewKey.toString(),
+    };
+  };
+};
+
+export default getViewKey;

--- a/libs/coin-modules/coin-aleo/src/signer/index.ts
+++ b/libs/coin-modules/coin-aleo/src/signer/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./getAddress";
+export * from "./getAddress";
+export * from "./getViewKey";

--- a/libs/coin-modules/coin-aleo/src/types/signer.ts
+++ b/libs/coin-modules/coin-aleo/src/types/signer.ts
@@ -1,4 +1,5 @@
 export interface AleoSigner {
   signTransaction(path: string, transaction: Buffer): Promise<Buffer>;
   getAddress: (path: string, display?: boolean) => Promise<Buffer>;
+  getViewKey: (path: string) => Promise<Buffer>;
 }

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -396,6 +396,7 @@
     "src/e2e/enum/TransactionStatus.ts",
     "src/e2e/models/BuySell.ts",
     "src/exchange/swap/const/blockchain.ts",
+    "src/families/aleo/hw/getViewKey/index.ts",
     "src/families/aleo/types.ts",
     "src/families/algorand/descriptor.ts",
     "src/families/aptos/config.ts",

--- a/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.test.ts
@@ -1,0 +1,173 @@
+import type Transport from "@ledgerhq/hw-transport";
+import type { Account } from "@ledgerhq/types-live";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { createAction, getViewKeyExec, Request, State, type ViewKeyProgress } from "./index";
+import { viewKeyResolver } from "../../setup";
+
+const mockViewKeyResolver = jest.mocked(viewKeyResolver);
+
+jest.mock("../../setup", () => ({
+  viewKeyResolver: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/logs", () => ({
+  log: jest.fn(),
+}));
+
+describe("getViewKey", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getViewKeyExec", () => {
+    const mockTransport = {} as Transport;
+    const mockCurrency = { id: "aleo" } as CryptoCurrency;
+    const mockAccount1 = {
+      id: "account1",
+      freshAddressPath: "44'/1234'/0'/0/0",
+    } as Account;
+    const mockAccount2 = {
+      id: "account2",
+      freshAddressPath: "44'/1234'/1'/0/0",
+    } as Account;
+
+    it("retrieves view key for single account", done => {
+      const viewKey = "viewkey123";
+      mockViewKeyResolver.mockResolvedValue({ viewKey });
+
+      const request: Request = {
+        currency: mockCurrency,
+        selectedAccounts: [mockAccount1],
+      };
+
+      getViewKeyExec(mockTransport, request).subscribe({
+        next: progress => {
+          expect(progress).toEqual({
+            viewKeys: { account1: viewKey },
+            completed: 1,
+            total: 1,
+          });
+        },
+        complete: () => {
+          expect(mockViewKeyResolver).toHaveBeenCalledWith(mockTransport, {
+            path: mockAccount1.freshAddressPath,
+            currency: mockCurrency,
+          });
+          done();
+        },
+        error: done,
+      });
+    });
+
+    it("retrieves view keys for multiple accounts with progress tracking", done => {
+      mockViewKeyResolver
+        .mockResolvedValueOnce({ viewKey: "key1" })
+        .mockResolvedValueOnce({ viewKey: "key2" });
+
+      const request: Request = {
+        currency: mockCurrency,
+        selectedAccounts: [mockAccount1, mockAccount2],
+      };
+
+      const progressUpdates: ViewKeyProgress[] = [];
+
+      getViewKeyExec(mockTransport, request).subscribe({
+        next: progress => progressUpdates.push(progress),
+        complete: () => {
+          expect(progressUpdates).toEqual([
+            { viewKeys: { account1: "key1" }, completed: 1, total: 2 },
+            { viewKeys: { account1: "key1", account2: "key2" }, completed: 2, total: 2 },
+          ]);
+          expect(mockViewKeyResolver).toHaveBeenCalledTimes(2);
+          done();
+        },
+        error: done,
+      });
+    });
+
+    it("propagates error when viewKeyResolver fails", done => {
+      const error = new Error("Hardware wallet error");
+      mockViewKeyResolver.mockRejectedValue(error);
+
+      const request: Request = {
+        currency: mockCurrency,
+        selectedAccounts: [mockAccount1],
+      };
+
+      getViewKeyExec(mockTransport, request).subscribe({
+        error: (err: Error) => {
+          expect(err).toBe(error);
+          done();
+        },
+      });
+    });
+
+    it("stops processing on first error", done => {
+      mockViewKeyResolver
+        .mockResolvedValueOnce({ viewKey: "key1" })
+        .mockRejectedValueOnce(new Error("Failed"));
+
+      const request: Request = {
+        currency: mockCurrency,
+        selectedAccounts: [mockAccount1, mockAccount2],
+      };
+
+      let emissionCount = 0;
+
+      getViewKeyExec(mockTransport, request).subscribe({
+        next: () => emissionCount++,
+        error: () => {
+          expect(emissionCount).toBe(1);
+          done();
+        },
+      });
+    });
+
+    it("throws when currency is missing", () => {
+      const request: Request = {
+        selectedAccounts: [mockAccount1],
+      };
+
+      expect(() => {
+        getViewKeyExec(mockTransport, request);
+      }).toThrow("currency is required");
+    });
+
+    it("throws when selectedAccounts is empty", () => {
+      const request: Request = {
+        currency: mockCurrency,
+        selectedAccounts: [],
+      };
+
+      expect(() => {
+        getViewKeyExec(mockTransport, request);
+      }).toThrow("selectedAccounts cannot be empty");
+    });
+  });
+
+  describe("createAction", () => {
+    const mockConnectAppExec = jest.fn();
+    const mockGetViewKey = jest.fn();
+
+    it("should return useHook and mapResult functions", () => {
+      const action = createAction(mockConnectAppExec, mockGetViewKey);
+
+      expect(action).toEqual({
+        useHook: expect.any(Function),
+        mapResult: expect.any(Function),
+      });
+    });
+
+    it("should map state.result correctly", () => {
+      const action = createAction(mockConnectAppExec, mockGetViewKey);
+      const mockState = {
+        result: { acc1: "viewkey1", acc2: "viewkey2" },
+        error: null,
+        sharePending: false,
+        shareProgress: { completed: 2, total: 2, viewKeys: {} },
+      } as unknown as State;
+
+      expect(action.mapResult(mockState)).toEqual(mockState.result);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.ts
+++ b/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.ts
@@ -1,0 +1,165 @@
+import invariant from "invariant";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { catchError, concatMap, defer, from, map, scan, type Observable } from "rxjs";
+import { log } from "@ledgerhq/logs";
+import type { Account } from "@ledgerhq/types-live";
+import type { GetViewKeyOptions } from "@ledgerhq/coin-aleo/signer/getViewKey";
+import type Transport from "@ledgerhq/hw-transport";
+import type { AppRequest, AppState } from "../../../../hw/actions/app";
+import { createAction as createAppAction } from "../../../../hw/actions/app";
+import type { Device } from "../../../../hw/actions/types";
+import type { ConnectAppEvent, Input as ConnectAppInput } from "../../../../hw/connectApp";
+import { withDevice } from "../../../../hw/deviceAccess";
+import { viewKeyResolver } from "../../setup";
+
+export type ViewKeysByAccountId = Record<string, string | null> | null;
+
+type BaseState = {
+  error: Error | null;
+  result: ViewKeysByAccountId;
+  sharePending: boolean;
+  shareProgress: {
+    completed: number;
+    total: number;
+    viewKeys: NonNullable<ViewKeysByAccountId>;
+  };
+};
+
+export type State = AppState & BaseState;
+
+export type ViewKeyProgress = {
+  viewKeys: NonNullable<ViewKeysByAccountId>;
+  completed: number;
+  total: number;
+};
+
+export interface Request extends AppRequest {
+  selectedAccounts: Account[];
+}
+
+export const getViewKeyExec = (
+  transport: Transport,
+  request: Request,
+): Observable<ViewKeyProgress> => {
+  invariant(request.currency, "getViewKey: currency is required");
+  invariant(request.selectedAccounts.length > 0, "getViewKey: selectedAccounts cannot be empty");
+
+  const { selectedAccounts, currency } = request;
+  const total = selectedAccounts.length;
+
+  return from(selectedAccounts).pipe(
+    concatMap(account => {
+      const { freshAddressPath: path } = account;
+      const options: GetViewKeyOptions = { path, currency };
+
+      return defer(() => viewKeyResolver(transport, options)).pipe(
+        map(result => {
+          const viewKey = result.viewKey ? result.viewKey : null;
+          log("hw", `getViewKey ${currency.id} on ${path}`, result);
+          return { accountId: account.id, viewKey };
+        }),
+        catchError(e => {
+          log("hw", `getViewKey ${currency.id} on ${path} FAILED ${String(e)}`);
+          throw e;
+        }),
+      );
+    }),
+    scan(
+      (acc, { accountId, viewKey }) => ({
+        viewKeys: { ...acc.viewKeys, [accountId]: viewKey },
+        completed: acc.completed + 1,
+        total,
+      }),
+      { viewKeys: {}, completed: 0, total } satisfies ViewKeyProgress,
+    ),
+  );
+};
+
+const initialState: BaseState = {
+  error: null,
+  result: null,
+  sharePending: false,
+  shareProgress: {
+    completed: 0,
+    total: 0,
+    viewKeys: {},
+  },
+};
+
+export const createAction = (
+  connectAppExec: (connectAppInput: ConnectAppInput) => Observable<ConnectAppEvent>,
+  getViewKey: (transport: Transport, request: Request) => Observable<ViewKeyProgress>,
+) => {
+  const useHook = (reduxDevice: Device | null | undefined, request: Request): State => {
+    const taskFired = useRef(false);
+    const [state, setState] = useState<BaseState>(initialState);
+    const appState: AppState = createAppAction(connectAppExec).useHook(reduxDevice, {
+      appName: request.appName,
+      dependencies: request.dependencies,
+    });
+
+    const { device, opened, inWrongDeviceForAccount, error } = appState;
+
+    const handleProgress = useCallback((progress: ViewKeyProgress) => {
+      const isComplete = progress.completed === progress.total;
+
+      setState(prev => ({
+        ...prev,
+        error: null,
+        result: isComplete ? progress.viewKeys : null,
+        sharePending: !isComplete,
+        shareProgress: progress,
+      }));
+    }, []);
+
+    const handleError = useCallback((error: Error) => {
+      setState(prev => ({
+        ...prev,
+        error,
+        sharePending: false,
+      }));
+
+      taskFired.current = false;
+    }, []);
+
+    useEffect(() => {
+      if (!device || !opened || inWrongDeviceForAccount || error || taskFired.current) {
+        return;
+      }
+
+      taskFired.current = true;
+
+      setState({
+        ...initialState,
+        sharePending: true,
+        shareProgress: {
+          completed: 0,
+          total: request.selectedAccounts.length,
+          viewKeys: {},
+        },
+      });
+
+      const subscription = withDevice(device.deviceId)(transport =>
+        getViewKey(transport, request),
+      ).subscribe({
+        next: handleProgress,
+        error: handleError,
+      });
+
+      return () => {
+        subscription.unsubscribe();
+      };
+    }, [device, opened, inWrongDeviceForAccount, error, request, handleProgress, handleError]);
+
+    return {
+      ...appState,
+      ...state,
+      error: appState.error || state.error,
+    };
+  };
+
+  return {
+    useHook,
+    mapResult: (state: State): ViewKeysByAccountId => state.result,
+  };
+};

--- a/libs/ledger-live-common/src/families/aleo/hw/getViewKey/resolver.ts
+++ b/libs/ledger-live-common/src/families/aleo/hw/getViewKey/resolver.ts
@@ -1,0 +1,23 @@
+import type Transport from "@ledgerhq/hw-transport";
+import type { SignerContext } from "@ledgerhq/coin-framework/signer";
+import type { GetViewKeyFn, GetViewKeyOptions } from "@ledgerhq/coin-aleo/signer/getViewKey";
+import type { CreateSigner } from "../../../../bridge/setup";
+import type { Resolver } from "./types";
+
+export type ViewKeyResolver<T> = (signerContext: SignerContext<T>) => GetViewKeyFn;
+
+/**
+ * Inject the `signer` so it can be used by the resolver function.
+ * @param signerFactory
+ * @param viewKeyResolver
+ * @returns Resolver
+ */
+export function createViewKeyResolver<T>(
+  signerFactory: CreateSigner<T>,
+  viewKeyResolver: ViewKeyResolver<T>,
+): Resolver {
+  return (transport: Transport, opts: GetViewKeyOptions): ReturnType<GetViewKeyFn> => {
+    const signerContext: SignerContext<T> = (_, fn) => fn(signerFactory(transport));
+    return viewKeyResolver(signerContext)("", opts);
+  };
+}

--- a/libs/ledger-live-common/src/families/aleo/hw/getViewKey/types.ts
+++ b/libs/ledger-live-common/src/families/aleo/hw/getViewKey/types.ts
@@ -1,0 +1,6 @@
+import type Transport from "@ledgerhq/hw-transport";
+import type { GetViewKeyResult, GetViewKeyOptions } from "@ledgerhq/coin-aleo/signer/getViewKey";
+
+export { GetViewKeyResult, GetViewKeyOptions };
+
+export type Resolver = (transport: Transport, opts: GetViewKeyOptions) => Promise<GetViewKeyResult>;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR is part of the "add account" flow for the Aleo chain. It adds a custom `getViewKey` method to the Aleo family.

During account creation, the device prompts the user to approve sharing the view key. Once approved, the view key will be retrieved and later stored in the `account.id`.

Demo of the flow: https://drive.google.com/file/d/1Yl5Elicpj0nc21uY01cDvkbIhOk_8U0b/view?usp=sharing

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-24446


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
