### PR TITLE
[QAA][LLD] fix Allure Test video not complete

### DIFF
--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -198,8 +198,11 @@ export const test = base.extend<TestFixtures>({
 
       await use(electronApp);
 
-      // close app
-      await electronApp.close();
+      try {
+        await electronApp.close();
+      } catch {
+        // App may already be closed when capturing failure video
+      }
     } finally {
       if (speculos) {
         await killSpeculos(speculos.id);
@@ -242,7 +245,7 @@ export const test = base.extend<TestFixtures>({
 
     // Take screenshot and video only on failure
     if (testInfo.status !== "passed") {
-      await captureArtifacts(page, testInfo);
+      await captureArtifacts(page, testInfo, electronApp);
     }
 
     //Remove video if test passed


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD E2E test

### 📝 Description

On failures, the screenshot often showed the real error but the attached video was shorter than the actual test run.

Playwright only finalizes the video when the browser/Electron context is closed. We were reading and attaching the video in captureArtifacts before the app was closed (in fixture teardown), so the file was still being written and the attached video was truncated.

captureArtifacts now takes electronApp. After capturing screenshot and logs, it closes the app so the video is finalized, then reads and attaches the full recording.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- CI [run](https://github.com/LedgerHQ/ledger-live/actions/runs/21917896802)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
