### PR TITLE
feat(LIVE-24446): support optional customData in account.id

### DIFF
--- a/.changeset/soft-mails-dance.md
+++ b/.changeset/soft-mails-dance.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/coin-framework": minor
+---
+
+feat: support optional customData in account.id

--- a/libs/coin-framework/src/account/accountId.ts
+++ b/libs/coin-framework/src/account/accountId.ts
@@ -47,11 +47,18 @@ export function encodeAccountId({
   currencyId,
   xpubOrAddress,
   derivationMode,
+  customData,
 }: AccountIdParams): string {
-  return `${ensureNoColon(type, "type")}:${ensureNoColon(version, "version")}:${ensureNoColon(
+  const base = `${ensureNoColon(type, "type")}:${ensureNoColon(version, "version")}:${ensureNoColon(
     currencyId,
     "currencyId",
   )}:${safeEncodeXpubOrAddress(xpubOrAddress)}:${ensureNoColon(derivationMode, "derivationMode")}`;
+
+  if (customData && customData.length > 0) {
+    return `${base}:${safeEncodeXpubOrAddress(customData)}`;
+  }
+
+  return base;
 }
 export function encodeTokenAccountId(accountId: string, token: TokenCurrency): string {
   return accountId + "+" + safeEncodeTokenId(token.id);
@@ -90,13 +97,16 @@ export async function decodeTokenAccountId(id: string): Promise<{
 export function decodeAccountId(accountId: string): AccountIdParams {
   invariant(typeof accountId === "string", "accountId is not a string");
   const splitted = accountId.split(":");
-  invariant(splitted.length === 5, "invalid size for accountId");
-  const [type, version, currencyId, encodedXpubOrAddress, derivationMode] = splitted;
+  invariant(splitted.length >= 5, "invalid size for accountId");
+  const [type, version, currencyId, encodedXpubOrAddress, derivationMode, customData] = splitted;
   return {
     type,
     version,
     currencyId,
     xpubOrAddress: safeDecodeXpubOrAddress(encodedXpubOrAddress),
     derivationMode: asDerivationMode(derivationMode),
+    ...(customData && {
+      customData: safeDecodeXpubOrAddress(customData),
+    }),
   };
 }

--- a/libs/coin-framework/src/bridge/jsHelpers.test.ts
+++ b/libs/coin-framework/src/bridge/jsHelpers.test.ts
@@ -105,6 +105,46 @@ describe("makeSync", () => {
     };
     expect(newAccount.id).toEqual(expectedAccount.id);
   });
+
+  it("does not add customData when not present", async () => {
+    // Given
+    const account = createAccount({
+      id: `js:2:bitcoin::`,
+      creationDate: new Date("2024-05-12T17:04:12"),
+      lastSyncDate: new Date("2024-05-12T17:04:12"),
+    });
+
+    // When
+    const accountUpdater = makeSync({
+      getAccountShape: (_accountShape: AccountShapeInfo) => Promise.resolve({} as Account),
+    })(account, {} as SyncConfig);
+    const updater = await firstValueFrom(accountUpdater);
+    const newAccount = updater(account);
+
+    // Then
+    expect(newAccount.id).toEqual("js:2:bitcoin::");
+    expect(newAccount.id).not.toContain("specific-chain-data");
+  });
+
+  it("preserves customData in account.id when present", async () => {
+    // Given
+    const customData = "specific-chain-data";
+    const account = createAccount({
+      id: `js:2:bitcoin:::${customData}`,
+      creationDate: new Date("2024-05-12T17:04:12"),
+      lastSyncDate: new Date("2024-05-12T17:04:12"),
+    });
+
+    // When
+    const accountUpdater = makeSync({
+      getAccountShape: (_accountShape: AccountShapeInfo) => Promise.resolve({} as Account),
+    })(account, {} as SyncConfig);
+    const updater = await firstValueFrom(accountUpdater);
+    const newAccount = updater(account);
+
+    // Then
+    expect(newAccount.id).toEqual(account.id);
+  });
 });
 
 describe("makeScanAccounts", () => {

--- a/libs/ledgerjs/packages/types-live/src/account.ts
+++ b/libs/ledgerjs/packages/types-live/src/account.ts
@@ -244,6 +244,7 @@ export type AccountIdParams = {
   currencyId: string;
   xpubOrAddress: string;
   derivationMode: DerivationMode;
+  customData?: string;
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - account.id may now contain an optional `customData` field
  - no existing/new account, no matter what the chain is, should be negatively affected by this change

### 📝 Description

This PR adds an optional `customData` field to `account.id`. This allows to store chain-specific data, e.g. view key of the Aleo account. 

The decision for Aleo is that an account cannot exist in LW without the view key shared during the "add account" flow, and that the view key should be part of the `account.id` so it is automatically supported by Ledger Sync.

Future usage example in Aleo's `sync.ts`:
```
  let viewKey: string | undefined;

  if (initialAccount) {
    viewKey = decodeAccountId(initialAccount.id).customData;
    invariant(viewKey, `aleo: viewKey is missing in ${address} initialAccount`);
  }

  const accountId = encodeAccountId({
    type: "js",
    version: "2",
    currencyId: currency.id,
    xpubOrAddress: address,
    derivationMode,
    ...(viewKey && {
      customData: viewKey,
    }),
  });
```

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-24446


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
