### PR TITLE
feat (LIVE-25390): add manifest permissions for wallet api storage

### DIFF
--- a/.changeset/friendly-pandas-study.md
+++ b/.changeset/friendly-pandas-study.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add manifest level storage protection

--- a/libs/ledger-live-common/src/platform/types.ts
+++ b/libs/ledger-live-common/src/platform/types.ts
@@ -130,6 +130,7 @@ export type LiveAppManifest = {
   visibility: Visibility;
   highlight?: boolean;
   featureFlags?: string[] | "*";
+  storage?: string[];
   providerTestBaseUrl?: string;
   providerTestId?: string;
   content: {

--- a/libs/ledger-live-common/src/wallet-api/logic.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/logic.test.ts
@@ -5,6 +5,7 @@ import {
   bitcoinFamilyAccountGetXPubLogic,
   broadcastTransactionLogic,
   completeExchangeLogic,
+  protectStorageLogic,
   receiveOnAccountLogic,
   signMessageLogic,
   WalletAPIContext,
@@ -1158,6 +1159,110 @@ describe("bitcoinFamilyAccountGetXPubLogic", () => {
     expect(mockBitcoinFamilyAccountXpubRequested).toHaveBeenCalledTimes(1);
     expect(mockBitcoinFamilyAccountXpubFail).toHaveBeenCalledTimes(0);
     expect(mockBitcoinFamilyAccountXpubSuccess).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("protectStorageLogic", () => {
+  const manifestBase: AppManifest = {
+    id: "my-live-app",
+    name: "Test App",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("allows access when storeId === manifest.id", () => {
+    const manifest = { ...manifestBase };
+    const handler = jest.fn().mockReturnValue("ok");
+    const wrapped = protectStorageLogic(manifest, handler);
+
+    const args = { key: "k", storeId: "my-live-app" };
+
+    const result = wrapped(args);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(args);
+    expect(result).toBe("ok");
+  });
+
+  it("allows access when storeId is in manifest.storage", () => {
+    const manifest = { ...manifestBase, storage: ["allowed-store"] };
+    const handler = jest.fn().mockReturnValue("done");
+    const wrapped = protectStorageLogic(manifest, handler);
+
+    const args = { key: "k", storeId: "allowed-store" };
+
+    const result = wrapped(args);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(args);
+    expect(result).toBe("done");
+  });
+
+  it("throws when storeId is not permitted", () => {
+    const manifest = { ...manifestBase, storage: ["allowed-store"] };
+    const handler = jest.fn();
+    const wrapped = protectStorageLogic(manifest, handler);
+
+    const args = { key: "k", storeId: "forbidden-store" };
+
+    expect(() => wrapped(args)).toThrow(
+      `Live App "my-live-app" is not permitted to access storage "forbidden-store".`,
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("throws when storeId is not permitted and manifest.storage is missing", () => {
+    const manifest = { ...manifestBase, storage: undefined };
+    const handler = jest.fn();
+    const wrapped = protectStorageLogic(manifest, handler);
+
+    const args = { key: "k", storeId: "another-store" };
+
+    expect(() => wrapped(args)).toThrow(
+      `Live App "my-live-app" is not permitted to access storage "another-store".`,
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("propagates errors thrown by the handler", () => {
+    const manifest = { ...manifestBase, storage: ["allowed-store"] };
+    const handler = jest.fn(() => {
+      throw new Error("Handler failed");
+    });
+    const wrapped = protectStorageLogic(manifest, handler);
+
+    const args = { key: "k", storeId: "allowed-store" };
+
+    expect(() => wrapped(args)).toThrow("Handler failed");
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports async handler returning Promise", async () => {
+    const manifest = { ...manifestBase, storage: ["allowed-store"] };
+    const handler = jest.fn(async () => "async-ok");
+    const wrapped = protectStorageLogic(manifest, handler);
+
+    const args = { key: "k", storeId: "allowed-store" };
+
+    const result = await wrapped(args);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result).toBe("async-ok");
+  });
+
+  it("rejects Promise when async handler throws", async () => {
+    const manifest = { ...manifestBase, storage: ["allowed-store"] };
+    const handler = jest.fn(async () => {
+      throw new Error("Async boom");
+    });
+    const wrapped = protectStorageLogic(manifest, handler);
+
+    const args = { key: "k", storeId: "allowed-store" };
+
+    await expect(wrapped(args)).rejects.toThrow("Async boom");
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/libs/ledger-live-common/src/wallet-api/logic.ts
+++ b/libs/ledger-live-common/src/wallet-api/logic.ts
@@ -644,3 +644,33 @@ export async function completeExchangeLogic(
 function getToCurrency(account: AccountLike, tokenAccount?: TokenAccount): CryptoOrTokenCurrency {
   return tokenAccount ? getCurrencyForAccount(tokenAccount) : getCurrencyForAccount(account);
 }
+
+type StorageGetArgs = {
+  key: string;
+  storeId: string;
+};
+
+type StorageSetArgs = {
+  key: string;
+  value: unknown;
+  storeId: string;
+};
+
+type StorageHandlerArgs = StorageGetArgs | StorageSetArgs;
+
+export function protectStorageLogic<T extends StorageHandlerArgs, R>(
+  manifest: AppManifest,
+  handler: (args: T) => R,
+) {
+  return (args: T) => {
+    const { storeId } = args;
+
+    // Either the live app can access storage created by itself OR storage explitly listed in the manifest's permissions
+    if (storeId !== manifest.id && (!manifest.storage || !manifest.storage.includes(storeId))) {
+      throw new Error(`Live App "${manifest.id}" is not permitted to access storage "${storeId}".`);
+    }
+
+    // Forward call to original handler
+    return handler(args);
+  };
+}

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -44,6 +44,7 @@ import {
   bitcoinFamilyAccountGetAddressesLogic,
   bitcoinFamilyAccountGetPublicKeyLogic,
   signRawTransactionLogic,
+  protectStorageLogic,
 } from "./logic";
 import { handlers as featureFlagsHandlers } from "./FeatureFlags";
 import { getAccountBridge } from "../bridge";
@@ -700,14 +701,14 @@ export function useWalletAPIServer({
   useEffect(() => {
     if (!uiStorageGet) return;
 
-    server.setHandler("storage.get", uiStorageGet);
-  }, [server, uiStorageGet]);
+    server.setHandler("storage.get", protectStorageLogic(manifest, uiStorageGet));
+  }, [manifest, server, uiStorageGet]);
 
   useEffect(() => {
     if (!uiStorageSet) return;
 
-    server.setHandler("storage.set", uiStorageSet);
-  }, [server, uiStorageSet]);
+    server.setHandler("storage.set", protectStorageLogic(manifest, uiStorageSet));
+  }, [manifest, server, uiStorageSet]);
 
   useEffect(() => {
     if (!uiTxSignRaw) return;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We need to be able to track user progression through a providers (baanx) card top up flow in order to give them a better experience on Ledger's card live app. In order to do this we will need to share a local storage store.

This PR adds a permissions model to a store based on the manifest config.

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-25390

Other PRs this relies on:
1. Remove logic that prevents any sharing between live apps (https://github.com/LedgerHQ/wallet-api/pull/516)
2. Update to the LW to use live-common v3.0.0 which contains breaking changes (https://github.com/LedgerHQ/ledger-live/pull/14422) we can then merge (1) and generate a new live-common release


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
