### PR TITLE
chore: android sourcemaps to be included in turbo cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -317,6 +317,15 @@
       "outputs": [
         "artifacts/**"
       ]
+    },
+    "live-mobile#android:apk": {
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "android/app/build/generated/**",
+        "android/app/build/intermediates/**"
+      ]
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

allows ongoing integration of sourcemaps to still be found in cache

proof https://github.com/LedgerHQ/ledger-live-build/actions/runs/21940984226/job/63372361383

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
