### PR TITLE
chore: force pre-mobile to set Datadog sampleRate to 100%

### DIFF
--- a/.changeset/fresh-dryers-drop.md
+++ b/.changeset/fresh-dryers-drop.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+force pre-mobile to set Datadog sampleRate to 100%

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -217,8 +217,11 @@ function App() {
       });
     };
     initializeDatadogProvider(
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      datadogFF?.params as PartialInitializationConfiguration,
+      {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        ...(datadogFF?.params as PartialInitializationConfiguration),
+        ...(Config.FORCE_DATADOG_SAMPLE_RATE_100 ? { sessionSamplingRate: 100 } : {}),
+      },
       isTrackingEnabled ? TrackingConsent.GRANTED : TrackingConsent.NOT_GRANTED,
     )
       .then(setUserEquipmentId)


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - mobile datadog integration
  - pre build will use this env

### 📝 Description

Introduce an env that pre-mobile.yml of ledger-live-build can use to force 100% of datadog usage for mobile prerelease builds.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26168


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
