### PR TITLE
[QAA][LWD] Reduce Allure report size

### DIFF
--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -9,6 +9,7 @@ import { Application } from "tests/page";
 import { safeAppendFile, NANO_APP_CATALOG_PATH } from "tests/utils/fileUtils";
 import { launchApp } from "tests/utils/electronUtils";
 import { captureArtifacts } from "tests/utils/allureUtils";
+import { isLastRetry } from "tests/utils/testInfoUtils";
 import { randomUUID } from "crypto";
 import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
 import { lastValueFrom, Observable } from "rxjs";
@@ -194,6 +195,7 @@ export const test = base.extend<TestFixtures>({
         userdataDestinationPath,
         simulateCamera,
         windowSize,
+        recordVideo: isLastRetry(testInfo),
       });
 
       await use(electronApp);

--- a/e2e/desktop/tests/utils/allureUtils.ts
+++ b/e2e/desktop/tests/utils/allureUtils.ts
@@ -4,6 +4,7 @@ import { promisify } from "util";
 import { readFile } from "fs";
 import { takeScreenshot } from "@ledgerhq/live-common/e2e/speculos";
 import * as allure from "allure-js-commons";
+import { isLastRetry } from "tests/utils/testInfoUtils";
 
 const readFileAsync = promisify(readFile);
 const IS_NOT_MOCK = process.env.MOCK == "0";
@@ -36,16 +37,18 @@ export async function captureArtifacts(
     });
   }
 
-  const filePath = `tests/artifacts/${testInfo.title.replace(/[^a-zA-Z0-9]/g, " ")}.json`;
+  if (isLastRetry(testInfo)) {
+    const filePath = `tests/artifacts/${testInfo.title.replace(/[^a-zA-Z0-9]/g, " ")}.json`;
 
-  await page.evaluate(filePath => {
-    window.saveLogs(filePath);
-  }, filePath);
+    await page.evaluate(filePath => {
+      window.saveLogs(filePath);
+    }, filePath);
 
-  await testInfo.attach("Test logs", {
-    path: filePath,
-    contentType: "application/json",
-  });
+    await testInfo.attach("Test logs", {
+      path: filePath,
+      contentType: "application/json",
+    });
+  }
 
   const video = page.video();
   const videoPath = video ? await video.path() : null;

--- a/e2e/desktop/tests/utils/electronUtils.ts
+++ b/e2e/desktop/tests/utils/electronUtils.ts
@@ -8,6 +8,7 @@ export async function launchApp({
   userdataDestinationPath,
   simulateCamera,
   windowSize,
+  recordVideo,
 }: {
   env: Record<string, string>;
   lang: string;
@@ -15,6 +16,7 @@ export async function launchApp({
   userdataDestinationPath: string;
   simulateCamera?: string;
   windowSize: { width: number; height: number };
+  recordVideo?: boolean;
 }): Promise<ElectronApplication> {
   return await electron.launch({
     args: [
@@ -31,10 +33,12 @@ export async function launchApp({
           ]
         : []),
     ],
-    recordVideo: {
-      dir: `${path.join(__dirname, "../artifacts/videos/")}`,
-      size: windowSize,
-    },
+    ...(recordVideo && {
+      recordVideo: {
+        dir: `${path.join(__dirname, "../artifacts/videos/")}`,
+        size: windowSize,
+      },
+    }),
     env,
     colorScheme: theme,
     locale: lang,

--- a/e2e/desktop/tests/utils/testInfoUtils.ts
+++ b/e2e/desktop/tests/utils/testInfoUtils.ts
@@ -1,0 +1,6 @@
+import { TestInfo } from "@playwright/test";
+
+/** True when this run is the last attempt */
+export function isLastRetry(testInfo: TestInfo): boolean {
+  return testInfo.retry === (testInfo.project?.retries ?? 0);
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LWD E2E

### 📝 Description

Reducing Allure report size by keeping video and app logs for last retry only.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/21948189867) with all test fail -> 198 MB
- [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/21949976599) without force fails


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
