### PR TITLE
:bug: fix(market): auto-refetch market banner on network reconnection

### DIFF
--- a/.changeset/old-bulldogs-collect.md
+++ b/.changeset/old-bulldogs-collect.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+refetch on network reconnect for the market banner

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useMarketBannerViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useMarketBannerViewModel.test.ts
@@ -1,0 +1,101 @@
+import { renderHook } from "tests/testSetup";
+import { useMarketBannerViewModel } from "../hooks/useMarketBannerViewModel";
+import { useMarketPerformers } from "@ledgerhq/live-common/market/hooks/useMarketPerformers";
+import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
+import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
+import { MOCK_MARKET_PERFORMERS } from "@ledgerhq/live-common/market/utils/fixtures";
+import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
+
+jest.mock("@ledgerhq/live-common/market/hooks/useMarketPerformers");
+jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog");
+jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index");
+
+const mockedUseMarketPerformers = jest.mocked(useMarketPerformers);
+
+function mockPerformersQuery(
+  overrides: Partial<{
+    data: MarketItemPerformer[];
+    isLoading: boolean;
+    isFetching: boolean;
+    isError: boolean;
+  }>,
+) {
+  mockedUseMarketPerformers.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    ...overrides,
+  } as ReturnType<typeof useMarketPerformers>);
+}
+
+describe("useMarketBannerViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    jest.mocked(useRampCatalog).mockReturnValue({
+      isCurrencyAvailable: () => true,
+    } as unknown as ReturnType<typeof useRampCatalog>);
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    jest.mocked(useFetchCurrencyAll).mockReturnValue({
+      data: ["bitcoin", "ethereum", "solana"],
+    } as unknown as ReturnType<typeof useFetchCurrencyAll>);
+  });
+
+  describe("isLoading", () => {
+    it("should be true during the initial load (no cached data)", () => {
+      mockPerformersQuery({ isLoading: true, isFetching: true });
+
+      const { result } = renderHook(() => useMarketBannerViewModel());
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toEqual([]);
+    });
+
+    it("should be true when fetching without any cached data", () => {
+      mockPerformersQuery({ isFetching: true });
+
+      const { result } = renderHook(() => useMarketBannerViewModel());
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("should be false during a background refetch when data already exists", () => {
+      mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS, isFetching: true });
+
+      const { result } = renderHook(() => useMarketBannerViewModel());
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data.length).toBeGreaterThan(0);
+    });
+
+    it("should be false when data is loaded and the query is idle", () => {
+      mockPerformersQuery({ data: MOCK_MARKET_PERFORMERS });
+
+      const { result } = renderHook(() => useMarketBannerViewModel());
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("isError", () => {
+    it("should be true when the query errors and is not refetching", () => {
+      mockPerformersQuery({ isError: true });
+
+      const { result } = renderHook(() => useMarketBannerViewModel());
+
+      expect(result.current.isError).toBe(true);
+    });
+
+    it("should be suppressed while a refetch is in progress", () => {
+      mockPerformersQuery({ isError: true, isFetching: true });
+
+      const { result } = renderHook(() => useMarketBannerViewModel());
+
+      expect(result.current.isError).toBe(false);
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useMarketBannerViewModel.ts
@@ -24,7 +24,7 @@ export const useMarketBannerViewModel = () => {
     [currenciesForSwapAll],
   );
 
-  const { data, isError, isLoading } = useMarketPerformers({
+  const { data, isError, isLoading, isFetching } = useMarketPerformers({
     sort: MARKET_BANNER_DATA_SORT_ORDER,
     counterCurrency: countervalue.ticker,
     range: TIME_RANGE,
@@ -45,5 +45,9 @@ export const useMarketBannerViewModel = () => {
     );
   }, [data, isCurrencyAvailable, currenciesForSwapAllSet]);
 
-  return { data: filteredItems, isError, isLoading };
+  return {
+    data: filteredItems,
+    isError: isError && !isFetching,
+    isLoading: isLoading || (isFetching && !data),
+  };
 };

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -33,6 +33,7 @@ import { setEnvOnAllThreads } from "~/helpers/env";
 import dbMiddleware from "~/renderer/middlewares/db";
 import type { ReduxStore, AppDispatch } from "~/renderer/createStore";
 import createStore from "~/renderer/createStore";
+import { setupListeners } from "@reduxjs/toolkit/query";
 import events from "~/renderer/events";
 import { initAccounts } from "~/renderer/actions/accounts";
 import { fetchSettings, setDeepLinkUrl } from "~/renderer/actions/settings";
@@ -124,6 +125,7 @@ async function init() {
   });
   const dispatch: AppDispatch = store.dispatch;
 
+  setupListeners(store.dispatch);
   setupRecentAddressesStore(store);
   setupCryptoAssetsStore(store);
 

--- a/apps/ledger-live-mobile/src/context/store.ts
+++ b/apps/ledger-live-mobile/src/context/store.ts
@@ -1,5 +1,7 @@
 import Config from "react-native-config";
 import { configureStore, StoreEnhancer } from "@reduxjs/toolkit";
+import { setupListeners } from "@reduxjs/toolkit/query";
+import NetInfo from "@react-native-community/netinfo";
 import reducers from "~/reducers";
 import { rebootMiddleware } from "~/middleware/rebootMiddleware";
 import { rozeniteDevToolsEnhancer } from "@rozenite/redux-devtools-plugin";
@@ -43,5 +45,15 @@ export const store = configureStore({
 export type StoreType = typeof store;
 export type AppDispatch = typeof store.dispatch;
 
+setupListeners(store.dispatch, (dispatch, { onOnline, onOffline }) => {
+  const unsubscribe = NetInfo.addEventListener(state => {
+    if (state.isConnected) {
+      dispatch(onOnline());
+    } else {
+      dispatch(onOffline());
+    }
+  });
+  return unsubscribe;
+});
 setupRecentAddressesStore(store);
 setupCryptoAssetsStore(store);

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
@@ -41,6 +41,7 @@ jest.mock("@react-native-community/netinfo", () => {
       none: "none",
     },
     useNetInfo: mockUseNetInfo,
+    addEventListener: jest.fn(() => jest.fn()),
   };
 });
 

--- a/libs/ledger-live-common/src/market/hooks/useMarketPerformers.ts
+++ b/libs/ledger-live-common/src/market/hooks/useMarketPerformers.ts
@@ -15,5 +15,6 @@ export const useMarketPerformers = ({
     { counterCurrency, range, limit, top, sort, supported },
     {
       pollingInterval: REFETCH_TIME_ONE_MINUTE * Number(refreshRate),
+      refetchOnReconnect: true,
     },
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new unit tests — the fix relies on RTK Query's built-in `refetchOnReconnect` mechanism which is well-tested upstream. Manual QA is recommended._
- [x] **Impact of the changes:**
      - Market Banner behavior when going offline/online
      - RTK Query refetch listeners are now active globally (setupListeners)
      - No impact on existing polling behavior

### 📝 Description

**Problem**: If Ledger Live is opened without internet, the Market Banner shows an error state. This error persists even after the internet connection is restored — the user has to restart the app to see the banner content.

**Solution**: Enabled RTK Query's built-in network reconnection detection:

- Added `setupListeners(store.dispatch)` in both **LLD** and **LLM** store initialization, which registers browser/RN network event listeners that RTK Query needs
- Passed `refetchOnReconnect: true` to the `useGetMarketPerformersQuery` hook so the market performers data is automatically refetched when connectivity is restored
- Used `isFetching` alongside `isLoading` in the viewmodel to show the loading skeleton during reconnection refetch

https://github.com/user-attachments/assets/bfeda5ea-4125-49be-b653-7552f0c08dba




### ❓ Context

- **JIRA or GitHub link**: [LIVE-25526](https://ledgerhq.atlassian.net/browse/LIVE-25526) & [LIVE-25529](https://ledgerhq.atlassian.net/browse/LIVE-25529)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25526]: https://ledgerhq.atlassian.net/browse/LIVE-25526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ