### PR TITLE
chore(mobile): make ios build generate sourcemap file + make sure cached in turbo

### DIFF
--- a/apps/ledger-live-mobile/ios/.xcode.env
+++ b/apps/ledger-live-mobile/ios/.xcode.env
@@ -1,1 +1,5 @@
 export NODE_BINARY=$(command -v node)
+
+# Generate sourcemap for release builds (Datadog RUM symbolication, Sentry, etc.)
+# Writes to ios/build so CI can find it for upload
+export SOURCEMAP_FILE="${PROJECT_DIR:-.}/build/main.jsbundle.map"

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile.xcodeproj/project.pbxproj
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=$(command -v node)\n\nset -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\n\nif [[ \"$SKIP_JS_BUNDLING\" == \"true\" ]]; then\n    REACT_NATIVE_XCODE=\"\"\n    echo \"Skipping JS bundle\"\nelse\n    echo \"Not skipping JS bundle\"\n    REACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\nfi\n\nBUNDLE_REACT_NATIVE=\"$REACT_NATIVE_XCODE\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT \\\"$BUNDLE_REACT_NATIVE\\\"\"\n";
+			shellScript = "export NODE_BINARY=$(command -v node)\n\nset -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\n\nif [[ \"$SKIP_JS_BUNDLING\" == \"true\" ]]; then\n    REACT_NATIVE_XCODE=\"\"\n    echo \"Skipping JS bundle\"\nelse\n    echo \"Not skipping JS bundle\"\n    REACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\nfi\n\nBUNDLE_REACT_NATIVE=\"$REACT_NATIVE_XCODE\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT \\\"$BUNDLE_REACT_NATIVE\\\"\"\n\n# Copy bundle to ios/build so CI can upload bundle+sourcemap to Datadog\nif [[ -f \"${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/main.jsbundle\" ]]; then\n  mkdir -p \"${PROJECT_DIR}/build\"\n  cp \"${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/main.jsbundle\" \"${PROJECT_DIR}/build/main.jsbundle\"\nfi\n";
 		};
 		3B8A85D90BB941F538378AA1 /* [CP-User] [RNFB] Core Configuration */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/turbo.json
+++ b/turbo.json
@@ -317,6 +317,31 @@
       "outputs": [
         "artifacts/**"
       ]
+    },
+    "live-mobile#android:apk": {
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "android/app/build/generated/**",
+        "android/app/build/intermediates/**"
+      ]
+    },
+    "live-mobile#ios:ci:adhoc": {
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "ios/build/**"
+      ]
+    },
+    "live-mobile#ios:local:ipa": {
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "ios/build/**"
+      ]
     }
   }
 }


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - mobile ios build now generates `ios/build/main.jsbundle.map` file

### 📝 Description

this PR also includes https://github.com/LedgerHQ/ledger-live/pull/14409

mobile app build currently don't generate sourcemap for iOS, only for Android. this fix it.

test: https://github.com/LedgerHQ/ledger-live-build/actions/runs/21992134684

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
