### PR TITLE
fix(mobile): move quick actions above banners in Portfolio for W4.0

### DIFF
--- a/.changeset/wet-cameras-ring.md
+++ b/.changeset/wet-cameras-ring.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Moove banner section under quick actions for W4.0. Ensure the layout works for all the cases

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -13,6 +13,9 @@ import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/t
 import { WalletTabNavigatorStackParamList } from "~/components/RootNavigator/types/WalletTabNavigator";
 import usePortfolioViewModel from "./usePortfolioViewModel";
 
+import { Box } from "@ledgerhq/native-ui";
+import { QuickActionsCtas, TransferDrawer } from "LLM/features/QuickActions";
+
 import {
   PortfolioAllocationsSection,
   PortfolioAssetsSection,
@@ -36,6 +39,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     hideEmptyTokenAccount,
     isAWalletCardDisplayed,
     isAccountListUIEnabled,
+    shouldDisplayQuickActionCtas,
     showAssets,
     isLNSUpsellBannerShown,
     isAddModalOpened,
@@ -65,6 +69,15 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
         <PortfolioEmptySection key="empty" isLNSUpsellBannerShown={isLNSUpsellBannerShown} />,
       );
       return sections;
+    }
+
+    if (shouldDisplayQuickActionCtas) {
+      sections.push(
+        <Box px={6} pt={shouldDisplayGraphRework ? 0 : 6} key="quickActions">
+          <QuickActionsCtas sourceScreenName={ScreenName.Portfolio} />
+          <TransferDrawer />
+        </Box>,
+      );
     }
 
     sections.push(
@@ -108,6 +121,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     shouldDisplayGraphRework,
     onBackFromUpdate,
     isLNSUpsellBannerShown,
+    shouldDisplayQuickActionCtas,
     isAccountListUIEnabled,
     hideEmptyTokenAccount,
     openAddModal,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
@@ -32,6 +32,7 @@ interface UsePortfolioViewModelResult {
   hideEmptyTokenAccount: boolean;
   isAWalletCardDisplayed: boolean;
   isAccountListUIEnabled: boolean;
+  shouldDisplayQuickActionCtas: boolean;
   showAssets: boolean;
   isLNSUpsellBannerShown: boolean;
   isAddModalOpened: boolean;
@@ -52,7 +53,8 @@ const usePortfolioViewModel = (navigation: {
   const [isAddModalOpened, setAddModalOpened] = useState(false);
   const { isAWalletCardDisplayed } = useDynamicContent();
   const accountListFF = useFeature("llmAccountListUI");
-  const { shouldDisplayGraphRework } = useWalletFeaturesConfig("mobile");
+  const { shouldDisplayGraphRework, shouldDisplayQuickActionCtas } =
+    useWalletFeaturesConfig("mobile");
   const isAccountListUIEnabled = accountListFF?.enabled ?? false;
   const llmDatadog = useFeature("llmDatadog");
   const allAccounts = useSelector(flattenAccountsSelector, shallowEqual);
@@ -135,6 +137,7 @@ const usePortfolioViewModel = (navigation: {
     hideEmptyTokenAccount,
     isAWalletCardDisplayed,
     isAccountListUIEnabled,
+    shouldDisplayQuickActionCtas,
     showAssets,
     isLNSUpsellBannerShown,
     isAddModalOpened,

--- a/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioAssets.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioAssets.tsx
@@ -17,7 +17,6 @@ import { setSelectedTabPortfolioAssets } from "~/actions/settings";
 import Assets from "./Assets";
 import PortfolioQuickActionsBar from "./PortfolioQuickActionsBar";
 import MarketBanner from "LLM/features/MarketBanner";
-import { QuickActionsCtas, TransferDrawer } from "LLM/features/QuickActions";
 import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import useListsAnimation, { type TabListType } from "./useListsAnimation";
 import TabSection, { TAB_OPTIONS } from "./TabSection";
@@ -133,13 +132,8 @@ const PortfolioAssets = ({ hideEmptyTokenAccount, openAddModal }: Props) => {
     [showAssets, isAccountListUIEnabled, navigation],
   );
 
-  const {
-    shouldDisplayMarketBanner,
-    shouldDisplayQuickActionCtas,
-    isEnabled: isLwmWallet40Enabled,
-  } = useWalletFeaturesConfig("mobile");
-
-  const isLwmWallet40Disabled = !isLwmWallet40Enabled;
+  const { shouldDisplayQuickActionCtas, shouldDisplayMarketBanner } =
+    useWalletFeaturesConfig("mobile");
 
   return (
     <>
@@ -149,17 +143,10 @@ const PortfolioAssets = ({ hideEmptyTokenAccount, openAddModal }: Props) => {
         discreet={discreetMode}
       />
 
-      {shouldDisplayQuickActionCtas ? (
+      {!shouldDisplayQuickActionCtas && (
         <Box my={24}>
-          <QuickActionsCtas sourceScreenName={ScreenName.Portfolio} />
-          <TransferDrawer />
+          <PortfolioQuickActionsBar />
         </Box>
-      ) : (
-        isLwmWallet40Disabled && (
-          <Box my={24}>
-            <PortfolioQuickActionsBar />
-          </Box>
-        )
       )}
 
       <Box>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Partial — layout change is visual; covered by existing snapshot/integration tests but no dedicated new tests added._
- [x] **Impact of the changes:**
      - Portfolio screen quick actions positioning
      - Banners section ordering in the Portfolio view
      - Fallback rendering when quick action CTAs feature flag is disabled

### 📝 Description

The quick actions (QuickActionsCtas + TransferDrawer) were rendered inside the `PortfolioAssets` component, placing them below the banners section. For Wallet 4.0, they need to appear above the banners.

Moved the quick actions rendering from `PortfolioAssets.tsx` up to the Portfolio screen level (`index.tsx`), inserting them before the banners section. Simplified the remaining logic in `PortfolioAssets.tsx` by removing the now-unnecessary `isLwmWallet40Enabled` / `isLwmWallet40Disabled` checks and only showing `PortfolioQuickActionsBar` as a fallback when `shouldDisplayQuickActionCtas` is off.



The following video is a demo of all the different states possible depending on the ff value

https://github.com/user-attachments/assets/555825c9-3edc-407d-a8d9-f82c5b887e6c



### ❓ Context

- **JIRA or GitHub link**: [LIVE-25892](https://ledgerhq.atlassian.net/browse/LIVE-25892)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25892]: https://ledgerhq.atlassian.net/browse/LIVE-25892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ