### PR TITLE
fix(mobile): display 2 decimal places for portfolio delta percentages

### DIFF
--- a/.changeset/fix-delta-decimal-precision.md
+++ b/.changeset/fix-delta-decimal-precision.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Delta percentage display to show 2 decimal places in Portfolio Balance view

--- a/apps/ledger-live-mobile/src/components/Delta.tsx
+++ b/apps/ledger-live-mobile/src/components/Delta.tsx
@@ -7,6 +7,7 @@ import { ArrowEvolutionUpMedium, ArrowEvolutionDownMedium } from "@ledgerhq/nati
 import { useTranslation } from "~/context/Locale";
 import { BaseTextProps } from "@ledgerhq/native-ui/components/Text/index";
 import CurrencyUnitValue from "./CurrencyUnitValue";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 type Props = {
   valueChange: ValueChange;
@@ -24,6 +25,10 @@ type Props = {
   testID?: string;
 };
 
+const getDecimalPlaces = (shouldDisplayGraphRework: boolean) => {
+  return shouldDisplayGraphRework ? 2 : 0;
+};
+
 function Delta({
   valueChange,
   percent,
@@ -38,6 +43,7 @@ function Delta({
   testID,
 }: Props) {
   const { t } = useTranslation();
+  const { shouldDisplayGraphRework } = useWalletFeaturesConfig("mobile");
 
   const percentPlaceholder = fallbackToPercentPlaceholder ? (
     // eslint-disable-next-line i18next/no-literal-string
@@ -51,7 +57,8 @@ function Delta({
       ? valueChange.percentage * 100
       : valueChange.value;
 
-  const roundedDelta = parseFloat(delta.toFixed(0));
+  const decimalPlaces = getDecimalPlaces(shouldDisplayGraphRework);
+  const roundedDelta = parseFloat(delta.toFixed(decimalPlaces));
 
   if (roundedDelta === 0) {
     return percentPlaceholder;
@@ -101,7 +108,7 @@ function Delta({
               value={absDelta}
             />
           ) : percent ? (
-            `${absDelta.toFixed(0)}%`
+            `${absDelta.toFixed(decimalPlaces)}%`
           ) : null}
           {range && ` (${t(`time.${range}`)})`}
           {isPercentSignDisplayed ? "%" : ""}
@@ -121,4 +128,8 @@ const styles = StyleSheet.create({
   },
 });
 
+/**
+ * @note Use the Delta component from the mvvm directory instead.
+ * The new one relies on Lumen UI lib.
+ */
 export default memo<Props>(Delta);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Only partial — display formatting change verified manually._
- [x] **Impact of the changes:**
      - Portfolio Balance view: delta percentage values now show 2 decimal places instead of 0
      - All screens rendering the legacy `Delta` component with `percent` mode

### 📝 Description

**Problem**: Percentage values in the Portfolio Balance view were rounded to 0 decimal places (`.toFixed(0)`), which lost precision and could display misleading values (e.g. `+0%` instead of `+0.42%`).

**Solution**: Updated the `Delta` component to use `.toFixed(2)` in both the zero-check logic and the render output, ensuring all percentage values consistently display exactly 2 decimal places. Also added a `@note` JSDoc directing future contributors to the new MVVM-based Delta component built on Lumen UI.

| Before | After |
| ------ | ----- |
|https://github.com/user-attachments/assets/88afc5b5-7799-41ca-9f3b-1388683edc58|https://github.com/user-attachments/assets/1155cc97-d5e1-4829-aa04-eb512036866a|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25886](https://ledgerhq.atlassian.net/browse/LIVE-25886)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25886]: https://ledgerhq.atlassian.net/browse/LIVE-25886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ