### PR TITLE
feat: migrates Wallet40 help section

### DIFF
--- a/.changeset/rotten-cycles-suffer.md
+++ b/.changeset/rotten-cycles-suffer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): wallet40 help migration

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/TopBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/TopBarView.tsx
@@ -1,20 +1,12 @@
-import React, { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { ItemContainer } from "~/renderer/components/TopBar/shared";
-import Tooltip from "~/renderer/components/Tooltip";
+import React from "react";
 import Breadcrumb from "~/renderer/components/Breadcrumb";
-import HelpSideBar from "~/renderer/modals/Help";
 
 import { LiveAppDrawer } from "~/renderer/components/LiveAppDrawer";
-import { IconsLegacy } from "@ledgerhq/react-ui";
 import { NavBar, NavBarTrailing, NavBarTitle } from "@ledgerhq/lumen-ui-react";
 import { TopBarViewProps } from "./types";
 import { TopBarActionsList } from "./components/ActionsList";
 
 const TopBarView = ({ slots }: TopBarViewProps) => {
-  const { t } = useTranslation();
-  const [helpSideBarVisible, setHelpSideBarVisible] = useState(false);
-
   return (
     <NavBar className="items-center px-32 pt-32 pb-24">
       <NavBarTitle className="h-48">
@@ -22,19 +14,7 @@ const TopBarView = ({ slots }: TopBarViewProps) => {
       </NavBarTitle>
       <NavBarTrailing className="h-48 gap-12">
         <LiveAppDrawer />
-
         <TopBarActionsList slots={slots} />
-
-        <Tooltip content={t("settings.helpButton")} placement="bottom">
-          <ItemContainer
-            data-testid="topbar-help-button"
-            isInteractive
-            onClick={() => setHelpSideBarVisible(true)}
-          >
-            <IconsLegacy.HelpMedium size={18} />
-          </ItemContainer>
-        </Tooltip>
-        <HelpSideBar isOpened={helpSideBarVisible} onClose={() => setHelpSideBarVisible(false)} />
       </NavBarTrailing>
     </NavBar>
   );

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/index.test.tsx
@@ -85,7 +85,6 @@ describe("TopBar", () => {
     expect(screen.getByTestId("topbar-action-button-synchronize")).toBeVisible();
     expect(screen.getByTestId("topbar-action-button-notifications")).toBeVisible();
     expect(screen.getByTestId("topbar-action-button-discreet")).toBeVisible();
-    expect(screen.getByTestId("topbar-help-button")).toBeVisible();
     expect(screen.getByTestId("topbar-action-button-settings")).toBeVisible();
   });
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/About/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/About/index.tsx
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from "uuid";
 import { developerModeSelector } from "~/renderer/reducers/settings";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { urls } from "~/config/urls";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 const SectionHelp = () => {
   const { t } = useTranslation();
@@ -22,6 +23,8 @@ const SectionHelp = () => {
   const { pushToast } = useToasts();
   const version = getEnv("PLAYWRIGHT_RUN") ? "0.0.0" : __APP_VERSION__;
   const [clickCounter, setClickCounter] = useState(0);
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("desktop");
+
   const onVersionClick = useCallback(() => {
     if (clickCounter < 10) {
       setClickCounter(counter => counter + 1);
@@ -51,6 +54,29 @@ const SectionHelp = () => {
         >
           <ReleaseNotesButton />
         </Row>
+
+        {shouldDisplayWallet40MainNav && (
+          <>
+            <RowItem
+              title={t("help.facebook.title")}
+              desc={t("help.facebook.desc")}
+              url={urls.social.facebook}
+              dataTestId="facebook-link"
+            />
+            <RowItem
+              title={t("help.twitter.title")}
+              desc={t("help.twitter.desc")}
+              url={urls.social.twitter}
+              dataTestId="twitter-link"
+            />
+            <RowItem
+              title={t("help.github.title")}
+              desc={t("help.github.desc")}
+              url={urls.social.github}
+              dataTestId="github-link"
+            />
+          </>
+        )}
 
         <RowItem
           title={t("settings.help.terms")}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/index.tsx
@@ -12,13 +12,14 @@ import RepairDeviceButton from "./RepairDeviceButton";
 import LaunchOnboardingBtn from "./LaunchOnboardingBtn";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { urls } from "~/config/urls";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 const SectionHelp = () => {
   const { t } = useTranslation();
 
   const urlFaq = useLocalizedUrl(urls.faq);
   const chatbotSupportFeature = useFeature("lldChatbotSupport");
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("desktop");
 
   return (
     <>
@@ -37,6 +38,22 @@ const SectionHelp = () => {
             url={urlFaq}
             dataTestId={"ledgerSupport"}
           />
+        )}
+        {shouldDisplayWallet40MainNav && (
+          <>
+            <RowItem
+              title={t("help.ledgerAcademy.title")}
+              desc={t("help.ledgerAcademy.desc")}
+              url={urls.helpModal.ledgerAcademy}
+              dataTestId="ledgerAcademy-link"
+            />
+            <RowItem
+              title={t("help.status.title")}
+              desc={t("help.status.desc")}
+              url={urls.helpModal.status}
+              dataTestId="status-link"
+            />
+          </>
         )}
         <Row
           title={t("settings.profile.softResetTitle")}


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a minor feature update to the Ledger Live Desktop application, focusing on the migration of help-related UI components as part of the "wallet40" initiative. The main changes involve removing the help button from the top bar and conditionally displaying new help and social links in the settings sections based on a feature flag.

https://github.com/user-attachments/assets/ac3b20d4-db3a-4155-bfec-8d6eb5e1ce76


### ❓ Context

[LIVE-26077](https://ledgerhq.atlassian.net/browse/LIVE-26077)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26077]: https://ledgerhq.atlassian.net/browse/LIVE-26077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ