### PR TITLE
chore: forward debug environment variables through Turborepo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "daemon": false,
-  "globalDependencies": [
-    "turbo.json",
-    "tsconfig.base.json"
-  ],
+  "globalDependencies": ["turbo.json", "tsconfig.base.json"],
   "globalEnv": [
     "ANDROID_HOME",
     "ANDROID_KEYSTORE_FILE",
@@ -77,52 +74,57 @@
     "DATADOG_PROD_APPLICATION_ID",
     "MOCK",
     "MOCK_COUNTERVALUES",
-    "ENABLE_MSW"
+    "MOCK_REMOTE_LIVE_MANIFEST",
+    "ENABLE_MSW",
+    "DEBUG_UPDATE",
+    "DEBUG_SKELETONS",
+    "DEBUG_FIRMWARE_UPDATE",
+    "DEBUG_THEME",
+    "DEBUG_LOTTIE",
+    "DEBUG_POSTONBOARDINGHUB",
+    "DEBUG_FW_VERSION",
+    "HIDE_DEBUG_MOCK",
+    "DISABLE_MOCK_POINTER_EVENTS",
+    "DISABLE_CONTEXT_MENU",
+    "SHOW_ETHEREUM_BRIDGE",
+    "OVERRIDE_MODELID",
+    "OVERRIDE_MODEL_ID",
+    "DEFAULT_EARN_MANIFEST_ID",
+    "DEFAULT_SWAP_MANIFEST_ID",
+    "USBTROUBLESHOOTING_PLATFORM",
+    "NO_DEBUG_DB",
+    "NO_DEBUG_ACTION",
+    "NO_DEBUG_TAB_KEY",
+    "NO_DEBUG_WS",
+    "NO_DEBUG_NETWORK",
+    "NO_DEBUG_ANALYTICS",
+    "NO_DEBUG_COUNTERVALUES"
   ],
   "ui": "tui",
   "tasks": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "dist/**",
-        "lib/**",
-        "lib-es/**",
-        "build/**"
-      ]
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "lib/**", "lib-es/**", "build/**"]
     },
     "lint": {
-      "env": [
-        "CI_OS"
-      ]
+      "env": ["CI_OS"]
     },
     "lint:fix": {
       "outputs": []
     },
     "typecheck": {
       "outputs": [],
-      "dependsOn": [
-        "^build"
-      ],
-      "env": [
-        "CI_OS"
-      ]
+      "dependsOn": ["^build"],
+      "env": ["CI_OS"]
     },
     "test": {
-      "dependsOn": [
-        "build"
-      ],
-      "env": [
-        "CI_OS"
-      ],
+      "dependsOn": ["build"],
+      "env": ["CI_OS"],
       "outputs": []
     },
     "start": {
       "cache": false,
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "persistent": true
     },
     "start:msw": {
@@ -137,67 +139,43 @@
       "cache": false
     },
     "android:apk:local": {
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "android:apk": {
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "ios:local:ipa": {
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "ios:ci:adhoc": {
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "nightly": {
       "cache": false,
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "pre-build": {
       "cache": false,
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "release": {
       "cache": false,
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "watch": {
       "cache": false,
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "persistent": true
     },
     "watch:es": {
       "cache": false,
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "persistent": true
     },
     "coverage": {
       "cache": true,
-      "dependsOn": [
-        "^build",
-        "build"
-      ],
-      "outputs": [
-        "coverage/lcov.info",
-        "coverage/sonar-executionTests-report.xml"
-      ]
+      "dependsOn": ["^build", "build"],
+      "outputs": ["coverage/lcov.info", "coverage/sonar-executionTests-report.xml"]
     },
     "clean": {
       "cache": false
@@ -206,142 +184,73 @@
       "cache": false
     },
     "web-tools#build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        ".next/**",
-        "!.next/cache/**"
-      ],
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**"],
       "cache": false
     },
     "ledger-live-desktop#build": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "cache": false
     },
     "@ledgerhq/icons-ui#build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "react/**",
-        "native/**",
-        "reactLegacy/**",
-        "nativeLegacy/**",
-        "index.js"
-      ]
+      "dependsOn": ["^build"],
+      "outputs": ["react/**", "native/**", "reactLegacy/**", "nativeLegacy/**", "index.js"]
     },
     "@ledgerhq/live-common#build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "lib/**",
-        "lib-es/**"
-      ]
+      "dependsOn": ["^build"],
+      "outputs": ["lib/**", "lib-es/**"]
     },
     "@ledgerhq/live-common#typecheck": {
-      "dependsOn": [
-        "build"
-      ],
-      "env": [
-        "CI_OS"
-      ],
+      "dependsOn": ["build"],
+      "env": ["CI_OS"],
       "outputs": []
     },
     "live-mobile#lint": {
-      "dependsOn": [
-        "^build"
-      ],
-      "env": [
-        "CI_OS"
-      ],
-      "outputs": [
-        "lint.json"
-      ]
+      "dependsOn": ["^build"],
+      "env": ["CI_OS"],
+      "outputs": ["lint.json"]
     },
     "ledger-live-desktop#lint": {
-      "dependsOn": [
-        "^build"
-      ],
-      "env": [
-        "CI_OS"
-      ],
-      "outputs": [
-        "lint.json",
-        "lint-desktop.json",
-        "lint-desktop-external.json"
-      ]
+      "dependsOn": ["^build"],
+      "env": ["CI_OS"],
+      "outputs": ["lint.json", "lint-desktop.json", "lint-desktop-external.json"]
     },
     "ledger-live-desktop#test": {
-      "dependsOn": [
-        "ledger-live-desktop#build:testing"
-      ],
-      "env": [
-        "CI_OS"
-      ],
+      "dependsOn": ["ledger-live-desktop#build:testing"],
+      "env": ["CI_OS"],
       "outputs": []
     },
     "ledger-live-desktop#build:testing": {
       "cache": false,
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "@ledgerhq/native-ui#typecheck": {
       "outputs": [],
-      "dependsOn": [
-        "build"
-      ],
-      "env": [
-        "CI_OS"
-      ]
+      "dependsOn": ["build"],
+      "env": ["CI_OS"]
     },
     "@ledgerhq/react-ui#typecheck": {
       "outputs": [],
-      "dependsOn": [
-        "build"
-      ],
-      "env": [
-        "CI_OS"
-      ]
+      "dependsOn": ["build"],
+      "env": ["CI_OS"]
     },
     "live-mobile#e2e:ci": {
       "cache": true,
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "inputs": [],
-      "outputs": [
-        "artifacts/**"
-      ]
+      "outputs": ["artifacts/**"]
     },
     "live-mobile#android:apk": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "android/app/build/generated/**",
-        "android/app/build/intermediates/**"
-      ]
+      "dependsOn": ["^build"],
+      "outputs": ["android/app/build/generated/**", "android/app/build/intermediates/**"]
     },
     "live-mobile#ios:ci:adhoc": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "ios/build/**"
-      ]
+      "dependsOn": ["^build"],
+      "outputs": ["ios/build/**"]
     },
     "live-mobile#ios:local:ipa": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "ios/build/**"
-      ]
+      "dependsOn": ["^build"],
+      "outputs": ["ios/build/**"]
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

### Problem

Debug/test environment variables like `DEBUG_UPDATE`, `DEBUG_SKELETONS`, `DEBUG_FIRMWARE_UPDATE`, `MOCK_REMOTE_LIVE_MANIFEST`, etc. were not working when running `pnpm dev:lld` from the monorepo root.

For example, `DEBUG_UPDATE=1 pnpm dev:lld` was supposed to display the DebugUpdater panel, but it never rendered.

These variables only worked in Playwright tests (which launch Electron directly with env vars, bypassing Turborepo).

### Root cause

`pnpm dev:lld` runs `pnpm turbo start --filter=ledger-live-desktop`. Turborepo filters environment variables and only forwards those explicitly listed in `globalEnv` to child tasks.

`MOCK` was already in `globalEnv` (which is why `MOCK=1 pnpm dev:lld` worked), but `DEBUG_UPDATE` and most other debug flags were missing. Turbo silently stripped them before they reached the Electron renderer process.

This was not an issue with the previous Vite-based dev setup because Vite serves source files as native ESM without bundling -- `process.env.X` was evaluated at runtime by Electron's Node.js, and the env vars were inherited from the parent process. With rspack, the renderer code is bundled, making it dependent on either DefinePlugin injection or runtime `process.env` access, both of which require the variable to survive Turbo's filtering.

### Changes

**`turbo.json`**: Added some missing environment variables to `globalEnv` so they are forwarded to the `start` task:

- Debug panels: `DEBUG_UPDATE`, `DEBUG_SKELETONS`, `DEBUG_FIRMWARE_UPDATE`, `DEBUG_THEME`, `DEBUG_LOTTIE`, `DEBUG_POSTONBOARDINGHUB`, `DEBUG_FW_VERSION`
- Mock/test flags: `HIDE_DEBUG_MOCK`, `MOCK_REMOTE_LIVE_MANIFEST`, `DISABLE_MOCK_POINTER_EVENTS`, `DISABLE_CONTEXT_MENU`
- Feature flags: `SHOW_ETHEREUM_BRIDGE`
- Device overrides: `OVERRIDE_MODELID`, `OVERRIDE_MODEL_ID`
- Manifest IDs: `DEFAULT_EARN_MANIFEST_ID`, `DEFAULT_SWAP_MANIFEST_ID`
- USB troubleshooting: `USBTROUBLESHOOTING_PLATFORM`
- Logger flags: `NO_DEBUG_DB`, `NO_DEBUG_ACTION`, `NO_DEBUG_TAB_KEY`, `NO_DEBUG_WS`, `NO_DEBUG_NETWORK`, `NO_DEBUG_ANALYTICS`, `NO_DEBUG_COUNTERVALUES`

### How to test

```bash
DEBUG_UPDATE=1 pnpm dev:lld
# -> DebugUpdater panel should appear in the app

DEBUG_SKELETONS=1 pnpm dev:lld
# -> Skeleton debug panel should appear

MOCK=1 pnpm dev:lld
# -> Still works as before
```

<img width="1585" height="1219" alt="image" src="https://github.com/user-attachments/assets/f5f7c730-d111-4e1c-a799-62b074d7cc76" />


### ❓ Context

- **JIRA or GitHub link**: N/A


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
