### PR TITLE
feat(desktop): disable Accounts sidebar entry when no accounts exist

### DIFF
--- a/.changeset/red-sloths-compare.md
+++ b/.changeset/red-sloths-compare.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+disable accounts entry from Sidebar when no accounts

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
@@ -63,6 +63,7 @@ export function SideBarView({ viewModel }: SideBarViewProps) {
               icon={Wallet}
               activeIcon={Wallet}
               label={t("sidebar.accounts")}
+              disabled={viewModel.isAccountsDisabled}
             />
             <SideBarItem
               value="swap"

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
@@ -85,6 +85,18 @@ describe("SideBar", () => {
       const cardButton = screen.getByText("Card").closest("button");
       expect(cardButton).toBeDisabled();
     });
+    it("should disable Accounts item when no accounts are present", () => {
+      renderSideBarWithRoute("/", {
+        accounts: [],
+        settings: {
+          ...defaultInitialState.settings,
+          hasCompletedOnboarding: true,
+        },
+      });
+
+      const accountsButton = screen.getByText("Accounts").closest("button");
+      expect(accountsButton).toBeDisabled();
+    });
   });
 
   describe("Navigation", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/testUtils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/testUtils.ts
@@ -1,6 +1,11 @@
+import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
 
+const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
+
 export const defaultInitialState = {
+  accounts: [genAccount("sidebar-test-btc", { currency: bitcoinCurrency })],
   settings: {
     ...INITIAL_STATE,
     hasCompletedOnboarding: true,
@@ -9,6 +14,7 @@ export const defaultInitialState = {
 
 export function withFeatureFlags(flags: Record<string, unknown>) {
   return {
+    ...defaultInitialState,
     settings: {
       ...INITIAL_STATE,
       hasCompletedOnboarding: true,

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
@@ -67,7 +67,7 @@ describe("useSideBarViewModel", () => {
 
     expect(result.current).toMatchObject({
       collapsed: false,
-      noAccounts: true,
+      noAccounts: false,
       totalStarredAccounts: 0,
       active: "home",
     });

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/types.ts
@@ -32,6 +32,7 @@ export interface SideBarViewModel {
   readonly displayBlueDot: boolean;
   readonly earnLabel: string;
   readonly isCardDisabled: boolean;
+  readonly isAccountsDisabled: boolean;
   readonly isLiveAppTabSelected: boolean;
   readonly isMarketBannerEnabled: boolean;
   readonly isQuickActionCtasEnabled: boolean;

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
@@ -281,6 +281,7 @@ export function useSideBarViewModel(): SideBarViewModel {
     displayBlueDot,
     earnLabel,
     isCardDisabled,
+    isAccountsDisabled: noAccounts,
     isLiveAppTabSelected,
     isMarketBannerEnabled,
     isQuickActionCtasEnabled,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Sidebar "Accounts" item is now disabled when the user has zero accounts
      - No navigation occurs when clicking a disabled item
      - All other sidebar navigation remains unaffected

### 📝 Description

**Problem**: The "Accounts" sidebar entry was always clickable, even when the user had no accounts. Clicking it would navigate to an empty accounts page, which is a poor user experience.

**Solution**: Added `isAccountsDisabled` to the `SideBarViewModel`, derived from the existing `noAccounts` selector. The `SideBarView` now passes `disabled={viewModel.isAccountsDisabled}` to the Accounts `SideBarItem`, preventing navigation when no accounts exist. This follows the same pattern already used for the "Card" item (`isCardDisabled`).

**Changes:**
- `useSideBarViewModel.ts`: Exposed `isAccountsDisabled: noAccounts` in the view model return
- `types.ts`: Added `isAccountsDisabled` to `SideBarViewModel` interface
- `SideBarView.tsx`: Added `disabled` prop to the Accounts `SideBarItem`
- Integration test: Added test verifying Accounts is disabled with no accounts
- `testUtils.ts`: Added a mock account to `defaultInitialState` so navigation tests work correctly

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)