### PR TITLE
Fix visibility check for last operations in subAccount test

### DIFF
--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -97,8 +97,8 @@ for (const token of subAccounts) {
           await app.portfolio.navigateToAsset(token.account.currency.name);
         }
         await app.account.navigateToToken(token.account);
-        await app.account.expectLastOperationsVisibility();
         await app.account.expectTokenAccount(token.account);
+        await app.account.expectLastOperationsVisibility();
       },
     );
   });


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - desktop e2e tests

### 📝 Description

This was peer programmed and investigated with @iqbalibrahim-ledger 

If the test is faster than the screen to actually navigate, we fall into a flaky case where the "last-operations" of the previous screen is still found in the DOM while the new screen didn't had time to remount and have the "last-operations" of the token account.

therefore, it makes more sense to first await for the TokenAccount to be visible, before scrolling to last operations.

See for yourself the error we constantly had in context of React 19 (which makes screen mounting / navigation more async with the Suspense behavior of React 19)

<img width="830" height="585" alt="Screenshot 2026-02-16 at 14 21 00" src="https://github.com/user-attachments/assets/d69113df-3045-470e-afca-b74a99b5a8ad" />

---

NB: i suspect there may more case like this we may want to find: basically we must not expect that a `click()` that produce a navigation have straightaway made the app navigated to the other screen. i'm attempting a general study of this in another PR.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
