### PR TITLE
fix(e2e): update topbar test IDs for W4.0 MVVM navigation

### DIFF
--- a/.changeset/early-seals-trade.md
+++ b/.changeset/early-seals-trade.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+fix main navigation ids for topbar in W4.0

--- a/e2e/desktop/tests/component/layout.component.ts
+++ b/e2e/desktop/tests/component/layout.component.ts
@@ -21,8 +21,12 @@ export class Layout extends Component {
   readonly topbarSynchronizeButton = this.topbarActionButton("synchronize").or(
     this.page.getByTestId("topbar-synchronize-button"),
   );
-  readonly topbarNotificationButton = this.page.getByTestId("topbar-notification-button");
-  readonly topbarSettingsButton = this.page.getByTestId("topbar-settings-button");
+  readonly topbarNotificationButton = this.topbarActionButton("notifications").or(
+    this.page.getByTestId("topbar-notification-button"),
+  );
+  readonly topbarSettingsButton = this.topbarActionButton("settings").or(
+    this.page.getByTestId("topbar-settings-button"),
+  );
   readonly topbarDiscreetButton = this.topbarActionButton("discreet").or(
     this.page.getByTestId("topbar-discreet-button"),
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This PR fixes E2E test selectors themselves — the navigation E2E spec validates the fix._
- [x] **Impact of the changes:**
  - E2E `main.navigation.spec.ts` test should now pass with the new MVVM topbar
  - No impact on production code — only E2E test selectors updated

### 📝 Description

The `main and top navigation redirect to the expected sections` E2E test was failing because the new MVVM topbar components use `topbar-action-button-*` test IDs (e.g., `topbar-action-button-notifications`, `topbar-action-button-settings`) instead of the old `topbar-*-button` pattern (`topbar-notification-button`, `topbar-settings-button`).

Updated `topbarNotificationButton` and `topbarSettingsButton` selectors in the E2E layout component to use the `.or()` fallback pattern, matching the approach already used by `topbarSynchronizeButton` and `topbarDiscreetButton`. This ensures compatibility with both old and new topbar implementations.

### ❓ Context

- **JIRA or GitHub link**: N/A — E2E test fix for W4.0 MVVM migration

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)