### PR TITLE
test: simulate react-router to slowly navigate to study test issues

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/react-router-patched.ts
+++ b/apps/ledger-live-desktop/src/renderer/react-router-patched.ts
@@ -1,0 +1,21 @@
+/**
+ * Temporary E2E hack: re-export react-router with useNavigate wrapped to add 1s delay
+ * on every navigation. Remove when tests use proper waits.
+ * (Used via rspack alias "react-router" -> this file in renderer only.)
+ */
+import * as RR from "react-router-original";
+
+const DELAY_MS = 1000;
+
+type NavigateFn = ReturnType<typeof RR.useNavigate>;
+
+function useNavigate(...args: Parameters<typeof RR.useNavigate>): NavigateFn {
+  const navigate = RR.useNavigate(...args);
+  const delayedNavigate: NavigateFn = (to, options) => {
+    setTimeout(() => navigate(to, options), DELAY_MS);
+  };
+  return delayedNavigate;
+}
+
+export * from "react-router-original";
+export { useNavigate };

--- a/apps/ledger-live-desktop/tools/rspack/rspack.renderer.ts
+++ b/apps/ledger-live-desktop/tools/rspack/rspack.renderer.ts
@@ -75,6 +75,9 @@ export function createRendererConfig(
       alias: {
         ...commonConfig.resolve?.alias,
         LLD: path.resolve(lldRoot, "src", "mvvm"),
+        // E2E hack: slow down all navigations by 1s (patch useNavigate)
+        "react-router-original": require.resolve("react-router", { paths: [lldRoot] }),
+        "react-router": path.resolve(lldRoot, "src", "renderer", "react-router-patched.ts"),
         "styled-components": styledComponentsPath,
         // Fix tests/time.js import for TIMEMACHINE feature
         "../../tests/time.js": path.resolve(rootFolder, "tests", "time.ts"),


### PR DESCRIPTION
attempt to reveal issue fixed in https://github.com/LedgerHQ/ledger-live/pull/14488 and possibly more

as a way to simulate screens to be lazily mounted, we force a 1s delay on all navigate()

that will allow us to study if tests are resilient enough for this

**of course, this PR is not for merge.**


e2e study https://github.com/LedgerHQ/ledger-live/actions/runs/22065713530
