### PR TITLE
test(e2e): add My Ledger topbar button to main navigation spec

### DIFF
--- a/.changeset/light-planets-repair.md
+++ b/.changeset/light-planets-repair.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+add my ledger case for topbar navigation for w4.0

--- a/e2e/desktop/tests/component/layout.component.ts
+++ b/e2e/desktop/tests/component/layout.component.ts
@@ -30,6 +30,7 @@ export class Layout extends Component {
   readonly topbarDiscreetButton = this.topbarActionButton("discreet").or(
     this.page.getByTestId("topbar-discreet-button"),
   );
+  readonly topbarMyLedgerButton = this.topbarActionButton("my-ledger");
 
   @step("Go to Portfolio")
   async goToPortfolio() {

--- a/e2e/desktop/tests/page/mainNavigation.page.ts
+++ b/e2e/desktop/tests/page/mainNavigation.page.ts
@@ -101,6 +101,12 @@ export class MainNavigationPage extends AppPage {
     await this.layout.topbarSynchronizeButton.click();
   }
 
+  @step("Open My Ledger from top navigation")
+  async openMyLedger() {
+    await this.layout.topbarMyLedgerButton.click();
+    await this.expectPath(/^\/manager(?:\/|$|\?)/);
+  }
+
   @step("Open Settings from top navigation")
   async openSettings() {
     await this.layout.topbarSettingsButton.click();

--- a/e2e/desktop/tests/specs/main.navigation.spec.ts
+++ b/e2e/desktop/tests/specs/main.navigation.spec.ts
@@ -56,6 +56,7 @@ test.describe("Main navigation", () => {
       await app.mainNavigation.openTargetFromMainNavigation("card");
       await app.mainNavigation.openNotificationCenter();
       await app.mainNavigation.clickActivityIndicator();
+      await app.mainNavigation.openMyLedger();
       await app.mainNavigation.openSettings();
     },
   );


### PR DESCRIPTION
Add e2e coverage for the My Ledger button in the topbar, verifying it navigates to /manager.

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add last test for my ledger in topbar in W4.0

### ❓ Context

- **JIRA or GitHub link**: N/A


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
