### PR TITLE
feat(LIVE-23974): aleo store view key in account.id

### DIFF
--- a/.changeset/tame-berries-applaud.md
+++ b/.changeset/tame-berries-applaud.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-aleo": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: store aleo view key in account.id

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/ModularDrawerAddAccountFlowManager.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/ModularDrawerAddAccountFlowManager.tsx
@@ -1,13 +1,18 @@
 import { AnimatePresence } from "framer-motion";
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch } from "LLD/hooks/redux";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
 import styled from "styled-components";
 import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
 import type { ViewKeysByAccountId } from "@ledgerhq/live-common/families/aleo/hw/getViewKey/index";
+import { patchAccountWithViewKey } from "@ledgerhq/live-common/families/aleo/utils";
+import { addAccountsAction } from "@ledgerhq/live-wallet/addAccounts";
 import { Flex } from "@ledgerhq/react-ui/index";
 import type { Account } from "@ledgerhq/types-live";
-import type { ModularDrawerAddAccountStep } from "LLD/features/AddAccountDrawer/domain";
+import {
+  WARNING_REASON,
+  type ModularDrawerAddAccountStep,
+} from "LLD/features/AddAccountDrawer/domain";
 import { MODULAR_DRAWER_PAGE_NAME } from "LLD/features/ModularDrawer/analytics/modularDrawer.types";
 import AnimatedScreenWrapper from "LLD/features/ModularDrawer/components/AnimatedScreenWrapper";
 import { BackButtonArrow } from "LLD/features/ModularDrawer/components/BackButton";
@@ -25,6 +30,7 @@ import {
   Title,
   type ModularDrawerAddAccountFlowManagerProps,
 } from "LLD/features/AddAccountDrawer/ModularDrawerAddAccountFlowManager";
+import { accountsSelector } from "~/renderer/reducers/accounts";
 import { setFlowValue } from "~/renderer/reducers/modularDrawer";
 import {
   ALEO_MODULAR_DRAWER_ADD_ACCOUNT_STEP,
@@ -48,6 +54,7 @@ const ModularDrawerAddAccountFlowManager = ({
 }: ModularDrawerAddAccountFlowManagerProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const existingAccounts = useSelector(accountsSelector);
 
   const [connectAppResult, setConnectAppResult] = useState<AppResult>();
   const [selectedAccounts, setSelectedAccounts] = useState<Account[]>([]);
@@ -69,6 +76,7 @@ const ModularDrawerAddAccountFlowManager = ({
     navigateToSelectAccount,
     navigateToScanAccounts,
     navigateToConnectDevice,
+    navigateToAccountsAdded,
   } = useAddAccountFlowNavigation({
     selectedAccounts,
     onAccountSelected,
@@ -86,7 +94,46 @@ const ModularDrawerAddAccountFlowManager = ({
     [navigateToViewKeyWarning],
   );
 
-  const handleViewKeyApproval = useCallback((_result: ViewKeysByAccountId) => {}, []);
+  const handleViewKeyApproval = useCallback(
+    (result: ViewKeysByAccountId) => {
+      if (!result) {
+        return;
+      }
+
+      const accountsWithViewKeys = selectedAccounts.reduce<Account[]>((acc, account) => {
+        const viewKey = result[account.id];
+        if (viewKey) {
+          acc.push(patchAccountWithViewKey(account, viewKey));
+        }
+        return acc;
+      }, []);
+
+      setSelectedAccounts(accountsWithViewKeys);
+
+      if (accountsWithViewKeys.length === 0) {
+        // TODO: dedicated NO_ACCOUNTS_ADDED reason & screen
+        navigateToWarningScreen(WARNING_REASON.NO_ASSOCIATED_ACCOUNTS);
+      } else {
+        dispatch(
+          addAccountsAction({
+            existingAccounts,
+            scannedAccounts: accountsWithViewKeys,
+            selectedIds: accountsWithViewKeys.map(a => a.id),
+            renamings: {},
+          }),
+        );
+
+        navigateToAccountsAdded();
+      }
+    },
+    [
+      existingAccounts,
+      selectedAccounts,
+      dispatch,
+      navigateToAccountsAdded,
+      navigateToWarningScreen,
+    ],
+  );
 
   const renderStepContent = (step: AleoModularDrawerAddAccountStep) => {
     switch (step) {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
@@ -5,12 +5,18 @@ import type { Account } from "@ledgerhq/types-live";
 import { act } from "react-dom/test-utils";
 import { render, screen, userEvent } from "tests/testSetup";
 import { urls } from "~/config/urls";
+import { openModal } from "~/renderer/actions/modals";
 import { track, trackPage } from "~/renderer/analytics/segment";
 import { openURL } from "~/renderer/linking";
 import type { State } from "~/renderer/reducers";
 import { mockDomMeasurements } from "LLD/features/__tests__/shared";
 import ModularDrawerAddAccountFlowManager from "LLD/features/AddAccountDrawer/ModularDrawerAddAccountFlowManager";
-import { ALEO_ACCOUNT_1, ALEO_ACCOUNT_2, ALEO_ACCOUNT_3 } from "../__mocks__/account.mock";
+import {
+  ALEO_ACCOUNT_1,
+  ALEO_ACCOUNT_2,
+  ALEO_ACCOUNT_3,
+  NEW_ALEO_ACCOUNT,
+} from "../__mocks__/account.mock";
 import { aleoCurrency } from "../__mocks__/currency.mock";
 
 beforeEach(async () => {
@@ -99,6 +105,11 @@ jest.mock("react-router", () => ({
   __esModule: true,
   ...jest.requireActual("react-router"),
   useNavigate: () => mockNavigate,
+}));
+
+jest.mock("~/renderer/actions/modals", () => ({
+  ...jest.requireActual("~/renderer/actions/modals"),
+  openModal: jest.fn().mockReturnValue({ type: "" }),
 }));
 
 jest.mock("~/renderer/linking", () => ({
@@ -215,5 +226,118 @@ describe("ModularDrawerAddAccountFlowManager", () => {
       { accountId: ALEO_ACCOUNT_2.id, viewKey: null }, // rejected
       { accountId: ALEO_ACCOUNT_3.id, viewKey: "vk_3" },
     ]);
+
+    expect(screen.getByText(/2 accounts added to your portfolio/i)).toBeInTheDocument();
+    expectTrackPage(5, "add account success");
+  });
+
+  it("should create an account", async () => {
+    setup();
+
+    expect(screen.getByText(/set up aleo private balance/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Allow" }));
+
+    expect(screen.getByText(/checking the blockchain/i)).toBeInTheDocument();
+    await mockScanAccountsSubscription([NEW_ALEO_ACCOUNT]);
+
+    expect(screen.getByText(/new account/i)).toBeInTheDocument();
+    expect(screen.queryByText(/we found 1 account/i)).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Share view key" }));
+
+    expect(screen.getByText(/approve on your Ledger/i)).toBeInTheDocument();
+    expect(screen.getAllByTestId("confirmation-account-row").length).toEqual(1);
+
+    await mockViewKeyProgressSubscription([{ accountId: NEW_ALEO_ACCOUNT.id, viewKey: "vk_new" }]);
+
+    expect(screen.getByText(/account added to your portfolio/i)).toBeInTheDocument();
+  });
+
+  it("should navigate to fund an account", async () => {
+    setup();
+
+    expect(screen.getByText(/set up aleo private balance/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Allow" }));
+
+    expect(screen.getByText(/checking the blockchain/i)).toBeInTheDocument();
+    await mockScanAccountsSubscription([ALEO_ACCOUNT_1]);
+    await userEvent.click(screen.getByRole("button", { name: "Share view key" }));
+
+    expect(screen.getByText(/approve on your Ledger/i)).toBeInTheDocument();
+    expect(screen.getAllByTestId("confirmation-account-row").length).toEqual(1);
+
+    await mockViewKeyProgressSubscription([{ accountId: ALEO_ACCOUNT_1.id, viewKey: "vk_1" }]);
+
+    await userEvent.click(screen.getByRole("button", { name: "Add funds to my account" }));
+    expect(track).toHaveBeenNthCalledWith(3, "button_clicked", {
+      button: "Fund my account",
+      flow: "Add account",
+      page: "add account success",
+    });
+
+    const receive = screen.getByText(/receive crypto from another wallet/i);
+    await userEvent.click(receive);
+    expect(openModal).toHaveBeenCalledWith("MODAL_RECEIVE", expect.objectContaining({}));
+  });
+
+  it("should hide previously added accounts and show new account", async () => {
+    setup({ accounts: [ALEO_ACCOUNT_1] });
+
+    expect(screen.getByText(/set up aleo private balance/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Allow" }));
+
+    expect(screen.getByText(/checking the blockchain/i)).toBeInTheDocument();
+    await mockScanAccountsSubscription([ALEO_ACCOUNT_1, NEW_ALEO_ACCOUNT]);
+
+    expect(screen.getByText(/new account/i)).toBeInTheDocument();
+    expect(screen.queryByText(/we found 1 account/i)).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Share view key" }));
+
+    expect(screen.getByText(/approve on your Ledger/i)).toBeInTheDocument();
+    expect(screen.getAllByTestId("confirmation-account-row").length).toEqual(1);
+
+    await mockViewKeyProgressSubscription([{ accountId: NEW_ALEO_ACCOUNT.id, viewKey: "vk_new" }]);
+
+    expect(screen.getByText(/account added to your portfolio/i)).toBeInTheDocument();
+  });
+
+  it("should error on already imported empty account", async () => {
+    setup({ accounts: [ALEO_ACCOUNT_1, NEW_ALEO_ACCOUNT] });
+
+    expect(screen.getByText(/set up aleo private balance/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Allow" }));
+
+    expect(screen.getByText(/checking the blockchain/i)).toBeInTheDocument();
+    await mockScanAccountsSubscription([ALEO_ACCOUNT_1, NEW_ALEO_ACCOUNT]);
+
+    expectTrackPage(4, "cant add new account", { reason: "ALREADY_EMPTY_ACCOUNT" });
+    expect(
+      screen.getByText(
+        "A new account cannot be added before you receive assets on your Aleo 4 account",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should allow name edit on already imported empty account", async () => {
+    setup({ accounts: [ALEO_ACCOUNT_1, NEW_ALEO_ACCOUNT] });
+    const OLD_NAME = "Aleo 4";
+    const NEW_NAME = "My Edited Account";
+
+    expect(screen.getByText(/set up aleo private balance/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Allow" }));
+
+    expect(screen.getByText(/checking the blockchain/i)).toBeInTheDocument();
+    await mockScanAccountsSubscription([ALEO_ACCOUNT_1, NEW_ALEO_ACCOUNT]);
+
+    await userEvent.click(screen.getByRole("button", { name: /Edit account item/i }));
+    expect(screen.getByText(/Edit account name/i)).toBeInTheDocument();
+
+    const input = screen.getByRole("textbox", { name: "account name" });
+    expect(input).toHaveValue(OLD_NAME);
+    await userEvent.clear(input);
+    await userEvent.type(input, NEW_NAME);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getByText(NEW_NAME)).toBeInTheDocument();
   });
 });

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/account.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/account.fixture.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import type { AleoAccount, AleoResources, AleoResourcesRaw } from "../../types";
+import type { AleoAccount, AleoAccountRaw, AleoResources, AleoResourcesRaw } from "../../types";
 import { getMockedCurrency } from "./currency.fixture";
 
 const defaultMockedCurrency = getMockedCurrency();
@@ -42,6 +42,35 @@ export const getMockedAccount = (overrides?: Partial<AleoAccount>): AleoAccount 
     swapHistory: [],
     subAccounts: [],
     aleoResources: mockAleoResources,
+    ...overrides,
+  };
+};
+
+export const getMockedAccountRaw = (overrides?: Partial<AleoAccountRaw>): AleoAccountRaw => {
+  return {
+    id: defaultMockAccountId,
+    seedIdentifier: "",
+    derivationMode: "",
+    index: 0,
+    freshAddress: "aleo1zcwqycj02lccfuu57dzjhva7w5dpzc7pngl0sxjhp58t6vlnnqxs6lnp6f",
+    freshAddressPath: "44'/683'/0'/0/0",
+    used: false,
+    balance: defaultBalance.toString(),
+    spendableBalance: defaultBalance.toString(),
+    creationDate: new Date().toISOString(),
+    blockHeight: 1234,
+    currencyId: defaultMockedCurrency.id,
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    lastSyncDate: new Date().toISOString(),
+    balanceHistoryCache: {
+      HOUR: { latestDate: null, balances: [] },
+      DAY: { latestDate: null, balances: [] },
+      WEEK: { latestDate: null, balances: [] },
+    },
+    swapHistory: [],
+    subAccounts: [],
     ...overrides,
   };
 };

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/operation.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/operation.fixture.ts
@@ -1,0 +1,22 @@
+import BigNumber from "bignumber.js";
+import type { Operation } from "@ledgerhq/types-live";
+
+export function getMockedOperation(overrides?: Partial<Operation>): Operation {
+  return {
+    id: "js:2:aleo:aleo1test:op1-OUT",
+    hash: "at1mockhashmockhashmockhashmockhash",
+    type: "OUT",
+    value: new BigNumber(100000000),
+    fee: new BigNumber(1000000),
+    blockHeight: 1000000,
+    blockHash: "ab1mockblockhash",
+    accountId: "js:2:aleo:aleo1test:",
+    senders: ["aleo1test"],
+    recipients: ["aleo1receiver"],
+    date: new Date("2024-01-01T00:00:00.000Z"),
+    transactionSequenceNumber: new BigNumber(0),
+    hasFailed: false,
+    extra: {},
+    ...overrides,
+  };
+}

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
@@ -44,6 +44,43 @@ describe("sync.ts", () => {
   });
 
   describe("getAccountShape", () => {
+    it("should preserve viewKey from initial account", async () => {
+      const result = await getAccountShape(
+        {
+          index: mockAccount.index,
+          derivationPath: mockAccount.freshAddressPath,
+          address: mockAccount.freshAddress,
+          currency: mockCurrency,
+          derivationMode: mockDerivationMode,
+          initialAccount: mockInitialAccount,
+        },
+        mockSyncConfig,
+      );
+
+      expect(result).toMatchObject({ id: mockInitialAccount.id });
+    });
+
+    it("should throw error if initial account has no viewKey", async () => {
+      const mockInvalidInitialAccount = {
+        ...mockInitialAccount,
+        id: "js:2:aleo:aleo1zcwqycj02lccfuu57dzjhva7w5dpzc7pngl0sxjhp58t6vlnnqxs6lnp6f:",
+      };
+
+      await expect(
+        getAccountShape(
+          {
+            index: mockAccount.index,
+            derivationPath: mockAccount.freshAddressPath,
+            address: mockAccount.freshAddress,
+            currency: mockCurrency,
+            derivationMode: mockDerivationMode,
+            initialAccount: mockInvalidInitialAccount,
+          },
+          mockSyncConfig,
+        ),
+      ).rejects.toThrow();
+    });
+
     it("should create account shape with native balance", async () => {
       const result = await getAccountShape(
         {

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -1,18 +1,27 @@
-import { type GetAccountShape, makeSync } from "@ledgerhq/coin-framework/bridge/jsHelpers";
-import { encodeAccountId } from "@ledgerhq/coin-framework/account/accountId";
-import type { Operation } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
+import invariant from "invariant";
+import { type GetAccountShape, makeSync } from "@ledgerhq/coin-framework/bridge/jsHelpers";
+import { decodeAccountId, encodeAccountId } from "@ledgerhq/coin-framework/account/accountId";
+import type { Operation } from "@ledgerhq/types-live";
 import { getBalance, lastBlock } from "../logic";
 import type { AleoAccount } from "../types";
 
 export const getAccountShape: GetAccountShape<AleoAccount> = async infos => {
-  const { address, derivationMode, currency } = infos;
+  const { initialAccount, address, derivationMode, currency } = infos;
+  let viewKey: string | undefined;
+
+  if (initialAccount) {
+    viewKey = decodeAccountId(initialAccount.id).customData;
+    invariant(viewKey, `aleo: viewKey is missing in ${address} initialAccount`);
+  }
+
   const accountId = encodeAccountId({
     type: "js",
     version: "2",
     currencyId: currency.id,
     xpubOrAddress: address,
     derivationMode,
+    ...(viewKey && { customData: viewKey }),
   });
 
   const [latestBlock, balances] = await Promise.all([

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -1,7 +1,9 @@
 import aleoConfig from "../config";
 import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
-import { getNetworkConfig, parseMicrocredits } from "./utils";
+import { getMockedAccount } from "../__tests__/fixtures/account.fixture";
+import { getMockedOperation } from "../__tests__/fixtures/operation.fixture";
+import { getNetworkConfig, parseMicrocredits, patchAccountWithViewKey } from "./utils";
 
 jest.mock("../config");
 
@@ -85,5 +87,89 @@ describe("parseMicrocredits", () => {
   it("should throw error for invalid format", () => {
     const value = "1000000u32";
     expect(() => parseMicrocredits(value)).toThrow();
+  });
+});
+
+describe("patchAccountWithViewKey", () => {
+  it("should encode viewKey in account id", () => {
+    const mockViewKey = "AViewKey1mockviewkey";
+    const mockAccount = getMockedAccount({
+      id: "js:2:aleo:aleo1test:",
+      operations: [],
+    });
+
+    const result = patchAccountWithViewKey(mockAccount, mockViewKey);
+
+    expect(result.id).not.toBe(mockAccount.id);
+    expect(result.id).toBe(`js:2:aleo:aleo1test::${mockViewKey}`);
+  });
+
+  it("should update operation ids with new account id", () => {
+    const mockViewKey = "AViewKey1mockviewkey";
+    const mockOp1 = getMockedOperation({
+      id: "js:2:aleo:aleo1test:-op1-OUT",
+      accountId: "js:2:aleo:aleo1test:",
+      hash: "op1",
+      type: "OUT",
+    });
+
+    const mockOp2 = getMockedOperation({
+      id: "js:2:aleo:aleo1test:-op2-IN",
+      accountId: "js:2:aleo:aleo1test:",
+      hash: "op2",
+      type: "IN",
+    });
+
+    const mockPendingOp1 = getMockedOperation({
+      id: "js:2:aleo:aleo1test:-pending1-OUT",
+      accountId: "js:2:aleo:aleo1test:",
+      hash: "pending1",
+      type: "OUT",
+    });
+
+    const mockPendingOp2 = getMockedOperation({
+      id: "js:2:aleo:aleo1test:-pending2-IN",
+      accountId: "js:2:aleo:aleo1test:",
+      hash: "pending2",
+      type: "IN",
+    });
+
+    const mockAccount = getMockedAccount({
+      id: "js:2:aleo:aleo1test:",
+      operations: [mockOp1, mockOp2],
+      pendingOperations: [mockPendingOp1, mockPendingOp2],
+    });
+
+    const result = patchAccountWithViewKey(mockAccount, mockViewKey);
+
+    expect(result.operations).toEqual([
+      expect.objectContaining({
+        id: `js:2:aleo:aleo1test::${mockViewKey}-op1-OUT`,
+        accountId: `js:2:aleo:aleo1test::${mockViewKey}`,
+      }),
+      expect.objectContaining({
+        id: `js:2:aleo:aleo1test::${mockViewKey}-op2-IN`,
+        accountId: `js:2:aleo:aleo1test::${mockViewKey}`,
+      }),
+    ]);
+    expect(result.pendingOperations).toEqual([
+      expect.objectContaining({
+        id: `js:2:aleo:aleo1test::${mockViewKey}-pending1-OUT`,
+        accountId: `js:2:aleo:aleo1test::${mockViewKey}`,
+      }),
+      expect.objectContaining({
+        id: `js:2:aleo:aleo1test::${mockViewKey}-pending2-IN`,
+        accountId: `js:2:aleo:aleo1test::${mockViewKey}`,
+      }),
+    ]);
+  });
+
+  it("should throw if viewKey is missing", () => {
+    const mockAccount = getMockedAccount({
+      id: "js:2:aleo:aleo1test:",
+      operations: [],
+    });
+
+    expect(() => patchAccountWithViewKey(mockAccount, "")).toThrow();
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -1,5 +1,8 @@
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import invariant from "invariant";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { Account, Operation } from "@ledgerhq/types-live";
+import { decodeAccountId, encodeAccountId } from "@ledgerhq/coin-framework/account/accountId";
+import { decodeOperationId, encodeOperationId } from "@ledgerhq/coin-framework/operation";
 import aleoConfig from "../config";
 
 export function parseMicrocredits(microcreditsU64: string): string {
@@ -17,5 +20,33 @@ export function getNetworkConfig(currency: CryptoCurrency) {
     nodeUrl: config.apiUrls.node,
     sdkUrl: config.apiUrls.sdk,
     networkType: config.networkType,
+  };
+}
+
+export function patchAccountWithViewKey(account: Account, viewKey: string): Account {
+  invariant(viewKey, `aleo: viewKey is missing in patchAccountWithViewKey ${account.freshAddress}`);
+  const accountIdParams = decodeAccountId(account.id);
+  const updatedAccountId = encodeAccountId({
+    ...accountIdParams,
+    customData: viewKey,
+  });
+
+  const updateOperations = (ops: Operation[]) =>
+    ops.map(op => {
+      const { hash, type } = decodeOperationId(op.id);
+      const updatedOperationId = encodeOperationId(updatedAccountId, hash, type);
+
+      return {
+        ...op,
+        id: updatedOperationId,
+        accountId: updatedAccountId,
+      };
+    });
+
+  return {
+    ...account,
+    id: updatedAccountId,
+    operations: updateOperations(account.operations),
+    pendingOperations: updateOperations(account.pendingOperations),
   };
 }

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -398,6 +398,7 @@
     "src/exchange/swap/const/blockchain.ts",
     "src/families/aleo/hw/getViewKey/index.ts",
     "src/families/aleo/types.ts",
+    "src/families/aleo/utils.ts",
     "src/families/algorand/descriptor.ts",
     "src/families/aptos/config.ts",
     "src/families/aptos/constants.ts",

--- a/libs/ledger-live-common/src/families/aleo/utils.ts
+++ b/libs/ledger-live-common/src/families/aleo/utils.ts
@@ -1,0 +1,2 @@
+// Encapsulate for LLD & LLM
+export * from "@ledgerhq/coin-aleo/logic/utils";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - it should be possible to add Aleo account

### 📝 Description

This PR completes view key sharing integration by updating `account.id` with view key for each of selected Aleo accounts.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-23971
- https://ledgerhq.atlassian.net/browse/LIVE-23974

**Depends on:**
- https://github.com/LedgerHQ/ledger-live/pull/14431

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
