### PR TITLE
feat(LIVE-26301): aleo no accounts added warning screen

### DIFF
--- a/.changeset/sharp-camels-bow.md
+++ b/.changeset/sharp-camels-bow.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat: aleo custom warning screen if no accounts were added

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/domain.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/domain.ts
@@ -14,6 +14,7 @@ export type ModularDrawerAddAccountStep =
 export const WARNING_REASON = {
   ALREADY_EMPTY_ACCOUNT: "ALREADY_EMPTY_ACCOUNT",
   NO_ASSOCIATED_ACCOUNTS: "NO_ASSOCIATED_ACCOUNTS",
+  NO_ACCOUNTS_ADDED: "NO_ACCOUNTS_ADDED",
 } as const;
 
 export type WarningReason = (typeof WARNING_REASON)[keyof typeof WARNING_REASON];

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsWarning/components/ActionButtons.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsWarning/components/ActionButtons.tsx
@@ -17,9 +17,11 @@ export const ActionButtons = ({ primaryAction, secondaryAction }: ActionButtonsP
         <Button onClick={primaryAction.onClick} size="large" variant="main" mb="3">
           {primaryAction.text}
         </Button>
-        <Button onClick={secondaryAction.onClick} size="large" variant="main" outline>
-          {secondaryAction.text}
-        </Button>
+        {secondaryAction && (
+          <Button onClick={secondaryAction.onClick} size="large" variant="main" outline>
+            {secondaryAction.text}
+          </Button>
+        )}
       </Flex>
     </Flex>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsWarning/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsWarning/index.tsx
@@ -2,7 +2,7 @@ import { Flex, Text } from "@ledgerhq/react-ui";
 import React from "react";
 import { TrackAddAccountScreen } from "../../analytics/TrackAddAccountScreen";
 import { ADD_ACCOUNT_PAGE_NAME } from "../../analytics/addAccount.types";
-import { WARNING_REASON } from "../../domain";
+import { WARNING_REASON, type WarningReason } from "../../domain";
 import { ActionButtons, IconContainer } from "./components";
 import { AccountsWarningProps } from "./types";
 import { useWarningConfig } from "./useWarningConfig";
@@ -18,18 +18,22 @@ const AccountsWarning = ({
   isAccountSelectionFlow,
 }: AccountsWarningProps) => {
   const source = useSelector(modularDrawerSourceSelector);
-  const { emptyAccountWarning, noAssociatedAccountsWarning } = useWarningConfig(
-    currency,
-    navigateToEditAccountName,
-    navigateToFundAccount,
-    isAccountSelectionFlow,
-    emptyAccount,
-  );
+  const { emptyAccountWarning, noAssociatedAccountsWarning, noAccountsAddedWarning } =
+    useWarningConfig(
+      currency,
+      navigateToEditAccountName,
+      navigateToFundAccount,
+      isAccountSelectionFlow,
+      emptyAccount,
+    );
 
-  const warning =
-    warningReason === WARNING_REASON.NO_ASSOCIATED_ACCOUNTS
-      ? noAssociatedAccountsWarning
-      : emptyAccountWarning;
+  const mapReasonToContent = {
+    [WARNING_REASON.NO_ASSOCIATED_ACCOUNTS]: noAssociatedAccountsWarning,
+    [WARNING_REASON.ALREADY_EMPTY_ACCOUNT]: emptyAccountWarning,
+    [WARNING_REASON.NO_ACCOUNTS_ADDED]: noAccountsAddedWarning,
+  } satisfies Record<WarningReason, unknown>;
+
+  const warning = mapReasonToContent[warningReason];
 
   return (
     <Flex flexDirection="column" height="100%" alignItems="center">

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsWarning/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsWarning/types.ts
@@ -10,7 +10,7 @@ export interface ActionButtonsProps {
   secondaryAction: {
     text: string;
     onClick: () => void;
-  };
+  } | null;
 }
 
 export interface AccountsWarningProps {

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsWarning/useWarningConfig.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsWarning/useWarningConfig.tsx
@@ -94,7 +94,21 @@ export const useWarningConfig = (
     },
   };
 
-  return { emptyAccountWarning, noAssociatedAccountsWarning };
+  const noAccountsAddedWarning = {
+    icon: <Icons.WarningFill size="L" color="warning.c70" />,
+    title: t("modularAssetDrawer.scanAccounts.warning.noAccountsAddedWarning.title", {
+      currency: currency.name,
+    }),
+    description: t(getNoAccountsWarningDescriptionKey(currency)),
+    accountRow: null,
+    primaryAction: {
+      text: t("modularAssetDrawer.scanAccounts.warning.noAccountsAddedWarning.close"),
+      onClick: handleClose,
+    },
+    secondaryAction: null,
+  };
+
+  return { noAccountsAddedWarning, emptyAccountWarning, noAssociatedAccountsWarning };
 };
 
 const getUrl = (currency: CryptoCurrency) => {
@@ -104,5 +118,15 @@ const getUrl = (currency: CryptoCurrency) => {
       return urls.hedera.supportArticleLink;
     default:
       return "";
+  }
+};
+
+const getNoAccountsWarningDescriptionKey = (currency: CryptoCurrency): string => {
+  const lowerCaseCurrencyId = currency.id.toLowerCase();
+  switch (lowerCaseCurrencyId) {
+    case "aleo":
+      return "aleo.addAccount.warnings.noAccountsAddedWarning.description";
+    default:
+      return "modularAssetDrawer.scanAccounts.warning.noAccountsAddedWarning.description";
   }
 };

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/ModularDrawerAddAccountFlowManager.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/ModularDrawerAddAccountFlowManager.tsx
@@ -111,8 +111,7 @@ const ModularDrawerAddAccountFlowManager = ({
       setSelectedAccounts(accountsWithViewKeys);
 
       if (accountsWithViewKeys.length === 0) {
-        // TODO: dedicated NO_ACCOUNTS_ADDED reason & screen
-        navigateToWarningScreen(WARNING_REASON.NO_ASSOCIATED_ACCOUNTS);
+        navigateToWarningScreen(WARNING_REASON.NO_ACCOUNTS_ADDED);
       } else {
         dispatch(
           addAccountsAction({

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
@@ -340,4 +340,28 @@ describe("ModularDrawerAddAccountFlowManager", () => {
 
     expect(screen.getByText(NEW_NAME)).toBeInTheDocument();
   });
+
+  it("should error when all view keys are rejected", async () => {
+    setup();
+
+    expect(screen.getByText(/set up aleo private balance/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Allow" }));
+
+    expect(screen.getByText(/checking the blockchain/i)).toBeInTheDocument();
+    await mockScanAccountsSubscription([ALEO_ACCOUNT_1, ALEO_ACCOUNT_2]);
+
+    expect(screen.queryByText(/we found 2 accounts/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Share view keys" }));
+
+    expect(screen.getByText(/approve on your Ledger/i)).toBeInTheDocument();
+    expect(screen.getAllByTestId("confirmation-account-row").length).toEqual(2);
+
+    await mockViewKeyProgressSubscription([
+      { accountId: ALEO_ACCOUNT_1.id, viewKey: null },
+      { accountId: ALEO_ACCOUNT_2.id, viewKey: null },
+    ]);
+
+    expectTrackPage(5, "cant add new account", { reason: "NO_ACCOUNTS_ADDED" });
+    expect(screen.getByText("No Aleo accounts were added")).toBeInTheDocument();
+  });
 });

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7846,6 +7846,11 @@
           "description": "In the {{currency}} ecosystem, only a select number of services can create new accounts. While Ledger does not currently offer this onboarding service, alternatives are available. You will be able to add your {{currency}} account on Ledger Wallet once it's created.",
           "cta": "How to create a {{currency}} account?",
           "close": "Close"
+        },
+        "noAccountsAddedWarning": {
+          "title": "No {{currency}} accounts were added",
+          "description": "You haven't completed the required setup for one or more selected accounts.",
+          "close": "Close"
         }
       },
       "status": {
@@ -8060,6 +8065,11 @@
         "cta": {
           "shareKey_one": "Share view key",
           "shareKey_other": "Share view keys"
+        }
+      },
+      "warnings": {
+        "noAccountsAddedWarning": {
+          "description": "You haven't shared view keys for any of the selected accounts. View keys are required to display your private balance in Ledger Wallet."
         }
       }
     },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - custom warning screen is visible if all view keys are rejected in Aleo's add account flow

### 📝 Description

This PR adds custom "No accounts added" warning screen to Aleo's add account flow. It is rendered when user rejects view key sharing for all selected accounts.

<img width="2560" height="1440" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/89570be7-afd9-4a5d-bc4f-88cf215a3c56" />

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-26301


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
