### PR TITLE
🐛 fix(desktop): align star filter with asset star icons on Market page

### DIFF
--- a/.changeset/ninety-stingrays-relate.md
+++ b/.changeset/ninety-stingrays-relate.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix star filter vertical misalignment with asset star icons on Market page

--- a/apps/ledger-live-desktop/src/mvvm/components/ScrollContainer/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/ScrollContainer/index.tsx
@@ -12,7 +12,7 @@ export const ScrollContainer = forwardRef<HTMLDivElement, ScrollContainerProps>(
       <div
         ref={ref}
         className={cn(
-          "min-h-0 w-full flex-1 overflow-auto [&::-webkit-scrollbar]:w-[6px] [&::-webkit-scrollbar-thumb]:rounded-[6px] [&::-webkit-scrollbar-thumb]:bg-muted-strong [&::-webkit-scrollbar-track]:rounded-[6px] [&::-webkit-scrollbar-track]:bg-muted",
+          "min-h-0 w-full flex-1 overflow-auto [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-[6px] [&::-webkit-scrollbar-thumb]:rounded-[6px] [&::-webkit-scrollbar-thumb]:bg-muted-strong [&::-webkit-scrollbar-track]:rounded-[6px] [&::-webkit-scrollbar-track]:bg-muted",
           className,
         )}
       >

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/ListHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/ListHeader.tsx
@@ -24,7 +24,7 @@ export const ListHeader = memo<ListHeaderProps>(function ListHeader({
 }) {
   return (
     <div className="px-20" data-testid="market-list-header">
-      <TableRow header>
+      <TableRow header style={{ paddingRight: 6 }}>
         <SortTableCell data-testid="market-sort-button" onClick={onToggleSortBy} order={order}>
           #
         </SortTableCell>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _CSS alignment fix — visual verification required._
- [x] **Impact of the changes:**
      - Market page star filter alignment in the header vs per-row star icons
      - Behavior with and without scrollbar (few results vs many results)
      - ScrollContainer gutter behavior across all usages

### 📝 Description

**Problem**: On the Market page, the star filter icon in the header was vertically misaligned with the star icons displayed next to each asset row. The header `TableRow` applied `padding-right: 12px` to compensate for the scrollbar, but the `ScrollContainer` uses a custom 6px-wide scrollbar — creating a 6px offset.

**Solution**:
- Override the header `TableRow` padding-right to `6px` (matching the actual scrollbar width) via inline style in `ListHeader.tsx`
- Add `scrollbar-gutter: stable` to `ScrollContainer` so the scrollbar gutter space is always reserved, ensuring consistent alignment whether or not the content overflows

<img width="212" height="455" alt="Screenshot 2026-02-17 at 15 36 48" src="https://github.com/user-attachments/assets/a96a9a3e-5647-4930-800c-5d97d7b1f9b7" />
<img width="163" height="403" alt="Screenshot 2026-02-17 at 15 36 41" src="https://github.com/user-attachments/assets/4d7c5f55-bc56-4870-b1a7-318da916667d" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-26374](https://ledgerhq.atlassian.net/browse/LIVE-26374)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26374]: https://ledgerhq.atlassian.net/browse/LIVE-26374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ