### PR TITLE
fix(ledger-sync): Patch connect flow

### DIFF
--- a/.changeset/strong-scissors-hug.md
+++ b/.changeset/strong-scissors-hug.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Patch Ledger Sync onboarding flow

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/Analytics/enums.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/Analytics/enums.ts
@@ -1,4 +1,5 @@
 export enum AnalyticsEvents {
   LedgerSyncActivated = "ledgersync_activated",
   LedgerSyncDeactivated = "ledgersync_deactivated",
+  LedgerSyncRejectedOnDevice = "ledgersync_rejected_on_device",
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/DeviceSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/DeviceSelection/index.tsx
@@ -63,9 +63,11 @@ const WalletSyncActivationDeviceSelection: React.FC<ChooseDeviceProps> = ({
 
   const onResult = useCallback(
     (payload: AppResult) => {
+      // clear device state so the DeviceActionModal closes cleanly and BLE scanning can restart
+      selectDevice(null);
       goToFollowInstructions(payload.device);
     },
-    [goToFollowInstructions],
+    [goToFollowInstructions, selectDevice],
   );
 
   const onError = (error: Error) => {


### PR DESCRIPTION
### 📝 Fix: Ledger Sync onboarding connect flow

- Handle UserRefusedOnDevice during Ledger Sync activation: The useAddMember hook now catches UserRefusedOnDevice errors.
- Track device rejection analytics: A new ledgersync_rejected_on_device event is emitted when the user refuses on-device.
- Fix DeviceActionModal cleanup on device selection: Clears the selected device (selectDevice(null)) before navigating to the follow-instructions screen so the DeviceActionModal closes cleanly and BLE scanning can restart on subsequent attempts.

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...



### ❓ Context

- **JIRA or GitHub link**: [LIVE-26073](https://ledgerhq.atlassian.net/browse/LIVE-26073)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26073]: https://ledgerhq.atlassian.net/browse/LIVE-26073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ