### PR TITLE
fix(ledger-sync): Patch connect flow

### DIFF
--- a/.changeset/strong-scissors-hug.md
+++ b/.changeset/strong-scissors-hug.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Patch Ledger Sync onboarding flow

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/Analytics/enums.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/Analytics/enums.ts
@@ -1,4 +1,5 @@
 export enum AnalyticsEvents {
   LedgerSyncActivated = "ledgersync_activated",
   LedgerSyncDeactivated = "ledgersync_deactivated",
+  LedgerSyncRejectedOnDevice = "ledgersync_rejected_on_device",
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/deviceSelectionCleanup.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/deviceSelectionCleanup.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { render } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+
+const mockSelectDevice = jest.fn();
+const mockGoToFollowInstructions = jest.fn();
+
+jest.mock("~/hooks/deviceActions", () => ({
+  useAppDeviceAction: () => jest.fn(),
+  useSelectDevice: () => ({
+    device: null,
+    selectDevice: mockSelectDevice,
+    registerDeviceSelection: jest.fn(),
+  }),
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useIsFocused: () => true,
+  useNavigation: () => ({
+    setOptions: jest.fn(),
+  }),
+}));
+
+jest.mock("~/components/SelectDevice2", () => {
+  const { View } = require("react-native");
+  return {
+    __esModule: true,
+    default: () => <View testID="select-device-2" />,
+  };
+});
+
+let capturedOnResult: ((payload: { device: Device }) => void) | undefined;
+let capturedOnClose: (() => void) | undefined;
+
+jest.mock("~/components/DeviceActionModal", () => {
+  const { View } = require("react-native");
+  return {
+    __esModule: true,
+    default: (props: { onResult: (payload: { device: Device }) => void; onClose: () => void }) => {
+      capturedOnResult = props.onResult;
+      capturedOnClose = props.onClose;
+      return <View testID="device-action-modal" />;
+    },
+  };
+});
+
+import DeviceSelection from "../screens/DeviceSelection";
+
+const MOCK_DEVICE = {
+  deviceId: "test-device-id",
+  deviceName: "Test Device",
+  modelId: DeviceModelId.stax,
+  wired: false,
+} as Device;
+
+const defaultProps = {
+  goToFollowInstructions: mockGoToFollowInstructions,
+  route: { params: {} } as never,
+  navigation: { setOptions: jest.fn() } as never,
+};
+
+describe("DeviceSelection onResult cleanup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedOnResult = undefined;
+    capturedOnClose = undefined;
+  });
+
+  it("should clear device state before navigating on result", () => {
+    render(<DeviceSelection {...defaultProps} />);
+
+    expect(capturedOnResult).toBeDefined();
+    capturedOnResult!({ device: MOCK_DEVICE });
+
+    expect(mockSelectDevice).toHaveBeenCalledWith(null);
+    expect(mockGoToFollowInstructions).toHaveBeenCalledWith(MOCK_DEVICE);
+
+    const selectDeviceCallOrder = mockSelectDevice.mock.invocationCallOrder[0];
+    const goToFollowCallOrder = mockGoToFollowInstructions.mock.invocationCallOrder[0];
+    expect(selectDeviceCallOrder).toBeLessThan(goToFollowCallOrder);
+  });
+
+  it("should clear device state on modal close", () => {
+    render(<DeviceSelection {...defaultProps} />);
+
+    expect(capturedOnClose).toBeDefined();
+    capturedOnClose!();
+
+    expect(mockSelectDevice).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/useAddMember.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/useAddMember.test.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import { Text } from "react-native";
+import { render, screen } from "@tests/test-renderer";
+import { useAddMember } from "../hooks/useAddMember";
+import { SceneKind } from "../hooks/useFollowInstructionDrawer";
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { track } from "~/analytics";
+import { AnalyticsEvents } from "../Analytics/enums";
+import { CONNECTION_TYPES } from "~/analytics/hooks/variables";
+import { State } from "~/reducers/types";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+
+const mockGetOrCreateTrustchain = jest.fn();
+jest.mock("../hooks/useTrustchainSdk", () => ({
+  useTrustchainSdk: () => ({
+    getOrCreateTrustchain: mockGetOrCreateTrustchain,
+  }),
+}));
+
+jest.mock("../hooks/useDestroyTrustchain", () => ({
+  useDestroyTrustchain: () => ({
+    deleteMutation: {
+      isPending: false,
+      error: null,
+      mutateAsync: jest.fn(),
+    },
+  }),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const INITIAL_STATE = (state: State) => ({
+  ...state,
+  settings: {
+    ...state.settings,
+    readOnlyModeEnabled: false,
+    hasCompletedOnboarding: true,
+    overriddenFeatureFlags: {
+      llmWalletSync: {
+        enabled: true,
+        params: {
+          environment: "STAGING",
+          watchConfig: {},
+        },
+      },
+    },
+  },
+  trustchain: {
+    ...state.trustchain,
+    memberCredentials: {
+      privatekey: "mock-private-key",
+      pubkey: "mock-public-key",
+    },
+  },
+});
+
+const MOCK_BLE_DEVICE = {
+  deviceId: "test-device-id",
+  deviceName: "Test Device",
+  modelId: DeviceModelId.stax,
+  wired: false,
+} as Device;
+
+const MOCK_USB_DEVICE = {
+  deviceId: "test-device-id",
+  deviceName: "Test Device",
+  modelId: DeviceModelId.stax,
+  wired: true,
+} as Device;
+
+function TestHarness({ device }: { device: Device }) {
+  const { scene } = useAddMember({ device });
+  return <Text testID="scene-kind">{SceneKind[scene.kind]}</Text>;
+}
+
+describe("useAddMember", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should set GenericError scene when UserRefusedOnDevice is thrown", async () => {
+    mockGetOrCreateTrustchain.mockRejectedValue(new UserRefusedOnDevice());
+
+    render(<TestHarness device={MOCK_BLE_DEVICE} />, {
+      overrideInitialState: INITIAL_STATE,
+    });
+
+    await jest.advanceTimersByTimeAsync(100);
+    jest.runAllTimers();
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(screen.getByTestId("scene-kind").props.children).toBe("GenericError");
+  });
+
+  it("should track LedgerSyncRejectedOnDevice with BLE connection type", async () => {
+    mockGetOrCreateTrustchain.mockRejectedValue(new UserRefusedOnDevice());
+
+    render(<TestHarness device={MOCK_BLE_DEVICE} />, {
+      overrideInitialState: INITIAL_STATE,
+    });
+
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(track).toHaveBeenCalledWith(AnalyticsEvents.LedgerSyncRejectedOnDevice, {
+      page: "Ledger Sync",
+      modelId: DeviceModelId.stax,
+      connectionType: CONNECTION_TYPES.BLE,
+    });
+  });
+
+  it("should track LedgerSyncRejectedOnDevice with USB connection type", async () => {
+    mockGetOrCreateTrustchain.mockRejectedValue(new UserRefusedOnDevice());
+
+    render(<TestHarness device={MOCK_USB_DEVICE} />, {
+      overrideInitialState: INITIAL_STATE,
+    });
+
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(track).toHaveBeenCalledWith(AnalyticsEvents.LedgerSyncRejectedOnDevice, {
+      page: "Ledger Sync",
+      modelId: DeviceModelId.stax,
+      connectionType: CONNECTION_TYPES.USB,
+    });
+  });
+
+  it("should set KeyError scene without tracking on TrustchainNotAllowed", async () => {
+    mockGetOrCreateTrustchain.mockRejectedValue(new TrustchainNotAllowed());
+
+    render(<TestHarness device={MOCK_BLE_DEVICE} />, {
+      overrideInitialState: INITIAL_STATE,
+    });
+
+    await jest.advanceTimersByTimeAsync(100);
+    jest.runAllTimers();
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(screen.getByTestId("scene-kind").props.children).toBe("KeyError");
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useAddMember.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useAddMember.ts
@@ -23,6 +23,8 @@ import { ScreenName } from "~/const";
 import { hasCompletedOnboardingSelector, onboardingTypeSelector } from "~/reducers/settings";
 import { DrawerProps, SceneKind, useFollowInstructionDrawer } from "./useFollowInstructionDrawer";
 import { OnboardingType } from "~/reducers/types";
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { CONNECTION_TYPES } from "~/analytics/hooks/variables";
 
 export function useAddMember({ device }: { device: Device | null }): DrawerProps {
   const trustchain = useSelector(trustchainSelector);
@@ -86,6 +88,13 @@ export function useAddMember({ device }: { device: Device | null }): DrawerProps
         } else if (error instanceof NoTrustchainInitialized) {
           setScene({ kind: SceneKind.UnbackedError });
         } else if (error instanceof Error) {
+          if (error instanceof UserRefusedOnDevice) {
+            track(AnalyticsEvents.LedgerSyncRejectedOnDevice, {
+              page: "Ledger Sync",
+              modelId: device?.modelId,
+              connectionType: device?.wired ? CONNECTION_TYPES.USB : CONNECTION_TYPES.BLE,
+            });
+          }
           setScene({ kind: SceneKind.GenericError, error });
         }
       }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/DeviceSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/DeviceSelection/index.tsx
@@ -63,9 +63,11 @@ const WalletSyncActivationDeviceSelection: React.FC<ChooseDeviceProps> = ({
 
   const onResult = useCallback(
     (payload: AppResult) => {
+      // clear device state so the DeviceActionModal closes cleanly and BLE scanning can restart
+      selectDevice(null);
       goToFollowInstructions(payload.device);
     },
-    [goToFollowInstructions],
+    [goToFollowInstructions, selectDevice],
   );
 
   const onError = (error: Error) => {


### PR DESCRIPTION
### 📝 Fix: Ledger Sync onboarding connect flow

- Handle UserRefusedOnDevice during Ledger Sync activation: The useAddMember hook now catches UserRefusedOnDevice errors.
- Track device rejection analytics: A new ledgersync_rejected_on_device event is emitted when the user refuses on-device.
- Fix DeviceActionModal cleanup on device selection: Clears the selected device (selectDevice(null)) before navigating to the follow-instructions screen so the DeviceActionModal closes cleanly and BLE scanning can restart on subsequent attempts.

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...


### ❓ Context

- **JIRA or GitHub link**: [LIVE-26073](https://ledgerhq.atlassian.net/browse/LIVE-26073)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26073]: https://ledgerhq.atlassian.net/browse/LIVE-26073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ