### PR TITLE
feat(LIVE-24451): aleo AccountBalanceSummaryFooter

### DIFF
--- a/.changeset/moody-snails-happen.md
+++ b/.changeset/moody-snails-happen.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat: aleo AccountBalanceSummaryFooter

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.test.tsx
@@ -1,0 +1,90 @@
+import BigNumber from "bignumber.js";
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import * as currencies from "@ledgerhq/live-common/currencies/index";
+import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import type { TokenAccount } from "@ledgerhq/types-live";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
+import { PRIVATE_BALANCE_PLACEHOLDER } from "./constants";
+import { ALEO_ACCOUNT_1 } from "./__mocks__/account.mock";
+
+jest.mock("~/renderer/hooks/useAccountUnit");
+jest.mock("@ledgerhq/live-common/currencies/index");
+
+const mockUseAccountUnit = jest.mocked(useAccountUnit);
+
+describe("AccountBalanceSummaryFooter", () => {
+  const mockSpendableBalance = BigNumber(100);
+  const mockTransparentBalance = BigNumber(60);
+  const mockAccount: AleoAccount = {
+    ...ALEO_ACCOUNT_1,
+    spendableBalance: mockSpendableBalance,
+    aleoResources: {
+      transparentBalance: mockTransparentBalance,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseAccountUnit.mockReturnValue({
+      code: "ALEO",
+      name: "Aleo",
+      magnitude: 6,
+    });
+
+    jest
+      .spyOn(currencies, "formatCurrencyUnit")
+      .mockImplementation((_unit, value, _formatConfig) => {
+        return value ? `formatted: ${value.toString()}` : PRIVATE_BALANCE_PLACEHOLDER;
+      });
+  });
+
+  it("should display available balance and transparent balance", () => {
+    render(<AccountBalanceSummaryFooter account={mockAccount} />);
+
+    expect(screen.getByText("Available balance")).toBeInTheDocument();
+    expect(screen.getByText(`formatted: ${mockSpendableBalance}`)).toBeInTheDocument();
+
+    expect(screen.getByText("Transparent balance")).toBeInTheDocument();
+    expect(screen.getByText(`formatted: ${mockTransparentBalance}`)).toBeInTheDocument();
+  });
+
+  it("should display *** for private balance when privateBalance is null", () => {
+    const mockAccountWithoutPrivateBalance = {
+      ...mockAccount,
+      aleoResources: {
+        ...mockAccount.aleoResources,
+      },
+    } as AleoAccount;
+
+    render(<AccountBalanceSummaryFooter account={mockAccountWithoutPrivateBalance} />);
+
+    expect(screen.getByText("***")).toBeInTheDocument();
+  });
+
+  it("should return null when account type is not Account", () => {
+    const mockTokenAccount = {
+      ...mockAccount,
+      type: "TokenAccount",
+    } as unknown as TokenAccount;
+
+    const { container } = render(<AccountBalanceSummaryFooter account={mockTokenAccount} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should return null when aleoResources is missing", () => {
+    const mockAccountWithoutResources = {
+      ...mockAccount,
+      aleoResources: undefined,
+    } as unknown as AleoAccount;
+
+    const { container } = render(
+      <AccountBalanceSummaryFooter account={mockAccountWithoutResources} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import { useSelector } from "LLD/hooks/redux";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import type { TokenAccount } from "@ledgerhq/types-live";
+import { localeSelector } from "~/renderer/reducers/settings";
+import Discreet, { useDiscreetMode } from "~/renderer/components/Discreet";
+import Box from "~/renderer/components/Box/Box";
+import Text from "~/renderer/components/Text";
+import InfoCircle from "~/renderer/icons/InfoCircle";
+import ToolTip from "~/renderer/components/Tooltip";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { PRIVATE_BALANCE_PLACEHOLDER } from "./constants";
+
+interface Props {
+  account: AleoAccount | TokenAccount;
+}
+
+const AccountBalanceSummaryFooter = ({ account }: Readonly<Props>) => {
+  const discreet = useDiscreetMode();
+  const locale = useSelector(localeSelector);
+  const unit = useAccountUnit(account);
+
+  if (account.type !== "Account" || !account.aleoResources) {
+    return null;
+  }
+
+  const formatConfig = {
+    alwaysShowSign: false,
+    showCode: true,
+    discreet,
+    locale,
+  };
+
+  const spendableBalance = account.spendableBalance;
+  const transparentBalance = account.aleoResources.transparentBalance;
+  const privateBalance = null; // private sync will be added later
+
+  const formattedAvailableBalance = formatCurrencyUnit(unit, spendableBalance, formatConfig);
+  const formattedTransparentBalance = formatCurrencyUnit(unit, transparentBalance, formatConfig);
+  const formattedPrivateBalance = privateBalance
+    ? formatCurrencyUnit(unit, privateBalance, formatConfig)
+    : PRIVATE_BALANCE_PLACEHOLDER;
+
+  return (
+    <Wrapper>
+      <BalanceDetail>
+        <ToolTip content={<Trans i18nKey="aleo.account.availableBalanceTooltip" />}>
+          <TitleWrapper>
+            <Title>
+              <Trans i18nKey="aleo.account.availableBalance" />
+            </Title>
+            <InfoCircle size={13} />
+          </TitleWrapper>
+        </ToolTip>
+        <AmountValue>
+          <Discreet>{formattedAvailableBalance}</Discreet>
+        </AmountValue>
+      </BalanceDetail>
+      <BalanceDetail>
+        <ToolTip content={<Trans i18nKey="aleo.account.transparentBalanceTooltip" />}>
+          <TitleWrapper>
+            <Title>
+              <Trans i18nKey="aleo.account.transparentBalance" />
+            </Title>
+            <InfoCircle size={13} />
+          </TitleWrapper>
+        </ToolTip>
+        <AmountValue>
+          <Discreet>{formattedTransparentBalance}</Discreet>
+        </AmountValue>
+      </BalanceDetail>
+      <BalanceDetail>
+        <ToolTip content={<Trans i18nKey="aleo.account.privateBalanceTooltip" />}>
+          <TitleWrapper>
+            <Title>
+              <Trans i18nKey="aleo.account.privateBalance" />
+            </Title>
+            <InfoCircle size={13} />
+          </TitleWrapper>
+        </ToolTip>
+        <AmountValue>
+          <Discreet>{formattedPrivateBalance}</Discreet>
+        </AmountValue>
+      </BalanceDetail>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled(Box).attrs(() => ({
+  horizontal: true,
+  mt: 4,
+  p: 5,
+  pb: 0,
+  scroll: true,
+}))`
+  border-top: 1px solid ${p => p.theme.colors.neutral.c30};
+`;
+
+const BalanceDetail = styled(Box).attrs(() => ({
+  flex: "0.25 0 auto",
+  alignItems: "start",
+  paddingRight: 20,
+}))``;
+
+const TitleWrapper = styled(Box).attrs(() => ({
+  horizontal: true,
+  alignItems: "center",
+  mb: 1,
+}))``;
+
+const Title = styled(Text).attrs(() => ({
+  fontSize: 4,
+  ff: "Inter|Medium",
+  color: "neutral.c70",
+}))`
+  line-height: ${p => p.theme.space[4]}px;
+  margin-right: ${p => p.theme.space[1]}px;
+`;
+
+const AmountValue = styled(Text).attrs(() => ({
+  fontSize: 6,
+  ff: "Inter|SemiBold",
+  color: "neutral.c100",
+}))<{ paddingRight?: number }>`
+  ${p => p.paddingRight && `padding-right: ${p.paddingRight}px`};
+`;
+
+export default AccountBalanceSummaryFooter;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/constants.ts
@@ -1,0 +1,1 @@
+export const PRIVATE_BALANCE_PLACEHOLDER = "***";

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/index.ts
@@ -1,7 +1,9 @@
+import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
 import ModularDrawerAddAccountFlowManager from "./ModularDrawerAddAccountFlowManager";
 import type { AleoFamily } from "./types";
 
 const family: AleoFamily = {
+  AccountBalanceSummaryFooter,
   ModularDrawerAddAccountFlowManager,
 };
 

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8062,6 +8062,14 @@
           "shareKey_other": "Share view keys"
         }
       }
+    },
+    "account": {
+      "availableBalance": "Available balance",
+      "availableBalanceTooltip": "Balance that can be transferred",
+      "transparentBalance": "Transparent balance",
+      "transparentBalanceTooltip": "Balance that is visible to the public",
+      "privateBalance": "Private balance",
+      "privateBalanceTooltip": "Balance that is hidden from the public"
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Balance summary footer should be visible on Aleo account details screen

### 📝 Description

This PR adds `AccountBalanceSummaryFooter` component to Aleo family. It renders spendable and transparent balance for now. Private balance has `***` placeholder and support for this will be added later.

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/52dca596-e33d-4f76-801f-0f7da70b5809" />

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-24451
- https://ledgerhq.atlassian.net/browse/LIVE-24452


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
