### PR TITLE
feat: safe area behind ff

### DIFF
--- a/.changeset/quiet-shoes-greet.md
+++ b/.changeset/quiet-shoes-greet.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat(lwm): remove safe area view for wallet40

--- a/apps/ledger-live-mobile/src/components/WalletTab/CollapsibleHeaderFlatList.tsx
+++ b/apps/ledger-live-mobile/src/components/WalletTab/CollapsibleHeaderFlatList.tsx
@@ -1,6 +1,6 @@
 import { useIsFocused, useRoute } from "@react-navigation/native";
 import React, { useContext, useCallback, useRef } from "react";
-import { Dimensions, Animated, StatusBar, FlatList, FlatListProps } from "react-native";
+import { Dimensions, Animated, StatusBar, FlatList, FlatListProps, View } from "react-native";
 import SafeAreaView from "../SafeAreaView";
 import { WalletTabNavigatorScrollContext } from "./WalletTabNavigatorScrollManager";
 import AnimatedProps = Animated.AnimatedProps;
@@ -9,11 +9,17 @@ import AnimatedProps = Animated.AnimatedProps;
 const DEFAULT_HEADER_HEIGHT = 0;
 const DEFAULT_TAB_BAR_HEIGHT = 0;
 
+type CollapsibleHeaderFlatListProps<T> = AnimatedProps<FlatListProps<T>> & {
+  /** When false, skip SafeAreaView (e.g. when parent nav already handles safe area). Default true. */
+  useSafeArea?: boolean;
+};
+
 function CollapsibleHeaderFlatList<T>({
   children,
   contentContainerStyle,
+  useSafeArea = true,
   ...otherProps
-}: AnimatedProps<FlatListProps<T>>) {
+}: CollapsibleHeaderFlatListProps<T>) {
   const context = useContext(WalletTabNavigatorScrollContext);
 
   // Fallback scrollY for when context is not available (direct navigation outside WalletTabNavigator)
@@ -46,36 +52,40 @@ function CollapsibleHeaderFlatList<T>({
     [onGetRef, route.name],
   );
 
-  return (
-    <SafeAreaView isFlex>
-      <Animated.FlatList<T>
-        {...otherProps}
-        scrollToOverflowEnabled={true}
-        ref={handleRef}
-        scrollEventThrottle={16}
-        onScroll={
-          isFocused && hasContext
-            ? Animated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
-                useNativeDriver: true,
-              })
-            : undefined
-        }
-        onScrollEndDrag={onMomentumScrollEnd}
-        onMomentumScrollEnd={onMomentumScrollEnd}
-        contentContainerStyle={[
-          {
-            paddingTop: headerHeight,
-            minHeight: windowHeight + (StatusBar.currentHeight || 0),
-            paddingBottom: tabBarHeight + (StatusBar.currentHeight || 0),
-          },
-          contentContainerStyle,
-        ]}
-        showsHorizontalScrollIndicator={false}
-        showsVerticalScrollIndicator={false}
-      >
-        {children}
-      </Animated.FlatList>
-    </SafeAreaView>
+  const list = (
+    <Animated.FlatList<T>
+      {...otherProps}
+      scrollToOverflowEnabled={true}
+      ref={handleRef}
+      scrollEventThrottle={16}
+      onScroll={
+        isFocused && hasContext
+          ? Animated.event([{ nativeEvent: { contentOffset: { y: scrollY } } }], {
+              useNativeDriver: true,
+            })
+          : undefined
+      }
+      onScrollEndDrag={onMomentumScrollEnd}
+      onMomentumScrollEnd={onMomentumScrollEnd}
+      contentContainerStyle={[
+        {
+          paddingTop: headerHeight,
+          minHeight: windowHeight + (StatusBar.currentHeight || 0),
+          paddingBottom: tabBarHeight + (StatusBar.currentHeight || 0),
+        },
+        contentContainerStyle,
+      ]}
+      showsHorizontalScrollIndicator={false}
+      showsVerticalScrollIndicator={false}
+    >
+      {children}
+    </Animated.FlatList>
+  );
+
+  return useSafeArea ? (
+    <SafeAreaView isFlex>{list}</SafeAreaView>
+  ) : (
+    <View style={{ flex: 1 }}>{list}</View>
   );
 }
 

--- a/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
+++ b/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
@@ -11,12 +11,14 @@ type Props = {
   error?: Error;
   isError?: boolean;
   forwardedRef?: React.Ref<unknown>;
+  /** Override or extend refresh control options per render (e.g. progressViewOffset). Merged with defaultRefreshControlProps. */
+  overrideRefreshControlProps?: Partial<RefreshControlProps>;
 };
 export default <P,>(
   ScrollListLike: React.ComponentType<P>,
-  refreshControlprops?: Partial<RefreshControlProps>,
+  defaultRefreshControlProps?: Partial<RefreshControlProps>,
 ) => {
-  function Inner({ forwardedRef, ...scrollListLikeProps }: Props & P) {
+  function Inner({ forwardedRef, overrideRefreshControlProps, ...scrollListLikeProps }: Props & P) {
     const { colors, dark } = useTheme();
     const [refreshing, setRefreshing] = useState(false);
     const setSyncBehavior = useBridgeSync();
@@ -53,6 +55,11 @@ export default <P,>(
       };
     }, [refreshing]);
 
+    const mergedRefreshControlProps = {
+      ...defaultRefreshControlProps,
+      ...overrideRefreshControlProps,
+    };
+
     return (
       <ScrollListLike
         {...(scrollListLikeProps as P)}
@@ -64,7 +71,7 @@ export default <P,>(
             tintColor={colors.live}
             refreshing={refreshing}
             onRefresh={onRefresh}
-            {...refreshControlprops}
+            {...mergedRefreshControlProps}
           />
         }
       />

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Pull-to-refresh spinner offset (progressViewOffset).
+ * Tune per layout: legacy has SafeAreaView, Wallet40 does not.
+ */
+export const PROGRESS_VIEW_OFFSET_LEGACY_ANDROID = 64;
+export const PROGRESS_VIEW_OFFSET_LEGACY_IOS = 0;
+export const PROGRESS_VIEW_OFFSET_WALLET40_ANDROID = 0;
+export const PROGRESS_VIEW_OFFSET_WALLET40_IOS = 64;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
 import { Platform } from "react-native";
 import Animated from "react-native-reanimated";
-
 import CheckLanguageAvailability from "~/components/CheckLanguageAvailability";
 import CheckTermOfUseUpdate from "~/components/CheckTermOfUseUpdate";
 import CollapsibleHeaderFlatList from "~/components/WalletTab/CollapsibleHeaderFlatList";
@@ -12,6 +11,11 @@ import { renderItem } from "LLM/utils/renderItem";
 import { ScreenName } from "~/const";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { WalletTabNavigatorStackParamList } from "~/components/RootNavigator/types/WalletTabNavigator";
+import {
+  PROGRESS_VIEW_OFFSET_LEGACY_ANDROID,
+  PROGRESS_VIEW_OFFSET_LEGACY_IOS,
+} from "../../constants";
+import { getProgressViewOffset } from "../../utils/getProgressViewOffset";
 import usePortfolioViewModel from "./usePortfolioViewModel";
 
 import { Box } from "@ledgerhq/native-ui";
@@ -32,7 +36,10 @@ type NavigationProps = BaseComposite<
 >;
 
 const RefreshableCollapsibleHeaderFlatList = globalSyncRefreshControl(CollapsibleHeaderFlatList, {
-  progressViewOffset: Platform.OS === "android" ? 64 : 0,
+  progressViewOffset:
+    Platform.OS === "android"
+      ? PROGRESS_VIEW_OFFSET_LEGACY_ANDROID
+      : PROGRESS_VIEW_OFFSET_LEGACY_IOS,
 });
 
 export const PortfolioScreen = ({ navigation }: NavigationProps) => {
@@ -51,7 +58,10 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     handleHeightChange,
     onBackFromUpdate,
     goToAnalyticsAllocations,
+    shouldDisplayWallet40MainNav,
   } = usePortfolioViewModel(navigation);
+
+  const progressViewOffset = getProgressViewOffset(Platform.OS, shouldDisplayWallet40MainNav);
 
   const { isDrawerOpen, handleCloseDrawer } = useWalletV4TourDrawer();
 
@@ -145,6 +155,8 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
           keyExtractor={(_: unknown, index: number) => String(index)}
           showsVerticalScrollIndicator={false}
           testID={showAssets ? "PortfolioAccountsList" : "PortfolioEmptyList"}
+          useSafeArea={!shouldDisplayWallet40MainNav}
+          overrideRefreshControlProps={{ progressViewOffset }}
         />
         <AddAccountDrawer
           isOpened={isAddModalOpened}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
@@ -43,6 +43,7 @@ interface UsePortfolioViewModelResult {
   handleHeightChange: (newHeight: number) => void;
   onBackFromUpdate: () => void;
   goToAnalyticsAllocations: () => void;
+  shouldDisplayWallet40MainNav: boolean;
 }
 
 const usePortfolioViewModel = (navigation: {
@@ -53,7 +54,7 @@ const usePortfolioViewModel = (navigation: {
   const [isAddModalOpened, setAddModalOpened] = useState(false);
   const { isAWalletCardDisplayed } = useDynamicContent();
   const accountListFF = useFeature("llmAccountListUI");
-  const { shouldDisplayGraphRework, shouldDisplayQuickActionCtas } =
+  const { shouldDisplayGraphRework, shouldDisplayQuickActionCtas, shouldDisplayWallet40MainNav } =
     useWalletFeaturesConfig("mobile");
   const isAccountListUIEnabled = accountListFF?.enabled ?? false;
   const llmDatadog = useFeature("llmDatadog");
@@ -148,6 +149,7 @@ const usePortfolioViewModel = (navigation: {
     handleHeightChange,
     onBackFromUpdate,
     goToAnalyticsAllocations,
+    shouldDisplayWallet40MainNav,
   };
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/index.tsx
@@ -26,6 +26,7 @@ function ReadOnlyPortfolioScreen({ navigation }: NavigationProps) {
     source,
     goToAssets,
     onBackFromUpdate,
+    shouldDisplayWallet40MainNav,
   } = useReadOnlyPortfolioViewModel(navigation);
 
   const data = useMemo(
@@ -63,6 +64,7 @@ function ReadOnlyPortfolioScreen({ navigation }: NavigationProps) {
         keyExtractor={(_: unknown, index: number) => String(index)}
         showsVerticalScrollIndicator={false}
         testID="PortfolioReadOnlyItems"
+        useSafeArea={!shouldDisplayWallet40MainNav}
       />
     </>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/useReadOnlyPortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/useReadOnlyPortfolioViewModel.ts
@@ -19,13 +19,15 @@ interface UseReadOnlyPortfolioViewModelResult {
   source: string | undefined;
   goToAssets: () => void;
   onBackFromUpdate: () => void;
+  shouldDisplayWallet40MainNav: boolean;
 }
 
 const useReadOnlyPortfolioViewModel = (navigation: {
   goBack: () => void;
   navigate: (name: string, params?: object) => void;
 }): UseReadOnlyPortfolioViewModelResult => {
-  const { shouldDisplayGraphRework } = useWalletFeaturesConfig("mobile");
+  const { shouldDisplayGraphRework, shouldDisplayWallet40MainNav } =
+    useWalletFeaturesConfig("mobile");
   const isLNSUpsellBannerShown = useLNSUpsellBannerState("wallet").isShown;
 
   const { sortedCryptoCurrencies } = useReadOnlyCoins({ maxDisplayed: MAX_ASSETS_TO_DISPLAY });
@@ -71,6 +73,7 @@ const useReadOnlyPortfolioViewModel = (navigation: {
     source,
     goToAssets,
     onBackFromUpdate,
+    shouldDisplayWallet40MainNav,
   };
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/utils/getProgressViewOffset.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/utils/getProgressViewOffset.ts
@@ -1,0 +1,15 @@
+import {
+  PROGRESS_VIEW_OFFSET_LEGACY_ANDROID,
+  PROGRESS_VIEW_OFFSET_LEGACY_IOS,
+  PROGRESS_VIEW_OFFSET_WALLET40_ANDROID,
+  PROGRESS_VIEW_OFFSET_WALLET40_IOS,
+} from "../constants";
+
+export function getProgressViewOffset(platform: string, isWallet40MainNav: boolean): number {
+  if (platform === "android") {
+    return isWallet40MainNav
+      ? PROGRESS_VIEW_OFFSET_WALLET40_ANDROID
+      : PROGRESS_VIEW_OFFSET_LEGACY_ANDROID;
+  }
+  return isWallet40MainNav ? PROGRESS_VIEW_OFFSET_WALLET40_IOS : PROGRESS_VIEW_OFFSET_LEGACY_IOS;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces changes to improve layout handling and refresh control customization for wallet screens, especially in the context of the new Wallet40 navigation. The main focus is to remove redundant SafeAreaView components when Wallet40 navigation is active, allow screens to control SafeAreaView usage, and enable per-screen customization of refresh control properties such as spinner position.

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-17 at 16 09 43" src="https://github.com/user-attachments/assets/e8d95841-9b90-4fdb-b7f9-6ea28c36acc1" />
<img width="1080" height="2400" alt="Screenshot_1771343349" src="https://github.com/user-attachments/assets/09e6641c-ebdd-43dd-ba7b-3cb00b71a86f" />



### ❓ Context

[LIVE-26003](https://ledgerhq.atlassian.net/browse/LIVE-26003)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26003]: https://ledgerhq.atlassian.net/browse/LIVE-26003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ