### PR TITLE
feat(mobile): add useNavigationBarHeights hook for PTX webview padding

### DIFF
--- a/.changeset/navigation-bar-heights-hook.md
+++ b/.changeset/navigation-bar-heights-hook.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add useNavigationBarHeights hook for PTX webview padding calculations

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useNavigationBarHeights.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useNavigationBarHeights.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from "@tests/test-renderer";
+import { useNavigationBarHeights } from "../useNavigationBarHeights";
+import { State } from "~/reducers/types";
+import { INITIAL_STATE as SETTINGS_INITIAL_STATE } from "~/reducers/settings";
+import { TAB_BAR_HEIGHT } from "~/components/TabBar/shared";
+
+const mockInsets = { top: 44, bottom: 34, left: 0, right: 0 };
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => mockInsets,
+}));
+
+const withFeatureFlag = (enabled: boolean) => (state: State) => ({
+  ...state,
+  settings: {
+    ...SETTINGS_INITIAL_STATE,
+    overriddenFeatureFlags: {
+      lwmWallet40: {
+        enabled,
+        params: { mainNavigation: true },
+      },
+    },
+  },
+});
+
+const withTabBarVisibility = (isVisible: boolean) => (state: State) => ({
+  ...withFeatureFlag(true)(state),
+  appstate: {
+    ...state.appstate,
+    isMainNavigatorVisible: isVisible,
+  },
+});
+
+describe("useNavigationBarHeights", () => {
+  describe("when lwmWallet40 feature flag is disabled", () => {
+    it("should throw error", () => {
+      expect(() => {
+        renderHook(() => useNavigationBarHeights(), {
+          overrideInitialState: withFeatureFlag(false),
+        });
+      }).toThrow(
+        "[useNavigationBarHeights] This hook requires the 'lwmWallet40' feature flag to be enabled",
+      );
+    });
+  });
+
+  describe("when lwmWallet40 feature flag is enabled", () => {
+    it("should calculate top height as insets.top + 60", () => {
+      const { result } = renderHook(() => useNavigationBarHeights(), {
+        overrideInitialState: withTabBarVisibility(true),
+      });
+
+      expect(result.current.top).toBe(104); // 44 + 60
+    });
+
+    it("should return TAB_BAR_HEIGHT when tab bar is visible", () => {
+      const { result } = renderHook(() => useNavigationBarHeights(), {
+        overrideInitialState: withTabBarVisibility(true),
+      });
+
+      expect(result.current.bottom).toBe(TAB_BAR_HEIGHT);
+    });
+
+    it("should return 0 when tab bar is hidden", () => {
+      const { result } = renderHook(() => useNavigationBarHeights(), {
+        overrideInitialState: withTabBarVisibility(false),
+      });
+
+      expect(result.current.bottom).toBe(0);
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useNavigationBarHeights.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useNavigationBarHeights.ts
@@ -1,0 +1,56 @@
+import { useMemo } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { useSelector } from "~/context/hooks";
+import { isMainNavigatorVisibleSelector } from "~/reducers/appstate";
+import { TAB_BAR_HEIGHT } from "~/components/TabBar/shared";
+
+const TOP_BAR_HEIGHT = 60;
+
+export interface NavigationBarHeights {
+  readonly top: number;
+  readonly bottom: number;
+}
+
+/**
+ * Hook to calculate navigation bar heights for Wallet 4.0 screens.
+ *
+ * Returns top and bottom offsets to account for navigation bars (TopBar + TabBar).
+ * Used primarily for PTX WebView screens that need proper content padding.
+ *
+ * @throws {Error} If the `lwmWallet40` feature flag is not enabled
+ *
+ * @example
+ * ```tsx
+ * const { top, bottom } = useNavigationBarHeights();
+ * const webviewInputs = {
+ *   paddingTop: top.toString(),
+ *   paddingBottom: bottom.toString(),
+ * };
+ * ```
+ *
+ * @returns `{ top: number, bottom: number }` - Top includes safe area + 60px, bottom is 56px or 0
+ */
+export function useNavigationBarHeights(): NavigationBarHeights {
+  const { isEnabled: isWallet40Enabled } = useWalletFeaturesConfig("mobile");
+  const insets = useSafeAreaInsets();
+  const isTabBarVisible = useSelector(isMainNavigatorVisibleSelector);
+
+  const result = useMemo(
+    () => ({
+      top: insets.top + TOP_BAR_HEIGHT,
+      bottom: isTabBarVisible ? TAB_BAR_HEIGHT : 0,
+    }),
+    [insets.top, isTabBarVisible],
+  );
+
+  if (!isWallet40Enabled) {
+    throw new Error(
+      "[useNavigationBarHeights] This hook requires the 'lwmWallet40' feature flag to be enabled. " +
+        "Ensure that any component using this hook is only rendered within Wallet 4.0-gated navigation trees " +
+        "where useWalletFeaturesConfig('mobile').isEnabled is true, or handle this error via an error boundary.",
+    );
+  }
+
+  return result;
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - PTX screens using navigation bar heights
  - WebView padding calculations
  - Hook behavior under Wallet 4.0 feature flag

### 📝 Description

This PR introduces a new hook \`useNavigationBarHeights()\` that provides navigation bar heights for content padding calculations in Wallet 4.0 screens.

**Problem**: PTX teams need precise padding values to ensure their webviews display correctly beneath the top and bottom navigation bars.

**Solution**: Created a hook that returns:
- \`top\`: Safe area inset + TopBar height (60px)
- \`bottom\`: TabBar height (56px when visible, 0 when hidden)

The hook is feature-flagged and only available when \`lwmWallet40\` is enabled.

**Usage example**:
\`\`\`typescript
const { top, bottom } = useNavigationBarHeights();
const webviewInputs = {
  paddingTop: top.toString(),
  paddingBottom: bottom.toString(),
};
\`\`\`

### 📦 Files Changed

- \`apps/ledger-live-mobile/src/mvvm/hooks/useNavigationBarHeights.ts\` - Hook implementation
- \`apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useNavigationBarHeights.test.ts\` - Test suite

### ❓ Context

- **JIRA link**: [LIVE-26002](https://ledgerhq.atlassian.net/browse/LIVE-26002)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-26002]: https://ledgerhq.atlassian.net/browse/LIVE-26002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ