### PR TITLE
✨ feat(desktop): unify background for live-apps in W4.0

### DIFF
--- a/.changeset/tasty-needles-sell.md
+++ b/.changeset/tasty-needles-sell.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+unify background for live-apps in W4.0

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
@@ -4,9 +4,9 @@
  * - RightPanel (swap sidebar)
  * - Wallet40Layout with pt-32 spacing
  */
-const WALLET_40_PAGES = new Set(["/", "/market", "/analytics"]);
+const WALLET_40_PAGES = new Set(["/", "/market", "/analytics", "/earn", "/perps"]);
 
-const WALLET_40_PREFIXES = ["/card", "/swap"];
+const WALLET_40_PREFIXES = ["/card", "/swap", "/exchange"];
 
 /**
  * Pages that display the right panel (swap sidebar)


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No visual tests needed — this change only adds routes to an existing page-layout allowlist._
- [x] **Impact of the changes:**
      - Background color consistency on `/earn`, `/perps`, and `/exchange` pages
      - Wallet 4.0 layout (Tailwind background + `pt-32` spacing) now applied to all live-app routes

### 📝 Description

**Problem**: Several live-app pages (`/earn`, `/perps`, `/exchange`) were not included in the Wallet 4.0 layout configuration, resulting in inconsistent backgrounds compared to other W4.0 pages.

**Solution**: Added the missing routes to the `WALLET_40_PAGES` set and `WALLET_40_PREFIXES` array in `Page/utils.ts` so that all live-app pages share the unified Tailwind background and spacing of the Wallet 4.0 experience.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26384](https://ledgerhq.atlassian.net/browse/LIVE-26384)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26384]: https://ledgerhq.atlassian.net/browse/LIVE-26384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ