### PR TITLE
chore(desktop): make build correctly display errors on CI

### DIFF
--- a/.changeset/breezy-gorillas-swim.md
+++ b/.changeset/breezy-gorillas-swim.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Build system to properly display errors on CI

--- a/apps/ledger-live-desktop/tools/main-rspack.ts
+++ b/apps/ledger-live-desktop/tools/main-rspack.ts
@@ -140,6 +140,15 @@ const build = async (argv: { port?: number }) => {
           }
 
           if (stats?.hasErrors()) {
+            // Log to stdout first so CI always shows a readable summary (stderr may be dropped or truncated)
+            const json = stats?.toJson({ all: false, errors: true });
+            const errors = json?.errors || [];
+            console.log(`\n❌ ${name} build failed with ${errors.length} error(s):`);
+            errors.forEach((e: { message?: string; moduleName?: string }, i: number) => {
+              const msg = typeof e.message === "string" ? e.message : String(e.message ?? e);
+              const truncated = msg.length > 500 ? msg.slice(0, 500) + "\n... [truncated]" : msg;
+              console.log(`  ${i + 1}. ${e.moduleName || "?"}: ${truncated.split("\n").join(" ")}`);
+            });
             console.error(`❌ ${name} build failed with errors:`);
             console.error(stats.toString({ colors: true, errors: true }));
             reject(new Error(`${name} build failed`));


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - desktop build

### 📝 Description

tested with https://github.com/LedgerHQ/ledger-live/pull/14553
the CI will now properly see the error that you could see in a dev console
eg

<img width="989" height="525" alt="Screenshot 2026-02-17 at 19 49 11" src="https://github.com/user-attachments/assets/80a4dde5-53aa-4ba6-a216-ad052c08975f" />


before this , it wasn't even display, you had a big bloat of bundle code in the CI logs

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
