### PR TITLE
fix(e2e): make swap tests resilient to quote API failures

### DIFF
--- a/libs/ledger-live-common/src/e2e/swap.ts
+++ b/libs/ledger-live-common/src/e2e/swap.ts
@@ -1,30 +1,79 @@
 import { Account } from "./enum/Account";
 import { sanitizeError } from "./index";
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 
-export async function getMinimumSwapAmount(AccountFrom: Account, AccountTo: Account) {
+// Target a sensible USD amount that works for most pairs
+const FALLBACK_TARGET_USD = 50;
+
+const COUNTERVALUES_URL = "https://countervalues.live.ledger.com/v3/spot/simple";
+const SWAP_QUOTE_URL = "https://swap-stg.ledger-test.com/v5/quote";
+
+/** Smallest amount sent to the quote API to discover minimum thresholds. */
+const PROBE_AMOUNT = 0.0001;
+const PROBE_NETWORK_FEES = 0.001;
+
+const PROVIDERS_WHITELIST = "changelly_v2,exodus,thorswap,uniswap,cic_v2,nearintents";
+
+type QuoteErrorItem = {
+  parameter?: { minAmount?: string };
+};
+
+function isQuoteErrorItem(item: unknown): item is QuoteErrorItem {
+  return typeof item === "object" && item !== null && "parameter" in item;
+}
+
+/**
+ * Fetches the current USD price for a currency from the Ledger countervalues API
+ * and converts a target USD value into the equivalent crypto amount.
+ */
+async function getAmountFromUSD(currencyId: string, targetUSD: number): Promise<number | null> {
   try {
-    const addressFrom = AccountFrom.address || AccountFrom.parentAccount?.address;
+    const { data } = await axios.get(COUNTERVALUES_URL, {
+      params: {
+        froms: currencyId,
+        to: "USD",
+      },
+    });
+
+    const price = data?.[currencyId];
+    if (!price || price <= 0) {
+      console.warn(`No USD price found for ${currencyId}`);
+      return null;
+    }
+
+    return targetUSD / price;
+  } catch (error: unknown) {
+    console.warn(`Failed to fetch countervalue for ${currencyId}:`, sanitizeError(error));
+    return null;
+  }
+}
+
+export async function getMinimumSwapAmount(
+  accountFrom: Account,
+  accountTo: Account,
+): Promise<number | null> {
+  try {
+    const addressFrom = accountFrom.address || accountFrom.parentAccount?.address;
 
     if (!addressFrom) {
       throw new Error("No address available from accounts when requesting minimum swap amount.");
     }
 
-    const requestConfig = {
+    const requestConfig: AxiosRequestConfig = {
       method: "GET",
-      url: "https://swap-stg.ledger-test.com/v5/quote",
+      url: SWAP_QUOTE_URL,
       params: {
-        from: AccountFrom.currency.id,
-        to: AccountTo.currency.id,
-        amountFrom: 0.0001,
+        from: accountFrom.currency.id,
+        to: accountTo.currency.id,
+        amountFrom: PROBE_AMOUNT,
         addressFrom,
         fiatForCounterValue: "USD",
         slippage: 1,
-        networkFees: 0.001,
-        networkFeesCurrency: AccountTo.currency.speculosApp.name.toLowerCase(),
+        networkFees: PROBE_NETWORK_FEES,
+        networkFeesCurrency: accountTo.currency.speculosApp.name.toLowerCase(),
         displayLanguage: "en",
         theme: "light",
-        "providers-whitelist": "changelly_v2,exodus,thorswap,uniswap,cic_v2,nearintents",
+        "providers-whitelist": PROVIDERS_WHITELIST,
         tradeType: "INPUT",
         uniswapOrderType: "uniswapxv1",
       },
@@ -33,20 +82,37 @@ export async function getMinimumSwapAmount(AccountFrom: Account, AccountTo: Acco
 
     const { data } = await axios(requestConfig);
 
-    const minimumAmounts = data
-      .filter((item: any) => item.parameter?.minAmount !== undefined)
-      .map((item: any) => Number.parseFloat(item.parameter.minAmount))
-      .filter((amount: number) => !Number.isNaN(amount));
-
-    if (minimumAmounts.length === 0) {
-      throw new Error("No valid minimum amounts returned from swap quote API.");
+    if (!Array.isArray(data)) {
+      console.warn("Unexpected quote API response, falling back to countervalues");
+      return await getAmountFromUSD(accountFrom.currency.id, FALLBACK_TARGET_USD);
     }
 
-    return Math.max(...minimumAmounts);
-  } catch (error: any) {
+    // Try to extract minAmount from AMOUNT_OFF_LIMITS errors
+    const minimumAmounts = data
+      .filter(isQuoteErrorItem)
+      .filter(item => item.parameter?.minAmount !== undefined)
+      .map(item => Number.parseFloat(item.parameter!.minAmount!))
+      .filter((amount: number) => !Number.isNaN(amount) && amount > 0);
+
+    if (minimumAmounts.length > 0) {
+      return Math.max(...minimumAmounts);
+    }
+
+    // No minAmount returned — compute a sensible fallback from countervalues
+    console.warn(
+      `No minAmount from quote API for ${accountFrom.currency.id} → ${accountTo.currency.id}, ` +
+        `computing fallback from countervalues (~$${FALLBACK_TARGET_USD} USD)`,
+    );
+    return await getAmountFromUSD(accountFrom.currency.id, FALLBACK_TARGET_USD);
+  } catch (error: unknown) {
     const sanitizedError = sanitizeError(error);
-    console.error("Error fetching swap minimum amount:", sanitizedError);
-    // throw the sanitized error, not the original circular Axios error
-    throw sanitizedError;
+    console.warn("Error fetching swap minimum amount:", sanitizedError);
+
+    // Last resort: try to compute a sensible amount even if the quote call failed entirely
+    try {
+      return await getAmountFromUSD(accountFrom.currency.id, FALLBACK_TARGET_USD);
+    } catch {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* Instead of throwing when the swap quote API returns an error or no valid minimum amounts, fall back to a sensible USD-based amount (~$50) computed from the Ledger countervalues API. This prevents flaky test failures caused by transient backend issues.
* extract constants, replace any with unknown, add Array.isArray guard, and rename params to camelCase.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://github.com/LedgerHQ/qaa-flaky-tests/issues/14
- CI [Desktop](https://github.com/LedgerHQ/ledger-live/actions/runs/22110161256)
- CI [Mobile](https://github.com/LedgerHQ/ledger-live/actions/runs/22109453183)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
