### PR TITLE
feat(mobile): update Discover screen navigation for Wallet 4.0

### DIFF
--- a/.changeset/discover-wallet40-nav-update.md
+++ b/.changeset/discover-wallet40-nav-update.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update Discover Catalog screen navigation for Wallet 4.0: add permanent back arrow header and inline Cancel button in search mode when lwmWallet40 feature flag is active

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
@@ -1,4 +1,6 @@
 import { renderHook, act } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { State } from "~/reducers/types";
 import { expectedNavigationParams } from "../const";
 import { useTopBarViewModel } from "../useTopBarViewModel";
 
@@ -10,6 +12,16 @@ jest.mock("@react-navigation/native", () => ({
 }));
 
 const mockNavigation = { navigate: mockNavigate };
+
+const withWeb3Hub = (enabled: boolean) => (state: State) => ({
+  ...state,
+  settings: {
+    ...state.settings,
+    overriddenFeatureFlags: {
+      web3hub: { enabled },
+    },
+  },
+});
 
 describe("useTopBarViewModel", () => {
   beforeEach(() => {
@@ -30,18 +42,35 @@ describe("useTopBarViewModel", () => {
     );
   });
 
-  it("should call navigate with expected params when onDiscoverPress is invoked", () => {
-    const { result } = renderHook(() => useTopBarViewModel(mockNavigation as never));
+  describe("onDiscoverPress", () => {
+    it("should navigate to Discover when web3hub feature flag is absent", () => {
+      const { result } = renderHook(() => useTopBarViewModel(mockNavigation as never));
 
-    act(() => {
-      result.current.onDiscoverPress();
+      act(() => {
+        result.current.onDiscoverPress();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expectedNavigationParams.discover.name,
+        expectedNavigationParams.discover.params,
+      );
     });
 
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith(
-      expectedNavigationParams.discover.name,
-      expectedNavigationParams.discover.params,
-    );
+    it("should navigate to Web3HubTab when web3hub feature flag is enabled", () => {
+      const { result } = renderHook(() => useTopBarViewModel(mockNavigation as never), {
+        overrideInitialState: withWeb3Hub(true),
+      });
+
+      act(() => {
+        result.current.onDiscoverPress();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Web3HubTab, {
+        screen: ScreenName.Web3HubMain,
+      });
+    });
   });
 
   it("should call navigate with expected params when onNotificationsPress is invoked", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
@@ -3,12 +3,14 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { NavigatorName, ScreenName } from "~/const";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
 import { track } from "~/analytics";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 export function useTopBarViewModel(
   navigation: NativeStackNavigationProp<{ [key: string]: object | undefined }>,
   screenName?: string,
 ) {
   const { notificationCards } = useDynamicContent();
+  const web3hub = useFeature("web3hub");
   const page = screenName ?? ScreenName.Portfolio;
 
   const hasUnreadNotifications = useMemo(
@@ -30,10 +32,16 @@ export function useTopBarViewModel(
 
   const onDiscoverPress = useCallback(() => {
     track("menuentry_clicked", { button: "Discover", page });
-    navigation.navigate(NavigatorName.Discover, {
-      screen: ScreenName.DiscoverScreen,
-    });
-  }, [navigation, page]);
+    if (web3hub?.enabled) {
+      navigation.navigate(NavigatorName.Web3HubTab, {
+        screen: ScreenName.Web3HubMain,
+      });
+    } else {
+      navigation.navigate(NavigatorName.Discover, {
+        screen: ScreenName.DiscoverScreen,
+      });
+    }
+  }, [navigation, page, web3hub?.enabled]);
 
   const onNotificationsPress = useCallback(() => {
     track("menuentry_clicked", { button: "Notifications", page });

--- a/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/Search/SearchBar.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/Search/SearchBar.tsx
@@ -1,21 +1,31 @@
-import { Flex, SearchInput } from "@ledgerhq/native-ui";
+import { Flex, SearchInput, Text } from "@ledgerhq/native-ui";
 import React from "react";
+import { TouchableOpacity } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { Search } from "../../types";
 
 export function SearchBar({
   search: { input, inputRef, onChange, onFocus },
+  onCancel,
 }: {
   search: Pick<Search, "input" | "inputRef" | "onChange" | "onFocus">;
+  onCancel?: () => void;
 }) {
   const { t } = useTranslation();
 
   return (
     <>
-      <Flex backgroundColor="background.main" marginBottom={16} flexDirection={"row"} zIndex={10}>
+      <Flex
+        backgroundColor="background.main"
+        marginBottom={16}
+        flexDirection={"row"}
+        alignItems="center"
+        zIndex={10}
+      >
         <SearchInput
           containerStyle={{
             flexGrow: 1,
+            flexShrink: 1,
             width: 100,
           }}
           testID="platform-catalog-search-input"
@@ -26,6 +36,18 @@ export function SearchBar({
           onFocus={onFocus}
           autoCorrect={false}
         />
+        {onCancel && (
+          <TouchableOpacity
+            onPress={onCancel}
+            testID="catalog-search-cancel"
+            accessibilityLabel={t("common.cancel")}
+            accessibilityRole="button"
+          >
+            <Text variant="body" fontWeight="semiBold" color="primary.c80" marginLeft={4}>
+              {t("common.cancel")}
+            </Text>
+          </TouchableOpacity>
+        )}
       </Flex>
     </>
   );

--- a/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/Search/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/Search/index.tsx
@@ -12,7 +12,7 @@ import Illustration from "~/images/illustration/Illustration";
 import { ManifestList } from "../ManifestList";
 import { SearchBar } from "./SearchBar";
 import { Disclaimer } from "../../hooks";
-import { Search as SearchType } from "../../types";
+import type { Search as SearchType } from "../../types";
 
 export * from "./SearchBar";
 
@@ -22,14 +22,13 @@ const noResultIllustration = {
 };
 
 interface Props {
-  title: React.ReactNode;
-  subtitle?: React.ReactNode;
-  listTitle?: React.ReactNode;
+  title?: React.ReactNode;
   disclaimer: Pick<Disclaimer, "onSelect">;
   search: SearchType;
+  isLegacySearch?: boolean;
 }
 
-export function Search({ title, disclaimer, search }: Props) {
+export function Search({ title, disclaimer, search, isLegacySearch = true }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
 
@@ -71,23 +70,29 @@ export function Search({ title, disclaimer, search }: Props) {
   return (
     <>
       <Layout
-        isTitleVisible={true}
+        isTitleVisible={!!title}
         title={title}
         topHeaderContent={
-          <TouchableOpacity
-            hitSlop={{
-              bottom: 10,
-              left: 24,
-              right: 24,
-              top: 10,
-            }}
-            style={{ paddingVertical: 16 }}
-            onPress={search.onCancel}
-          >
-            <ArrowLeft size={18} color={colors.neutral.c100} testID="catalog-search-arrow-left" />
-          </TouchableOpacity>
+          isLegacySearch ? (
+            <TouchableOpacity
+              hitSlop={{
+                bottom: 10,
+                left: 24,
+                right: 24,
+                top: 10,
+              }}
+              style={{ paddingVertical: 16 }}
+              onPress={search.onCancel}
+              accessibilityLabel={t("common.back")}
+              accessibilityRole="button"
+            >
+              <ArrowLeft size={18} color={colors.neutral.c100} testID="catalog-search-arrow-left" />
+            </TouchableOpacity>
+          ) : undefined
         }
-        searchContent={<SearchBar search={search} />}
+        searchContent={
+          <SearchBar search={search} onCancel={isLegacySearch ? undefined : search.onCancel} />
+        }
         bodyContent={
           search.isSearching ? (
             <Flex marginTop={100}>

--- a/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/v2/Catalog/index.tsx
@@ -1,8 +1,13 @@
 import React from "react";
-import { View } from "react-native";
-import Animated, { FadeInUp } from "react-native-reanimated";
+import { TouchableOpacity, View } from "react-native";
+import Animated, { FadeIn, FadeInUp, FadeOut } from "react-native-reanimated";
 import { Flex, Text } from "@ledgerhq/native-ui";
+import { useTheme } from "styled-components/native";
 import { useTranslation } from "~/context/Locale";
+import { useNavigation, useRoute } from "@react-navigation/native";
+import { NavigationProps } from "../types";
+import ArrowLeft from "~/icons/ArrowLeft";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import TabBarSafeAreaView from "~/components/TabBar/TabBarSafeAreaView";
 import { Layout } from "./Layout";
 import { useCatalog } from "../hooks";
@@ -13,13 +18,16 @@ import { RecentlyUsed } from "./RecentlyUsed";
 import { CatalogSection } from "./CatalogSection";
 import { DAppDisclaimer } from "./DAppDisclaimer";
 import { LocalLiveApp } from "./LocalLiveApp";
-import { useRoute } from "@react-navigation/native";
 
 export function Catalog() {
   const { t } = useTranslation();
+  const { colors } = useTheme();
+  const navigation = useNavigation<NavigationProps["navigation"]>();
   const title = t("browseWeb3.catalog.title");
 
   const { params } = useRoute();
+
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
 
   const deeplinkInitialCategory =
     params && "category" in params && typeof params.category === "string" ? params.category : null;
@@ -36,11 +44,42 @@ export function Catalog() {
       </View>
 
       {search.isActive ? (
-        <Search title={title} disclaimer={disclaimer} search={search} />
+        <Animated.View
+          key="search-mode"
+          entering={FadeIn.duration(300)}
+          exiting={FadeOut.duration(200)}
+          style={{ flex: 1 }}
+        >
+          <Search
+            title={shouldDisplayWallet40MainNav ? undefined : title}
+            disclaimer={disclaimer}
+            search={search}
+            isLegacySearch={!shouldDisplayWallet40MainNav}
+          />
+        </Animated.View>
       ) : (
-        <>
+        <Animated.View
+          key="normal-mode"
+          entering={FadeIn.duration(300)}
+          exiting={FadeOut.duration(200)}
+          style={{ flex: 1 }}
+        >
           <Layout
             listStickyElement={[2]}
+            topHeaderContent={
+              shouldDisplayWallet40MainNav ? (
+                <TouchableOpacity
+                  hitSlop={{ bottom: 10, left: 24, right: 24, top: 10 }}
+                  style={{ paddingVertical: 16 }}
+                  onPress={() => navigation.goBack()}
+                  accessibilityLabel={t("common.back")}
+                  accessibilityRole="button"
+                >
+                  <ArrowLeft size={18} color={colors.neutral.c100} testID="catalog-back-arrow" />
+                </TouchableOpacity>
+              ) : undefined
+            }
+            title={shouldDisplayWallet40MainNav ? title : undefined}
             middleHeaderContent={
               <>
                 <Flex marginBottom={16}>
@@ -68,7 +107,7 @@ export function Catalog() {
               </Animated.View>
             }
           />
-        </>
+        </Animated.View>
       )}
     </TabBarSafeAreaView>
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _UI/navigation changes, not covered by automated tests._
- [x] **Impact of the changes:**
  - Discover screen (Catalog v2) — normal mode and search mode
  - Only when the \`lwmWallet40.mainNavigation\` feature flag is active
  - No impact on legacy behavior

### 📝 Description

With the new Wallet 4.0 navigation, the Discover screen is no longer a bottom tab — it is accessed via the Compass icon in the TopBar and pushed onto the navigation stack. This broke the navigation: there was no back button on the first page, and in search mode the left arrow was closing the search instead of navigating back.

**Solution:**
- Added a permanent back arrow header (\`navigation.goBack()\`) to the Catalog v2 when \`shouldDisplayWallet40MainNav\` is active
- In search mode: the back arrow navigates to the previous screen, and an inline **Cancel** button (right of the SearchBar) allows exiting search mode
- Smooth transition between normal and search modes using \`FadeIn\`/\`FadeOut\` animations (Reanimated) to avoid the visual blink on state change
- Legacy behavior unchanged when the FF is inactive


https://github.com/user-attachments/assets/61e3a399-79b5-4347-9199-533c0038d993


### ❓ Context

- **JIRA or GitHub link**: [LIVE-26370](https://ledgerhq.atlassian.net/browse/LIVE-26370)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-26370]: https://ledgerhq.atlassian.net/browse/LIVE-26370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ