### PR TITLE
test(e2e): update USDT subAccount test to use ETH_USDT_3

### DIFF
--- a/.changeset/update-usdt-e2e-account.md
+++ b/.changeset/update-usdt-e2e-account.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+---
+
+Update USDT e2e test account to use ETH_USDT_3

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -517,7 +517,7 @@ for (const transaction of tokenTransactionInvalid) {
 test.describe("Send token (subAccount) - valid address & amount input", () => {
   const tokenTransactionValid = new Transaction(
     TokenAccount.ETH_USDT_1,
-    TokenAccount.ETH_USDT_2,
+    TokenAccount.ETH_USDT_3,
     "1",
     Fee.MEDIUM,
   );

--- a/libs/ledger-live-common/src/e2e/enum/Account.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Account.ts
@@ -326,6 +326,15 @@ export class TokenAccount extends Account {
     Account.ETH_2,
   );
 
+  static readonly ETH_USDT_3 = new TokenAccount(
+    Currency.ETH_USDT,
+    "Tether USD 3",
+    2,
+    Account.ETH_3.accountPath,
+    TokenType.ERC20,
+    Account.ETH_3,
+  );
+
   static readonly SOL_GIGA_1 = new TokenAccount(
     Currency.SOL_GIGA,
     "GIGACHAD 1",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - E2E subAccount valid address test for USDT token transactions
  - New `ETH_USDT_3` token account definition in test fixtures

### 📝 Description

The USDT subAccount e2e test was using `ETH_USDT_2` as the recipient address, which needed to be updated.

This PR adds a new `ETH_USDT_3` token account (backed by `ETH_3`) and updates the subAccount valid address e2e test to use it as the recipient instead of `ETH_USDT_2`.

https://github.com/LedgerHQ/ledger-live/actions/runs/22136466109

### ❓ Context

- **Packages impacted**: `@ledgerhq/live-common`, `ledger-live-desktop`

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)