### PR TITLE
Feat/live 24884 cold start

### DIFF
--- a/.changeset/quick-lamps-listen.md
+++ b/.changeset/quick-lamps-listen.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): balance loading state on coldstart

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/index.test.tsx
@@ -1,8 +1,12 @@
 import React from "react";
-import BigNumber from "bignumber.js";
 import { render, screen } from "tests/testSetup";
 import userEvent from "@testing-library/user-event";
 import TopBar from "../index";
+import { BTC_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
+
+jest.mock("~/renderer/families", () => ({
+  getLLDCoinFamily: () => ({}),
+}));
 
 jest.mock("@braze/web-sdk", () => ({
   getCachedContentCards: () => ({ cards: [] }),
@@ -15,27 +19,6 @@ jest.mock("@braze/web-sdk", () => ({
   logCardDismissal: () => {},
   logContentCardClick: () => {},
 }));
-
-const mockBalance = new BigNumber(0);
-
-const mockAccount = {
-  id: "account1",
-  balance: mockBalance,
-  spendableBalance: mockBalance,
-  swapHistory: [],
-  operations: [],
-  operationsCount: 0,
-  pendingOperations: [],
-  lastSyncDate: new Date(),
-  currency: {
-    id: "bitcoin",
-    type: "CryptoCurrency",
-    ticker: "BTC",
-    name: "Bitcoin",
-    family: "bitcoin",
-    blockAvgTime: 10 * 60,
-  },
-};
 
 describe("TopBar", () => {
   const getDefaultInitialState = (overrides = {}) => ({
@@ -60,7 +43,7 @@ describe("TopBar", () => {
   it("renders ActivityIndicator when hasAccounts is true", () => {
     render(<TopBar />, {
       initialState: getDefaultInitialState({
-        accounts: [mockAccount],
+        accounts: [BTC_ACCOUNT],
       }),
     });
 
@@ -78,7 +61,7 @@ describe("TopBar", () => {
   it("renders all slot actions when hasAccounts is true", () => {
     render(<TopBar />, {
       initialState: getDefaultInitialState({
-        accounts: [mockAccount],
+        accounts: [BTC_ACCOUNT],
       }),
     });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useAccountsSyncStatus.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useAccountsSyncStatus.test.ts
@@ -11,6 +11,7 @@ const createAccountWithUpToDateCheck = (
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   account: {
     id,
+    type: "Account" as const,
     currency: { ticker },
     lastSyncDate: new Date(),
   } as AccountWithUpToDateCheck["account"],

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
@@ -1,110 +1,167 @@
-import BigNumber from "bignumber.js";
 import { Refresh } from "@ledgerhq/lumen-ui-react/symbols";
 import { renderHook, act } from "tests/testSetup";
 import { useActivityIndicator } from "../useActivityIndicator";
+import { BTC_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
 
-jest.mock("../useAccountsSyncStatus");
-jest.mock("../useActivityIndicatorTooltip");
+const mockBridgeSync = jest.fn();
+const mockCvPoll = jest.fn();
+const mockOnUserRefresh = jest.fn();
+
+// Bridge: useActivityIndicator + useAccountsSyncStatus both use this package
 jest.mock("@ledgerhq/live-common/bridge/react/index", () => ({
-  useBridgeSync: () => jest.fn(),
-  useGlobalSyncState: () => ({ pending: false, error: null }),
+  useBridgeSync: jest.fn(() => mockBridgeSync),
+  useGlobalSyncState: jest.fn(() => ({ pending: false, error: null })),
+  useBatchAccountsSyncState: jest.fn(({ accounts }: { accounts: { id: string }[] }) =>
+    accounts.map(account => ({ syncState: { pending: false, error: null }, account })),
+  ),
 }));
-jest.mock("@ledgerhq/live-countervalues-react", () => {
-  const actual = jest.requireActual<typeof import("@ledgerhq/live-countervalues-react")>(
+
+jest.mock("@ledgerhq/live-countervalues-react", () => ({
+  ...jest.requireActual<typeof import("@ledgerhq/live-countervalues-react")>(
     "@ledgerhq/live-countervalues-react",
-  );
-  return {
-    ...actual,
-    useCountervaluesPolling: () => ({ pending: false, error: null, poll: jest.fn() }),
-  };
-});
+  ),
+  useCountervaluesPolling: jest.fn(() => ({
+    pending: false,
+    error: null,
+    poll: mockCvPoll,
+    start: jest.fn(),
+    stop: jest.fn(),
+    wipe: jest.fn(),
+  })),
+}));
+
 jest.mock("LLD/features/WalletSync/components/WalletSyncContext", () => ({
-  useWalletSyncUserState: () => ({
+  useWalletSyncUserState: jest.fn(() => ({
     visualPending: false,
     walletSyncError: null,
-    onUserRefresh: jest.fn(),
-  }),
+    onUserRefresh: mockOnUserRefresh,
+  })),
 }));
 
-const mockUseAccountsSyncStatus = jest.requireMock(
-  "../useAccountsSyncStatus",
-).useAccountsSyncStatus;
-const mockUseActivityIndicatorTooltip = jest.requireMock(
-  "../useActivityIndicatorTooltip",
-).useActivityIndicatorTooltip;
+jest.mock("LLD/hooks/usePortfolioSyncStatus", () => ({
+  usePortfolioSyncStatus: jest.fn(() => ({ isColdStart: false })),
+}));
 
-const getDefaultInitialState = (overrides: Record<string, unknown> = {}) => ({
-  accounts: [],
-  ...overrides,
-});
+const mockUseGlobalSyncState = jest.requireMock(
+  "@ledgerhq/live-common/bridge/react/index",
+).useGlobalSyncState;
+const mockUseCountervaluesPolling = jest.requireMock(
+  "@ledgerhq/live-countervalues-react",
+).useCountervaluesPolling;
+const mockUseWalletSyncUserState = jest.requireMock(
+  "LLD/features/WalletSync/components/WalletSyncContext",
+).useWalletSyncUserState;
+const mockUsePortfolioSyncStatus = jest.requireMock(
+  "LLD/hooks/usePortfolioSyncStatus",
+).usePortfolioSyncStatus;
 
-const mockAccount = {
-  id: "a1",
-  balance: new BigNumber(0),
-  spendableBalance: new BigNumber(0),
-  swapHistory: [],
-  operations: [],
-  operationsCount: 0,
-  pendingOperations: [],
-  lastSyncDate: new Date(),
-  currency: {
-    id: "bitcoin",
-    type: "CryptoCurrency",
-    ticker: "BTC",
-    name: "Bitcoin",
-    family: "bitcoin",
-    blockAvgTime: 10 * 60,
-  },
-};
+const defaultInitialState: { accounts: unknown[] } = { accounts: [] };
 
 describe("useActivityIndicator", () => {
-  const mockBridgeSync = jest.fn();
-  const mockCvPoll = jest.fn();
-  const mockOnUserRefresh = jest.fn();
-
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.requireMock("@ledgerhq/live-common/bridge/react/index").useBridgeSync = () =>
-      mockBridgeSync;
-    jest.requireMock("@ledgerhq/live-countervalues-react").useCountervaluesPolling = () => ({
+    mockUseGlobalSyncState.mockReturnValue({ pending: false, error: null });
+    mockUseCountervaluesPolling.mockReturnValue({
       pending: false,
       error: null,
       poll: mockCvPoll,
+      start: jest.fn(),
+      stop: jest.fn(),
+      wipe: jest.fn(),
     });
-    jest.requireMock(
-      "LLD/features/WalletSync/components/WalletSyncContext",
-    ).useWalletSyncUserState = () => ({
+    mockUseWalletSyncUserState.mockReturnValue({
       visualPending: false,
       walletSyncError: null,
       onUserRefresh: mockOnUserRefresh,
     });
-    mockUseAccountsSyncStatus.mockReturnValue({
-      allAccounts: [{ id: "a1", lastSyncDate: new Date(), currency: { ticker: "BTC" } }],
-      listOfErrorAccountNames: "",
-      areAllAccountsUpToDate: true,
-    });
-    mockUseActivityIndicatorTooltip.mockReturnValue("Tap to refresh");
+    mockUsePortfolioSyncStatus.mockReturnValue({ isColdStart: false });
   });
 
-  it("returns hasAccounts, handleSync, isError, isRotating, isDisabled, tooltip, icon", () => {
+  it("returns hasAccounts, handleSync, isError, isRotating, tooltip, icon", () => {
     const { result } = renderHook(() => useActivityIndicator(), {
-      initialState: getDefaultInitialState({ accounts: [mockAccount] }),
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
     });
 
     expect(result.current).toMatchObject({
       hasAccounts: true,
       isError: false,
       isRotating: false,
-      isDisabled: false,
-      tooltip: "Tap to refresh",
     });
+    expect(result.current.tooltip).toBeDefined();
+    expect(typeof result.current.tooltip).toBe("string");
     expect(result.current.handleSync).toBeDefined();
     expect(result.current.icon).toBe(Refresh);
   });
 
-  it("handleSync calls onUserRefresh, poll, bridgeSync and track", () => {
+  it("returns isRotating false when only countervalues polling is pending (no user click)", () => {
+    mockUseCountervaluesPolling.mockReturnValue({
+      pending: true,
+      error: null,
+      poll: mockCvPoll,
+      start: jest.fn(),
+      stop: jest.fn(),
+      wipe: jest.fn(),
+    });
+
     const { result } = renderHook(() => useActivityIndicator(), {
-      initialState: getDefaultInitialState({ accounts: [mockAccount] }),
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    expect(result.current.isRotating).toBe(false);
+  });
+
+  it("returns isRotating true on cold start when portfolio balance is not available", () => {
+    mockUsePortfolioSyncStatus.mockReturnValue({ isColdStart: true });
+
+    const { result } = renderHook(() => useActivityIndicator(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    expect(result.current.isRotating).toBe(true);
+    expect(result.current.tooltip).toBeNull();
+  });
+
+  it("returns isRotating false when only global sync state is pending (no user click)", () => {
+    mockUseGlobalSyncState.mockReturnValue({ pending: true, error: null });
+
+    const { result } = renderHook(() => useActivityIndicator(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    expect(result.current.isRotating).toBe(false);
+  });
+
+  it("returns isRotating false when only wallet sync visualPending is true (no user click)", () => {
+    mockUseWalletSyncUserState.mockReturnValue({
+      visualPending: true,
+      walletSyncError: null,
+      onUserRefresh: mockOnUserRefresh,
+    });
+
+    const { result } = renderHook(() => useActivityIndicator(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    expect(result.current.isRotating).toBe(false);
+  });
+
+  it("returns isRotating false after user click when sync is not pending", () => {
+    const { result } = renderHook(() => useActivityIndicator(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    expect(result.current.isRotating).toBe(false);
+
+    act(() => {
+      result.current.handleSync();
+    });
+
+    expect(result.current.isRotating).toBe(false);
+  });
+
+  it("handleSync calls onUserRefresh, cvPolling.poll, bridgeSync and track", () => {
+    const { result } = renderHook(() => useActivityIndicator(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
     });
     const { track } = jest.requireMock("~/renderer/analytics/segment");
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
@@ -29,7 +29,6 @@ describe("useTopBarViewModel", () => {
     mockUseActivityIndicator.mockReturnValue({
       hasAccounts: true,
       handleSync: mockHandleSync,
-      isDisabled: false,
       isRotating: false,
       isError: false,
       tooltip: "Refresh",
@@ -79,7 +78,6 @@ describe("useTopBarViewModel", () => {
     mockUseActivityIndicator.mockReturnValue({
       hasAccounts: false,
       handleSync: mockHandleSync,
-      isDisabled: false,
       isRotating: false,
       isError: false,
       tooltip: "Refresh",
@@ -98,11 +96,10 @@ describe("useTopBarViewModel", () => {
     expect(slotLabels).toEqual(["notification", "discreet", "settings", "my ledger"]);
   });
 
-  it("passes isDisabled from useActivityIndicator as isInteractive false on sync action", () => {
+  it("passes isRotating from useActivityIndicator as isInteractive false on sync action", () => {
     mockUseActivityIndicator.mockReturnValue({
       hasAccounts: true,
       handleSync: mockHandleSync,
-      isDisabled: true,
       isRotating: true,
       isError: true,
       tooltip: "Error",

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useReducer, useState } from "react";
 import { useSelector } from "LLD/hooks/redux";
 import { hasAccountsSelector, isUpToDateSelector } from "~/renderer/reducers/accounts";
 import { useWalletSyncUserState } from "LLD/features/WalletSync/components/WalletSyncContext";
@@ -7,6 +7,7 @@ import { useBridgeSync, useGlobalSyncState } from "@ledgerhq/live-common/bridge/
 import { getEnv } from "@ledgerhq/live-env";
 import { track } from "~/renderer/analytics/segment";
 
+import { usePortfolioSyncStatus } from "LLD/hooks/usePortfolioSyncStatus";
 import { useAccountsSyncStatus } from "./useAccountsSyncStatus";
 import { useActivityIndicatorTooltip } from "./useActivityIndicatorTooltip";
 import { getActivityIndicatorIcon } from "../utils/getActivityIndicatorIcon";
@@ -21,10 +22,11 @@ export const useActivityIndicator = () => {
   const accountsWithUpToDateCheck = useSelector(isUpToDateSelector);
   const wsUserState = useWalletSyncUserState();
   const cvPolling = useCountervaluesPolling();
+  const { isColdStart } = usePortfolioSyncStatus();
   const bridgeSync = useBridgeSync();
   const globalSyncState = useGlobalSyncState();
   const [lastClickTime, setLastClickTime] = useState(0);
-  const [, setTick] = useState(0);
+  const [, forceTooltipUpdate] = useReducer((tick: number) => tick + 1, 0);
 
   const { allAccounts, listOfErrorAccountNames, areAllAccountsUpToDate } =
     useAccountsSyncStatus(accountsWithUpToDateCheck);
@@ -34,7 +36,7 @@ export const useActivityIndicator = () => {
   const needsTooltipUpdates = hasAccounts && lastSyncMs > 0;
   useEffect(() => {
     if (!needsTooltipUpdates) return;
-    const id = setInterval(() => setTick(t => t + 1), TOOLTIP_UPDATE_INTERVAL_MS);
+    const id = setInterval(forceTooltipUpdate, TOOLTIP_UPDATE_INTERVAL_MS);
     return () => clearInterval(id);
   }, [needsTooltipUpdates]);
 
@@ -47,8 +49,7 @@ export const useActivityIndicator = () => {
     ? PLAYWRIGHT_CLICK_SPIN_DURATION_MS
     : USER_CLICK_SPIN_DURATION_MS;
   const isUserClick = Date.now() - lastClickTime < userClickSpinMs;
-  const isRotating = isPending && isUserClick;
-  const isDisabled = isRotating;
+  const isRotating = isColdStart || (isUserClick && isPending);
 
   const icon = getActivityIndicatorIcon(isError, isRotating);
   const tooltip = useActivityIndicatorTooltip({
@@ -75,7 +76,6 @@ export const useActivityIndicator = () => {
     handleSync,
     isError,
     isRotating,
-    isDisabled,
     tooltip,
     icon,
   };

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
@@ -9,7 +9,7 @@ const useTopBarViewModel = () => {
   const {
     hasAccounts,
     handleSync,
-    isDisabled,
+    isRotating,
     icon: activityIndicatorIcon,
     tooltip: activityIndicatorTooltip,
   } = useActivityIndicator();
@@ -25,7 +25,7 @@ const useTopBarViewModel = () => {
               label: "synchronize",
               tooltip: activityIndicatorTooltip,
               icon: activityIndicatorIcon,
-              isInteractive: !isDisabled,
+              isInteractive: !isRotating,
               onClick: handleSync,
             },
           },

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -12,6 +12,7 @@ import type {
 } from "@ledgerhq/types-live";
 import { PortfolioView } from "../PortfolioView";
 import * as portfolioReact from "@ledgerhq/live-countervalues-react/portfolio";
+import * as countervaluesReact from "@ledgerhq/live-countervalues-react";
 import { useNavigate } from "react-router";
 import { BTC_ACCOUNT, EMPTY_BTC_ACCOUNT } from "../../__mocks__/accounts.mock";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
@@ -75,7 +76,17 @@ jest.mock("@ledgerhq/live-common/exchange/swap/hooks/index", () => ({
   }),
 }));
 
-const mockUsePortfolio = jest.spyOn(portfolioReact, "usePortfolio");
+const mockUsePortfolioThrottled = jest.spyOn(portfolioReact, "usePortfolioThrottled");
+const mockUseCountervaluesPolling = jest.spyOn(countervaluesReact, "useCountervaluesPolling");
+
+const defaultPollingMock = {
+  pending: false,
+  error: null,
+  poll: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+  wipe: jest.fn(),
+};
 
 const createPortfolioMock = (countervalueChange: {
   percentage: number | null;
@@ -114,7 +125,8 @@ describe("PortfolioView", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUsePortfolio.mockReturnValue(defaultPortfolioMock);
+    mockUsePortfolioThrottled.mockReturnValue(defaultPortfolioMock);
+    mockUseCountervaluesPolling.mockReturnValue(defaultPollingMock);
     mockedUseNavigate.mockReturnValue(mockNavigate);
   });
 
@@ -122,13 +134,9 @@ describe("PortfolioView", () => {
     server.resetHandlers();
   });
 
-  it("should render BannerSection", () => {
+  it("should render BannerSection and portfolio container", () => {
     render(<PortfolioView {...defaultProps} />);
     expect(screen.getByTestId("banner-section")).toBeVisible();
-  });
-
-  it("should render portfolio container", () => {
-    render(<PortfolioView {...defaultProps} />);
     expect(screen.getByTestId("portfolio-container")).toBeVisible();
   });
 
@@ -252,7 +260,7 @@ describe("PortfolioView", () => {
       expect(balanceElement).not.toHaveTextContent("$1,000.00");
     });
 
-    it("should display actual balance when discreet mode is disabled", () => {
+    it("should render Balance with total balance and show actual amount when discreet mode is disabled", () => {
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
         initialState: {
           accounts: [BTC_ACCOUNT],
@@ -265,17 +273,75 @@ describe("PortfolioView", () => {
         },
       });
 
+      expect(screen.getByTestId("portfolio-balance")).toBeVisible();
       const balanceElement = screen.getByTestId("portfolio-total-balance");
       // TODO: Update once lumen releases a fix for the DisplayAmount animation
       // See LIVE-26796
       expect(balanceElement).toHaveAttribute("aria-label", "$ 1,000.00");
       expect(balanceElement).not.toHaveTextContent("••••"); // Ensure no placeholders
     });
+
+    it("should not show loading when countervalues are polling but balance is already available", () => {
+      mockUseCountervaluesPolling.mockReturnValue({
+        ...defaultPollingMock,
+        pending: true,
+      });
+
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+        initialState: {
+          accounts: [BTC_ACCOUNT],
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+            lastSeenDevice: MOCK_LAST_SEEN_DEVICE,
+            overriddenFeatureFlags: {
+              ...INITIAL_STATE.overriddenFeatureFlags,
+              lwdWallet40: {
+                enabled: true,
+                params: { balanceRefreshRework: true },
+              },
+            },
+          },
+        },
+      });
+
+      expect(screen.getByTestId("portfolio-balance")).toBeVisible();
+    });
+
+    it("should display loading state when balance is not yet available", () => {
+      mockUsePortfolioThrottled.mockReturnValue({
+        ...defaultPortfolioMock,
+        balanceAvailable: false,
+      });
+
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+        initialState: {
+          accounts: [BTC_ACCOUNT],
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+            lastSeenDevice: MOCK_LAST_SEEN_DEVICE,
+            overriddenFeatureFlags: {
+              ...INITIAL_STATE.overriddenFeatureFlags,
+              lwdWallet40: {
+                enabled: true,
+                params: { balanceRefreshRework: true },
+              },
+            },
+          },
+        },
+      });
+
+      expect(screen.getByTestId("portfolio-balance")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-trend")).toBeNull();
+    });
   });
 
   describe("Trend", () => {
     it("should render Trend with positive percentage and display separator with Today label", () => {
-      mockUsePortfolio.mockReturnValue(createPortfolioMock({ percentage: 0.0542, value: 5000 }));
+      mockUsePortfolioThrottled.mockReturnValue(
+        createPortfolioMock({ percentage: 0.0542, value: 5000 }),
+      );
 
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
         initialState: {
@@ -294,7 +360,9 @@ describe("PortfolioView", () => {
     });
 
     it("should render Trend with negative percentage", () => {
-      mockUsePortfolio.mockReturnValue(createPortfolioMock({ percentage: -0.0315, value: -3000 }));
+      mockUsePortfolioThrottled.mockReturnValue(
+        createPortfolioMock({ percentage: -0.0315, value: -3000 }),
+      );
 
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
         initialState: {
@@ -312,7 +380,7 @@ describe("PortfolioView", () => {
     });
 
     it("should show 0% when percentage is zero", () => {
-      mockUsePortfolio.mockReturnValue(createPortfolioMock({ percentage: 0, value: 0 }));
+      mockUsePortfolioThrottled.mockReturnValue(createPortfolioMock({ percentage: 0, value: 0 }));
 
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework />, {
         initialState: {
@@ -460,13 +528,9 @@ describe("PortfolioView", () => {
     });
   });
 
-  it("should not render FeaturedButtons", () => {
+  it("should not render legacy dashboard components (FeaturedButtons, BalanceSummary)", () => {
     render(<PortfolioView {...defaultProps} />);
     expect(screen.queryByTestId("featured-buttons")).toBeNull();
-  });
-
-  it("should not render BalanceSummary", () => {
-    render(<PortfolioView {...defaultProps} />);
     expect(screen.queryByTestId("balance-summary")).toBeNull();
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/BalanceView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/BalanceView.tsx
@@ -10,13 +10,14 @@ export const BalanceView = ({
   valueChange,
   navigateToAnalytics,
   handleKeyDown,
+  isColdStart,
+  shouldDisplayBalanceRefreshRework,
 }: BalanceViewProps) => {
   return (
-    <div
-      className="flex cursor-pointer items-baseline gap-12"
+    <button
+      type="button"
+      className="flex cursor-pointer items-baseline gap-12 border-0 bg-transparent p-0 text-inherit"
       data-testid="portfolio-balance"
-      role="button"
-      tabIndex={0}
       onClick={navigateToAnalytics}
       onKeyDown={handleKeyDown}
       aria-label="View portfolio analytics"
@@ -25,9 +26,11 @@ export const BalanceView = ({
         value={balance}
         formatter={formatter}
         hidden={discreet}
+        animate={shouldDisplayBalanceRefreshRework}
+        loading={shouldDisplayBalanceRefreshRework && isColdStart}
         data-testid="portfolio-total-balance"
       />
-      <Trend valueChange={valueChange} />
-    </div>
+      {!isColdStart && <Trend valueChange={valueChange} />}
+    </button>
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
@@ -7,7 +7,9 @@ export interface BalanceViewProps {
   readonly discreet: boolean;
   readonly valueChange: ValueChange;
   readonly navigateToAnalytics: () => void;
-  readonly handleKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+  readonly handleKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
+  readonly isColdStart: boolean;
+  readonly shouldDisplayBalanceRefreshRework: boolean;
 }
 
 export type BalanceViewModelResult = BalanceViewProps & {

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
@@ -2,10 +2,14 @@ import { renderHook } from "tests/testSetup";
 import { useBalanceViewModel } from "../useBalanceViewModel";
 import * as portfolioModule from "@ledgerhq/live-countervalues-react/portfolio";
 import { Portfolio } from "@ledgerhq/types-live";
+import { BTC_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
 
-jest.mock("@ledgerhq/live-countervalues-react/portfolio");
+jest.mock("@ledgerhq/live-countervalues-react/portfolio", () => ({
+  usePortfolioThrottled: jest.fn(),
+}));
 
-const mockUsePortfolio = jest.mocked(portfolioModule.usePortfolio);
+const mockUsePortfolioThrottled = jest.mocked(portfolioModule.usePortfolioThrottled);
 
 const mockCounterValue = {
   type: "FiatCurrency" as const,
@@ -27,60 +31,95 @@ const mockPortfolio: Portfolio = {
   countervalueChange: { percentage: 5.5, value: 100 },
 };
 
+const wallet40WithBalanceRefreshRework = {
+  ...INITIAL_STATE.overriddenFeatureFlags,
+  lwdWallet40: {
+    enabled: true,
+    params: { balanceRefreshRework: true },
+  },
+};
+
 const initialState = {
   settings: {
+    ...INITIAL_STATE,
     counterValue: "USD",
     counterValueCurrency: mockCounterValue,
     selectedTimeRange: "week" as const,
+    overriddenFeatureFlags: wallet40WithBalanceRefreshRework,
   },
 };
 
 describe("useBalanceViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUsePortfolio.mockReturnValue(mockPortfolio);
+    mockUsePortfolioThrottled.mockReturnValue(mockPortfolio);
   });
 
-  it("should return portfolio data correctly", () => {
+  it("returns balance data and flags when balance is available", () => {
     const { result } = renderHook(() => useBalanceViewModel(), { initialState });
 
-    expect(result.current.formatter).toBeDefined();
     expect(result.current.balance).toBe(1500);
-    const formatted = result.current.formatter(result.current.balance);
-    expect(formatted.integerPart).toContain("15");
+    expect(result.current.formatter).toBeDefined();
+    expect(result.current.formatter(result.current.balance).integerPart).toContain("15");
     expect(result.current.valueChange).toEqual(mockPortfolio.countervalueChange);
+    expect(result.current.isColdStart).toBe(false);
+    expect(result.current.shouldDisplayBalanceRefreshRework).toBe(true);
+    expect(result.current.hasAccount).toBeDefined();
+    expect(result.current.hasOnboardedDevice).toBeDefined();
   });
 
-  it("should return 0 when balance history is empty", () => {
-    mockUsePortfolio.mockReturnValue({
-      ...mockPortfolio,
-      balanceHistory: [],
-    });
+  it("returns balance 0 when balance history is empty", () => {
+    mockUsePortfolioThrottled.mockReturnValue({ ...mockPortfolio, balanceHistory: [] });
 
     const { result } = renderHook(() => useBalanceViewModel(), { initialState });
 
     expect(result.current.balance).toBe(0);
-    const formatted = result.current.formatter(result.current.balance);
-    expect(formatted.integerPart).toContain("0");
+    expect(result.current.formatter(result.current.balance).integerPart).toContain("0");
   });
 
-  it("should use 'day' range by default", () => {
+  it("uses day range by default", () => {
     renderHook(() => useBalanceViewModel(), { initialState });
 
-    expect(portfolioModule.usePortfolio).toHaveBeenCalledWith(
+    expect(portfolioModule.usePortfolioThrottled).toHaveBeenCalledWith(
       expect.objectContaining({ range: "day" }),
     );
   });
 
-  it("should use selected time range when useLegacyRange is true", () => {
-    renderHook(() => useBalanceViewModel({ useLegacyRange: true }), {
+  it("uses selected time range when legacyRange is true", () => {
+    renderHook(() => useBalanceViewModel({ legacyRange: true }), {
       initialState: {
         settings: { ...initialState.settings, selectedTimeRange: "month" as const },
       },
     });
 
-    expect(portfolioModule.usePortfolio).toHaveBeenCalledWith(
+    expect(portfolioModule.usePortfolioThrottled).toHaveBeenCalledWith(
       expect.objectContaining({ range: "month" }),
     );
+  });
+
+  it("returns isColdStart true on cold start when portfolio balance is not yet available", () => {
+    mockUsePortfolioThrottled.mockReturnValue({ ...mockPortfolio, balanceAvailable: false });
+
+    const { result } = renderHook(() => useBalanceViewModel(), {
+      initialState: { ...initialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    expect(result.current.isColdStart).toBe(true);
+  });
+
+  it("returns shouldDisplayBalanceRefreshRework false when lwdWallet40 has balanceRefreshRework false", () => {
+    const { result } = renderHook(() => useBalanceViewModel(), {
+      initialState: {
+        settings: {
+          ...initialState.settings,
+          overriddenFeatureFlags: {
+            ...wallet40WithBalanceRefreshRework,
+            lwdWallet40: { enabled: true, params: { balanceRefreshRework: false } },
+          },
+        },
+      },
+    });
+
+    expect(result.current.shouldDisplayBalanceRefreshRework).toBe(false);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -1,15 +1,12 @@
 import { useCallback } from "react";
 import { useSelector } from "LLD/hooks/redux";
-import { usePortfolio as usePortfolioRaw } from "@ledgerhq/live-countervalues-react/portfolio";
 import {
-  counterValueCurrencySelector,
-  selectedTimeRangeSelector,
+  hasOnboardedDeviceSelector,
   localeSelector,
   discreetModeSelector,
-  hasOnboardedDeviceSelector,
 } from "~/renderer/reducers/settings";
-import { accountsSelector } from "~/renderer/reducers/accounts";
 import { useAccountStatus } from "LLD/hooks/useAccountStatus";
+import { usePortfolioSyncStatus } from "LLD/hooks/usePortfolioSyncStatus";
 import { BalanceViewModelResult } from "../components/Balance/types";
 import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
@@ -18,32 +15,24 @@ import BigNumber from "bignumber.js";
 import { track } from "~/renderer/analytics/segment";
 import { PORTFOLIO_TRACKING_PAGE_NAME } from "../utils/constants";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
-
-const NEW_FLOW_RANGE = "day" as const;
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 interface UseBalanceViewModelOptions {
-  readonly useLegacyRange?: boolean;
+  readonly legacyRange?: boolean;
 }
 
 export const useBalanceViewModel = (
   options: UseBalanceViewModelOptions = {},
 ): BalanceViewModelResult => {
-  const { useLegacyRange = false } = options;
+  const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("desktop");
+  const { legacyRange = false } = options;
   const navigate = useNavigate();
-  const accounts = useSelector(accountsSelector);
-  const counterValue = useSelector(counterValueCurrencySelector);
-  const selectedTimeRange = useSelector(selectedTimeRangeSelector);
   const locale = useSelector(localeSelector);
   const discreet = useSelector(discreetModeSelector);
-  const { hasAccount } = useAccountStatus();
   const hasOnboardedDevice = useSelector(hasOnboardedDeviceSelector);
-
-  const range = useLegacyRange ? selectedTimeRange : NEW_FLOW_RANGE;
-
-  const portfolio = usePortfolioRaw({
-    accounts,
-    range,
-    to: counterValue,
+  const { hasAccount } = useAccountStatus();
+  const { portfolio, counterValue, isColdStart } = usePortfolioSyncStatus({
+    legacyRange,
   });
 
   const latestBalanceValue =
@@ -62,7 +51,7 @@ export const useBalanceViewModel = (
   }, [navigate]);
 
   const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
         navigateToAnalytics();
@@ -89,5 +78,7 @@ export const useBalanceViewModel = (
     handleKeyDown,
     hasAccount,
     hasOnboardedDevice,
+    isColdStart,
+    shouldDisplayBalanceRefreshRework,
   };
 };

--- a/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioSyncStatus.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioSyncStatus.test.ts
@@ -1,0 +1,112 @@
+import { renderHook } from "tests/testSetup";
+import { usePortfolioSyncStatus } from "./usePortfolioSyncStatus";
+import * as portfolioModule from "@ledgerhq/live-countervalues-react/portfolio";
+import { Portfolio } from "@ledgerhq/types-live";
+import { BTC_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
+
+jest.mock("@ledgerhq/live-countervalues-react/portfolio", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues-react/portfolio"),
+  usePortfolioThrottled: jest.fn(),
+}));
+
+const mockUsePortfolioThrottled = jest.mocked(portfolioModule.usePortfolioThrottled);
+
+const mockCounterValue = {
+  type: "FiatCurrency" as const,
+  ticker: "USD",
+  name: "US Dollar",
+  units: [{ name: "US Dollar", code: "$", magnitude: 2, showAllDigits: true, prefixCode: true }],
+};
+
+const mockPortfolio: Portfolio = {
+  balanceHistory: [{ date: new Date(), value: 100000 }],
+  balanceAvailable: true,
+  availableAccounts: [],
+  unavailableCurrencies: [],
+  accounts: [],
+  range: "day",
+  histories: [],
+  countervalueReceiveSum: 0,
+  countervalueSendSum: 0,
+  countervalueChange: { percentage: 5.42, value: 5000 },
+};
+
+const defaultInitialState = {
+  settings: {
+    counterValue: "USD",
+    counterValueCurrency: mockCounterValue,
+    selectedTimeRange: "week" as const,
+  },
+  accounts: [],
+};
+
+describe("usePortfolioSyncStatus", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePortfolioThrottled.mockReturnValue(mockPortfolio);
+  });
+
+  it("returns portfolio, counterValue and isColdStart from usePortfolioThrottled and selectors", () => {
+    const { result } = renderHook(() => usePortfolioSyncStatus(), {
+      initialState: defaultInitialState,
+    });
+
+    expect(result.current.portfolio).toEqual(mockPortfolio);
+    expect(result.current.counterValue).toMatchObject({
+      type: "FiatCurrency",
+      ticker: "USD",
+      name: "US Dollar",
+      units: [{ code: "$", magnitude: 2 }],
+    });
+    expect(result.current.isColdStart).toBe(false);
+  });
+
+  it("returns isColdStart true when hasAccounts and balance not yet available", () => {
+    mockUsePortfolioThrottled.mockReturnValue({ ...mockPortfolio, balanceAvailable: false });
+
+    const { result } = renderHook(() => usePortfolioSyncStatus(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    expect(result.current.isColdStart).toBe(true);
+  });
+
+  it("returns isColdStart false when no accounts", () => {
+    mockUsePortfolioThrottled.mockReturnValue({ ...mockPortfolio, balanceAvailable: false });
+
+    const { result } = renderHook(() => usePortfolioSyncStatus(), {
+      initialState: defaultInitialState,
+    });
+
+    expect(result.current.isColdStart).toBe(false);
+  });
+
+  it("returns isColdStart false when balance is available even with accounts", () => {
+    const { result } = renderHook(() => usePortfolioSyncStatus(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    expect(result.current.isColdStart).toBe(false);
+  });
+
+  it("uses day range (DEFAULT_PORTFOLIO_RANGE) when legacyRange is false", () => {
+    renderHook(() => usePortfolioSyncStatus(), { initialState: defaultInitialState });
+
+    expect(portfolioModule.usePortfolioThrottled).toHaveBeenCalledWith(
+      expect.objectContaining({ range: "day" }),
+    );
+  });
+
+  it("uses selectedTimeRange when legacyRange is true", () => {
+    renderHook(() => usePortfolioSyncStatus({ legacyRange: true }), {
+      initialState: {
+        ...defaultInitialState,
+        settings: { ...defaultInitialState.settings, selectedTimeRange: "month" as const },
+      },
+    });
+
+    expect(portfolioModule.usePortfolioThrottled).toHaveBeenCalledWith(
+      expect.objectContaining({ range: "month" }),
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioSyncStatus.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioSyncStatus.ts
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+import { useSelector } from "LLD/hooks/redux";
+import { accountsSelector, hasAccountsSelector } from "~/renderer/reducers/accounts";
+import {
+  counterValueCurrencySelector,
+  selectedTimeRangeSelector,
+} from "~/renderer/reducers/settings";
+import { usePortfolioThrottled } from "@ledgerhq/live-countervalues-react/portfolio";
+import { DEFAULT_PORTFOLIO_RANGE } from "LLD/utils/constants";
+
+export interface UsePortfolioSyncStatusOptions {
+  /** When true, use the user's selected time range instead of DEFAULT_PORTFOLIO_RANGE (e.g. for legacy Portfolio views). */
+  readonly legacyRange?: boolean;
+}
+
+/**
+ * Shared hook for portfolio + countervalue sync status used by Balance (cold start loading)
+ * and TopBar activity indicator (cold start rotation).
+ * Uses throttled portfolio computation and returns isColdStart.
+ */
+export function usePortfolioSyncStatus(options: UsePortfolioSyncStatusOptions = {}) {
+  const { legacyRange = false } = options;
+  const accounts = useSelector(accountsSelector);
+  const counterValue = useSelector(counterValueCurrencySelector);
+  const hasAccounts = useSelector(hasAccountsSelector);
+  const selectedTimeRange = useSelector(selectedTimeRangeSelector);
+  const range = legacyRange ? selectedTimeRange : DEFAULT_PORTFOLIO_RANGE;
+
+  const portfolio = usePortfolioThrottled({
+    accounts,
+    range,
+    to: counterValue,
+  });
+
+  const balanceAvailable = portfolio.balanceAvailable;
+  const isColdStart = hasAccounts && !balanceAvailable;
+
+  return useMemo(
+    () => ({
+      portfolio,
+      counterValue,
+      isColdStart,
+    }),
+    [portfolio, counterValue, isColdStart],
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/utils/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/utils/constants.ts
@@ -1,0 +1,2 @@
+/** Default time range for portfolio/countervalue sync (cold start, balance availability). */
+export const DEFAULT_PORTFOLIO_RANGE = "day" as const;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a minor feature to Ledger Live Desktop that improves the handling and display of the portfolio balance loading state, especially during a cold start (when the app is first opened and balance data is not yet available). It also refactors and extends unit and integration tests to ensure correct UI behavior for loading and balance display. The changes include new logic for balance loading, enhancements to the `useActivityIndicator` hook, and improved test coverage for these scenarios.


https://github.com/user-attachments/assets/58c1df66-3f7f-470e-8922-fdfd434f6ddd


JIRA => https://ledgerhq.atlassian.net/browse/LIVE-24884

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
