### PR TITLE
feat(LIVE-26235): add onboarding has device state to desktop settings

### DIFF
--- a/.changeset/clean-experts-help.md
+++ b/.changeset/clean-experts-help.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat: add flag to track whether the user has onboarded a device

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -392,3 +392,8 @@ export const setHasSeenWalletV4Tour = (hasSeenWalletV4Tour: boolean) => ({
   type: "SET_HAS_SEEN_WALLET_V4_TOUR",
   payload: hasSeenWalletV4Tour,
 });
+
+export const setOnboardingHasDevice = (onboardingHasDevice: boolean) => ({
+  type: "SET_ONBOARDING_HAS_DEVICE",
+  payload: onboardingHasDevice,
+});

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -127,6 +127,7 @@ export type SettingsState = {
   alwaysShowMemoTagInfo: boolean;
   anonymousUserNotifications: { LNSUpsell?: number } & Record<string, number>;
   hasSeenWalletV4Tour: boolean;
+  onboardingHasDevice: boolean;
   doNotAskAgainSkipMemo: boolean;
 };
 
@@ -227,6 +228,7 @@ export const INITIAL_STATE: SettingsState = {
   alwaysShowMemoTagInfo: true,
   anonymousUserNotifications: {},
   hasSeenWalletV4Tour: false,
+  onboardingHasDevice: false,
   doNotAskAgainSkipMemo: false,
 };
 
@@ -286,6 +288,7 @@ type HandlersPayloads = {
     notifications: Record<string, number>;
   };
   SET_HAS_SEEN_WALLET_V4_TOUR: boolean;
+  SET_ONBOARDING_HAS_DEVICE: boolean;
 };
 type SettingsHandlers<PreciseKey = true> = Handlers<SettingsState, HandlersPayloads, PreciseKey>;
 
@@ -505,6 +508,10 @@ const handlers: SettingsHandlers = {
   SET_HAS_SEEN_WALLET_V4_TOUR: (state: SettingsState, { payload }) => ({
     ...state,
     hasSeenWalletV4Tour: payload,
+  }),
+  SET_ONBOARDING_HAS_DEVICE: (state: SettingsState, { payload }) => ({
+    ...state,
+    onboardingHasDevice: payload,
   }),
 };
 
@@ -800,3 +807,4 @@ export const alwaysShowMemoTagInfoSelector = (state: State) => state.settings.al
 export const anonymousUserNotificationsSelector = (state: State) =>
   state.settings.anonymousUserNotifications;
 export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasSeenWalletV4Tour;
+export const onboardingHasDeviceSelector = (state: State) => state.settings.onboardingHasDevice;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop settings now include `onboardingHasDevice` as a strict `boolean` (default `false`).
  - Added Redux action `SET_ONBOARDING_HAS_DEVICE` and action creator `setOnboardingHasDevice`.
  - Added selector `onboardingHasDeviceSelector` for lazy onboarding UI flow decisions.
  - Value persists through existing desktop settings persistence (`SAVE_SETTINGS` / `FETCH_SETTINGS`) without DB middleware changes.

### 📝 Description

This PR implements LIVE-26235 by adding desktop support for lazy onboarding device state.

A new `onboardingHasDevice` field is added to desktop `SettingsState` with a default value of `false`, plus:
- a dedicated action creator to update
- a reducer case to handle updates,
- and a selector to read it from the store.

The implementation follows existing desktop settings patterns and uses the current settings persistence pipeline so the value survives app restarts.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26235](https://ledgerhq.atlassian.net/browse/LIVE-26235)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (s have been profiled or benchmarked if necessary)

[LIVE-26235]: https://ledgerhq.atlassian.net/browse/LIVE-26235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ