### PR TITLE
feat(LIVE-26240): sync onboardingHasDevice transition after device pairing (follow-up LIVE-26235)

### DIFF
--- a/.changeset/stale-dragons-own.md
+++ b/.changeset/stale-dragons-own.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat: update the onboarding has device flag for new and existing users

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -60,6 +60,7 @@ import { useAutoDismissPostOnboardingEntryPoint } from "@ledgerhq/live-common/po
 import { setShareAnalytics, setSharePersonalizedRecommendations } from "./actions/settings";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useEnforceSupportedLanguage } from "./hooks/useEnforceSupportedLanguage";
+import { useSyncOnboardingHasDevice } from "./hooks/useSyncOnboardingHasDevice";
 import { useDeviceManagementKit } from "@ledgerhq/live-dmk-desktop";
 import { AppGeoBlocker } from "LLD/features/AppBlockers/components/AppGeoBlocker";
 import { AppVersionBlocker } from "LLD/features/AppBlockers/components/AppVersionBlocker";
@@ -359,6 +360,7 @@ export default function Default() {
   useRecoverRestoreOnboarding();
   useAutoDismissPostOnboardingEntryPoint();
   useEnforceSupportedLanguage();
+  useSyncOnboardingHasDevice();
 
   const analyticsFF = useFeature("lldAnalyticsOptInPrompt");
   const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useSyncOnboardingHasDevice.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useSyncOnboardingHasDevice.test.ts
@@ -1,0 +1,167 @@
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { act, renderHook, waitFor } from "tests/testSetup";
+import { track } from "~/renderer/analytics/segment";
+import { useSyncOnboardingHasDevice } from "./useSyncOnboardingHasDevice";
+
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: jest.fn(),
+  setAnalyticsFeatureFlagMethod: jest.fn(),
+}));
+
+const trackMock = jest.mocked(track);
+
+const lazyOnboardingEnabledFlag = {
+  lwdWallet40: {
+    enabled: true,
+    params: {
+      lazyOnboarding: true,
+    },
+  },
+};
+
+describe("useSyncOnboardingHasDevice", () => {
+  beforeEach(() => {
+    trackMock.mockReset();
+  });
+
+  it("should not transition when feature flag is disabled", () => {
+    const { store } = renderHook(() => useSyncOnboardingHasDevice(), {
+      initialState: {
+        settings: {
+          onboardingHasDevice: false,
+          lastSeenDevice: {
+            modelId: DeviceModelId.nanoS,
+          },
+          overriddenFeatureFlags: {
+            lwdWallet40: {
+              enabled: true,
+              params: {
+                lazyOnboarding: false,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(store.getState().settings.onboardingHasDevice).toBe(false);
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it("should not transition when onboardingHasDevice is already true", () => {
+    const { store } = renderHook(() => useSyncOnboardingHasDevice(), {
+      initialState: {
+        settings: {
+          onboardingHasDevice: true,
+          lastSeenDevice: {
+            modelId: DeviceModelId.nanoS,
+          },
+          overriddenFeatureFlags: lazyOnboardingEnabledFlag,
+        },
+      },
+    });
+
+    expect(store.getState().settings.onboardingHasDevice).toBe(true);
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it("should not transition when lastSeenDevice is null", () => {
+    const { store } = renderHook(() => useSyncOnboardingHasDevice(), {
+      initialState: {
+        settings: {
+          onboardingHasDevice: false,
+          lastSeenDevice: null,
+          overriddenFeatureFlags: lazyOnboardingEnabledFlag,
+        },
+      },
+    });
+
+    expect(store.getState().settings.onboardingHasDevice).toBe(false);
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it("should dispatch setOnboardingHasDevice and fire analytics when lazy user connects a device during session", async () => {
+    const { store, rerender } = renderHook(() => useSyncOnboardingHasDevice(), {
+      initialState: {
+        settings: {
+          onboardingHasDevice: false,
+          lastSeenDevice: null,
+          overriddenFeatureFlags: lazyOnboardingEnabledFlag,
+        },
+      },
+    });
+
+    act(() => {
+      store.dispatch({
+        type: "SAVE_SETTINGS",
+        payload: {
+          lastSeenDevice: {
+            modelId: DeviceModelId.nanoS,
+          },
+        },
+      });
+    });
+
+    rerender();
+
+    await waitFor(() => {
+      expect(store.getState().settings.onboardingHasDevice).toBe(true);
+    });
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith("lazy_onboarding_device_paired");
+  });
+
+  it("should dispatch setOnboardingHasDevice without analytics when lastSeenDevice was already set on mount", async () => {
+    const { store } = renderHook(() => useSyncOnboardingHasDevice(), {
+      initialState: {
+        settings: {
+          onboardingHasDevice: false,
+          lastSeenDevice: {
+            modelId: DeviceModelId.nanoS,
+          },
+          overriddenFeatureFlags: lazyOnboardingEnabledFlag,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(store.getState().settings.onboardingHasDevice).toBe(true);
+    });
+
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it("should not dispatch twice on subsequent re-renders", async () => {
+    const { store, rerender } = renderHook(() => useSyncOnboardingHasDevice(), {
+      initialState: {
+        settings: {
+          onboardingHasDevice: false,
+          lastSeenDevice: null,
+          overriddenFeatureFlags: lazyOnboardingEnabledFlag,
+        },
+      },
+    });
+
+    act(() => {
+      store.dispatch({
+        type: "SAVE_SETTINGS",
+        payload: {
+          lastSeenDevice: {
+            modelId: DeviceModelId.nanoS,
+          },
+        },
+      });
+    });
+
+    rerender();
+    rerender();
+    rerender();
+
+    await waitFor(() => {
+      expect(store.getState().settings.onboardingHasDevice).toBe(true);
+    });
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/hooks/useSyncOnboardingHasDevice.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useSyncOnboardingHasDevice.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { setOnboardingHasDevice } from "~/renderer/actions/settings";
+import { track } from "~/renderer/analytics/segment";
+import { lastSeenDeviceSelector, onboardingHasDeviceSelector } from "~/renderer/reducers/settings";
+
+export const useSyncOnboardingHasDevice = (): void => {
+  const dispatch = useDispatch();
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("desktop");
+  const onboardingHasDevice = useSelector(onboardingHasDeviceSelector);
+  const lastSeenDevice = useSelector(lastSeenDeviceSelector);
+
+  const hasTransitioned = useRef(false);
+  const initialLastSeenDevice = useRef(lastSeenDevice);
+
+  useEffect(() => {
+    if (
+      !shouldUseLazyOnboarding ||
+      onboardingHasDevice ||
+      !lastSeenDevice ||
+      hasTransitioned.current
+    ) {
+      return;
+    }
+
+    dispatch(setOnboardingHasDevice(true));
+
+    if (!initialLastSeenDevice.current) {
+      track("lazy_onboarding_device_paired");
+    }
+
+    hasTransitioned.current = true;
+  }, [dispatch, shouldUseLazyOnboarding, onboardingHasDevice, lastSeenDevice]);
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Adds automatic transition from `onboardingHasDevice = false` to `true` when a device is confirmed as connected (`lastSeenDevice` available) under lazy onboarding.
  - Introduces a global hook (`useSyncOnboardingHasDevice`) mounted in `Default.tsx`, so the behavior applies consistently across app routes.
  - Handles existing users safely: when `lastSeenDevice` is already present at mount, the flag is backfilled without firing conversion analytics.
  - Fires `lazy_onboarding_device_paired` only for real in-session transitions (`lastSeenDevice` changes from null to non-null), preventing analytics pollution.

### 📝 Description

This PR builds on LIVE-26235 by implementing the runtime transition logic for `onboardingHasDevice`.

Compared to `feat/LIVE-26235/add-onboarding-device-state` (which introduced state/action/selector), this PR adds a dedicated desktop hook that listens to `lastSeenDevice` and updates `onboardingHasDevice` when applicable. The hook is mounted at app-shell level (`Default.tsx`) to ensure consistent behaviour across onboarding and non-onboarding routes.

It also distinguishes backfill vs real pairing:
- If `lastSeenDevice` was already set at mount, we only backfill the state (`onboardingHasDevice = true`) without analytics.
- If `lastSeenDevice` transitions during the current session, we update state and track conversion via `lazy_onboarding_device_paired`.

Tests added for:
- feature flag disabled
- already-onboarded state
- no device case
- real in-session transition (with analytics)
- backfill case (without analytics)
- duplice-prevention on rerenders

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26240](https://ledgerhq.atlassian.net/browse/LIVE-26240)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26240]: https://ledgerhq.atlassian.net/browse/LIVE-26240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ