### PR TITLE
ci: stop making SonarQube failing PRs

### DIFF
--- a/.github/workflows/scan-sonar-reusable.yml
+++ b/.github/workflows/scan-sonar-reusable.yml
@@ -24,6 +24,7 @@ jobs:
   scan-sonar:
     name: "Sonar Cloud"
     runs-on: [ubuntu-22.04]
+    continue-on-error: true # keep PRs green until we make SonarQube failing case more constructive
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Problem: most PRs (80%+) appears as ❌  due to SonarQube failing and our too strict conditions we have on SonarQube rules.

The current status quo is that we don't make SonarQube PRs blocking the PR merge, which means it's only use in an informational way. So **on the short term** we should also make the PR displayed as so and keeping SonarQube informal via a comment.

**on the long term**, we should rediscuss and redefine which part of sonarqube is the mandatory bit, but at the moment it has way too unrealistic goals.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
