### PR TITLE
chore(sonar): app and lib e2e was originally excluded

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -28,9 +28,11 @@ apps/ledger-live-mobile/react-native.config,\
 apps/ledger-live-desktop/tools/**,\
 apps/**.test.ts,\
 apps/**.test.tsx,\
+apps/**/e2e/**,\
 libs/**.test.ts,\
 libs/**.test.tsx,\
 libs/**/specs.ts,\
+libs/**/e2e/**,\
 libs/coin-tester*/**,\
 e2e/**/userdata/*.json,\
 **/__mocks__/**,\


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Small PR to clean up unintentional side effect of bringing e2e in scope.

The nested e2e (eg within apps and libs) was excluded originally, see https://github.com/LedgerHQ/ledger-live/pull/14410/changes#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL5.

This excludes the nested e2e but keeps the added top level e2e scope.

Sonar analysis run: https://github.com/LedgerHQ/ledger-live/actions/runs/22176953386

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: clean up of https://ledgerhq.atlassian.net/browse/QAA-994


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
