### PR TITLE
fix(desktop): stabilize flaky ModularDialog selectAccountFlow test

### DIFF
--- a/.changeset/hot-bugs-relate.md
+++ b/.changeset/hot-bugs-relate.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+stabilize mad test on desktop

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectAccountFlow.test.tsx
@@ -58,6 +58,16 @@ const defaultModularDrawerState = {
   dialogParams: { currencies: mockCurrencies, onAccountSelected: mockOnAccountSelected },
 };
 
+const createFilteredModularDrawerState = (currencies: string[]) => ({
+  searchedValue: undefined,
+  isOpen: true,
+  dialogParams: {
+    currencies,
+    onAccountSelected: mockOnAccountSelected,
+    areCurrenciesFiltered: true,
+  },
+});
+
 describe("ModularDialogFlowManager - Select Account Flow", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -132,32 +142,21 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
       ...INITIAL_STATE,
       initialState: {
         accounts: [ETH_ACCOUNT],
-        modularDrawer: {
-          isOpen: true,
-          dialogParams: {
-            currencies: [ethereumCurrency.id],
-            onAccountSelected: mockOnAccountSelected,
-            areCurrenciesFiltered: true,
-          },
-        },
+        modularDrawer: createFilteredModularDrawerState([ethereumCurrency.id]),
       },
     });
 
-    await waitFor(() => expect(screen.getByText(/ethereum 2/i)).toBeVisible());
+    await waitFor(() =>
+      expect(screen.getByTestId("modular-dialog-screen-ACCOUNT_SELECTION")).toBeVisible(),
+    );
+    expect(await screen.findByText(/ethereum 2/i)).toBeVisible();
   });
 
   it("should navigate directly to networkSelection step", async () => {
     render(<ModularDialogFlowManager />, {
       ...INITIAL_STATE,
       initialState: {
-        modularDrawer: {
-          isOpen: true,
-          dialogParams: {
-            currencies: [ethereumCurrency.id, arbitrumCurrency.id],
-            onAccountSelected: mockOnAccountSelected,
-            areCurrenciesFiltered: true,
-          },
-        },
+        modularDrawer: createFilteredModularDrawerState([ethereumCurrency.id, arbitrumCurrency.id]),
       },
     });
 
@@ -170,14 +169,7 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
     render(<ModularDialogFlowManager />, {
       ...INITIAL_STATE,
       initialState: {
-        modularDrawer: {
-          isOpen: true,
-          dialogParams: {
-            currencies: [bitcoinCurrency.id],
-            onAccountSelected: mockOnAccountSelected,
-            areCurrenciesFiltered: true,
-          },
-        },
+        modularDrawer: createFilteredModularDrawerState([bitcoinCurrency.id]),
       },
     });
 
@@ -193,14 +185,7 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
     const { user } = render(<ModularDialogFlowManager />, {
       ...INITIAL_STATE,
       initialState: {
-        modularDrawer: {
-          isOpen: true,
-          dialogParams: {
-            currencies: [bitcoinCurrency.id],
-            onAccountSelected: mockOnAccountSelected,
-            areCurrenciesFiltered: true,
-          },
-        },
+        modularDrawer: createFilteredModularDrawerState([bitcoinCurrency.id]),
       },
     });
 
@@ -269,14 +254,7 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
     render(<ModularDialogFlowManager />, {
       ...INITIAL_STATE,
       initialState: {
-        modularDrawer: {
-          isOpen: true,
-          dialogParams: {
-            currencies: [ethereumCurrency.id],
-            onAccountSelected: mockOnAccountSelected,
-            areCurrenciesFiltered: true,
-          },
-        },
+        modularDrawer: createFilteredModularDrawerState([ethereumCurrency.id]),
       },
     });
 
@@ -288,14 +266,7 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
     render(<ModularDialogFlowManager />, {
       ...INITIAL_STATE,
       initialState: {
-        modularDrawer: {
-          isOpen: true,
-          dialogParams: {
-            currencies: [ethereumCurrency.id, arbitrumCurrency.id],
-            onAccountSelected: mockOnAccountSelected,
-            areCurrenciesFiltered: true,
-          },
-        },
+        modularDrawer: createFilteredModularDrawerState([ethereumCurrency.id, arbitrumCurrency.id]),
       },
     });
 
@@ -409,14 +380,7 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
       ...INITIAL_STATE,
       initialState: {
         accounts: [ETH_ACCOUNT_WITH_USDC],
-        modularDrawer: {
-          isOpen: true,
-          dialogParams: {
-            currencies: [usdcToken.id],
-            onAccountSelected: mockOnAccountSelected,
-            areCurrenciesFiltered: true,
-          },
-        },
+        modularDrawer: createFilteredModularDrawerState([usdcToken.id]),
       },
     });
 
@@ -430,14 +394,11 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
       ...INITIAL_STATE,
       initialState: {
         accounts: [BASE_ACCOUNT, ARB_ACCOUNT, BTC_ACCOUNT],
-        modularDrawer: {
-          isOpen: true,
-          dialogParams: {
-            currencies: [baseCurrency.id, scrollCurrency.id, bitcoinCurrency.id],
-            onAccountSelected: mockOnAccountSelected,
-            areCurrenciesFiltered: true,
-          },
-        },
+        modularDrawer: createFilteredModularDrawerState([
+          baseCurrency.id,
+          scrollCurrency.id,
+          bitcoinCurrency.id,
+        ]),
       },
     });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - ModularDialog selectAccountFlow test stability
      - No production code changed, test-only

### 📝 Description

The `should navigate directly to accountSelection step` test in `selectAccountFlow.test.tsx` was flaky because it asserted on account content (`/ethereum 2/i`) before the async flow had transitioned from `ASSET_SELECTION` to `ACCOUNT_SELECTION`. On slower CI runs, the MSW response hadn't resolved yet, so the dialog was still showing the asset selection skeleton.

**Fix:**
- Added `waitFor` on `getByTestId("modular-dialog-screen-ACCOUNT_SELECTION")` before asserting account text, ensuring the flow has fully transitioned.
- Extracted a `createFilteredModularDrawerState(currencies)` helper to DRY up 8 identical `initialState.modularDrawer` blocks with `areCurrenciesFiltered: true` and `searchedValue: undefined`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26579](https://ledgerhq.atlassian.net/browse/LIVE-26579)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26579]: https://ledgerhq.atlassian.net/browse/LIVE-26579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ