### PR TITLE
feat(desktop): add UpdaterButton view for W4.0 top bar

### DIFF
--- a/.changeset/lazy-rivers-appear.md
+++ b/.changeset/lazy-rivers-appear.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+introduce new updater UI in W4.0

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/TopBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/TopBarView.tsx
@@ -5,6 +5,7 @@ import { LiveAppDrawer } from "~/renderer/components/LiveAppDrawer";
 import { NavBar, NavBarTrailing, NavBarTitle } from "@ledgerhq/lumen-ui-react";
 import { TopBarViewProps } from "./types";
 import { TopBarActionsList } from "./components/ActionsList";
+import Updater from "LLD/features/Updater";
 
 const TopBarView = ({ slots }: TopBarViewProps) => {
   return (
@@ -14,6 +15,7 @@ const TopBarView = ({ slots }: TopBarViewProps) => {
       </NavBarTitle>
       <NavBarTrailing className="h-48 gap-12">
         <LiveAppDrawer />
+        <Updater />
         <TopBarActionsList slots={slots} />
       </NavBarTrailing>
     </NavBar>

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/UpdaterButtonView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/UpdaterButtonView.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { Download } from "@ledgerhq/lumen-ui-react/symbols";
+import type { UpdaterButtonProps } from "./types";
+
+const UpdaterButtonView = ({ label, appearance, isLoading, onClick }: UpdaterButtonProps) => (
+  <Button
+    appearance={appearance}
+    size="sm"
+    icon={Download}
+    loading={isLoading}
+    onClick={onClick}
+    data-testid="updater-top-bar-button"
+  >
+    {label}
+  </Button>
+);
+
+export default UpdaterButtonView;

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/__integrations__/updater.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/__integrations__/updater.integration.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { UpdaterContext, UpdaterContextType } from "~/renderer/components/Updater/UpdaterContext";
+import Updater from "../index";
+import { defaultContext } from "../__tests__/helpers";
+
+const renderWithContext = (overrides: Partial<UpdaterContextType> = {}) =>
+  render(
+    <UpdaterContext.Provider value={{ ...defaultContext, ...overrides }}>
+      <Updater />
+    </UpdaterContext.Provider>,
+  );
+
+describe("Updater", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render nothing when status is idle", () => {
+    const { container } = renderWithContext({ status: "idle" });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render 'New update available' button when update-available", () => {
+    renderWithContext({ status: "update-available" });
+
+    const button = screen.getByRole("button", { name: /new update available/i });
+    expect(button).toBeVisible();
+  });
+
+  it("should render progress percentage when downloading", () => {
+    renderWithContext({ status: "download-progress", downloadProgress: 12 });
+
+    const button = screen.getByRole("button", { name: /12%/i });
+    expect(button).toBeVisible();
+  });
+
+  it("should render error button when status is error", () => {
+    renderWithContext({ status: "error" });
+
+    const button = screen.getByRole("button", { name: /error during update, try again/i });
+    expect(button).toBeVisible();
+  });
+
+  it("should render 'Install update and relaunch' when check-success", () => {
+    renderWithContext({ status: "check-success" });
+
+    const button = screen.getByRole("button", { name: /install update and relaunch/i });
+    expect(button).toBeVisible();
+  });
+
+  it("should call quitAndInstall when clicking install button", async () => {
+    const quitAndInstall = jest.fn();
+    const { user } = renderWithContext({ status: "check-success", quitAndInstall });
+
+    const button = screen.getByRole("button", { name: /install update and relaunch/i });
+    await user.click(button);
+    expect(quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/__tests__/helpers.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/__tests__/helpers.ts
@@ -1,0 +1,22 @@
+import React from "react";
+import { UpdaterContext, UpdaterContextType } from "~/renderer/components/Updater/UpdaterContext";
+
+export const defaultContext: UpdaterContextType = {
+  status: "idle",
+  downloadProgress: 0,
+  version: "2.0.0",
+  quitAndInstall: jest.fn(),
+  setStatus: jest.fn(),
+  error: null,
+};
+
+export const createContextWrapper = (overrides: Partial<UpdaterContextType> = {}) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      UpdaterContext.Provider,
+      { value: { ...defaultContext, ...overrides } },
+      children,
+    );
+  Wrapper.displayName = "UpdaterTestWrapper";
+  return Wrapper;
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/__tests__/useUpdaterViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/__tests__/useUpdaterViewModel.test.tsx
@@ -1,0 +1,90 @@
+import { renderHook } from "tests/testSetup";
+import { UpdateStatus } from "~/renderer/components/Updater/UpdaterContext";
+import useUpdaterViewModel from "../hooks/useUpdaterViewModel";
+import { createContextWrapper } from "./helpers";
+
+describe("useUpdaterViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const hiddenStatuses: UpdateStatus[] = [
+    "idle",
+    "update-not-available",
+    "checking-for-update",
+    "checking",
+    "downloading-update",
+    "update-downloaded",
+  ];
+
+  it.each(hiddenStatuses)("should return null when status is %s", status => {
+    const { result } = renderHook(() => useUpdaterViewModel(), {
+      wrapper: createContextWrapper({ status }),
+    });
+
+    expect(result.current).toBeNull();
+  });
+
+  it("should return base appearance when status is update-available", () => {
+    const { result } = renderHook(() => useUpdaterViewModel(), {
+      wrapper: createContextWrapper({ status: "update-available" }),
+    });
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        appearance: "base",
+        isLoading: false,
+      }),
+    );
+  });
+
+  it("should return loading state with progress label when status is download-progress", () => {
+    const { result } = renderHook(() => useUpdaterViewModel(), {
+      wrapper: createContextWrapper({ status: "download-progress", downloadProgress: 42 }),
+    });
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        appearance: "base",
+        isLoading: true,
+      }),
+    );
+    expect(result.current?.label).toContain("42");
+  });
+
+  it("should return red appearance when status is error", () => {
+    const { result } = renderHook(() => useUpdaterViewModel(), {
+      wrapper: createContextWrapper({ status: "error" }),
+    });
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        appearance: "red",
+        isLoading: false,
+      }),
+    );
+  });
+
+  it("should return base appearance when status is check-success", () => {
+    const { result } = renderHook(() => useUpdaterViewModel(), {
+      wrapper: createContextWrapper({ status: "check-success" }),
+    });
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        appearance: "base",
+        isLoading: false,
+      }),
+    );
+  });
+
+  it("should wire quitAndInstall as onClick when status is check-success", () => {
+    const quitAndInstall = jest.fn();
+    const { result } = renderHook(() => useUpdaterViewModel(), {
+      wrapper: createContextWrapper({ status: "check-success", quitAndInstall }),
+    });
+
+    result.current?.onClick();
+    expect(quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/hooks/useUpdaterViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/hooks/useUpdaterViewModel.ts
@@ -1,0 +1,61 @@
+import { useContext } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  UpdaterContext,
+  MaybeUpdateContextType,
+  UpdateStatus,
+} from "~/renderer/components/Updater/UpdaterContext";
+import type { UpdaterButtonProps } from "../types";
+
+const noop = () => {};
+
+type StatusConfig = {
+  labelKey: string;
+  appearance: UpdaterButtonProps["appearance"];
+  isLoading: boolean;
+};
+
+const STATUS_MAP: Partial<Record<UpdateStatus, StatusConfig>> = {
+  "update-available": {
+    labelKey: "updater.newUpdateAvailable",
+    appearance: "base",
+    isLoading: false,
+  },
+  "download-progress": {
+    labelKey: "updater.downloadProgress",
+    appearance: "base",
+    isLoading: true,
+  },
+  error: {
+    labelKey: "updater.errorTryAgain",
+    appearance: "red",
+    isLoading: false,
+  },
+  "check-success": {
+    labelKey: "updater.installAndRelaunch",
+    appearance: "base",
+    isLoading: false,
+  },
+};
+
+const useUpdaterViewModel = (): UpdaterButtonProps | null => {
+  const context = useContext<MaybeUpdateContextType>(UpdaterContext);
+  const { t } = useTranslation();
+
+  if (!context) return null;
+
+  const { status, downloadProgress, quitAndInstall } = context;
+  const config = STATUS_MAP[status];
+
+  if (!config) return null;
+
+  const { labelKey, ...rest } = config;
+
+  return {
+    ...rest,
+    label: t(labelKey, { progress: downloadProgress }),
+    onClick: status === "check-success" ? quitAndInstall : noop,
+  };
+};
+
+export default useUpdaterViewModel;

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/index.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import useUpdaterViewModel from "./hooks/useUpdaterViewModel";
+import UpdaterButtonView from "./UpdaterButtonView";
+
+const Updater = () => {
+  const viewModel = useUpdaterViewModel();
+  if (!viewModel) return null;
+  return <UpdaterButtonView {...viewModel} />;
+};
+
+export default Updater;

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/types.ts
@@ -1,0 +1,6 @@
+export type UpdaterButtonProps = {
+  label: string;
+  appearance: "red" | "base";
+  isLoading: boolean;
+  onClick: () => void;
+};

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -227,7 +227,7 @@ const MainAppContent = ({
 
     <Page>
       <TopBannerContainer>
-        <UpdateBanner />
+        {!shouldDisplayWallet40MainNav && <UpdateBanner />}
         <FirmwareUpdateBanner />
         <VaultSignerBanner />
       </TopBannerContainer>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8100,5 +8100,11 @@
         "private": "Private"
       }
     }
+  },
+  "updater": {
+    "newUpdateAvailable": "New update available",
+    "downloadProgress": "{{progress}}%",
+    "errorTryAgain": "Error during update, try again",
+    "installAndRelaunch": "Install update and relaunch"
   }
 }

--- a/apps/ledger-live-desktop/tests/testSetup.tsx
+++ b/apps/ledger-live-desktop/tests/testSetup.tsx
@@ -234,6 +234,8 @@ function render(ui: React.JSX.Element, options: ExtraOptions = {}): RenderReturn
  * @param {DeepPartial<State>} [options.initialState] - The initial state for the Redux store.
  * @param {ReduxStore} [options.store] - The Redux store to be used.
  * @param {Boolean} [options.minimal] - Does not include all providers when true.
+ * @param {Boolean} [options.skipRouter] - Skips the MemoryRouter wrapper when true.
+ * @param {React.ComponentType<{ children: React.ReactNode }>} [options.wrapper] - Additional wrapper rendered inside the default Providers. Useful for injecting custom React Context providers (e.g. UpdaterContext) while still benefiting from the built-in i18n, Redux, and router setup.
  *
  * @returns {RenderHookResult<Result, Props>} The rendered hook result with the context providers and store.
  */
@@ -246,6 +248,7 @@ function renderHook<Result, Props>(
     store?: ReduxStore;
     minimal?: boolean;
     skipRouter?: boolean;
+    wrapper?: React.ComponentType<{ children: React.ReactNode }>;
   } = {},
 ): RenderHookResult<Result, Props> & { store: ReduxStore } {
   const {
@@ -255,6 +258,7 @@ function renderHook<Result, Props>(
     store = createStore({ state: initialState as State, dbMiddleware }),
     minimal = true,
     skipRouter = false,
+    wrapper: Wrapper,
   } = options;
 
   return {
@@ -262,7 +266,7 @@ function renderHook<Result, Props>(
     ...rtlRenderHook(hook, {
       wrapper: ({ children }) => (
         <Providers store={store} minimal={minimal} skipRouter={skipRouter}>
-          {children}
+          {Wrapper ? <Wrapper>{children}</Wrapper> : children}
         </Providers>
       ),
       initialProps,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Updater top-bar button rendering per status (update-available, download-progress, error, check-success)
      - MVVM Updater feature wiring in TopBarView

### 📝 Description

Adds the MVVM Updater feature for the W4.0 top bar: `UpdaterButtonView` (presentational), `useUpdaterViewModel` (status-to-props mapping), container `index.tsx`, types, test helpers, unit tests, and integration tests.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26428](https://ledgerhq.atlassian.net/browse/LIVE-26428)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26428]: https://ledgerhq.atlassian.net/browse/LIVE-26428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ