### PR TITLE
test(desktop): improve coverage for W4.0 features and hooks

### DIFF
--- a/.changeset/twenty-islands-push.md
+++ b/.changeset/twenty-islands-push.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+improve coverage for W4.0 fetaures/hooks

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/usePageViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/usePageViewModel.test.ts
@@ -1,0 +1,100 @@
+import { act, renderHook } from "tests/testSetup";
+import { useLocation } from "react-router";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import { usePageViewModel } from "../usePageViewModel";
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useLocation: jest.fn(),
+}));
+
+const mockedUseLocation = jest.mocked(useLocation);
+const createLocation = (pathname: string) => ({
+  pathname,
+  search: "",
+  hash: "",
+  state: null,
+  key: "test-location",
+});
+
+const wallet40WithRightPanelFlags = {
+  ...INITIAL_STATE.overriddenFeatureFlags,
+  lwdWallet40: { enabled: true, params: { mainNavigation: true } },
+  ptxSwapLiveAppOnPortfolio: { enabled: true },
+};
+
+describe("usePageViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("computes shouldRenderRightPanel based on current pathname and feature flags", () => {
+    mockedUseLocation.mockReturnValue(createLocation("/analytics"));
+    const { result, rerender } = renderHook(() => usePageViewModel(), {
+      initialState: {
+        settings: {
+          ...INITIAL_STATE,
+          overriddenFeatureFlags: wallet40WithRightPanelFlags,
+        },
+      },
+    });
+
+    expect(result.current.shouldRenderRightPanel).toBe(true);
+
+    mockedUseLocation.mockReturnValue(createLocation("/market"));
+    rerender();
+
+    expect(result.current.shouldRenderRightPanel).toBe(false);
+  });
+
+  it("tracks scroll state and scrolls to top on user action", () => {
+    mockedUseLocation.mockReturnValue(createLocation("/"));
+    const { result } = renderHook(() => usePageViewModel(), {
+      initialState: {
+        settings: {
+          ...INITIAL_STATE,
+          overriddenFeatureFlags: wallet40WithRightPanelFlags,
+        },
+      },
+    });
+
+    let listener: ((event: Event) => void) | undefined;
+    const scroller = document.createElement("div");
+    Object.defineProperty(scroller, "scrollTop", { value: 0, writable: true });
+    scroller.scrollTo = jest.fn();
+    const addEventListenerSpy = jest
+      .spyOn(scroller, "addEventListener")
+      .mockImplementation((event, callback) => {
+        if (event === "scroll" && typeof callback === "function") {
+          listener = callback;
+        }
+      });
+
+    act(() => {
+      result.current.pageScrollerRef(scroller);
+    });
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith("scroll", expect.any(Function), {
+      passive: true,
+    });
+    expect(result.current.isScrollAtUpperBound).toBe(true);
+    expect(result.current.isScrollUpButtonVisible).toBe(false);
+
+    act(() => {
+      scroller.scrollTop = 900;
+      listener?.(new Event("scroll"));
+    });
+
+    expect(result.current.isScrollAtUpperBound).toBe(false);
+    expect(result.current.isScrollUpButtonVisible).toBe(true);
+
+    act(() => {
+      result.current.onClickScrollUp();
+    });
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
@@ -1,0 +1,29 @@
+import { isWallet40Page, shouldDisplayRightPanel } from "../utils";
+
+describe("Page utils", () => {
+  describe("isWallet40Page", () => {
+    it("returns true for wallet 4.0 root pages", () => {
+      expect(isWallet40Page("/")).toBe(true);
+      expect(isWallet40Page("/market")).toBe(true);
+      expect(isWallet40Page("/analytics")).toBe(true);
+    });
+
+    it("returns true for wallet 4.0 prefixed pages", () => {
+      expect(isWallet40Page("/card")).toBe(true);
+      expect(isWallet40Page("/swap")).toBe(true);
+      expect(isWallet40Page("/swap/bridge")).toBe(true);
+    });
+
+    it("returns false for non wallet 4.0 pages", () => {
+      expect(isWallet40Page("/accounts")).toBe(false);
+    });
+  });
+
+  describe("shouldDisplayRightPanel", () => {
+    it("returns true only for right panel pages", () => {
+      expect(shouldDisplayRightPanel("/")).toBe(true);
+      expect(shouldDisplayRightPanel("/analytics")).toBe(true);
+      expect(shouldDisplayRightPanel("/market")).toBe(false);
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/useRightPanelViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/useRightPanelViewModel.test.ts
@@ -1,0 +1,55 @@
+import { renderHook } from "tests/testSetup";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import { useRightPanelViewModel } from "../useRightPanelViewModel";
+
+describe("useRightPanelViewModel", () => {
+  it("enables the right panel when wallet 4.0 and ptxSwap flags are enabled", () => {
+    const { result } = renderHook(() => useRightPanelViewModel(), {
+      initialState: {
+        settings: {
+          ...INITIAL_STATE,
+          overriddenFeatureFlags: {
+            ...INITIAL_STATE.overriddenFeatureFlags,
+            lwdWallet40: { enabled: true, params: {} },
+            ptxSwapLiveAppOnPortfolio: { enabled: true },
+          },
+        },
+      },
+    });
+
+    expect(result.current.shouldDisplay).toBe(true);
+  });
+
+  it("disables the right panel when wallet 4.0 is disabled", () => {
+    const { result } = renderHook(() => useRightPanelViewModel(), {
+      initialState: {
+        settings: {
+          ...INITIAL_STATE,
+          overriddenFeatureFlags: {
+            ...INITIAL_STATE.overriddenFeatureFlags,
+            lwdWallet40: { enabled: false, params: {} },
+            ptxSwapLiveAppOnPortfolio: { enabled: true },
+          },
+        },
+      },
+    });
+
+    expect(result.current.shouldDisplay).toBe(false);
+  });
+
+  it("disables the right panel when ptxSwap flag is absent", () => {
+    const { result } = renderHook(() => useRightPanelViewModel(), {
+      initialState: {
+        settings: {
+          ...INITIAL_STATE,
+          overriddenFeatureFlags: {
+            ...INITIAL_STATE.overriddenFeatureFlags,
+            lwdWallet40: { enabled: true, params: {} },
+          },
+        },
+      },
+    });
+
+    expect(result.current.shouldDisplay).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__tests__/useAnalyticsViewModel.test.ts
@@ -1,0 +1,49 @@
+import { act, renderHook } from "tests/testSetup";
+import { useNavigate } from "react-router";
+import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import useAnalyticsViewModel from "../useAnalyticsViewModel";
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(),
+}));
+
+const mockedUseNavigate = jest.mocked(useNavigate);
+describe("useAnalyticsViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns expected values and navigates back to dashboard", () => {
+    const navigate = jest.fn();
+    mockedUseNavigate.mockReturnValue(navigate);
+
+    const { result } = renderHook(() => useAnalyticsViewModel(), {
+      initialState: {
+        settings: {
+          ...INITIAL_STATE,
+          counterValue: "USD",
+          selectedTimeRange: "day",
+          overriddenFeatureFlags: {
+            ...INITIAL_STATE.overriddenFeatureFlags,
+            lwdWallet40: {
+              enabled: true,
+              params: { graphRework: true },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.current.counterValue).toBe(getFiatCurrencyByTicker("USD"));
+    expect(result.current.selectedTimeRange).toBe("day");
+    expect(result.current.shouldDisplayGraphRework).toBe(true);
+
+    act(() => {
+      result.current.navigateToDashboard();
+    });
+
+    expect(navigate).toHaveBeenCalledWith("/");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/usePortfolioViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/usePortfolioViewModel.test.ts
@@ -1,0 +1,130 @@
+import { renderHook } from "tests/testSetup";
+import { genAccount, genTokenAccount } from "@ledgerhq/coin-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { BigNumber } from "bignumber.js";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import { usePortfolioViewModel } from "../usePortfolioViewModel";
+
+const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
+const ethereumCurrency = getCryptoCurrencyById("ethereum");
+const wallet40AndExchangeFlags = {
+  ...INITIAL_STATE.overriddenFeatureFlags,
+  portfolioExchangeBanner: { enabled: true },
+  lwdWallet40: {
+    enabled: true,
+    params: {
+      marketBanner: true,
+      graphRework: true,
+      quickActionCtas: true,
+    },
+  },
+};
+const wallet40AndExchangeSettings = {
+  ...INITIAL_STATE,
+  overriddenFeatureFlags: wallet40AndExchangeFlags,
+};
+
+const addressPoisoningFlags = {
+  ...INITIAL_STATE.overriddenFeatureFlags,
+  addressPoisoningOperationsFilter: {
+    enabled: true,
+    params: { families: ["evm"] },
+  },
+};
+
+function createPoisonedTokenAccount() {
+  const parentAccount = genAccount("eth-poison-parent", {
+    currency: ethereumCurrency,
+    operationsSize: 0,
+  });
+  const tokenAccount = genTokenAccount(0, parentAccount, usdcToken);
+  const poisonedOp = { ...tokenAccount.operations[0], value: new BigNumber(0) };
+  parentAccount.subAccounts = [tokenAccount];
+  return { parentAccount, tokenAccount, poisonedOp };
+}
+
+describe("usePortfolioViewModel", () => {
+  it("should compute account and portfolio totals when accounts are provided", () => {
+    const accounts = [
+      genAccount("btc-account", { currency: bitcoinCurrency, operationsSize: 1 }),
+      genAccount("eth-account-1", { currency: ethereumCurrency, operationsSize: 2 }),
+      genAccount("eth-account-2", { currency: ethereumCurrency, operationsSize: 0 }),
+    ];
+
+    const { result } = renderHook(() => usePortfolioViewModel(), {
+      initialState: {
+        accounts,
+        settings: {
+          ...wallet40AndExchangeSettings,
+          filterTokenOperationsZeroAmount: true,
+          showClearCacheBanner: true,
+        },
+      },
+    });
+
+    expect(result.current.totalAccounts).toBe(3);
+    expect(result.current.totalCurrencies).toBe(2);
+    expect(result.current.totalOperations).toBe(3);
+  });
+
+  it("should expose wallet40 and exchange banner flags when enabled in settings", () => {
+    const { result } = renderHook(() => usePortfolioViewModel(), {
+      initialState: {
+        settings: wallet40AndExchangeSettings,
+      },
+    });
+
+    expect(result.current.hasExchangeBannerCTA).toBe(true);
+    expect(result.current.shouldDisplayMarketBanner).toBe(true);
+    expect(result.current.shouldDisplayGraphRework).toBe(true);
+    expect(result.current.shouldDisplayQuickActionCtas).toBe(true);
+    expect(result.current.isWallet40Enabled).toBe(true);
+  });
+
+  it("should expose clear cache banner visibility when enabled in settings", () => {
+    const { result } = renderHook(() => usePortfolioViewModel(), {
+      initialState: {
+        settings: {
+          ...INITIAL_STATE,
+          showClearCacheBanner: true,
+        },
+      },
+    });
+
+    expect(result.current.isClearCacheBannerVisible).toBe(true);
+  });
+
+  it("should filter poisoned operations when zero amount filtering is enabled", () => {
+    const { parentAccount, tokenAccount, poisonedOp } = createPoisonedTokenAccount();
+
+    const { result } = renderHook(() => usePortfolioViewModel(), {
+      initialState: {
+        accounts: [parentAccount],
+        settings: {
+          ...INITIAL_STATE,
+          filterTokenOperationsZeroAmount: true,
+          overriddenFeatureFlags: addressPoisoningFlags,
+        },
+      },
+    });
+
+    expect(result.current.filterOperations(poisonedOp, tokenAccount)).toBe(false);
+  });
+
+  it("should keep poisoned operations when zero amount filtering is disabled", () => {
+    const { parentAccount, tokenAccount, poisonedOp } = createPoisonedTokenAccount();
+
+    const { result } = renderHook(() => usePortfolioViewModel(), {
+      initialState: {
+        accounts: [parentAccount],
+        settings: {
+          ...INITIAL_STATE,
+          filterTokenOperationsZeroAmount: false,
+        },
+      },
+    });
+
+    expect(result.current.filterOperations(poisonedOp, tokenAccount)).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useAccountStatus.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useAccountStatus.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from "tests/testSetup";
+import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import BigNumber from "bignumber.js";
+import { useAccountStatus } from "./useAccountStatus";
+
+const ethereumCurrency = getCryptoCurrencyById("ethereum");
+
+const createAccountWithFunds = () =>
+  genAccount("eth-with-funds", {
+    currency: ethereumCurrency,
+    operationsSize: 1,
+  });
+
+const createEmptyAccount = () => {
+  const account = genAccount("eth-empty", {
+    currency: ethereumCurrency,
+    operationsSize: 0,
+  });
+  account.balance = new BigNumber(0);
+  account.spendableBalance = new BigNumber(0);
+  return account;
+};
+
+describe("useAccountStatus", () => {
+  it("returns hasFunds=true when user has at least one funded account", () => {
+    const { result } = renderHook(() => useAccountStatus(), {
+      initialState: {
+        accounts: [createAccountWithFunds()],
+      },
+    });
+
+    expect(result.current).toEqual({
+      hasAccount: true,
+      hasFunds: true,
+    });
+  });
+
+  it("returns hasFunds=false when all accounts are empty", () => {
+    const { result } = renderHook(() => useAccountStatus(), {
+      initialState: {
+        accounts: [createEmptyAccount()],
+      },
+    });
+
+    expect(result.current).toEqual({
+      hasAccount: true,
+      hasFunds: false,
+    });
+  });
+
+  it("returns hasFunds=false when there is no account", () => {
+    const { result } = renderHook(() => useAccountStatus(), {
+      initialState: {
+        accounts: [],
+      },
+    });
+
+    expect(result.current).toEqual({
+      hasAccount: false,
+      hasFunds: false,
+    });
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Test-only PR, no production code changed
      - Covers W4.0 hooks and utilities in `src/mvvm/`

### 📝 Description

Improves unit test coverage for Wallet 4.0 features and shared hooks on Desktop.

**New test files (6):**

| File | What's tested |
|------|--------------|
| `Page/__tests__/usePageViewModel.test.ts` | Right panel routing logic, scroll state tracking, scroll-to-top action |
| `Page/__tests__/utils.test.ts` | `isWallet40Page` and `shouldDisplayRightPanel` route helpers |
| `RightPanel/__tests__/useRightPanelViewModel.test.ts` | Feature flag combinations for right panel visibility |
| `Analytics/__tests__/useAnalyticsViewModel.test.ts` | Counter value, time range, graph rework flag, navigation |
| `Portfolio/hooks/__tests__/usePortfolioViewModel.test.ts` | Account/currency totals, W4.0 flags, exchange banner, address poisoning filter |
| `hooks/useAccountStatus.test.ts` | `hasAccount` / `hasFunds` computation from Redux accounts |

### ❓ Context

- Hardening test coverage ahead of W4.0 feature stabilization.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)