### PR TITLE
feat(desktop): add shared updater status hook and wire ViewModel

### DIFF
--- a/.changeset/gorgeous-phones-suffer.md
+++ b/.changeset/gorgeous-phones-suffer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add shared updater status hook and wire ViewModel for top bar updater button

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/__integrations__/updater.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/__integrations__/updater.integration.test.tsx
@@ -1,8 +1,18 @@
 import React from "react";
 import { render, screen } from "tests/testSetup";
 import { UpdaterContext, UpdaterContextType } from "~/renderer/components/Updater/UpdaterContext";
+import { openURL } from "~/renderer/linking";
 import Updater from "../index";
 import { defaultContext } from "../__tests__/helpers";
+import { urls } from "~/config/urls";
+
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
+}));
+
+jest.mock("~/renderer/hooks/useLocalizedUrls", () => ({
+  useLocalizedUrl: (url: string) => url,
+}));
 
 const renderWithContext = (overrides: Partial<UpdaterContextType> = {}) =>
   render(
@@ -56,5 +66,13 @@ describe("Updater", () => {
     const button = screen.getByRole("button", { name: /install update and relaunch/i });
     await user.click(button);
     expect(quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("should open re-download url when clicking error button", async () => {
+    const { user } = renderWithContext({ status: "error" });
+
+    const button = screen.getByRole("button", { name: /error during update, try again/i });
+    await user.click(button);
+    expect(openURL).toHaveBeenCalledWith(urls.liveHome);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/__tests__/useUpdaterStatus.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/__tests__/useUpdaterStatus.test.ts
@@ -1,0 +1,116 @@
+import React from "react";
+import { renderHook } from "tests/testSetup";
+import { UpdaterContext, UpdateStatus } from "~/renderer/components/Updater/UpdaterContext";
+import { openURL } from "~/renderer/linking";
+import {
+  useUpdaterStatus,
+  BANNER_VISIBLE_STATUS,
+  TOP_BAR_VISIBLE_STATUS,
+} from "../hooks/useUpdaterStatus";
+import { createContextWrapper } from "./helpers";
+
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
+}));
+
+jest.mock("~/renderer/hooks/useLocalizedUrls", () => ({
+  useLocalizedUrl: (url: string) => url,
+}));
+
+const createNullWrapper = () => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(UpdaterContext.Provider, { value: null }, children);
+  Wrapper.displayName = "NullUpdaterModelTestWrapper";
+  return Wrapper;
+};
+
+const ALL_STATUSES: UpdateStatus[] = [
+  "idle",
+  "checking-for-update",
+  "update-available",
+  "update-not-available",
+  "download-progress",
+  "update-downloaded",
+  "checking",
+  "check-success",
+  "downloading-update",
+  "error",
+];
+
+describe("useUpdaterStatus", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when context is null", () => {
+    it("should return isBannerVisible false", () => {
+      const { result } = renderHook(() => useUpdaterStatus(), { wrapper: createNullWrapper() });
+      expect(result.current.isBannerVisible).toBe(false);
+    });
+
+    it("should return isTopBarVisible false", () => {
+      const { result } = renderHook(() => useUpdaterStatus(), { wrapper: createNullWrapper() });
+      expect(result.current.isTopBarVisible).toBe(false);
+    });
+
+    it("should return undefined from getActionHandler", () => {
+      const { result } = renderHook(() => useUpdaterStatus(), { wrapper: createNullWrapper() });
+      const handler = result.current.getActionHandler("check-success");
+      expect(handler).toBeUndefined();
+    });
+  });
+
+  describe("isBannerVisible", () => {
+    it("should be false when version is undefined", () => {
+      const { result } = renderHook(() => useUpdaterStatus(), {
+        wrapper: createContextWrapper({ status: "update-available", version: undefined }),
+      });
+      expect(result.current.isBannerVisible).toBe(false);
+    });
+
+    it.each(ALL_STATUSES)("status '%s' → isBannerVisible = %s", status => {
+      const { result } = renderHook(() => useUpdaterStatus(), {
+        wrapper: createContextWrapper({ status }),
+      });
+      expect(result.current.isBannerVisible).toBe(BANNER_VISIBLE_STATUS.includes(status));
+    });
+  });
+
+  describe("isTopBarVisible", () => {
+    it.each(ALL_STATUSES)("status '%s' → isTopBarVisible = %s", status => {
+      const { result } = renderHook(() => useUpdaterStatus(), {
+        wrapper: createContextWrapper({ status }),
+      });
+      expect(result.current.isTopBarVisible).toBe(TOP_BAR_VISIBLE_STATUS.includes(status));
+    });
+  });
+
+  describe("getActionHandler", () => {
+    it("should return quitAndInstall for check-success", () => {
+      const quitAndInstall = jest.fn();
+      const { result } = renderHook(() => useUpdaterStatus(), {
+        wrapper: createContextWrapper({ status: "check-success", quitAndInstall }),
+      });
+
+      result.current.getActionHandler("check-success")?.();
+      expect(quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return reDownload (openURL) for error", () => {
+      const { result } = renderHook(() => useUpdaterStatus(), {
+        wrapper: createContextWrapper({ status: "error" }),
+      });
+
+      result.current.getActionHandler("error")?.();
+      expect(openURL).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return undefined for non-actionable statuses", () => {
+      const { result } = renderHook(() => useUpdaterStatus(), {
+        wrapper: createContextWrapper({ status: "update-available" }),
+      });
+
+      expect(result.current.getActionHandler("update-available")).toBeUndefined();
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/__tests__/useUpdaterViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/__tests__/useUpdaterViewModel.test.tsx
@@ -1,7 +1,17 @@
 import { renderHook } from "tests/testSetup";
 import { UpdateStatus } from "~/renderer/components/Updater/UpdaterContext";
+import { openURL } from "~/renderer/linking";
 import useUpdaterViewModel from "../hooks/useUpdaterViewModel";
 import { createContextWrapper } from "./helpers";
+import { urls } from "~/config/urls";
+
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
+}));
+
+jest.mock("~/renderer/hooks/useLocalizedUrls", () => ({
+  useLocalizedUrl: (url: string) => url,
+}));
 
 describe("useUpdaterViewModel", () => {
   beforeEach(() => {
@@ -84,7 +94,16 @@ describe("useUpdaterViewModel", () => {
       wrapper: createContextWrapper({ status: "check-success", quitAndInstall }),
     });
 
-    result.current?.onClick();
+    result.current?.onClick?.();
     expect(quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("should wire re-download action as onClick when status is error", () => {
+    const { result } = renderHook(() => useUpdaterViewModel(), {
+      wrapper: createContextWrapper({ status: "error" }),
+    });
+
+    result.current?.onClick?.();
+    expect(openURL).toHaveBeenCalledWith(urls.liveHome);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/hooks/useUpdaterStatus.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/hooks/useUpdaterStatus.ts
@@ -1,0 +1,51 @@
+import { useCallback, useContext } from "react";
+import { urls } from "~/config/urls";
+import { openURL } from "~/renderer/linking";
+import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
+import { UpdaterContext, UpdateStatus } from "~/renderer/components/Updater/UpdaterContext";
+
+export const BANNER_VISIBLE_STATUS: readonly UpdateStatus[] = [
+  "download-progress",
+  "checking",
+  "check-success",
+  "error",
+  "update-available",
+  "downloading-update",
+];
+
+export const TOP_BAR_VISIBLE_STATUS: readonly UpdateStatus[] = [
+  "update-available",
+  "download-progress",
+  "error",
+  "check-success",
+];
+
+export const useUpdaterStatus = () => {
+  const context = useContext(UpdaterContext);
+  const urlLive = useLocalizedUrl(urls.liveHome);
+
+  const reDownload = useCallback(() => openURL(urlLive), [urlLive]);
+
+  const getActionHandler = useCallback(
+    (status: UpdateStatus): (() => void) | undefined => {
+      if (!context) return undefined;
+
+      if (status === "check-success") return context.quitAndInstall;
+      if (status === "error") return reDownload;
+      return undefined;
+    },
+    [context, reDownload],
+  );
+
+  const isBannerVisible =
+    !!context && !!context.version && BANNER_VISIBLE_STATUS.includes(context.status);
+
+  const isTopBarVisible = !!context && TOP_BAR_VISIBLE_STATUS.includes(context.status);
+
+  return {
+    context,
+    isBannerVisible,
+    isTopBarVisible,
+    getActionHandler,
+  };
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/hooks/useUpdaterViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/hooks/useUpdaterViewModel.ts
@@ -1,13 +1,7 @@
-import { useContext } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  UpdaterContext,
-  MaybeUpdateContextType,
-  UpdateStatus,
-} from "~/renderer/components/Updater/UpdaterContext";
+import { UpdateStatus } from "~/renderer/components/Updater/UpdaterContext";
+import { useUpdaterStatus } from "./useUpdaterStatus";
 import type { UpdaterButtonProps } from "../types";
-
-const noop = () => {};
 
 type StatusConfig = {
   labelKey: string;
@@ -39,12 +33,12 @@ const STATUS_MAP: Partial<Record<UpdateStatus, StatusConfig>> = {
 };
 
 const useUpdaterViewModel = (): UpdaterButtonProps | null => {
-  const context = useContext<MaybeUpdateContextType>(UpdaterContext);
+  const { context, isTopBarVisible, getActionHandler } = useUpdaterStatus();
   const { t } = useTranslation();
 
-  if (!context) return null;
+  if (!context || !isTopBarVisible) return null;
 
-  const { status, downloadProgress, quitAndInstall } = context;
+  const { status, downloadProgress } = context;
   const config = STATUS_MAP[status];
 
   if (!config) return null;
@@ -54,7 +48,7 @@ const useUpdaterViewModel = (): UpdaterButtonProps | null => {
   return {
     ...rest,
     label: t(labelKey, { progress: downloadProgress }),
-    onClick: status === "check-success" ? quitAndInstall : noop,
+    onClick: getActionHandler(status),
   };
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Updater/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Updater/types.ts
@@ -2,5 +2,5 @@ export type UpdaterButtonProps = {
   label: string;
   appearance: "red" | "base";
   isLoading: boolean;
-  onClick: () => void;
+  onClick?: () => void;
 };

--- a/apps/ledger-live-desktop/src/renderer/components/Updater/Banner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Updater/Banner.tsx
@@ -1,31 +1,24 @@
-import React, { useContext } from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
-import { urls } from "~/config/urls";
-import { openURL } from "~/renderer/linking";
 import IconUpdate from "~/renderer/icons/Update";
 import IconDonjon from "~/renderer/icons/Donjon";
 import IconWarning from "~/renderer/icons/TriangleWarning";
 import Spinner from "~/renderer/components/Spinner";
 import TopBanner, { FakeLink, Content } from "~/renderer/components/TopBanner";
-import { UpdaterContext } from "./UpdaterContext";
-import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { TFunction } from "i18next";
+import {
+  BANNER_VISIBLE_STATUS,
+  useUpdaterStatus,
+} from "LLD/features/Updater/hooks/useUpdaterStatus";
 
-export const VISIBLE_STATUS = [
-  "download-progress",
-  "checking",
-  "check-success",
-  "error",
-  "update-available",
-  "downloading-update",
-];
+export const VISIBLE_STATUS = BANNER_VISIBLE_STATUS;
 
 const getContentByStatus = (
-  quitAndInstall: () => void,
-  reDownload: () => void,
   progress: number,
   version: string,
   t: TFunction,
+  quitAndInstall?: () => void,
+  reDownload?: () => void,
 ): Record<string, Content> => ({
   "download-progress": {
     Icon: Spinner,
@@ -57,15 +50,15 @@ const getContentByStatus = (
 });
 
 const UpdaterTopBanner: React.FC = () => {
-  const context = useContext(UpdaterContext);
-  const urlLive = useLocalizedUrl(urls.liveHome);
+  const { context, isBannerVisible, getActionHandler } = useUpdaterStatus();
   const { t } = useTranslation();
 
-  const reDownload = () => openURL(urlLive);
+  const quitAndInstall = getActionHandler("check-success");
+  const reDownload = getActionHandler("error");
 
-  if (!context?.version || !VISIBLE_STATUS.includes(context.status)) return null;
-  const { status, quitAndInstall, downloadProgress, version } = context;
-  const content = getContentByStatus(quitAndInstall, reDownload, downloadProgress, version, t)[
+  if (!context || !isBannerVisible) return null;
+  const { status, downloadProgress, version } = context;
+  const content = getContentByStatus(downloadProgress, version!, t, quitAndInstall, reDownload)[
     status
   ];
 

--- a/apps/ledger-live-desktop/src/renderer/components/Updater/useIsUpdateAvailable.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Updater/useIsUpdateAvailable.ts
@@ -1,9 +1,7 @@
-import { useContext } from "react";
-import { UpdaterContext } from "./UpdaterContext";
-import { VISIBLE_STATUS } from "./Banner";
+import { useUpdaterStatus } from "LLD/features/Updater/hooks/useUpdaterStatus";
 
 const useIsUpdateAvailable = () => {
-  const context = useContext(UpdaterContext);
-  return context && context.version && VISIBLE_STATUS.includes(context.status);
+  const { isBannerVisible } = useUpdaterStatus();
+  return isBannerVisible;
 };
 export default useIsUpdateAvailable;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Updater top-bar button rendering and click behavior (install & relaunch, re-download on error)
      - Legacy updater banner (should behave identically — uses same shared hook)
      - Status visibility matrix for both top-bar and banner UIs

### 📝 Description

**Problem**: The updater button ViewModel (`useUpdaterViewModel`) and the legacy updater banner (`Banner.tsx`) each had their own independent status-to-action mapping logic, leading to duplication and potential drift.

**Solution**: Introduced `useUpdaterStatus` — a shared hook under `mvvm/features/Updater/hooks/` that centralizes:
- Visibility flags (`isBannerVisible`, `isTopBarVisible`) per updater status
- Action handler wiring (`quitAndInstall` for success, `openURL` re-download for error, noop otherwise)

Both `useUpdaterViewModel` (MVVM top-bar button) and `Banner.tsx` (legacy banner) now consume this shared hook, each adapting it to their own UI contract. This ensures parity and eliminates duplicated status logic.

**Test coverage**:
- Dedicated unit tests for `useUpdaterStatus` (visibility matrix, action handler branches, null context)
- Extended unit tests for `useUpdaterViewModel` (error click → re-download)
- Extended integration tests for the full Updater component (error button → `openURL`)
- Existing legacy banner tests pass unchanged

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26429](https://ledgerhq.atlassian.net/browse/LIVE-26429)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26429]: https://ledgerhq.atlassian.net/browse/LIVE-26429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ