### PR TITLE
chore: fix global flakiness on mobile tests

### DIFF
--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -22,7 +22,21 @@ beforeAll(() =>
     onUnhandledRequest: "bypass",
   }),
 );
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  server.resetHandlers();
+  // Reset shared mocks to prevent state leaking between tests (mock cannibalization)
+  mockRNCNetInfo.useNetInfo.mockReturnValue({
+    type: "cellular",
+    isConnected: true,
+    isInternetReachable: true,
+    details: { isConnectionExpensive: true, cellularGeneration: "3g" },
+  });
+  mockUseCameraPermission.mockReturnValue({
+    hasPermission: true,
+    requestPermission: jest.fn(() => Promise.resolve(true)),
+  });
+  mockGetCameraPermissionStatus.mockReturnValue("granted");
+});
 afterAll(() => server.close());
 
 NativeModules.RNAnalytics = {};
@@ -73,6 +87,10 @@ jest.mock("react-native-share", () => ({
 
 export const mockSimulateBarcodeScanned = jest.fn();
 export const mockGetCameraPermissionStatus = jest.fn(() => "granted");
+const mockUseCameraPermission = jest.fn(() => ({
+  hasPermission: true,
+  requestPermission: jest.fn(() => Promise.resolve(true)),
+}));
 
 jest.mock("react-native-vision-camera", () => {
   const CameraMock = jest.fn(({ codeScanner }) => {
@@ -87,10 +105,7 @@ jest.mock("react-native-vision-camera", () => {
 
   return {
     Camera: CameraMock,
-    useCameraPermission: jest.fn(() => ({
-      hasPermission: true,
-      requestPermission: jest.fn(() => Promise.resolve(true)),
-    })),
+    useCameraPermission: mockUseCameraPermission,
     useCameraDevice: jest.fn(() => ({
       id: "mock-camera-device",
       position: "back",

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/UpdateBanner.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/UpdateBanner.test.tsx
@@ -94,10 +94,14 @@ const newUpdateFlowSupportedDataSet: Array<{
 describe("<UpdateBanner />", () => {
   let PlatformSpy: jest.SpyInstance;
   beforeEach(() => {
-    jest.restoreAllMocks();
-    //Can't reset all mocks https://github.com/facebook/react-native/issues/42904
+    // Use clearAllMocks instead of restoreAllMocks to avoid restoring global mocks
+    // that other tests depend on (netinfo, vision-camera, etc.)
+    jest.clearAllMocks();
     navigateToNewUpdateFlow.mockClear();
     PlatformSpy = jest.spyOn(ReactNative, "Platform", "get");
+  });
+  afterEach(() => {
+    PlatformSpy?.mockRestore();
   });
 
   it("should not display the firmware update banner if there is no update", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/useUpdateBannerViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/useUpdateBannerViewModel.test.tsx
@@ -72,8 +72,11 @@ const { navigateToNewUpdateFlow } = jest.requireMock("../../utils/navigateToNewU
 describe("useUpdateBannerViewModel", () => {
   let PlatformSpy: jest.SpyInstance;
   beforeEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
     PlatformSpy = jest.spyOn(ReactNative, "Platform", "get");
+  });
+  afterEach(() => {
+    PlatformSpy?.mockRestore();
   });
 
   it("should return bannerVisible: true if conditions are fulfilled", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
@@ -8,10 +8,11 @@ import { track } from "~/analytics";
 import { LNSUpsellBanner } from ".";
 
 describe("LNSUpsellBanner ", () => {
-  const { t } = renderHook(useTranslation).result.current;
+  let t: ReturnType<typeof useTranslation>["t"];
 
   beforeEach(() => {
     jest.clearAllMocks();
+    t = renderHook(useTranslation).result.current.t;
   });
 
   describe.each([

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/__integrations__/largeMoverLandingPage.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/__integrations__/largeMoverLandingPage.integration.test.tsx
@@ -32,8 +32,8 @@ const mockRoute: RouteProp<LandingPagesNavigatorParamList, ScreenName.LargeMover
 
 describe("LargeMoverLandingPage Integration Tests", () => {
   beforeEach(() => {
-    jest.mocked(navigationModule.useNavigation).mockReturnValue(mockNavigation);
     jest.clearAllMocks();
+    jest.mocked(navigationModule.useNavigation).mockReturnValue(mockNavigation);
   });
 
   it("displays the ticker of the first currency", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/__tests__/MarketListLayout.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/__tests__/MarketListLayout.test.tsx
@@ -8,13 +8,7 @@ import MarketList from "../index";
 import { ScreenName } from "~/const";
 import { State } from "~/reducers/types";
 
-jest.mock("@react-native-community/netinfo", () => {
-  return {
-    __esModule: true,
-    default: { addEventListener: jest.fn },
-    useNetInfo: jest.fn(() => ({ isConnected: true })),
-  };
-});
+// Use global netinfo mock from jest-setup - do not replace to avoid mock cannibalization
 
 const setNetInfoState = (state: { isConnected: boolean }) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
@@ -27,24 +27,7 @@ jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () =>
 
 const mockUseAcceptedCurrency = jest.fn(() => () => true);
 
-jest.mock("@react-native-community/netinfo", () => {
-  const mockUseNetInfo = jest.fn(() => ({
-    isConnected: true,
-    isInternetReachable: true,
-    type: "unknown",
-    details: null,
-  }));
-
-  return {
-    NetInfoStateType: {
-      unknown: "unknown",
-      none: "none",
-    },
-    useNetInfo: mockUseNetInfo,
-    addEventListener: jest.fn(() => jest.fn()),
-  };
-});
-
+// Use global netinfo mock from jest-setup - do not replace to avoid mock cannibalization
 type NetInfoOverride =
   | ({
       type: NetInfoStateType.none;

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -102,6 +102,10 @@ const initialStateWithFilterEnabledButNoEvmFamily = (state: State): State => ({
 });
 
 describe("useOperationsV1 integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should filter out token operations with 0 value (address poisoning) when filter is enabled", () => {
     const accountWithZeroValueTokenOp = createAccountWithZeroValueTokenOperation();
 

--- a/apps/ledger-live-mobile/src/screens/SendFunds/07-SendBroadcastError.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/07-SendBroadcastError.test.tsx
@@ -35,6 +35,7 @@ const mockExportLogs = jest.fn();
 const setup = (error: Error | null, url: string | null = null) => {
   const mockRoute = {
     params: {
+      accountId: mockAccount.id,
       error: error ? { ...error, url } : null,
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Try to stabilize mobile unit test runs

### 📝 Description

## Test stabilization
  Fixes flaky mobile tests when running `pnpm mobile test:jest` with parallel workers
  (`--maxWorkers=50%`).
  ### Root causes
  1. **Mock cannibalization** – Multiple tests mocked the same modules
  (`@react-native-community/netinfo`, `react-native-vision-camera`) and leaked state
  between runs.
  2. **Aggressive `jest.restoreAllMocks()`** – Some tests restored all mocks, including
   global ones used by other tests.
  3. **Incorrect `beforeEach` order** – `jest.clearAllMocks()` ran after
  `mockReturnValue()`, clearing the configured mocks.
  4. **Hooks at describe load time** – `renderHook()` was called when the describe
  block loaded instead of inside the test lifecycle, causing worker crashes.
  ### Changes
  #### Global setup (`__tests__/jest-setup.js`)
  - Reset shared mocks in `afterEach`: `mockRNCNetInfo.useNetInfo`,
  `mockUseCameraPermission`, `mockGetCameraPermissionStatus`.
  - Use a shared `mockUseCameraPermission` reference for the vision-camera mock.
  #### Duplicate mocks removed
  - **modularDrawer.test.tsx** – Removed
  `jest.mock("@react-native-community/netinfo")`, rely on global mock.
  - **MarketListLayout.test.tsx** – Same change for `@react-native-community/netinfo`.
  #### `beforeEach` / `afterEach` fixes
  - **largeMoverLandingPage.integration.test.tsx** – Call `jest.clearAllMocks()` before
   `mockReturnValue()`.
  - **UpdateBanner.test.tsx** – Replace `jest.restoreAllMocks()` with
  `jest.clearAllMocks()`, add `afterEach` to restore `PlatformSpy`.
  - **useUpdateBannerViewModel.test.tsx** – Same pattern as `UpdateBanner.test.tsx`.
  - **useOperationsV1.integration.test.ts** – Add `beforeEach(() =>
  jest.clearAllMocks())`.
  #### Test robustness
  - **SendBroadcastError.test.tsx** – Add `accountId` to route params so
  `accountScreenSelector` behaves consistently.
  - **LNSUpsellBanner.test.tsx** – Move `renderHook(useTranslation)` from describe load
   time into `beforeEach` to avoid worker crashes.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->https://ledgerhq.atlassian.net/browse/LIVE-26611


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
