### PR TITLE
:bug: fix(desktop): set workerIdleMemoryLimit to prevent Jest OOM crashes

### DIFF
--- a/.changeset/fix-jest-oom-worker.md
+++ b/.changeset/fix-jest-oom-worker.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Jest worker OOM crash by setting workerIdleMemoryLimit

--- a/apps/ledger-live-desktop/jest.config.js
+++ b/apps/ledger-live-desktop/jest.config.js
@@ -92,6 +92,7 @@ const commonConfig = {
 };
 
 module.exports = {
+  workerIdleMemoryLimit: "1GB",
   collectCoverageFrom: [
     "src/**/*.{ts,tsx}",
     "!src/**/*.test.{ts,tsx}",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This is a CI/test infrastructure fix — it will be validated by the CI pipeline itself passing without OOM crashes._
- [x] **Impact of the changes:**
  - Desktop unit tests CI stability
  - No runtime behavior change for the application

### 📝 Description

**Problem**: Desktop unit tests intermittently crash in CI with `Jest worker ran out of memory and crashed` on the `SuccessStep.test.tsx` test suite (and potentially others). This is a [known Node.js memory leak issue](https://github.com/jestjs/jest/issues/11956) affecting Node versions >16.11.0, where Jest workers accumulate memory over time without releasing it. With 228 test suites running in `--coverage` mode and `--max-old-space-size=7168`, workers eventually exhaust memory and crash — particularly for test suites executed late in the run.

This flaky failure affects **any PR** regardless of its content (e.g. [#14605](https://github.com/LedgerHQ/ledger-live/pull/14605), [#14582](https://github.com/LedgerHQ/ledger-live/pull/14582)), since the OOM crash is not caused by the test logic itself but by memory accumulation across all preceding suites.

**Solution**: Add [`workerIdleMemoryLimit: "1GB"`](https://jestjs.io/docs/configuration#workeridlememorylimit-numberstring) to the desktop Jest config. This is the [official Jest workaround](https://github.com/jestjs/jest/issues/11956) — it forces Jest to recycle (kill and restart) a worker after it exceeds 1GB of memory usage upon completing a test suite. This prevents unbounded memory growth while keeping restart overhead minimal.

**Why 1GB?** The CI runner allocates 7GB heap (`--max-old-space-size=7168`) with `--maxWorkers=50%`. A 1GB threshold allows each worker to handle multiple test suites before being recycled, while staying well within safe memory bounds.

### ❓ Context

- **Related issues**:
  - [Jest #11956 — Memory consumption issues on Node JS 16.11.0+](https://github.com/jestjs/jest/issues/11956)
  - [Jest docs — workerIdleMemoryLimit](https://jestjs.io/docs/configuration#workeridlememorylimit-numberstring)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)