### PR TITLE
fix(desktop): clean up leaked timers to prevent Jest worker OOM and graceful exit failures

### DIFF
--- a/.changeset/fix-desktop-timer-leaks.md
+++ b/.changeset/fix-desktop-timer-leaks.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix timer leaks (setTimeout/setInterval without cleanup) to prevent Jest worker OOM crashes and graceful exit failures

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/LogContentCardWrapper.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/LogContentCardWrapper.tsx
@@ -35,6 +35,7 @@ const LogContentCardWrapper: React.FC<LogContentCardWrapperProps> = ({
   const dispatch = useDispatch();
   const isContentCardVisibleRef = useRef(false);
   const isContainerVisibleRef = useRef(false);
+  const notificationTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const currentCard = useMemo(() => {
     const cards = braze.getCachedContentCards()?.cards ?? [];
@@ -60,7 +61,7 @@ const LogContentCardWrapper: React.FC<LogContentCardWrapperProps> = ({
             anonymousUserNotifications[currentCard.id as string] !==
             currentCard?.expiresAt?.getTime()
           ) {
-            setTimeout(() => {
+            notificationTimerRef.current = setTimeout(() => {
               dispatch(
                 updateAnonymousUserNotifications({
                   notifications: {
@@ -90,6 +91,7 @@ const LogContentCardWrapper: React.FC<LogContentCardWrapperProps> = ({
     }
 
     return () => {
+      clearTimeout(notificationTimerRef.current);
       if (currentRef) {
         intersectionObserver.unobserve(currentRef);
       }

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/useViewNotification.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/useViewNotification.ts
@@ -14,9 +14,10 @@ export function useViewNotification(location: LNSBannerLocation, variant: LNSBan
     if (variant.type !== "notification" || location !== "notification_center" || viewed) return;
 
     const viewedAt = Date.now();
-    setTimeout(
+    const timer = setTimeout(
       () => dispatch(updateAnonymousUserNotifications({ notifications: { LNSUpsell: viewedAt } })),
       OFFLINE_SEEN_DELAY,
     );
+    return () => clearTimeout(timer);
   }, [variant, location, viewed, dispatch]);
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/WelcomeNew/hooks/useVideoCarousel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/WelcomeNew/hooks/useVideoCarousel.ts
@@ -57,10 +57,10 @@ export function useVideoCarousel() {
   // Visibility detection effect
   useEffect(() => {
     if (!document.getElementById("loader-container")) {
-      setTimeout(() => {
+      const earlyTimeout = setTimeout(() => {
         setIsVisible(true);
       }, 50);
-      return;
+      return () => clearTimeout(earlyTimeout);
     }
 
     const fallbackTimeout = setTimeout(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/utils/__tests__/dateFormatter.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/utils/__tests__/dateFormatter.test.ts
@@ -50,12 +50,12 @@ describe("dateFormatter utils", () => {
     const DAY_MS = 24 * HOUR_MS;
     const WEEK_MS = 7 * DAY_MS;
 
-    beforeAll(() => {
+    beforeEach(() => {
       jest.useFakeTimers();
       jest.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
     });
 
-    afterAll(() => {
+    afterEach(() => {
       jest.useRealTimers();
     });
 

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/Disconnected.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/Disconnected.tsx
@@ -104,9 +104,10 @@ const Disconnected = ({ onTryAgain }: { onTryAgain: (a: boolean) => void }) => {
     navigate("/");
   }, [navigate]);
   useEffect(() => {
-    setTimeout(() => {
+    const timerRef = setTimeout(() => {
       setReadyToDecide(true);
     }, 3000);
+    return () => clearTimeout(timerRef);
   }, []);
   useEffect(() => {
     let sub: Subscription;

--- a/apps/ledger-live-desktop/tests/jestSetup.js
+++ b/apps/ledger-live-desktop/tests/jestSetup.js
@@ -35,7 +35,10 @@ beforeAll(() =>
     onUnhandledRequest: "bypass",
   }),
 );
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  server.resetHandlers();
+  jest.clearAllTimers();
+});
 afterAll(() => server.close());
 
 jest.mock("src/sentry/install", () => ({


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Timer cleanup is validated indirectly by the existing test suite no longer leaking timers. `jest.clearAllTimers()` added to `afterEach` as a safety net._
- [x] **Impact of the changes:**
  - Desktop Jest test suite stability (no more OOM crashes from leaked timers)
  - Manager Disconnected screen timer lifecycle
  - DynamicContent LogContentCardWrapper notification timer lifecycle
  - LNS Upsell banner view notification timer lifecycle
  - Onboarding WelcomeNew video carousel timer lifecycle

### 📝 Description

**Problem**: Several components in ledger-live-desktop used `setTimeout` or `setInterval` without proper cleanup in their `useEffect` return functions. These leaked timers accumulated across test runs, causing Jest workers to run out of memory (OOM) and fail to exit gracefully.

**Solution**: 
- Added `clearTimeout` / `clearInterval` cleanup in `useEffect` return functions for `Disconnected.tsx`, `LogContentCardWrapper.tsx`, `useViewNotification.ts`, and `useVideoCarousel.ts`
- Added `jest.clearAllTimers()` in `afterEach` in `jestSetup.js` as a global safety net to prevent future timer leaks from breaking CI

### ❓ Context

- **Related**: Desktop CI Jest OOM worker failures

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)