### PR TITLE
feat(desktop): navigate to device selection from connect quick action

### DIFF
--- a/.changeset/hot-bugs-relate.md
+++ b/.changeset/hot-bugs-relate.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": minor
 ---
 
-stabilize mad test on desktop
+Connect quick action now navigates to device selection screen instead of opening connect device modal

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
@@ -406,8 +406,8 @@ describe("useQuickActions", () => {
       expect(actionTitles).toContain("Buy a Ledger");
     });
 
-    it("should open connect device modal when connect action is triggered", () => {
-      const { result, store } = renderHook(() => useQuickActions(trackingPageName), {
+    it("should navigate to device selection when connect action is triggered", () => {
+      const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
           settings: { hasCompletedOnboarding: false },
@@ -418,8 +418,8 @@ describe("useQuickActions", () => {
         result.current.actionsList[0].onAction();
       });
 
-      expect(store.getState().modals).toMatchObject({
-        MODAL_CONNECT_DEVICE: { isOpened: true },
+      expect(mockNavigate).toHaveBeenCalledWith("/onboarding/select-device", {
+        state: { fromQuickAction: true },
       });
     });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
@@ -110,8 +110,8 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
       page: trackingPageName,
     });
 
-    dispatch(openModal("MODAL_CONNECT_DEVICE", { onResult: () => {} }));
-  }, [dispatch, trackingPageName]);
+    navigate("/onboarding/select-device", { state: { fromQuickAction: true } });
+  }, [navigate, trackingPageName]);
 
   const onBuyALedger = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/SelectDevice/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/SelectDevice/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useLocation } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import styled from "styled-components";
@@ -34,8 +34,10 @@ const TitleText = styled(Text).attrs({
 export function SelectDevice() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const { setDeviceModelId } = useContext(OnboardingContext);
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const fromQuickAction = !!location.state?.fromQuickAction;
 
   const handleDeviceSelect = useCallback(
     (deviceModelId: DeviceModelId) => {
@@ -56,7 +58,13 @@ export function SelectDevice() {
       <TrackPage category="Onboarding Device - Selection" flow="Onboarding" />
       <OnboardingNavHeader
         onClickPrevious={() =>
-          navigate(hasCompletedOnboarding ? "/settings/help" : "/onboarding/welcome")
+          navigate(
+            fromQuickAction
+              ? "/"
+              : hasCompletedOnboarding
+                ? "/settings/help"
+                : "/onboarding/welcome",
+          )
         }
       />
       <DeviceSelector onClick={handleDeviceSelect} />


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Connect quick action behavior (pre-onboarding state)
      - Device selection screen back navigation

### 📝 Description

The "Connect" quick action on Desktop was opening `MODAL_CONNECT_DEVICE`, which directly attempts a device connection without letting the user choose a device model first. On Mobile, this flow navigates to device selection.

This PR aligns Desktop with Mobile by navigating to `/onboarding/select-device` instead, where users can choose their device model (Stax, Europa, Nano S, Nano SP, Nano X). The back button on the device selection screen returns to `"/"` when arriving from the quick action, rather than the default onboarding/settings routes.

### ❓ Context

- Aligns Desktop connect quick action with Mobile behavior https://ledgerhq.atlassian.net/browse/LIVE-26617

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)