### PR TITLE
feat(desktop): skip device onboarding (lazy onboarding)

### DIFF
--- a/.changeset/skip-device-onboarding-live-26237.md
+++ b/.changeset/skip-device-onboarding-live-26237.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add lazy onboarding: allow completing onboarding without a device and defer device setup

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/WelcomeNew/hooks/__tests__/useWelcomeNewViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/WelcomeNew/hooks/__tests__/useWelcomeNewViewModel.test.ts
@@ -1,0 +1,121 @@
+import { renderHook, act } from "tests/testSetup";
+import { useNavigate } from "react-router";
+import { useWelcomeNewViewModel } from "../useWelcomeNewViewModel";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("~/renderer/terms", () => ({
+  acceptTerms: jest.fn(),
+}));
+
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
+}));
+
+jest.mock("LLD/features/AnalyticsOptInPrompt/hooks/useCommonLogic", () => ({
+  useAnalyticsOptInPrompt: jest.fn(() => ({
+    analyticsOptInPromptProps: {},
+    isFeatureFlagsAnalyticsPrefDisplayed: false,
+    openAnalyticsOptInPrompt: jest.fn(),
+    onSubmit: jest.fn(),
+  })),
+}));
+
+jest.mock("LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer", () => ({
+  useActivationDrawer: jest.fn(() => ({
+    openDrawer: jest.fn(),
+    closeDrawer: jest.fn(),
+  })),
+}));
+
+const mockedUseNavigate = useNavigate as jest.MockedFunction<typeof useNavigate>;
+
+describe("useWelcomeNewViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseNavigate.mockReturnValue(mockNavigate);
+  });
+
+  describe("navigation effect when onboarding is completed", () => {
+    it('should navigate to "/" when shouldUseLazyOnboarding is true and onboarding completed', () => {
+      renderHook(() => useWelcomeNewViewModel(), {
+        initialState: {
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+            overriddenFeatureFlags: {
+              lwdWallet40: {
+                enabled: true,
+                params: { lazyOnboarding: true },
+              },
+            },
+          },
+        },
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith("/");
+    });
+
+    it('should navigate to "/onboarding/select-device" when shouldUseLazyOnboarding is false and onboarding completed', () => {
+      renderHook(() => useWelcomeNewViewModel(), {
+        initialState: {
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+          },
+        },
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith("/onboarding/select-device");
+    });
+  });
+
+  describe("handleGetStarted with lazy onboarding", () => {
+    it('should set hasCompletedOnboarding to true and navigate to "/" when lazy onboarding is enabled', () => {
+      const { result, store } = renderHook(() => useWelcomeNewViewModel(), {
+        initialState: {
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: false,
+            overriddenFeatureFlags: {
+              lwdWallet40: {
+                enabled: true,
+                params: { lazyOnboarding: true },
+              },
+            },
+          },
+        },
+      });
+
+      act(() => {
+        result.current.handleGetStarted();
+      });
+
+      expect(store.getState().settings.hasCompletedOnboarding).toBe(true);
+      expect(mockNavigate).toHaveBeenCalledWith("/");
+    });
+
+    it('should navigate to "/onboarding/select-device" when lazy onboarding is disabled', () => {
+      const { result } = renderHook(() => useWelcomeNewViewModel(), {
+        initialState: {
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: false,
+          },
+        },
+      });
+
+      act(() => {
+        result.current.handleGetStarted();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith("/onboarding/select-device");
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/WelcomeNew/hooks/useWelcomeNewViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/WelcomeNew/hooks/useWelcomeNewViewModel.ts
@@ -12,13 +12,14 @@ import { useAnalyticsOptInPrompt } from "LLD/features/AnalyticsOptInPrompt/hooks
 import { EntryPoint } from "LLD/features/AnalyticsOptInPrompt/types/AnalyticsOptInPromptNavigator";
 import { useActivationDrawer } from "LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer";
 import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 export function useWelcomeNewViewModel() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const lldRebornABtest = useFeature("lldRebornABtest");
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("desktop");
 
   // URLs
   const urlBuyNew = useLocalizedUrl(urls.buyNew);
@@ -40,9 +41,13 @@ export function useWelcomeNewViewModel() {
   // Navigation effect
   useEffect(() => {
     if (shouldInitiallySelectDevice.current) {
-      navigate("/onboarding/select-device");
+      if (shouldUseLazyOnboarding) {
+        navigate("/");
+      } else {
+        navigate("/onboarding/select-device");
+      }
     }
-  }, [navigate]);
+  }, [navigate, shouldUseLazyOnboarding]);
 
   // Feature flags easter egg state
   const countRef1 = useRef(0);
@@ -81,16 +86,25 @@ export function useWelcomeNewViewModel() {
   }, [navigate]);
 
   // Skip onboarding (dev only)
-  const skipOnboarding = useCallback(() => {
+  const skipOnboardingDev = useCallback(() => {
     dispatch(saveSettings({ hasCompletedOnboarding: true }));
     navigate("/settings");
   }, [dispatch, navigate]);
 
+  const skipOnboarding = useCallback(() => {
+    dispatch(saveSettings({ hasCompletedOnboarding: true }));
+    navigate("/");
+  }, [dispatch, navigate]);
   // Main navigation handlers
   const handleAcceptTermsAndGetStarted = useCallback(() => {
     acceptTerms();
-    navigate("/onboarding/select-device");
-  }, [navigate]);
+
+    if (shouldUseLazyOnboarding) {
+      skipOnboarding();
+    } else {
+      navigate("/onboarding/select-device");
+    }
+  }, [navigate, shouldUseLazyOnboarding, skipOnboarding]);
 
   // Analytics opt-in prompt
   const {
@@ -170,7 +184,7 @@ export function useWelcomeNewViewModel() {
     handleOpenFeatureFlagsDrawer,
 
     // Dev utilities
-    skipOnboarding,
+    skipOnboarding: skipOnboardingDev,
 
     // Action handlers
     handleGetStarted,

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/WelcomeNew/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/WelcomeNew/index.tsx
@@ -22,6 +22,7 @@ import {
   TermsAndConditionsText,
   StyledLink,
 } from "./components/WelcomeNewStyles";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 export function WelcomeNew() {
   const {
@@ -52,6 +53,8 @@ export function WelcomeNew() {
   } = useVideoCarousel();
 
   const { colors } = useTheme();
+
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("desktop");
 
   return (
     <WelcomeContainer ref={containerRef}>
@@ -110,25 +113,29 @@ export function WelcomeNew() {
               {t("onboarding.screens.welcome.nextButton")}
             </Button>
 
-            <Button
-              data-testid="onboarding-device-button"
-              iconPosition="right"
-              variant="neutral"
-              onClick={handleBuyNew}
-              outline={true}
-              flexDirection="column"
-              whiteSpace="normal"
-              minWidth="250px"
-            >
-              {t("onboarding.screens.welcome.buyLink")}
-            </Button>
+            {!shouldUseLazyOnboarding && (
+              <Button
+                data-testid="onboarding-device-button"
+                iconPosition="right"
+                variant="neutral"
+                onClick={handleBuyNew}
+                outline={true}
+                flexDirection="column"
+                whiteSpace="normal"
+                minWidth="250px"
+              >
+                {t("onboarding.screens.welcome.buyLink")}
+              </Button>
+            )}
           </Flex>
 
-          <LedgerSyncEntryPoint
-            entryPoint={LSEntryPoint.onboarding}
-            needEligibleDevice={false}
-            onPress={handleSetupLedgerSync}
-          />
+          {!shouldUseLazyOnboarding && (
+            <LedgerSyncEntryPoint
+              entryPoint={LSEntryPoint.onboarding}
+              needEligibleDevice={false}
+              onPress={handleSetupLedgerSync}
+            />
+          )}
 
           {__DEV__ ? (
             <Button

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -3,8 +3,13 @@ import { render, screen, waitFor } from "tests/testSetup";
 import { server, http, HttpResponse } from "tests/server";
 import { MarketMockedResponse } from "tests/handlers/fixtures/market";
 import { TFunction } from "i18next";
-import { Portfolio as PortfolioType } from "@ledgerhq/types-live";
 import PortfolioPage from "../index";
+import { DeviceModelId } from "@ledgerhq/devices";
+import type {
+  Portfolio as PortfolioType,
+  DeviceInfo as DeviceInfoType,
+  DeviceModelInfo as DeviceModelInfoType,
+} from "@ledgerhq/types-live";
 import { PortfolioView } from "../PortfolioView";
 import * as portfolioReact from "@ledgerhq/live-countervalues-react/portfolio";
 import { useNavigate } from "react-router";
@@ -12,6 +17,14 @@ import { BTC_ACCOUNT, EMPTY_BTC_ACCOUNT } from "../../__mocks__/accounts.mock";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
 import { track } from "~/renderer/analytics/segment";
 import { PORTFOLIO_TRACKING_PAGE_NAME } from "../utils/constants";
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const MOCK_LAST_SEEN_DEVICE: DeviceModelInfoType = {
+  modelId: DeviceModelId.nanoX,
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  deviceInfo: {} as DeviceInfoType,
+  apps: [],
+};
 
 const MARKET_API_ENDPOINT = "https://countervalues.live.ledger.com/v3/markets";
 
@@ -127,6 +140,7 @@ describe("PortfolioView", () => {
           settings: {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
+            lastSeenDevice: MOCK_LAST_SEEN_DEVICE,
           },
         },
       });
@@ -147,6 +161,7 @@ describe("PortfolioView", () => {
           settings: {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
+            lastSeenDevice: MOCK_LAST_SEEN_DEVICE,
           },
         },
       });
@@ -163,6 +178,7 @@ describe("PortfolioView", () => {
           settings: {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
+            lastSeenDevice: MOCK_LAST_SEEN_DEVICE,
           },
         },
       });
@@ -178,6 +194,7 @@ describe("PortfolioView", () => {
           settings: {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
+            lastSeenDevice: MOCK_LAST_SEEN_DEVICE,
           },
         },
       });
@@ -185,13 +202,14 @@ describe("PortfolioView", () => {
       expect(screen.queryByTestId("portfolio-balance")).toBeVisible();
     });
 
-    it("should render NoDeviceView when user has not completed onboarding", () => {
+    it("should render NoDeviceView when no device has been onboarded", () => {
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
         initialState: {
           accounts: [],
           settings: {
             ...INITIAL_STATE,
-            hasCompletedOnboarding: false,
+            hasCompletedOnboarding: true,
+            lastSeenDevice: null,
           },
         },
       });
@@ -200,6 +218,22 @@ describe("PortfolioView", () => {
       expect(screen.queryByTestId("portfolio-balance")).toBeNull();
       expect(screen.queryByTestId("no-balance-title")).toBeNull();
     });
+
+    it("should render NoDeviceView when user completed lazy onboarding without a device", () => {
+      render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
+        initialState: {
+          accounts: [],
+          settings: {
+            ...INITIAL_STATE,
+            hasCompletedOnboarding: true,
+            lastSeenDevice: null,
+          },
+        },
+      });
+
+      expect(screen.getByTestId("no-device-title")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-balance")).toBeNull();
+    });
     it("should display discreet placeholders when discreet mode is enabled", () => {
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
         initialState: {
@@ -207,6 +241,7 @@ describe("PortfolioView", () => {
           settings: {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
+            lastSeenDevice: MOCK_LAST_SEEN_DEVICE,
             discreetMode: true,
           },
         },
@@ -224,6 +259,7 @@ describe("PortfolioView", () => {
           settings: {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
+            lastSeenDevice: MOCK_LAST_SEEN_DEVICE,
             discreetMode: false,
           },
         },
@@ -245,6 +281,7 @@ describe("PortfolioView", () => {
           settings: {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
+            lastSeenDevice: MOCK_LAST_SEEN_DEVICE,
           },
         },
       });
@@ -263,6 +300,7 @@ describe("PortfolioView", () => {
           settings: {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
+            lastSeenDevice: MOCK_LAST_SEEN_DEVICE,
           },
         },
       });
@@ -280,6 +318,7 @@ describe("PortfolioView", () => {
           settings: {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
+            lastSeenDevice: MOCK_LAST_SEEN_DEVICE,
           },
         },
       });

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/index.tsx
@@ -5,9 +5,9 @@ import { NoBalanceView } from "./NoBalanceView";
 import { NoDeviceView } from "./NoDeviceView";
 
 export const Balance = () => {
-  const { hasCompletedOnboarding, hasAccount, ...viewModel } = useBalanceViewModel();
+  const { hasOnboardedDevice, hasAccount, ...viewModel } = useBalanceViewModel();
 
-  if (!hasCompletedOnboarding) {
+  if (!hasOnboardedDevice) {
     return <NoDeviceView />;
   }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
@@ -12,5 +12,5 @@ export interface BalanceViewProps {
 
 export type BalanceViewModelResult = BalanceViewProps & {
   readonly hasAccount: boolean;
-  readonly hasCompletedOnboarding: boolean;
+  readonly hasOnboardedDevice: boolean;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -6,7 +6,7 @@ import {
   selectedTimeRangeSelector,
   localeSelector,
   discreetModeSelector,
-  hasCompletedOnboardingSelector,
+  hasOnboardedDeviceSelector,
 } from "~/renderer/reducers/settings";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { useAccountStatus } from "LLD/hooks/useAccountStatus";
@@ -36,7 +36,7 @@ export const useBalanceViewModel = (
   const locale = useSelector(localeSelector);
   const discreet = useSelector(discreetModeSelector);
   const { hasAccount } = useAccountStatus();
-  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const hasOnboardedDevice = useSelector(hasOnboardedDeviceSelector);
 
   const range = useLegacyRange ? selectedTimeRange : NEW_FLOW_RANGE;
 
@@ -88,6 +88,6 @@ export const useBalanceViewModel = (
     navigateToAnalytics,
     handleKeyDown,
     hasAccount,
-    hasCompletedOnboarding,
+    hasOnboardedDevice,
   };
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
@@ -6,10 +6,19 @@ import { useNavigate, useLocation } from "react-router";
 import { ArrowDown, Plus, Minus, ArrowUp } from "@ledgerhq/lumen-ui-react/symbols";
 import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { DeviceModelId } from "@ledgerhq/devices";
 import BigNumber from "bignumber.js";
-import type { Account } from "@ledgerhq/types-live";
+import type { Account, DeviceInfo, DeviceModelInfo } from "@ledgerhq/types-live";
 import { urls } from "~/config/urls";
 import { openURL } from "~/renderer/linking";
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const MOCK_LAST_SEEN_DEVICE: DeviceModelInfo = {
+  modelId: DeviceModelId.nanoX,
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  deviceInfo: {} as DeviceInfo,
+  apps: [],
+};
 
 jest.mock("LLD/features/Send/hooks/useOpenSendFlow");
 jest.mock("LLD/features/ModularDialog/hooks/useOpenAssetFlow");
@@ -79,7 +88,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -93,7 +102,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -107,7 +116,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -120,7 +129,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -136,7 +145,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -148,7 +157,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createEmptyAccount()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -160,7 +169,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -172,7 +181,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createEmptyAccount(), createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -186,7 +195,7 @@ describe("useQuickActions", () => {
       const { result, store } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -203,7 +212,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -218,7 +227,7 @@ describe("useQuickActions", () => {
       const { result, store } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -235,7 +244,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -252,7 +261,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -269,7 +278,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -288,7 +297,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -307,7 +316,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -324,7 +333,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -342,7 +351,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -358,7 +367,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -370,7 +379,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createEmptyAccount()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -382,7 +391,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createEmptyAccount(), createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: MOCK_LAST_SEEN_DEVICE },
         },
       });
 
@@ -391,12 +400,12 @@ describe("useQuickActions", () => {
     });
   });
 
-  describe("when onboarding is not completed", () => {
+  describe("when no device has been onboarded", () => {
     it("should return only connect and buy a ledger actions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: false },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: null },
         },
       });
 
@@ -410,7 +419,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: false },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: null },
         },
       });
 
@@ -427,7 +436,7 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: false },
+          settings: { hasCompletedOnboarding: true, lastSeenDevice: null },
         },
       });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
@@ -17,7 +17,7 @@ import { QuickAction } from "../types";
 import { useOpenAssetFlow } from "../../ModularDialog/hooks/useOpenAssetFlow";
 import { ModularDrawerLocation } from "../../ModularDrawer";
 import { track } from "~/renderer/analytics/segment";
-import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
+import { hasOnboardedDeviceSelector } from "~/renderer/reducers/settings";
 import { urls } from "~/config/urls";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { openURL } from "~/renderer/linking";
@@ -29,7 +29,7 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
   const location = useLocation();
   const { t } = useTranslation();
   const { hasAccount, hasFunds } = useAccountStatus();
-  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const hasOnboardedDevice = useSelector(hasOnboardedDeviceSelector);
   const urlLedgerShop = useLocalizedUrl(urls.ledgerShop);
   const openLedgerShop = useCallback(() => openURL(urlLedgerShop), [urlLedgerShop]);
 
@@ -123,7 +123,7 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
   }, [trackingPageName, openLedgerShop]);
 
   const actionsList = useMemo((): QuickAction[] => {
-    if (!hasCompletedOnboarding) {
+    if (!hasOnboardedDevice) {
       return [
         {
           title: t("quickActions.connect"),
@@ -173,7 +173,7 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
       },
     ];
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasCompletedOnboarding, hasFunds, hasAccount]);
+  }, [hasOnboardedDevice, hasFunds, hasAccount]);
 
   return { actionsList };
 };

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/Disclaimer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/Disclaimer.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Markdown, { Notes } from "~/renderer/components/Markdown";
-import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
+import { hasOnboardedDeviceSelector } from "~/renderer/reducers/settings";
 
 type Props = {
   firmware: FirmwareUpdateContext;
@@ -14,7 +14,7 @@ type Props = {
 
 export default function Disclaimer({ firmware, onContinue }: Props) {
   const { t } = useTranslation();
-  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const hasOnboardedDevice = useSelector(hasOnboardedDeviceSelector);
 
   return (
     <Flex flex={1} flexDirection="column" justifyContent="space-between" overflowY="hidden">
@@ -28,7 +28,7 @@ export default function Disclaimer({ firmware, onContinue }: Props) {
         my={12}
       >
         <TrackPage category="Manager" name="DisclaimerModal" />
-        {hasCompletedOnboarding && (
+        {hasOnboardedDevice && (
           <Alert
             type="info"
             title={t("manager.firmware.prepareSeed")}

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/hasOnboardedDeviceSelector.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/hasOnboardedDeviceSelector.test.ts
@@ -1,0 +1,45 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import type { DeviceInfo, DeviceModelInfo } from "@ledgerhq/types-live";
+import { hasOnboardedDeviceSelector } from "../settings";
+import { INITIAL_STATE } from "../settings";
+import type { State } from "../index";
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const VALID_DEVICE: DeviceModelInfo = {
+  modelId: DeviceModelId.nanoX,
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  deviceInfo: {} as DeviceInfo,
+  apps: [],
+};
+
+const createState = (lastSeenDevice: DeviceModelInfo | null | undefined) =>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  ({
+    settings: {
+      ...INITIAL_STATE,
+      lastSeenDevice,
+    },
+  }) as unknown as State;
+
+describe("hasOnboardedDeviceSelector", () => {
+  it("should return false when lastSeenDevice is null", () => {
+    expect(hasOnboardedDeviceSelector(createState(null))).toBe(false);
+  });
+
+  it("should return true when lastSeenDevice is set with a valid modelId", () => {
+    expect(hasOnboardedDeviceSelector(createState(VALID_DEVICE))).toBe(true);
+  });
+
+  it("should return false when lastSeenDevice is undefined", () => {
+    expect(hasOnboardedDeviceSelector(createState(undefined))).toBe(false);
+  });
+
+  it("should return false when lastSeenDevice has an unrecognized modelId", () => {
+    const invalidDevice: DeviceModelInfo = {
+      ...VALID_DEVICE,
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      modelId: "unknownModel" as DeviceModelId,
+    };
+    expect(hasOnboardedDeviceSelector(createState(invalidDevice))).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -770,6 +770,7 @@ export const lastSeenDeviceSelector = (state: State): DeviceModelInfo | null | u
     return null;
   return lastSeenDevice;
 };
+export const hasOnboardedDeviceSelector = (state: State) => lastSeenDeviceSelector(state) !== null;
 export const devicesModelListSelector = (state: State): DeviceModelId[] =>
   state.settings.devicesModelList;
 export const latestFirmwareSelector = (state: State) => state.settings.latestFirmware;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio: balance vs NoDeviceView when no device is onboarded (lazy onboarding)
  - QuickActions: Connect / Buy a Ledger vs full actions based on device presence
  - Onboarding: WelcomeNew flow with lwdWallet40 lazyOnboarding flag (navigate to "/" or select-device)
  - Update Firmware modal: recovery phrase alert gated on hasOnboardedDevice

### 📝 Description

**Problem:** Users cannot complete onboarding without connecting a physical Ledger device. This blocks access to the app for users who want to explore or buy a device later.

**Solution:** Introduce lazy onboarding so users can finish onboarding without a device and defer device setup. Key changes:

- **`hasOnboardedDeviceSelector`**: New selector (and unit tests) that uses `lastSeenDeviceSelector` so “has a device” is based on a valid `lastSeenDevice` (with `modelId` validation), not just `hasCompletedOnboarding`.
- **Portfolio & QuickActions**: Use `hasOnboardedDevice` instead of `hasCompletedOnboarding` for balance visibility and quick actions (NoDeviceView vs balance; Connect/Buy a Ledger vs Receive/Buy/Sell/Send).
- **WelcomeNew**: When `lwdWallet40` has `lazyOnboarding: true`, completed onboarding navigates to "/" instead of "/onboarding/select-device"; “Get started” sets `hasCompletedOnboarding` and navigates to "/" (skip device step).
- **Update Firmware modal (Disclaimer)**: Recovery phrase alert is shown only when `hasOnboardedDevice` is true (semantic fix: firmware update implies a device).
- **Tests**: Unit tests for `hasOnboardedDeviceSelector`, `useWelcomeNewViewModel` lazy branching, and updates to QuickActions, Portfolio integration, and SideBar test utils so device state is explicit in initial state.

| Before        | After         |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/1551234a-718a-4d46-9f23-c0d1eaad4f95" /> | <video src="https://github.com/user-attachments/assets/12f0910a-55ed-49fa-8d34-541da84c49df" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26237](https://ledgerhq.atlassian.net/browse/LIVE-26237)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26237]: https://ledgerhq.atlassian.net/browse/LIVE-26237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ