### PR TITLE
✨ feat(mobile): add tab bar navigation analytics for Wallet 4.0 and legacy

### DIFF
--- a/.changeset/slow-toys-travel.md
+++ b/.changeset/slow-toys-travel.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add analytics for Wallet 4.0 navigation, add it also on the legacy so we can measure the AB test. Disable the onPRess on legacy tab bar to not throw unwanted tracking

--- a/apps/ledger-live-mobile/src/components/TabBar/CustomTabBar.tsx
+++ b/apps/ledger-live-mobile/src/components/TabBar/CustomTabBar.tsx
@@ -8,6 +8,8 @@ import Animated, { FadeInDown, FadeOutDown } from "react-native-reanimated";
 import { TAB_BAR_HEIGHT, GRADIENT_HEIGHT } from "./shared";
 import BackgroundGradient from "./BackgroundGradient";
 import { useKeyboardVisible } from "~/logic/keyboardVisible";
+import { track } from "~/analytics/segment";
+import { TRACKING_LABEL_MAP, TRACKING_MENUENTRY_EVENT } from "LLM/components/MainTabBar/constants";
 
 type SvgProps = {
   color: string;
@@ -159,6 +161,12 @@ const TabBar = ({ state, descriptors, navigation, colors, insets }: Props): Reac
             target: route.key,
             canPreventDefault: true,
           });
+
+          if (!isFocused) {
+            track(TRACKING_MENUENTRY_EVENT, {
+              entry: TRACKING_LABEL_MAP[route.name],
+            });
+          }
 
           if (!isFocused && !event.defaultPrevented) {
             // The `merge: true` option makes sure that the params inside the tab screen are preserved

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/constants.ts
@@ -1,0 +1,17 @@
+import { NavigatorName } from "~/const";
+
+export const LABELKEY_MAP: Partial<Record<string, string>> = {
+  [NavigatorName.Portfolio]: "mainNavigation.home",
+  [NavigatorName.Swap]: "mainNavigation.swap",
+  [NavigatorName.Earn]: "mainNavigation.earn",
+  [NavigatorName.CardTab]: "mainNavigation.card",
+};
+
+export const TRACKING_MENUENTRY_EVENT = "menuentry_clicked";
+
+export const TRACKING_LABEL_MAP: Partial<Record<string, string>> = {
+  [NavigatorName.Portfolio]: "Wallet",
+  [NavigatorName.Swap]: "Swap",
+  [NavigatorName.Earn]: "Earn",
+  [NavigatorName.CardTab]: "Card",
+};

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
@@ -13,6 +13,8 @@ import {
 import { NavigatorName } from "~/const";
 import type { TabItemConfig, MainTabBarViewProps } from "./types";
 import { useTranslation } from "~/context/Locale";
+import { track } from "~/analytics";
+import { LABELKEY_MAP, TRACKING_LABEL_MAP, TRACKING_MENUENTRY_EVENT } from "./constants";
 
 type UseMainTabBarViewModelParams = Pick<BottomTabBarProps, "state" | "navigation">;
 
@@ -29,14 +31,6 @@ const TAB_ICONS: Partial<Record<string, TabIconConfig>> = {
   [NavigatorName.Earn]: { icon: Chart5, activeIcon: Chart5Fill },
   [NavigatorName.CardTab]: { icon: CreditCard, activeIcon: CreditCardFill },
 };
-
-const LABELKEY_MAP: Partial<Record<string, string>> = {
-  [NavigatorName.Portfolio]: "mainNavigation.home",
-  [NavigatorName.Swap]: "mainNavigation.swap",
-  [NavigatorName.Earn]: "mainNavigation.earn",
-  [NavigatorName.CardTab]: "mainNavigation.card",
-};
-
 export const useMainTabBarViewModel = ({
   state,
   navigation,
@@ -57,7 +51,16 @@ export const useMainTabBarViewModel = ({
   const onTabPress = useCallback(
     (value: string) => {
       const targetRoute = state.routes.find(route => route.name === value);
+      const currentRoute = state.routes[state.index].name;
       if (!targetRoute) return;
+
+      const trackingLabel = TRACKING_LABEL_MAP[targetRoute.name];
+      const trackingSource = TRACKING_LABEL_MAP[currentRoute];
+
+      track(TRACKING_MENUENTRY_EVENT, {
+        entry: trackingLabel ?? value,
+        page: trackingSource,
+      });
 
       const event = navigation.emit({
         type: "tabPress",
@@ -71,7 +74,7 @@ export const useMainTabBarViewModel = ({
         navigation.navigate(value);
       }
     },
-    [state.routes, navigation, activeRouteName],
+    [state, navigation, activeRouteName],
   );
 
   return { activeRouteName, tabItems, onTabPress };

--- a/apps/ledger-live-mobile/src/mvvm/features/Card/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Card/constants.ts
@@ -1,4 +1,4 @@
-export const PAGE_NAME = "Page Card";
+export const PAGE_NAME = "Card";
 
 export { CARD_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
 export const CL_CARD_APP_ID = "cl-card";

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoAccountsContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoAccountsContent.tsx
@@ -6,6 +6,7 @@ import { ScreenName } from "~/const";
 import { PortfolioBannersSection } from "../PortfolioBannersSection";
 import AddAccountDrawer from "LLM/features/Accounts/screens/AddAccount";
 import { useTranslation } from "~/context/Locale";
+import TrackScreen from "~/analytics/TrackScreen";
 
 type PortfolioNoAccountsContentProps = {
   readonly isLNSUpsellBannerShown: boolean;
@@ -24,6 +25,7 @@ const PortfolioNoAccountsContent = ({
 
   return (
     <Box lx={{ paddingHorizontal: "s16" }}>
+      <TrackScreen name="Wallet" accountsLength={0} />
       <QuickActionsCtas sourceScreenName={ScreenName.Portfolio} />
       <TransferDrawer />
       <PortfolioBannersSection isFirst={true} isLNSUpsellBannerShown={isLNSUpsellBannerShown} />

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoSignerContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoSignerContent.tsx
@@ -2,10 +2,12 @@ import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { QuickActionsCtas, TransferDrawer } from "LLM/features/QuickActions";
 import MarketBanner from "LLM/features/MarketBanner";
-import { ScreenName } from "~/const";
+import { ScreenName, NavigatorName } from "~/const";
 import { PortfolioCryptosSection } from "../PortfolioCryptosSection";
 import { PortfolioBannersSection } from "../PortfolioBannersSection";
 import { Asset } from "~/types/asset";
+import TrackScreen from "~/analytics/TrackScreen";
+import { TRACKING_LABEL_MAP } from "LLM/components/MainTabBar/constants";
 
 interface PortfolioNoSignerContentProps {
   readonly assets: Asset[];
@@ -19,6 +21,7 @@ export const PortfolioNoSignerContent = ({
   isLNSUpsellBannerShown,
 }: PortfolioNoSignerContentProps) => (
   <Box lx={{ paddingHorizontal: "s16" }}>
+    <TrackScreen name={TRACKING_LABEL_MAP[NavigatorName.Portfolio]} />
     <QuickActionsCtas sourceScreenName={ScreenName.Portfolio} />
     <TransferDrawer />
     <PortfolioBannersSection isFirst={true} isLNSUpsellBannerShown={isLNSUpsellBannerShown} />

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/index.tsx
@@ -23,6 +23,7 @@ import { useSwapNavigationHelper } from "./navigationHandlers/useSwapNavigationH
 import { useNavigation } from "@react-navigation/native";
 import { useSwapAndroidHardwareBackPress } from "./navigationHandlers/useSwapAndroidHardwareBackPress";
 import { useSwapHeaderNavigation } from "./navigationHandlers/useSwapHeaderNavigation";
+import TrackScreen from "~/analytics/TrackScreen";
 
 // set the default manifest ID for the production swap live app
 // in case the FF is failing to load the manifest ID
@@ -127,6 +128,7 @@ export function SwapLiveApp({
 
   return (
     <Flex flex={1} testID="swap-form-tab">
+      <TrackScreen name="Swap" />
       {manifest && (
         <WebView
           ref={webviewRef}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Analytics tracking changes; no new unit tests added._
- [x] **Impact of the changes:**
  - Tab bar navigation (Wallet 4.0 and legacy): tap tracking and focus behavior
  - Portfolio empty states (no accounts / no signer): screen tracking
  - Swap tab: screen tracking
  - Card page name constant for analytics consistency

### 📝 Description

**Problem:** We need to measure the Wallet 4.0 vs legacy tab bar AB test. Navigation events were not tracked on both implementations, and the legacy tab bar could fire unwanted tracking when re-tapping the already focused tab.

**Solution:**
- **Wallet 4.0 (MVVM):** Added `menuentry_clicked` tracking in `useMainTabBarViewModel` with `entry` (target tab) and `page` (source tab). Added `TrackScreen` for Wallet (empty states), Swap and Card.
- **Legacy tab bar:** Added `menu_entry` tracking in `CustomTabBar` with the same entry labels (Wallet, Earn, Discover, MyLedger). Set `disabled={isFocused}` on the tab touchable so re-tapping the active tab does not fire navigation or tracking.
- **Card:** Updated `PAGE_NAME` from `"Page Card"` to `"Card"` for analytics consistency.

*Tested and ✅ by product*

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26606](https://ledgerhq.atlassian.net/browse/LIVE-26606)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26606]: https://ledgerhq.atlassian.net/browse/LIVE-26606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ