### PR TITLE
docs(readme): add Ledger Developer Portal link to documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ It includes background information about the project and how to setup, run and b
 
 Please check the [**wiki**](https://github.com/LedgerHQ/ledger-live/wiki) for additional documentation.
 
+For comprehensive developer documentation — including architecture, MVVM pattern, testing strategy, git conventions, and integration guides (blockchain, tokens, swap, staking, Discover/Live Apps, etc.) — visit the [**Ledger Developer Portal**](https://developers.ledger.com/docs/ledger-live/contributing/getting-started).
+
 ## Structure
 
 The sub-packages are (roughly) split into three categories.


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not applicable — docs-only change to root README, no package impacted._
- [ ] **Covered by automatic tests.** _Not applicable — documentation change only._
- [x] **Impact of the changes:**
      - Root `README.md` documentation section updated

### 📝 Description

Adds a reference to the [Ledger Developer Portal](https://developers.ledger.com/docs/ledger-live/discover/getting-started) in the **Documentation** section of the root `README.md`.

This portal contains comprehensive documentation covering architecture, MVVM pattern, testing strategy, git conventions, and integration guides (blockchain, tokens, swap, staking, Discover/Live Apps, etc.) that is useful for contributors and integrators.

### ❓ Context

- No associated ticket — minor documentation improvement.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)