### PR TITLE
fix(lwd): set beforeEach and afterEach for dateFormatter test

### DIFF
--- a/.changeset/swift-beds-perform.md
+++ b/.changeset/swift-beds-perform.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(lwd): set beforeEach and afterEach for dateFormatter test

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/utils/__tests__/dateFormatter.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/utils/__tests__/dateFormatter.test.ts
@@ -50,12 +50,12 @@ describe("dateFormatter utils", () => {
     const DAY_MS = 24 * HOUR_MS;
     const WEEK_MS = 7 * DAY_MS;
 
-    beforeAll(() => {
+    beforeEach(() => {
       jest.useFakeTimers();
       jest.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
     });
 
-    afterAll(() => {
+    afterEach(() => {
       jest.useRealTimers();
     });
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

In the dateFormatter tests, fake timers setup was moved from `beforeAll`/`afterAll` to `beforeEach`/`afterEach`, so each test runs with its own fake time and restores real timers afterward.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
