### PR TITLE
:bug: fix(mobile): gate Analytics swap CTA and redirect to main swap when Wallet40

### DIFF
--- a/.changeset/strange-worms-collect.md
+++ b/.changeset/strange-worms-collect.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Gate Analytics allocation swap CTA with ptxServiceCtaExchangeDrawer and redirect to main swap screen when Wallet40 main nav is enabled

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/__integrations__/analyticsMain.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/__integrations__/analyticsMain.integration.test.tsx
@@ -21,7 +21,11 @@ jest.mock("@react-navigation/native", () => ({
 }));
 
 describe("AnalyticsMain Integration Tests", () => {
-  const mockState = (state: State): State => {
+  const mockState = (
+    state: State,
+    isExchangeEnabled: boolean = true,
+    isWallet40MainNavigation: boolean = true,
+  ): State => {
     const btcAccount = createMockAccount(mockBitcoinCurrency, "btc-1");
     const ethAccount = createMockAccount(mockEthereumCurrency, "eth-1");
     const adaAccount = createMockAccount(mockCardanoCurrency, "ada-1");
@@ -31,6 +35,13 @@ describe("AnalyticsMain Integration Tests", () => {
       accounts: {
         ...state.accounts,
         active: [btcAccount, ethAccount, adaAccount],
+      },
+      settings: {
+        ...state.settings,
+        overriddenFeatureFlags: {
+          ptxServiceCtaExchangeDrawer: { enabled: isExchangeEnabled },
+          lwmWallet40: { enabled: true, params: { mainNavigation: isWallet40MainNavigation } },
+        },
       },
     };
   };
@@ -55,9 +66,17 @@ describe("AnalyticsMain Integration Tests", () => {
     expect(screen.getByText(/swap/i)).toBeVisible();
   });
 
+  it("should not display swap button if exchange is disabled", () => {
+    render(<TestNavigatorWrapper />, {
+      overrideInitialState: state => mockState(state, false),
+    });
+
+    expect(screen.queryByText(/swap/i)).toBeNull();
+  });
+
   it("should track and navigate to swap when swap button is pressed", async () => {
     const { user } = render(<TestNavigatorWrapper />, {
-      overrideInitialState: mockState,
+      overrideInitialState: state => mockState(state, true, false),
     });
 
     await user.press(screen.getByText(/swap/i));
@@ -68,6 +87,18 @@ describe("AnalyticsMain Integration Tests", () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Swap);
+  });
+
+  it("should navigate to swap tab bar screen when swap button is pressed and Wallet40 main navigation is enabled", async () => {
+    const { user } = render(<TestNavigatorWrapper />, {
+      overrideInitialState: state => mockState(state, true),
+    });
+
+    await user.press(screen.getByText(/swap/i));
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Main, {
+      screen: NavigatorName.Swap,
+    });
   });
 
   it("should track and navigate to detailed allocation when allocation component is pressed", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/FooterButton.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/FooterButton.tsx
@@ -5,18 +5,30 @@ import { Button } from "@ledgerhq/lumen-ui-rnative";
 import { NavigatorName } from "~/const";
 import { track } from "~/analytics";
 import { ANALYTICS_PAGE } from "../../../const";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 const FooterButton: React.FC = () => {
   const { t } = useTranslation();
   const navigation = useNavigation();
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
+
+  const redirectToSwap = useCallback(() => {
+    if (shouldDisplayWallet40MainNav) {
+      navigation.navigate(NavigatorName.Main, {
+        screen: NavigatorName.Swap,
+      });
+    } else {
+      navigation.navigate(NavigatorName.Swap);
+    }
+  }, [navigation, shouldDisplayWallet40MainNav]);
 
   const onPress = useCallback(() => {
     track("button_clicked", {
       button: "Swap",
       page: ANALYTICS_PAGE,
     });
-    navigation.navigate(NavigatorName.Swap);
-  }, [navigation]);
+    redirectToSwap();
+  }, [redirectToSwap]);
 
   return (
     <Button appearance="base" size="md" onPress={onPress}>

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/index.tsx
@@ -10,12 +10,14 @@ import FooterButton from "./components/FooterButton";
 import MainGraph from "./components/MainGraph";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { ANALYTICS_PAGE } from "../../const";
+import useAnalyticsMainViewModel from "./useAnalyticsMainViewModel";
 
 type Props = StackNavigatorProps<AnalyticsNavigatorParamsList, ScreenName.Analytics>;
 
 export default function AnalyticsMain({ route }: Props): JSX.Element {
   const { params } = route;
   const sourceScreenName = params?.sourceScreenName;
+  const { isExchangeEnabled } = useAnalyticsMainViewModel();
 
   return (
     <SafeAreaView edges={["left", "right", "bottom"]} isFlex>
@@ -27,9 +29,11 @@ export default function AnalyticsMain({ route }: Props): JSX.Element {
             <AssetAllocationBanner />
           </Box>
         </Box>
-        <Box lx={FooterButtonContainer}>
-          <FooterButton />
-        </Box>
+        {isExchangeEnabled && (
+          <Box lx={FooterButtonContainer}>
+            <FooterButton />
+          </Box>
+        )}
       </Box>
     </SafeAreaView>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/useAnalyticsMainViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/useAnalyticsMainViewModel.ts
@@ -1,0 +1,11 @@
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+
+const useAnalyticsMainViewModel = () => {
+  const ptxServiceCtaExchangeDrawer = useFeature("ptxServiceCtaExchangeDrawer");
+  const isExchangeEnabled = ptxServiceCtaExchangeDrawer?.enabled ?? true;
+  return {
+    isExchangeEnabled,
+  };
+};
+
+export default useAnalyticsMainViewModel;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Analytics allocation screen: swap button visibility when `ptxServiceCtaExchangeDrawer` is disabled
  - Swap button navigation: legacy navigator vs Wallet40 main nav (Main > Swap)

### 📝 Description

**Problem:** On the Analytics allocation screen, the Swap footer button was always shown and always navigated to the legacy Swap navigator. It did not respect the `ptxServiceCtaExchangeDrawer` feature flag, and when Wallet40 main navigation is enabled, users should be taken to the main swap screen (tab) instead.

**Solution:**
- Introduced `useAnalyticsMainViewModel` to read `ptxServiceCtaExchangeDrawer` and expose `isExchangeEnabled`. The Swap footer button is only rendered when exchange is enabled.
- Updated `FooterButton` to use `useWalletFeaturesConfig` and redirect to `NavigatorName.Main` + `NavigatorName.Swap` when Wallet40 main nav is enabled, otherwise to `NavigatorName.Swap`.
- Extended AnalyticsMain integration tests: mock state with feature flags, test that swap button is hidden when exchange is disabled, and test navigation to main swap screen when Wallet40 main nav is enabled.

**DEMO**

https://github.com/user-attachments/assets/d65338cb-fd6d-47d0-8acd-136573102c52


### ❓ Context

- **JIRA or GitHub link**: [LIVE-26685](https://ledgerhq.atlassian.net/browse/LIVE-26685)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26685]: https://ledgerhq.atlassian.net/browse/LIVE-26685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ