### PR TITLE
🐛 fix(back-10752): return failed trc20 transaction

### DIFF
--- a/.changeset/gold-mugs-bow.md
+++ b/.changeset/gold-mugs-bow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+Tron coin-module now returns failed trc20 transfers

--- a/libs/coin-modules/coin-tron/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/listOperations.integ.test.ts
@@ -42,6 +42,32 @@ describe("listOperations", () => {
     });
   });
 
+  describe("Account TTZQfHheDCDbY2kW5tETUGJrPKLUa3T4ag with failed trc20 transaction", () => {
+    const testingAccount = "TTZQfHheDCDbY2kW5tETUGJrPKLUa3T4ag";
+    const options = { ...defaultOptions, minHeight: 80285000, softLimit: 500 };
+    describe("listOperations", () => {
+      it("should return failed trc20 transaction", async () => {
+        // https://tronscan.org/#/address/TTZQfHheDCDbY2kW5tETUGJrPKLUa3T4ag
+        // Includes failed REVERT tx f8a52daf9a247f73432afa292b8063d5c5429c8fdb0f8c66f5e8b15b3767e14b at block 80285488
+        const failedTxHash = "f8a52daf9a247f73432afa292b8063d5c5429c8fdb0f8c66f5e8b15b3767e14b";
+        const [operations] = await listOperations(testingAccount, options);
+        expect(operations).toContainEqual(
+          expect.objectContaining({
+            tx: expect.objectContaining({
+              hash: failedTxHash,
+              failed: true,
+            }),
+            value: 0n, // unfortunately the value is not captured, it should be 300000000000
+            asset: {
+              type: "trc20",
+              assetReference: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", // USDT
+            },
+          }),
+        );
+      });
+    });
+  });
+
   describe("Account TRRYfGVrzuUvJYRe9UaA8KqxjgVSwU9m6L withe more than 15k+ txs, with minHeight 0 / order asc / softLimit 2", () => {
     // https://tronscan.org/#/address/TRRYfGVrzuUvJYRe9UaA8KqxjgVSwU9m6L
 

--- a/libs/coin-modules/coin-tron/src/network/format.ts
+++ b/libs/coin-modules/coin-tron/src/network/format.ts
@@ -101,13 +101,17 @@ export const formatTrongridTxResponse = (
     const value = getValue();
     const fee = get(tx, "ret[0].fee", detail && detail.fee ? detail.fee : undefined);
     const blockHeight = blockNumber || detail?.blockNumber;
+    const isTrc20 = type === "TriggerSmartContract" && contract_address;
+    const isTrc10 = type === "TransferAssetContract";
+    const tokenType = isTrc10 ? "trc10" : isTrc20 ? "trc20" : undefined;
     const txInfo: TrongridTxInfo = {
       txID,
       date,
       type,
       tokenId,
-      // TRX native is TransferContract
-      tokenType: type === "TransferAssetContract" ? "trc10" : undefined,
+      // TRX native is TransferContract, TRC20 uses TriggerSmartContract
+      tokenType,
+      tokenAddress: isTrc20 ? encode58Check(contract_address) : undefined,
       from,
       to,
       value: !value.isNaN() ? value : new BigNumber(0),

--- a/libs/coin-modules/coin-tron/src/network/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.test.ts
@@ -49,6 +49,92 @@ function doAfterAll(server: SetupServerApi): () => void {
   return () => server.close();
 }
 
+function buildTriggerSmartContractFixture(txId: string, contractRet: "REVERT" | "SUCCESS") {
+  return {
+    ret: [{ contractRet, fee: 0 }],
+    signature: ["sig"],
+    txID: txId,
+    net_usage: 0,
+    raw_data_hex: "",
+    net_fee: 0,
+    energy_usage: 0,
+    block_timestamp: 1717419792000,
+    blockNumber: 80285488,
+    energy_fee: 0,
+    energy_usage_total: 0,
+    raw_data: {
+      contract: [
+        {
+          parameter: {
+            value: {
+              owner_address: "4105cc125604448afeb6867eb688efb7e80411d57a",
+              contract_address: "41a614f803b6fd780986a42c78ec9c7f77e6ded13c",
+              data: "",
+            },
+            type_url: "type.googleapis.com/protocol.TriggerSmartContract",
+          },
+          type: "TriggerSmartContract",
+        },
+      ],
+      ref_block_bytes: "00",
+      ref_block_hash: "00",
+      expiration: 1717419846000,
+      timestamp: 1717419788444,
+    },
+    internal_transactions: [],
+  };
+}
+
+function buildTrc20TransferFixture(txId: string) {
+  return {
+    transaction_id: txId,
+    token_info: {
+      symbol: "USDT",
+      address: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+      decimals: 6,
+      name: "Tether USD",
+    },
+    block_timestamp: 1717419792000,
+    from: "TQ7pF3NTDL2Tjz5rdJ6ECjQWjaWHpLZJMH",
+    to: "TAVrrARNdnjHgCGMQYeQV7hv4PSu7mVsMj",
+    detail: {
+      ret: [{ contractRet: "SUCCESS", fee: 0 }],
+      signature: ["sig"],
+      txID: txId,
+      net_usage: 345,
+      raw_data_hex: "",
+      net_fee: 0,
+      energy_usage: 0,
+      blockNumber: 80285488,
+      block_timestamp: 1717419792000,
+      energy_fee: 0,
+      energy_usage_total: 0,
+      raw_data: {
+        contract: [
+          {
+            parameter: {
+              value: {
+                owner_address: "4105cc125604448afeb6867eb688efb7e80411d57a",
+                contract_address: "41a614f803b6fd780986a42c78ec9c7f77e6ded13c",
+                data: "",
+              },
+              type_url: "type.googleapis.com/protocol.TriggerSmartContract",
+            },
+            type: "TriggerSmartContract",
+          },
+        ],
+        ref_block_bytes: "00",
+        ref_block_hash: "00",
+        expiration: 1717419846000,
+        timestamp: 1717419788444,
+      },
+      internal_transactions: [],
+    },
+    type: "Transfer",
+    value: "1000000",
+  };
+}
+
 describe("fetchTronAccountTxs", () => {
   const handlers = [defaultGetTransactionsH, defaultGetTrc20TransactionsH, defaultGetTxInfo];
 
@@ -122,6 +208,81 @@ describe("fetchTronAccountTxs with invalid TRC20 (see LIVE-18992)", () => {
     // THEN
     expect(results).toContainEqual(expect.objectContaining({ txID: tx1Hash }));
     expect(results).toContainEqual(expect.objectContaining({ txID: tx2Hash }));
+  }, 10_000);
+});
+
+describe("Failed TRC20 txs", () => {
+  const txId = "f8a52daf9a247f73432afa292b8063d5c5429c8fdb0f8c66f5e8b15b3767e14b";
+  const mockServer = setupServer(defaultGetTxInfo);
+
+  const getTrc20 = (trc20Txs: any[]) =>
+    http.get(`${TRON_BASE_URL_TEST}/v1/accounts/:addr/transactions/trc20`, () =>
+      HttpResponse.json({
+        data: trc20Txs,
+        success: true,
+        meta: { at: 0, page_size: 0 },
+      }),
+    );
+
+  const getEmptyTrc20 = getTrc20([]);
+
+  const getNativeTx = (nativeTxs: any[]) =>
+    http.get(`${TRON_BASE_URL_TEST}/v1/accounts/:addr/transactions`, () =>
+      HttpResponse.json({
+        data: nativeTxs,
+        success: true,
+        meta: { at: 1717419792000, page_size: 1 },
+      }),
+    );
+
+  const fetchTxs = (address: string) =>
+    fetchTronAccountTxs(address, () => true, {}, defaultFetchParams);
+
+  beforeAll(doBeforeAll(mockServer));
+  beforeEach(doBeforeEach(mockServer));
+  afterAll(doAfterAll(mockServer));
+
+  // this scenario is to make sure that failed TRC20 tx are returned
+  it("returns the failed TriggerSmartContract tx when tx not in TRC20 set", async () => {
+    const failedTriggerSmartContractFixture = buildTriggerSmartContractFixture(txId, "REVERT");
+    mockServer.use(getNativeTx([failedTriggerSmartContractFixture]), getEmptyTrc20);
+
+    const results = await fetchTxs("ADDRESS");
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        txID: txId,
+        hasFailed: true,
+        type: "TriggerSmartContract",
+      }),
+    ]);
+  }, 10_000);
+
+  it("excludes successful TriggerSmartContract tx when tx not in TRC20 set", async () => {
+    const successfulTriggerSmartContractFixture = buildTriggerSmartContractFixture(txId, "SUCCESS");
+    mockServer.use(getNativeTx([successfulTriggerSmartContractFixture]), getEmptyTrc20);
+
+    const results = await fetchTxs("ADDRESS");
+
+    expect(results).not.toContainEqual(expect.objectContaining({ txID: txId }));
+  }, 10_000);
+
+  it("returns a single successful TriggerSmartContract from TRC20 (deduped with native) when tx is in TRC20 set", async () => {
+    const successfulTriggerSmartContractFixture = buildTriggerSmartContractFixture(txId, "SUCCESS");
+    mockServer.use(
+      getNativeTx([successfulTriggerSmartContractFixture]),
+      getTrc20([buildTrc20TransferFixture(txId)]),
+    );
+
+    const results = await fetchTxs("ADDRESS");
+    expect(results).toEqual([
+      expect.objectContaining({
+        txID: txId,
+        hasFailed: false,
+        type: "TriggerSmartContract",
+        tokenType: "trc20",
+      }),
+    ]);
   }, 10_000);
 });
 

--- a/libs/coin-modules/coin-tron/src/network/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.ts
@@ -538,14 +538,13 @@ export async function fetchTronAccountTxs(
         tx.txID && tx.internal_transactions && tx.internal_transactions.length > 0;
       // and also a duplicated malformed tx that we have to ignore
       const isDuplicated = tx.tx_id;
-      const type = tx.raw_data.contract[0].type;
 
       if (hasInternalTxs) {
         // log once
         log("tron-error", `unsupported transaction ${tx.txID}`);
       }
 
-      return !isDuplicated && !hasInternalTxs && type !== "TriggerSmartContract";
+      return !isDuplicated && !hasInternalTxs;
     })
     .map(tx => formatTrongridTxResponse(tx));
 
@@ -621,11 +620,21 @@ export async function fetchTronAccountTxs(
     }
   }
 
-  const trc20Txs = (await getTrc20TxsWithRetry(null, 3)).map(formatTrongridTrc20TxResponse);
-
-  const txInfos: TrongridTxInfo[] = compact(nativeTxs.concat(trc20Txs)).sort(
-    (a, b) => b.date.getTime() - a.date.getTime(),
+  const trc20Txs = compact(
+    (await getTrc20TxsWithRetry(null, 3)).map(formatTrongridTrc20TxResponse),
   );
+  const trc20TxIds = new Set(trc20Txs.map(t => t.txID));
+  const isSuccessfulTriggerSmartContract = (tx: TrongridTxInfo) =>
+    tx.type === "TriggerSmartContract" && !tx.hasFailed;
+  const nativeDeduped = compact(nativeTxs)
+    // remove any trc20 transaction from native
+    .filter(tx => !trc20TxIds.has(tx.txID))
+    // remove any successful TriggerSmartContract from native; successful ones must come from TRC20
+    .filter(tx => !isSuccessfulTriggerSmartContract(tx));
+
+  const txInfos: TrongridTxInfo[] = nativeDeduped
+    .concat(trc20Txs)
+    .sort((a, b) => b.date.getTime() - a.date.getTime());
   return txInfos;
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - listOperations can return failed trc20 transfers. This can impact user operation list.
  - potentially we return any failed TriggerSmartContract that is not a transfer (if that species ever exists in the wild)

### 📝 Description

The txID f8a52daf9a247f73432afa292b8063d5c5429c8fdb0f8c66f5e8b15b3767e14b is a TriggerSmartContract with contractRet: "REVERT".

LES needs to retrieve all operations that has been broadcasted for a managed account.

It is not returned by listOperations because
- In [libs/coin-modules/coin-tron/src/network/index.ts](https://github.com/LedgerHQ/ledger-live/compare/libs/coin-modules/coin-tron/src/network/index.ts) (line 547), all TriggerSmartContract txs are filtered out: type !== "TriggerSmartContract".
- Failed smart contract txs do not appear on the TRC20 endpoint (only successful TRC20 transfers do), so this tx is dropped entirely.

This PR let failed TriggerSmartContract bubble up till the API 

#### Caveat: the actual transfer value is not fetched

The actual value of the transfer is not captured. We could do it by examining the data field of the transaction.

Standard TRC20 transfer(address,uint256) calldata layout (same as ERC20):
4 bytes (8 hex chars): selector a9059cbb
32 bytes (64 hex chars): to address (padded)
32 bytes (64 hex chars): amount (uint256, big-endian)

Example from the failing tx:
data = "a9059cbb000000000000000000000041106e953a540af62e91250d2340660731d86eec7100000000000000000000000000000000000000000000000000000045d964b800"
Last 64 hex chars 0000000000000000000000000000000000000000000000000000045d964b800 = 300000000000 (0x45d964b800).

=> if we do that, it means we know how to decode data, and we may want to to remove completely the separate call we make to fetch the trc transfers.


### ❓ Context

https://ledgerhq.atlassian.net/browse/BACK-10752


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
