### PR TITLE
fix: stop race condition on skip onboarding

### DIFF
--- a/.changeset/large-hairs-cover.md
+++ b/.changeset/large-hairs-cover.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: stop a race condition when skipping onboarding

--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/WelcomeNew/hooks/useWelcomeNewViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/WelcomeNew/hooks/useWelcomeNewViewModel.ts
@@ -35,13 +35,14 @@ export function useWelcomeNewViewModel() {
   // Redux selectors
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const trustchain = useSelector(trustchainSelector);
+  const shouldInitiallySelectDevice = useRef(hasCompletedOnboarding && !trustchain);
 
   // Navigation effect
   useEffect(() => {
-    if (hasCompletedOnboarding && !trustchain) {
+    if (shouldInitiallySelectDevice.current) {
       navigate("/onboarding/select-device");
     }
-  }, [hasCompletedOnboarding, navigate, trustchain]);
+  }, [navigate]);
 
   // Feature flags easter egg state
   const countRef1 = useRef(0);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

* There existed a race condition between an effect hook supposed to safeguard the user from seeing the onboarding if they had already completed it AND navigation to the settings page after manually setting `hasCompletedOnboarding`.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
