### PR TITLE
bug(lwd): fixed send max toggle not working until focused

### DIFF
--- a/.changeset/rude-deers-joke.md
+++ b/.changeset/rude-deers-joke.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+bug(lwd): fixed send max toggle not working until focused

--- a/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
@@ -99,6 +99,7 @@ function InputCurrency(props: Props) {
     placeholder,
     loading = false,
     autoFocus = false,
+    disabled,
     decimals,
     renderRight = null,
     ...rest
@@ -136,10 +137,9 @@ function InputCurrency(props: Props) {
   );
 
   // Synchronously reformat display when value/unit change while not focused
-  // (useLayoutEffect matches the old UNSAFE_componentWillReceiveProps timing)
   useLayoutEffect(() => {
     setState(prev => {
-      if (prev.isFocused) return prev;
+      if (prev.isFocused && !disabled) return prev;
       const displayValue =
         !value || value.isNaN() || value.isZero()
           ? ""
@@ -149,9 +149,9 @@ function InputCurrency(props: Props) {
               showAllDigits,
               subMagnitude,
             });
-      return { ...prev, rawValue: "", displayValue };
+      return { ...prev, isFocused: false, rawValue: "", displayValue };
     });
-  }, [value, unit, showAllDigits, subMagnitude, locale]);
+  }, [value, unit, showAllDigits, subMagnitude, locale, disabled]);
 
   const handleChange = useCallback(
     (val: string) => {
@@ -201,6 +201,7 @@ function InputCurrency(props: Props) {
   return (
     <Input
       {...rest}
+      disabled={disabled}
       ff="Inter"
       ref={forwardedRef}
       value={state.displayValue}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - only on desktop, input currency field

### 📝 Description

The `InputCurrency` component was refactored during the React 19 migration and caused this minor regression spotted by @francois-guerin-ledger. It applies to desktop only, and the issue is that clicking the 'SEND MAX' toggle does not work, unless you focus into the currency input field first. This was fixed by ensuring the field is disabled when toggling 'SEND MAX' to true, so the field cannot be edited; this allows the field value to sync with the max value available, and works regardless of focus state.

Fix screen recording showing toggle populates the field with the full value, and untoggle empties the value


Uploading Screen Recording 2026-02-23 at 16.14.20.mov…








### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26851

No JIRA ticket.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
