### PR TITLE
fix(LIVE-25439): aleo adjust private sync configuration

### DIFF
--- a/.changeset/six-chefs-impress.md
+++ b/.changeset/six-chefs-impress.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+fix: adapt aleo private sync to latest changes

--- a/libs/coin-modules/coin-aleo/package.json
+++ b/libs/coin-modules/coin-aleo/package.json
@@ -99,6 +99,7 @@
     "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/live-network": "workspace:^",
     "@ledgerhq/live-promise": "workspace:^",
+    "@ledgerhq/logs": "workspace:^",
     "@ledgerhq/types-cryptoassets": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "bignumber.js": "^9.1.2",

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -6,9 +6,10 @@ import {
   mergeOps,
 } from "@ledgerhq/coin-framework/bridge/jsHelpers";
 import { decodeAccountId, encodeAccountId } from "@ledgerhq/coin-framework/account/accountId";
+import { log } from "@ledgerhq/logs";
 import { getBalance, lastBlock, listOperations } from "../logic";
-import type { AleoAccount, ProvableApi } from "../types";
 import { accessProvableApi } from "../network/utils";
+import type { AleoAccount, ProvableApi } from "../types";
 
 export const getAccountShape: GetAccountShape<AleoAccount> = async infos => {
   const { initialAccount, address, derivationMode, currency } = infos;
@@ -24,6 +25,11 @@ export const getAccountShape: GetAccountShape<AleoAccount> = async infos => {
       viewKey,
       address,
       provableApi: initialAccount.aleoResources?.provableApi ?? null,
+    }).catch(err => {
+      // private sync logic will be probably handled separately with https://ledgerhq.atlassian.net/browse/LIVE-26440
+      // for now, if provable API access configuration fails, we still want to sync public data
+      log("aleo/sync", "Error while configuring record scanner API access", { err, address });
+      return initialAccount.aleoResources?.provableApi ?? null;
     });
   }
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -354,26 +354,26 @@ describe("toBridgeOperation", () => {
       encodeOperationId(ledgerAccountId, enriched.rawTx.transaction_id, "OUT"),
     );
   });
+});
 
-  describe("generateUniqueUsername", () => {
-    it("should generate a SHA-256 hash from timestamp and address", () => {
-      const mockAddress = "aleo1test123";
-      const result = generateUniqueUsername(mockAddress);
+describe("generateUniqueUsername", () => {
+  it("should generate a SHA-256 hash from timestamp and address", () => {
+    const mockAddress = "aleo1test123";
+    const result = generateUniqueUsername(mockAddress);
 
-      expect(result).toMatch(/^[a-f0-9]{64}$/);
-    });
+    expect(result).toMatch(/^[a-f0-9]{64}$/);
+  });
 
-    it("should generate unique hashes for different addresses", () => {
-      const address1 = "aleo1address1";
-      const address2 = "aleo1address2";
+  it("should generate unique hashes for different addresses", () => {
+    const address1 = "aleo1address1";
+    const address2 = "aleo1address2";
 
-      const result1 = generateUniqueUsername(address1);
-      const result2 = generateUniqueUsername(address2);
+    const result1 = generateUniqueUsername(address1);
+    const result2 = generateUniqueUsername(address2);
 
-      expect(result1).toMatch(/^[a-f0-9]{64}$/);
-      expect(result2).toMatch(/^[a-f0-9]{64}$/);
-      expect(result1).not.toBe(result2);
-    });
+    expect(result1).toMatch(/^[a-f0-9]{64}$/);
+    expect(result2).toMatch(/^[a-f0-9]{64}$/);
+    expect(result1).not.toBe(result2);
   });
 });
 

--- a/libs/coin-modules/coin-aleo/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/sdk.test.ts
@@ -21,16 +21,18 @@ describe("sdkClient", () => {
   });
 
   describe("encryptRegistrationPayload", () => {
+    const mockResponse: AleoEncryptedRegistrationResponse = {
+      encrypted: "mock_encrypted_data",
+    };
+
     it("should call getNetworkConfig with the provided currency", async () => {
-      const mockResponse: AleoEncryptedRegistrationResponse = {
-        encrypted_data: "mock_encrypted_data",
-      };
       jest.mocked(network).mockResolvedValue({ data: mockResponse });
 
       await sdkClient.encryptRegistrationPayload({
         currency: mockCurrency,
         publicKey: "aleo1publickey",
         viewKey: "AViewKey1viewkey",
+        start: 0,
       });
 
       expect(getNetworkConfig).toHaveBeenCalledTimes(1);
@@ -38,84 +40,60 @@ describe("sdkClient", () => {
     });
 
     it("should call network with correct method, url and data", async () => {
-      const mockResponse: AleoEncryptedRegistrationResponse = {
-        encrypted_data: "mock_encrypted_data",
-      };
       jest.mocked(network).mockResolvedValue({ data: mockResponse });
 
       await sdkClient.encryptRegistrationPayload({
         currency: mockCurrency,
         publicKey: "aleo1publickey",
         viewKey: "AViewKey1viewkey",
+        start: 0,
       });
 
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: "https://sdk.aleo.network/network/mainnet/encrypt_registration",
+        url: `${mockNetworkConfig.sdkUrl}/encrypt_registration`,
         data: {
           public_key: "aleo1publickey",
           view_key: "AViewKey1viewkey",
-          start: undefined,
+          start: 0,
         },
       });
     });
 
-    it("should include start in request data when provided", async () => {
-      const mockResponse: AleoEncryptedRegistrationResponse = {
-        encrypted_data: "mock_encrypted_data",
-      };
-      jest.mocked(network).mockResolvedValue({ data: mockResponse });
-
-      await sdkClient.encryptRegistrationPayload({
-        currency: mockCurrency,
-        publicKey: "aleo1publickey",
-        viewKey: "AViewKey1viewkey",
-        start: 42,
-      });
-
-      expect(network).toHaveBeenCalledTimes(1);
-      expect(network).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ start: 42 }),
-        }),
-      );
-    });
-
     it("should return res.data from the network response", async () => {
-      const mockResponse: AleoEncryptedRegistrationResponse = {
-        encrypted_data: "mock_encrypted_data",
-      };
       jest.mocked(network).mockResolvedValue({ data: mockResponse });
 
       const result = await sdkClient.encryptRegistrationPayload({
         currency: mockCurrency,
         publicKey: "aleo1publickey",
         viewKey: "AViewKey1viewkey",
+        start: 0,
       });
 
       expect(result).toEqual(mockResponse);
     });
 
-    it("should construct the URL using sdkUrl and networkType from getNetworkConfig", async () => {
+    it("should construct the URL using sdkUrl from getNetworkConfig", async () => {
       const testnetConfig = {
         nodeUrl: "https://node.testnet.aleo.network",
         sdkUrl: "https://sdk.testnet.aleo.network",
         networkType: "testnet",
       };
       jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
-      jest.mocked(network).mockResolvedValue({ data: { encrypted_data: "data" } });
+      jest.mocked(network).mockResolvedValue({ data: mockResponse });
 
       await sdkClient.encryptRegistrationPayload({
         currency: mockCurrency,
         publicKey: "aleo1publickey",
         viewKey: "AViewKey1viewkey",
+        start: 0,
       });
 
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: "https://sdk.testnet.aleo.network/network/testnet/encrypt_registration",
+          url: `${testnetConfig.sdkUrl}/encrypt_registration`,
         }),
       );
     });
@@ -129,6 +107,7 @@ describe("sdkClient", () => {
           currency: mockCurrency,
           publicKey: "aleo1publickey",
           viewKey: "AViewKey1viewkey",
+          start: 0,
         }),
       ).rejects.toThrow("Network error");
     });

--- a/libs/coin-modules/coin-aleo/src/network/sdk.ts
+++ b/libs/coin-modules/coin-aleo/src/network/sdk.ts
@@ -1,7 +1,7 @@
 import network from "@ledgerhq/live-network";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getNetworkConfig } from "../logic/utils";
-import { AleoEncryptedRegistrationResponse } from "../types/sdk";
+import type { AleoEncryptedRegistrationResponse } from "../types/sdk";
 
 async function encryptRegistrationPayload({
   currency,
@@ -12,13 +12,13 @@ async function encryptRegistrationPayload({
   currency: CryptoCurrency;
   publicKey: string;
   viewKey: string;
-  start?: number;
+  start: number;
 }): Promise<AleoEncryptedRegistrationResponse> {
-  const { sdkUrl, networkType } = getNetworkConfig(currency);
+  const { sdkUrl } = getNetworkConfig(currency);
 
   const res = await network<AleoEncryptedRegistrationResponse>({
     method: "POST",
-    url: `${sdkUrl}/network/${networkType}/encrypt_registration`,
+    url: `${sdkUrl}/encrypt_registration`,
     data: {
       public_key: publicKey,
       view_key: viewKey,

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -379,7 +379,7 @@ describe("network/utils", () => {
       jest.clearAllMocks();
       mockGenerateUniqueUsername.mockReturnValue(mockUsername);
       mockGetPublicKey.mockResolvedValue({ public_key: mockPublicKey, key_id: mockKeyId });
-      mockEncryptRegistrationPayload.mockResolvedValue({ encrypted_data: mockEncryptedData });
+      mockEncryptRegistrationPayload.mockResolvedValue({ encrypted: mockEncryptedData });
     });
 
     describe("Initial registration flow", () => {
@@ -668,6 +668,7 @@ describe("network/utils", () => {
           currency: mockCurrency,
           publicKey: mockPublicKey,
           viewKey: mockViewKey,
+          start: 0,
         });
         expect(mockRegisterForScanningAccountRecords).toHaveBeenCalledTimes(1);
         expect(mockRegisterForScanningAccountRecords).toHaveBeenCalledWith({

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -199,10 +199,11 @@ export async function accessProvableApi({
   if (!uuid) {
     const { public_key, key_id } = await apiClient.getPublicKey(currency, jwt.token);
 
-    const { encrypted_data: encryptedData } = await sdkClient.encryptRegistrationPayload({
+    const { encrypted: encryptedData } = await sdkClient.encryptRegistrationPayload({
       currency,
       publicKey: public_key,
       viewKey,
+      start: 0,
     });
 
     const { uuid: accountUuid } = await apiClient.registerForScanningAccountRecordsEncrypted({

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -10,6 +10,7 @@ export type EnrichedTransaction = {
   rawTx: AleoPublicTransaction;
   details: AleoPublicTransactionDetailsResponse | null;
 };
+
 export interface ProvableApi {
   apiKey?: string;
   consumerId?: string;

--- a/libs/coin-modules/coin-aleo/src/types/sdk.ts
+++ b/libs/coin-modules/coin-aleo/src/types/sdk.ts
@@ -1,3 +1,3 @@
 export interface AleoEncryptedRegistrationResponse {
-  encrypted_data: string;
+  encrypted: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2777,6 +2777,9 @@ importers:
       '@ledgerhq/live-promise':
         specifier: workspace:^
         version: link:../../promise
+      '@ledgerhq/logs':
+        specifier: workspace:^
+        version: link:../../ledgerjs/packages/logs
       '@ledgerhq/types-cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/types-cryptoassets


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - private sync failure won't block public synchronisation process

### 📝 Description

This PR adjusts private sync logic to latest backend changes + makes it optional by catching and logging the error of API access configuration. This is because:
- changes required in SDK backend are not deployed yet
- future goal is to keep private sync separated (https://ledgerhq.atlassian.net/browse/LIVE-26440)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-25439


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
