### PR TITLE
feat: [INFRAPRJ-11493] Migrate E2E to GitHub-hosted runners

### DIFF
--- a/.changeset/migrate-e2e-to-large-runner.md
+++ b/.changeset/migrate-e2e-to-large-runner.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+---
+
+Migrate desktop E2E Playwright tests from 5-shard matrix on standard runners to single large runner (8 CPU, 32 GB RAM) with 6 parallel workers (75% of available cores)
+
+

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -107,80 +107,93 @@ permissions:
   contents: read
 
 jobs:
-  e2e-tests-linux:
-    name: "Ubuntu E2E"
+  e2e-tests:
+    name: "Desktop E2E"
+    runs-on: [ledger-live-linux-e2e-speculos-8CPU-32RAM]
+    timeout-minutes: 90
     env:
-      NODE_OPTIONS: "--max-old-space-size=7168"
+      NODE_OPTIONS: "--max-old-space-size=14336"
       INSTRUMENT_BUILD: true
       FORCE_COLOR: 3
       CI_OS: "ubuntu-latest"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      npm_config_loglevel: warn
+      TURBO_TELEMETRY_DISABLED: 1
+      DO_NOT_TRACK: 1
       SPECULOS_IMAGE_TAG: ghcr.io/ledgerhq/speculos:${{ inputs.speculos_device == 'nanoS' && '1be65b91a8e0691866f880fd437ac05fce78af9d' || 'latest' }}
       SPECULOS_DEVICE: ${{ inputs.speculos_device || 'nanoSP' }}
-    runs-on: [ledger-live-4xlarge-e2e]
+      COINAPPS: ${{ github.workspace }}/coin-apps
     outputs:
-      status_1: ${{ steps.set-output.outputs.status_1 }}
-      status_2: ${{ steps.set-output.outputs.status_2 }}
-      status_3: ${{ steps.set-output.outputs.status_3 }}
-      status_4: ${{ steps.set-output.outputs.status_4 }}
-      status_5: ${{ steps.set-output.outputs.status_5 }}
-    strategy:
-      fail-fast: false
-      matrix:
-        shardIndex: [1, 2, 3, 4, 5]
-        shardTotal: [5]
+      test_passed: ${{ steps.run-playwright.outputs.passed }}
+      test_failed: ${{ steps.run-playwright.outputs.failed }}
+      test_total: ${{ steps.run-playwright.outputs.total }}
+      test_exit_code: ${{ steps.run-playwright.outputs.exit_code }}
     steps:
-      - name: generate token
+      - name: Generate GitHub App token
         id: generate-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # 2.2.1
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           repositories: |
-            coin-apps
             ledger-live
+            coin-apps
 
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Checkout ledger-live monorepo (shallow clone)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ inputs.ref || github.sha }}
           repository: LedgerHQ/ledger-live
           token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 1
+
+      - name: Checkout coin-apps (device firmware binaries)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: LedgerHQ/coin-apps
+          ref: master
+          token: ${{ steps.generate-token.outputs.token }}
+          path: coin-apps
+          fetch-depth: 1
 
       - name: Setup caches
         id: caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         with:
+          install-proto: "true"
           skip-turbo-cache: "false"
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
           turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
 
-      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-test-desktop@develop
-        id: setup-test-desktop
-        with:
-          build_type: ${{ inputs.build_type || 'testing' }}
-          turborepo-server-port: ${{ steps.caches.outputs.port }}
-
-      - name: Retrieving coin apps
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          ref: master
-          repository: LedgerHQ/coin-apps
-          token: ${{ steps.generate-token.outputs.token }}
-          path: coin-apps
-
-      - name: Pull docker image
+      - name: Pull Speculos docker image
         run: docker pull ${{ env.SPECULOS_IMAGE_TAG }}
         shell: bash
 
-      - name: Set test environment variables
+      - name: Install dependencies and build LLD
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-test-desktop@develop
+        id: setup-test-desktop
+        with:
+          build_type: ${{ inputs.build_type || 'testing' }}
+
+      - name: Verify Speculos Docker image is ready
+        run: |
+          while ! docker image inspect ${{ env.SPECULOS_IMAGE_TAG }} > /dev/null 2>&1; do
+            echo "Waiting for Speculos image pull to complete..."
+            sleep 2
+          done
+          echo "Speculos image ready: ${{ env.SPECULOS_IMAGE_TAG }}"
+          docker image inspect ${{ env.SPECULOS_IMAGE_TAG }} --format '{{.Size}}' | numfmt --to=iec
+        shell: bash
+
+      - name: Configure test environment (API endpoints, broadcast settings)
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-env@develop
         with:
           enable_broadcast: ${{ inputs.enable_broadcast }}
           build_type: ${{ inputs.build_type }}
 
-      - name: Prepare test filter
+      - name: Build Playwright grep filter from inputs
         id: test-filter
         run: |
           BASE_FILTER="${{ inputs.test_filter }}"
@@ -198,8 +211,7 @@ jobs:
           fi
         shell: bash
 
-      - name: Write summary
-        if: ${{ matrix.shardIndex == 1 }}
+      - name: Write workflow context to GitHub Summary
         run: |
           FILTER_PATTERN="${{ steps.test-filter.outputs.filter }}"
           DEVICE="${{ inputs.speculos_device || 'nanoSP' }}"
@@ -223,64 +235,54 @@ jobs:
             echo "- **Broadcast enabled:** $BROADCAST_ENABLED"
           } >> $GITHUB_STEP_SUMMARY
 
-      - name: Run Playwright Tests
+      - name: Run Playwright E2E tests
         id: run-playwright
         uses: LedgerHQ/ledger-live/tools/actions/composites/run-e2e-playwright-tests@develop
         with:
           speculos_device: ${{ inputs.speculos_device || 'nanoSP' }}
           test_filter: ${{ steps.test-filter.outputs.filter }}
           invert_filter: ${{ inputs.invert_filter || false }}
-          shard_index: ${{ matrix.shardIndex }}
-          shard_total: ${{ matrix.shardTotal }}
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
           XRAY: ${{ inputs.export_to_xray }}
           TEST_EXECUTION: ${{ inputs.test_execution }}
           PROJECT_KEY: B2CQA
           SWAP_API_BASE: ${{ env.SWAP_API_BASE }}
-#          REMOTE_SPECULOS: "true"
-#          GITHUB_TOKEN: ${{ secrets.LL_SPECULOS_CI }}
 
-      - name: Upload Allure Results
+      - name: Upload Allure test results artifact
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: allure-results-${{ matrix.shardIndex }}
+          name: allure-results
           path: "e2e/desktop/allure-results"
 
-      - name: Upload Xray Results
+      - name: Upload Xray test results for Jira
         if: ${{ !cancelled() && inputs.export_to_xray }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: xray-reports-${{ matrix.shardIndex }}
+          name: xray-reports
           path: e2e/desktop/tests/artifacts/xray/xray-report.json
 
-      - name: Set job output based on test result
-        id: set-output
-        if: ${{ !cancelled() }}
-        run: |
-          echo "status_${{ matrix.shardIndex }}=${{ steps.run-playwright.outcome }}" >> $GITHUB_OUTPUT
   report-to-allure:
-    name: "Create Allure Report and upload it"
+    name: "Create Allure Report"
     runs-on: [ledger-live-medium]
-    needs: e2e-tests-linux
+    needs: e2e-tests
     outputs:
       test_result: ${{ steps.summary.outputs.test_result }}
       status_color: ${{ steps.summary.outputs.status_color }}
       status_emoji: ${{ steps.summary.outputs.status_emoji }}
       report-url: ${{ steps.allure-server.outputs.report-url }}
-      missingShards: ${{ steps.aggregate.outputs.missingShards }}
     if: ${{ !cancelled() }}
     env:
       ALLURE_RESULTS: "allure-results"
     steps:
-      - name: Download Allure Report
+      - name: Download Allure results from test job
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
+          name: allure-results
           path: ${{ env.ALLURE_RESULTS }}
-          pattern: ${{ env.ALLURE_RESULTS }}*
-          merge-multiple: true
-      - name: Publish report on Allure Server
+
+      - name: Publish report to Allure Server
         id: allure-server
         if: ${{ !cancelled() }}
         uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report@develop
@@ -290,24 +292,13 @@ jobs:
           password: ${{ secrets.ALLURE_LEDGER_LIVE_PASSWORD }}
           path: ${{ env.ALLURE_RESULTS }}
 
-      - name: Get summary
+      - name: Extract test summary for Slack notification
         if: ${{ !cancelled() && (inputs.slack_notif || github.event_name == 'schedule' )}}
         id: summary
         uses: LedgerHQ/ledger-live/tools/actions/composites/get-allure-summary@develop
         with:
           allure-results-path: ${{ env.ALLURE_RESULTS }}
           platform: linux
-
-      - name: Aggregate test results
-        id: aggregate
-        uses: LedgerHQ/ledger-live/tools/actions/composites/aggregate-shard-results@develop
-        with:
-          total_shards: 5
-          status_1: ${{ needs.e2e-tests-linux.outputs.status_1 }}
-          status_2: ${{ needs.e2e-tests-linux.outputs.status_2 }}
-          status_3: ${{ needs.e2e-tests-linux.outputs.status_3 }}
-          status_4: ${{ needs.e2e-tests-linux.outputs.status_4 }}
-          status_5: ${{ needs.e2e-tests-linux.outputs.status_5 }}
 
   upload-to-xray:
     name: "Upload to Xray"
@@ -317,7 +308,7 @@ jobs:
       XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}
       XRAY_API_URL: https://xray.cloud.getxray.app/api/v2
       JIRA_URL: https://ledgerhq.atlassian.net/browse
-    needs: e2e-tests-linux
+    needs: e2e-tests
     if: ${{ !cancelled() && inputs.export_to_xray }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -325,48 +316,38 @@ jobs:
       - name: Download Xray Results
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
+          name: xray-reports
           path: "e2e/desktop/artifacts/xray"
-          pattern: xray-reports-*
-          merge-multiple: false
-
-      - name: Extract and Aggregate Xray results
-        run: e2e/desktop/aggregate-xray-reports.sh e2e/desktop/artifacts/xray
-
-      - name: Upload aggregated xray results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: aggregated-xray-reports
-          path: "e2e/desktop/artifacts/xray/aggregated-xray-reports.json"
 
       - name: Authenticate to Xray
         id: authenticate
         run: |
           response=$(curl -H "Content-Type: application/json" -X POST --data '{"client_id": "${{ secrets.XRAY_CLIENT_ID }}", "client_secret": "${{ secrets.XRAY_CLIENT_SECRET }}"}' ${{ env.XRAY_API_URL }}/authenticate)
           echo "xray_token=$response" >> $GITHUB_OUTPUT
-      - name: Publish merged report on Xray
+
+      - name: Publish report on Xray
         id: publish-xray
         run: |
           response=$(curl -H "Content-Type: application/json" \
                     -H "Authorization: Bearer ${{ steps.authenticate.outputs.xray_token }}" \
                     -X POST \
-                    --data @e2e/desktop/artifacts/xray/aggregated-xray-reports.json \
+                    --data @e2e/desktop/artifacts/xray/xray-report.json \
                     ${{ env.XRAY_API_URL }}/import/execution)
-            key=$(echo $response | jq -r '.key')
-            echo "xray_key=$key" >> $GITHUB_OUTPUT
+          key=$(echo $response | jq -r '.key')
+          echo "xray_key=$key" >> $GITHUB_OUTPUT
+
       - name: Write Xray report in summary
         shell: bash
         run: echo "::notice title=Xray report URL::${{ env.JIRA_URL }}/${{ steps.publish-xray.outputs.xray_key }}"
 
   notify-to-slack:
-    name: "Notify to slack"
+    name: "Notify to Slack"
     runs-on: [ledger-live-medium]
     needs: report-to-allure
     if: ${{ !cancelled() && (inputs.slack_notif || github.event_name == 'schedule' )}}
-    env:
-      MISSING_SHARDS: ${{ needs.report-to-allure.outputs.missingShards }}
     steps:
       - uses: actions/github-script@v7
-        name: prepare status
+        name: Prepare Slack payload
         id: status
         env:
           STATUS_EMOJI: ${{ needs.report-to-allure.outputs.status_emoji }}
@@ -394,33 +375,24 @@ jobs:
                   "type": "mrkdwn",
                   "text": `- 🐧 linux : ${statusEmoji} ${{ needs.report-to-allure.outputs.test_result || 'No test results' }}`
                 }
+              },
+              {
+                "type": "divider"
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Allure Report*\n<${{ needs.report-to-allure.outputs.report-url }}|allure-results-linux>"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>"
+                  }
+                ]
               }
             ];
-            if (process.env.MISSING_SHARDS) {
-              blocks.push({
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": `⚠️ Warning: Missing results for shard(s): ${process.env.MISSING_SHARDS}.`
-                }
-              });
-            }
-            blocks.push({
-              "type": "divider"
-            });
-            blocks.push({
-              "type": "section",
-              "fields": [
-                {
-                  "type": "mrkdwn",
-                  "text": "*Allure Report*\n<${{ needs.report-to-allure.outputs.report-url }}|allure-results-linux>"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>"
-                }
-              ]
-            });
             if (process.env.EXPORT_TO_XRAY === 'true') {
               blocks.push({
                 "type": "section",
@@ -441,10 +413,8 @@ jobs:
               ]
             };
             fs.writeFileSync("payload-slack-content.json", JSON.stringify(slackPayload), "utf-8");
-      - name: Print Slack Payload Content
-        run: cat ${{ github.workspace }}/payload-slack-content.json
 
-      - name: Post to a Slack channel
+      - name: Post to Slack channel
         id: slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
@@ -452,4 +422,3 @@ jobs:
           payload-file-path: ${{ github.workspace }}/payload-slack-content.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}
-          STATUS_COLOR: ${{ needs.report-to-allure.outputs.status_color }}

--- a/e2e/desktop/playwright.config.ts
+++ b/e2e/desktop/playwright.config.ts
@@ -20,12 +20,10 @@ const config: PlaywrightTestConfig = {
   maxFailures: process.env.CI ? 5 : undefined,
   reportSlowTests: process.env.CI ? { max: 0, threshold: 60000 } : null,
   fullyParallel: true,
-  workers: "50%", // NOTE: 'macos-latest' and 'windows-latest' can't run 3 concurrent workers
+  workers: "100%",
   reporter: process.env.CI
     ? [
-        ["html", { open: "never", outputFolder: "artifacts/html-report" }],
-        ["github"],
-        ["line"],
+        ["list"],
         [
           "allure-playwright",
           {

--- a/libs/speculos-transport/src/index.ts
+++ b/libs/speculos-transport/src/index.ts
@@ -219,29 +219,31 @@ export async function createSpeculosDevice(
   const subpath = overridesAppPath || conventionalAppSubpath(model, firmware, appName, appVersion);
   const appPath = `./apps/${subpath}`;
 
+  const getPortMappings = (): string[] => {
+    if (process.env.CI) {
+      return [];
+    }
+    if (isSpeculosWebsocket) {
+      return [
+        "-p",
+        `${ports.apduPort}:40000`,
+        "-p",
+        `${ports.vncPort}:41000`,
+        "-p",
+        `${ports.buttonPort}:42000`,
+        "-p",
+        `${ports.automationPort}:43000`,
+      ];
+    }
+    return ["-p", `${ports.apiPort}:40000`, "-p", `${ports.vncPort}:41000`];
+  };
+
   const params = [
     "run",
+    ...(process.env.CI ? ["--network=host"] : []),
     "-v",
     `${coinapps}:/speculos/apps`,
-    ...(isSpeculosWebsocket
-      ? [
-          // websocket ports
-          "-p",
-          `${ports.apduPort}:40000`,
-          "-p",
-          `${ports.vncPort}:41000`,
-          "-p",
-          `${ports.buttonPort}:42000`,
-          "-p",
-          `${ports.automationPort}:43000`,
-        ]
-      : [
-          // http ports
-          "-p",
-          `${ports.apiPort}:40000`,
-          "-p",
-          `${ports.vncPort}:41000`,
-        ]),
+    ...getPortMappings(),
     "-e",
     `SPECULOS_APPNAME=${appName}:${appVersion}`,
     "--name",
@@ -265,23 +267,18 @@ export async function createSpeculosDevice(
     ...(sdk ? ["--sdk", sdk] : []),
     "--display",
     "headless",
-    ...(getEnv("PLAYWRIGHT_RUN") || getEnv("DETOX") ? ["-p"] : []), // to use the production PKI
-    ...(process.env.CI ? ["--vnc-password", "live", "--vnc-port", "41000"] : []),
+    ...(getEnv("PLAYWRIGHT_RUN") || getEnv("DETOX") ? ["-p"] : []),
+    ...(process.env.CI ? ["--vnc-password", "live", "--vnc-port", `${ports.vncPort}`] : []),
     ...(isSpeculosWebsocket
       ? [
-          // websocket ports
           "--apdu-port",
-          "40000",
+          process.env.CI ? `${ports.apduPort}` : "40000",
           "--button-port",
-          "42000",
+          process.env.CI ? `${ports.buttonPort}` : "42000",
           "--automation-port",
-          "43000",
+          process.env.CI ? `${ports.automationPort}` : "43000",
         ]
-      : [
-          // http ports
-          "--api-port",
-          "40000",
-        ]),
+      : ["--api-port", process.env.CI ? `${ports.apiPort}` : "40000"]),
   ];
 
   log("speculos", `${speculosID}: spawning = ${params.join(" ")}`);

--- a/tools/actions/composites/run-e2e-playwright-tests/action.yml
+++ b/tools/actions/composites/run-e2e-playwright-tests/action.yml
@@ -11,19 +11,44 @@ inputs:
     description: "Invert the test filter"
     required: false
   shard_index:
-    description: "Shard index for test distribution"
-    required: true
+    description: "Shard index for test distribution (omit to run all tests)"
+    required: false
   shard_total:
-    description: "Total number of shards"
-    required: true
+    description: "Total number of shards (omit to run all tests)"
+    required: false
+outputs:
+  passed:
+    description: "Number of passed tests"
+    value: ${{ steps.run-tests.outputs.passed }}
+  failed:
+    description: "Number of failed tests"
+    value: ${{ steps.run-tests.outputs.failed }}
+  skipped:
+    description: "Number of skipped tests"
+    value: ${{ steps.run-tests.outputs.skipped }}
+  total:
+    description: "Total number of tests"
+    value: ${{ steps.run-tests.outputs.total }}
+  exit_code:
+    description: "Playwright exit code"
+    value: ${{ steps.run-tests.outputs.exit_code }}
 
 runs:
   using: "composite"
   steps:
-    - name: Set up environment variables
+    - name: Run E2E tests
+      id: run-tests
       run: |
         export SPECULOS_IMAGE_TAG="${{ env.SPECULOS_IMAGE_TAG }}"
-        export COINAPPS="$PWD/coin-apps"
+        if [ -z "${COINAPPS}" ]; then
+          echo "Warning: COINAPPS not set, using default: $PWD/coin-apps"
+          export COINAPPS="$PWD/coin-apps"
+        fi
+        if [ ! -d "${COINAPPS}" ]; then
+          echo "Error: COINAPPS directory does not exist: ${COINAPPS}"
+          echo "Ensure the coin-apps repository is checked out before calling this action."
+          exit 1
+        fi
         export MOCK=0
 
         case "${{ inputs.speculos_device }}" in
@@ -37,7 +62,6 @@ runs:
         esac
 
         if [ -n "${{ inputs.test_filter }}" ]; then
-          # If test_filter contains a space but not a pipe, treat as OR by replacing spaces with pipes
           if [[ "${{ inputs.test_filter }}" == *' '* && "${{ inputs.test_filter }}" != *'|'* ]]; then
             or_filter=$(echo "${{ inputs.test_filter }}" | sed 's/ /|/g')
             grep_filter="$device_tag.*($or_filter)|($or_filter).*$device_tag"
@@ -56,9 +80,86 @@ runs:
 
         echo "Running tests with filter: $grep_option $grep_filter"
 
+        SHARD_ARG=""
+        if [ -n "${{ inputs.shard_index }}" ] && [ -n "${{ inputs.shard_total }}" ]; then
+          SHARD_ARG="--shard=${{ inputs.shard_index }}/${{ inputs.shard_total }}"
+        fi
+
+        set +e
         xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" \
           -- pnpm e2e:desktop test:playwright \
           --max-failures 50 \
           $grep_option "$grep_filter" \
-          --shard=${{ inputs.shard_index }}/${{ inputs.shard_total }}
+          $SHARD_ARG 2>&1 | tee /tmp/playwright-output.log
+        TEST_EXIT_CODE=${PIPESTATUS[0]}
+        set -e
+
+        PASSED=$(grep -oP '\d+ passed' /tmp/playwright-output.log | grep -oP '\d+' || echo "0")
+        FAILED=$(grep -oP '\d+ failed' /tmp/playwright-output.log | grep -oP '\d+' || echo "0")
+        SKIPPED=$(grep -oP '\d+ skipped' /tmp/playwright-output.log | grep -oP '\d+' || echo "0")
+        FLAKY=$(grep -oP '\d+ flaky' /tmp/playwright-output.log | grep -oP '\d+' || echo "0")
+        TOTAL=$((PASSED + FAILED + SKIPPED + FLAKY))
+
+        echo "passed=${PASSED}" >> $GITHUB_OUTPUT
+        echo "failed=${FAILED}" >> $GITHUB_OUTPUT
+        echo "skipped=${SKIPPED}" >> $GITHUB_OUTPUT
+        echo "total=${TOTAL}" >> $GITHUB_OUTPUT
+        echo "exit_code=${TEST_EXIT_CODE}" >> $GITHUB_OUTPUT
+
+        PASS_RATE=0
+        if [ "${TOTAL}" -gt 0 ]; then
+          PASS_RATE=$(( (PASSED + FLAKY) * 100 / TOTAL ))
+        fi
+
+        echo ""
+        echo "========================================"
+        echo "  PLAYWRIGHT TEST SUMMARY"
+        echo "========================================"
+        echo "  Total:   ${TOTAL}"
+        echo "  Passed:  ${PASSED}"
+        echo "  Failed:  ${FAILED}"
+        echo "  Flaky:   ${FLAKY}"
+        echo "  Skipped: ${SKIPPED}"
+        echo "  Pass rate: ${PASS_RATE}%"
+        echo "========================================"
+        if [ "${TEST_EXIT_CODE}" -eq 0 ]; then
+          echo "  Result:  ALL PASSED"
+        elif [ "${TOTAL}" -gt 0 ]; then
+          echo "  Result:  ${FAILED} FAILED -- see Allure report"
+        else
+          echo "  Result:  NO TESTS RAN (infrastructure error?)"
+          echo "========================================"
+          exit 1
+        fi
+        echo "========================================"
+        echo ""
+
+        STATUS_ICON="✅"
+        STATUS_TEXT="All tests passed"
+        if [ "${FAILED}" -gt 0 ]; then
+          STATUS_ICON="⚠️"
+          STATUS_TEXT="${FAILED} tests failed -- see Allure report for details"
+        fi
+        if [ "${TOTAL}" -eq 0 ]; then
+          STATUS_ICON="❌"
+          STATUS_TEXT="No tests executed -- possible infrastructure issue"
+        fi
+
+        {
+          echo "## ${STATUS_ICON} Playwright Test Results"
+          echo ""
+          echo "| Metric | Count |"
+          echo "|--------|-------|"
+          echo "| Total | ${TOTAL} |"
+          echo "| Passed | ${PASSED} |"
+          echo "| Failed | ${FAILED} |"
+          echo "| Flaky | ${FLAKY} |"
+          echo "| Skipped | ${SKIPPED} |"
+          echo "| **Pass rate** | **${PASS_RATE}%** |"
+          echo ""
+          echo "> ${STATUS_TEXT}"
+        } >> $GITHUB_STEP_SUMMARY
+
+        # Note: TOTAL=0 case already exits at line 124, so we only reach here when TOTAL > 0
+        exit ${TEST_EXIT_CODE}
       shell: bash


### PR DESCRIPTION
Workflow execution: https://github.com/LedgerHQ/ledger-live/actions/runs/22359291091
Smoke tests on PR execution: https://github.com/LedgerHQ/ledger-live/actions/runs/22360309015/job/64711568702

## Description

Migrate desktop E2E Playwright tests from a 5-shard matrix running on standard runners to a single large runner. This consolidates the test execution, simplifies the workflow, and improves resource utilization.

Key changes:
- Replace matrix-based sharding with single-runner parallel execution
- Update common Playwright test execution logic in a reusable composite action (`run-e2e-playwright-tests`)
- Update runner 
- Consolidate artifact upload and reporting

## Context

[INFRAPRJ-11493](https://ledgerhq.atlassian.net/browse/INFRAPRJ-11493)



[INFRAPRJ-11493]: https://ledgerhq.atlassian.net/browse/INFRAPRJ-11493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ