### PR TITLE
bugfix: update state for ledger sync in lazy onboarding

### DIFF
--- a/.changeset/young-cougars-crash.md
+++ b/.changeset/young-cougars-crash.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update state for ledger sync in lazy onboarding

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationLoading.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationLoading.tsx
@@ -13,9 +13,15 @@ import { useTheme } from "styled-components/native";
 import { useTranslation } from "~/context/Locale";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { hasCompletedOnboardingSelector, onboardingTypeSelector } from "~/reducers/settings";
-import { completeOnboarding, setIsReborn, setOnboardingHasDevice } from "~/actions/settings";
+import {
+  completeOnboarding,
+  setIsReborn,
+  setOnboardingHasDevice,
+  setReadOnlyMode,
+} from "~/actions/settings";
 import PreventNativeBack from "~/components/PreventNativeBack";
 import { OnboardingType } from "~/reducers/types";
+import { updateMainNavigatorVisibility } from "~/actions/appstate";
 
 type Props = BaseComposite<
   StackNavigatorProps<WalletSyncNavigatorStackParamList, ScreenName.WalletSyncLoading>
@@ -36,9 +42,11 @@ export function ActivationLoading({ route }: Props) {
   useEffect(() => {
     if (!hasCompletedOnboarding && onboardingType !== OnboardingType.setupNew) {
       dispatch(completeOnboarding());
-      dispatch(setIsReborn(false));
-      dispatch(setOnboardingHasDevice(true));
     }
+    dispatch(setOnboardingHasDevice(true));
+    dispatch(setIsReborn(false));
+    dispatch(setReadOnlyMode(false));
+    dispatch(updateMainNavigatorVisibility(true));
   }, [dispatch, hasCompletedOnboarding, onboardingType]);
 
   return (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

A user going through the ledger sync process in lazy onboarding did not have the updated top bar in Portfolio screen and was continued to be set as readonly, this PR adds correct state when going through sync flow.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26678


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
