### PR TITLE
feat(common): add assetSection param to wallet 4.0 feature flag

### DIFF
--- a/.changeset/eight-months-begin.md
+++ b/.changeset/eight-months-begin.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/types-live": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+add assetSection in ff for w4.0

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
@@ -11,6 +11,7 @@ export const WALLET_FEATURES_PARAMS = [
   { key: "newReceiveDialog", label: "New Receive Dialog" },
   { key: "background", label: "Background" },
   { key: "balanceRefreshRework", label: "Balance Refresh Rework" },
+  { key: "assetSection", label: "Asset Section" },
 ] as const;
 
 export type WalletFeatureParamKey = (typeof WALLET_FEATURES_PARAMS)[number]["key"];

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
@@ -11,6 +11,7 @@ export const WALLET_40_PARAMS = [
   { key: "mainNavigation", label: "Main Navigation" },
   { key: "lazyOnboarding", label: "Lazy Onboarding" },
   { key: "balanceRefreshRework", label: "Balance Refresh Rework" },
+  { key: "assetSection", label: "Asset Section" },
 ] as const;
 
 type WalletFeatureParamKey = (typeof WALLET_40_PARAMS)[number]["key"];

--- a/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
+++ b/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
@@ -25,5 +25,6 @@ export const getWallet40Attributes = (
     newReceiveDialog: wallet40FeatureFlag?.params?.newReceiveDialog ?? false,
     lazyOnboarding: wallet40FeatureFlag?.params?.lazyOnboarding ?? false,
     balanceRefreshRework: wallet40FeatureFlag?.params?.balanceRefreshRework ?? false,
+    assetSection: wallet40FeatureFlag?.params?.assetSection ?? false,
   };
 };

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -789,6 +789,7 @@ export const DEFAULT_FEATURES: Features = {
       mainNavigation: true,
       lazyOnboarding: true,
       balanceRefreshRework: true,
+      assetSection: true,
     },
   },
   lwdWallet40: {
@@ -802,6 +803,7 @@ export const DEFAULT_FEATURES: Features = {
       lazyOnboarding: true,
       newReceiveDialog: true,
       balanceRefreshRework: true,
+      assetSection: true,
     },
   },
   addressPoisoningOperationsFilter: {

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
@@ -41,6 +41,7 @@ const DISABLED_CONFIG: WalletFeaturesConfig = {
   shouldUseLazyOnboarding: false,
   shouldDisplayBalanceRefreshRework: false,
   shouldDisplayTour: false,
+  shouldDisplayAssetSection: false,
 };
 
 const ENABLED_NO_PARAMS_CONFIG: WalletFeaturesConfig = {
@@ -53,6 +54,7 @@ const ENABLED_NO_PARAMS_CONFIG: WalletFeaturesConfig = {
   shouldUseLazyOnboarding: false,
   shouldDisplayBalanceRefreshRework: false,
   shouldDisplayTour: false,
+  shouldDisplayAssetSection: false,
 };
 
 const ALL_ENABLED_CONFIG: WalletFeaturesConfig = {
@@ -65,6 +67,7 @@ const ALL_ENABLED_CONFIG: WalletFeaturesConfig = {
   shouldUseLazyOnboarding: true,
   shouldDisplayBalanceRefreshRework: true,
   shouldDisplayTour: true,
+  shouldDisplayAssetSection: true,
 };
 
 const ALL_PARAMS_ENABLED: Wallet40Params = {
@@ -76,6 +79,7 @@ const ALL_PARAMS_ENABLED: Wallet40Params = {
   lazyOnboarding: true,
   balanceRefreshRework: true,
   tour: true,
+  assetSection: true,
 };
 
 describe("useWalletFeaturesConfig hook", () => {
@@ -127,6 +131,7 @@ describe("useWalletFeaturesConfig hook", () => {
           { shouldDisplayBalanceRefreshRework: true },
         ],
         ["tour", { tour: true }, { shouldDisplayTour: true }],
+        ["assetSection", { assetSection: true }, { shouldDisplayAssetSection: true }],
       ])("should return correct config when only %s is enabled", (_, params, expectedOverrides) => {
         const { result } = renderWalletFeaturesConfig(platform, {
           [flagKey]: createFeatureFlag(true, params),

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
@@ -40,6 +40,7 @@ export const useWalletFeaturesConfig = (platform: WalletPlatform): WalletFeature
       shouldUseLazyOnboarding: isEnabled && Boolean(params?.lazyOnboarding),
       shouldDisplayBalanceRefreshRework: isEnabled && Boolean(params?.balanceRefreshRework),
       shouldDisplayTour: isEnabled && Boolean(params?.tour),
+      shouldDisplayAssetSection: isEnabled && Boolean(params?.assetSection),
     };
   }, [walletFeatureFlag]);
 };

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -810,6 +810,7 @@ type Feature_Wallet40_Params = {
   tour: boolean;
   lazyOnboarding: boolean;
   balanceRefreshRework: boolean;
+  assetSection: boolean;
 
   // Specifics
   newReceiveDialog?: boolean;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Wallet 4.0 feature flag configuration on both mobile and desktop
      - Analytics tracking for the new `assetSection` param
      - Developer debug tools (desktop & mobile) for toggling the param

### 📝 Description

This PR adds the `assetSection` parameter to the Wallet 4.0 feature flag, enabling control over the asset section display through remote configuration.

**Changes across the stack:**
- **Types** (`@ledgerhq/types-live`): Added `assetSection: boolean` to `Feature_Wallet40_Params`
- **Default features** (`@ledgerhq/live-common`): Enabled `assetSection` by default in both `llmWallet40` and `lwdWallet40`
- **Analytics** (`@ledgerhq/live-common`): Track `assetSection` in wallet 4.0 analytics attributes
- **Config hook** (`@ledgerhq/live-common`): Exposed `shouldDisplayAssetSection` from `useWalletFeaturesConfig`
- **Dev tools**: Added toggle in both desktop and mobile debug screens
- **Tests**: Updated test fixtures and added parameterized test case

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26272](https://ledgerhq.atlassian.net/browse/LIVE-26272)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26272]: https://ledgerhq.atlassian.net/browse/LIVE-26272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ