### PR TITLE
fix(e2e): use swipe instead of scrollToId for network list on Android

### DIFF
--- a/e2e/mobile/page/drawer/modular.drawer.ts
+++ b/e2e/mobile/page/drawer/modular.drawer.ts
@@ -89,9 +89,17 @@ export default class ModularDrawer {
     const id = this.networkItemIdMAD(networkName);
     if (!(await IsIdVisible(id))) {
       await getElementById(this.networkBasedTitleIdMAD).swipe("up");
-      await scrollToId(id, this.networkSelectionScrollViewId);
+      await this.swipeToNetworkItem(id);
     }
     await tapById(id, 0);
+  }
+
+  private async swipeToNetworkItem(id: string | RegExp, maxAttempts = 5): Promise<void> {
+    const scrollView = getElementById(this.networkSelectionScrollViewId);
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (await IsIdVisible(id)) return;
+      await scrollView.swipe("up", "slow", 0.2, 0.5);
+    }
   }
 
   @Step("Select currency in modular drawer")
@@ -148,7 +156,7 @@ export default class ModularDrawer {
     await getElementById(this.networkBasedTitleIdMAD).swipe("up");
     for (const network of networks) {
       const networkItemId = this.networkItemIdMAD(network);
-      await scrollToId(networkItemId, this.networkSelectionScrollViewId);
+      await this.swipeToNetworkItem(networkItemId);
       await detoxExpect(getElementById(networkItemId)).toBeVisible();
     }
   }


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

scrollToId silently no-ops on the BottomSheetFlatList inside the bottom sheet on Android. Replace with swipe-based scrolling in selectNetwork and validateNetworksScreen.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
