### PR TITLE
fix(mobile): remove invalid // comments from styled-components template literals

### DIFF
--- a/.changeset/nervous-eggs-sort.md
+++ b/.changeset/nervous-eggs-sort.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Remove invalid // comments from styled-components template literals (CSS parse risk with v6)

--- a/apps/ledger-live-mobile/src/screens/NpsRatingsModal/Form.tsx
+++ b/apps/ledger-live-mobile/src/screens/NpsRatingsModal/Form.tsx
@@ -61,7 +61,7 @@ true;
 `;
 
 const StyledWebview = styled(WebView)`
-  background-color: transparent; // avoids white background before page loads
+  background-color: transparent;
   flex: 1;
 `;
 

--- a/apps/ledger-live-mobile/src/screens/RatingsModal/DisappointedForm.tsx
+++ b/apps/ledger-live-mobile/src/screens/RatingsModal/DisappointedForm.tsx
@@ -59,7 +59,7 @@ const formInjectedJavaScript = `
 `;
 
 const StyledWebview = styled(WebView)`
-  background-color: transparent; // avoids white background before page loads
+  background-color: transparent;
   flex: 1;
 `;
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Styling-only change; no behavior change._
- [x] **Impact of the changes:**
  - Ratings modals (NPS and Disappointed form) WebView styling unchanged visually
  - No functional change; only removal of invalid CSS comments

### 📝 Description

**Problem:** In styled-components, template literals are parsed as CSS. CSS only supports `/* */` comments. Using `//` inside a styled template literal can cause parse errors or undefined behavior with styled-components v6.

**Solution:** Removed the invalid `//` comments from the `StyledWebview` styled-components in:
- `RatingsModal/DisappointedForm.tsx`
- `NpsRatingsModal/Form.tsx`

The styles (`background-color: transparent` and `flex: 1`) are unchanged; only the trailing comment was removed.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26837](https://ledgerhq.atlassian.net/browse/LIVE-26837)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-26837]: https://ledgerhq.atlassian.net/browse/LIVE-26837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ