### PR TITLE
feat(mobile): add navigation header to My Ledger screen for wallet 4.0

### DIFF
--- a/.changeset/strong-brooms-eat.md
+++ b/.changeset/strong-brooms-eat.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+When wallet 40 main navigation is ON we now have a navigation header on my Ledger screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MyLedgerNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MyLedgerNavigator.tsx
@@ -5,6 +5,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useSelector } from "~/context/hooks";
 import { Box, IconsLegacy, Flex, Icons } from "@ledgerhq/native-ui";
 import { DeviceModelId } from "@ledgerhq/types-devices";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { ScreenName } from "~/const";
 import { hasAvailableUpdateSelector, lastSeenDeviceSelector } from "~/reducers/settings";
 import MyLedgerChooseDeviceScreen, { headerOptions } from "~/screens/MyLedgerChooseDevice";
@@ -13,6 +14,7 @@ import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import TabIcon from "../TabIcon";
 import { useIsNavLocked } from "./CustomBlockRouterNavigator";
 import { MyLedgerNavigatorStackParamList } from "./types/MyLedgerNavigator";
+import { wallet40HeaderOptions } from "~/screens/MyLedgerChooseDevice/wallet40HeaderOptions";
 
 const BadgeContainer = styled(Flex).attrs({
   position: "absolute",
@@ -39,6 +41,20 @@ const Badge = () => {
 export default function MyLedgerNavigator() {
   const { colors } = useTheme();
   const stackNavConfig = useMemo(() => getStackNavigatorConfig(colors), [colors]);
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
+
+  const chooseDeviceOptions = useMemo(
+    () =>
+      shouldDisplayWallet40MainNav
+        ? { ...wallet40HeaderOptions, gestureEnabled: true }
+        : { ...headerOptions, gestureEnabled: false },
+    [shouldDisplayWallet40MainNav],
+  );
+
+  const myLedgerDeviceOptions = useMemo(
+    () => (shouldDisplayWallet40MainNav ? wallet40HeaderOptions : { title: "" }),
+    [shouldDisplayWallet40MainNav],
+  );
 
   return (
     <Stack.Navigator
@@ -49,15 +65,12 @@ export default function MyLedgerNavigator() {
       <Stack.Screen
         name={ScreenName.MyLedgerChooseDevice}
         component={MyLedgerChooseDeviceScreen}
-        options={{
-          ...headerOptions,
-          gestureEnabled: false,
-        }}
+        options={chooseDeviceOptions}
       />
       <Stack.Screen
         name={ScreenName.MyLedgerDevice}
         component={MyLedgerDeviceScreen}
-        options={{ title: "" }}
+        options={myLedgerDeviceOptions}
       />
     </Stack.Navigator>
   );

--- a/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useIsFocused, useNavigation, useRoute } from "@react-navigation/native";
 import { useTranslation } from "~/context/Locale";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -24,6 +24,9 @@ import ContentCardsLocation from "~/dynamicContent/ContentCardsLocation";
 import { ContentCardLocation } from "~/dynamicContent/types";
 import { useAutoRedirectToPostOnboarding } from "~/hooks/useAutoRedirectToPostOnboarding";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import SafeAreaView from "~/components/SafeAreaView";
+import { wallet40HeaderOptions } from "~/screens/MyLedgerChooseDevice/wallet40HeaderOptions";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<MyLedgerNavigatorStackParamList, ScreenName.MyLedgerChooseDevice>
@@ -45,6 +48,7 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
   const action = useManagerDeviceAction();
   const [device, setDevice] = useState<Device | null>();
   const [isHeaderOverridden, setIsHeaderOverridden] = useState<boolean>(false);
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
 
   const navigation = useNavigation<NavigationProps["navigation"]>();
   const { params } = useRoute<NavigationProps["route"]>();
@@ -104,35 +108,41 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
       if (request.type === "set") {
         navigation.setOptions({
           headerShown: true,
+          headerTitle: "",
           headerLeft: request.options.headerLeft,
           headerRight: request.options.headerRight,
           title: "",
         });
         setIsHeaderOverridden(true);
       } else {
-        // Sets back the header to its initial values set for this screen
-        navigation.setOptions({
-          headerLeft: () => null,
-          headerRight: () => null,
-          ...headerOptions,
-        });
+        navigation.setOptions(
+          shouldDisplayWallet40MainNav
+            ? { ...wallet40HeaderOptions, headerRight: () => null }
+            : { headerLeft: () => null, headerRight: () => null, ...headerOptions },
+        );
         setIsHeaderOverridden(false);
       }
     },
-    [navigation],
+    [navigation, shouldDisplayWallet40MainNav],
+  );
+
+  const Container = shouldDisplayWallet40MainNav ? SafeAreaView : TabBarSafeAreaView;
+  const containerProps = useMemo(
+    () => (shouldDisplayWallet40MainNav ? { isFlex: true, edges: ["left", "right"] as const } : {}),
+    [shouldDisplayWallet40MainNav],
   );
 
   if (!isFocused) return null;
 
+  const showInlineTitle = !shouldDisplayWallet40MainNav && !isHeaderOverridden;
+
   return (
-    <TabBarSafeAreaView>
+    <Container {...containerProps}>
       <TrackScreen category="Manager" name="ChooseDevice" />
-      {!isHeaderOverridden ? (
-        <Flex px={16} pb={8}>
-          <Text pt={3} fontWeight="semiBold" variant="h4" testID="manager-title">
-            {t("manager.title")}
-          </Text>
-        </Flex>
+      {showInlineTitle ? (
+        <Text pt={3} px={16} pb={8} fontWeight="semiBold" variant="h4" testID="manager-title">
+          {t("manager.title")}
+        </Text>
       ) : null}
       <Flex flex={1}>
         <SelectDevice2
@@ -159,7 +169,7 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
         onError={onError}
         location={HOOKS_TRACKING_LOCATIONS.myLedgerDashboard}
       />
-    </TabBarSafeAreaView>
+    </Container>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/wallet40HeaderOptions.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/wallet40HeaderOptions.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import HeaderBackButton from "LLM/components/Navigation/HeaderBackButton";
+import HeaderTitle from "LLM/components/Navigation/HeaderTitle";
+
+export const wallet40HeaderOptions = {
+  headerShown: true,
+  headerTitle: () => <HeaderTitle titleKey="manager.title" />,
+  headerLeft: () => <HeaderBackButton />,
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No automated tests added — this is a UI/navigation change gated by a feature flag, verified manually on physical devices._
- [x] **Impact of the changes:**
      - My Ledger choose device screen header appearance when wallet 4.0 main nav FF is ON vs OFF
      - Navigation back button behavior on the My Ledger screen
      - Screen container (SafeAreaView vs TabBarSafeAreaView) depending on FF state
      - BLE pairing flow header override behavior with FF ON
      - Verify on both large (iPhone 17 Pro Max) and small (iPhone SE) screen sizes

### 📝 Description

When the wallet 4.0 main navigation feature flag is enabled, the My Ledger tab is accessed from a different navigation structure that requires its own header. Currently the screen lacks a proper navigation header in this mode.

This PR adds a conditional navigation header with a back button and title (`HeaderBackButton` / `HeaderTitle` from the MVVM navigation components) when `shouldDisplayWallet40MainNav` is true. When the FF is off, the existing behavior (inline title, no gesture, tab bar safe area) is preserved. The screen container also switches from `TabBarSafeAreaView` to `SafeAreaView` accordingly.

Additionally:
- **Shared header config**: Extracted `wallet40HeaderOptions` into its own file to avoid duplicating the header configuration across the navigator and the screen's header reset logic.
- **BLE pairing fix**: Added `headerTitle: ""` in the BLE pairing header override to prevent the "My Ledger" title from leaking through when the FF is on.
- **Memoization**: Wrapped `containerProps` in `useMemo` for stable references across renders.

**Full DEMO:**

https://github.com/user-attachments/assets/49368193-21cd-46f0-a5da-19900f150c10




### ❓ Context

- **JIRA or GitHub link**: [LIVE-26254](https://ledgerhq.atlassian.net/browse/LIVE-26254)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26254]: https://ledgerhq.atlassian.net/browse/LIVE-26254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ