### PR TITLE
STUDY: rethinking Account models, split into slices, compatible with existing stack

### DIFF
--- a/apps/web-tools/package.json
+++ b/apps/web-tools/package.json
@@ -18,6 +18,9 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/view": "^6.39.5",
     "@ledgerhq/coin-framework": "workspace:^",
+    "@reduxjs/toolkit": "catalog:",
+    "react-redux": "catalog:",
+    "redux": "catalog:",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/crypto-icons": "catalog:",
     "@ledgerhq/domain-service": "workspace:^",
@@ -61,7 +64,8 @@
     "styled-components": "catalog:",
     "stylis": "catalog:",
     "typescript": "catalog:",
-    "utf-8-validate": "^6.0.6"
+    "utf-8-validate": "^6.0.6",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@rsbuild/core": "catalog:",

--- a/apps/web-tools/rsbuild.config.ts
+++ b/apps/web-tools/rsbuild.config.ts
@@ -1,8 +1,15 @@
+import path from "path";
+import fs from "fs";
 import { rspack } from "@rspack/core";
 import { defineConfig } from "@rsbuild/core";
 import { pluginReact } from "@rsbuild/plugin-react";
 import { pluginNodePolyfill } from "@rsbuild/plugin-node-polyfill";
 import { pluginStyledComponents } from "@rsbuild/plugin-styled-components";
+
+const liveCommonRoot = path.resolve(process.cwd(), "node_modules/@ledgerhq/live-common");
+const liveCommonResolved = fs.existsSync(liveCommonRoot)
+  ? fs.realpathSync(liveCommonRoot)
+  : liveCommonRoot;
 
 export default defineConfig({
   plugins: [
@@ -51,6 +58,21 @@ export default defineConfig({
         tls: false,
         http2: false,
         dns: false,
+      };
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        "@ledgerhq/live-common/bridge/generic-alpaca/alpaca": path.join(
+          liveCommonResolved,
+          "lib-es/bridge/generic-alpaca/alpaca/index.js",
+        ),
+        "@ledgerhq/live-common/bridge/generic-alpaca/utils": path.join(
+          liveCommonResolved,
+          "lib-es/bridge/generic-alpaca/utils.js",
+        ),
+        "@ledgerhq/live-common/bridge/generic-alpaca/buildSubAccounts": path.join(
+          liveCommonResolved,
+          "lib-es/bridge/generic-alpaca/buildSubAccounts.js",
+        ),
       };
       appendPlugins([new rspack.IgnorePlugin({ resourceRegExp: /^electron$/ })]);
     },

--- a/apps/web-tools/src/pages/index.tsx
+++ b/apps/web-tools/src/pages/index.tsx
@@ -34,6 +34,9 @@ export default function Home() {
         <li>
           <Link to="/crypto-icons">Crypto Icons</Link>
         </li>
+        <li>
+          <Link to="/v4-account-model-playground">V4 Account Model Playground</Link>
+        </li>
       </ul>
     </main>
   );

--- a/apps/web-tools/src/pages/v4-account-model-playground.tsx
+++ b/apps/web-tools/src/pages/v4-account-model-playground.tsx
@@ -1,0 +1,3 @@
+import App from "../v4-account-model-playground";
+
+export default App;

--- a/apps/web-tools/src/routes.tsx
+++ b/apps/web-tools/src/routes.tsx
@@ -10,6 +10,7 @@ import NetworkTroubleshoot from "./pages/networkTroubleshoot";
 import Repl from "./pages/repl";
 import Sync from "./pages/sync";
 import Trustchain from "./pages/trustchain";
+import V4AccountModelPlayground from "./pages/v4-account-model-playground";
 
 const NotFound = () => <main>Not found</main>;
 
@@ -26,6 +27,7 @@ export const AppRoutes = () => (
     <Route path="/repl" element={<Repl />} />
     <Route path="/trustchain" element={<Trustchain />} />
     <Route path="/crypto-icons" element={<CryptoIcons />} />
+    <Route path="/v4-account-model-playground" element={<V4AccountModelPlayground />} />
     <Route path="*" element={<NotFound />} />
   </Routes>
 );

--- a/apps/web-tools/src/v4-account-model-playground/README.md
+++ b/apps/web-tools/src/v4-account-model-playground/README.md
@@ -1,0 +1,183 @@
+NB: this folder will eventually be moved to its own app. and the data-layers will be a top level concept to follow more the re-architecture of the project.
+
+# V4 Account Model Playground
+
+Experiment to rework the Account model and validate a slice-based architecture before future integration in Ledger Live. This playground lives in web-tools.
+
+**Challenge**: We still have to put the **coin-specific fields** we used to have on **Account** somewhere (e.g. `bitcoinResources`, `cosmosResources`). The bridge returns and expects a full **Account**, including those extras. So we need an additional slice that keeps them in memory and gives them back when we reconstruct **Account** for the bridge. See §2 (new slice) and the field mapping below.
+
+---
+
+## 1. Structure
+
+- **Entry**: Route and page (e.g. `/v4-account-model-playground`), lazy-loading the main App.
+- **Layout**: `index.ts` exporting the main App, optional `context.ts` for shared dependencies (e.g. sync drivers, bridge vs alpaca), `useEnv.ts` if needed for API/env.
+- **UI**: `components/` with one main `App.tsx` and feature components (e.g. account list, per-slice panels, sync controls).
+- **State**: Redux store (`store/index.ts`) combining the v4 slices (see below); we use Redux from the start for the multi-slice model. Redux DevTools are enabled for debugging.
+
+---
+
+## 2. The Slices (including coin-specifics)
+
+Data is no longer stored in a single **Account[]** store. It is split into **five slices** (the first four are in `libs/live-wallet/src/playground/entities/v4/`; the fifth is for the POC):
+
+| Slice | Store shape | Purpose |
+|-------|-------------|--------|
+| **accounts** | `{ byId: Record<id, AccountV4>, allIds: string[] }` | Core account; token accounts as **AccountV4.subAccounts** (TokenAccountV4). Ops for token accounts live in operationHistory, not on the type. |
+| **operationHistory** | `{ byAccountId: Record<accountId, { operations, nextPagingToken? }> }` | Operations per account (consumed by transaction list). **nextPagingToken** (optional) for “load more” when the API supports pagination. |
+| **transactional** | `{ pendingOperationsByAccountId }` | Pending ops per account (Send flow). Errors are UI state (component-local). |
+| **balanceHistory** | `{ byAccountId: Record<accountId, BalanceHistoryCache> }` | Balance history per account (consumed by portfolio graph). Today and in this POC it is **derived state** computed from operations + balance; in the future it will be a dedicated API. |
+| **swapHistory** | (same idea) | **Out of scope for this POC** — forget swap history here |
+| **accountCoinResources** | `{ byAccountId: Record<accountId, AccountResources> }` | **TEMPORARY PLACEHOLDER.** Single generic bucket for all coin-specific extras (bitcoinResources, tezosResources, nfts, etc.) so we can reconstruct **Account** for the bridge. Target later: one slice per coin (see below). |
+
+- **AccountV4** and **TokenAccountV4** are the types used in this playground. They are **copied in place** into `apps/web-tools/src/v4-account-model-playground/` (from `libs/live-wallet/src/playground/entities/v4/`). All new code for this experiment lives only inside that folder.
+- Data layer lives under `data-layer/` with one folder per domain (accounts, operationHistory, balanceHistory, accountCoinResources), each with `schema.ts`, `slice.ts`, `actions.ts` (when needed), `selectors.ts`.
+
+### Top-level selectors (reconstructing legacy Account) — §2.1
+
+**Goal**: Expose a single “account view” that recomposes the legacy **Account** (types-live) from the v4 slices, so the UI can be migrated incrementally: screens that still expect **Account** can rely on these selectors instead of reading five slices separately.
+
+- **Per-slice selectors** (in each domain’s `selectors.ts`) give raw slice data by `accountId`. They are the building blocks.
+- **Top-level selectors** live above the domains (e.g. `store/selectors.ts` or `shared/topLevelSelectors.ts`) and **compose** all slices for one account:
+  - **Sync**: `selectAccountReconstructionInput(state, accountId)` returns the bundle of slice data (accountV4, operations, pendingOperations from **transactional** slice, balanceHistory, accountCoinResources) needed to call `reconstructAccountFromReconstructionInput(input)`, or `undefined` if the account is missing. This is a pure selector; no async work.
+  - **Async**: The full legacy **Account** requires token resolution (`findTokenById`), so it cannot be a pure selector. The intended pattern is: a hook (e.g. `useReconstructedAccount(accountId)`) that uses `selectAccountReconstructionInput` and, when defined, calls `reconstructAccountFromSlices(...)` and returns the resulting `Promise<Account>`, with loading/error state as needed.
+- **Why this helps migration**: Existing UI that takes an **Account** can switch to `useReconstructedAccount(accountId)` and keep working while the store is already slice-based. New UI can still read slices directly where a full **Account** is not needed (e.g. operation list by account id). Bridge callers (e.g. sync) already use `reconstructAccountFromSlices` with data they have; top-level selectors centralize “get everything needed for this account from the store” in one place.
+
+### Coin-specific resources: placeholder vs coin-by-coin
+
+**accountCoinResources** is a **temporary placeholder**: one generic slice storing every coin’s extras (`Record<accountId, Record<string, unknown>>`). It exists so we can split/reconstruct the legacy **Account** without touching the bridge contract. It is **not** the target design:
+
+- No typed API per family (everything is `unknown`).
+- No family-specific persistence or “db” (one flat map for all coins).
+- No collocated logic (load, selectors, persistence) per coin.
+
+**Target direction: one slice per coin family.** Each family (Bitcoin, Cosmos, Tezos, etc.) should have its own domain with:
+
+- **Own schema** — e.g. `BitcoinResources` (utxos, walletAccount) with Zod; no generic bag.
+- **Own “db”** — state keyed by accountId for that family only; e.g. `bitcoinResources.byAccountId` only holds Bitcoin accounts.
+- **Collocated logic** — load (e.g. sync UTXOs only), selectors, and future persistence live in that domain.
+- **Clear ownership** — Bitcoin-specific types and rules stay in the Bitcoin domain; reconstruction reads from `bitcoinResources` when the account is Bitcoin.
+
+**bitcoinResources** in this playground is the **reference example**: see `data-layer/bitcoinResources/` (schema, slice, selectors, README). When the bridge returns a Bitcoin account, we dispatch `bitcoinResources` into that slice and **exclude** `bitcoinResources` from the generic `accountCoinResources` placeholder. Other families (cosmosResources, tezosResources, etc.) still go into the placeholder until they get their own slice. Adding a new coin slice follows the same pattern: new domain under `data-layer/<coin>Resources/`, wire split/reconstruct to use it, and stop putting that key in the placeholder.
+
+### Field mapping: Account (types-live) → slices
+
+Every field on **Account** (and **TokenAccount**) must live in exactly one slice so we can reconstruct the full **Account** when calling the bridge.
+
+| Field on Account / TokenAccount | Slice |
+|---------------------------------|--------|
+| type, id, seedIdentifier, xpub?, derivationMode, index, freshAddress, freshAddressPath, used, **currencyId**, **balance** (string), **spendableBalance** (string), creationDate, blockHeight, **feesCurrencyId**?, operationsCount, subAccounts? (each with **tokenId**), lastSyncDate, syncHash? | **accounts** (AccountV4 / TokenAccountV4). Stored as ids + strings for serializability; see §8. |
+| operations (each op with **value**, **fee** as string) | **operationHistory** |
+| pendingOperations (same shape) | **transactional** (pendingOperationsByAccountId) |
+| balanceHistoryCache | **balanceHistory** |
+| swapHistory | **swapHistory** (out of POC scope) |
+| **Coin-specific resources** (see list below) | **accountCoinResources** (placeholder) |
+| nfts? | **accountCoinResources** |
+
+**Coin-specific resource fields** (Account & { ... } per family). All live in **accountCoinResources** placeholder for this POC: bitcoinResources, tezosResources, suiResources, solanaResources, cosmosResources, concordiumResources, celoResources, tronResources, polkadotResources, nearResources, multiversxResources, iconResources, cardanoResources, aptosResources, algorandResources, kaspaResources, hederaResources, cantonResources, aleoResources.
+
+Some families also extend **TokenAccount** (e.g. SolanaTokenAccount, CantonTokenAccount, TonSubAccount); token-account-level extras can be stored in **accountCoinResources** keyed by token account id if needed for reconstruction.
+
+---
+
+## 3. Sync Flow: One Source of Truth, Multiple Stores
+
+- **Today**: Sync produces a single **Account** (with nested operations, balanceHistory, etc.) and the app stores it in one place.
+- **Target**: Sync still uses the **existing bridge interface** that returns a full **Account** (for compatibility). We do **not** change the bridge contract in this POC.
+- **Our job**: When we receive that **Account** from the bridge (or from an alpaca-driven path, see below), we **split** it and **dispatch into each slice**:
+  - **accounts slice**: upsert the account (and token accounts) as **AccountV4** / **TokenAccountV4**. SubAccounts persist **inside AccountV4** as **TokenAccountV4**; their operations are **not** on the type — they live in the **operationHistory** slice, keyed by (token) account id.
+  - **operationHistory slice**: Thunk `loadOperationHistory` triggers fetch; reducers apply payload (operations + nextPagingToken). Sync action `setOperationHistoryForAccount(accountId, operations, nextPagingToken?)` also available.
+  - **transactional slice**: Pending operations applied via `loadAccountData.fulfilled` / `loadOperationHistory.fulfilled` or `setPendingOperationsForAccount` / `addPendingOperationForAccount`.
+  - **balanceHistory slice**: `setBalanceHistoryForAccount(accountId, history)`.
+  - **accountCoinResources slice** (placeholder): store all coin extras (bitcoinResources, tezosResources, nfts, etc.).
+- **Bridge full sync enriches all stores**: When we **load accounts via the bridge** (legacy path), we already have the full **Account** (operations, balanceHistoryCache, etc.). We dispatch into **operationHistory** and **balanceHistory** from that same sync result so the Operations and Balance history sections **do not need a separate reload** — one full sync fills every slice.
+- **Reconstruction**: Rebuild the full **Account** from: accounts + operationHistory + balanceHistory + **accountCoinResources** (placeholder) (+ swapHistory when in scope). The caller uses accountCoinResources when reconstructing for the bridge. **Top-level selectors** (see §2.1) provide a sync selector for the reconstruction inputs and an async hook pattern for the full **Account** so the UI can depend on a single account view. In this POC there is no send flow, so reconstruction is only for sync. The Alpaca path does not need reconstruction for its slice-optimized fetches.
+
+Summary: **Single sync output (Account) → split into slices on dispatch; single “full Account” only when calling the bridge. When using the bridge, one account load enriches every store so no extra reload is needed.**
+
+**Important**: The `loadAccountData` thunk (shared) is for the **legacy (bridge) path** only: one full sync fills all slices. On the **Alpaca path** we do **not** "tout load"; each section (account card, operations list, balance history) triggers its own slice-optimized fetch.
+
+---
+
+## 4. Branching at the Slice Level: Bridge vs Alpaca
+
+We allow an **alternative integration path per coin family**:
+
+- **Legacy path**: Use the **bridge** (e.g. `getCurrencyBridge` / `getAccountBridge`) as today. Sync returns a full **Account**; we then split and dispatch into the v4 slices.
+- **Optimized path (POC candidate: EVM)**: For **coin-evm** (and coins using the same pattern), we use a **minimized sync** that talks directly to the **Alpaca-style API** (e.g. `getBalance`, `listOperations`, etc.), inspired by the **bridge alpaca adaptor** (`libs/ledger-live-common/src/bridge/generic-alpaca/`). Each slice can be fed without building a full **Account** first:
+  - **accounts slice**: minimal account + balances from Alpaca.
+  - **operationHistory slice**: from `listOperations` (or equivalent).
+  - **balanceHistory slice**: see §6 Balance history below. Today it is derived from operations + balance; same in this POC (including Alpaca-driven). Future: dedicated API.
+
+For **other coin families** we keep using the **legacy bridge** and the “reconstruct Account when needed” approach above.
+
+**POC scope**: Assume **coin-evm** is the candidate for the Alpaca/minimized interface; all other families use the legacy bridge. Implementation should make it easy to plug in the alpacaized interface (e.g. adaptors inspired by `generic-alpaca`) without duplicating UI.
+
+**Sync trigger**:
+- **Bridge path**: Sync runs when **any** slice needs a data refresh (e.g. balance or operations). Both balance and operations needs trigger the same full sync, since the bridge returns one **Account**.
+- **Alpaca path**: Only **fetch the necessary part** (e.g. only the slice that is being refreshed).
+
+---
+
+## 5. Account import and “accounts being used”
+
+- **Import by account ID**: One input field to enter an account id (same idea as the Sync page, `apps/web-tools/src/pages/sync.tsx`), plus an **[ADD]** button. On [ADD], validate/normalize the id (e.g. via `decodeAccountId` or an `inferAccountId`-style helper as in sync.tsx) and add it to the list of **accounts being used**. That list is the set of account ids the playground will sync and display.
+- **Wallet Sync import (optional)**: User can pull account ids from Wallet Sync (e.g. from a connected device). The input used for “account ids” has `name="account-ids"` so the browser can save/restore it. Member credentials are not persisted; each import obtains fresh credentials from the device. See `walletSyncImport.ts`.
+- No need to auto-sync on paste; the user explicitly adds ids, then uses LOAD/REFRESH per section to fetch data.
+
+---
+
+## 6. UI Features (per slice)
+
+UI should mimic the app lightly; keep it minimal. Each section has a **LOAD / REFRESH** action that triggers the underlying load logic:
+
+- **Bridge path**: LOAD/REFRESH triggers a **full sync** for the selected account(s); we then split the returned **Account** into slices and dispatch. Reconstruction is used whenever we call the bridge (it only understands **Account**).
+- **Alpaca path**: LOAD/REFRESH triggers only the **slice-optimized** fetch (e.g. only balance, or only operations, or only what’s needed for that section).
+
+Sections:
+
+- **Account display (accounts slice)**  
+  Show balance, name, address (or id), currency. Token accounts under parent as **AccountV4.subAccounts** (TokenAccountV4). A **LOAD/REFRESH** button runs the logic that fills the accounts slice (full sync for bridge, or minimal account+balance for Alpaca). On bridge path, this load also enriches operationHistory and balanceHistory so Operations and Balance history sections are already filled. Per-account load errors are shown on the failing account card; other accounts continue to load.
+
+- **Account operations list (operationHistory slice)**  
+  Operations are stored **by account id** in the operationHistory slice; token account operations live in the same store keyed by their **account id** (not on TokenAccountV4). UI: user selects **one account or one token account**; ops are shown for that id only. **LOAD/REFRESH** loads operations for the selected account (full sync for bridge, or slice fetch for Alpaca). **Pagination**: first page (e.g. 20 ops) is shown; a **Load more** button appears when there are more (client-side when the API returns all ops at once, server-side when it returns `nextPagingToken`). After a bridge account load, ops are already in the store so no separate operations load is needed.
+
+- **Account balance history (balanceHistory slice)**  
+  Mini graph (or tabular) for balance over time. **Balance history today** is **derived state** calculated from operations + balance; we do the same here in the POC (bridge and Alpaca-driven). Use a derived/placeholder implementation that builds the balance history from balance + operations (e.g. in the slice or a small helper). **Document in code** that in the future this will be a **dedicated balance history API**; keep the derivation logic localized in the slice/playground for now. After a bridge account load, balance history is already in the store so no separate balance history load is needed.
+
+**Explicitly out of scope for this POC**: Swap history UI and any swap-specific flows.
+
+---
+
+
+## 7. TO BE DISCUSSED
+
+### WIP and placeholders in this playground
+
+- **accountCoinResources** is a **temporary placeholder** (see §2). All coin-specific extras (bitcoinResources, tezosResources, etc.) live there; target later is one slice per coin family.
+- **Balance history** is **derived** from operations + balance in this POC. It is documented as future **dedicated API**; the derivation logic is local to the playground.
+- **Operations pagination**: UI supports “Load more” (client-side or server-side when the API returns `nextPagingToken`). Backend support for `limit` / `lastPagingToken` may still be partial; behavior is prepared for when Alpaca (or equivalent) fully supports it.
+- **Reconstruction** from slices is **async** when tokens are involved (`findTokenById`). Callers that need a full **Account** for the bridge must await `reconstructAccountFromSlices`. **Top-level selectors** (§2.1) expose a sync selector for reconstruction inputs and recommend a hook (e.g. `useReconstructedAccount`) for UI that needs the full legacy **Account**.
+- **AccountV4** still contains fields that likely belong to other domains and should be split out: key chain–related, blockchain-related, sync management–related.
+- **pendingOperations** live in the **transactional** slice (`pendingOperationsByAccountId`); **operationHistory** holds only confirmed operations.
+
+### Serializability tradeoff: no Token / Currency / BigNumber in the stored model
+
+To keep the Redux state **serializable** (e.g. for persistence, DevTools, or future sync), we **do not** store **Token** (TokenCurrency), **Currency** (CryptoCurrency), or **BigNumber** in the slices:
+
+- **Accounts**: we store **currencyId** and **tokenId** (and **feesCurrencyId**) instead of `currency` / `token` / `feesCurrency`. **Balance** and **spendableBalance** are stored as **strings** (parsed to BigNumber only when needed).
+- **Operations**: we store **value** and **fee** (and **transactionSequenceNumber**) as **strings**; same idea, parse to BigNumber at use site.
+
+**Consequence**: the **UI (and any code that needs “full” objects)** must **resolve** every time:
+
+- **Currency**: `getCryptoCurrencyById(account.currencyId)` (sync).
+- **Token**: `getCryptoAssetsStore().findTokenById(tokenAccount.tokenId)` (async).
+- **Balances / op amounts**: `new BigNumber(account.balance)`, `new BigNumber(op.value)`, etc., when formatting or computing.
+
+Reconstruction of the full **Account** for the bridge also does these lookups (sync for currency, async for tokens and feesCurrency).
+
+This **tradeoff** (serializable store vs. resolution cost and async where tokens are involved) is intentional for the POC and **needs to be discussed** for production: e.g. caching of resolved currencies/tokens, or accepting non-serializable state in parts of the app, vs. keeping a fully serializable store and paying the resolution cost at read time.
+
+---
+
+**Implementation**: The above is the full spec; §7 captures open points and tradeoffs to be discussed. Implementation can proceed from §1 (structure) through §6.

--- a/apps/web-tools/src/v4-account-model-playground/components/AccountDisplaySection.tsx
+++ b/apps/web-tools/src/v4-account-model-playground/components/AccountDisplaySection.tsx
@@ -1,0 +1,256 @@
+import React, { useCallback, useState } from "react";
+import styled from "styled-components";
+import { useDispatch, useSelector } from "react-redux";
+import BigNumber from "bignumber.js";
+import { RootState, store } from "../store";
+import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/formatCurrencyUnit";
+import { loadAccountsForAccountId } from "../shared/accountDataActions";
+import { isAlpacaForAccountId } from "../shared/syncStrategy";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { useTokenById } from "@ledgerhq/cryptoassets/hooks";
+
+function getErrorMessage(e: unknown): string {
+  return e instanceof globalThis.Error ? e.message : String(e);
+}
+
+const Section = styled.section`
+  margin: 24px 0;
+  padding: 16px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fafafa;
+`;
+
+const SectionTitle = styled.h3`
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+`;
+
+const Button = styled.button`
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 4px;
+  border: 1px solid #333;
+  background: #333;
+  color: #fff;
+  cursor: pointer;
+  margin-bottom: 16px;
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;
+
+const Error = styled.span`
+  color: #c00;
+  font-size: 13px;
+  display: block;
+  margin-top: 8px;
+`;
+
+const AccountCard = styled.div`
+  position: relative;
+  padding: 12px;
+  margin: 0;
+  border: 1px solid #ddd;
+  border-top: none;
+  background: #fff;
+  &:first-of-type {
+    border-top: 1px solid #ddd;
+    border-radius: 6px 6px 0 0;
+  }
+  &:last-of-type {
+    border-radius: 0 0 6px 6px;
+  }
+  &:only-of-type {
+    border-radius: 6px;
+  }
+`;
+
+const PathTag = styled.span<{ $alpaca: boolean }>`
+  position: absolute;
+  bottom: 6px;
+  right: 8px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 5px;
+  border-radius: 3px;
+  background: ${p => (p.$alpaca ? "#e8d5a3" : "#e5e5e5")};
+  color: ${p => (p.$alpaca ? "#7a6910" : "#555")};
+`;
+
+const PerfDurationCorner = styled.span`
+  position: absolute;
+  bottom: 6px;
+  left: 8px;
+  font-size: 11px;
+  color: #0a0;
+`;
+
+const RadioRow = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  margin: 4px 0;
+  font-size: 13px;
+`;
+
+const BalanceRow = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
+`;
+
+const SubRow = styled.div`
+  margin-left: 24px;
+  font-size: 12px;
+`;
+
+function TokenAccountRow({
+  ta,
+  selectedAccountId,
+  onSelectedAccountIdChange,
+}: {
+  key?: string;
+  ta: { id?: string; tokenId?: string; balance?: string };
+  selectedAccountId: string | null;
+  onSelectedAccountIdChange: (id: string | null) => void;
+}) {
+  const tokenId = ta.tokenId ?? "";
+  const { token } = useTokenById(tokenId);
+  const ticker = token?.ticker ?? tokenId;
+  const unit = token?.units[0];
+  return (
+    <RadioRow>
+      <input
+        type="radio"
+        name="selectedAccount"
+        checked={selectedAccountId === ta.id}
+        onChange={() => onSelectedAccountIdChange(ta.id ?? null)}
+      />
+      <BalanceRow>
+        <span>
+          └ {ticker}:{" "}
+          {unit
+            ? formatCurrencyUnit(unit, new BigNumber(ta.balance ?? "0"), { showCode: true })
+            : ta.balance ?? "0"}
+        </span>
+      </BalanceRow>
+    </RadioRow>
+  );
+}
+
+export default function AccountDisplaySection({
+  accountsBeingUsed,
+  selectedAccountId,
+  onSelectedAccountIdChange,
+}: {
+  accountsBeingUsed: string[];
+  selectedAccountId: string | null;
+  onSelectedAccountIdChange: (id: string | null) => void;
+}) {
+  const dispatch = useDispatch();
+  const accounts = useSelector((s: RootState) => s.accounts);
+  const [loading, setLoading] = useState(false);
+  const [loadErrors, setLoadErrors] = useState<Record<string, string>>({});
+  const [loadDurations, setLoadDurations] = useState<Record<string, number>>({});
+
+  const idsToLoad = accountsBeingUsed.length > 0 ? accountsBeingUsed : accounts.allIds;
+
+  const handleLoad = useCallback(async () => {
+    if (idsToLoad.length === 0) return;
+    setLoading(true);
+    setLoadErrors(prev => {
+      const next = { ...prev };
+      idsToLoad.forEach(id => delete next[id]);
+      return next;
+    });
+    for (const id of idsToLoad) {
+      const start = Date.now();
+      try {
+        await loadAccountsForAccountId(id, dispatch);
+        const durationSec = (Date.now() - start) / 1000;
+        const state = store.getState();
+        const acc = state.accounts.byId[id];
+        const updates: Record<string, number> = { [id]: durationSec };
+        for (const ta of acc?.subAccounts ?? []) {
+          updates[ta.id] = durationSec;
+        }
+        setLoadDurations(prev => ({ ...prev, ...updates }));
+      } catch (e) {
+        setLoadErrors(prev => ({ ...prev, [id]: getErrorMessage(e) }));
+      }
+    }
+    setLoading(false);
+  }, [idsToLoad, dispatch]);
+
+  return (
+    <Section>
+      <SectionTitle>Account display ( ⛁ accounts)</SectionTitle>
+      <p style={{ fontSize: 12, color: "#666", margin: "0 0 8px" }}>
+        Select an account for Operations & Balance history below.
+      </p>
+      <Button onClick={handleLoad} disabled={loading || idsToLoad.length === 0}>
+        {loading ? "Loading…" : "LOAD / REFRESH"}
+      </Button>
+      {Array.from(new Set([...idsToLoad, ...accounts.allIds])).map(id => {
+        const err = loadErrors[id];
+        if (err) {
+          return (
+            <AccountCard key={id}>
+              <Error>Load failed: {err}</Error>
+              <span style={{ fontSize: 12, color: "#666" }}>Account id: {id}</span>
+            </AccountCard>
+          );
+        }
+        const acc = accounts.byId[id];
+        if (!acc) return null;
+        const isAlpaca = isAlpacaForAccountId(acc.id);
+        const currency = getCryptoCurrencyById(acc.currencyId);
+        return (
+          <AccountCard key={acc.id}>
+            {loadDurations[acc.id] != null && (
+              <PerfDurationCorner>{loadDurations[acc.id].toFixed(1)}s</PerfDurationCorner>
+            )}
+            <PathTag $alpaca={isAlpaca}>{isAlpaca ? "Alpaca" : "Legacy"}</PathTag>
+            <RadioRow>
+              <input
+                type="radio"
+                name="selectedAccount"
+                checked={selectedAccountId === acc.id}
+                onChange={() => onSelectedAccountIdChange(acc.id)}
+              />
+              <BalanceRow>
+                <span>
+                  <strong>{currency.name}</strong>{" "}
+                  {formatCurrencyUnit(currency.units[0], new BigNumber(acc.balance), {
+                    showCode: true,
+                  })}{" "}
+                  — {acc.freshAddress}
+                </span>
+              </BalanceRow>
+            </RadioRow>
+            {(acc.subAccounts?.length ?? 0) > 0 && (
+              <SubRow>
+                {acc.subAccounts!.map(ta => (
+                  <TokenAccountRow
+                    key={ta.id}
+                    ta={ta}
+                    selectedAccountId={selectedAccountId}
+                    onSelectedAccountIdChange={onSelectedAccountIdChange}
+                  />
+                ))}
+              </SubRow>
+            )}
+          </AccountCard>
+        );
+      })}
+    </Section>
+  );
+}

--- a/apps/web-tools/src/v4-account-model-playground/components/AccountImportSection.tsx
+++ b/apps/web-tools/src/v4-account-model-playground/components/AccountImportSection.tsx
@@ -1,0 +1,176 @@
+import React, { useCallback, useState } from "react";
+import styled from "styled-components";
+import { inferAccountId } from "../shared/compatibility";
+import { importAccountIdsFromWalletSync } from "../shared/walletSyncImport";
+
+function getErrorMessage(e: unknown): string {
+  return e instanceof globalThis.Error ? e.message : String(e);
+}
+
+const Section = styled.section`
+  margin: 24px 0;
+  padding: 16px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fafafa;
+`;
+
+const SectionTitle = styled.h3`
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+`;
+
+const InputRow = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+`;
+
+const Input = styled.input`
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+`;
+
+const Button = styled.button`
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 4px;
+  border: 1px solid #333;
+  background: #333;
+  color: #fff;
+  cursor: pointer;
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;
+
+const Error = styled.span`
+  color: #c00;
+  font-size: 13px;
+`;
+
+const AccountIdList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0 0 12px;
+  font-size: 13px;
+  max-height: 120px;
+  overflow-y: auto;
+`;
+
+const AccountIdItem = styled.li`
+  padding: 4px 0;
+  border-bottom: 1px solid #eee;
+  font-family: monospace;
+  word-break: break-all;
+`;
+
+const DeviceRow = styled.div`
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #eee;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export default function AccountImportSection({
+  accountsBeingUsed,
+  onAccountsBeingUsedChange,
+  onAddAccountsBeingUsed,
+}: {
+  accountsBeingUsed: string[];
+  onAccountsBeingUsedChange: (ids: string[]) => void;
+  onAddAccountsBeingUsed: (ids: string[]) => void;
+}) {
+  const [accountIdInput, setAccountIdInput] = useState("");
+  const [accountIdError, setAccountIdError] = useState("");
+  const [deviceLoading, setDeviceLoading] = useState(false);
+  const [deviceError, setDeviceError] = useState<string | null>(null);
+  const handleAdd = useCallback(() => {
+    const normalized = accountIdInput.replace(/\\"/g, "").replace(/"/g, "").trim();
+    if (!normalized) return;
+    const rawIds = normalized
+      .split(/\s+/)
+      .map(s => s.trim())
+      .filter(Boolean);
+    if (rawIds.length === 0) return;
+    setAccountIdError("");
+    const added: string[] = [];
+    const errors: string[] = [];
+    for (const raw of rawIds) {
+      try {
+        const id = inferAccountId(raw);
+        if (!accountsBeingUsed.includes(id) && !added.includes(id)) added.push(id);
+      } catch (e) {
+        errors.push(`${raw}: ${getErrorMessage(e)}`);
+      }
+    }
+    if (added.length) {
+      onAccountsBeingUsedChange([...accountsBeingUsed, ...added]);
+      setAccountIdInput("");
+    }
+    if (errors.length)
+      setAccountIdError(
+        errors.length === 1 ? errors[0] : `${errors.length} invalid ID(s). First: ${errors[0]}`,
+      );
+  }, [accountIdInput, accountsBeingUsed, onAccountsBeingUsedChange]);
+
+  const runImportFromWalletSync = useCallback(() => {
+    setDeviceError(null);
+    setDeviceLoading(true);
+    importAccountIdsFromWalletSync("webhid")
+      .then(ids => {
+        setDeviceLoading(false);
+        if (ids.length) onAddAccountsBeingUsed(ids);
+      })
+      .catch(err => {
+        setDeviceError(getErrorMessage(err));
+        setDeviceLoading(false);
+      });
+  }, [onAddAccountsBeingUsed]);
+
+  return (
+    <Section>
+      <SectionTitle>Import account by ID</SectionTitle>
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          handleAdd();
+        }}
+      >
+        <InputRow>
+          <Input
+            name="account-ids"
+            type="text"
+            placeholder="Account id(s), space-separated (e.g. js:2:ethereum:0x…)"
+            value={accountIdInput}
+            onChange={e => setAccountIdInput(e.target.value)}
+          />
+          <Button type="submit">ADD</Button>
+        </InputRow>
+      </form>
+      {accountIdError && <Error>{accountIdError}</Error>}
+      <DeviceRow style={{ flexWrap: "wrap" }}>
+        <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <Button type="button" onClick={runImportFromWalletSync} disabled={deviceLoading}>
+            {deviceLoading ? "Syncing…" : "Import from Wallet Sync with device"}
+          </Button>
+        </span>
+        {deviceError && (
+          <Error style={{ display: "block", width: "100%", marginTop: 8 }}>{deviceError}</Error>
+        )}
+      </DeviceRow>
+      <AccountIdList>
+        {accountsBeingUsed.map(id => (
+          <AccountIdItem key={id}>{id}</AccountIdItem>
+        ))}
+      </AccountIdList>
+    </Section>
+  );
+}

--- a/apps/web-tools/src/v4-account-model-playground/components/App.tsx
+++ b/apps/web-tools/src/v4-account-model-playground/components/App.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useState } from "react";
+import styled from "styled-components";
+import AccountImportSection from "./AccountImportSection";
+import AccountDisplaySection from "./AccountDisplaySection";
+import TransactionalSection from "./TransactionalSection";
+import OperationsSection from "./OperationsSection";
+import BalanceHistorySection from "./BalanceHistorySection";
+
+const Container = styled.div`
+  padding: 0 16px 32px;
+  max-width: 1240px;
+  margin: 0 auto;
+  font-family: sans-serif;
+`;
+
+const Header = styled.h1`
+  margin: 0 0 16px;
+`;
+
+const Panels = styled.div`
+  display: flex;
+  gap: 24px;
+  align-items: flex-start;
+`;
+
+const LeftPanel = styled.div`
+  flex: 0 0 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+`;
+
+const RightPanel = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+`;
+
+export default function App() {
+  const [accountsBeingUsed, setAccountsBeingUsed] = useState<string[]>([]);
+  const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
+
+  const handleAccountsBeingUsedChange = useCallback((ids: string[]) => {
+    setAccountsBeingUsed(ids);
+  }, []);
+
+  const handleAddAccountsBeingUsed = useCallback((ids: string[]) => {
+    setAccountsBeingUsed(prev => Array.from(new Set([...prev, ...ids])));
+  }, []);
+
+  return (
+    <Container>
+      <Header>V4 Account Model Playground</Header>
+
+      <Panels>
+        <LeftPanel>
+          <AccountImportSection
+            accountsBeingUsed={accountsBeingUsed}
+            onAccountsBeingUsedChange={handleAccountsBeingUsedChange}
+            onAddAccountsBeingUsed={handleAddAccountsBeingUsed}
+          />
+          <AccountDisplaySection
+            accountsBeingUsed={accountsBeingUsed}
+            selectedAccountId={selectedAccountId}
+            onSelectedAccountIdChange={setSelectedAccountId}
+          />
+        </LeftPanel>
+
+        <RightPanel>
+          <OperationsSection
+            accountsBeingUsed={accountsBeingUsed}
+            selectedAccountId={selectedAccountId}
+          />
+          <BalanceHistorySection selectedAccountId={selectedAccountId} />
+          <TransactionalSection
+            accountsBeingUsed={accountsBeingUsed}
+            selectedAccountId={selectedAccountId}
+          />
+        </RightPanel>
+      </Panels>
+    </Container>
+  );
+}

--- a/apps/web-tools/src/v4-account-model-playground/components/BalanceHistorySection.tsx
+++ b/apps/web-tools/src/v4-account-model-playground/components/BalanceHistorySection.tsx
@@ -1,0 +1,171 @@
+import React, { useCallback, useState } from "react";
+import styled from "styled-components";
+import { useDispatch, useSelector } from "react-redux";
+import type { RootState } from "../store";
+import { loadBalanceHistoryForAccountId } from "../data-layer/balanceHistory/actions";
+
+const Section = styled.section`
+  position: relative;
+  margin: 24px 0;
+  padding: 16px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fafafa;
+`;
+
+const TitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0 0 12px;
+`;
+
+const SectionTitle = styled.h3`
+  margin: 0;
+  font-size: 1.1rem;
+`;
+
+const PerfDuration = styled.span`
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  font-size: 11px;
+  color: #0a0;
+`;
+
+const Button = styled.button`
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 4px;
+  border: 1px solid #333;
+  background: #fff;
+  color: #333;
+  cursor: pointer;
+  margin-top: 8px;
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;
+
+const GraphWrapper = styled.div`
+  height: 140px;
+  background: #e8e8e8;
+  border-radius: 4px;
+  padding: 10px;
+  margin-top: 8px;
+`;
+
+function BalanceCurveSvg({ balances }: { balances: number[] }) {
+  if (balances.length === 0) {
+    return (
+      <GraphWrapper
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "#666",
+          fontSize: 13,
+        }}
+      >
+        No data
+      </GraphWrapper>
+    );
+  }
+  const width = 400;
+  const height = 120;
+  const min = Math.min(...balances);
+  const max = Math.max(...balances);
+  const range = max - min || 1;
+  const padding = 2;
+  const n = balances.length;
+  const points = balances.map((v, i) => {
+    const x = (i / (n - 1 || 1)) * (width - 2 * padding) + padding;
+    const y = height - padding - ((v - min) / range) * (height - 2 * padding);
+    return `${x},${y}`;
+  });
+  const pathD = `M ${points.join(" L ")}`;
+  const areaD = `${pathD} L ${width - padding},${height - padding} L ${padding},${height - padding} Z`;
+  return (
+    <GraphWrapper>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        style={{ width: "100%", height: 120, display: "block" }}
+      >
+        <path d={areaD} fill="rgba(0,0,0,0.12)" />
+        <path
+          d={pathD}
+          fill="none"
+          stroke="#555"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </GraphWrapper>
+  );
+}
+
+export default function BalanceHistorySection({
+  selectedAccountId,
+}: {
+  selectedAccountId: string | null;
+}) {
+  const dispatch = useDispatch();
+  const accounts = useSelector((s: RootState) => s.accounts);
+  const balanceHistory = useSelector((s: RootState) => s.balanceHistory);
+  const [loading, setLoading] = useState(false);
+  const [loadDurationSec, setLoadDurationSec] = useState<number | null>(null);
+
+  const accountIdList = React.useMemo(() => {
+    const ids: string[] = [];
+    for (const accountId of accounts.allIds) {
+      const acc = accounts.byId[accountId];
+      if (!acc) continue;
+      ids.push(accountId);
+      for (const sub of acc.subAccounts || []) ids.push(sub.id);
+    }
+    return ids;
+  }, [accounts.allIds, accounts.byId]);
+
+  const handleLoad = useCallback(async () => {
+    const id = selectedAccountId ?? accountIdList[0];
+    if (!id) return;
+    setLoading(true);
+    const start = Date.now();
+    try {
+      await loadBalanceHistoryForAccountId(id, dispatch);
+      setLoadDurationSec((Date.now() - start) / 1000);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedAccountId, accountIdList, dispatch]);
+
+  const selectedBalanceHistory = selectedAccountId
+    ? balanceHistory.byAccountId[selectedAccountId]
+    : null;
+
+  return (
+    <Section>
+      <TitleRow>
+        <SectionTitle>Balance history ( ⛁ balanceHistory)</SectionTitle>
+      </TitleRow>
+      <Button onClick={handleLoad} disabled={!selectedAccountId || loading}>
+        {loading ? "Loading…" : "LOAD / REFRESH"}
+      </Button>
+      {selectedBalanceHistory && (
+        <>
+          <p style={{ fontSize: 12, color: "#666", margin: "8px 0 0" }}>
+            DAY: {selectedBalanceHistory.DAY?.balances?.length ?? 0} points
+            {selectedBalanceHistory.DAY?.latestDate != null &&
+              ` (latest: ${new Date(selectedBalanceHistory.DAY.latestDate).toISOString().slice(0, 10)})`}
+          </p>
+          <BalanceCurveSvg balances={selectedBalanceHistory.DAY?.balances ?? []} />
+        </>
+      )}
+      {loadDurationSec != null && <PerfDuration>{loadDurationSec.toFixed(1)}s</PerfDuration>}
+    </Section>
+  );
+}

--- a/apps/web-tools/src/v4-account-model-playground/components/OperationsSection.tsx
+++ b/apps/web-tools/src/v4-account-model-playground/components/OperationsSection.tsx
@@ -1,0 +1,311 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import styled from "styled-components";
+import { useDispatch, useSelector } from "react-redux";
+import BigNumber from "bignumber.js";
+import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/formatCurrencyUnit";
+import type { Unit } from "@ledgerhq/types-cryptoassets";
+import { RootState } from "../store";
+import { loadOperationHistoryForAccountId } from "../data-layer/operationHistory/actions";
+import { selectPendingOperationsByAccountId } from "../data-layer/transactional/selectors";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { useTokenById } from "@ledgerhq/cryptoassets/hooks";
+
+const OPERATIONS_PAGE_SIZE = 20;
+
+function getErrorMessage(e: unknown): string {
+  return e instanceof globalThis.Error ? e.message : String(e);
+}
+
+const Section = styled.section`
+  position: relative;
+  margin: 24px 0;
+  padding: 16px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fafafa;
+`;
+
+const TitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0 0 12px;
+`;
+
+const SectionTitle = styled.h3`
+  margin: 0;
+  font-size: 1.1rem;
+`;
+
+const PerfDuration = styled.span`
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  font-size: 11px;
+  color: #0a0;
+`;
+
+const Button = styled.button`
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 4px;
+  border: 1px solid #333;
+  background: #fff;
+  color: #333;
+  cursor: pointer;
+  margin-top: 8px;
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;
+
+const Error = styled.span`
+  color: #c00;
+  font-size: 13px;
+  display: block;
+  margin-top: 8px;
+`;
+
+const OpList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 13px;
+  max-height: 300px;
+  overflow: auto;
+`;
+
+const OpItem = styled.li`
+  padding: 6px 0;
+  border-bottom: 1px solid #eee;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+`;
+
+const OpType = styled.span`
+  flex-shrink: 0;
+  min-width: 4.5em;
+`;
+
+const OpDate = styled.span`
+  flex-shrink: 0;
+`;
+
+const OpAddress = styled.span`
+  min-width: 0;
+  flex: 1;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const OpAmount = styled.span`
+  flex-shrink: 0;
+  margin-left: auto;
+`;
+
+function getTokenIdFromOp(op: { tokenId?: string; extra?: unknown }): string {
+  if (typeof op.tokenId === "string" && op.tokenId) return op.tokenId;
+  const extra = op.extra;
+  if (!extra || typeof extra !== "object" || !("tokenId" in extra)) return "";
+  const v = (extra as Record<string, unknown>).tokenId;
+  return typeof v === "string" ? v : "";
+}
+
+function OpRow({
+  op,
+  selectedUnit,
+  selectedTokenId,
+}: {
+  key?: string;
+  op: {
+    id?: string;
+    type?: string;
+    value?: string;
+    hash?: string;
+    date?: Date | string | number;
+    tokenId?: string;
+    senders?: string[];
+    recipients?: string[];
+    extra?: unknown;
+  };
+  selectedUnit: Unit | null;
+  selectedTokenId: string;
+}) {
+  const opTokenId = getTokenIdFromOp(op);
+  const effectiveTokenId = opTokenId || selectedTokenId;
+  const { token } = useTokenById(effectiveTokenId);
+  const unit = effectiveTokenId ? token?.units[0] ?? null : selectedUnit;
+  const address =
+    op.type === "IN"
+      ? op.senders?.[0] ?? op.recipients?.[0] ?? op.hash ?? ""
+      : op.recipients?.[0] ?? op.senders?.[0] ?? op.hash ?? "";
+  const dateStr =
+    typeof op.date === "number"
+      ? new Date(op.date).toISOString().slice(0, 10)
+      : op.date instanceof Date
+        ? op.date.toISOString().slice(0, 10)
+        : String(op.date ?? "");
+  const amountStr = unit
+    ? formatCurrencyUnit(unit, new BigNumber(op.value ?? "0"), { showCode: true })
+    : op.value ?? "0";
+  return (
+    <OpItem>
+      <OpType>{op.type ?? ""}</OpType>
+      <OpDate>{dateStr}</OpDate>
+      <OpAddress>{address}</OpAddress>
+      <OpAmount>{amountStr}</OpAmount>
+    </OpItem>
+  );
+}
+
+export default function OperationsSection({
+  selectedAccountId,
+}: {
+  accountsBeingUsed: string[];
+  selectedAccountId: string | null;
+}) {
+  const dispatch = useDispatch();
+  const accounts = useSelector((s: RootState) => s.accounts);
+  const operationHistory = useSelector((s: RootState) => s.operationHistory);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loadDurationSec, setLoadDurationSec] = useState<number | null>(null);
+  /** Client-side: how many ops to show when API didn't return nextPagingToken (bridge or Alpaca without pagination). */
+  const [visibleCount, setVisibleCount] = useState(OPERATIONS_PAGE_SIZE);
+
+  useEffect(() => {
+    setVisibleCount(OPERATIONS_PAGE_SIZE);
+  }, [selectedAccountId]);
+
+  const handleLoad = useCallback(async () => {
+    if (!selectedAccountId) return;
+    setLoading(true);
+    setError(null);
+    setVisibleCount(OPERATIONS_PAGE_SIZE);
+    const start = Date.now();
+    try {
+      await loadOperationHistoryForAccountId(selectedAccountId, dispatch, {
+        limit: OPERATIONS_PAGE_SIZE,
+      });
+      setLoadDurationSec((Date.now() - start) / 1000);
+    } catch (e) {
+      setError(getErrorMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedAccountId, dispatch]);
+
+  const handleLoadMore = useCallback(async () => {
+    if (!selectedAccountId) return;
+    const entry = operationHistory.byAccountId[selectedAccountId];
+    if (entry?.nextPagingToken) {
+      setLoadingMore(true);
+      setError(null);
+      try {
+        await loadOperationHistoryForAccountId(selectedAccountId, dispatch, {
+          limit: OPERATIONS_PAGE_SIZE,
+          pagingToken: entry.nextPagingToken,
+        });
+      } catch (e) {
+        setError(getErrorMessage(e));
+      } finally {
+        setLoadingMore(false);
+      }
+    } else {
+      setVisibleCount(prev => prev + OPERATIONS_PAGE_SIZE);
+    }
+  }, [selectedAccountId, dispatch, operationHistory.byAccountId]);
+
+  const selectedOps = selectedAccountId ? operationHistory.byAccountId[selectedAccountId] : null;
+  const pendingOps = useSelector((s: RootState) =>
+    selectedAccountId ? selectPendingOperationsByAccountId(s, selectedAccountId) : [],
+  );
+  /** Dedupe by id: pending (transactional) + confirmed (operationHistory). */
+  const allOpsDeduped = useMemo(() => {
+    const combined = selectedOps ? [...pendingOps, ...selectedOps.operations] : [];
+    const seen = new Set<string>();
+    return combined.filter(op => {
+      if (seen.has(op.id)) return false;
+      seen.add(op.id);
+      return true;
+    });
+  }, [pendingOps, selectedOps?.operations]);
+  /** Server-side pagination: show all ops we have (append already added them). Client-side: slice by visibleCount. */
+  const displayedOps =
+    selectedOps?.nextPagingToken != null ? allOpsDeduped : allOpsDeduped.slice(0, visibleCount);
+  const hasMoreClientSide = !selectedOps?.nextPagingToken && allOpsDeduped.length > visibleCount;
+  const hasMoreServerSide = Boolean(selectedOps?.nextPagingToken);
+  const canLoadMore = hasMoreClientSide || hasMoreServerSide;
+
+  /** TokenId of the selected account when it's a token account; else "". */
+  const selectedTokenId = useMemo((): string => {
+    if (!selectedAccountId) return "";
+    if (accounts.byId[selectedAccountId]) return "";
+    for (const acc of Object.values(accounts.byId)) {
+      const sub = acc.subAccounts?.find(s => s.id === selectedAccountId);
+      if (sub) return sub.tokenId;
+    }
+    return "";
+  }, [selectedAccountId, accounts.byId]);
+  const { token: selectedToken } = useTokenById(selectedTokenId);
+
+  /** Default unit: main account = currency unit, token account = that token's unit. */
+  const selectedUnit = useMemo((): Unit | null => {
+    if (!selectedAccountId) return null;
+    const main = accounts.byId[selectedAccountId];
+    if (main) return getCryptoCurrencyById(main.currencyId).units[0];
+    return selectedToken?.units[0] ?? null;
+  }, [selectedAccountId, accounts.byId, selectedToken]);
+
+  return (
+    <Section>
+      <TitleRow>
+        <SectionTitle>Operations ( ⛁ operationHistory)</SectionTitle>
+      </TitleRow>
+      <p style={{ fontSize: 12, color: "#666", margin: "0 0 8px" }}>
+        Loads operations for the selected account only.
+      </p>
+      <Button onClick={handleLoad} disabled={loading || !selectedAccountId}>
+        {loading ? "Loading…" : "LOAD / REFRESH"}
+      </Button>
+      {error && <Error>{error}</Error>}
+      {loadDurationSec != null && !loading && (
+        <PerfDuration>{loadDurationSec.toFixed(1)}s</PerfDuration>
+      )}
+      {selectedOps && (
+        <>
+          <OpList>
+            {allOpsDeduped.length === 0 && <li style={{ color: "#666" }}>No operations</li>}
+            {displayedOps.map(op => (
+              <OpRow
+                key={op.id}
+                op={op}
+                selectedUnit={selectedUnit}
+                selectedTokenId={selectedTokenId}
+              />
+            ))}
+          </OpList>
+          {canLoadMore && (
+            <Button
+              type="button"
+              onClick={handleLoadMore}
+              disabled={loadingMore}
+              style={{ marginTop: 8 }}
+            >
+              {loadingMore ? "Loading…" : `Load more (${OPERATIONS_PAGE_SIZE})`}
+            </Button>
+          )}
+        </>
+      )}
+    </Section>
+  );
+}

--- a/apps/web-tools/src/v4-account-model-playground/components/TransactionalSection.tsx
+++ b/apps/web-tools/src/v4-account-model-playground/components/TransactionalSection.tsx
@@ -1,0 +1,340 @@
+/**
+ * Transactional UI brick: Prepare → Sign (device) → Broadcast → pending op.
+ * Prepare validates; Sign calls device; Broadcast adds pending op (prepended in Operations).
+ */
+import React, { useCallback, useRef, useState } from "react";
+import styled from "styled-components";
+import BigNumber from "bignumber.js";
+import { useDispatch } from "react-redux";
+import { firstValueFrom } from "rxjs";
+import { filter } from "rxjs/operators";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import type { Account, SignedOperation } from "@ledgerhq/types-live";
+import { store } from "../store";
+import type { RootState } from "../store";
+import { selectAccountReconstructionInput } from "../store/selectors";
+import { reconstructAccountFromReconstructionInput } from "../shared/compatibility";
+import { getAlpacaTransactionAdapter } from "../shared/alpacaTransactionAdapter";
+import { isAlpacaForAccountId } from "../shared/syncStrategy";
+import { addPendingOperationForAccount } from "../data-layer/transactional/slice";
+import { operationToStored } from "../data-layer/operationHistory/actions";
+
+const Section = styled.section`
+  margin: 24px 0;
+  padding: 16px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fafafa;
+`;
+
+const SectionTitle = styled.h3`
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+`;
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+`;
+
+const Label = styled.label`
+  font-size: 13px;
+  font-weight: 500;
+`;
+
+const Input = styled.input`
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+`;
+
+const Button = styled.button`
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 4px;
+  border: 1px solid #333;
+  background: #333;
+  color: #fff;
+  cursor: pointer;
+  margin-right: 8px;
+  margin-top: 4px;
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;
+
+const ButtonSuccess = styled(Button)`
+  background: #0a0;
+  border-color: #0a0;
+`;
+
+const Error = styled.span`
+  color: #c00;
+  font-size: 13px;
+  display: block;
+  margin-top: 8px;
+`;
+
+const Success = styled.span`
+  color: #0a0;
+  font-size: 13px;
+  display: block;
+  margin-top: 8px;
+`;
+
+const JsonBlock = styled.pre`
+  margin: 12px 0 0;
+  padding: 12px;
+  font-size: 11px;
+  background: #1e1e1e;
+  color: #d4d4d4;
+  border-radius: 4px;
+  overflow: auto;
+  max-height: 280px;
+  white-space: pre-wrap;
+  word-break: break-all;
+`;
+
+const JsonLabel = styled.div`
+  font-size: 12px;
+  font-weight: 600;
+  margin-top: 16px;
+  margin-bottom: 4px;
+`;
+
+function toDisplayJson(obj: unknown): string {
+  return JSON.stringify(
+    obj,
+    (_, v) => {
+      if (v instanceof BigNumber) return v.toString();
+      if (v != null && typeof v === "object" && typeof (v as { toString?: () => string }).toString === "function")
+        if ("isBigNumber" in v || "toFixed" in v) return (v as { toString: () => string }).toString();
+      return v;
+    },
+    2,
+  );
+}
+
+async function getAccount(accountId: string): Promise<Account | undefined> {
+  const state = store.getState() as RootState;
+  const input = selectAccountReconstructionInput(state, accountId);
+  if (!input) return undefined;
+  return reconstructAccountFromReconstructionInput(input);
+}
+
+type Step = "idle" | "prepared" | "signed";
+
+export default function TransactionalSection({
+  selectedAccountId,
+}: {
+  accountsBeingUsed: string[];
+  selectedAccountId: string | null;
+}) {
+  const dispatch = useDispatch();
+  const [recipient, setRecipient] = useState("");
+  const [amount, setAmount] = useState("");
+  const [step, setStep] = useState<Step>("idle");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [preparedTransactionJson, setPreparedTransactionJson] = useState<string | null>(null);
+  const [statusJson, setStatusJson] = useState<string | null>(null);
+  const [signedOperationJson, setSignedOperationJson] = useState<string | null>(null);
+
+  const preparedAccountRef = useRef<Account | null>(null);
+  const preparedTransactionRef = useRef<unknown>(null);
+  const signedOperationRef = useRef<SignedOperation | null>(null);
+
+  const resetToIdle = useCallback(() => {
+    setStep("idle");
+    setPreparedTransactionJson(null);
+    setStatusJson(null);
+    setSignedOperationJson(null);
+    setSuccessMsg(null);
+    preparedAccountRef.current = null;
+    preparedTransactionRef.current = null;
+    signedOperationRef.current = null;
+  }, []);
+
+  const handlePrepare = useCallback(async () => {
+    if (!selectedAccountId || !recipient.trim() || !amount.trim()) return;
+    setError(null);
+    setSuccessMsg(null);
+    setPreparedTransactionJson(null);
+    setStatusJson(null);
+    setSignedOperationJson(null);
+    setLoading(true);
+    try {
+      const account = await getAccount(selectedAccountId);
+      if (!account) {
+        setError("Account not in store. Load it first.");
+        return;
+      }
+      if (!isAlpacaForAccountId(selectedAccountId)) {
+        setError("Send is only wired for Alpaca accounts (EVM, XRP, Stellar, Tezos).");
+        return;
+      }
+      const bridge = getAccountBridge(account);
+      const transaction = bridge.createTransaction(account);
+      const updatedTransaction = bridge.updateTransaction(transaction, {
+        recipient: recipient.trim(),
+        amount: new BigNumber(amount.trim()),
+      });
+      const adapter = getAlpacaTransactionAdapter(getAccount);
+      const preparedTransaction = await adapter.prepareTransaction(account, updatedTransaction);
+      const status = await adapter.getTransactionStatus(account, preparedTransaction);
+      setPreparedTransactionJson(toDisplayJson(preparedTransaction));
+      setStatusJson(toDisplayJson(status));
+      const statusErrors =
+        status && typeof status === "object" && "errors" in status && (status as { errors?: Record<string, unknown> }).errors;
+      const firstError =
+        statusErrors && Object.keys(statusErrors).length > 0 ? Object.values(statusErrors)[0] : null;
+      if (firstError != null) {
+        const message =
+          typeof firstError === "object" &&
+          firstError !== null &&
+          "message" in firstError &&
+          typeof (firstError as Error).message === "string"
+            ? (firstError as Error).message
+            : String(firstError);
+        setError(message);
+      } else {
+        preparedAccountRef.current = account;
+        preparedTransactionRef.current = preparedTransaction;
+        setStep("prepared");
+        setSuccessMsg("Transaction prepared. Sign on your Ledger device.");
+      }
+    } catch (e: unknown) {
+      const message =
+        typeof e === "object" && e !== null && "message" in e && typeof (e as Error).message === "string"
+          ? (e as Error).message
+          : String(e);
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedAccountId, recipient, amount]);
+
+  const handleSign = useCallback(async () => {
+    const account = preparedAccountRef.current;
+    const transaction = preparedTransactionRef.current;
+    if (!account || !transaction || !selectedAccountId) return;
+    setError(null);
+    setLoading(true);
+    try {
+      const bridge = getAccountBridge(account);
+      const obs = bridge.signOperation({
+        account,
+        transaction,
+        deviceId: "webhid",
+      });
+      const signedEvent = await firstValueFrom(
+        obs.pipe(filter((e: { type: string }): e is { type: "signed"; signedOperation: SignedOperation } => e.type === "signed")),
+      );
+      const signedOp = signedEvent.signedOperation;
+      signedOperationRef.current = signedOp;
+      setSignedOperationJson(toDisplayJson(signedOp));
+      setStep("signed");
+      setSuccessMsg("Signed. You can broadcast.");
+      setPreparedTransactionJson(null);
+      setStatusJson(null);
+    } catch (e: unknown) {
+      const message =
+        typeof e === "object" && e !== null && "message" in e && typeof (e as Error).message === "string"
+          ? (e as Error).message
+          : String(e);
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedAccountId]);
+
+  const handleBroadcast = useCallback(async () => {
+    const account = preparedAccountRef.current;
+    const signedOp = signedOperationRef.current;
+    if (!account || !signedOp || !selectedAccountId) return;
+    setError(null);
+    setLoading(true);
+    try {
+      const adapter = getAlpacaTransactionAdapter(getAccount);
+      const operationWithHash = await adapter.broadcast({
+        account,
+        signedOperation: signedOp,
+      });
+      const stored = operationToStored(operationWithHash);
+      dispatch(addPendingOperationForAccount({ accountId: selectedAccountId, operation: stored }));
+      setSuccessMsg("Broadcast done. Pending op added (prepended in Operations).");
+      resetToIdle();
+    } catch (e: unknown) {
+      const message =
+        typeof e === "object" && e !== null && "message" in e && typeof (e as Error).message === "string"
+          ? (e as Error).message
+          : String(e);
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedAccountId, dispatch, resetToIdle]);
+
+  const isPrepared = step === "prepared";
+  const isSigned = step === "signed";
+
+  return (
+    <Section>
+      <SectionTitle>Send (transactional)</SectionTitle>
+      <p style={{ fontSize: 12, color: "#666", margin: "0 0 12px" }}>
+        Prepare → Sign on device → Broadcast. Pending op appears at top of Operations.
+      </p>
+      <Row>
+        <Label>Recipient</Label>
+        <Input
+          type="text"
+          placeholder="0x… or address"
+          value={recipient}
+          onChange={e => setRecipient(e.target.value)}
+        />
+      </Row>
+      <Row>
+        <Label>Amount</Label>
+        <Input type="text" placeholder="0" value={amount} onChange={e => setAmount(e.target.value)} />
+      </Row>
+      <Button onClick={handlePrepare} disabled={loading || !selectedAccountId}>
+        {loading && step === "idle" ? "Preparing…" : "Prepare"}
+      </Button>
+      {isPrepared && (
+        <ButtonSuccess onClick={handleSign} disabled={loading}>
+          {loading ? "Signing…" : "Sign"}
+        </ButtonSuccess>
+      )}
+      {isSigned && (
+        <ButtonSuccess onClick={handleBroadcast} disabled={loading}>
+          {loading ? "Broadcasting…" : "Broadcast"}
+        </ButtonSuccess>
+      )}
+      {error != null && <Error>{error}</Error>}
+      {successMsg && <Success>{successMsg}</Success>}
+      {isSigned && signedOperationJson != null && (
+        <>
+          <JsonLabel>Signed operation</JsonLabel>
+          <JsonBlock>{signedOperationJson}</JsonBlock>
+        </>
+      )}
+      {!isSigned && preparedTransactionJson != null && (
+        <>
+          <JsonLabel>Prepared transaction</JsonLabel>
+          <JsonBlock>{preparedTransactionJson}</JsonBlock>
+        </>
+      )}
+      {!isSigned && statusJson != null && (
+        <>
+          <JsonLabel>Status</JsonLabel>
+          <JsonBlock>{statusJson}</JsonBlock>
+        </>
+      )}
+    </Section>
+  );
+}

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/accountCoinResources/schema.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/accountCoinResources/schema.ts
@@ -1,0 +1,20 @@
+/**
+ * AccountCoinResources domain – TEMPORARY PLACEHOLDER.
+ *
+ * This slice is a single generic bucket for all coin-specific Account extras
+ * (bitcoinResources, tezosResources, etc.) so we can reconstruct Account for the bridge.
+ * It is intentionally temporary: the target architecture is one slice per coin family
+ * (e.g. bitcoinResources, cosmosResources), each with its own schema, persistence, and
+ * collocated logic. See README § "Coin-specific resources: placeholder vs coin-by-coin"
+ * (see README).
+ */
+import { z } from "zod";
+
+export const AccountCoinResourcesStateSchema = z.object({
+  byAccountId: z.record(z.record(z.unknown())),
+});
+
+export type AccountCoinResourcesState = z.infer<typeof AccountCoinResourcesStateSchema>;
+
+/** Per-account coin-specific extras (for reconstruction). Placeholder: prefer coin-specific slices when they exist. */
+export type AccountCoinResources = Record<string, unknown>;

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/accountCoinResources/selectors.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/accountCoinResources/selectors.ts
@@ -1,0 +1,6 @@
+import type { RootState } from "../../store";
+
+export const selectAccountCoinResourcesState = (state: RootState) => state.accountCoinResources;
+
+export const selectAccountCoinResourcesByAccountId = (state: RootState, accountId: string) =>
+  state.accountCoinResources.byAccountId[accountId];

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/accountCoinResources/slice.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/accountCoinResources/slice.ts
@@ -1,0 +1,38 @@
+/**
+ * TEMPORARY PLACEHOLDER slice for all coin-specific resources in one store.
+ * See schema.ts and README.
+ */
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+import type { AccountCoinResourcesState, AccountCoinResources } from "./schema";
+import { loadAccountData } from "../../shared/accountDataActions";
+
+const initialState: AccountCoinResourcesState = {
+  byAccountId: {},
+};
+
+export const accountCoinResourcesSlice = createSlice({
+  name: "v4AccountCoinResources",
+  initialState,
+  reducers: {
+    setAccountCoinResources(
+      state,
+      action: PayloadAction<{ accountId: string; resources: AccountCoinResources }>,
+    ) {
+      state.byAccountId[action.payload.accountId] = action.payload.resources;
+    },
+    clearAccountCoinResources(state, action: PayloadAction<string>) {
+      delete state.byAccountId[action.payload];
+    },
+  },
+  extraReducers: builder => {
+    builder.addCase(loadAccountData.fulfilled, (state, action) => {
+      const { accountV4, accountCoinResources } = action.payload;
+      state.byAccountId[accountV4.id] = accountCoinResources;
+    });
+  },
+});
+
+export const { setAccountCoinResources, clearAccountCoinResources } =
+  accountCoinResourcesSlice.actions;
+export const accountCoinResourcesReducer = accountCoinResourcesSlice.reducer;

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/accounts/actions.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/accounts/actions.ts
@@ -1,0 +1,70 @@
+/**
+ * Accounts domain – fetch logic (bridge full sync vs Alpaca).
+ * Returns payload only; thunks in shared dispatch intent; reducers apply load logic.
+ *
+ * **Bridge (legacy)**: fetchAccountDataUpdates = one full sync → payload for ALL slices.
+ * **Alpaca**: minimal payload (account + balance + coin resources only); ops/history empty —
+ * those are loaded per-slice when the user opens Operations or Balance history.
+ */
+import { emptyHistoryCache } from "@ledgerhq/live-common/account/index";
+import type { BalanceHistoryCache } from "@ledgerhq/types-live";
+import { isAlpacaForAccountId } from "../../shared/syncStrategy";
+import { fetchAccountDataViaAlpaca } from "./fetchAccountViaAlpaca";
+import { syncAccountViaBridge, splitAccountIntoSliceUpdates } from "../../shared/compatibility";
+import type { AccountV4 } from "./schema";
+import type { AccountCoinResources } from "../accountCoinResources/schema";
+import { operationToStored } from "../operationHistory/actions";
+import type { StoredOperation } from "../operationHistory/schema";
+
+/** Payload returned by fetchAccountDataUpdates; reducers apply this into each slice. */
+export interface AccountDataLoadPayload {
+  accountV4: AccountV4;
+  operations: StoredOperation[];
+  pendingOperations: StoredOperation[];
+  balanceHistory: BalanceHistoryCache;
+  accountCoinResources: AccountCoinResources;
+  tokenAccountIds: string[];
+  tokenAccountOperations: {
+    accountId: string;
+    operations: StoredOperation[];
+    pendingOperations: StoredOperation[];
+  }[];
+}
+
+/**
+ * Fetch account data. Returns payload only; no dispatch.
+ * - **Bridge**: full sync → payload fills all slices (account, ops, balanceHistory, coin resources).
+ * - **Alpaca**: minimal payload (account + balance + coin resources only); ops/history empty —
+ *   those are loaded per-slice when the user opens Operations or Balance history.
+ */
+export async function fetchAccountDataUpdates(accountId: string): Promise<AccountDataLoadPayload> {
+  const isAlpaca = isAlpacaForAccountId(accountId);
+  if (isAlpaca) {
+    const updates = await fetchAccountDataViaAlpaca(accountId);
+    return {
+      accountV4: updates.accountV4,
+      operations: [],
+      pendingOperations: [],
+      balanceHistory: emptyHistoryCache,
+      accountCoinResources: updates.accountCoinResources,
+      tokenAccountIds: [],
+      tokenAccountOperations: [],
+    };
+  }
+  const account = await syncAccountViaBridge(accountId);
+  const updates = splitAccountIntoSliceUpdates(account);
+  const tokenAccountOperations = (account.subAccounts ?? []).map(ta => ({
+    accountId: ta.id,
+    operations: (ta.operations ?? []).map(operationToStored),
+    pendingOperations: (ta.pendingOperations ?? []).map(operationToStored),
+  }));
+  return {
+    accountV4: updates.accountV4,
+    operations: updates.operations.map(operationToStored),
+    pendingOperations: updates.pendingOperations.map(operationToStored),
+    balanceHistory: updates.balanceHistory,
+    accountCoinResources: updates.accountCoinResources,
+    tokenAccountIds: updates.tokenAccountIds,
+    tokenAccountOperations,
+  };
+}

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/accounts/fetchAccountViaAlpaca.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/accounts/fetchAccountViaAlpaca.ts
@@ -1,0 +1,105 @@
+/**
+ * Accounts domain – fetch via Alpaca API only (no bridge.sync).
+ * Used when isAlpacaForAccountId(accountId) is true (evm, xrp, stellar, tezos).
+ * Fetches balance + lastBlock + token balances; no listOperations (see operationHistory/actions).
+ */
+import { decodeAccountId } from "@ledgerhq/live-common/account/index";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { encodeAccountId, getSyncHash } from "@ledgerhq/coin-framework/account/index";
+// @ts-expect-error subpath may not resolve in web-tools tsconfig
+import { getAlpacaApi } from "@ledgerhq/live-common/bridge/generic-alpaca/alpaca";
+import { extractBalance } from "@ledgerhq/live-common/bridge/generic-alpaca/utils";
+import { buildSubAccounts } from "@ledgerhq/live-common/bridge/generic-alpaca/buildSubAccounts";
+import type { AccountV4, TokenAccountV4 } from "./schema";
+import type { AccountCoinResources } from "../accountCoinResources/schema";
+import { inferAccount } from "../../shared/compatibility";
+
+export interface AlpacaAccountDataResult {
+  accountV4: AccountV4;
+  accountCoinResources: AccountCoinResources;
+}
+
+/**
+ * Fetch account data only (balance + lastBlock + token balances). No listOperations.
+ * Returns payload; no dispatch. Used by accounts/actions fetchAccountDataUpdates.
+ */
+export async function fetchAccountDataViaAlpaca(
+  accountId: string,
+): Promise<AlpacaAccountDataResult> {
+  const { currencyId, xpubOrAddress: address, derivationMode } = decodeAccountId(accountId);
+  const currency = getCryptoCurrencyById(currencyId);
+  const alpacaApi = getAlpacaApi(currency.id, "local");
+
+  const id = encodeAccountId({
+    type: "js",
+    version: "2",
+    currencyId: currency.id,
+    xpubOrAddress: address,
+    derivationMode,
+  });
+
+  const [blockInfo, balanceRes] = await Promise.all([
+    alpacaApi.lastBlock(),
+    alpacaApi.getBalance(address),
+  ]);
+
+  const nativeAsset = extractBalance(balanceRes, "native");
+  const allTokenAssetsBalances = balanceRes.filter(
+    (b: { asset: { type: string } }) => b.asset.type !== "native",
+  );
+  const nativeBalance = BigInt(nativeAsset?.value ?? "0");
+  const spendableBalance = BigInt(nativeBalance - BigInt(nativeAsset?.locked ?? "0"));
+
+  const syncConfig = { blacklistedTokenIds: [] as string[], paginationConfig: {} };
+  const subAccounts = await buildSubAccounts({
+    accountId: id,
+    allTokenAssetsBalances,
+    syncConfig,
+    operations: [],
+    getTokenFromAsset: alpacaApi.getTokenFromAsset,
+  });
+
+  const initialAccount = inferAccount(accountId);
+  const syncHash = await getSyncHash(currency.id, syncConfig.blacklistedTokenIds);
+  const accountV4: AccountV4 = {
+    type: "Account",
+    id,
+    derivationMode: initialAccount.derivationMode,
+    index: initialAccount.index,
+    freshAddress: address,
+    freshAddressPath: initialAccount.freshAddressPath,
+    currencyId: currency.id,
+    balance: nativeBalance.toString(),
+    blockHeight: blockInfo?.height ?? 0,
+    spendableBalance: spendableBalance.toString(),
+    feesCurrencyId: initialAccount.feesCurrency?.id,
+    subAccounts: subAccounts.map(
+      (ta): TokenAccountV4 => ({
+        type: "TokenAccount",
+        id: ta.id,
+        parentId: ta.parentId,
+        tokenId: ta.token.id,
+        balance: ta.balance.toString(),
+        spendableBalance: ta.spendableBalance.toString(),
+        creationDate:
+          ta.creationDate instanceof Date ? ta.creationDate.getTime() : Number(ta.creationDate),
+        operationsCount: ta.operationsCount,
+      }),
+    ),
+    used: true,
+    creationDate:
+      initialAccount.creationDate instanceof Date
+        ? initialAccount.creationDate.getTime()
+        : Date.now(),
+    operationsCount: 0,
+    seedIdentifier: address,
+    xpub: address,
+    lastSyncDate: Date.now(),
+    syncHash,
+  };
+
+  return {
+    accountV4,
+    accountCoinResources: {},
+  };
+}

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/accounts/schema.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/accounts/schema.ts
@@ -1,0 +1,57 @@
+/**
+ * Accounts domain – Zod schemas and inferred types.
+ * Collocated with slice/load/selectors.
+ */
+import { z } from "zod";
+
+const TokenAccountV4Schema = z.object({
+  type: z.literal("TokenAccount"),
+  id: z.string(),
+  parentId: z.string(),
+  tokenId: z.string(), // resolve via lookup (e.g. getCryptoAssetsStore().findTokenById) for TokenCurrency
+  balance: z.string(), // serializable; parse to BigNumber when needed
+  spendableBalance: z.string(), // serializable; parse to BigNumber when needed
+  // derived data that we may drop => deprecated
+  creationDate: z.number(), // timestamp ms; restore with new Date() when needed
+  operationsCount: z.number(),
+});
+
+const AccountV4Schema = z.object({
+  type: z.literal("Account"),
+  id: z.string(),
+  currencyId: z.string(), // resolve via getCryptoCurrencyById for CryptoCurrency
+  balance: z.string(), // serializable; parse to BigNumber when needed
+  subAccounts: z.array(TokenAccountV4Schema).optional(),
+
+  // key chain / HDD / device derivation / discovery of account / device signer
+  derivationMode: z.string(),
+  index: z.number(),
+  freshAddress: z.string(), // "address"
+  freshAddressPath: z.string(), // 49'/0'/{index}'/23/0
+
+  // coin specifics / related to transactional flows
+  spendableBalance: z.string(), // serializable; parse to BigNumber when needed
+  feesCurrencyId: z.string().optional(), // CryptoCurrency.id or TokenCurrency.id; resolve by lookup
+  // derived data that we may drop => deprecated
+  used: z.boolean(), // useful for scan accounts only. not used by UI. can be made into an API?
+  creationDate: z.number(), // timestamp ms; restore with new Date() when needed
+  operationsCount: z.number(), // UI don't need?
+  // non UI data
+  seedIdentifier: z.string(), // UI don't need. but wallet sync use.
+  xpub: z.string().optional(), // UI don't need except in settings account. used by coin implem.
+  // slice transaction / block
+  blockHeight: z.number(), // blockchain specific but used to determine on UI if op is "confirmed"
+  // => Slice Account Sync ? these sync related fields should be moved outside
+  lastSyncDate: z.number(), // timestamp ms; restore with new Date() when needed
+  syncHash: z.string().optional(), // UI don't need?
+});
+
+/** Accounts slice state: byId = id → Account, allIds = ordered list of account ids. */
+export const AccountsStateSchema = z.object({
+  byId: z.record(AccountV4Schema), // id -> Account
+  allIds: z.array(z.string()), // ordered list of account ids
+});
+
+export type TokenAccountV4 = z.infer<typeof TokenAccountV4Schema>;
+export type AccountV4 = z.infer<typeof AccountV4Schema>;
+export type AccountsState = z.infer<typeof AccountsStateSchema>;

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/accounts/selectors.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/accounts/selectors.ts
@@ -1,0 +1,11 @@
+import type { RootState } from "../../store";
+import type { AccountV4 } from "./schema";
+
+export const selectAccountsState = (state: RootState) => state.accounts;
+
+export const selectAccountsById = (state: RootState) => state.accounts.byId;
+
+export const selectAccountIds = (state: RootState) => state.accounts.allIds;
+
+export const selectAccountById = (state: RootState, accountId: string): AccountV4 | undefined =>
+  state.accounts.byId[accountId];

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/accounts/slice.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/accounts/slice.ts
@@ -1,0 +1,50 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+import type { AccountV4, AccountsState } from "./schema";
+import { loadAccountData } from "../../shared/accountDataActions";
+
+const initialState: AccountsState = {
+  byId: {},
+  allIds: [],
+};
+
+export const accountsSlice = createSlice({
+  name: "v4Accounts",
+  initialState,
+  reducers: {
+    setAccounts(state, action: PayloadAction<AccountV4[]>) {
+      const byId: Record<string, AccountV4> = {};
+      const allIds: string[] = [];
+      action.payload.forEach(account => {
+        byId[account.id] = account;
+        allIds.push(account.id);
+      });
+      state.byId = byId;
+      state.allIds = allIds;
+    },
+    upsertAccount(state, action: PayloadAction<AccountV4>) {
+      const account = action.payload;
+      state.byId[account.id] = account;
+      if (!state.allIds.includes(account.id)) {
+        state.allIds.push(account.id);
+      }
+    },
+    removeAccount(state, action: PayloadAction<string>) {
+      const accountId = action.payload;
+      delete state.byId[accountId];
+      state.allIds = state.allIds.filter(id => id !== accountId);
+    },
+  },
+  extraReducers: builder => {
+    builder.addCase(loadAccountData.fulfilled, (state, action) => {
+      const { accountV4 } = action.payload;
+      state.byId[accountV4.id] = accountV4;
+      if (!state.allIds.includes(accountV4.id)) {
+        state.allIds.push(accountV4.id);
+      }
+    });
+  },
+});
+
+export const { setAccounts, upsertAccount, removeAccount } = accountsSlice.actions;
+export const accountsReducer = accountsSlice.reducer;

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/balanceHistory/actions.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/balanceHistory/actions.ts
@@ -1,0 +1,111 @@
+/**
+ * BalanceHistory domain – thunk orchestrates load (account + ops if needed); slice reducers apply.
+ */
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import BigNumber from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import type { AppDispatch, RootState } from "../../store";
+import { isAlpacaForAccountId } from "../../shared/syncStrategy";
+import {
+  syncAccountViaBridge,
+  splitAccountIntoSliceUpdates,
+  deriveBalanceHistoryFromOperations,
+} from "../../shared/compatibility";
+import { setBalanceHistoryForAccount } from "./slice";
+import { loadOperationHistory } from "../operationHistory/actions";
+import { loadAccountData } from "../../shared/accountDataActions";
+
+function getParentAccountId(state: RootState, accountId: string): string | null {
+  if (state.accounts.byId[accountId]) return null;
+  for (const main of Object.values(state.accounts.byId)) {
+    if (main.subAccounts?.some(s => s.id === accountId)) return main.id;
+  }
+  return null;
+}
+
+function getBalanceForAccountId(state: RootState, accountId: string): BigNumber | null {
+  const acc = state.accounts.byId[accountId];
+  if (acc) return new BigNumber(acc.balance);
+  for (const main of Object.values(state.accounts.byId)) {
+    const sub = main.subAccounts?.find(s => s.id === accountId);
+    if (sub) return new BigNumber(sub.balance);
+  }
+  return null;
+}
+
+function hasOpsInContext(state: RootState, accountId: string): boolean {
+  return accountId in state.operationHistory.byAccountId;
+}
+
+export const loadBalanceHistory = createAsyncThunk(
+  "balanceHistory/load",
+  async (accountId: string, { getState, dispatch }) => {
+    const state = getState() as RootState;
+    const parentId = getParentAccountId(state, accountId);
+    const mainId = parentId ?? accountId;
+    const isAlpaca = isAlpacaForAccountId(mainId);
+
+    const balance = getBalanceForAccountId(state, accountId);
+    const hasOps = hasOpsInContext(state, accountId);
+
+    if (balance != null && hasOps) {
+      await applyDeriveAndDispatch(accountId, getState as () => RootState, dispatch);
+      return;
+    }
+
+    if (parentId != null) {
+      if (balance == null) await dispatch(loadAccountData(parentId)).unwrap();
+      if (!hasOps) await dispatch(loadOperationHistory({ accountId: parentId }));
+      await applyDeriveAndDispatch(accountId, getState as () => RootState, dispatch);
+      return;
+    }
+
+    if (isAlpaca) {
+      if (balance == null) await dispatch(loadAccountData(mainId)).unwrap();
+      if (!hasOps) await dispatch(loadOperationHistory({ accountId: mainId }));
+      await applyDeriveAndDispatch(accountId, getState as () => RootState, dispatch);
+      return;
+    }
+
+    const account = await syncAccountViaBridge(accountId);
+    const updates = splitAccountIntoSliceUpdates(account);
+    dispatch(
+      setBalanceHistoryForAccount({
+        accountId: account.id,
+        history: updates.balanceHistory,
+      }),
+    );
+  },
+);
+
+async function applyDeriveAndDispatch(
+  accountId: string,
+  getState: () => RootState,
+  dispatch: AppDispatch,
+): Promise<void> {
+  const state = getState();
+  const balance = getBalanceForAccountId(state, accountId);
+  const entry = state.operationHistory.byAccountId[accountId];
+  const pending = state.transactional.pendingOperationsByAccountId[accountId] ?? [];
+  if (balance == null || !entry) return;
+  const storedOps = [...pending, ...entry.operations];
+  const ops = storedOps.map(op => ({
+    ...op,
+    value: new BigNumber(op.value),
+    fee: new BigNumber(op.fee),
+    date: new Date(op.date),
+    transactionSequenceNumber: op.transactionSequenceNumber
+      ? new BigNumber(op.transactionSequenceNumber)
+      : undefined,
+  })) as Account["operations"];
+  const history = deriveBalanceHistoryFromOperations(balance, ops, accountId);
+  dispatch(setBalanceHistoryForAccount({ accountId, history }));
+}
+
+/** Legacy entry: dispatch thunk (e.g. from UI). */
+export async function loadBalanceHistoryForAccountId(
+  accountId: string,
+  dispatch: AppDispatch,
+): Promise<void> {
+  await dispatch(loadBalanceHistory(accountId)).unwrap();
+}

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/balanceHistory/schema.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/balanceHistory/schema.ts
@@ -1,0 +1,12 @@
+/**
+ * BalanceHistory domain – Zod schemas and inferred types.
+ */
+import { z } from "zod";
+
+const BalanceHistoryCacheSchema = z.any(); // BalanceHistoryCache from types-live
+
+export const BalanceHistoryStateSchema = z.object({
+  byAccountId: z.record(BalanceHistoryCacheSchema),
+});
+
+export type BalanceHistoryState = z.infer<typeof BalanceHistoryStateSchema>;

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/balanceHistory/selectors.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/balanceHistory/selectors.ts
@@ -1,0 +1,6 @@
+import type { RootState } from "../../store";
+
+export const selectBalanceHistoryState = (state: RootState) => state.balanceHistory;
+
+export const selectBalanceHistoryByAccountId = (state: RootState, accountId: string) =>
+  state.balanceHistory.byAccountId[accountId];

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/balanceHistory/slice.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/balanceHistory/slice.ts
@@ -1,0 +1,35 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+import type { BalanceHistoryCache } from "@ledgerhq/types-live";
+import type { BalanceHistoryState } from "./schema";
+import { loadAccountData } from "../../shared/accountDataActions";
+
+const initialState: BalanceHistoryState = {
+  byAccountId: {},
+};
+
+export const balanceHistorySlice = createSlice({
+  name: "v4BalanceHistory",
+  initialState,
+  reducers: {
+    setBalanceHistoryForAccount(
+      state,
+      action: PayloadAction<{ accountId: string; history: BalanceHistoryCache }>,
+    ) {
+      state.byAccountId[action.payload.accountId] = action.payload.history;
+    },
+    clearBalanceHistoryForAccount(state, action: PayloadAction<string>) {
+      delete state.byAccountId[action.payload];
+    },
+  },
+  extraReducers: builder => {
+    builder.addCase(loadAccountData.fulfilled, (state, action) => {
+      const { accountV4, balanceHistory } = action.payload;
+      state.byAccountId[accountV4.id] = balanceHistory;
+    });
+  },
+});
+
+export const { setBalanceHistoryForAccount, clearBalanceHistoryForAccount } =
+  balanceHistorySlice.actions;
+export const balanceHistoryReducer = balanceHistorySlice.reducer;

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/operationHistory/actions.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/operationHistory/actions.ts
@@ -1,0 +1,305 @@
+/**
+ * OperationHistory domain – fetch logic + thunk. Thunk triggers fetch; slice reducers apply payload.
+ * Bridge vs Alpaca (listOperations, flattened ops). Supports pagination via options.pagingToken.
+ */
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import {
+  decodeAccountId,
+  decodeTokenAccountIdSync,
+  encodeAccountId,
+  encodeTokenAccountId,
+} from "@ledgerhq/coin-framework/account";
+import type { Operation as CoreOperation } from "@ledgerhq/coin-framework/api/types";
+// @ts-expect-error subpath may not resolve in web-tools tsconfig
+import { getAlpacaApi } from "@ledgerhq/live-common/bridge/generic-alpaca/alpaca";
+import { adaptCoreOperationToLiveOperation } from "@ledgerhq/live-common/bridge/generic-alpaca/utils";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import type { Account, Operation } from "@ledgerhq/types-live";
+import type { AppDispatch } from "../../store";
+import { isAlpacaForAccountId } from "../../shared/syncStrategy";
+import { syncAccountViaBridge, splitAccountIntoSliceUpdates } from "../../shared/compatibility";
+import type { LoadOperationsOptions, LoadOperationsResult, StoredOperation } from "./schema";
+
+/** Payload for slice: replace (full set) or append (page). Reducers apply this. */
+export type OperationHistoryUpdatesPayload =
+  | {
+      mode: "replace";
+      mainAccountId: string;
+      operations: StoredOperation[];
+      pendingOperations: StoredOperation[];
+      nextPagingToken?: string;
+      tokenAccountUpdates: {
+        accountId: string;
+        operations: StoredOperation[];
+        pendingOperations: StoredOperation[];
+      }[];
+    }
+  | {
+      mode: "append";
+      accountId: string;
+      operations: StoredOperation[];
+      nextPagingToken?: string;
+    };
+
+export interface FetchOperationHistoryResult {
+  updates: OperationHistoryUpdatesPayload;
+  result: LoadOperationsResult;
+}
+
+/** Serialize Operation (value/fee BigNumber, date Date) to StoredOperation (value/fee string, date timestamp). */
+export function operationToStored(op: Operation): StoredOperation {
+  const date =
+    op.date instanceof Date ? op.date.getTime() : typeof op.date === "number" ? op.date : 0;
+  return {
+    ...op,
+    value: op.value.toString(),
+    fee: op.fee.toString(),
+    transactionSequenceNumber: op.transactionSequenceNumber?.toString(),
+    date,
+  } as StoredOperation;
+}
+
+function isNftCoreOp(operation: CoreOperation): boolean {
+  return (
+    typeof operation.details?.ledgerOpType === "string" &&
+    ["NFT_IN", "NFT_OUT"].includes(operation.details?.ledgerOpType)
+  );
+}
+
+function isIncomingCoreOp(operation: CoreOperation): boolean {
+  const type =
+    typeof operation.details?.ledgerOpType === "string"
+      ? operation.details.ledgerOpType
+      : operation.type;
+  return type === "IN";
+}
+
+function isInternalLiveOp(operation: Operation): boolean {
+  return !!(operation.extra as Record<string, unknown>)?.internal;
+}
+
+export interface AlpacaOperationsResult {
+  accountId: string;
+  operations: Account["operations"];
+  pendingOperations: Account["pendingOperations"];
+  nextPagingToken?: string;
+  hasMore: boolean;
+  tokenAccountOperations: {
+    accountId: string;
+    operations: Operation[];
+    pendingOperations: Operation[];
+  }[];
+}
+
+/** Fetch operations via Alpaca API only (no bridge). Returns payload; no dispatch. */
+async function fetchOperationsViaAlpaca(
+  accountId: string,
+  options?: LoadOperationsOptions,
+): Promise<AlpacaOperationsResult> {
+  const { currencyId, xpubOrAddress: address, derivationMode } = decodeAccountId(accountId);
+  const currency = getCryptoCurrencyById(currencyId);
+  const alpacaApi = getAlpacaApi(currency.id, "local");
+
+  const id = encodeAccountId({
+    type: "js",
+    version: "2",
+    currencyId: currency.id,
+    xpubOrAddress: address,
+    derivationMode,
+  });
+
+  const pagination: { minHeight: number; order: "desc"; limit?: number; lastPagingToken?: string } =
+    {
+      minHeight: 0,
+      order: "desc",
+    };
+  if (options?.limit != null) pagination.limit = options.limit;
+  if (options?.pagingToken) pagination.lastPagingToken = options.pagingToken;
+
+  const [balanceRes, [newCoreOps, nextPagingToken]] = await Promise.all([
+    alpacaApi.getBalance(address),
+    alpacaApi.listOperations(address, pagination),
+  ]);
+  const hasMore = Boolean(nextPagingToken && nextPagingToken !== "");
+
+  const allTokenAssetsBalances = balanceRes.filter(
+    (b: { asset: { type: string } }) => b.asset.type !== "native",
+  );
+
+  const newOps: Operation[] = newCoreOps
+    .filter((op: CoreOperation) => !isNftCoreOp(op) && (!isIncomingCoreOp(op) || !op.tx.failed))
+    .map((op: CoreOperation) => adaptCoreOperationToLiveOperation(id, op))
+    .filter((op: Operation) => !isInternalLiveOp(op));
+
+  const flattenedOperations = [...newOps].sort((a, b) => {
+    const ta = a.date instanceof Date ? a.date.getTime() : new Date(a.date).getTime();
+    const tb = b.date instanceof Date ? b.date.getTime() : new Date(b.date).getTime();
+    return tb - ta;
+  });
+
+  /** Map (assetReference, assetOwner) -> tokenId so we can tag ops with tokenId for correct unit in UI. */
+  const assetRefToTokenId = new Map<string, string>();
+  const tokenAccountOperations: AlpacaOperationsResult["tokenAccountOperations"] = [];
+  for (const balance of allTokenAssetsBalances) {
+    const asset = balance.asset as { assetReference?: string; assetOwner?: string } | undefined;
+    const token = await alpacaApi.getTokenFromAsset?.(balance.asset);
+    if (!token) continue;
+    const tokenAccountId = encodeTokenAccountId(id, token);
+    const assetKey = `${asset?.assetReference ?? ""}\0${asset?.assetOwner ?? ""}`;
+    assetRefToTokenId.set(assetKey, token.id);
+    const ops = newOps.filter(
+      op =>
+        (op.extra as Record<string, unknown>)?.assetReference === asset?.assetReference &&
+        (op.extra as Record<string, unknown>)?.assetOwner === asset?.assetOwner,
+    );
+    if (ops.length === 0) continue;
+    tokenAccountOperations.push({
+      accountId: tokenAccountId,
+      operations: ops.map(op => ({
+        ...op,
+        accountId: tokenAccountId,
+        id: `${tokenAccountId}-${op.hash}-${op.type}`,
+        tokenId: token.id,
+      })),
+      pendingOperations: [],
+    });
+  }
+
+  /** Tag each op with tokenId when it's a token op so UI can use the token's unit for formatting. */
+  const flattenedWithTokenId = flattenedOperations.map(op => {
+    const extra = op.extra as Record<string, unknown>;
+    const assetRef = extra?.assetReference;
+    const assetOwner = extra?.assetOwner;
+    const assetKey =
+      typeof assetRef === "string" || typeof assetOwner === "string"
+        ? `${String(assetRef ?? "")}\0${String(assetOwner ?? "")}`
+        : null;
+    const tokenId = assetKey != null ? assetRefToTokenId.get(assetKey) : undefined;
+    if (!tokenId) return op;
+    return { ...op, extra: { ...extra, tokenId } };
+  });
+
+  return {
+    accountId: id,
+    operations: flattenedWithTokenId,
+    pendingOperations: [],
+    nextPagingToken: hasMore ? nextPagingToken : undefined,
+    hasMore,
+    tokenAccountOperations,
+  };
+}
+
+function toMainAccountId(accountId: string): string {
+  if (accountId.includes("+")) {
+    return decodeTokenAccountIdSync(accountId).accountId;
+  }
+  return accountId;
+}
+
+const DEFAULT_PAGE_SIZE = 20;
+
+/**
+ * Fetch operation history. Returns payload for reducers + result (hasMore, nextPagingToken).
+ * No dispatch – thunk calls this and slice applies via extraReducers.
+ */
+export async function fetchOperationHistoryUpdates(
+  accountId: string,
+  options?: LoadOperationsOptions,
+): Promise<FetchOperationHistoryResult> {
+  const mainAccountId = toMainAccountId(accountId);
+  const isAlpaca = isAlpacaForAccountId(mainAccountId);
+
+  if (isAlpaca) {
+    return fetchOperationHistoryViaAlpaca(mainAccountId, options);
+  }
+  return fetchOperationHistoryViaBridge(mainAccountId);
+}
+
+async function fetchOperationHistoryViaAlpaca(
+  accountId: string,
+  options?: LoadOperationsOptions,
+): Promise<FetchOperationHistoryResult> {
+  const raw = await fetchOperationsViaAlpaca(accountId, {
+    limit: options?.limit ?? (options?.pagingToken ? DEFAULT_PAGE_SIZE : undefined),
+    pagingToken: options?.pagingToken,
+  });
+
+  const isAppend = Boolean(options?.pagingToken);
+  if (isAppend) {
+    return {
+      updates: {
+        mode: "append",
+        accountId: raw.accountId,
+        operations: raw.operations.map(operationToStored),
+        nextPagingToken: raw.nextPagingToken,
+      },
+      result: { nextPagingToken: raw.nextPagingToken, hasMore: raw.hasMore },
+    };
+  }
+  return {
+    updates: {
+      mode: "replace",
+      mainAccountId: raw.accountId,
+      operations: raw.operations.map(operationToStored),
+      pendingOperations: raw.pendingOperations.map(operationToStored),
+      nextPagingToken: raw.nextPagingToken,
+      tokenAccountUpdates: raw.tokenAccountOperations.map(ta => ({
+        accountId: ta.accountId,
+        operations: ta.operations.map(operationToStored),
+        pendingOperations: ta.pendingOperations.map(operationToStored),
+      })),
+    },
+    result: { nextPagingToken: raw.nextPagingToken, hasMore: raw.hasMore },
+  };
+}
+
+async function fetchOperationHistoryViaBridge(
+  accountId: string,
+): Promise<FetchOperationHistoryResult> {
+  const account = await syncAccountViaBridge(accountId);
+  const updates = splitAccountIntoSliceUpdates(account);
+
+  const tokenAccountUpdates = (account.subAccounts ?? [])
+    .filter(ta => updates.tokenAccountIds.includes(ta.id))
+    .map(ta => {
+      const tokenId = ta.token.id;
+      const toStored = (op: Account["operations"][0]) => operationToStored({ ...op, tokenId });
+      return {
+        accountId: ta.id,
+        operations: (ta.operations || []).map(toStored),
+        pendingOperations: (ta.pendingOperations || []).map(toStored),
+      };
+    });
+
+  return {
+    updates: {
+      mode: "replace",
+      mainAccountId: account.id,
+      operations: updates.operations.map(operationToStored),
+      pendingOperations: updates.pendingOperations.map(operationToStored),
+      tokenAccountUpdates,
+    },
+    result: { hasMore: false },
+  };
+}
+
+export const loadOperationHistory = createAsyncThunk(
+  "operationHistory/load",
+  (
+    { accountId, options }: { accountId: string; options?: LoadOperationsOptions },
+    { rejectWithValue },
+  ) =>
+    fetchOperationHistoryUpdates(accountId, options).catch(e =>
+      rejectWithValue(e instanceof Error ? e.message : String(e)),
+    ),
+);
+
+/** Legacy entry: dispatch thunk and return result (e.g. for balanceHistory orchestration). */
+export async function loadOperationHistoryForAccountId(
+  accountId: string,
+  dispatch: AppDispatch,
+  options?: LoadOperationsOptions,
+): Promise<LoadOperationsResult> {
+  const out = await dispatch(loadOperationHistory({ accountId, options })).unwrap();
+  return out.result;
+}

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/operationHistory/schema.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/operationHistory/schema.ts
@@ -1,0 +1,108 @@
+/**
+ * OperationHistory domain – Zod schemas and inferred types.
+ * Supports progressive pagination: optional nextPagingToken for "load more" from API.
+ * OperationSchema: value/fee as string (serializable); parse to BigNumber when needed.
+ */
+import { z } from "zod";
+
+/** Matches OperationType from @ledgerhq/types-live. */
+export const OperationTypeSchema = z.enum([
+  "IN",
+  "OUT",
+  "NONE",
+  "CREATE",
+  "REVEAL",
+  "UNKNOWN",
+  "DELEGATE",
+  "UNDELEGATE",
+  "REDELEGATE",
+  "REWARD",
+  "FEES",
+  "FREEZE",
+  "UNFREEZE",
+  "WITHDRAW_EXPIRE_UNFREEZE",
+  "UNDELEGATE_RESOURCE",
+  "LEGACY_UNFREEZE",
+  "VOTE",
+  "REWARD_PAYOUT",
+  "BOND",
+  "UNBOND",
+  "WITHDRAW_UNBONDED",
+  "SET_CONTROLLER",
+  "SLASH",
+  "NOMINATE",
+  "CHILL",
+  "APPROVE",
+  "OPT_IN",
+  "OPT_OUT",
+  "LOCK",
+  "UNLOCK",
+  "WITHDRAW",
+  "REVOKE",
+  "ACTIVATE",
+  "REGISTER",
+  "NFT_IN",
+  "NFT_OUT",
+  "STAKE",
+  "UNSTAKE",
+  "WITHDRAW_UNSTAKED",
+  "BURN",
+  "ASSOCIATE_TOKEN",
+  "CONTRACT_CALL",
+  "UPDATE_ACCOUNT",
+  "PRE_APPROVAL",
+  "TRANSFER_PROPOSAL",
+  "TRANSFER_REJECTED",
+  "TRANSFER_WITHDRAWN",
+]);
+
+/** Flat operation: no subOperations/internalOperations/nftOperations (no recursion). value/fee serializable as string. */
+export const OperationSchema = z.object({
+  id: z.string(),
+  hash: z.string(),
+  type: OperationTypeSchema,
+  value: z.string(), // serializable; parse to BigNumber when needed
+  fee: z.string(), // serializable; parse to BigNumber when needed
+  senders: z.array(z.string()),
+  recipients: z.array(z.string()),
+  blockHeight: z.number().nullable().optional(),
+  blockHash: z.string().nullable().optional(),
+  transactionSequenceNumber: z.string().optional(),
+  accountId: z.string(),
+  standard: z.string().optional(),
+  operator: z.string().optional(),
+  contract: z.string().optional(),
+  tokenId: z.string().optional(),
+  date: z.number(), // timestamp ms; restore with new Date() when needed
+  hasFailed: z.boolean().optional(),
+  transactionRaw: z.unknown().optional(),
+  extra: z.unknown(),
+});
+
+export type StoredOperation = z.infer<typeof OperationSchema>;
+
+/** Confirmed operations only; pendingOperations live in transactional slice. */
+export const OperationHistoryEntrySchema = z.object({
+  operations: z.array(OperationSchema),
+  /** When set, the API has more pages; use this token in loadOperationHistory(..., { pagingToken }) to append. */
+  nextPagingToken: z.string().optional(),
+});
+
+export const OperationHistoryStateSchema = z.object({
+  byAccountId: z.record(OperationHistoryEntrySchema),
+});
+
+export type OperationHistoryEntry = z.infer<typeof OperationHistoryEntrySchema>;
+export type OperationHistoryState = z.infer<typeof OperationHistoryStateSchema>;
+
+/** Options for progressive pagination (Alpaca may support; bridge ignores). */
+export interface LoadOperationsOptions {
+  limit?: number;
+  pagingToken?: string;
+}
+
+/** Result of a paginated load: when hasMore is true, next load should use nextPagingToken. */
+export interface LoadOperationsResult {
+  nextPagingToken?: string;
+  hasMore: boolean;
+}

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/operationHistory/selectors.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/operationHistory/selectors.ts
@@ -1,0 +1,6 @@
+import type { RootState } from "../../store";
+
+export const selectOperationHistoryState = (state: RootState) => state.operationHistory;
+
+export const selectOperationHistoryByAccountId = (state: RootState, accountId: string) =>
+  state.operationHistory.byAccountId[accountId];

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/operationHistory/slice.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/operationHistory/slice.ts
@@ -1,0 +1,98 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+import type { OperationHistoryState, StoredOperation } from "./schema";
+import { loadAccountData } from "../../shared/accountDataActions";
+import { loadOperationHistory } from "./actions";
+import type { OperationHistoryUpdatesPayload } from "./actions";
+
+const initialState: OperationHistoryState = {
+  byAccountId: {},
+};
+
+function applyUpdatesPayload(
+  state: OperationHistoryState,
+  updates: OperationHistoryUpdatesPayload,
+): void {
+  if (updates.mode === "replace") {
+    state.byAccountId[updates.mainAccountId] = {
+      operations: updates.operations,
+      nextPagingToken: updates.nextPagingToken,
+    };
+    for (const ta of updates.tokenAccountUpdates) {
+      state.byAccountId[ta.accountId] = {
+        operations: ta.operations,
+      };
+    }
+  } else {
+    const entry = state.byAccountId[updates.accountId];
+    if (!entry) return;
+    const existingIds = new Set(entry.operations.map(o => o.id));
+    const newOps = updates.operations.filter(op => !existingIds.has(op.id));
+    entry.operations = entry.operations.concat(newOps);
+    if (updates.nextPagingToken !== undefined) {
+      entry.nextPagingToken = updates.nextPagingToken;
+    }
+  }
+}
+
+export const operationHistorySlice = createSlice({
+  name: "v4OperationHistory",
+  initialState,
+  reducers: {
+    setOperationHistoryForAccount(
+      state,
+      action: PayloadAction<{
+        accountId: string;
+        operations: StoredOperation[];
+        nextPagingToken?: string;
+      }>,
+    ) {
+      state.byAccountId[action.payload.accountId] = {
+        operations: action.payload.operations,
+        nextPagingToken: action.payload.nextPagingToken,
+      };
+    },
+    /** Append operations (e.g. "load more" page). Dedupes by op.id so we never duplicate if API returns same page. */
+    appendOperationsForAccount(
+      state,
+      action: PayloadAction<{
+        accountId: string;
+        operations: StoredOperation[];
+        nextPagingToken?: string;
+      }>,
+    ) {
+      const entry = state.byAccountId[action.payload.accountId];
+      if (!entry) return;
+      const existingIds = new Set(entry.operations.map(o => o.id));
+      const newOps = action.payload.operations.filter(op => !existingIds.has(op.id));
+      entry.operations = entry.operations.concat(newOps);
+      if (action.payload.nextPagingToken !== undefined) {
+        entry.nextPagingToken = action.payload.nextPagingToken;
+      }
+    },
+    clearOperationHistoryForAccount(state, action: PayloadAction<string>) {
+      delete state.byAccountId[action.payload];
+    },
+  },
+  extraReducers: builder => {
+    builder.addCase(loadAccountData.fulfilled, (state, action) => {
+      const { accountV4, operations, tokenAccountOperations } = action.payload;
+      state.byAccountId[accountV4.id] = { operations };
+      for (const ta of tokenAccountOperations) {
+        state.byAccountId[ta.accountId] = { operations: ta.operations };
+      }
+    });
+    builder.addCase(loadOperationHistory.fulfilled, (state, action) => {
+      if (action.payload?.updates) {
+        applyUpdatesPayload(state, action.payload.updates);
+      }
+    });
+  },
+});
+
+export const {
+  setOperationHistoryForAccount,
+  appendOperationsForAccount,
+  clearOperationHistoryForAccount,
+} = operationHistorySlice.actions;
+export const operationHistoryReducer = operationHistorySlice.reducer;

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/operationHistory/storedToLive.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/operationHistory/storedToLive.ts
@@ -1,0 +1,21 @@
+/**
+ * Deserialize StoredOperation → Operation (for reconstruction / top-level selectors).
+ * Kept separate from actions.ts to avoid circular dependency with shared/compatibility.
+ */
+/* eslint-disable @typescript-eslint/consistent-type-assertions -- StoredOperation has required id/hash/type; spread narrows to optional */
+import { BigNumber } from "bignumber.js";
+import type { Operation } from "@ledgerhq/types-live";
+import type { StoredOperation } from "./schema";
+
+export function storedOperationToLive(stored: StoredOperation): Operation {
+  return {
+    ...stored,
+    value: new BigNumber(stored.value),
+    fee: new BigNumber(stored.fee),
+    date: new Date(stored.date),
+    transactionSequenceNumber:
+      stored.transactionSequenceNumber != null
+        ? new BigNumber(stored.transactionSequenceNumber)
+        : undefined,
+  } as Operation; // spread from StoredOperation narrows id/hash/type to optional
+}

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/transactional/schema.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/transactional/schema.ts
@@ -1,0 +1,17 @@
+/**
+ * Transactional slice – schema and state shape.
+ * Holds pending operations (per account). Error messages are UI state (component-local).
+ */
+import { z } from "zod";
+import { OperationSchema } from "../operationHistory/schema";
+
+/** StoredOperation for pending ops (re-use operationHistory schema). */
+const StoredOperationSchema = OperationSchema;
+
+/** Pending operations only; no UI state (errors live in component state). */
+export const TransactionalStateSchema = z.object({
+  /** Pending (unconfirmed) operations per account id. Source of truth for reconstruction / UI. */
+  pendingOperationsByAccountId: z.record(z.string(), z.array(StoredOperationSchema)),
+});
+
+export type TransactionalState = z.infer<typeof TransactionalStateSchema>;

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/transactional/selectors.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/transactional/selectors.ts
@@ -1,0 +1,6 @@
+import type { RootState } from "../../store";
+
+export const selectTransactionalState = (state: RootState) => state.transactional;
+
+export const selectPendingOperationsByAccountId = (state: RootState, accountId: string) =>
+  state.transactional.pendingOperationsByAccountId[accountId] ?? [];

--- a/apps/web-tools/src/v4-account-model-playground/data-layer/transactional/slice.ts
+++ b/apps/web-tools/src/v4-account-model-playground/data-layer/transactional/slice.ts
@@ -1,0 +1,70 @@
+/**
+ * Transactional slice – pending operations + prepare/validate/broadcast state.
+ * pendingOperationsByAccountId is the source of truth; operationHistory holds only confirmed ops.
+ */
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+import type { StoredOperation } from "../operationHistory/schema";
+import type { TransactionalState } from "./schema";
+import { loadAccountData } from "../../shared/accountDataActions";
+import { loadOperationHistory } from "../operationHistory/actions";
+
+const initialState: TransactionalState = {
+  pendingOperationsByAccountId: {},
+};
+
+export const transactionalSlice = createSlice({
+  name: "v4Transactional",
+  initialState,
+  reducers: {
+    setPendingOperationsForAccount(
+      state,
+      action: PayloadAction<{ accountId: string; pendingOperations: StoredOperation[] }>,
+    ) {
+      const { accountId, pendingOperations } = action.payload;
+      if (pendingOperations.length === 0) {
+        delete state.pendingOperationsByAccountId[accountId];
+      } else {
+        state.pendingOperationsByAccountId[accountId] = pendingOperations;
+      }
+    },
+    addPendingOperationForAccount(
+      state,
+      action: PayloadAction<{ accountId: string; operation: StoredOperation }>,
+    ) {
+      const { accountId, operation } = action.payload;
+      const list = state.pendingOperationsByAccountId[accountId] ?? [];
+      if (list.some(op => op.id === operation.id)) return;
+      state.pendingOperationsByAccountId[accountId] = [...list, operation];
+    },
+  },
+  extraReducers: builder => {
+    builder.addCase(loadAccountData.fulfilled, (state, action) => {
+      const { accountV4, pendingOperations, tokenAccountOperations } = action.payload;
+      if (pendingOperations.length > 0) {
+        state.pendingOperationsByAccountId[accountV4.id] = pendingOperations;
+      }
+      for (const ta of tokenAccountOperations) {
+        if (ta.pendingOperations.length > 0) {
+          state.pendingOperationsByAccountId[ta.accountId] = ta.pendingOperations;
+        }
+      }
+    });
+    builder.addCase(loadOperationHistory.fulfilled, (state, action) => {
+      const updates = action.payload?.updates;
+      if (!updates || updates.mode !== "replace") return;
+      if (updates.pendingOperations.length > 0) {
+        state.pendingOperationsByAccountId[updates.mainAccountId] = updates.pendingOperations;
+      }
+      for (const ta of updates.tokenAccountUpdates) {
+        if (ta.pendingOperations.length > 0) {
+          state.pendingOperationsByAccountId[ta.accountId] = ta.pendingOperations;
+        }
+      }
+    });
+  },
+});
+
+export const { setPendingOperationsForAccount, addPendingOperationForAccount } =
+  transactionalSlice.actions;
+export const transactionalReducer = transactionalSlice.reducer;

--- a/apps/web-tools/src/v4-account-model-playground/index.tsx
+++ b/apps/web-tools/src/v4-account-model-playground/index.tsx
@@ -1,0 +1,12 @@
+import "../live-common-setup";
+import App from "./components/App";
+import { Provider } from "react-redux";
+import { store } from "./store";
+
+export default function V4AccountModelPlayground() {
+  return (
+    <Provider store={store}>
+      <App />
+    </Provider>
+  );
+}

--- a/apps/web-tools/src/v4-account-model-playground/shared/accountDataActions.ts
+++ b/apps/web-tools/src/v4-account-model-playground/shared/accountDataActions.ts
@@ -1,0 +1,28 @@
+/**
+ * Account data load – async thunk in shared (no cross-deps between slices).
+ *
+ * **Legacy (bridge) path only**: This thunk is for the full-sync flow: one bridge.sync()
+ * returns the full Account, we split and push to all slices (accounts, operationHistory,
+ * balanceHistory, accountCoinResources). One load fills everything.
+ *
+ * **Alpaca path**: We do NOT "tout load" here. Each section (account display, operations list,
+ * balance history) should trigger its own slice-optimized fetch (e.g. loadOperations only,
+ * loadBalanceHistory only). For Alpaca, the UI uses per-section loaders; this thunk is only
+ * used when we still need a minimal account+balance payload for the account card (and we
+ * return empty ops/history so we don’t pretend to fill those slices).
+ */
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import type { AppDispatch } from "../store";
+import { fetchAccountDataUpdates } from "../data-layer/accounts/actions";
+
+export const loadAccountData = createAsyncThunk("accountData/load", (accountId: string) =>
+  fetchAccountDataUpdates(accountId),
+);
+
+/** Legacy entry: dispatch loadAccountData thunk (use from UI or balanceHistory load). */
+export async function loadAccountsForAccountId(
+  accountId: string,
+  dispatch: AppDispatch,
+): Promise<void> {
+  await dispatch(loadAccountData(accountId)).unwrap();
+}

--- a/apps/web-tools/src/v4-account-model-playground/shared/alpacaTransactionAdapter.ts
+++ b/apps/web-tools/src/v4-account-model-playground/shared/alpacaTransactionAdapter.ts
@@ -1,0 +1,70 @@
+/**
+ * Beginning of an adaptor to replace the bridge's way of making transactions
+ * (preparing, validating, broadcasting) with Alpaca-style API.
+ *
+ * Infers what Alpaca provides: prepareTransaction, getTransactionStatus, broadcast
+ * (see libs/ledger-live-common/src/bridge/generic-alpaca/). For Alpaca families
+ * (evm, xrp, stellar, tezos) the bridge is already getAlpacaAccountBridge(family, "local");
+ * this module exposes a small facade so the transactional slice (or UI) can call
+ * prepare/validate/broadcast by accountId + getAccount, without depending on
+ * getAccountBridge(account) directly. Later we can swap to direct Alpaca API if needed.
+ */
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { isAlpacaForAccountId } from "./syncStrategy";
+import type { Account, BroadcastConfig } from "@ledgerhq/types-live";
+
+export interface AlpacaTransactionAdapter {
+  /** Prepare transaction (fees, etc.) via Alpaca/bridge. */
+  prepareTransaction: (account: Account, transaction: unknown) => Promise<unknown>;
+  /** Validate transaction status. */
+  getTransactionStatus: (account: Account, transaction: unknown) => Promise<unknown>;
+  /** Broadcast signed operation. */
+  broadcast: (params: {
+    account: Account;
+    signedOperation: { signature: string; operation: unknown };
+    broadcastConfig?: unknown;
+  }) => Promise<unknown>;
+}
+
+/**
+ * Return an adaptor for transaction prepare/validate/broadcast.
+ * When account is Alpaca-family, uses the same bridge as getAccountBridge(account)
+ * (Alpaca account bridge). Callers pass getAccount so we can resolve Account from
+ * accountId (e.g. from slices via reconstructAccountFromReconstructionInput).
+ */
+export function getAlpacaTransactionAdapter(
+  _getAccount?: (accountId: string) => Promise<Account>,
+): AlpacaTransactionAdapter {
+  return {
+    async prepareTransaction(account: Account, transaction: unknown) {
+      if (!isAlpacaForAccountId(account.id)) {
+        throw new Error("alpacaTransactionAdapter: account is not Alpaca-family");
+      }
+      const bridge = getAccountBridge(account);
+      return bridge.prepareTransaction(account, transaction as never);
+    },
+    async getTransactionStatus(account: Account, transaction: unknown) {
+      if (!isAlpacaForAccountId(account.id)) {
+        throw new Error("alpacaTransactionAdapter: account is not Alpaca-family");
+      }
+      const bridge = getAccountBridge(account);
+      return bridge.getTransactionStatus(account, transaction as never);
+    },
+    async broadcast(params) {
+      const { account, signedOperation, broadcastConfig } = params;
+      if (!isAlpacaForAccountId(account.id)) {
+        throw new Error("alpacaTransactionAdapter: account is not Alpaca-family");
+      }
+      const bridge = getAccountBridge(account);
+      const config: BroadcastConfig = {
+        mevProtected: false,
+        ...(broadcastConfig as Partial<BroadcastConfig>),
+      };
+      return bridge.broadcast({
+        account,
+        signedOperation: signedOperation as never,
+        broadcastConfig: config,
+      });
+    },
+  };
+}

--- a/apps/web-tools/src/v4-account-model-playground/shared/compatibility.ts
+++ b/apps/web-tools/src/v4-account-model-playground/shared/compatibility.ts
@@ -1,0 +1,364 @@
+/**
+ * Compatibility layer: infer account, bridge sync, split into slices, reconstruct.
+ * Converts between legacy Account (types-live) and v4 slices (AccountV4, etc.).
+ * Balance history is derived from operations + balance (see README: future dedicated API).
+ */
+import { BigNumber } from "bignumber.js";
+import { lastValueFrom } from "rxjs";
+import { reduce } from "rxjs/operators";
+import {
+  encodeAccountId,
+  decodeAccountId,
+  emptyHistoryCache,
+} from "@ledgerhq/live-common/account/index";
+import {
+  findCryptoCurrencyById,
+  getCryptoCurrencyById,
+} from "@ledgerhq/live-common/currencies/index";
+import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { makeBridgeCacheSystem } from "@ledgerhq/live-common/bridge/cache";
+import {
+  getDerivationScheme,
+  runDerivationScheme,
+  asDerivationMode,
+} from "@ledgerhq/coin-framework/derivation";
+import { generateHistoryFromOperations } from "@ledgerhq/coin-framework/account/balanceHistoryCache";
+import type { Account, TokenAccount, DerivationMode } from "@ledgerhq/types-live";
+import type { AccountV4, TokenAccountV4 } from "../data-layer/accounts/schema";
+import type { AccountCoinResources } from "../data-layer/accountCoinResources/schema";
+import type { StoredOperation } from "../data-layer/operationHistory/schema";
+import { storedOperationToLive } from "../data-layer/operationHistory/storedToLive";
+
+const localCache: Record<string, unknown> = {};
+export const bridgeCache = makeBridgeCacheSystem({
+  saveData(c, d) {
+    localCache[c.id] = d;
+    return Promise.resolve();
+  },
+  getData(c) {
+    return Promise.resolve(localCache[c.id]);
+  },
+});
+
+/** Normalize/validate account id (same idea as sync.tsx inferAccountId). */
+export function inferAccountId(id: string): string {
+  try {
+    decodeAccountId(id);
+    return id;
+  } catch {
+    const splitted = id.split(":");
+    const findAndEat = (predicate: (str: string) => unknown) => {
+      const res = splitted.find(predicate);
+      if (typeof res === "string") {
+        splitted.splice(splitted.indexOf(res), 1);
+        return res;
+      }
+    };
+    const currencyId = findAndEat(s => findCryptoCurrencyById(s));
+    if (!currencyId) throw new Error("invalid id: missing currency part");
+    const type = "js";
+    findAndEat(s => s === "js");
+    const version = findAndEat(s => s.match(/^\d+$/)) || "2";
+    const derivationMode = asDerivationMode(
+      findAndEat(s => {
+        try {
+          return asDerivationMode(s);
+        } catch {
+          return undefined;
+        }
+      }) ?? "",
+    );
+    if (splitted.length === 0) throw new Error("invalid id: missing xpub or address part");
+    if (splitted.length > 1)
+      throw new Error("invalid id: couldn't understand xpub/address part: " + splitted.join(" | "));
+    const xpubOrAddress = splitted[0];
+    return encodeAccountId({ type, version, currencyId, xpubOrAddress, derivationMode });
+  }
+}
+
+/** Build a minimal Account for bridge.sync (same idea as sync.tsx inferAccount). */
+export function inferAccount(id: string): Account {
+  const { derivationMode, xpubOrAddress, currencyId } = decodeAccountId(id);
+  const currency = getCryptoCurrencyById(currencyId);
+  const scheme = getDerivationScheme({
+    derivationMode: derivationMode as DerivationMode,
+    currency,
+  });
+  const index = 0;
+  const freshAddressPath = runDerivationScheme(scheme, currency, {
+    account: index,
+    node: 0,
+    address: 0,
+  });
+  return {
+    type: "Account",
+    id,
+    xpub: xpubOrAddress,
+    seedIdentifier: xpubOrAddress,
+    used: true,
+    swapHistory: [],
+    derivationMode,
+    currency,
+    index,
+    freshAddress: xpubOrAddress,
+    freshAddressPath,
+    creationDate: new Date(),
+    lastSyncDate: new Date(0),
+    blockHeight: 0,
+    balance: new BigNumber(0),
+    spendableBalance: new BigNumber(0),
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    balanceHistoryCache: emptyHistoryCache,
+  };
+}
+
+/** Full sync via bridge; returns the full Account. */
+export async function syncAccountViaBridge(id: string): Promise<Account> {
+  const account = inferAccount(id);
+  const bridge = getAccountBridge(account);
+  await bridgeCache.prepareCurrency(account.currency);
+  const syncConfig = { paginationConfig: {}, blacklistedTokenIds: [] as string[] };
+  const observable = bridge.sync(account, syncConfig);
+  const synced = await lastValueFrom(observable.pipe(reduce((a, f) => f(a), account)));
+  return synced;
+}
+
+/** Known coin-specific keys on Account (for extraction / reconstruction). */
+const COIN_RESOURCE_KEYS = new Set([
+  "bitcoinResources",
+  "tezosResources",
+  "suiResources",
+  "solanaResources",
+  "cosmosResources",
+  "concordiumResources",
+  "celoResources",
+  "tronResources",
+  "polkadotResources",
+  "nearResources",
+  "multiversxResources",
+  "iconResources",
+  "cardanoResources",
+  "aptosResources",
+  "algorandResources",
+  "kaspaResources",
+  "hederaResources",
+  "cantonResources",
+  "aleoResources",
+]);
+const OTHER_ACCOUNT_EXTRA_KEYS = new Set(["nfts"]);
+
+function accountToAccountV4(account: Account): AccountV4 {
+  const subAccounts: TokenAccountV4[] | undefined = account.subAccounts?.map(ta => ({
+    type: "TokenAccount" as const,
+    id: ta.id,
+    parentId: ta.parentId,
+    tokenId: ta.token.id,
+    balance: ta.balance.toString(),
+    spendableBalance: ta.spendableBalance.toString(),
+    creationDate:
+      ta.creationDate instanceof Date ? ta.creationDate.getTime() : Number(ta.creationDate),
+    operationsCount: ta.operationsCount,
+  }));
+  const lastSyncTs =
+    account.lastSyncDate instanceof Date
+      ? account.lastSyncDate.getTime()
+      : typeof account.lastSyncDate === "number"
+        ? account.lastSyncDate
+        : new Date(account.lastSyncDate).getTime();
+  return {
+    type: "Account",
+    id: account.id,
+    derivationMode: account.derivationMode,
+    index: account.index,
+    freshAddress: account.freshAddress,
+    freshAddressPath: account.freshAddressPath,
+    currencyId: account.currency.id,
+    balance: account.balance.toString(),
+    blockHeight: account.blockHeight,
+    spendableBalance: account.spendableBalance.toString(),
+    feesCurrencyId: account.feesCurrency?.id,
+    subAccounts,
+    used: account.used,
+    creationDate:
+      account.creationDate instanceof Date
+        ? account.creationDate.getTime()
+        : Number(account.creationDate),
+    operationsCount: account.operationsCount,
+    seedIdentifier: account.seedIdentifier,
+    xpub: account.xpub,
+    lastSyncDate: lastSyncTs,
+    syncHash: account.syncHash,
+  };
+}
+
+/** Extract coin-specific and other extras from Account into accountCoinResources (all families, including bitcoin). */
+function extractAccountCoinResources(account: Account): AccountCoinResources {
+  const resources: AccountCoinResources = {};
+  for (const key of Array.from(COIN_RESOURCE_KEYS)) {
+    if (key in account && (account as Record<string, unknown>)[key] !== undefined) {
+      resources[key] = (account as Record<string, unknown>)[key];
+    }
+  }
+  for (const key of Array.from(OTHER_ACCOUNT_EXTRA_KEYS)) {
+    if (key in account && (account as Record<string, unknown>)[key] !== undefined) {
+      resources[key] = (account as Record<string, unknown>)[key];
+    }
+  }
+  return resources;
+}
+
+export interface SliceUpdates {
+  accountV4: AccountV4;
+  operations: Account["operations"];
+  pendingOperations: Account["pendingOperations"];
+  balanceHistory: Account["balanceHistoryCache"];
+  accountCoinResources: AccountCoinResources;
+  tokenAccountIds: string[];
+}
+
+/**
+ * Split a full Account into per-slice updates (for dispatch).
+ * operationHistory is flat: main account ops + each token account ops
+ * are stored by their accountId in the same byAccountId map.
+ */
+export function splitAccountIntoSliceUpdates(account: Account): SliceUpdates {
+  const accountV4 = accountToAccountV4(account);
+  const accountCoinResources = extractAccountCoinResources(account);
+  const tokenAccountIds = (account.subAccounts || []).map(ta => ta.id);
+  return {
+    accountV4,
+    operations: account.operations || [],
+    pendingOperations: account.pendingOperations || [],
+    balanceHistory: account.balanceHistoryCache,
+    accountCoinResources,
+    tokenAccountIds,
+  };
+}
+
+/**
+ * Bundle of slice data for reconstruction (sync selector output).
+ * All coin-specific data (including bitcoin) lives in accountCoinResources.
+ */
+export interface AccountReconstructionInput {
+  accountV4: AccountV4;
+  operations: StoredOperation[];
+  pendingOperations: StoredOperation[];
+  balanceHistory: Account["balanceHistoryCache"];
+  accountCoinResources: AccountCoinResources;
+}
+
+/** Resolve feesCurrencyId to CryptoCurrency or TokenCurrency (try currency first, then token). */
+async function resolveFeesCurrency(
+  feesCurrencyId: string | undefined,
+): Promise<Account["feesCurrency"]> {
+  if (!feesCurrencyId) return undefined;
+  try {
+    return getCryptoCurrencyById(feesCurrencyId);
+  } catch {
+    return getCryptoAssetsStore().findTokenById(feesCurrencyId) ?? undefined;
+  }
+}
+
+/**
+ * Reconstruct full Account from sync selector output (StoredOperation[] → Operation[] inside).
+ * Use this when you have selectAccountReconstructionInput(state, accountId).
+ */
+export async function reconstructAccountFromReconstructionInput(
+  input: AccountReconstructionInput,
+): Promise<Account> {
+  return reconstructAccountFromSlices(
+    input.accountV4,
+    input.operations.map(storedOperationToLive),
+    input.pendingOperations.map(storedOperationToLive),
+    input.balanceHistory,
+    input.accountCoinResources,
+  );
+}
+
+/** Reconstruct full Account from slices (for bridge when needed). Lookup currency/token by id. */
+export async function reconstructAccountFromSlices(
+  accountV4: AccountV4,
+  operations: Account["operations"],
+  pendingOperations: Account["pendingOperations"],
+  balanceHistory: Account["balanceHistoryCache"],
+  accountCoinResources: AccountCoinResources,
+): Promise<Account> {
+  const currency = getCryptoCurrencyById(accountV4.currencyId);
+  const feesCurrency = await resolveFeesCurrency(accountV4.feesCurrencyId);
+  const tokenStore = getCryptoAssetsStore();
+  const subAccounts: TokenAccount[] | undefined = accountV4.subAccounts
+    ? await Promise.all(
+        accountV4.subAccounts.map(async ta => {
+          const token = await tokenStore.findTokenById(ta.tokenId);
+          if (!token)
+            throw new Error(
+              `reconstructAccountFromSlices: token not found for tokenId ${ta.tokenId}`,
+            );
+          return {
+            type: "TokenAccount" as const,
+            id: ta.id,
+            parentId: ta.parentId,
+            token,
+            balance: new BigNumber(ta.balance),
+            spendableBalance: new BigNumber(ta.spendableBalance),
+            creationDate: new Date(ta.creationDate as number),
+            operationsCount: ta.operationsCount,
+            operations: [] as Account["operations"],
+            pendingOperations: [] as Account["pendingOperations"],
+            balanceHistoryCache: emptyHistoryCache,
+            swapHistory: [],
+          };
+        }),
+      )
+    : undefined;
+  const account: Account = {
+    type: "Account",
+    id: accountV4.id,
+    seedIdentifier: accountV4.seedIdentifier,
+    xpub: accountV4.xpub,
+    derivationMode: accountV4.derivationMode as DerivationMode,
+    index: accountV4.index,
+    freshAddress: accountV4.freshAddress,
+    freshAddressPath: accountV4.freshAddressPath,
+    used: accountV4.used,
+    balance: new BigNumber(accountV4.balance),
+    spendableBalance: new BigNumber(accountV4.spendableBalance),
+    creationDate: new Date(accountV4.creationDate as number),
+    blockHeight: accountV4.blockHeight,
+    currency,
+    feesCurrency,
+    operationsCount: accountV4.operationsCount,
+    operations,
+    pendingOperations: pendingOperations || [],
+    lastSyncDate: new Date(accountV4.lastSyncDate as number),
+    subAccounts,
+    balanceHistoryCache: balanceHistory,
+    swapHistory: [],
+    syncHash: accountV4.syncHash,
+  };
+  for (const key of Object.keys(accountCoinResources)) {
+    (account as Record<string, unknown>)[key] = accountCoinResources[key];
+  }
+  return account;
+}
+
+/**
+ * Derive balance history from operations + balance (placeholder; see README).
+ * In the future this will be a dedicated balance history API.
+ */
+export function deriveBalanceHistoryFromOperations(
+  balance: Account["balance"],
+  operations: Account["operations"],
+  _accountId: string,
+): Account["balanceHistoryCache"] {
+  const accountLike = {
+    balance,
+    operations: operations || [],
+    pendingOperations: [] as Account["pendingOperations"],
+    balanceHistoryCache: emptyHistoryCache,
+  };
+  return generateHistoryFromOperations(accountLike as unknown as Account);
+}

--- a/apps/web-tools/src/v4-account-model-playground/shared/syncStrategy.ts
+++ b/apps/web-tools/src/v4-account-model-playground/shared/syncStrategy.ts
@@ -1,0 +1,34 @@
+/**
+ * Choix Alpaca vs Bridge par famille de currency.
+ * Aligné sur libs/ledger-live-common/src/bridge/impl.ts (alpacaized).
+ *
+ * - isAlpacaForCurrency(currencyId) / isAlpacaForAccountId(accountId) : true pour
+ *   evm, xrp, stellar, tezos. Ces familles ont une API Alpaca (getBalance, listOperations, etc.).
+ * - Alpaca path : pas de bridge. On appelle directement getAlpacaApi(currencyId, "local")
+ *   puis getBalance, lastBlock, listOperations ; on construit AccountV4 et les slices
+ *   (voir data-layer/accounts/fetchAccountViaAlpaca.ts et les thunks operationHistory / balanceHistory).
+ */
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+
+const ALPACA_FAMILIES: Record<string, boolean> = {
+  evm: true,
+  xrp: true,
+  stellar: true,
+  tezos: true,
+};
+
+export function isAlpacaForCurrency(currencyId: string): boolean {
+  try {
+    const currency = getCryptoCurrencyById(currencyId);
+    return Boolean(ALPACA_FAMILIES[currency.family]);
+  } catch {
+    return false;
+  }
+}
+
+import { decodeAccountId } from "@ledgerhq/live-common/account/index";
+
+export function isAlpacaForAccountId(accountId: string): boolean {
+  const { currencyId } = decodeAccountId(accountId);
+  return isAlpacaForCurrency(currencyId);
+}

--- a/apps/web-tools/src/v4-account-model-playground/shared/walletSyncImport.ts
+++ b/apps/web-tools/src/v4-account-model-playground/shared/walletSyncImport.ts
@@ -1,0 +1,58 @@
+/**
+ * Import account IDs from Ledger Wallet Sync (Cloud Sync): device + trustchain + pull.
+ * Same idea as trustchain AppAccountsSync: get trustchain from device, then CloudSync pull to get accounts list.
+ *
+ * Member credentials are never persisted (no sessionStorage). We always obtain fresh credentials
+ * via the device per import to avoid storing sensitive data in clear text.
+ */
+import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
+import { getSdk } from "@ledgerhq/ledger-key-ring-protocol";
+import type { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
+import { CloudSyncSDK } from "@ledgerhq/live-wallet/cloudsync/index";
+import walletsync, { liveSlug } from "@ledgerhq/live-wallet/walletsync/index";
+import type { DistantState } from "@ledgerhq/live-wallet/walletsync/index";
+import getEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
+
+/**
+ * Import account IDs from Wallet Sync (Cloud Sync). Connects to device, gets or creates trustchain,
+ * pulls cloud data and returns the list of account IDs stored in the cloud.
+ * Obtains fresh member credentials from the device each time (never stored).
+ */
+export async function importAccountIdsFromWalletSync(deviceId: string): Promise<string[]> {
+  const { cloudSyncApiBaseUrl, trustchainApiBaseUrl } = getEnvironmentParams("STAGING");
+
+  const context = {
+    applicationId: 16,
+    name: "WebTools",
+    apiBaseUrl: trustchainApiBaseUrl,
+  };
+
+  const trustchainSdk = getSdk(false, context, withDevice);
+
+  const memberCredentials: MemberCredentials = await trustchainSdk.initMemberCredentials();
+
+  const result = await trustchainSdk.getOrCreateTrustchain(deviceId, memberCredentials);
+  const trustchain: Trustchain = result.trustchain;
+
+  let capturedIds: string[] = [];
+  const walletSyncSdk = new CloudSyncSDK({
+    apiBaseUrl: cloudSyncApiBaseUrl,
+    slug: liveSlug,
+    schema: walletsync.schema,
+    trustchainSdk,
+    getCurrentVersion: () => undefined,
+    saveNewUpdate: async event => {
+      if (event.type === "new-data" && event.data) {
+        const data = event.data as DistantState;
+        if (Array.isArray(data?.accounts)) {
+          capturedIds = data.accounts.map((a: { id: string }) => a.id);
+        }
+      } else if (event.type === "deleted-data") {
+        capturedIds = [];
+      }
+    },
+  });
+
+  await walletSyncSdk.pull(trustchain, memberCredentials);
+  return capturedIds;
+}

--- a/apps/web-tools/src/v4-account-model-playground/store/index.ts
+++ b/apps/web-tools/src/v4-account-model-playground/store/index.ts
@@ -1,0 +1,24 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { cryptoAssetsApi } from "@ledgerhq/cryptoassets/cal-client";
+import { accountsReducer } from "../data-layer/accounts/slice";
+import { operationHistoryReducer } from "../data-layer/operationHistory/slice";
+import { balanceHistoryReducer } from "../data-layer/balanceHistory/slice";
+import { accountCoinResourcesReducer } from "../data-layer/accountCoinResources/slice";
+import { transactionalReducer } from "../data-layer/transactional/slice";
+
+export const store = configureStore({
+  reducer: {
+    accounts: accountsReducer,
+    operationHistory: operationHistoryReducer,
+    balanceHistory: balanceHistoryReducer,
+    accountCoinResources: accountCoinResourcesReducer,
+    transactional: transactionalReducer,
+    [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer,
+  },
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware().concat(cryptoAssetsApi.middleware),
+  devTools: true,
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/apps/web-tools/src/v4-account-model-playground/store/selectors.ts
+++ b/apps/web-tools/src/v4-account-model-playground/store/selectors.ts
@@ -1,0 +1,40 @@
+/**
+ * Top-level selectors that compose all slices to expose a single "account view".
+ * See README §2.1: sync selector for reconstruction input; use
+ * reconstructAccountFromReconstructionInput(input) for the async legacy Account.
+ */
+import { emptyHistoryCache } from "@ledgerhq/live-common/account/index";
+import type { RootState } from "./index";
+import type { AccountReconstructionInput } from "../shared/compatibility";
+import { selectAccountById } from "../data-layer/accounts/selectors";
+import { selectOperationHistoryByAccountId } from "../data-layer/operationHistory/selectors";
+import { selectPendingOperationsByAccountId } from "../data-layer/transactional/selectors";
+import { selectBalanceHistoryByAccountId } from "../data-layer/balanceHistory/selectors";
+import { selectAccountCoinResourcesByAccountId } from "../data-layer/accountCoinResources/selectors";
+
+/**
+ * Returns the bundle of slice data needed to reconstruct the full legacy Account
+ * for the given (main) account id, or undefined if the account is not in the store.
+ * Use with reconstructAccountFromReconstructionInput(input) for the async step.
+ * pendingOperations come from the transactional slice.
+ */
+export function selectAccountReconstructionInput(
+  state: RootState,
+  accountId: string,
+): AccountReconstructionInput | undefined {
+  const accountV4 = selectAccountById(state, accountId);
+  if (!accountV4) return undefined;
+
+  const operationEntry = selectOperationHistoryByAccountId(state, accountId);
+  const pendingOperations = selectPendingOperationsByAccountId(state, accountId);
+  const balanceHistory = selectBalanceHistoryByAccountId(state, accountId);
+  const accountCoinResources = selectAccountCoinResourcesByAccountId(state, accountId);
+
+  return {
+    accountV4,
+    operations: operationEntry?.operations ?? [],
+    pendingOperations,
+    balanceHistory: balanceHistory ?? emptyHistoryCache,
+    accountCoinResources: accountCoinResources ?? {},
+  };
+}

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -73,6 +73,24 @@
       "require": "./lib/bridge/descriptor.js",
       "default": "./lib-es/bridge/descriptor.js"
     },
+    "./bridge/generic-alpaca/alpaca": {
+      "types": "./lib/bridge/generic-alpaca/alpaca.d.ts",
+      "import": "./lib-es/bridge/generic-alpaca/alpaca.js",
+      "require": "./lib/bridge/generic-alpaca/alpaca.js",
+      "default": "./lib-es/bridge/generic-alpaca/alpaca.js"
+    },
+    "./bridge/generic-alpaca/utils": {
+      "types": "./lib/bridge/generic-alpaca/utils.d.ts",
+      "import": "./lib-es/bridge/generic-alpaca/utils.js",
+      "require": "./lib/bridge/generic-alpaca/utils.js",
+      "default": "./lib-es/bridge/generic-alpaca/utils.js"
+    },
+    "./bridge/generic-alpaca/buildSubAccounts": {
+      "types": "./lib/bridge/generic-alpaca/buildSubAccounts.d.ts",
+      "import": "./lib-es/bridge/generic-alpaca/buildSubAccounts.js",
+      "require": "./lib/bridge/generic-alpaca/buildSubAccounts.js",
+      "default": "./lib-es/bridge/generic-alpaca/buildSubAccounts.js"
+    },
     "./test-helpers/cryptoAssetsStore": {
       "types": "./lib/test-helpers/cryptoAssetsStore.d.ts",
       "require": "./lib/test-helpers/cryptoAssetsStore.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2206,6 +2206,9 @@ importers:
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/types-live
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.0.0)(redux@5.0.1))(react@19.0.0)
       '@uiw/react-codemirror':
         specifier: ^4.25.4
         version: 4.25.4(@codemirror/view@6.39.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2245,6 +2248,9 @@ importers:
       react-inspector:
         specifier: ^4.0.1
         version: 4.0.1(react@19.0.0)
+      react-redux:
+        specifier: 'catalog:'
+        version: 9.2.0(@types/react@19.0.14)(react@19.0.0)(redux@5.0.1)
       react-router-dom:
         specifier: ^6.30.3
         version: 6.30.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2257,6 +2263,9 @@ importers:
       react-tooltip:
         specifier: ^5.30.0
         version: 5.30.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      redux:
+        specifier: 'catalog:'
+        version: 5.0.1
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -2275,6 +2284,9 @@ importers:
       utf-8-validate:
         specifier: ^6.0.6
         version: 6.0.6
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
@@ -58200,7 +58212,7 @@ snapshots:
       bignumber.js: 9.1.2
       iso-base: 4.0.0
       iso-web: 1.0.6
-      zod: 3.23.8
+      zod: 3.25.76
 
   iso-kv@3.0.3:
     dependencies:


### PR DESCRIPTION
This PR serves as a continuous study to rethink our account models, see what the slices could look like in a more denormalized fashion, see how we can keep compatibility with existing stack (AccountBridge/CurrencyBridge that most implementation of coin still are built on) while allowing new implementation to exist with a model that is optimized for them: e.g. operations / balanceHistory to be only loaded on demand.

[**=> THE DOC <=**](https://github.com/LedgerHQ/ledger-live/tree/playground/v4-slices/apps/web-tools/src/v4-account-model-playground)

There are still a lot of things that can be splitted and explored and the main README tries to document it all and highlight some topics of discussion.

`pnpm web-tools dev`

<img width="1250" height="1202" alt="Screenshot 2026-02-24 at 10 15 12" src="https://github.com/user-attachments/assets/47a36e9f-b09b-41cc-809d-23c115b6c530" />
