### PR TITLE
test(desktop-e2e): stabilize portfolio reborn mode quick actions coverage

### DIFF
--- a/.changeset/silent-turtles-beam.md
+++ b/.changeset/silent-turtles-beam.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+adapt e2e test for portfolio with reborn mode

--- a/e2e/desktop/tests/page/portfolio.page.ts
+++ b/e2e/desktop/tests/page/portfolio.page.ts
@@ -30,7 +30,10 @@ export class PortfolioPage extends AppPage {
   private noBalanceTitle = this.page.getByTestId("no-balance-title");
   private quickActionButton = (action: QuickActionButton) =>
     this.page.getByTestId(`quick-action-button-${action}`);
+  private connectQuickActionButton = this.page.getByTestId("quick-action-button-connect");
+  private buyALedgerQuickActionButton = this.page.getByTestId("quick-action-button-buy-a-ledger");
   private portfolioAddAccountButton = this.page.getByTestId("portfolio-add-account-button");
+  private noDeviceTitle = this.page.getByTestId("no-device-title");
 
   private async checkVisibility(locator: Locator) {
     await expect(locator).toBeVisible();
@@ -230,6 +233,16 @@ export class PortfolioPage extends AppPage {
     await this.checkVisibility(this.quickActionButton("buy"));
   }
 
+  @step("Check connect button is visible")
+  async checkConnectButtonVisibility() {
+    await this.checkVisibility(this.connectQuickActionButton);
+  }
+
+  @step("Check buy a ledger button is visible")
+  async checkBuyALedgerButtonVisibility() {
+    await this.checkVisibility(this.buyALedgerQuickActionButton);
+  }
+
   @step("Check sell button is disabled")
   async checkSellButtonDisabled() {
     await expect(this.quickActionButton("sell")).toBeDisabled();
@@ -253,6 +266,11 @@ export class PortfolioPage extends AppPage {
   @step("Check add account button visibility")
   async checkAddAccountButtonVisibility() {
     await this.checkVisibility(this.portfolioAddAccountButton);
+  }
+
+  @step("Check no device title is visible")
+  async checkNoDeviceTitleVisibility() {
+    await this.checkVisibility(this.noDeviceTitle);
   }
 
   @step("Click add account button")

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -33,7 +33,7 @@ test.describe("Portfolio", () => {
 test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
   const currency = Currency.BTC;
   test.use({
-    userdata: "skip-onboarding",
+    userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: currency.speculosApp,
     // to-do remove when wallet 4.0 is default
     featureFlags: {
@@ -43,6 +43,7 @@ test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
           marketBanner: true,
           graphRework: true,
           quickActionCtas: true,
+          mainNavigation: true,
         },
       },
     },
@@ -79,7 +80,7 @@ test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
 test.describe("Portfolio Wallet 4.0 - With Account", () => {
   const currency = Currency.BTC;
   test.use({
-    userdata: "skip-onboarding",
+    userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: currency.speculosApp,
     cliCommands: [
       (appjsonPath: string) => {
@@ -99,6 +100,7 @@ test.describe("Portfolio Wallet 4.0 - With Account", () => {
           marketBanner: true,
           graphRework: true,
           quickActionCtas: true,
+          mainNavigation: true,
         },
       },
     },
@@ -126,6 +128,36 @@ test.describe("Portfolio Wallet 4.0 - With Account", () => {
       await app.analytics.expectAnalyticsScreenToBeVisible();
       await app.analytics.clickBackButton();
       await app.portfolio.expectPortfolioScreenToBeVisible();
+    },
+  );
+});
+
+test.describe("Portfolio Wallet 4.0 - No seen device (Reborn mode)", () => {
+  test.use({
+    userdata: "skip-onboarding",
+    // to-do remove when wallet 4.0 is default
+    featureFlags: {
+      lwdWallet40: {
+        enabled: true,
+        params: {
+          marketBanner: true,
+          graphRework: true,
+          quickActionCtas: true,
+          mainNavigation: true,
+        },
+      },
+    },
+  });
+
+  test(
+    "Portfolio no seen device: verify reborn quick actions are displayed",
+    {
+      tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+    },
+    async ({ app }) => {
+      await app.portfolio.checkNoDeviceTitleVisibility();
+      await app.portfolio.checkConnectButtonVisibility();
+      await app.portfolio.checkBuyALedgerButtonVisibility();
     },
   );
 });

--- a/e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json
+++ b/e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json
@@ -1,0 +1,57 @@
+{
+  "data": {
+    "PLAYWRIGHT_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2042-01-01"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": null,
+      "region": null,
+      "locale": "en-US",
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "selectedTimeRange": "month",
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sharePersonalizedRecommandations": false,
+      "sentryLogs": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "nanoSP",
+      "hasInstalledApps": true,
+      "hasAcceptedSwapKYC": false,
+      "lastSeenDevice": {
+        "modelId": "nanoSP",
+        "deviceInfo": {},
+        "apps": []
+      },
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [],
+    "countervalues": {}
+  }
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Partial: E2E scenarios were added/updated but not executed in this run._
- [x] **Impact of the changes:**
      - Portfolio Wallet 4.0 quick actions behavior when `lastSeenDevice` is set vs unset
      - Determinism of desktop E2E setup for reborn/non-reborn states
      - Regression coverage for no-seen-device reborn mode

### 📝 Description

Portfolio Wallet 4.0 desktop E2E scenarios were flaky/ambiguous because `skip-onboarding` seeds `lastSeenDevice` as `null`, which keeps the app in reborn mode and can mismatch tests expecting standard quick actions.

This PR introduces a dedicated userdata fixture with a seeded `lastSeenDevice` for non-reborn Wallet 4.0 scenarios, updates portfolio E2E specs to use it where needed, and adds a dedicated no-seen-device (reborn mode) case asserting `Connect` and `Buy a Ledger` quick actions. Page-object helpers were extended for explicit reborn assertions.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26849](https://ledgerhq.atlassian.net/browse/LIVE-26849)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26849]: https://ledgerhq.atlassian.net/browse/LIVE-26849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ