### PR TITLE
feat(desktop,mobile): update ptx player top bar for lw40

### DIFF
--- a/.changeset/funny-melons-cough.md
+++ b/.changeset/funny-melons-cough.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Update ptx player top bar to work with LW40

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.test.tsx
@@ -113,7 +113,7 @@ describe("TopBar", () => {
         <TopBar {...defaultProps} manifest={{ ...mockManifest, id: "" }} />
       </MemoryRouter>,
     );
-    expect(screen.getByText("common.backToMatchingURL")).toBeInTheDocument();
+    expect(screen.getByText("common.back")).toBeInTheDocument();
     expect(screen.getByText("common.sync.refresh")).toBeInTheDocument();
     expect(screen.queryByText("common.sync.devTools")).toBeNull();
   });

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.tsx
@@ -212,8 +212,8 @@ export const TopBar = ({
       card: t("card.backToCard"),
     };
 
-    return screenMap[lastScreen] || manifest.name;
-  }, [localStorage, manifest, t]);
+    return screenMap[lastScreen] || null;
+  }, [localStorage, t]);
 
   const handleReload = useCallback(() => {
     const webview = safeGetRefValue(webviewAPIRef);
@@ -262,13 +262,19 @@ export const TopBar = ({
     return null;
   }
 
+  const buttonLabel = getButtonLabel();
+
   return (
     <Container>
       {!isInternalApp ? (
         <ItemContainer isInteractive onClick={onBackToMatchingURL}>
           <ArrowRight flipped size={16} />
           <ItemContent>
-            <Trans i18nKey="common.backToMatchingURL" values={{ appName: getButtonLabel() }} />
+            {buttonLabel ? (
+              <Trans i18nKey="common.backToMatchingURL" values={{ appName: buttonLabel }} />
+            ) : (
+              <Trans i18nKey="common.back" />
+            )}
           </ItemContent>
         </ItemContainer>
       ) : null}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
@@ -4,7 +4,7 @@ import { useTheme } from "styled-components/native";
 import { findCryptoCurrencyByKeyword } from "@ledgerhq/live-common/currencies/index";
 import { BUY_SELL_UI_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { NavigatorName, ScreenName } from "~/const";
+import { ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import { useTranslation } from "~/context/Locale";
 import styles from "~/navigation/styles";
@@ -43,7 +43,6 @@ const createExchangeScreen =
         {...props}
         config={{
           screen: screenName,
-          navigator: NavigatorName.Exchange,
           btnText: t("common.quote"),
         }}
         route={{

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/PtxNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/PtxNavigator.ts
@@ -1,4 +1,4 @@
-import { ScreenName } from "~/const";
+import { NavigatorName, ScreenName } from "~/const";
 
 type CommonParams = {
   goToURL?: string;
@@ -24,4 +24,5 @@ export type PtxNavigatorParamList = {
   };
   [ScreenName.ExchangeSell]?: ExchangeParams;
   [ScreenName.Card]?: CommonParams;
+  [NavigatorName.CardTab]?: CommonParams;
 };

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/BackToLwButton.test.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/BackToLwButton.test.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { BackToInternalDomain } from "./BackToLwButton";
+import { NavigatorName, ScreenName } from "~/const";
+import storage from "LLM/storage";
+import { track } from "~/analytics";
+import { handleBackToLwEntryPoint } from "./handleBackToLwEntryPoint";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock("LLM/storage", () => ({
+  __esModule: true,
+  default: {
+    getString: jest.fn(),
+  },
+}));
+
+jest.mock("~/analytics", () => ({
+  track: jest.fn(),
+}));
+
+jest.mock("./handleBackToLwEntryPoint", () => ({
+  handleBackToLwEntryPoint: jest.fn(),
+}));
+
+const mockedStorage = jest.mocked(storage);
+const mockedTrack = jest.mocked(track);
+const mockedHandleBackToLwEntryPoint = jest.mocked(handleBackToLwEntryPoint);
+
+describe("BackToInternalDomain", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedStorage.getString.mockResolvedValue(null);
+  });
+
+  it("should render with default back label when btnText is not provided", () => {
+    render(
+      <BackToInternalDomain
+        config={{
+          screen: ScreenName.ExchangeBuy,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Back")).toBeOnTheScreen();
+  });
+
+  it("should render with custom back label when btnText is provided", () => {
+    render(
+      <BackToInternalDomain
+        config={{
+          screen: ScreenName.ExchangeBuy,
+          btnText: "Live App",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Back to Live App")).toBeOnTheScreen();
+  });
+
+  it("should call handleBackToLwEntryPoint with correct screen when button is pressed", async () => {
+    const { user } = render(
+      <BackToInternalDomain
+        config={{
+          screen: ScreenName.Card,
+        }}
+      />,
+    );
+
+    await user.press(screen.getByText("Back"));
+
+    expect(mockedHandleBackToLwEntryPoint).toHaveBeenCalledTimes(1);
+    expect(mockedHandleBackToLwEntryPoint).toHaveBeenCalledWith(
+      { navigate: mockNavigate },
+      ScreenName.Card,
+      { referrer: "isExternal" },
+    );
+  });
+
+  it("should navigate to Exchange when screen is ExchangeBuy", async () => {
+    const { user } = render(
+      <BackToInternalDomain
+        config={{
+          screen: ScreenName.ExchangeBuy,
+        }}
+      />,
+    );
+
+    await user.press(screen.getByText("Back"));
+
+    expect(mockedHandleBackToLwEntryPoint).toHaveBeenCalledWith(
+      { navigate: mockNavigate },
+      ScreenName.ExchangeBuy,
+      { referrer: "isExternal" },
+    );
+  });
+
+  it("should track button_clicked with back to quote when last-screen is compare_providers", async () => {
+    mockedStorage.getString.mockImplementation((key: string): Promise<string | null> => {
+      const data: Record<string, string> = {
+        "manifest-id": "provider-123",
+        "last-screen": "compare_providers",
+        "flow-name": "buy-flow",
+      };
+      return Promise.resolve(data[key] ?? null);
+    });
+
+    const { user } = render(
+      <BackToInternalDomain
+        config={{
+          screen: ScreenName.ExchangeSell,
+        }}
+      />,
+    );
+
+    await user.press(screen.getByText("Back"));
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      button: "back to quote",
+      provider: "provider-123",
+      flow: "buy-flow",
+    });
+  });
+
+  it("should track button_clicked with back to liveapp when last-screen is not compare_providers", async () => {
+    mockedStorage.getString.mockImplementation((key: string): Promise<string | null> => {
+      const data: Record<string, string> = {
+        "manifest-id": "provider-456",
+        "last-screen": "quote",
+        "flow-name": "sell-flow",
+      };
+      return Promise.resolve(data[key] ?? null);
+    });
+
+    const { user } = render(
+      <BackToInternalDomain
+        config={{
+          screen: NavigatorName.CardTab,
+        }}
+      />,
+    );
+
+    await user.press(screen.getByText("Back"));
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      button: "back to liveapp",
+      provider: "provider-456",
+      flow: "sell-flow",
+    });
+  });
+
+  it("should not track when manifest-id is empty", async () => {
+    mockedStorage.getString.mockResolvedValue(null);
+
+    const { user } = render(
+      <BackToInternalDomain
+        config={{
+          screen: ScreenName.Card,
+        }}
+      />,
+    );
+
+    await user.press(screen.getByText("Back"));
+
+    expect(mockedTrack).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/BackToLwButton.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/BackToLwButton.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo } from "react";
+import { StyleSheet, View, TouchableOpacity } from "react-native";
+import { useTranslation } from "~/context/Locale";
+
+import { Flex, Icon, Text } from "@ledgerhq/native-ui";
+
+import storage from "LLM/storage";
+import { useNavigation } from "@react-navigation/native";
+
+import { RootNavigationComposite, StackNavigatorNavigation } from "../RootNavigator/types/helpers";
+import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigator";
+import { track } from "~/analytics";
+import { NavigatorName, ScreenName } from "~/const";
+import { handleBackToLwEntryPoint } from "./handleBackToLwEntryPoint";
+
+export type BackConfig = {
+  screen:
+    | ScreenName.ExchangeBuy
+    | ScreenName.ExchangeSell
+    | ScreenName.Card
+    | NavigatorName.CardTab;
+  btnText?: string;
+};
+
+type BackToInternalDomainProps = {
+  config: BackConfig;
+};
+
+const styles = StyleSheet.create({
+  headerLeft: {
+    display: "flex",
+    flexDirection: "row",
+    paddingRight: 8,
+  },
+});
+
+export function BackToInternalDomain({ config }: BackToInternalDomainProps) {
+  const { t } = useTranslation();
+  const { screen, btnText } = config;
+  const navigation =
+    useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();
+
+  const handleBackClick = async () => {
+    const manifestId = (await storage.getString("manifest-id")) ?? "";
+    const [lastScreen = "", flowName = ""] = await Promise.all([
+      storage.getString("last-screen"),
+      storage.getString("flow-name"),
+    ]);
+
+    if (manifestId) {
+      track("button_clicked", {
+        button: lastScreen === "compare_providers" ? "back to quote" : "back to liveapp",
+        provider: manifestId,
+        flow: flowName,
+      });
+    }
+
+    handleBackToLwEntryPoint(navigation, screen, {
+      referrer: "isExternal",
+    });
+  };
+
+  const buttonLabel = useMemo(() => {
+    return btnText ? t("common.backTo", { to: btnText }) : t("common.back");
+  }, [t, btnText]);
+
+  return (
+    <View style={styles.headerLeft}>
+      <TouchableOpacity onPress={handleBackClick}>
+        <Flex alignItems="center" flexDirection="row" height={40}>
+          <Icon name="ChevronLeft" color="neutral.c100" size={30} />
+          <Text fontWeight="semiBold" fontSize={16} color="neutral.c100">
+            {buttonLabel}
+          </Text>
+        </Flex>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/handleBackToLwEntryPoint.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/handleBackToLwEntryPoint.ts
@@ -1,0 +1,35 @@
+import { RootNavigationComposite, StackNavigatorNavigation } from "../RootNavigator/types/helpers";
+import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigator";
+
+import { NavigatorName, ScreenName } from "~/const";
+
+export function handleBackToLwEntryPoint(
+  navigation: RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>,
+  screen: ScreenName | NavigatorName.CardTab,
+  params?: Record<string, unknown>,
+) {
+  switch (screen) {
+    case ScreenName.ExchangeBuy:
+    case ScreenName.ExchangeSell:
+      navigation.navigate(NavigatorName.Exchange, {
+        screen,
+        params,
+      });
+      break;
+    case ScreenName.Card:
+      navigation.navigate(NavigatorName.Card, {
+        screen,
+        params,
+      });
+      break;
+    case NavigatorName.CardTab:
+      navigation.navigate(NavigatorName.Main, {
+        screen,
+      });
+      break;
+    default:
+      navigation.navigate(NavigatorName.Base, {
+        screen: NavigatorName.Main,
+      });
+  }
+}

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { StyleSheet, BackHandler, Platform, View, TouchableOpacity } from "react-native";
-import { useTranslation } from "~/context/Locale";
+import { BackHandler, Platform } from "react-native";
 import { useSelector } from "~/context/hooks";
-
-import { Flex, Icon, Text } from "@ledgerhq/native-ui";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
 import { INTERNAL_APP_IDS } from "@ledgerhq/live-common/wallet-api/constants";
@@ -13,7 +10,6 @@ import { safeUrl } from "@ledgerhq/live-common/wallet-api/helpers";
 import storage from "LLM/storage";
 import { useNavigation } from "@react-navigation/native";
 
-import { useTheme } from "styled-components/native";
 import SafeAreaView from "~/components/SafeAreaView";
 
 import { flattenAccountsSelector } from "~/reducers/accounts";
@@ -22,121 +18,21 @@ import { Web3AppWebview } from "../Web3AppWebview";
 import { RootNavigationComposite, StackNavigatorNavigation } from "../RootNavigator/types/helpers";
 import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigator";
 import { initialWebviewState } from "../Web3AppWebview/helpers";
-import { track } from "~/analytics";
-import { NavigationHeaderCloseButtonAdvanced } from "../NavigationHeaderCloseButton";
-import { NavigatorName, ScreenName } from "~/const";
+import { ScreenName } from "~/const";
 import { Loading } from "../Loading";
 import { usePTXCustomHandlers } from "./CustomHandlers";
 import { useDeeplinkCustomHandlers } from "../WebPlatformPlayer/CustomHandlers";
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
+import { BackConfig, BackToInternalDomain } from "./BackToLwButton";
+import { handleBackToLwEntryPoint } from "./handleBackToLwEntryPoint";
 
-type BackToInternalDomainProps = {
-  config: {
-    screen: ScreenName.ExchangeBuy | ScreenName.ExchangeSell | ScreenName.Card;
-    navigator: NavigatorName.Exchange | NavigatorName.Card;
-    btnText: string;
-  };
-};
-
-function BackToInternalDomain({ config }: BackToInternalDomainProps) {
-  const { t } = useTranslation();
-  const { screen, navigator, btnText } = config;
-  const navigation =
-    useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();
-
-  const handleBackClick = async () => {
-    const manifestId = (await storage.getString("manifest-id")) ?? "";
-
-    if (manifestId) {
-      const [lastScreen = "", flowName = ""] = await Promise.all([
-        storage.getString("last-screen"),
-        storage.getString("flow-name"),
-      ]);
-
-      track("button_clicked", {
-        button: lastScreen === "compare_providers" ? "back to quote" : "back to liveapp",
-        provider: manifestId,
-        flow: flowName,
-      });
-
-      navigation.navigate(navigator, {
-        screen,
-        params: {
-          referrer: "isExternal",
-        },
-      });
-    } else {
-      // We've lost our persisted state so go all the back home
-      navigation.getParent()?.navigate(NavigatorName.Base, {
-        screen: NavigatorName.Main,
-      });
-    }
-  };
-
-  const buttonLabel = useMemo(() => {
-    return t("common.backTo", { to: btnText });
-  }, [t, btnText]);
-
-  return (
-    <View style={styles.headerLeft}>
-      <TouchableOpacity onPress={handleBackClick}>
-        <Flex alignItems="center" flexDirection="row" height={40}>
-          <Icon name="ChevronLeft" color="neutral.c100" size={30} />
-          <Text fontWeight="semiBold" fontSize={16} color="neutral.c100">
-            {buttonLabel}
-          </Text>
-        </Flex>
-      </TouchableOpacity>
-    </View>
-  );
-}
-
-function HeaderRight({ softExit }: { softExit: boolean }) {
-  const navigation =
-    useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();
-  const { colors } = useTheme();
-
-  const onClose = useCallback(() => {
-    softExit
-      ? navigation.goBack()
-      : navigation.navigate(NavigatorName.Base, {
-          screen: NavigatorName.Main,
-        });
-  }, [navigation, softExit]);
-
-  return (
-    <NavigationHeaderCloseButtonAdvanced
-      onClose={onClose}
-      color={colors.neutral.c100}
-      skipNavigation={softExit}
-    />
-  );
-}
+export type { BackConfig } from "./BackToLwButton";
 
 export type InterstitialType = React.ComponentType<{
   manifest: LiveAppManifest;
   isLoading: boolean;
   description?: string;
 }>;
-
-type Props = {
-  manifest: LiveAppManifest;
-  inputs?: Record<string, string | undefined>;
-  disableHeader?: boolean;
-  config?:
-    | {
-        screen: ScreenName.ExchangeBuy | ScreenName.ExchangeSell;
-        navigator: NavigatorName.Exchange;
-        btnText: string;
-      }
-    | {
-        screen: ScreenName.Card;
-        navigator: NavigatorName.Card;
-        btnText: string;
-      };
-  softExit?: boolean;
-  Interstitial?: InterstitialType;
-};
 
 export const WebPTXPlayer = ({
   manifest,
@@ -145,11 +41,17 @@ export const WebPTXPlayer = ({
   config = {
     screen: ScreenName.ExchangeSell,
     btnText: manifest.name,
-    navigator: NavigatorName.Exchange,
   },
   softExit = false,
   Interstitial,
-}: Props) => {
+}: {
+  manifest: LiveAppManifest;
+  inputs?: Record<string, string | undefined>;
+  disableHeader?: boolean;
+  config?: BackConfig;
+  softExit?: boolean;
+  Interstitial?: InterstitialType;
+}) => {
   const lastMatchingURL = useRef<string | null>(null);
   const webviewAPIRef = useRef<WebviewAPI>(null);
   const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
@@ -193,12 +95,9 @@ export const WebPTXPlayer = ({
               storage.saveString("last-screen", lastScreen),
             ]);
 
-            navigation.navigate(config.navigator, {
-              screen: config.screen,
-              params: {
-                platform: manifestId,
-                goToURL,
-              },
+            handleBackToLwEntryPoint(navigation, config.screen, {
+              platform: manifestId,
+              goToURL,
             });
 
             return void 0;
@@ -210,7 +109,7 @@ export const WebPTXPlayer = ({
         lastMatchingURL.current = webviewState.url;
       }
     })();
-  }, [config.navigator, config.screen, isInternalApp, navigation, webviewState.url]);
+  }, [config.screen, isInternalApp, navigation, webviewState.url]);
 
   const handleHardwareBackPress = useCallback(() => {
     const webview = safeGetRefValue(webviewAPIRef);
@@ -254,7 +153,7 @@ export const WebPTXPlayer = ({
   useEffect(() => {
     if (!disableHeader) {
       navigation.setOptions({
-        headerRight: () => (isInternalApp ? null : <HeaderRight softExit={softExit} />),
+        headerRight: () => null,
         headerLeft: () => (isInternalApp ? null : <BackToInternalDomain config={config} />),
         headerTitle: () => null,
         title: "",
@@ -290,15 +189,3 @@ export const WebPTXPlayer = ({
 const PTXLoader = () => {
   return <Loading />;
 };
-
-const styles = StyleSheet.create({
-  headerLeft: {
-    display: "flex",
-    flexDirection: "row",
-    paddingRight: 8,
-  },
-  buttons: {
-    paddingVertical: 8,
-    paddingHorizontal: 8,
-  },
-});

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -7248,7 +7248,8 @@
         "website": "website"
       },
       "back": {
-        "card": "all cards"
+        "card": "all cards",
+        "cardTab": "card"
       }
     }
   },

--- a/apps/ledger-live-mobile/src/mvvm/features/Card/screens/CardLiveAppScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Card/screens/CardLiveAppScreen/index.tsx
@@ -5,20 +5,30 @@ import { NavigatorName, ScreenName } from "~/const";
 import { useTranslation } from "~/context/Locale";
 import { PtxScreen } from "~/screens/PTX";
 import { CARD_APP_ID } from "../../constants";
+import { BackConfig } from "~/components/WebPTXPlayer";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 type CardLiveAppScreenProps = StackNavigatorProps<PtxNavigatorParamList, ScreenName.Card>;
 
 export function CardLiveAppScreen(props: CardLiveAppScreenProps) {
   const { t } = useTranslation();
   const { goToURL, lastScreen, platform, path, referrer } = props.route.params || {};
+  const lwmWallet40 = useFeature("lwmWallet40");
+  const config: BackConfig =
+    !lwmWallet40?.enabled || platform === CARD_APP_ID
+      ? {
+          screen: ScreenName.Card,
+          btnText: t("browseWeb3.webPlatformPlayer.back.card"),
+        }
+      : {
+          screen: NavigatorName.CardTab,
+          btnText: t("browseWeb3.webPlatformPlayer.back.cardTab"),
+        };
+
   return (
     <PtxScreen
       {...props}
-      config={{
-        screen: ScreenName.Card,
-        navigator: NavigatorName.Card,
-        btnText: t("browseWeb3.webPlatformPlayer.back.card"),
-      }}
+      config={config}
       route={{
         ...props.route,
         params: {

--- a/apps/ledger-live-mobile/src/screens/PTX/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/index.tsx
@@ -15,10 +15,10 @@ import { useTheme } from "styled-components/native";
 import { Flex, InfiniteLoader } from "@ledgerhq/native-ui";
 import TrackScreen from "~/analytics/TrackScreen";
 import GenericErrorView from "~/components/GenericErrorView";
-import { WebPTXPlayer } from "~/components/WebPTXPlayer";
+import { BackConfig, WebPTXPlayer } from "~/components/WebPTXPlayer";
 import { PtxNavigatorParamList } from "~/components/RootNavigator/types/PtxNavigator";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
-import { ScreenName, NavigatorName } from "~/const";
+import { ScreenName } from "~/const";
 import { accountsSelector } from "~/reducers/accounts";
 import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 import { INTERNAL_APP_IDS, WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
@@ -33,17 +33,7 @@ export type Props = StackNavigatorProps<
   PtxNavigatorParamList,
   ScreenName.ExchangeBuy | ScreenName.ExchangeSell | ScreenName.Card
 > & {
-  config?:
-    | {
-        screen: ScreenName.ExchangeBuy | ScreenName.ExchangeSell;
-        navigator: NavigatorName.Exchange;
-        btnText: string;
-      }
-    | {
-        screen: ScreenName.Card;
-        navigator: NavigatorName.Card;
-        btnText: string;
-      };
+  config?: BackConfig;
 };
 
 const appManifestNotFoundError = new Error("App not found"); // FIXME move this elsewhere.


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The top bar behaves in mysterious ways on LWM. 

1. I'm being more explicit with the actions it takes when you click the back button. So we only send down screen and then the ptx player chooses the navigator to use - the component was using types to tightly bind these anyway so this simplifies it's use.

2. Close button is removed, the functionality this brought was almost exactly the same as the back button.

3. Fixed issues with the config when returning to the new tab view on LWM

4. Updated copy in both LWM and LWD to make it clearer what is going to happen when you click the button

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-25901

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
