### PR TITLE
fix(live-common) [LIVE-26834]: Fix onboarding showing error instead of recovery UI in bootloader mode

### DIFF
--- a/.changeset/fix-onboarding-bootloader-polling.md
+++ b/.changeset/fix-onboarding-bootloader-polling.md
@@ -2,4 +2,4 @@
 "@ledgerhq/live-common": patch
 ---
 
-Fix onboarding polling showing CLA_NOT_SUPPORTED error instead of firmware recovery UI when device is in bootloader mode
+Fix onboarding polling error when device is in bootloader mode: call getVersion first and handle both CLA_NOT_SUPPORTED and INS_NOT_SUPPORTED errors to trigger quitApp only when an app is intercepting

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
@@ -347,57 +347,70 @@ describe("getOnboardingStatePolling", () => {
       jest.advanceTimersByTime(pollingPeriodMs - 1);
     });
 
-    it("should call quitApp and retry getVersion when getVersion fails with INS_NOT_SUPPORTED", done => {
-      const insError = new TransportStatusError(StatusCodes.INS_NOT_SUPPORTED);
-      mockedGetVersion.mockRejectedValueOnce(insError).mockResolvedValue(aFirmwareInfo);
-      mockedExtractOnboardingState.mockReturnValue(anOnboardingState);
+    it.each([
+      { name: "INS_NOT_SUPPORTED", statusCode: StatusCodes.INS_NOT_SUPPORTED },
+      { name: "CLA_NOT_SUPPORTED", statusCode: StatusCodes.CLA_NOT_SUPPORTED },
+    ])(
+      "should call quitApp and retry getVersion when getVersion fails with $name",
+      ({ statusCode }, done) => {
+        const error = new TransportStatusError(statusCode);
+        mockedGetVersion.mockRejectedValueOnce(error).mockResolvedValue(aFirmwareInfo);
+        mockedExtractOnboardingState.mockReturnValue(anOnboardingState);
 
-      const device = aDevice;
+        const device = aDevice;
 
-      onboardingStatePollingSubscription = getOnboardingStatePolling({
-        deviceId: device.deviceId,
-        deviceName: null,
-        pollingPeriodMs,
-      }).subscribe({
-        next: value => {
-          try {
-            expect(value.onboardingState).toEqual(anOnboardingState);
-            expect(mockedQuitApp).toHaveBeenCalledTimes(1);
-            expect(mockedGetVersion).toHaveBeenCalledTimes(2);
-            done();
-          } catch (err) {
-            done(err);
-          }
-        },
-        error: err => done(err),
-      });
+        onboardingStatePollingSubscription = getOnboardingStatePolling({
+          deviceId: device.deviceId,
+          deviceName: null,
+          pollingPeriodMs,
+        }).subscribe({
+          next: value => {
+            try {
+              expect(value.onboardingState).toEqual(anOnboardingState);
+              expect(mockedQuitApp).toHaveBeenCalledTimes(1);
+              expect(mockedGetVersion).toHaveBeenCalledTimes(2);
+              done();
+            } catch (err) {
+              done(err);
+            }
+          },
+          error: err => done(err),
+        });
 
-      jest.advanceTimersByTime(pollingPeriodMs - 1);
-    });
+        jest.advanceTimersByTime(pollingPeriodMs - 1);
+      },
+    );
 
-    it("should only attempt quitApp once even if getVersion keeps failing with INS_NOT_SUPPORTED", async () => {
-      const insError = new TransportStatusError(StatusCodes.INS_NOT_SUPPORTED);
-      mockedGetVersion.mockRejectedValue(insError);
-      mockedExtractOnboardingState.mockReturnValue(anOnboardingState);
+    it.each([
+      { name: "INS_NOT_SUPPORTED", statusCode: StatusCodes.INS_NOT_SUPPORTED },
+      { name: "CLA_NOT_SUPPORTED", statusCode: StatusCodes.CLA_NOT_SUPPORTED },
+    ])(
+      "should only attempt quitApp once even if getVersion keeps failing with $name",
+      async ({ statusCode }) => {
+        const appError = new TransportStatusError(statusCode);
+        mockedGetVersion.mockRejectedValue(appError);
+        mockedExtractOnboardingState.mockReturnValue(anOnboardingState);
 
-      const device = aDevice;
-      const values: { onboardingState: OnboardingState | null; allowedError: Error | null }[] = [];
+        const device = aDevice;
+        const values: { onboardingState: OnboardingState | null; allowedError: Error | null }[] =
+          [];
 
-      onboardingStatePollingSubscription = getOnboardingStatePolling({
-        deviceId: device.deviceId,
-        deviceName: null,
-        pollingPeriodMs,
-      }).subscribe({
-        next: value => values.push(value),
-      });
+        onboardingStatePollingSubscription = getOnboardingStatePolling({
+          deviceId: device.deviceId,
+          deviceName: null,
+          pollingPeriodMs,
+        }).subscribe({
+          next: value => values.push(value),
+        });
 
-      await jest.advanceTimersByTimeAsync(pollingPeriodMs * 3);
+        await jest.advanceTimersByTimeAsync(pollingPeriodMs * 3);
 
-      expect(values.length).toBeGreaterThanOrEqual(1);
-      expect(values[0].onboardingState).toBeNull();
-      expect(values[0].allowedError).toBeInstanceOf(TransportStatusError);
-      expect(mockedQuitApp).toHaveBeenCalledTimes(1);
-    });
+        expect(values.length).toBeGreaterThanOrEqual(1);
+        expect(values[0].onboardingState).toBeNull();
+        expect(values[0].allowedError).toBeInstanceOf(TransportStatusError);
+        expect(mockedQuitApp).toHaveBeenCalledTimes(1);
+      },
+    );
 
     it("should not call getVersion retry until quitApp completes", async () => {
       const insError = new TransportStatusError(StatusCodes.INS_NOT_SUPPORTED);

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
@@ -73,11 +73,13 @@ export const getOnboardingStatePolling = ({
 
       return getVersionObs.pipe(
         catchError((error: unknown) => {
-          const isInsNotSupported =
+          const isApduNotSupported =
             error instanceof TransportStatusError &&
-            error.statusCode === StatusCodes.INS_NOT_SUPPORTED;
+            [StatusCodes.CLA_NOT_SUPPORTED, StatusCodes.INS_NOT_SUPPORTED].includes(
+              (error as TransportStatusError).statusCode,
+            );
 
-          if (isInsNotSupported && !hasQuitAppAlreadyRun) {
+          if (isApduNotSupported && !hasQuitAppAlreadyRun) {
             hasQuitAppAlreadyRun = true;
             return quitApp(t).pipe(switchMap(() => getVersionObs));
           }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Onboarding flow when device is in bootloader mode (firmware update interrupted)
  - Onboarding flow when an app is left open on the device
  - Normal onboarding polling (no behavioral change in the happy path)

### 📝 Description

**Problem:** PR #13876 introduced a `quitApp` call before `getVersion` in the onboarding state polling. When a device is in bootloader mode, the bootloader does not support the `getAppAndVersion` (APDU `b0 01 00 00 00`) that `quitApp` sends first. This returns `6e00` (CLA_NOT_SUPPORTED), a `TransportStatusError`. Since this is an allowed error, the polling surfaces it to the UI as an error state — showing a troubleshooting drawer instead of properly detecting bootloader mode and displaying the firmware recovery flow.

The root cause: `quitApp` fails before `getVersion` is ever reached, so `isBootloader` is never detected, `UnexpectedBootloader` is never thrown, and the recovery `DeviceAction` is never shown.

**Solution:** Reversed the approach — call `getVersion` first (APDU `e0 01 00 00 00`), which works in bootloader, dashboard, and fails with INS_NOT_SUPPORTED / CLA_NOT_SUPPORTED (depending on the app), in which case we fall back to calling quitApp.

<table>
<tr>
<td valign="top">

#### Before (broken flow introduced by #13876)

<img width="1000" height="1816" alt="824b220b-ecc2-4213-8dc9-d12d3163e2d7-1" src="https://github.com/user-attachments/assets/bec675ba-7659-4d73-b9e9-13481446a35f" />


</td>
<td valign="top">

#### After (this fix)

<img width="1166" height="2558" alt="a26bde55-9ecf-4be5-bbfa-acd71f1b746a" src="https://github.com/user-attachments/assets/95dadec3-073a-463f-9043-6ebe180df2fe" />


</td>
</tr>
</table>

### ❓ Context

- **JIRA link**: [LIVE-26834](https://ledgerhq.atlassian.net/browse/LIVE-26834)
- **GitHub link**: Regression introduced by #13876

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26834]: https://ledgerhq.atlassian.net/browse/LIVE-26834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ