### PR TITLE
fix(market-banner): add eslint-plugin-import to resolve lint failure

### DIFF
--- a/.changeset/funny-gifts-wait.md
+++ b/.changeset/funny-gifts-wait.md
@@ -1,0 +1,5 @@
+---
+"@features/market-banner": minor
+---
+
+fix import duplicates eslint rule

--- a/features/market-banner/.eslintrc.js
+++ b/features/market-banner/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
       jsx: true,
     },
   },
-  plugins: ["@typescript-eslint", "react", "react-hooks", "better-tailwindcss"],
+  plugins: ["@typescript-eslint", "react", "react-hooks", "import", "better-tailwindcss"],
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",

--- a/features/market-banner/package.json
+++ b/features/market-banner/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "tailwindcss": "catalog:",
     "eslint-plugin-better-tailwindcss": "catalog:",
+    "eslint-plugin-import": "2.32.0",
     "@gorhom/bottom-sheet": "catalog:",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2543,6 +2543,9 @@ importers:
       eslint-plugin-better-tailwindcss:
         specifier: 'catalog:'
         version: 4.0.0-beta.3(eslint@8.57.0)(tailwindcss@4.1.18)(typescript@5.4.3)
+      eslint-plugin-import:
+        specifier: 2.32.0
+        version: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)
       jest:
         specifier: 'catalog:'
         version: 30.2.0(@types/node@22.19.3)


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _ESLint config change — validated by the CI lint step itself._
- [x] **Impact of the changes:**
  - `@features/market-banner` lint task passes in CI

### 📝 Description

The `chore/lumen-bump` PR (#14721) caused the `@features/market-banner` lint CI job to fail with 9 errors: `Definition for rule 'import/no-duplicates' was not found`.

The market-banner ESLint config spreads rules from the mobile and desktop configs (`...mobileConfig.rules`, `...desktopConfig.rules`), which include `"import/no-duplicates": "error"`. However, `eslint-plugin-import` was neither declared in the `plugins` array nor listed as a dependency, so ESLint couldn't resolve the rule.

**Fix:**
- Added `"import"` to the `plugins` array in `.eslintrc.js`
- Added `"eslint-plugin-import": "2.32.0"` as a `devDependency` (same version used by both desktop and mobile apps)

### ❓ Context

- **GitHub link**: https://github.com/LedgerHQ/ledger-live/actions/runs/22351335050/job/64678974071

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)