### PR TITLE
fix(mobile): always trigger opt-in notifications after pairing device

### DIFF
--- a/.changeset/six-laws-thank.md
+++ b/.changeset/six-laws-thank.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: show drawer optimise opt in notifs after onboarding

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/useCompletePostOnboarding.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/useCompletePostOnboarding.ts
@@ -4,19 +4,24 @@ import { useDispatch } from "~/context/hooks";
 import { useNavigation } from "@react-navigation/native";
 import { postOnboardingSetFinished } from "@ledgerhq/live-common/postOnboarding/actions";
 import { NavigatorName } from "~/const";
+import { useNotifications } from "LLM/features/NotificationsPrompt";
 
 export function useCompletePostOnboarding() {
   const dispatch = useDispatch();
   const navigation = useNavigation();
 
+  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
+
   const closePostOnboarding = useCallback(() => {
+    tryTriggerPushNotificationDrawerAfterAction("onboarding");
+
     dispatch(postOnboardingSetFinished());
 
     navigation.navigate(NavigatorName.Main, {
       screen: NavigatorName.Portfolio,
       params: { screen: NavigatorName.WalletTab },
     });
-  }, [dispatch, navigation]);
+  }, [dispatch, navigation, tryTriggerPushNotificationDrawerAfterAction]);
 
   return closePostOnboarding;
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This fix is a one-line behavioral change that wires an existing notification trigger into an existing hook; manual QA verification is sufficient._
- [x] **Impact of the changes:**
  - Opt-in push notification drawer should now consistently appear after the LedgerSync activation drawer is closed post-onboarding
  - Verify the drawer does **not** appear at unexpected times (outside of the onboarding flow)

### 📝 Description

Previously, when a user paired a device and went through the LedgerSync activation flow during onboarding, the opt-in push notifications drawer was not being triggered after the activation drawer was dismissed. This caused users to never see the notification opt-in prompt after pairing.

The fix calls `tryTriggerPushNotificationDrawerAfterAction("onboarding")` inside `closeActivationDrawer`, so the notification prompt fires correctly at the end of the LedgerSync onboarding step — consistent with how other post-onboarding actions behave.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26862

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
