### PR TITLE
feat(desktop): transparent background for buy/sell exchange

### DIFF
--- a/.changeset/quiet-flowers-trade.md
+++ b/.changeset/quiet-flowers-trade.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Transparent background for buy/sell

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -3,7 +3,6 @@ import semver from "semver";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
-import Card from "~/renderer/components/Box/Card";
 import {
   counterValueCurrencySelector,
   developerModeSelector,
@@ -35,6 +34,7 @@ import { NetworkErrorScreen } from "~/renderer/components/Web3AppWebview/Network
 import { ProviderInterstitial } from "LLD/components/ProviderInterstitial";
 import PageHeader from "LLD/components/PageHeader";
 import { getWallet40HeaderKey } from "./helpers";
+import Box from "~/renderer/components/Box/Box";
 
 type ExchangeState = { account?: string } | undefined;
 
@@ -108,12 +108,13 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
   }
 
   const headerKey = getWallet40HeaderKey(manifest.id);
+
   return (
     <>
       {shouldDisplayWallet40MainNav && headerKey ? (
         <PageHeader title={t(headerKey)} onBack={() => navigate(-1)} />
       ) : null}
-      <Card
+      <Box
         grow
         style={{
           overflow: "hidden",
@@ -141,7 +142,7 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
           }}
           Loader={providerInterstitialEnabled ? ProviderInterstitial : undefined}
         />
-      </Card>
+      </Box>
     </>
   );
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Exchange screen is existing UI; no new tests added for this visual change._
- [x] **Impact of the changes:**
  - Buy/Sell (Exchange) screen container: Card replaced with Box for transparent background
  - Visual consistency with transparent background behind the webview

### 📝 Description

**Problem:** The buy/sell (exchange) screen used a `Card` component, which renders an opaque background. This will clash with LW40 plans for the background where we need it to be transparent

**Solution:** Replaced the `Card` wrapper with a `Box` component on the Exchange screen

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-26390

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)