### PR TITLE
:bug: fix: [LIVE-26778] near continue after selecting validator fix

### DIFF
--- a/.changeset/thin-oranges-design.md
+++ b/.changeset/thin-oranges-design.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix Near LWM continue step after selecting validator

--- a/apps/ledger-live-mobile/src/families/near/StakingFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/near/StakingFlow/02-Summary.tsx
@@ -56,8 +56,8 @@ export default function StakingSummary({ navigation, route }: Props) {
     return validators[0];
   }, [validators, validator]);
 
-  const { transaction, updateTransaction, setTransaction, status, bridgePending, bridgeError } =
-    useBridgeTransaction(() => {
+  const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    () => {
       const tx = route.params.transaction;
 
       if (!tx) {
@@ -73,17 +73,13 @@ export default function StakingSummary({ navigation, route }: Props) {
       }
 
       return { account, transaction: tx };
-    });
+    },
+  );
 
   invariant(transaction, "transaction must be defined");
   invariant(transaction.family === "near", "transaction near");
 
   useEffect(() => {
-    const tmpTransaction = route.params.transaction;
-    if (tmpTransaction) {
-      updateTransaction(_ => tmpTransaction);
-    }
-
     if (chosenValidator.validatorAddress !== transaction.recipient) {
       setTransaction(
         bridge.updateTransaction(transaction, {
@@ -91,15 +87,7 @@ export default function StakingSummary({ navigation, route }: Props) {
         }),
       );
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    route.params,
-    bridge,
-    setTransaction,
-    chosenValidator,
-    updateTransaction,
-    route.params.transaction,
-  ]);
+  }, [bridge, setTransaction, chosenValidator, transaction]);
 
   const [rotateAnim] = useState(() => new Animated.Value(0));
   useEffect(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - fix Near LWM continue step after selecting validator

### 📝 Description

On LWM the user was stuck on selecting validator process due to a continuous re-render state.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26778


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
