### PR TITLE
fix(desktop): wait for webview before market buy page screenshot

### DIFF
--- a/.changeset/large-boats-cross.md
+++ b/.changeset/large-boats-cross.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix flaky market test

--- a/apps/ledger-live-desktop/tests/specs/market/market.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/market/market.spec.ts
@@ -182,6 +182,7 @@ test("Market", async ({ page, electronApp }) => {
 
   await test.step("buy bitcoin from market page", async () => {
     await marketPage.openBuyPage("btc");
+    await page.locator("webview").waitFor({ state: "attached" });
     await expect
       .soft(page)
       .toHaveScreenshot("market-btc-buy-page.png", { mask: [page.locator("webview")] });
@@ -210,6 +211,7 @@ test("Market", async ({ page, electronApp }) => {
 
   await test.step("buy bitcoin from coin page", async () => {
     await marketCoinPage.openBuyPage();
+    await page.locator("webview").waitFor({ state: "attached" });
     await expect
       .soft(page)
       .toHaveScreenshot("market-btc-buy-page.png", { mask: [page.locator("webview")] });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This PR fixes an existing E2E test — snapshot regeneration is required after merge._
- [x] **Impact of the changes:**
      - Market E2E screenshot test stability
      - No runtime/UI impact — test-only change

### 📝 Description

The market E2E test (`market.spec.ts`) was failing with a 63% pixel difference on the `market-btc-buy-page` screenshot.

**Problem**: The screenshot was taken immediately after navigating to `/exchange`, before the `<webview>` element mounted in the DOM. The mask `page.locator("webview")` matched nothing and was silently skipped, causing the screenshot to capture a transitional loading state instead of the expected page layout.

**Fix**: Added `await page.locator("webview").waitFor({ state: "attached" })` before both buy-page screenshot assertions (from market page and from coin page) to ensure the webview is present and correctly masked.

> **Note**: The snapshot `market-btc-buy-page-linux.png` needs to be regenerated after this fix by triggering the "[Desktop] - Generate Screenshots - Manual" workflow.

### ❓ Context

- **GitHub link**: Fixes flaky `market.spec.ts` E2E test in CI

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)