### PR TITLE
fix(mobile): android webview with blur

### DIFF
--- a/.changeset/silent-spoons-hang.md
+++ b/.changeset/silent-spoons-hang.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix blur conflicts with webview on RN

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -78,6 +78,7 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
           onLoadError();
           setError(true);
         }}
+        androidLayerType="software"
         onOpenWindow={onOpenWindow}
         overScrollMode="content"
         bounces={false}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Android doc regarding the prop https://developer.android.com/reference/android/webkit/WebView#setLayerType(int,%20android.graphics.Paint)


Android build: https://github.com/LedgerHQ/ledger-live-build/actions/runs/22400456065

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26832](https://ledgerhq.atlassian.net/browse/LIVE-26832)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26832]: https://ledgerhq.atlassian.net/browse/LIVE-26832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ