### PR TITLE
fix(mobile): android show opt-in notifications drawer after onboarding

### DIFF
--- a/.changeset/nervous-tigers-shop.md
+++ b/.changeset/nervous-tigers-shop.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: android prompt notifications drawer after onboarding

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPrompt.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPrompt.test.tsx
@@ -79,6 +79,7 @@ describe("NotificationsPrompt Integration", () => {
     dateOfNextAllowedRequest,
     alreadyDelayedToLater,
     variant = ABTestingVariants.variantB,
+    skipStorageSetup = false,
   }: {
     actionSource?: Exclude<NotificationsState["drawerSource"], undefined | "inactivity">;
     osPermission: AuthorizationStatusType;
@@ -87,14 +88,17 @@ describe("NotificationsPrompt Integration", () => {
     dateOfNextAllowedRequest?: Date;
     alreadyDelayedToLater?: boolean;
     variant?: ABTestingVariants;
+    skipStorageSetup?: boolean;
   }) {
     mockHasPermission.mockResolvedValue(osPermission);
     mockRequestPermission.mockResolvedValue(osPermission);
-    await setPushNotificationsDataOfUserInStorage({
-      lastActionAt,
-      dateOfNextAllowedRequest,
-      alreadyDelayedToLater,
-    });
+    if (!skipStorageSetup) {
+      await setPushNotificationsDataOfUserInStorage({
+        lastActionAt,
+        dateOfNextAllowedRequest,
+        alreadyDelayedToLater,
+      });
+    }
 
     function SetupComponent() {
       const [isReady, setIsReady] = useState(false);
@@ -853,6 +857,21 @@ describe("NotificationsPrompt Integration", () => {
         act(() => jest.runOnlyPendingTimers());
         expect(screen.getByText(/allow notifications/i)).toBeOnTheScreen();
       });
+    });
+  });
+
+  describe("protected onboarding flow", () => {
+    it("should skip permissions sync and show notifications drawer after an action", async () => {
+      const { tryTriggerDrawer } = await setup({
+        skipStorageSetup: true,
+        osPermission: AuthorizationStatus.NOT_DETERMINED,
+        appNotifications: true,
+        actionSource: "onboarding",
+      });
+
+      await tryTriggerDrawer();
+
+      expect(screen.getByText(/allow notifications/i)).toBeOnTheScreen();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsData.ts
@@ -78,6 +78,11 @@ export const useNotificationsData = () => {
       osPermissionStatus: (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus],
       storedUserData: DataOfUser | null,
     ) => {
+      // user has just been onboarded but is quickly redirected to the recover upsell screen.
+      // So ignore the sync of permissions state.
+      if (storedUserData == null) {
+        return;
+      }
       const isAuthorized = osPermissionStatus === AuthorizationStatus.AUTHORIZED;
       // Handle legacy users who opted out before the new drawer system
       const hasLegacyOptOutData =


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Notifications opt-in drawer on Android after onboarding / pair device flow
  - Fresh onboarded users (no stored notifications data) should see the drawer instead of permissions sync skipping it

### 📝 Description

**Problem:** On Android, after onboarding (pair device flow), the user is quickly redirected to the recover upsell screen. The notifications permissions sync was running with `storedUserData == null` and could prevent the opt-in notifications drawer from being shown.

**Solution:** In `useNotificationsData`, when `storedUserData` is null (fresh onboarded user), skip the permissions sync so the drawer can be triggered and shown. Added integration test for the protected onboarding flow to assert the drawer is shown after an onboarding action when storage is not set up.

### ❓ Context

- **JIRA or GitHub link**: 
https://ledgerhq.atlassian.net/browse/LIVE-26916 

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
