### PR TITLE
refactor(desktop,mobile): rename store files to consistent state-manager/configureStore

### DIFF
--- a/.changeset/consistent-configure-store-files.md
+++ b/.changeset/consistent-configure-store-files.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Rename store files to consistent state-manager/configureStore convention

--- a/apps/ledger-live-desktop/src/mvvm/features/AppBlockers/components/AppGeoBlocker/__integrations__/AppGeoblocker.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AppBlockers/components/AppGeoBlocker/__integrations__/AppGeoblocker.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { getEnv } from "@ledgerhq/live-env";
 import { server, HttpResponse, http } from "tests/server";
 import { waitFor, render, screen, cleanup } from "tests/testSetup";
-import createStore from "~/renderer/createStore";
+import createStore from "~/state-manager/configureStore";
 import { AppGeoBlocker } from "../index";
 
 jest.mock("~/renderer/linking", () => ({

--- a/apps/ledger-live-desktop/src/mvvm/hooks/redux.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/redux.ts
@@ -4,7 +4,7 @@ import {
   useStore as useStoreBase,
 } from "react-redux";
 import type { State } from "~/renderer/reducers";
-import type { AppDispatch, ReduxStore } from "~/renderer/createStore";
+import type { AppDispatch, ReduxStore } from "~/state-manager/configureStore";
 
 export const useDispatch = useDispatchBase.withTypes<AppDispatch>();
 export const useSelector = useSelectorBase.withTypes<State>();

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
@@ -1,6 +1,6 @@
 import { Account, TokenAccount } from "@ledgerhq/types-live";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { AppDispatch } from "~/renderer/createStore";
+import type { AppDispatch } from "~/state-manager/configureStore";
 
 export type NavigateFn = (
   pathname: string,

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -28,8 +28,8 @@ import { enableGlobalTab, disableGlobalTab, isGlobalTabEnabled } from "~/config/
 import sentry from "~/sentry/renderer";
 import { setEnvOnAllThreads } from "~/helpers/env";
 import dbMiddleware from "~/renderer/middlewares/db";
-import type { ReduxStore, AppDispatch } from "~/renderer/createStore";
-import createStore from "~/renderer/createStore";
+import type { ReduxStore, AppDispatch } from "~/state-manager/configureStore";
+import createStore from "~/state-manager/configureStore";
 import { setupListeners } from "@reduxjs/toolkit/query";
 import events from "~/renderer/events";
 import { initAccounts } from "~/renderer/actions/accounts";

--- a/apps/ledger-live-desktop/src/renderer/recentAddresses.ts
+++ b/apps/ledger-live-desktop/src/renderer/recentAddresses.ts
@@ -4,9 +4,9 @@ import {
   RecentAddressesCache,
 } from "@ledgerhq/live-common/account/index";
 import { updateRecentAddresses } from "@ledgerhq/live-wallet/store";
-import { ReduxStore } from "./createStore";
-import { recentAddressesSelector } from "./reducers/wallet";
-import { Unsubscribe } from "@reduxjs/toolkit";
+import type { Unsubscribe } from "@reduxjs/toolkit";
+import type { ReduxStore } from "~/state-manager/configureStore";
+import { recentAddressesSelector } from "~/renderer/reducers/wallet";
 
 let unsubscribe: Unsubscribe;
 

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -2,7 +2,7 @@ import { configureStore, Middleware, ThunkDispatch } from "@reduxjs/toolkit";
 import { UnknownAction } from "redux";
 import logger from "~/renderer/middlewares/logger";
 import reducers, { State } from "~/renderer/reducers";
-import { applyLldRTKApiMiddlewares } from "./reducers/rtkQueryApi";
+import { applyLldRTKApiMiddlewares } from "~/renderer/reducers/rtkQueryApi";
 import { createIdentitiesSyncMiddleware } from "@ledgerhq/client-ids/store";
 import { trackingEnabledSelector } from "~/renderer/reducers/settings";
 import { getUserId } from "~/helpers/user";

--- a/apps/ledger-live-desktop/tests/testSetup.tsx
+++ b/apps/ledger-live-desktop/tests/testSetup.tsx
@@ -18,8 +18,8 @@ import ContextMenuWrapper from "~/renderer/components/ContextMenu/ContextMenuWra
 import { useCountervaluesMarketcapBridge } from "~/renderer/components/CountervaluesMarketcapProvider";
 import { useCountervaluesBridge } from "~/renderer/components/CountervaluesProvider";
 import { FirebaseFeatureFlagsProvider } from "~/renderer/components/FirebaseFeatureFlags";
-import type { ReduxStore } from "~/renderer/createStore";
-import createStore from "~/renderer/createStore";
+import type { ReduxStore } from "~/state-manager/configureStore";
+import createStore from "~/state-manager/configureStore";
 import DrawerProvider from "~/renderer/drawers/Provider";
 import i18n from "~/renderer/i18n/init";
 import dbMiddleware from "~/renderer/middlewares/db";

--- a/apps/ledger-live-mobile/.eslintrc.js
+++ b/apps/ledger-live-mobile/.eslintrc.js
@@ -139,19 +139,6 @@ module.exports = {
   },
   overrides: [
     {
-      // Allow direct react-redux imports in hooks.ts/store.ts where typed hooks are defined
-      files: ["src/context/hooks.ts", "src/context/store.ts", "src/context/selectors.ts"],
-      rules: {
-        "no-restricted-imports": [
-          "error",
-          {
-            patterns: commonImportRestrictions,
-            paths: lodashImportRestriction,
-          },
-        ],
-      },
-    },
-    {
       files: [
         "src/**/*.test.{ts,tsx}",
         "src/screens/Settings/Debug/**/*",

--- a/apps/ledger-live-mobile/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/client.ts
@@ -1,7 +1,7 @@
 import { Platform } from "react-native";
 import invariant from "invariant";
 import { Subject } from "rxjs";
-import { store } from "~/context/store";
+import { store } from "~/state-manager/configureStore";
 import {
   importSettings,
   setLastConnectedDevice,

--- a/apps/ledger-live-mobile/src/config/bridge-setup.ts
+++ b/apps/ledger-live-mobile/src/config/bridge-setup.ts
@@ -1,6 +1,6 @@
 import { cryptoAssetsApi, createRtkCryptoAssetsStore } from "@ledgerhq/cryptoassets/cal-client";
 import { setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
-import { StoreType } from "../context/store";
+import type { StoreType } from "~/state-manager/configureStore";
 
 export function setupCryptoAssetsStore(store: StoreType) {
   const cryptoAssetsStore = createRtkCryptoAssetsStore(cryptoAssetsApi, async <T>(action: T) => {

--- a/apps/ledger-live-mobile/src/context/hooks.ts
+++ b/apps/ledger-live-mobile/src/context/hooks.ts
@@ -1,10 +1,11 @@
+/* eslint-disable no-restricted-imports */
 import {
   useDispatch as useDispatchBase,
   useSelector as useSelectorBase,
   useStore as useStoreBase,
 } from "react-redux";
 import type { State } from "~/reducers/types";
-import type { store } from "./store";
+import { store } from "~/state-manager/configureStore";
 
 type AppDispatch = typeof store.dispatch;
 type StoreType = typeof store;

--- a/apps/ledger-live-mobile/src/context/selectors.ts
+++ b/apps/ledger-live-mobile/src/context/selectors.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import {
   createStructuredSelector as createStructuredSelectorBase,
   createSelector as createSelectorBase,

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -34,7 +34,7 @@ import LocaleProvider, { i18n } from "~/context/Locale";
 import AuthPass from "~/context/AuthPass";
 import LedgerStoreProvider from "~/context/LedgerStore";
 import { useSelector, useDispatch } from "~/context/hooks";
-import { store } from "~/context/store";
+import { store } from "~/state-manager/configureStore";
 import LoadingApp from "~/components/LoadingApp";
 import StyledStatusBar from "~/components/StyledStatusBar";
 import AnalyticsConsole from "~/components/AnalyticsConsole";

--- a/apps/ledger-live-mobile/src/logic/terms.tsx
+++ b/apps/ledger-live-mobile/src/logic/terms.tsx
@@ -6,7 +6,7 @@ import { urls } from "~/utils/urls";
 import { generalTermsVersionAcceptedSelector } from "~/reducers/settings";
 import { setGeneralTermsVersionAccepted } from "~/actions/settings";
 import { useSelector, useDispatch } from "~/context/hooks";
-import { StoreType } from "~/context/store";
+import type { StoreType } from "~/state-manager/configureStore";
 
 const generalTermsVersionRequired = "2022-05-10";
 

--- a/apps/ledger-live-mobile/src/mvvm/storage/recentAddresses.ts
+++ b/apps/ledger-live-mobile/src/mvvm/storage/recentAddresses.ts
@@ -4,7 +4,7 @@ import {
   getRecentAddressesStore,
 } from "@ledgerhq/live-common/account/index";
 import { updateRecentAddresses } from "@ledgerhq/live-wallet/store";
-import { StoreType } from "~/context/store";
+import type { StoreType } from "~/state-manager/configureStore";
 import { recentAddressesSelector } from "~/reducers/wallet";
 import { Unsubscribe } from "@reduxjs/toolkit";
 

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -5,15 +5,14 @@ import NetInfo from "@react-native-community/netinfo";
 import reducers from "~/reducers";
 import { rebootMiddleware } from "~/middleware/rebootMiddleware";
 import { rozeniteDevToolsEnhancer } from "@rozenite/redux-devtools-plugin";
-import { applyLlmRTKApiMiddlewares } from "./rtkQueryApi";
-import { setupCryptoAssetsStore } from "../config/bridge-setup";
+import { applyLlmRTKApiMiddlewares } from "~/context/rtkQueryApi";
+import { setupCryptoAssetsStore } from "~/config/bridge-setup";
 import { setupRecentAddressesStore } from "LLM/storage/recentAddresses";
 import { createIdentitiesSyncMiddleware } from "@ledgerhq/client-ids/store";
 import { State } from "~/reducers/types";
 import { trackingEnabledSelector } from "~/reducers/settings";
 import getOrCreateUser from "~/user";
 
-// === STORE CONFIGURATION ===
 export const store = configureStore({
   reducer: reducers,
   devTools: !!Config.DEBUG_RNDEBUGGER,

--- a/apps/ledger-live-mobile/src/utils/datadogUtils.ts
+++ b/apps/ledger-live-mobile/src/utils/datadogUtils.ts
@@ -3,7 +3,7 @@ import { Primitive } from "~/types/helpers";
 import { enabledExperimentalFeatures } from "../experimental";
 import { getAllDivergedFlags } from "../components/FirebaseFeatureFlags";
 import { languageSelector } from "../reducers/settings";
-import { store } from "../context/store";
+import { store } from "~/state-manager/configureStore";
 
 const MAX_KEYLEN = 32;
 const parseSafeKey = (k: string): string => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _This is a pure file rename/import path refactor with no behavioral changes. Existing tests validate the store still initializes correctly._
- [x] **Impact of the changes:**
      - Rename to Desktop app Redux store configureation
      - Rename of Mobile app Redux store configuration
      - All import paths referencing the renamed files

### 📝 Description

Both `ledger-live-desktop` and `ledger-live-mobile` had inconsistent naming for their Redux store configuration files — desktop used `renderer/createStore.ts` while mobile used `context/store.ts`.

This PR renames both to a consistent `state-manager/configureStore.ts` convention, aligning the project structure and making it easier to navigate between the two apps. All import paths across 14 files have been updated accordingly. No runtime behavior has changed.

https://ledgerhq.atlassian.net/browse/LIVE-27032

### ❓ Context

- No associated ticket — this is a housekeeping refactor to improve codebase consistency.
- Changes based on [[Guidelines] Data Layer Structure](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6111232117/Guideline+Data+Layer+Data+Layer+Structure+Flow)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
