### PR TITLE
fix(mobile): welcome footer bottom spacing

### DIFF
--- a/.changeset/fix-welcome-footer-safe-area.md
+++ b/.changeset/fix-welcome-footer-safe-area.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+---
+
+fix(mobile): WelcomeFooter safe area padding
+
+- Use dynamic paddingBottom in WelcomeFooter so insets are applied at render time

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/WelcomeFooter.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/WelcomeFooter.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from "react-native";
 import { Trans, useTranslation } from "~/context/Locale";
 import { Button, Text as LText } from "@ledgerhq/native-ui";
 import { useWelcomeNavigation } from "../hooks/useWelcomeNavigation";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 /**
  * WelcomeFooter component to display the footer with a button and disclaimer text.
@@ -15,9 +16,10 @@ import { useWelcomeNavigation } from "../hooks/useWelcomeNavigation";
 export function WelcomeFooter() {
   const { t } = useTranslation();
   const { onGetStarted, onPrivacyPolicy, onTermsAndConditions } = useWelcomeNavigation();
+  const insets = useSafeAreaInsets();
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingBottom: Math.max(0, 27 - insets.bottom) }]}>
       <Button
         type="main"
         size="large"
@@ -43,7 +45,6 @@ export function WelcomeFooter() {
 const styles = StyleSheet.create({
   container: {
     paddingHorizontal: 16,
-    paddingBottom: 30,
     marginTop: "auto",
     zIndex: 1,
     backgroundColor: "transparent",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Welcome / onboarding: Footer bottom padding
  
  New Screenshot:
  
<img width="367" height="777" alt="image" src="https://github.com/user-attachments/assets/8215829e-ff9f-4e56-887b-660d6020d42f" />

### 📝 Description

Problem: On the Welcome footer bottom spacing is too big, mainly in iphone.

Solution: Base padding bottom logic in insets (mobile safe area).


### ❓ Context

- JIRA or GitHub link: LIVE-24059 (https://ledgerhq.atlassian.net/browse/LIVE-24059)



---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
