### PR TITLE
fix(desktop): rename portfolio to home in sidebar and breadcrumb

### DIFF
--- a/.changeset/stale-pumpkins-know.md
+++ b/.changeset/stale-pumpkins-know.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"ledger-live-desktop-e2e-tests": minor
+---
+
+update naming in sidebar and breadcrumb for portfolio

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
@@ -52,12 +52,7 @@ export function SideBarView({ viewModel }: SideBarViewProps) {
           onCollapsedChange={viewModel.handleCollapsedChange}
         >
           <SideBarLeading>
-            <SideBarItem
-              value="home"
-              icon={Home}
-              activeIcon={HomeFill}
-              label={t("dashboard.title")}
-            />
+            <SideBarItem value="home" icon={Home} activeIcon={HomeFill} label={t("sidebar.home")} />
             <SideBarItem
               value="accounts"
               icon={Wallet}

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
@@ -46,7 +46,7 @@ describe("SideBar", () => {
     it("should render all leading sidebar items with correct labels", () => {
       renderSideBarWithRoute("/");
 
-      expect(screen.getByText("Portfolio")).toBeVisible();
+      expect(screen.getByText("Home")).toBeVisible();
       expect(screen.getByText("Accounts")).toBeVisible();
       expect(screen.getByText("Swap")).toBeVisible();
       expect(screen.getByText("Earn")).toBeVisible();
@@ -144,7 +144,7 @@ describe("SideBar", () => {
     it("should not navigate when clicking the already active item", async () => {
       const { user } = renderSideBarWithRoute("/");
 
-      await user.click(screen.getByText("Portfolio"));
+      await user.click(screen.getByText("Home"));
 
       expect(mockNavigate).not.toHaveBeenCalled();
     });
@@ -154,8 +154,8 @@ describe("SideBar", () => {
     it("should set home as active when on root path", () => {
       renderSideBarWithRoute("/");
 
-      const portfolioButton = screen.getByText("Portfolio").closest("button");
-      expect(portfolioButton).toHaveAttribute("aria-current", "page");
+      const homeButton = screen.getByText("Home").closest("button");
+      expect(homeButton).toHaveAttribute("aria-current", "page");
     });
 
     it("should set accounts as active when on accounts path", () => {
@@ -172,11 +172,11 @@ describe("SideBar", () => {
       expect(swapButton).toHaveAttribute("aria-current", "page");
     });
 
-    it("should set home as active when on asset sub-path", () => {
+    it("should not set home as active when on asset sub-path", () => {
       renderSideBarWithRoute("/asset/bitcoin");
 
-      const portfolioButton = screen.getByText("Portfolio").closest("button");
-      expect(portfolioButton).toHaveAttribute("aria-current", "page");
+      const homeButton = screen.getByText("Home").closest("button");
+      expect(homeButton).not.toHaveAttribute("aria-current", "page");
     });
 
     it("should set discover as active when on platform path", () => {
@@ -203,8 +203,8 @@ describe("SideBar", () => {
     it("should not set non-active items as current page", () => {
       renderSideBarWithRoute("/accounts");
 
-      const portfolioButton = screen.getByText("Portfolio").closest("button");
-      expect(portfolioButton).not.toHaveAttribute("aria-current");
+      const homeButton = screen.getByText("Home").closest("button");
+      expect(homeButton).not.toHaveAttribute("aria-current");
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/utils/__tests__/helpers.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/utils/__tests__/helpers.test.ts
@@ -4,7 +4,7 @@ import { SIDEBAR_VALUE_TO_PATH } from "../constants";
 describe("pathnameToActive", () => {
   it.each([
     { pathname: SIDEBAR_VALUE_TO_PATH.home, expected: "home" },
-    { pathname: "/asset/bitcoin", expected: "home" },
+    { pathname: "/asset/bitcoin", expected: "" },
     { pathname: SIDEBAR_VALUE_TO_PATH.accounts, expected: "accounts" },
     { pathname: "/account/abc-123", expected: "accounts" },
     { pathname: SIDEBAR_VALUE_TO_PATH.swap, expected: "swap" },

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/utils/helpers.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/utils/helpers.ts
@@ -16,7 +16,7 @@ export function pathnameToActive(
   referPath: string | undefined,
 ): SideBarActiveValue {
   if (referPath && pathname.startsWith(referPath)) return SIDEBAR_SPECIAL_VALUES.refer;
-  if (pathname === "/" || pathname.startsWith("/asset/")) return "home";
+  if (pathname === "/") return "home";
   if (pathname.startsWith("/account")) return "accounts";
   if (pathname.startsWith("/swap")) return "swap";
   if (pathname === "/earn") return "earn";

--- a/apps/ledger-live-desktop/src/renderer/components/Breadcrumb/AssetCrumb.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Breadcrumb/AssetCrumb.tsx
@@ -15,6 +15,7 @@ import { DistributionItem } from "@ledgerhq/types-live";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { hideEmptyTokenAccountsSelector } from "~/renderer/reducers/settings";
 import { useSelector } from "LLD/hooks/redux";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 type ItemShape = {
   key: string;
@@ -24,6 +25,7 @@ type ItemShape = {
 
 export default function AssetCrumb() {
   const { t } = useTranslation();
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("desktop");
   const hideEmptyTokenAccount = useSelector(hideEmptyTokenAccountsSelector);
   const distribution = useDistribution({ hideEmptyTokenAccount });
   const navigate = useNavigate();
@@ -82,7 +84,7 @@ export default function AssetCrumb() {
             navigate("/");
           }}
         >
-          {t("dashboard.title")}
+          {shouldDisplayWallet40MainNav ? t("sidebar.home") : t("dashboard.title")}
         </Button>
       </TextLink>
       <Separator />

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -308,6 +308,7 @@
     "exchange": "Buy / Sell",
     "swap": "Swap",
     "perps": "Perpetuals",
+    "home": "Home",
     "refer": "Refer a friend",
     "lend": "Lend",
     "catalog": "Discover",

--- a/e2e/desktop/tests/page/mainNavigation.page.ts
+++ b/e2e/desktop/tests/page/mainNavigation.page.ts
@@ -12,7 +12,7 @@ type NavigationTarget = {
 };
 
 export type TargetName =
-  | "portfolio"
+  | "home"
   | "accounts"
   | "swap"
   | "earn"
@@ -36,9 +36,9 @@ export class MainNavigationPage extends AppPage {
 
   private get sidebarTargets(): Readonly<Record<TargetName, NavigationTarget>> {
     return {
-      portfolio: {
+      home: {
         expectActive: true,
-        selector: () => this.sideBarButton("portfolio"),
+        selector: () => this.sideBarButton("home"),
       },
       accounts: {
         expectActive: true,

--- a/e2e/desktop/tests/specs/main.navigation.spec.ts
+++ b/e2e/desktop/tests/specs/main.navigation.spec.ts
@@ -40,8 +40,8 @@ test.describe("Main navigation", () => {
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-      await app.mainNavigation.openTargetFromMainNavigation("portfolio");
-      await app.mainNavigation.validateTargetFromMainNavigation("portfolio");
+      await app.mainNavigation.openTargetFromMainNavigation("home");
+      await app.mainNavigation.validateTargetFromMainNavigation("home");
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.mainNavigation.validateTargetFromMainNavigation("accounts");
       await app.mainNavigation.openTargetFromMainNavigation("swap");


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Sidebar "Portfolio" label renamed to "Home"
      - Breadcrumb root label conditionally updated based on wallet 4.0 feature flag
      - Active state no longer highlights "Home" on `/asset/` sub-paths

### 📝 Description

The sidebar and breadcrumb were still showing "Portfolio" as the label for the home entry, which is inconsistent with the Wallet 4.0 navigation naming conventions.

This PR:
- Replaces the "Portfolio" label with "Home" in the sidebar using a new `sidebar.home` i18n key
- Updates the breadcrumb (`AssetCrumb`) to conditionally show "Home" when the wallet 4.0 main nav feature flag is enabled
- Removes the `/asset/` sub-path from the home active state mapping so 2nd-level pages no longer highlight "Home" in the sidebar
- Updates integration tests and E2E tests accordingly

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26960](https://ledgerhq.atlassian.net/browse/LIVE-26960)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26960]: https://ledgerhq.atlassian.net/browse/LIVE-26960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ