### PR TITLE
fix(cosmos validators list): :bug: cosmos validators list is empty

### DIFF
--- a/.changeset/dirty-vans-smell.md
+++ b/.changeset/dirty-vans-smell.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix cosmos validators list empty on e2e tests

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
@@ -16,6 +16,8 @@ import Text from "~/renderer/components/Text";
 import ValidatorRow from "~/renderer/families/cosmos/shared/components/CosmosFamilyValidatorRow";
 import IconAngleDown from "~/renderer/icons/AngleDown";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { prepareCurrency } from "~/renderer/bridge/cache";
+
 type Props = {
   t: TFunction;
   account: Account;
@@ -44,6 +46,11 @@ const ValidatorField = ({ account, onChangeValidator, chosenVoteAccAddr }: Props
       setShowAll(true);
     }
   }, [isPerOrQuickAccount]);
+
+  useEffect(() => {
+    if (validators.length > 0 || account.type !== "Account" || search !== "") return;
+    prepareCurrency(account.currency).catch(() => {});
+  }, [account.type, account.currency, validators.length, search]);
 
   const chosenValidator = useMemo(() => {
     if (validators.length === 0) return [];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Some times the cache is empty and we do not fetch validators list again so it cause Validator's list to be empty!

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-26451](https://ledgerhq.atlassian.net/browse/LIVE-26451)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26451]: https://ledgerhq.atlassian.net/browse/LIVE-26451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ