### PR TITLE
fix(desktop): stabilize hide-token-null-value e2e test

### DIFF
--- a/.changeset/fair-parents-move.md
+++ b/.changeset/fair-parents-move.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix flaky test for hide-token-null-value

--- a/apps/ledger-live-desktop/tests/page/account.page.ts
+++ b/apps/ledger-live-desktop/tests/page/account.page.ts
@@ -36,10 +36,10 @@ export class AccountPage extends AppPage {
   @step("Scroll to operations")
   async scrollToOperations() {
     const operationList = this.page.locator("id=operation-list");
-    // Wait for the operation list to be attached to the DOM before scrolling.
-    // React 19's concurrent rendering may temporarily detach elements during re-renders
-    // (e.g. after navigating to a token sub-account).
-    await operationList.waitFor({ state: "attached" });
+    // Wait for the operation list to be visible (not just attached) before scrolling.
+    // React 19's concurrent rendering may temporarily attach/detach elements during re-renders
+    // (e.g. after navigating to a token sub-account). "visible" ensures the element is stable.
+    await operationList.waitFor({ state: "visible" });
     await operationList.scrollIntoViewIfNeeded();
   }
 
@@ -63,10 +63,12 @@ export class AccountPage extends AppPage {
   @step("Navigate to token account")
   async navigateToToken(tokenTestId: string) {
     const tokenRow = this.page.getByTestId(tokenTestId);
-    // Wait for the token row to be attached to the DOM before navigating to it.
-    // React 19's concurrent rendering may temporarily detach elements during re-renders
     await tokenRow.waitFor({ state: "attached" });
     await tokenRow.click();
+    // The token row belongs to the parent account page. Waiting for it to detach
+    // guarantees React 19 has committed the new token sub-account page render,
+    // so subsequent interactions target the new DOM — not a stale element mid-transition.
+    await tokenRow.waitFor({ state: "detached" });
   }
 
   async operationRowByTestId(operationTestId: string) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - E2E test stability for hide-token-null-value spec
      - No production code changes

### 📝 Description

The `hide-token-null-value` E2E test was flaky due to React 19's concurrent rendering temporarily detaching DOM elements during in-page navigation from a parent account to a token sub-account.

**Fix:** In `navigateToToken`, wait for the clicked token row to detach from the DOM after clicking, which guarantees React 19 has committed the new token sub-account page render. Also strengthened `scrollToOperations` to wait for `state: "visible"` instead of `state: "attached"` to avoid resolving on a stale element mid-transition.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26965](https://ledgerhq.atlassian.net/browse/LIVE-26965)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26965]: https://ledgerhq.atlassian.net/browse/LIVE-26965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ