### PR TITLE
feat(LIVE-26864): hedera utils for new erc20 indexer

### DIFF
--- a/.changeset/silver-spiders-shake.md
+++ b/.changeset/silver-spiders-shake.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+feat: hedera utils for new erc20 indexer

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -190,6 +190,28 @@ describe("createApi", () => {
       invariant(rawTx instanceof TransferTransaction, "TransferTransaction type guard");
       expect(rawTx.maxTransactionFee).toEqual(expectedMaxFee);
     });
+
+    it("throws if useAllAmount is true", async () => {
+      await expect(
+        api.craftTransaction({
+          intentType: "transaction",
+          asset: {
+            type: "native",
+          },
+          amount: BigInt(100),
+          useAllAmount: true,
+          sender: MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+          senderPublicKey: MAINNET_TEST_ACCOUNTS.withoutTokens.publicKey,
+          recipient: MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+          type: HEDERA_TRANSACTION_MODES.TokenAssociate,
+          memo: {
+            kind: "text",
+            type: "string",
+            value: "token association",
+          },
+        }),
+      ).rejects.toThrow("useAllAmount is not supported");
+    });
   });
 
   describe("estimateFees", () => {
@@ -590,10 +612,9 @@ describe("createApi", () => {
 
   describe("listOperations", () => {
     it("returns empty array for pristine account", async () => {
-      const block = await api.lastBlock();
       const { items: operations } = await api.listOperations(
         MAINNET_TEST_ACCOUNTS.pristine.accountId,
-        { minHeight: block.height, order: "desc" },
+        { minHeight: 0, order: "desc" },
       );
 
       expect(operations).toBeInstanceOf(Array);
@@ -602,9 +623,8 @@ describe("createApi", () => {
 
     it("returns operations with valid synthetic block info", async () => {
       const cursor = "1753099264.927988000";
-      const block = await api.lastBlock();
       const { items: ops } = await api.listOperations(MAINNET_TEST_ACCOUNTS.withTokens.accountId, {
-        minHeight: block.height,
+        minHeight: 0,
         cursor,
         limit: 4,
         order: "asc",
@@ -619,9 +639,8 @@ describe("createApi", () => {
 
     it("returns operations for real account with tokens", async () => {
       const cursor = "1753099264.927988000";
-      const block = await api.lastBlock();
       const { items: ops } = await api.listOperations(MAINNET_TEST_ACCOUNTS.withTokens.accountId, {
-        minHeight: block.height,
+        minHeight: 0,
         cursor,
         limit: 100,
         order: "desc",
@@ -670,10 +689,9 @@ describe("createApi", () => {
 
     it("returns staking operations with correct metadata", async () => {
       const cursor = "1762202113.000000000";
-      const block = await api.lastBlock();
       const { items: ops } = await api.listOperations(
         MAINNET_TEST_ACCOUNTS.activeStaking.accountId,
-        { minHeight: block.height, cursor, limit: 30, order: "desc" },
+        { minHeight: 0, cursor, limit: 30, order: "desc" },
       );
 
       const rewardOp = ops.find(op => op.type === "REWARD");
@@ -709,10 +727,9 @@ describe("createApi", () => {
     });
 
     it("returns valid stakedAmount, respecting uncommitted balance changes", async () => {
-      const block = await api.lastBlock();
       const { items: ops } = await api.listOperations(
         MAINNET_TEST_ACCOUNTS.withQuickBalanceChanges.accountId,
-        { minHeight: block.height, limit: 10, order: "asc" },
+        { minHeight: 0, limit: 10, order: "asc" },
       );
 
       const opDelegate1 = ops[2];

--- a/libs/coin-modules/coin-hedera/src/api/index.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.ts
@@ -5,6 +5,7 @@ import type {
   TransactionValidation,
 } from "@ledgerhq/coin-framework/api/index";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import invariant from "invariant";
 import coinConfig from "../config";
 import { HARDCODED_BLOCK_HEIGHT, HEDERA_OPERATION_TYPES } from "../constants";
 import {
@@ -44,6 +45,7 @@ export function createApi(config: Record<string, never>): Api<HederaMemo> {
     },
     combine,
     craftTransaction: async (txIntent, customFees) => {
+      invariant(!txIntent.useAllAmount, "useAllAmount is not supported");
       const { serializedTx } = await craftTransaction(txIntent, customFees);
 
       return {
@@ -75,10 +77,9 @@ export function createApi(config: Record<string, never>): Api<HederaMemo> {
     getBlock: height => getBlock(height),
     getBlockInfo: height => getBlockInfo(height),
     lastBlock,
-    listOperations: async (address, { cursor, limit, order }) => {
-      // FIXME This listOperations implementation ignores the required minHeight option entirely.
-      //  Implementations must error when minHeight != 0 is not supported, this should either filter
-      //  by minHeight or explicitly throw a "not supported" error when minHeight is non-zero.
+    listOperations: async (address, { cursor, limit, order, minHeight }) => {
+      invariant(minHeight === 0, "minHeight is not supported");
+
       const mirrorTokens = await apiClient.getAccountTokens(address);
       const latestAccountOperations = await logicListOperations({
         currency,

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
@@ -193,6 +193,7 @@ export const buildIterateResult: IterateResultBuilder = async ({ result: rootRes
   };
 };
 
+// TODO: remove once migration to new API is complete
 // it might be necessary to remove pending operations after ERC20 patching done by `integrateERC20Operations`
 export const postSync = (_initial: Account, synced: Account): Account => {
   const erc20Operations = synced.operations.filter(op => op.standard === "erc20");

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.ts
@@ -388,6 +388,7 @@ export function patchOperationWithExtra(
   };
 }
 
+// TODO: remove once migration to new API is complete
 // filter out CONTRACT_CALL operations based on pending and already existing ERC20 operations to avoid duplicates
 export const removeDuplicatedContractCallOperations = (
   operations: Operation[],
@@ -406,6 +407,7 @@ export const removeDuplicatedContractCallOperations = (
   });
 };
 
+// TODO: remove once migration to new API is complete
 // loop over latestERC20Operations and prepare lists of transactions that should be patched and added
 // - patching happens when we have a matching CONTRACT_CALL operation without blockHash set (mirror node transaction without ERC20 details)
 // - adding happens when we have no matching operation
@@ -444,6 +446,7 @@ export const classifyERC20Operations = ({
   return { erc20OperationsToPatch, erc20OperationsToAdd };
 };
 
+// TODO: remove once migration to new API is complete
 // extracts common fields from an ERC20 operation
 const buildERC20OperationFields = ({
   erc20Operation,
@@ -498,10 +501,12 @@ const buildERC20OperationFields = ({
     blockHash,
     extra,
     standard,
+    contract: erc20Operation.token.contractAddress,
     hasFailed: false,
   };
 };
 
+// TODO: remove once migration to new API is complete
 // patches an existing CONTRACT_CALL operation with ERC20 token operation details
 export const patchContractCallOperation = ({
   relatedExistingOperation,
@@ -525,6 +530,7 @@ export const patchContractCallOperation = ({
   });
 };
 
+// TODO: remove once migration to new API is complete
 export const integrateERC20Operations = async ({
   ledgerAccountId,
   address,

--- a/libs/coin-modules/coin-hedera/src/constants.ts
+++ b/libs/coin-modules/coin-hedera/src/constants.ts
@@ -97,6 +97,8 @@ export const BASE_USD_FEE_BY_OPERATION_TYPE = {
  * This is a temporary solution to allow bypassing deprecated methods.
  * It is essential to update this list in the future to ensure support
  * for other erc20 tokens.
+ *
+ * task that should remove this: https://ledgerhq.atlassian.net/browse/LIVE-24948
  */
 export const SUPPORTED_ERC20_TOKENS = [
   {

--- a/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
@@ -25,11 +25,15 @@ import * as preloadData from "../preload-data";
 
 const mockGetCurrentHederaPreloadData = preloadData.getCurrentHederaPreloadData as jest.Mock;
 import { getMockedAccount, getMockedTokenAccount } from "../test/fixtures/account.fixture";
+import { getMockedEnrichedERC20Transfer } from "../test/fixtures/common.fixture";
 import {
   getMockedERC20TokenCurrency,
   getMockedHTSTokenCurrency,
 } from "../test/fixtures/currency.fixture";
-import { getMockedMirrorAccount } from "../test/fixtures/mirror.fixture";
+import {
+  getMockedMirrorAccount,
+  getMockedMirrorTransaction,
+} from "../test/fixtures/mirror.fixture";
 import { getMockedOperation } from "../test/fixtures/operation.fixture";
 import type {
   HederaAccount,
@@ -76,6 +80,8 @@ import {
   calculateAPY,
   analyzeStakingOperation,
   calculateUncommittedBalanceChange,
+  toEntityId,
+  mergeTransactionsFromDifferentSources,
 } from "./utils";
 
 jest.mock("../network/api");
@@ -1263,6 +1269,347 @@ describe("logic utils", () => {
       const result = await analyzeStakingOperation(mockAddress, mockTx);
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe("toEntityId", () => {
+    it("should format entity ID with default shard and realm", () => {
+      expect(toEntityId({ num: 12345 })).toBe("0.0.12345");
+    });
+
+    it("should format entity ID with custom shard and realm", () => {
+      expect(toEntityId({ num: 12345, shard: 1, realm: 2 })).toBe("1.2.12345");
+    });
+
+    it("should throw error for negative values", () => {
+      expect(() => toEntityId({ num: -1 })).toThrow("invalid account num: -1");
+      expect(() => toEntityId({ num: 123, shard: -1 })).toThrow("invalid account shard: -1");
+      expect(() => toEntityId({ num: 123, realm: -1 })).toThrow("invalid account realm: -1");
+    });
+
+    it("should throw error for non-integers", () => {
+      expect(() => toEntityId({ num: 1.5 })).toThrow("invalid account num: 1.5");
+      expect(() => toEntityId({ num: 123, shard: 1.5 })).toThrow("invalid account shard: 1.5");
+      expect(() => toEntityId({ num: 123, realm: 1.5 })).toThrow("invalid account realm: 1.5");
+    });
+  });
+
+  describe("mergeTransactionsFromDifferentSources", () => {
+    it("should merge mirror transactions and erc20 transfers", () => {
+      const mockMirrorTx = getMockedMirrorTransaction({ consensus_timestamp: "1000.000000000" });
+      const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
+        mirrorTransaction: getMockedMirrorTransaction({ consensus_timestamp: "2000.000000000" }),
+      });
+
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [mockMirrorTx],
+        enrichedERC20Transfers: [mockEnrichedERC20Transfer],
+        order: "desc",
+        limit: 10,
+        latestHgraphIndexedTimestampNs: new BigNumber("3000.000000000").multipliedBy(10 ** 9),
+        fetchAllPages: false,
+      });
+
+      expect(result.merged.map(tx => tx.type)).toEqual(["erc20", "mirror"]);
+    });
+    it("should handle multiple ERC20 transfers with deduplication correctly", () => {
+      const sharedHash1 = "hash-1";
+      const sharedHash2 = "hash-2";
+
+      const mockMirrorTx1 = getMockedMirrorTransaction({
+        consensus_timestamp: "1000.000000000",
+        transaction_hash: sharedHash1,
+        name: "CONTRACTCALL",
+      });
+
+      const mockMirrorTx2 = getMockedMirrorTransaction({
+        consensus_timestamp: "2000.000000000",
+        transaction_hash: sharedHash2,
+        name: "CONTRACTCALL",
+      });
+
+      const mockMirrorTx3 = getMockedMirrorTransaction({
+        consensus_timestamp: "3000.000000000",
+        transaction_hash: "unique-hash",
+        name: "CONTRACTCALL",
+      });
+
+      const mockERC20_1 = getMockedEnrichedERC20Transfer({
+        mirrorTransaction: getMockedMirrorTransaction({
+          consensus_timestamp: "1000.000000000",
+          transaction_hash: sharedHash1,
+        }),
+      });
+
+      const mockERC20_2 = getMockedEnrichedERC20Transfer({
+        mirrorTransaction: getMockedMirrorTransaction({
+          consensus_timestamp: "2000.000000000",
+          transaction_hash: sharedHash2,
+        }),
+      });
+
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [mockMirrorTx1, mockMirrorTx2, mockMirrorTx3],
+        enrichedERC20Transfers: [mockERC20_1, mockERC20_2],
+        order: "desc",
+        limit: 10,
+        latestHgraphIndexedTimestampNs: new BigNumber("4000.000000000").multipliedBy(10 ** 9),
+        fetchAllPages: false,
+      });
+
+      // Should have: 2 ERC20 transfers + 1 unique CONTRACT_CALL = 3 total
+      expect(result.merged).toHaveLength(3);
+      expect(result.merged.filter(tx => tx.type === "erc20")).toHaveLength(2);
+      expect(result.merged.filter(tx => tx.type === "mirror")).toHaveLength(1);
+    });
+
+    it("should sort transactions in descending order by consensus timestamp", () => {
+      const mockMirrorTx1 = getMockedMirrorTransaction({ consensus_timestamp: "1000.000000000" });
+      const mockMirrorTx2 = getMockedMirrorTransaction({ consensus_timestamp: "3000.000000000" });
+      const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
+        mirrorTransaction: getMockedMirrorTransaction({ consensus_timestamp: "2000.000000000" }),
+      });
+
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [mockMirrorTx1, mockMirrorTx2],
+        enrichedERC20Transfers: [mockEnrichedERC20Transfer],
+        order: "desc",
+        limit: 10,
+        latestHgraphIndexedTimestampNs: new BigNumber("3000.000000000").multipliedBy(10 ** 9),
+        fetchAllPages: false,
+      });
+
+      const timestamps = result.merged.map(tx => {
+        const mirrorTx = tx.type === "mirror" ? tx.data : tx.data.mirrorTransaction;
+        return mirrorTx.consensus_timestamp;
+      });
+
+      expect(timestamps).toEqual([
+        mockMirrorTx2.consensus_timestamp,
+        mockEnrichedERC20Transfer.mirrorTransaction.consensus_timestamp,
+        mockMirrorTx1.consensus_timestamp,
+      ]);
+    });
+
+    it("should sort transactions in ascending order by consensus timestamp", () => {
+      const mockMirrorTx1 = getMockedMirrorTransaction({ consensus_timestamp: "3000.000000000" });
+      const mockMirrorTx2 = getMockedMirrorTransaction({ consensus_timestamp: "1000.000000000" });
+      const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
+        mirrorTransaction: getMockedMirrorTransaction({ consensus_timestamp: "2000.000000000" }),
+      });
+
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [mockMirrorTx1, mockMirrorTx2],
+        enrichedERC20Transfers: [mockEnrichedERC20Transfer],
+        order: "asc",
+        limit: 10,
+        latestHgraphIndexedTimestampNs: new BigNumber("3000.000000000").multipliedBy(10 ** 9),
+        fetchAllPages: false,
+      });
+
+      const timestamps = result.merged.map(tx => {
+        const mirrorTx = tx.type === "mirror" ? tx.data : tx.data.mirrorTransaction;
+        return mirrorTx.consensus_timestamp;
+      });
+
+      expect(timestamps).toEqual([
+        mockMirrorTx2.consensus_timestamp,
+        mockEnrichedERC20Transfer.mirrorTransaction.consensus_timestamp,
+        mockMirrorTx1.consensus_timestamp,
+      ]);
+    });
+
+    it("should maintain nanosecond precision when sorting", () => {
+      const mockMirrorTx1 = getMockedMirrorTransaction({ consensus_timestamp: "1000.000000001" });
+      const mockMirrorTx2 = getMockedMirrorTransaction({ consensus_timestamp: "1000.000000003" });
+      const mockMirrorTx3 = getMockedMirrorTransaction({ consensus_timestamp: "1000.000000002" });
+
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [mockMirrorTx1, mockMirrorTx2, mockMirrorTx3],
+        enrichedERC20Transfers: [],
+        order: "asc",
+        limit: 10,
+        latestHgraphIndexedTimestampNs: new BigNumber("2000.000000000").multipliedBy(10 ** 9),
+        fetchAllPages: false,
+      });
+
+      const timestamps = result.merged.map(tx => {
+        const mirrorTx = tx.type === "mirror" ? tx.data : tx.data.mirrorTransaction;
+        return mirrorTx.consensus_timestamp;
+      });
+
+      expect(timestamps).toEqual([
+        mockMirrorTx1.consensus_timestamp,
+        mockMirrorTx3.consensus_timestamp,
+        mockMirrorTx2.consensus_timestamp,
+      ]);
+    });
+
+    it("should filter transactions when CONTRACT_CALL timestamp exceeds hgraph indexed timestamp", () => {
+      const mirrorTx1 = getMockedMirrorTransaction({
+        consensus_timestamp: "1000.000000000",
+        name: "CRYPTOTRANSFER",
+      });
+      const mirrorTx2 = getMockedMirrorTransaction({
+        consensus_timestamp: `3000.000000000`,
+        name: "CONTRACTCALL",
+      });
+
+      // hgraph is stuck on 1000, but mirror node returned 3000 already
+      const latestHgraphIndexedTimestampNs = new BigNumber(
+        mirrorTx1.consensus_timestamp,
+      ).multipliedBy(10 ** 9);
+
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [mirrorTx1, mirrorTx2],
+        enrichedERC20Transfers: [],
+        order: "desc",
+        limit: 10,
+        latestHgraphIndexedTimestampNs,
+        fetchAllPages: false,
+      });
+
+      const timestamps = result.merged.map(tx => {
+        const mirrorTx = tx.type === "mirror" ? tx.data : tx.data.mirrorTransaction;
+        return mirrorTx.consensus_timestamp;
+      });
+
+      expect(timestamps).toEqual([mirrorTx1.consensus_timestamp]);
+    });
+
+    it("should not trigger delay detection for non-CONTRACTCALL transactions", () => {
+      const mockMirrorTx1 = getMockedMirrorTransaction({
+        consensus_timestamp: `1000.000000000`,
+        name: "CRYPTOTRANSFER",
+      });
+      const mockMirrorTx2 = getMockedMirrorTransaction({
+        consensus_timestamp: `3000.000000000`,
+        name: "CRYPTOTRANSFER",
+      });
+
+      // hgraph is stuck on 1000, but mirror node returned 3000 already
+      const latestHgraphIndexedTimestampNs = new BigNumber(
+        mockMirrorTx1.consensus_timestamp,
+      ).multipliedBy(10 ** 9);
+
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [mockMirrorTx1, mockMirrorTx2],
+        enrichedERC20Transfers: [],
+        order: "desc",
+        limit: 10,
+        latestHgraphIndexedTimestampNs,
+        fetchAllPages: false,
+      });
+
+      const timestamps = result.merged.map(tx => {
+        const mirrorTx = tx.type === "mirror" ? tx.data : tx.data.mirrorTransaction;
+        return mirrorTx.consensus_timestamp;
+      });
+
+      expect(timestamps).toEqual([
+        mockMirrorTx2.consensus_timestamp,
+        mockMirrorTx1.consensus_timestamp,
+      ]);
+    });
+
+    it("should apply limit when fetchAllPages is false", () => {
+      const mockMirrorTx1 = getMockedMirrorTransaction({ consensus_timestamp: "1000.000000000" });
+      const mockMirrorTx2 = getMockedMirrorTransaction({ consensus_timestamp: "2000.000000000" });
+      const mockMirrorTx3 = getMockedMirrorTransaction({ consensus_timestamp: "3000.000000000" });
+      const mockMirrorTx4 = getMockedMirrorTransaction({ consensus_timestamp: "4000.000000000" });
+
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [mockMirrorTx1, mockMirrorTx2, mockMirrorTx3, mockMirrorTx4],
+        enrichedERC20Transfers: [],
+        order: "desc",
+        limit: 2,
+        latestHgraphIndexedTimestampNs: new BigNumber("5000.000000000").multipliedBy(10 ** 9),
+        fetchAllPages: false,
+      });
+
+      const timestamps = result.merged.map(tx => {
+        const mirrorTx = tx.type === "mirror" ? tx.data : tx.data.mirrorTransaction;
+        return mirrorTx.consensus_timestamp;
+      });
+
+      expect(timestamps).toEqual([
+        mockMirrorTx4.consensus_timestamp,
+        mockMirrorTx3.consensus_timestamp,
+      ]);
+    });
+
+    it("should not apply limit when fetchAllPages is true", () => {
+      const mockMirrorTx1 = getMockedMirrorTransaction({ consensus_timestamp: "1000.000000000" });
+      const mockMirrorTx2 = getMockedMirrorTransaction({ consensus_timestamp: "2000.000000000" });
+      const mockMirrorTx3 = getMockedMirrorTransaction({ consensus_timestamp: "3000.000000000" });
+
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [mockMirrorTx1, mockMirrorTx2, mockMirrorTx3],
+        enrichedERC20Transfers: [],
+        order: "desc",
+        limit: 2,
+        latestHgraphIndexedTimestampNs: new BigNumber("5000.000000000").multipliedBy(10 ** 9),
+        fetchAllPages: true,
+      });
+
+      const timestamps = result.merged.map(tx => {
+        const mirrorTx = tx.type === "mirror" ? tx.data : tx.data.mirrorTransaction;
+        return mirrorTx.consensus_timestamp;
+      });
+
+      expect(timestamps).toEqual([
+        mockMirrorTx3.consensus_timestamp,
+        mockMirrorTx2.consensus_timestamp,
+        mockMirrorTx1.consensus_timestamp,
+      ]);
+    });
+
+    it("should set nextCursor to last transaction timestamp in desc order", () => {
+      const mockMirrorTx1 = getMockedMirrorTransaction({ consensus_timestamp: "3000.000000000" });
+      const mockMirrorTx2 = getMockedMirrorTransaction({ consensus_timestamp: "2000.000000000" });
+      const mockMirrorTx3 = getMockedMirrorTransaction({ consensus_timestamp: "1000.000000000" });
+
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [mockMirrorTx1, mockMirrorTx2, mockMirrorTx3],
+        enrichedERC20Transfers: [],
+        order: "desc",
+        limit: 10,
+        latestHgraphIndexedTimestampNs: new BigNumber("5000.000000000").multipliedBy(10 ** 9),
+        fetchAllPages: false,
+      });
+
+      expect(result.nextCursor).toBe(mockMirrorTx3.consensus_timestamp);
+    });
+
+    it("should set nextCursor to last transaction timestamp in asc order", () => {
+      const mockMirrorTx1 = getMockedMirrorTransaction({ consensus_timestamp: "1000.000000000" });
+      const mockMirrorTx2 = getMockedMirrorTransaction({ consensus_timestamp: "2000.000000000" });
+      const mockMirrorTx3 = getMockedMirrorTransaction({ consensus_timestamp: "3000.000000000" });
+
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [mockMirrorTx1, mockMirrorTx2, mockMirrorTx3],
+        enrichedERC20Transfers: [],
+        order: "asc",
+        limit: 10,
+        latestHgraphIndexedTimestampNs: new BigNumber("5000.000000000").multipliedBy(10 ** 9),
+        fetchAllPages: false,
+      });
+
+      expect(result.nextCursor).toBe(mockMirrorTx3.consensus_timestamp);
+    });
+
+    it("should return null nextCursor when no transactions", () => {
+      const result = mergeTransactionsFromDifferentSources({
+        mirrorTransactions: [],
+        enrichedERC20Transfers: [],
+        order: "desc",
+        limit: 10,
+        latestHgraphIndexedTimestampNs: new BigNumber("5000.000000000").multipliedBy(10 ** 9),
+        fetchAllPages: false,
+      });
+
+      expect(result.nextCursor).toBeNull();
+      expect(result.merged).toEqual([]);
     });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.ts
@@ -12,6 +12,7 @@ import { InvalidAddress } from "@ledgerhq/errors";
 import cvsApi from "@ledgerhq/live-countervalues/api/index";
 import { getEnv } from "@ledgerhq/live-env";
 import { makeLRUCache, seconds } from "@ledgerhq/live-network/cache";
+import { log } from "@ledgerhq/logs";
 import type { Currency, ExplorerView, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { AccountLike, Operation as LiveOperation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
@@ -23,24 +24,28 @@ import {
   SYNTHETIC_BLOCK_WINDOW_SECONDS,
   TINYBAR_SCALE,
   OP_TYPES_EXCLUDING_FEES,
+  HEDERA_TRANSACTION_NAMES,
 } from "../constants";
 import { HederaRecipientInvalidChecksum } from "../errors";
 import { apiClient } from "../network/api";
 import { rpcClient } from "../network/rpc";
 import { getCurrentHederaPreloadData } from "../preload-data";
 import type {
+  EnrichedERC20Transfer,
   HederaAccount,
   HederaMemo,
   HederaMirrorTransaction,
   HederaOperationExtra,
   HederaTxData,
   HederaValidator,
+  MergedTransaction,
   OperationDetailsExtraField,
   StakingAnalysis,
   Transaction,
   TransactionStaking,
   TransactionStatus,
   TransactionTokenAssociate,
+  SyntheticBlock,
 } from "../types";
 
 export const serializeSignature = (signature: Uint8Array) => {
@@ -342,7 +347,7 @@ export function getBlockHash(blockHeight: number): string {
 export function getSyntheticBlock(
   consensusTimestamp: string,
   blockWindowSeconds = SYNTHETIC_BLOCK_WINDOW_SECONDS,
-) {
+): SyntheticBlock {
   const seconds = Math.floor(Number(consensusTimestamp));
 
   if (Number.isNaN(seconds) || seconds === 0) {
@@ -637,4 +642,131 @@ export const analyzeStakingOperation = async (
     targetStakingNodeId,
     stakedAmount: BigInt(actualStakedAmount.toString()), // always entire balance on Hedera (fully liquid)
   };
+};
+
+export const toEntityId = ({
+  num,
+  shard = 0,
+  realm = 0,
+}: {
+  num: number;
+  shard?: number;
+  realm?: number;
+}): string => {
+  invariant(Number.isInteger(shard) && shard >= 0, `invalid account shard: ${shard}`);
+  invariant(Number.isInteger(realm) && realm >= 0, `invalid account realm: ${realm}`);
+  invariant(Number.isInteger(num) && num >= 0, `invalid account num: ${num}`);
+
+  return `${shard}.${realm}.${num}`;
+};
+
+/**
+ * Merges transactions from Mirror Node and Hgraph ERC20 transfers into a unified, sorted list.
+ *
+ * This function handles the complexity of combining two data sources that may have different indexing speeds:
+ * - Mirror Node transactions (native HBAR transfers, HTS tokens, contract calls, etc.)
+ * - Hgraph ERC20 transfers (indexed separately, may lag behind Mirror Node)
+ *
+ * Key behaviors:
+ * 1. Merges both sources into a single array with type discrimination
+ * 2. Sorts by consensus timestamp (nanosecond precision) in specified order
+ * 3. Detects and handles ERC20 indexing delays by filtering out transactions after Hgraph's latest timestamp
+ * 4. Applies pagination limit and generates next cursor for pagination
+ *
+ * @param mirrorTransactions - Transactions from Mirror Node API
+ * @param enrichedERC20Transfers - enriched ERC20 transfers from Hgraph API
+ * @param order - Sort order: "asc" or "desc"
+ * @param limit - Maximum number of transactions to return (only applied when fetchAllPages is false)
+ * @param latestHgraphIndexedTimestampNs - Latest consensus timestamp indexed by Hgraph (used for delay detection)
+ * @param fetchAllPages - If true, returns all transactions; if false, applies limit
+ * @returns Object containing merged transactions and next cursor that can be used for pagination
+ */
+export const mergeTransactionsFromDifferentSources = ({
+  mirrorTransactions,
+  enrichedERC20Transfers,
+  order,
+  limit,
+  latestHgraphIndexedTimestampNs,
+  fetchAllPages,
+}: {
+  mirrorTransactions: HederaMirrorTransaction[];
+  enrichedERC20Transfers: EnrichedERC20Transfer[];
+  order: "asc" | "desc";
+  limit: number;
+  latestHgraphIndexedTimestampNs: BigNumber;
+  fetchAllPages: boolean;
+}) => {
+  let merged: MergedTransaction[] = [];
+  let nextCursor: string | null = null;
+  const latestHgraphIndexedTimestampSeconds = latestHgraphIndexedTimestampNs.dividedBy(10 ** 9);
+
+  // merge both transaction sources
+  merged.push(
+    ...mirrorTransactions.map(tx => ({ type: "mirror" as const, data: tx })),
+    ...enrichedERC20Transfers.map(tx => ({ type: "erc20" as const, data: tx })),
+  );
+
+  // lookup map of ERC20 transfers by mirror transaction hash for deduplication purposes
+  const erc20TransferByMirrorHash = new Map(
+    merged
+      .filter((item): item is Extract<MergedTransaction, { type: "erc20" }> => {
+        return item.type === "erc20";
+      })
+      .map(item => [item.data.mirrorTransaction.transaction_hash, item.data]),
+  );
+
+  // deduplicate CONTRACT_CALL transactions from mirror node if they are also present in erc20 transfers
+  merged = merged.filter(item => {
+    if (item.type !== "mirror") return true;
+    if (item.data.name !== HEDERA_TRANSACTION_NAMES.ContractCall) return true;
+    return !erc20TransferByMirrorHash.has(item.data.transaction_hash);
+  });
+
+  // sort merged transactions by consensus timestamp, keeping nanoseconds precision
+  merged.sort((a, b) => {
+    const aMirrorTx = a.type === "mirror" ? a.data : a.data.mirrorTransaction;
+    const bMirrorTx = b.type === "mirror" ? b.data : b.data.mirrorTransaction;
+    const aTime = new BigNumber(aMirrorTx.consensus_timestamp);
+    const bTime = new BigNumber(bMirrorTx.consensus_timestamp);
+
+    const result = order === "desc" ? bTime.minus(aTime) : aTime.minus(bTime);
+    return result.toNumber();
+  });
+
+  // if mirror node returned CONTRACT_CALL with timestamp higher than latest hgraph indexed timestamp,
+  // we need to remove all transactions that happened after that timestamp to avoid duplicates in next sync
+  const isERC20Delayed = merged.some(
+    i =>
+      i.type === "mirror" &&
+      i.data.name === HEDERA_TRANSACTION_NAMES.ContractCall &&
+      new BigNumber(i.data.consensus_timestamp).gt(latestHgraphIndexedTimestampSeconds),
+  );
+
+  if (isERC20Delayed) {
+    log(
+      "hedera/sync",
+      `detected ERC20 indexing delay, filtering out transactions after ${latestHgraphIndexedTimestampSeconds.toString()}`,
+    );
+
+    merged = merged.filter(i => {
+      const mirrorTx = i.type === "mirror" ? i.data : i.data.mirrorTransaction;
+      return new BigNumber(mirrorTx.consensus_timestamp).lte(latestHgraphIndexedTimestampSeconds);
+    });
+  }
+
+  // apply final limit in pagination mode
+  if (!fetchAllPages && merged.length >= limit) {
+    merged = merged.slice(0, limit);
+  }
+
+  // for pagination mode, set nextCursor as the timestamp of the latest transaction
+  // desc: using oldest (last) timestamp to fetch older operations next
+  // asc: using newest (last) timestamp to fetch newer operations next
+  const last = merged.at(-1);
+  if (last) {
+    const lastMirrorTx = last.type === "mirror" ? last.data : last.data.mirrorTransaction;
+    nextCursor = lastMirrorTx.consensus_timestamp;
+  }
+
+  return { merged, nextCursor };
 };

--- a/libs/coin-modules/coin-hedera/src/network/api.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.test.ts
@@ -370,6 +370,109 @@ describe("findTransactionByContractCall", () => {
   });
 });
 
+describe("findTransactionByContractCallV2", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should call the correct endpoint and return transaction details", async () => {
+    const mockConsensusTimestamp = "1758733200.632122898";
+    const mockPayerAddress = "0.0.1234";
+    const mockedResults: HederaMirrorTransaction = {
+      transfers: [],
+      token_transfers: [],
+      staking_reward_transfers: [],
+      charged_tx_fee: 100,
+      transaction_hash: "",
+      result: "",
+      consensus_timestamp: mockConsensusTimestamp,
+      entity_id: "0.0.1",
+      transaction_id: `${mockPayerAddress}-${mockConsensusTimestamp}`,
+      name: "CONTRACTCALL",
+    };
+
+    mockedNetwork.mockResolvedValueOnce(
+      getMockResponse({
+        transactions: [mockedResults],
+      }),
+    );
+
+    const result = await apiClient.findTransactionByContractCallV2({
+      timestamp: mockConsensusTimestamp,
+      payerAddress: mockPayerAddress,
+    });
+    const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+    expect(result).toEqual(mockedResults);
+    expect(requestUrl).toContain("/api/v1/transactions?limit=100&order=desc");
+    expect(requestUrl).toContain("timestamp=gte");
+    expect(requestUrl).toContain("timestamp=lte");
+    expect(mockedNetwork).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return null for non existing contract calls", async () => {
+    const mockConsensusTimestamp1 = "1758733200.632122898";
+    const mockConsensusTimestamp2 = "1758733300.632122898";
+    const mockPayerAddress1 = "0.0.1234";
+    const mockPayerAddress2 = "0.0.4321";
+    mockedNetwork.mockResolvedValueOnce(
+      getMockResponse({
+        transactions: [
+          {
+            transfers: [],
+            token_transfers: [],
+            staking_reward_transfers: [],
+            charged_tx_fee: 100,
+            transaction_hash: "zzz",
+            transaction_id: `${mockPayerAddress1}-${mockConsensusTimestamp1}`,
+            consensus_timestamp: mockConsensusTimestamp1,
+            result: "",
+            entity_id: "0.0.1",
+            name: "NOT_CONTRACTCALL",
+          },
+          {
+            transfers: [],
+            token_transfers: [],
+            staking_reward_transfers: [],
+            charged_tx_fee: 100,
+            transaction_hash: "yyy",
+            transaction_id: `${mockPayerAddress2}-${mockConsensusTimestamp2}`,
+            consensus_timestamp: mockConsensusTimestamp2,
+            result: "",
+            entity_id: "0.0.2",
+            name: "CONTRACTCALL",
+          },
+        ] satisfies Partial<HederaMirrorTransaction>[],
+      }),
+    );
+
+    const result = await apiClient.findTransactionByContractCallV2({
+      timestamp: mockConsensusTimestamp1,
+      payerAddress: mockPayerAddress1,
+    });
+
+    expect(result).toEqual(null);
+  });
+
+  it("should call the correct endpoint and return null for empty transactions list", async () => {
+    const mockConsensusTimestamp = "1758733200.632122898";
+    const mockPayerAddress = "0.0.1234";
+
+    mockedNetwork.mockResolvedValueOnce(
+      getMockResponse({
+        transactions: [],
+      }),
+    );
+
+    const result = await apiClient.findTransactionByContractCallV2({
+      timestamp: mockConsensusTimestamp,
+      payerAddress: mockPayerAddress,
+    });
+
+    expect(result).toEqual(null);
+  });
+});
+
 describe("getERC20Balance", () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/libs/coin-modules/coin-hedera/src/network/api.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.ts
@@ -201,6 +201,7 @@ async function getContractCallResult(
   return res.data;
 }
 
+// TODO: remove once migration to new API is complete
 async function findTransactionByContractCall(
   timestamp: string,
   contractId: string,
@@ -217,6 +218,42 @@ async function findTransactionByContractCall(
   return relatedTx ?? null;
 }
 
+async function findTransactionByContractCallV2({
+  timestamp,
+  payerAddress,
+}: {
+  timestamp: string;
+  payerAddress: string;
+}): Promise<HederaMirrorTransaction | null> {
+  // Hgraph API returns timestamp as number and nanoseconds precision is lost during parsing
+  // instead of using `timestamp=eq:${timestamp}`, we need to fetch transactions in a small range
+  // +-10 microseconds is used to bypass hgraph precision issue
+  const timestampAsNumber = new BigNumber(timestamp).multipliedBy(10 ** 9);
+  const timestampDiffNs = new BigNumber(10_000);
+  const from = new BigNumber(timestampAsNumber).minus(timestampDiffNs).dividedBy(10 ** 9);
+  const to = new BigNumber(timestampAsNumber).plus(timestampDiffNs).dividedBy(10 ** 9);
+
+  const params = new URLSearchParams({ limit: "100", order: "desc" });
+  params.append("timestamp", `gte:${from.toFixed(9)}`);
+  params.append("timestamp", `lte:${to.toFixed(9)}`);
+
+  const res = await network<HederaMirrorTransactionsResponse>({
+    method: "GET",
+    url: `${API_URL}/api/v1/transactions?${params.toString()}`,
+  });
+
+  // try to find the CONTRACT_CALL transaction related to the given address
+  const relatedTx = res.data.transactions.find(tx => {
+    return (
+      tx.name === HEDERA_TRANSACTION_NAMES.ContractCall &&
+      tx.transaction_id.startsWith(payerAddress)
+    );
+  });
+
+  return relatedTx ?? null;
+}
+
+// TODO: remove once migration to new API is complete
 async function getERC20Balance(
   accountEvmAddress: string,
   contractEvmAddress: string,
@@ -359,6 +396,7 @@ export const apiClient = {
   getNetworkFees,
   getContractCallResult,
   findTransactionByContractCall,
+  findTransactionByContractCallV2,
   getERC20Balance,
   estimateContractCallGas,
   getTransactionsByTimestampRange,

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -1,22 +1,33 @@
 import { setupMockCryptoAssetsStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
 import BigNumber from "bignumber.js";
+import { SUPPORTED_ERC20_TOKENS } from "../constants";
 import { getMockedAccount } from "../test/fixtures/account.fixture";
 import { getMockedERC20TokenCurrency } from "../test/fixtures/currency.fixture";
 import {
+  getMockedERC20TokenBalance,
+  getMockedERC20TokenTransfer,
+} from "../test/fixtures/hgraph.fixture";
+import {
   createMirrorCoinTransfer,
   createMirrorTokenTransfer,
+  getMockedMirrorTransaction,
+  getMockedMirrorContractCallResult,
 } from "../test/fixtures/mirror.fixture";
 import { getMockedThirdwebTransaction } from "../test/fixtures/thirdweb.fixture";
 import type { HederaMirrorCoinTransfer } from "../types";
 import { apiClient } from "./api";
+import { hgraphClient } from "./hgraph";
 import {
+  enrichERC20Transfers,
   getERC20BalancesForAccount,
+  getERC20BalancesForAccountV2,
   getERC20Operations,
   parseThirdwebTransactionParams,
   parseTransfers,
 } from "./utils";
 
 jest.mock("./api");
+jest.mock("./hgraph");
 
 describe("network utils", () => {
   beforeEach(() => {
@@ -219,6 +230,38 @@ describe("network utils", () => {
     });
   });
 
+  describe("getERC20BalancesForAccountV2", () => {
+    it("returns balances only for supported ERC20 tokens and calls hgraphClient.getERC20Balances accordingly", async () => {
+      const mockAccount = getMockedAccount();
+      const erc20Token = getMockedERC20TokenCurrency();
+
+      (hgraphClient.getERC20Balances as jest.Mock).mockResolvedValue([
+        getMockedERC20TokenBalance({ token_id: 0, balance: 100 }),
+        getMockedERC20TokenBalance({ token_id: 2, balance: 200 }),
+        // token id from SUPPORTED_ERC20_TOKENS
+        getMockedERC20TokenBalance({ token_id: 9470869, balance: 300 }),
+      ]);
+      setupMockCryptoAssetsStore({
+        findTokenById: jest.fn().mockReturnValue(erc20Token),
+      });
+
+      const res = await getERC20BalancesForAccountV2(mockAccount.freshAddress);
+
+      expect(hgraphClient.getERC20Balances).toHaveBeenCalledTimes(1);
+      expect(hgraphClient.getERC20Balances).toHaveBeenCalledWith({
+        address: mockAccount.freshAddress,
+      });
+      expect(res).toEqual([
+        {
+          balance: new BigNumber(300),
+          token: expect.objectContaining({
+            contractAddress: erc20Token.contractAddress,
+          }),
+        },
+      ]);
+    });
+  });
+
   describe("getERC20Operations", () => {
     beforeEach(() => {
       jest.clearAllMocks();
@@ -368,6 +411,99 @@ describe("network utils", () => {
       const result = parseThirdwebTransactionParams(mockTransaction);
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe("enrichERC20Transfers", () => {
+    const payerAccountId = 1234;
+    const erc20Token = SUPPORTED_ERC20_TOKENS[0];
+    const mockMirrorTransaction = getMockedMirrorTransaction({
+      entity_id: erc20Token.tokenId,
+      consensus_timestamp: "1704067200.000000000",
+      transaction_id: `0.0.${payerAccountId}-1704067200-000000000`,
+      transaction_hash: "hash123",
+      name: "CONTRACTCALL",
+    });
+    const mockERC20Transfer = getMockedERC20TokenTransfer({
+      token_id: Number(erc20Token.tokenId.split(".").pop()),
+      token_evm_address: erc20Token.contractAddress,
+      consensus_timestamp: Number(mockMirrorTransaction.consensus_timestamp) * 10 ** 9,
+      payer_account_id: payerAccountId,
+      transaction_hash: mockMirrorTransaction.transaction_hash,
+    });
+    const mockContractCallResult = getMockedMirrorContractCallResult({
+      contract_id: erc20Token.tokenId,
+      timestamp: mockMirrorTransaction.consensus_timestamp,
+    });
+
+    beforeEach(() => {
+      (apiClient.getContractCallResult as jest.Mock).mockResolvedValue(mockContractCallResult);
+      (apiClient.findTransactionByContractCallV2 as jest.Mock).mockResolvedValue(
+        mockMirrorTransaction,
+      );
+    });
+
+    it("should enrich supported ERC20 transfers with contract call result and mirror transaction", async () => {
+      const result = await enrichERC20Transfers([mockERC20Transfer]);
+
+      expect(result).toEqual([
+        {
+          transfer: mockERC20Transfer,
+          contractCallResult: mockContractCallResult,
+          mirrorTransaction: mockMirrorTransaction,
+        },
+      ]);
+      expect(apiClient.getContractCallResult).toHaveBeenCalledTimes(1);
+      expect(apiClient.getContractCallResult).toHaveBeenCalledWith("hash123");
+      expect(apiClient.findTransactionByContractCallV2).toHaveBeenCalledTimes(1);
+      expect(apiClient.findTransactionByContractCallV2).toHaveBeenCalledWith({
+        timestamp: "1704067200.000000000",
+        payerAddress: `0.0.${payerAccountId}`,
+      });
+    });
+
+    it("should skip transfers where mirror transaction is not found", async () => {
+      (apiClient.findTransactionByContractCallV2 as jest.Mock).mockResolvedValue(null);
+
+      const result = await enrichERC20Transfers([mockERC20Transfer]);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle multiple transfers", async () => {
+      const transfers = [mockERC20Transfer, { ...mockERC20Transfer, transaction_hash: "hash456" }];
+
+      (apiClient.findTransactionByContractCallV2 as jest.Mock).mockResolvedValue(
+        mockMirrorTransaction,
+      );
+
+      const result = await enrichERC20Transfers(transfers);
+      const txHashes = result.map(r => r.transfer.transaction_hash);
+
+      expect(txHashes).toEqual([mockERC20Transfer.transaction_hash, "hash456"]);
+    });
+
+    it("should correctly convert consensus timestamp to seconds format", async () => {
+      const transferWithTimestamp = {
+        ...mockERC20Transfer,
+        consensus_timestamp: 1768092990 * 10 ** 9,
+      };
+
+      await enrichERC20Transfers([transferWithTimestamp]);
+
+      expect(apiClient.findTransactionByContractCallV2).toHaveBeenCalledTimes(1);
+      expect(apiClient.findTransactionByContractCallV2).toHaveBeenCalledWith({
+        timestamp: "1768092990.000000000",
+        payerAddress: `0.0.${payerAccountId}`,
+      });
+    });
+
+    it("should handle empty array", async () => {
+      const result = await enrichERC20Transfers([]);
+
+      expect(result).toEqual([]);
+      expect(apiClient.getContractCallResult).not.toHaveBeenCalled();
+      expect(apiClient.findTransactionByContractCallV2).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -4,6 +4,7 @@ import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { SUPPORTED_ERC20_TOKENS } from "../constants";
+import { toEntityId } from "../logic/utils";
 import type {
   HederaMirrorTokenTransfer,
   HederaMirrorCoinTransfer,
@@ -11,8 +12,11 @@ import type {
   HederaThirdwebDecodedTransferParams,
   OperationERC20,
   HederaERC20TokenBalance,
+  ERC20TokenTransfer,
+  EnrichedERC20Transfer,
 } from "../types";
 import { apiClient } from "./api";
+import { hgraphClient } from "./hgraph";
 
 function isValidRecipient(accountId: AccountId, recipients: string[]): boolean {
   if (accountId.shard.eq(0) && accountId.realm.eq(0)) {
@@ -68,6 +72,7 @@ export function parseTransfers(
   };
 }
 
+// TODO: remove once migration to new API is complete
 export async function getERC20BalancesForAccount(
   evmAccountId: string,
   supportedTokenIds = SUPPORTED_ERC20_TOKENS.map(token => token.id),
@@ -96,6 +101,40 @@ export async function getERC20BalancesForAccount(
   return balances;
 }
 
+export async function getERC20BalancesForAccountV2(
+  address: string,
+): Promise<HederaERC20TokenBalance[]> {
+  const balances: HederaERC20TokenBalance[] = [];
+
+  const rawBalances = await hgraphClient.getERC20Balances({ address });
+
+  for (const rawBalance of rawBalances) {
+    const rawBalanceTokenId = toEntityId({ num: rawBalance.token_id });
+
+    const supportedToken = SUPPORTED_ERC20_TOKENS.find(token => {
+      return token.tokenId === rawBalanceTokenId;
+    });
+
+    if (!supportedToken) {
+      continue;
+    }
+
+    const calToken = await getCryptoAssetsStore().findTokenById(supportedToken.id);
+
+    if (!calToken) {
+      continue;
+    }
+
+    balances.push({
+      token: calToken,
+      balance: new BigNumber(rawBalance.balance),
+    });
+  }
+
+  return balances;
+}
+
+// TODO: remove once migration to new API is complete
 export const getERC20Operations = async (
   latestERC20Transactions: HederaThirdwebTransaction[],
 ): Promise<OperationERC20[]> => {
@@ -127,6 +166,7 @@ export const getERC20Operations = async (
   return latestERC20Operations;
 };
 
+// TODO: remove once migration to new API is complete
 export function parseThirdwebTransactionParams(
   transaction: HederaThirdwebTransaction,
 ): HederaThirdwebDecodedTransferParams | null {
@@ -138,3 +178,43 @@ export function parseThirdwebTransactionParams(
 
   return { from, to, value };
 }
+
+/**
+ * Enriches raw ERC20 transfers from Hgraph with additional data needed for operations:
+ * - fetches contract call result containing gas metrics and block hash
+ * - finds the corresponding Mirror Node transaction by consensus timestamp
+ *
+ * @param erc20Transfers - Raw ERC20 transfers from Hgraph API
+ * @returns Array of enriched transfers with complete operation data, filtered to supported tokens only
+ */
+export const enrichERC20Transfers = async (erc20Transfers: ERC20TokenTransfer[]) => {
+  const enrichedTransfers: EnrichedERC20Transfer[] = [];
+
+  for (const rawTransfer of erc20Transfers) {
+    const payerAddress = toEntityId({ num: rawTransfer.payer_account_id });
+    const hash = rawTransfer.transaction_hash;
+    const inaccurateConsensusTimestamp = new BigNumber(rawTransfer.consensus_timestamp)
+      .dividedBy(10 ** 9)
+      .toFixed(9);
+
+    const [contractCallResult, mirrorTransaction] = await Promise.all([
+      apiClient.getContractCallResult(hash),
+      apiClient.findTransactionByContractCallV2({
+        payerAddress,
+        timestamp: inaccurateConsensusTimestamp,
+      }),
+    ]);
+
+    if (!mirrorTransaction) {
+      continue;
+    }
+
+    enrichedTransfers.push({
+      transfer: rawTransfer,
+      contractCallResult,
+      mirrorTransaction,
+    });
+  }
+
+  return enrichedTransfers;
+};

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/account.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/account.fixture.ts
@@ -139,6 +139,7 @@ export const MAINNET_TEST_ACCOUNTS = {
     associatedTokenWithBalance: "0.0.456858",
     associatedTokenWithoutBalance: "0.0.7243470",
     notAssociatedToken: "0.0.3176721",
+    erc20Token: "0xca367694cdac8f152e33683bb36cc9d6a73f1ef2",
   },
   withQuickBalanceChanges: {
     accountId: "0.0.10176637",

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/common.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/common.fixture.ts
@@ -1,7 +1,8 @@
 import type network from "@ledgerhq/live-network";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
-import type { ERC20OperationFields, OperationERC20 } from "../../types";
+import type { ERC20OperationFields, EnrichedERC20Transfer, OperationERC20 } from "../../types";
+import { getMockedMirrorTransaction } from "./mirror.fixture";
 import { getMockedThirdwebTransaction } from "./thirdweb.fixture";
 
 export const getMockResponse = (data: unknown): Awaited<ReturnType<typeof network>> => ({
@@ -9,6 +10,7 @@ export const getMockResponse = (data: unknown): Awaited<ReturnType<typeof networ
   status: 200,
 });
 
+// TODO: remove once migration to new API is complete
 export const getMockERC20Operation = ({
   hash,
   from,
@@ -50,6 +52,7 @@ export const getMockERC20Operation = ({
   token,
 });
 
+// TODO: remove once migration to new API is complete
 export const getMockERC20Fields = (
   overrides?: Partial<ERC20OperationFields>,
 ): ERC20OperationFields => ({
@@ -69,6 +72,44 @@ export const getMockERC20Fields = (
     gasUsed: 50000,
   },
   standard: "erc20",
+  contract: "0xca367694cdac8f152e33683bb36cc9d6a73f1ef2",
   hasFailed: false,
   ...overrides,
 });
+
+export const getMockedEnrichedERC20Transfer = (
+  overrides?: Partial<EnrichedERC20Transfer>,
+): EnrichedERC20Transfer => {
+  const consensusTimestamp =
+    overrides?.mirrorTransaction?.consensus_timestamp ?? "1625097600.000000000";
+
+  return {
+    transfer: {
+      token_id: 12345,
+      token_evm_address: "0x1234",
+      sender_account_id: 1234,
+      receiver_account_id: 5678,
+      sender_evm_address: "0x1234",
+      receiver_evm_address: "0x5678",
+      payer_account_id: 1234,
+      amount: 1000,
+      transaction_hash: `hash_erc20_${consensusTimestamp}`,
+      consensus_timestamp: Number(consensusTimestamp) * 10 ** 9,
+      transfer_type: "transfer",
+    },
+    contractCallResult: {
+      block_hash: "0xblock",
+      contract_id: "0.0.12345",
+      block_gas_used: 100000,
+      gas_consumed: 50000,
+      gas_limit: 100000,
+      gas_used: 50000,
+      timestamp: consensusTimestamp,
+    },
+    mirrorTransaction: getMockedMirrorTransaction({
+      consensus_timestamp: consensusTimestamp,
+      name: "CONTRACTCALL",
+    }),
+    ...overrides,
+  };
+};

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/mirror.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/mirror.fixture.ts
@@ -1,8 +1,10 @@
 import type {
   HederaMirrorAccount,
   HederaMirrorCoinTransfer,
+  HederaMirrorContractCallResult,
   HederaMirrorToken,
   HederaMirrorTokenTransfer,
+  HederaMirrorTransaction,
 } from "../../types";
 
 export const getMockedMirrorToken = (overrides?: Partial<HederaMirrorToken>): HederaMirrorToken => {
@@ -52,4 +54,38 @@ export const createMirrorTokenTransfer = (
   token_id: tokenId,
   account,
   amount,
+});
+
+export const getMockedMirrorTransaction = (
+  overrides?: Partial<HederaMirrorTransaction>,
+): HederaMirrorTransaction => {
+  const timestamp = overrides?.consensus_timestamp ?? "1764932745.835883000";
+
+  return {
+    entity_id: "0.0.1234",
+    transaction_id: `0.0.1234-${timestamp}`,
+    transaction_hash: `hash_${timestamp}`,
+    consensus_timestamp: timestamp,
+    charged_tx_fee: 100000,
+    result: "SUCCESS",
+    name: "CRYPTOTRANSFER",
+    staking_reward_transfers: [],
+    transfers: [],
+    token_transfers: [],
+    memo_base64: "",
+    ...overrides,
+  };
+};
+
+export const getMockedMirrorContractCallResult = (
+  overrides?: Partial<HederaMirrorContractCallResult>,
+): HederaMirrorContractCallResult => ({
+  contract_id: "0.0.12345",
+  timestamp: "1764932745.835883000",
+  block_hash: "0xblockhash",
+  block_gas_used: 100000,
+  gas_consumed: 50000,
+  gas_limit: 100000,
+  gas_used: 50000,
+  ...overrides,
 });

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/thirdweb.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/thirdweb.fixture.ts
@@ -1,3 +1,4 @@
+// TODO: remove once migration to new API is complete
 import { ERC20_TRANSFER_EVENT_TOPIC } from "../../constants";
 import type { HederaThirdwebTransaction } from "../../types";
 

--- a/libs/coin-modules/coin-hedera/src/types/index.ts
+++ b/libs/coin-modules/coin-hedera/src/types/index.ts
@@ -4,4 +4,5 @@ export * from "./logic";
 export * from "./hgraph";
 export * from "./mirror";
 export * from "./signer";
+// TODO: remove once migration to new API is complete
 export * from "./thirdweb";

--- a/libs/coin-modules/coin-hedera/src/types/logic.ts
+++ b/libs/coin-modules/coin-hedera/src/types/logic.ts
@@ -4,6 +4,7 @@ import type { OperationType } from "@ledgerhq/types-live";
 import type BigNumber from "bignumber.js";
 import type { HEDERA_OPERATION_TYPES } from "../constants";
 import type { HederaOperationExtra } from "./bridge";
+import type { ERC20TokenTransfer } from "./hgraph";
 import type { HederaMirrorContractCallResult, HederaMirrorTransaction } from "./mirror";
 import type { HederaThirdwebTransaction } from "./thirdweb";
 
@@ -22,6 +23,7 @@ export interface EstimateFeesResult {
   gas?: BigNumber;
 }
 
+// TODO: remove once migration to new API is complete
 export interface OperationERC20 {
   thirdwebTransaction: HederaThirdwebTransaction;
   mirrorTransaction: HederaMirrorTransaction;
@@ -39,6 +41,7 @@ export interface ERC20OperationFields {
   blockHeight: number;
   blockHash: string;
   extra: HederaOperationExtra;
+  contract: string;
   standard: "erc20";
   hasFailed: false;
 }
@@ -53,4 +56,20 @@ export interface StakingAnalysis {
   targetStakingNodeId: number | null;
   previousStakingNodeId: number | null;
   stakedAmount: bigint;
+}
+
+export interface EnrichedERC20Transfer {
+  transfer: ERC20TokenTransfer;
+  contractCallResult: HederaMirrorContractCallResult;
+  mirrorTransaction: HederaMirrorTransaction;
+}
+
+export type MergedTransaction =
+  | { type: "mirror"; data: HederaMirrorTransaction }
+  | { type: "erc20"; data: EnrichedERC20Transfer };
+
+export interface SyntheticBlock {
+  blockHeight: number;
+  blockHash: string;
+  blockTime: Date;
 }

--- a/libs/coin-modules/coin-hedera/src/types/mirror.ts
+++ b/libs/coin-modules/coin-hedera/src/types/mirror.ts
@@ -88,6 +88,7 @@ export interface HederaMirrorNetworkFees {
 
 export interface HederaMirrorContractCallResult {
   contract_id: string;
+  block_hash: string;
   block_gas_used: number;
   gas_consumed: number;
   gas_limit: number;

--- a/libs/coin-modules/coin-hedera/src/types/thirdweb.ts
+++ b/libs/coin-modules/coin-hedera/src/types/thirdweb.ts
@@ -1,3 +1,4 @@
+// TODO: remove once migration to new API is complete
 export interface HederaThirdwebDecodedTransferParams {
   from: string;
   to: string;

--- a/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
@@ -167,7 +167,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
       "delegation": {
         "delegated": "333985159",
         "nodeId": 18,
-        "pendingReward": "898920",
+        "pendingReward": "979446",
       },
       "isAutoTokenAssociationEnabled": false,
       "maxAutomaticTokenAssociations": 0,
@@ -194,12 +194,12 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "type": "TokenAccountRaw",
   },
   {
-    "balance": "40096",
+    "balance": "40100",
     "id": "js:2:hedera:0.0.8313485:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
     "operationsCount": 4,
     "parentId": "js:2:hedera:0.0.8313485:hederaBip44",
     "pendingOperations": [],
-    "spendableBalance": "40096",
+    "spendableBalance": "40100",
     "swapHistory": [],
     "tokenId": "hedera/erc20/bonzo_atoken_usdc_0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
     "type": "TokenAccountRaw",
@@ -3025,6 +3025,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.7305122:hederaBip44",
       "blockHash": "0x782060bf6ae2a6810e5b47798bf90cd420f346c8c1dbb7f12064fa58900d928d",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1765992619.916268000",
         "gasConsumed": 271278,
@@ -3218,6 +3219,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.7305122:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "blockHash": "0xcdbd0227f60691af152a1d1226c8692944f25cf02e9385c09419bf1dc57c4128",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1765992359.883350234",
         "gasConsumed": 271278,
@@ -3243,6 +3245,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.7305122:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "blockHash": "0x782060bf6ae2a6810e5b47798bf90cd420f346c8c1dbb7f12064fa58900d928d",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1765992619.916268000",
         "gasConsumed": 271278,
@@ -3890,6 +3893,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": "0xe2cbd241357c4e302918a92401868d6c52508724ec2dee80f5475af1c35d56a6",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1766063963.625248000",
         "gasConsumed": 202934,
@@ -3962,6 +3966,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": "0xcdbd0227f60691af152a1d1226c8692944f25cf02e9385c09419bf1dc57c4128",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1765992359.883350234",
         "gasConsumed": 271278,
@@ -4748,6 +4753,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.8313485:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "blockHash": "0xe2cbd241357c4e302918a92401868d6c52508724ec2dee80f5475af1c35d56a6",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1766063963.625248000",
         "gasConsumed": 202934,
@@ -4775,6 +4781,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.8313485:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "blockHash": "0xcdbd0227f60691af152a1d1226c8692944f25cf02e9385c09419bf1dc57c4128",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1765992359.883350234",
         "gasConsumed": 271278,
@@ -4801,6 +4808,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.8313485:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "blockHash": "0x93a5f12cb50c6091a9435f9b0619b825eb43e62307ad638c4498bba54f4b7be5",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1765992000.873157685",
         "gasConsumed": 266997,
@@ -4826,6 +4834,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.8313485:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "blockHash": "0x2932ac1afe6726350ea55660b30c83823c185a896c8a9b228e12007ee76c15a7",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1766059747.925585000",
         "gasConsumed": 248195,
@@ -4927,6 +4936,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.10096785:hederaBip44",
       "blockHash": "0x2932ac1afe6726350ea55660b30c83823c185a896c8a9b228e12007ee76c15a7",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1766059747.925585000",
         "gasConsumed": 248195,
@@ -5002,6 +5012,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.10096785:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "blockHash": "0x782060bf6ae2a6810e5b47798bf90cd420f346c8c1dbb7f12064fa58900d928d",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1765992619.916268000",
         "gasConsumed": 271278,
@@ -5027,6 +5038,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "accountId": "js:2:hedera:0.0.10096785:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "blockHash": "0x2932ac1afe6726350ea55660b30c83823c185a896c8a9b228e12007ee76c15a7",
       "blockHeight": 5,
+      "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
         "consensusTimestamp": "1766059747.925585000",
         "gasConsumed": 248195,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no logic shouldn't be affected

### 📝 Description

This PR is a second part of `thirweb -> hgraph` migration in coin-hedera. The goal is to replace current ERC20 data source and expose ERC20 data in Alpaca.

Included changes:
- 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-26864
- source branch: https://github.com/LedgerHQ/ledger-live/pull/13683

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
