### PR TITLE
test(e2e-desktop): response might not be present if cancelled

### DIFF
--- a/e2e/desktop/tests/utils/webviewLogCollector.ts
+++ b/e2e/desktop/tests/utils/webviewLogCollector.ts
@@ -53,7 +53,11 @@ export class WebviewLogCollector {
       if (response.status() >= 400) {
         // capture data for 4xx and 5xx for debugging
         logEntry.postData = request.postData() ?? "";
-        logEntry.responseBody = await response.text();
+        try {
+          logEntry.responseBody = await response.text();
+        } catch (error) {
+          logEntry.responseBody = `Failed to get response body: ${error}`;
+        }
       }
     }
   };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix for: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/cef4dece-29f1-42f4-9e80-241bc4e128ae/#categories/6327b4f59846dcb5641ec4d43689d639/20ea144567afac31/
```
Error: response.text: Protocol error (Network.getResponseBody): No data found for resource with given identifier
```
Logs show a cancelled 400 request, the response body may not be available.

Run for the affected spec: https://github.com/LedgerHQ/ledger-live/actions/runs/22439678929

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
