### PR TITLE
fix(mobile): fix min height for lottie alignment in WV4 tour

### DIFF
--- a/.changeset/gorgeous-lemons-scream.md
+++ b/.changeset/gorgeous-lemons-scream.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: update min height for WV4 bottom sheet to fix alignment of lotties

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Drawer/components/SlideItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/Drawer/components/SlideItem.tsx
@@ -147,7 +147,7 @@ export function SlideItem({ title, description, index, lottieSrc, speed }: Slide
         <Box
           lx={{
             justifyContent: "center",
-            minHeight: "s56", // the height of 2 lines of text
+            minHeight: "s80", // the height of 2 lines of text
           }}
         >
           <Text


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual fix only — minHeight spacing adjustment for Lottie alignment in the WalletV4Tour drawer._
- [x] **Impact of the changes:**
      - WalletV4Tour bottom sheet drawer slide items
      - Lottie animation vertical alignment within the drawer

### 📝 Description

The Lottie animations in the WalletV4Tour bottom sheet drawer were misaligned due to an insufficient `minHeight` value on the text container.

Updated `minHeight` from `s56` to `s80` in `SlideItem.tsx` to properly accommodate the content and fix the vertical alignment of the Lottie animations.

| Before | After |
| ------ | ----- |
| <img width="502" height="1008" alt="lottie-alignment-before" src="https://github.com/user-attachments/assets/8a55f3ff-0925-40c6-9f4f-61e184d748a0" /> | <img width="502" height="1008" alt="lottie-alignment-after" src="https://github.com/user-attachments/assets/55ed4c53-5473-4163-888c-78cfa21dfa6e" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26919](https://ledgerhq.atlassian.net/browse/LIVE-26919)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-26919]: https://ledgerhq.atlassian.net/browse/LIVE-26919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ