### PR TITLE
ci: clean up pre-publish steps

### DIFF
--- a/libs/ui/packages/icons/package.json
+++ b/libs/ui/packages/icons/package.json
@@ -43,7 +43,6 @@
   },
   "scripts": {
     "build": "pnpm run clean && node scripts/build && node scripts/buildLegacy && tsc --noEmit false && node scripts/transpile",
-    "prepublishOnly": "pnpm run build",
     "clean": "rimraf react native reactLegacy nativeLegacy src/react src/native src/reactLegacy src/nativeLegacy",
     "unimported": "pnpm knip --directory ../../../.. -W libs/ui/packages/icons"
   },

--- a/libs/ui/packages/shared/package.json
+++ b/libs/ui/packages/shared/package.json
@@ -31,7 +31,6 @@
   ],
   "scripts": {
     "build": "tsc && node scripts/transpile",
-    "prepublishOnly": "npm run build",
     "clean": "rimraf lib",
     "unimported": "unimported"
   },


### PR DESCRIPTION
Remove prepublishOnly to avoid running build in pnpm i

Confirmed that the libs are built from the dependency graph on 

- pnpm run build:libs (used for npm publication)
- pnpm run build:llm:deps
- pnpm run build:lld