### PR TITLE
fix(mobile): show notifications drawer after ledger sync onboarding

### DIFF
--- a/.changeset/hot-crews-fetch.md
+++ b/.changeset/hot-crews-fetch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: show notifications drawer after onboarding with ledger sync

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/NotificationsPromptContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/components/NotificationsPromptContent.tsx
@@ -14,7 +14,7 @@ export const NotificationsPromptContent = () => {
 
   return (
     <>
-      <Text variant="h4" fontWeight="semiBold" color="neutral.c100" mt={5}>
+      <Text textAlign="center" variant="h4" fontWeight="semiBold" color="neutral.c100" mt={5}>
         {isVariantB ? t("notifications.prompt.titleVariantB") : t("notifications.prompt.title")}
       </Text>
 

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/WalletSyncNavigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/WalletSyncNavigator.tsx
@@ -21,6 +21,7 @@ import { AnalyticsPage } from "./hooks/useLedgerSyncAnalytics";
 import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
 import { hasCompletedOnboardingSelector } from "~/reducers/settings";
 import { useSelector } from "~/context/hooks";
+import { useNotifications } from "LLM/features/NotificationsPrompt";
 
 const Stack = createNativeStackNavigator<WalletSyncNavigatorStackParamList>();
 
@@ -39,6 +40,13 @@ export default function WalletSyncNavigator() {
     });
     navigation.goBack();
   }, []);
+
+  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
+
+  const onCloseFromLedgerSyncOnboarding = useCallback(() => {
+    close();
+    tryTriggerPushNotificationDrawerAfterAction("onboarding");
+  }, [close, tryTriggerPushNotificationDrawerAfterAction]);
 
   return (
     <Stack.Navigator screenOptions={stackNavConfig}>
@@ -66,7 +74,9 @@ export default function WalletSyncNavigator() {
           ...(hasCompletedOnboarding
             ? {
                 headerLeft: () => null,
-                headerRight: () => <NavigationHeaderCloseButton onPress={close} />,
+                headerRight: () => (
+                  <NavigationHeaderCloseButton onPress={onCloseFromLedgerSyncOnboarding} />
+                ),
               }
             : {
                 headerLeft: () => <NavigationHeaderBackButton onPress={close} />,

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationSuccess.tsx
@@ -8,6 +8,8 @@ import { AnalyticsButton, AnalyticsFlow, AnalyticsPage } from "../../hooks/useLe
 import { track } from "~/analytics";
 import { useClose } from "../../hooks/useClose";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
+import { useNotifications } from "LLM/features/NotificationsPrompt";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig";
 
 type Props = BaseComposite<
   StackNavigatorProps<WalletSyncNavigatorStackParamList, ScreenName.WalletSyncSuccess>
@@ -16,6 +18,8 @@ type Props = BaseComposite<
 export function ActivationSuccess({ route }: Props) {
   const { t } = useTranslation();
   const ledgerSyncOptimisationFlag = useFeature("lwmLedgerSyncOptimisation");
+  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
+
   const { created } = route.params;
   const title = ledgerSyncOptimisationFlag?.enabled
     ? "walletSync.success.complete.title"
@@ -31,6 +35,8 @@ export function ActivationSuccess({ route }: Props) {
 
   const close = useClose();
 
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("mobile");
+
   function onClose(): void {
     track("button_clicked", {
       button: AnalyticsButton.Close,
@@ -38,6 +44,13 @@ export function ActivationSuccess({ route }: Props) {
       flow: AnalyticsFlow.LedgerSync,
     });
     close();
+
+    // here we can't distinguish between ledger sync during onboarding or post-onboarding
+    // so we always try to trigger the notification drawer
+    // however since with the lazy onboarding, there will be no more onboarding flow, so we don't need to trigger the notification drawer
+    if (!shouldUseLazyOnboarding) {
+      tryTriggerPushNotificationDrawerAfterAction("onboarding");
+    }
   }
 
   return (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No dedicated automated test was added for this onboarding flow; behavior should be validated with manual QA._
- [x] **Impact of the changes:**
  - Wallet Sync activation/success close behavior in the mobile Ledger Sync flow.
  - Push notification opt-in drawer trigger after onboarding close/complete actions.
  - Lazy onboarding handling: skip notification drawer trigger on success close when `shouldUseLazyOnboarding` is enabled.

### 📝 Description

This PR fixes a mobile onboarding gap where the push notification opt-in drawer was not reliably shown after Ledger Sync onboarding actions.

The Ledger Sync close paths now trigger `tryTriggerPushNotificationDrawerAfterAction("onboarding")` where needed:
- In `WalletSyncNavigator`, the activation screen header close action now triggers the notification drawer after closing.
- In `ActivationSuccess`, the CTA close path attempts the same trigger, but skips it when `shouldUseLazyOnboarding` is enabled.
- A small UI adjustment aligns the notification prompt title text to center for consistency.

**Before:** Users could complete/close Ledger Sync onboarding without consistently seeing the push notification opt-in drawer.

**After:** Closing or completing the Ledger Sync onboarding success path correctly triggers the push notification opt-in drawer in the intended flows, while lazy onboarding remains exempt.


https://github.com/user-attachments/assets/d1d50acc-a43b-41be-ba12-c28752a61661



### ❓ Context

- **JIRA or GitHub link**: [LIVE-27007](https://ledgerhq.atlassian.net/browse/LIVE-27007)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27007]: https://ledgerhq.atlassian.net/browse/LIVE-27007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ