### PR TITLE
feat: add reborn url to buy device action

### DIFF
--- a/.changeset/empty-dryers-jump.md
+++ b/.changeset/empty-dryers-jump.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add reborn url to buy device action and remove buy device drawer from portfolio buy cta. Remove nano buy wall from card navigator

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -339,7 +339,6 @@ export default function BaseNavigator() {
           name={NavigatorName.Card}
           component={CardLiveAppNavigator}
           options={{ headerShown: false }}
-          {...noNanoBuyNanoWallScreenOptions}
         />
         <Stack.Screen
           name={NavigatorName.Exchange}

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
@@ -22,7 +22,7 @@ import { useTransferDrawerController } from "../../hooks/useTransferDrawerContro
 import { QuickActionCta, UserQuickActionsState } from "../../types";
 import { QUICK_ACTIONS_TEST_IDS } from "../../testIds";
 import { useTranslation } from "~/context/Locale";
-import { useRebornFlow } from "LLM/features/Reborn/hooks/useRebornFlow";
+import useBuyDeviceAction from "LLM/features/Reborn/hooks/useBuyDeviceAction";
 
 interface UseQuickActionsCtasViewModelProps {
   sourceScreenName?: string;
@@ -49,7 +49,7 @@ export const useQuickActionsCtasViewModel = ({
   const isExchangeEnabled = ptxServiceCtaExchangeDrawer?.enabled ?? true;
 
   const { openDrawer: openTransferDrawer } = useTransferDrawerController();
-  const { navigateToRebornFlow } = useRebornFlow();
+  const handleBuyDeviceAction = useBuyDeviceAction();
 
   // Determine user state
   const userState: UserQuickActionsState = useMemo(() => {
@@ -116,8 +116,8 @@ export const useQuickActionsCtasViewModel = ({
       flow: "buy_ledger",
       page: pageName,
     });
-    navigateToRebornFlow();
-  }, [navigateToRebornFlow, pageName]);
+    handleBuyDeviceAction();
+  }, [handleBuyDeviceAction, pageName]);
 
   // CTAs for no-signer state
   const noSignerActions: readonly QuickActionCta[] = useMemo(

--- a/apps/ledger-live-mobile/src/mvvm/features/Reborn/components/BuyDeviceView/useBuyDeviceViewModel.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Reborn/components/BuyDeviceView/useBuyDeviceViewModel.tsx
@@ -1,8 +1,6 @@
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useNavigation } from "@react-navigation/native";
 import { useCallback } from "react";
 import { useTranslation } from "~/context/Locale";
-import { Linking } from "react-native";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useTheme } from "styled-components/native";
 import { setOnboardingHasDevice } from "~/actions/settings";
@@ -16,8 +14,8 @@ import { OnboardingNavigatorParamList } from "~/components/RootNavigator/types/O
 import useIsAppInBackground from "~/components/useIsAppInBackground";
 import { ScreenName, NavigatorName } from "~/const";
 import { readOnlyModeEnabledSelector } from "~/reducers/settings";
-import { urls } from "~/utils/urls";
 import { useRebornBuyDeviceDrawerController } from "../../hooks/useRebornBuyDeviceDrawerController";
+import useBuyDeviceAction from "../../hooks/useBuyDeviceAction";
 
 type NavigationProp = BaseNavigationComposite<
   | StackNavigatorNavigation<BuyDeviceNavigatorParamList, ScreenName.GetDevice>
@@ -41,10 +39,10 @@ const useBuyDeviceViewModel = () => {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProp>();
   const { colors } = useTheme();
-  const buyDeviceFromLive = useFeature("buyDeviceFromLive");
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const dispatch = useDispatch();
   const isInOnboarding = getIsBaseOnboarding(navigation);
+  const handleBuyDeviceAction = useBuyDeviceAction();
 
   const { closeDrawer } = useRebornBuyDeviceDrawerController();
 
@@ -67,15 +65,9 @@ const useBuyDeviceViewModel = () => {
   }, [isInOnboarding, dispatch, navigation, readOnlyModeEnabled, closeDrawer]);
 
   const buyLedger = useCallback(() => {
-    if (buyDeviceFromLive?.enabled) {
-      navigation.navigate(NavigatorName.BuyDevice, {
-        screen: ScreenName.PurchaseDevice,
-      });
-    } else {
-      Linking.openURL(urls.buyFlex);
-    }
+    handleBuyDeviceAction();
     closeDrawer();
-  }, [buyDeviceFromLive?.enabled, navigation, closeDrawer]);
+  }, [handleBuyDeviceAction, closeDrawer]);
 
   const videoMounted = !useIsAppInBackground();
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Reborn/drawers/useRebornBuyDeviceViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Reborn/drawers/useRebornBuyDeviceViewModel.ts
@@ -1,9 +1,7 @@
 import { useCallback } from "react";
 import { useRebornBuyDeviceDrawerController } from "../hooks/useRebornBuyDeviceDrawerController";
 import { useTranslation } from "~/context/Locale";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useNavigation } from "@react-navigation/native";
-import { Linking } from "react-native";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { setOnboardingHasDevice } from "~/actions/settings";
 import { track } from "~/analytics";
@@ -15,7 +13,7 @@ import {
 import { OnboardingNavigatorParamList } from "~/components/RootNavigator/types/OnboardingNavigator";
 import { ScreenName, NavigatorName } from "~/const";
 import { readOnlyModeEnabledSelector } from "~/reducers/settings";
-import { urls } from "~/utils/urls";
+import useBuyDeviceAction from "../hooks/useBuyDeviceAction";
 
 type NavigationProp = BaseNavigationComposite<
   | StackNavigatorNavigation<BuyDeviceNavigatorParamList, ScreenName.GetDevice>
@@ -38,12 +36,11 @@ const getIsBaseOnboarding = (navigation: NavigationProp) => {
 function useRebornBuyDeviceViewModel() {
   const { isOpen, closeDrawer } = useRebornBuyDeviceDrawerController();
   const { t } = useTranslation();
-
   const navigation = useNavigation<NavigationProp>();
-  const buyDeviceFromLive = useFeature("buyDeviceFromLive");
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const dispatch = useDispatch();
   const isInOnboarding = getIsBaseOnboarding(navigation);
+  const handleBuyAction = useBuyDeviceAction();
 
   const setupDevice = useCallback(() => {
     if (isInOnboarding) dispatch(setOnboardingHasDevice(true));
@@ -64,15 +61,9 @@ function useRebornBuyDeviceViewModel() {
   }, [isInOnboarding, dispatch, navigation, readOnlyModeEnabled, closeDrawer]);
 
   const buyLedger = useCallback(() => {
-    if (buyDeviceFromLive?.enabled) {
-      navigation.navigate(NavigatorName.BuyDevice, {
-        screen: ScreenName.PurchaseDevice,
-      });
-    } else {
-      Linking.openURL(urls.buyFlex);
-    }
+    handleBuyAction();
     closeDrawer();
-  }, [buyDeviceFromLive?.enabled, navigation, closeDrawer]);
+  }, [handleBuyAction, closeDrawer]);
 
   return {
     handleClose: closeDrawer,

--- a/apps/ledger-live-mobile/src/mvvm/features/Reborn/hooks/useBuyDeviceAction.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Reborn/hooks/useBuyDeviceAction.ts
@@ -1,0 +1,38 @@
+import { Linking } from "react-native";
+import { useCallback } from "react";
+import { useNavigation } from "@react-navigation/native";
+import { BuyDeviceNavigatorParamList } from "~/components/RootNavigator/types/BuyDeviceNavigator";
+import {
+  BaseNavigationComposite,
+  StackNavigatorNavigation,
+} from "~/components/RootNavigator/types/helpers";
+import { ScreenName, NavigatorName } from "~/const";
+import { OnboardingNavigatorParamList } from "~/components/RootNavigator/types/OnboardingNavigator";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
+import { urls } from "~/utils/urls";
+
+type NavigationProp = BaseNavigationComposite<
+  | StackNavigatorNavigation<BuyDeviceNavigatorParamList, ScreenName.GetDevice>
+  | StackNavigatorNavigation<OnboardingNavigatorParamList, ScreenName.GetDevice>
+>;
+
+function useBuyDeviceAction() {
+  const navigation = useNavigation<NavigationProp>();
+  const buyDeviceFromLive = useFeature("buyDeviceFromLive");
+  const defaultURL = useLocalizedUrl(urls.reborn);
+
+  const handleBuyDeviceAction = useCallback(() => {
+    if (buyDeviceFromLive?.enabled) {
+      navigation.navigate(NavigatorName.BuyDevice, {
+        screen: ScreenName.PurchaseDevice,
+      });
+    } else {
+      Linking.openURL(defaultURL);
+    }
+  }, [buyDeviceFromLive?.enabled, defaultURL, navigation]);
+
+  return handleBuyDeviceAction;
+}
+
+export default useBuyDeviceAction;

--- a/apps/ledger-live-mobile/src/screens/PurchaseDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PurchaseDevice/index.tsx
@@ -23,7 +23,7 @@ const PurchaseDevice = () => {
   const dispatch = useDispatch();
   const buyDeviceFromLive = useFeature("buyDeviceFromLive");
 
-  const defaultURL = useLocalizedUrl(urls.buyFlex);
+  const defaultURL = useLocalizedUrl(urls.reborn);
 
   const [isURLDrawerOpen, setURLDrawerOpen] = useState(false);
   const [isMessageDrawerOpen, setMessageDrawerOpen] = useState(false);


### PR DESCRIPTION
feat: remove nano buy wall from card

chore: changeset

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Group redirects to buy url in lazy onboarding flow to same action, updates buy device url, and removes the nano upsell wall from card actions so that the user can go through card flow during lazy onboarding.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->


Uploading Simulator Screen Recording - iPhone 16 Pro - 2026-02-26 at 17.34.38.mp4…


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26903


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
