### PR TITLE
feat(modular-drawer): add perpetuals info banner in account selection

### DIFF
--- a/.changeset/perps-modular-drawer-banner.md
+++ b/.changeset/perps-modular-drawer-banner.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add perpetuals info banner in modular drawer account selection

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/ModularDialogFlowManager.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/ModularDialogFlowManager.tsx
@@ -12,6 +12,7 @@ import {
   modularDialogIsOpenSelector,
   modularDialogConfigurationSelector,
   modularDialogOnAccountSelectedSelector,
+  modularDialogUiUseCaseSelector,
 } from "~/renderer/reducers/modularDrawer";
 import { useModularDrawerConfiguration } from "@ledgerhq/live-common/modularDrawer/hooks/useModularDrawerConfiguration";
 import { Dialog, DialogContent } from "@ledgerhq/lumen-ui-react";
@@ -30,6 +31,7 @@ const ModularDialogFlowManager = ({ onClose }: ModularDialogFlowManagerProps) =>
   const isOpen = useSelector(modularDialogIsOpenSelector);
   const onAccountSelected = useSelector(modularDialogOnAccountSelectedSelector);
   const dialogConfiguration = useSelector(modularDialogConfigurationSelector);
+  const uiUseCase = useSelector(modularDialogUiUseCaseSelector);
 
   const handleClose = () => {
     track("button_clicked", {
@@ -101,7 +103,13 @@ const ModularDialogFlowManager = ({ onClose }: ModularDialogFlowManagerProps) =>
         );
       case MODULAR_DIALOG_STEP.ACCOUNT_SELECTION:
         if (selectedAsset && selectedNetwork && onAccountSelected) {
-          return <AccountSelector asset={selectedAsset} onAccountSelected={onAccountSelected} />;
+          return (
+            <AccountSelector
+              asset={selectedAsset}
+              onAccountSelected={onAccountSelected}
+              uiUseCase={uiUseCase}
+            />
+          );
         }
         return null;
       default:

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectAccountFlow.test.tsx
@@ -408,6 +408,48 @@ describe("ModularDialogFlowManager - Select Account Flow", () => {
     expect(screen.getByText(/bitcoin 2/i)).toBeVisible();
   });
 
+  it("should display perpetuals banner when uiUseCase is perpetuals", async () => {
+    const { user } = render(<ModularDialogFlowManager />, {
+      ...INITIAL_STATE,
+      initialState: {
+        accounts: [ETH_ACCOUNT],
+        modularDrawer: {
+          ...defaultModularDrawerState,
+          dialogParams: {
+            ...defaultModularDrawerState.dialogParams,
+            uiUseCase: "perpetuals",
+          },
+        },
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/ethereum/i)).toBeVisible());
+    await user.click(screen.getByText(/ethereum/i));
+    await user.click(screen.getByText(/ethereum/i));
+
+    expect(screen.getAllByText(/select account/i)[0]).toBeVisible();
+    expect(screen.getByText(/currently only supported with usdc on arbitrum chain/i)).toBeVisible();
+  });
+
+  it("should not display perpetuals banner when uiUseCase is not set", async () => {
+    const { user } = render(<ModularDialogFlowManager />, {
+      ...INITIAL_STATE,
+      initialState: {
+        accounts: [ETH_ACCOUNT],
+        modularDrawer: defaultModularDrawerState,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/ethereum/i)).toBeVisible());
+    await user.click(screen.getByText(/ethereum/i));
+    await user.click(screen.getByText(/ethereum/i));
+
+    expect(screen.getAllByText(/select account/i)[0]).toBeVisible();
+    expect(
+      screen.queryByText(/currently only supported with usdc on arbitrum chain/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("should auto focus on search input when autoFocus is true", async () => {
     render(<ModularDialogFlowManager />, {
       ...INITIAL_STATE,

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AccountSelector/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AccountSelector/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import styled from "styled-components";
+import { useTranslation } from "react-i18next";
+import { Banner } from "@ledgerhq/lumen-ui-react";
 import { AddAccountButton } from "./components/AddAccountButton";
 import { AccountSelectorContent } from "./components/AccountSelectorContent";
 import { AccountLike, Account } from "@ledgerhq/types-live";
@@ -15,6 +17,7 @@ type Props = {
   asset: CryptoOrTokenCurrency;
   hideAddAccountButton?: boolean;
   overridePageName?: ModularDialogEventName;
+  uiUseCase?: string;
   onAccountSelected: (account: AccountLike, parentAccount?: Account) => void;
 };
 
@@ -23,16 +26,27 @@ export const AccountSelector = ({
   onAccountSelected,
   hideAddAccountButton,
   overridePageName,
+  uiUseCase,
 }: Props) => {
+  const { t } = useTranslation();
   const { detailedAccounts, accounts, onAddAccountClick } = useDetailedAccounts(
     asset,
     onAccountSelected,
   );
 
   const BottomComponent = (
-    <AddAccountContainer>
-      <AddAccountButton onAddAccountClick={onAddAccountClick} />
-    </AddAccountContainer>
+    <>
+      {uiUseCase === "perpetuals" && (
+        <Banner
+          appearance="info"
+          title={t("drawers.selectAccount.perpetualsBanner")}
+          className="mt-16"
+        />
+      )}
+      <AddAccountContainer>
+        <AddAccountButton onAddAccountClick={onAddAccountClick} />
+      </AddAccountContainer>
+    </>
   );
 
   return (

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDrawer/ModularDrawerFlowManager.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDrawer/ModularDrawerFlowManager.tsx
@@ -17,6 +17,7 @@ const ModularDrawerFlowManager = ({
   currencies,
   drawerConfiguration,
   useCase,
+  uiUseCase,
   areCurrenciesFiltered,
   onAssetSelected,
   onAccountSelected,
@@ -85,7 +86,13 @@ const ModularDrawerFlowManager = ({
         );
       case MODULAR_DRAWER_STEP.ACCOUNT_SELECTION:
         if (selectedAsset && selectedNetwork && onAccountSelected) {
-          return <AccountSelection asset={selectedAsset} onAccountSelected={onAccountSelected} />;
+          return (
+            <AccountSelection
+              asset={selectedAsset}
+              onAccountSelected={onAccountSelected}
+              uiUseCase={uiUseCase}
+            />
+          );
         }
         return null;
       default:

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDrawer/Web3AppWebview/AssetAndAccountDrawer.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDrawer/Web3AppWebview/AssetAndAccountDrawer.tsx
@@ -23,14 +23,22 @@ type DrawerParams = {
   currencies?: string[];
   drawerConfiguration?: ModularDrawerConfiguration | EnhancedModularDrawerConfiguration;
   useCase?: string;
+  uiUseCase?: string;
   areCurrenciesFiltered?: boolean;
   onSuccess?: (account: AccountLike, parentAccount?: Account) => void;
   onCancel?: () => void;
 };
 
 function openAssetAndAccountDrawer(params: DrawerParams): void {
-  const { currencies, drawerConfiguration, useCase, areCurrenciesFiltered, onSuccess, onCancel } =
-    params;
+  const {
+    currencies,
+    drawerConfiguration,
+    useCase,
+    uiUseCase,
+    areCurrenciesFiltered,
+    onSuccess,
+    onCancel,
+  } = params;
 
   const modularDrawerConfiguration = createModularDrawerConfiguration(drawerConfiguration);
 
@@ -53,6 +61,7 @@ function openAssetAndAccountDrawer(params: DrawerParams): void {
       },
       drawerConfiguration: modularDrawerConfiguration,
       useCase,
+      uiUseCase,
       areCurrenciesFiltered,
     },
     {

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDrawer/__tests__/selectAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDrawer/__tests__/selectAccountFlow.test.tsx
@@ -456,6 +456,53 @@ describe("ModularDrawerFlowManager - Select Account Flow", () => {
     expect(screen.getByText(/add accounts/i)).toBeVisible();
   });
 
+  it("should display perpetuals banner when uiUseCase is perpetuals", async () => {
+    const { user } = render(
+      <ModularDrawerFlowManager
+        currencies={mockCurrencies}
+        onAccountSelected={mockOnAccountSelected}
+        uiUseCase="perpetuals"
+      />,
+      {
+        ...INITIAL_STATE,
+        initialState: {
+          accounts: [ETH_ACCOUNT],
+        },
+      },
+    );
+
+    await waitFor(() => expect(screen.getByText(/ethereum/i)).toBeVisible());
+    await user.click(screen.getByText(/ethereum/i));
+    await user.click(screen.getByText(/ethereum/i));
+
+    expect(screen.getByText(/select account/i)).toBeVisible();
+    expect(screen.getByText(/currently only supported with usdc on arbitrum chain/i)).toBeVisible();
+  });
+
+  it("should not display perpetuals banner when uiUseCase is not set", async () => {
+    const { user } = render(
+      <ModularDrawerFlowManager
+        currencies={mockCurrencies}
+        onAccountSelected={mockOnAccountSelected}
+      />,
+      {
+        ...INITIAL_STATE,
+        initialState: {
+          accounts: [ETH_ACCOUNT],
+        },
+      },
+    );
+
+    await waitFor(() => expect(screen.getByText(/ethereum/i)).toBeVisible());
+    await user.click(screen.getByText(/ethereum/i));
+    await user.click(screen.getByText(/ethereum/i));
+
+    expect(screen.getByText(/select account/i)).toBeVisible();
+    expect(
+      screen.queryByText(/currently only supported with usdc on arbitrum chain/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("should auto focus on search input when autoFocus is true", async () => {
     render(
       <ModularDrawerFlowManager

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDrawer/screens/AccountSelection/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDrawer/screens/AccountSelection/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import styled from "styled-components";
+import { useTranslation } from "react-i18next";
+import { Banner } from "@ledgerhq/lumen-ui-react";
 import { AddAccountButton } from "./components/AddAccountButton";
 import { SelectAccountList } from "./components/List";
 import { AccountLike, Account } from "@ledgerhq/types-live";
@@ -15,6 +17,7 @@ type Props = {
   asset: CryptoOrTokenCurrency;
   hideAddAccountButton?: boolean;
   overridePageName?: ModularDrawerEventName;
+  uiUseCase?: string;
   onAccountSelected: (account: AccountLike, parentAccount?: Account) => void;
 };
 
@@ -23,16 +26,27 @@ export const AccountSelection = ({
   onAccountSelected,
   hideAddAccountButton,
   overridePageName,
+  uiUseCase,
 }: Props) => {
+  const { t } = useTranslation();
   const { detailedAccounts, accounts, onAddAccountClick } = useDetailedAccounts(
     asset,
     onAccountSelected,
   );
 
   const BottomComponent = (
-    <AddAccountContainer>
-      <AddAccountButton onAddAccountClick={onAddAccountClick} />
-    </AddAccountContainer>
+    <>
+      {uiUseCase === "perpetuals" && (
+        <Banner
+          appearance="info"
+          title={t("drawers.selectAccount.perpetualsBanner")}
+          className="mt-16"
+        />
+      )}
+      <AddAccountContainer>
+        <AddAccountButton onAddAccountClick={onAddAccountClick} />
+      </AddAccountContainer>
+    </>
   );
 
   return (

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDrawer/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDrawer/types.ts
@@ -21,6 +21,7 @@ export type ModularDrawerFlowManagerProps = {
   currencies: string[];
   drawerConfiguration?: EnhancedModularDrawerConfiguration;
   useCase?: string;
+  uiUseCase?: string;
   areCurrenciesFiltered?: boolean;
   onAssetSelected?: (currency: CryptoOrTokenCurrency) => void;
   onAccountSelected?: (account: AccountLike, parentAccount?: Account) => void;

--- a/apps/ledger-live-desktop/src/renderer/reducers/modularDrawer.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/modularDrawer.ts
@@ -8,6 +8,7 @@ export interface ModularDialogParams {
   currencies?: string[];
   dialogConfiguration?: EnhancedModularDrawerConfiguration;
   useCase?: string;
+  uiUseCase?: string;
   areCurrenciesFiltered?: boolean;
   onAssetSelected?: (currency: CryptoOrTokenCurrency) => void;
   onAccountSelected?: (account: AccountLike, parentAccount?: Account) => void;
@@ -76,6 +77,8 @@ export const modularDialogCurrenciesSelector = (state: State) =>
   state.modularDrawer.dialogParams?.currencies;
 export const modularDialogUseCaseSelector = (state: State) =>
   state.modularDrawer.dialogParams?.useCase;
+export const modularDialogUiUseCaseSelector = (state: State) =>
+  state.modularDrawer.dialogParams?.uiUseCase;
 export const modularDialogAreCurrenciesFilteredSelector = (state: State) =>
   state.modularDrawer.dialogParams?.areCurrenciesFiltered;
 

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7556,7 +7556,8 @@
     },
     "selectAccount": {
       "title": "choose account",
-      "addAccount": "Add new or existing account"
+      "addAccount": "Add new or existing account",
+      "perpetualsBanner": "Currently only supported with USDC on Arbitrum chain."
     }
   },
   "customImage": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8333,6 +8333,7 @@
     "emptyAssetList": "No assets found",
     "accountCount_one": "{{count}} account",
     "accountCount_other": "{{count}} accounts",
+    "perpetualsBanner": "Currently only supported with USDC on Arbitrum chain.",
     "errors": {
       "title": "Connection failed",
       "backend": "Something went wrong on our end. Please try again later",

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawer.tsx
@@ -41,8 +41,10 @@ export type ModularDrawerProps = {
   /** Callback fired when an account is selected */
   readonly onAccountSelected: (account: AccountLike, parentAccount?: AccountLike) => void;
 
-  /** The use case identifier for the drawer */
+  /** The use case identifier for the drawer (sent to API as transaction param) */
   readonly useCase?: string;
+  /** UI-only use case identifier for conditional rendering (e.g. perpetuals banner) */
+  readonly uiUseCase?: string;
   /** Whether the currencies are filtered */
   readonly areCurrenciesFiltered?: boolean;
 };
@@ -59,6 +61,7 @@ export function ModularDrawer({
   networksConfiguration,
   onAccountSelected,
   useCase,
+  uiUseCase,
   areCurrenciesFiltered,
 }: ModularDrawerProps) {
   const { isEnabled } = useWalletFeaturesConfig("mobile");
@@ -122,6 +125,7 @@ export function ModularDrawer({
       onAddNewAccount,
       asset: accountCurrency,
       onAccountSelected,
+      uiUseCase,
     },
   };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerWrapper.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerWrapper.tsx
@@ -11,6 +11,7 @@ export function ModularDrawerWrapper() {
     assetsConfiguration,
     networksConfiguration,
     useCase,
+    uiUseCase,
     areCurrenciesFiltered,
   } = useModularDrawerController();
 
@@ -23,6 +24,7 @@ export function ModularDrawerWrapper() {
       networksConfiguration={networksConfiguration}
       onAccountSelected={handleAccountSelected}
       useCase={useCase}
+      uiUseCase={uiUseCase}
       areCurrenciesFiltered={areCurrenciesFiltered}
     />
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -35,6 +35,7 @@ export const useModularDrawerController = () => {
     assetsConfiguration,
     networksConfiguration,
     useCase,
+    uiUseCase,
     areCurrenciesFiltered,
   } = useSelector(modularDrawerStateSelector);
 
@@ -92,6 +93,7 @@ export const useModularDrawerController = () => {
     assetsConfiguration,
     networksConfiguration,
     useCase,
+    uiUseCase,
     areCurrenciesFiltered,
     openDrawer,
     closeDrawer,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AccountSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AccountSelection/index.tsx
@@ -1,5 +1,5 @@
 import { FlatList, StyleSheet } from "react-native";
-import { BottomSheetVirtualizedList, BottomSheetHeader } from "@ledgerhq/lumen-ui-rnative";
+import { BottomSheetVirtualizedList, BottomSheetHeader, Banner } from "@ledgerhq/lumen-ui-rnative";
 import {
   TrackDrawerScreen,
   EVENTS_NAME,
@@ -21,6 +21,7 @@ export type AccountSelectionStepProps = {
   asset?: CryptoOrTokenCurrency | null;
   onAddNewAccount: () => void;
   useLumenBottomSheet?: boolean;
+  uiUseCase?: string;
 };
 
 const HEADER_HEIGHT = 64;
@@ -32,6 +33,7 @@ const AccountSelectionContent = ({
   onAddNewAccount,
   onAccountSelected,
   useLumenBottomSheet = false,
+  uiUseCase,
 }: Readonly<AccountSelectionStepProps> & { asset: CryptoOrTokenCurrency }) => {
   const flow = useSelector(modularDrawerFlowSelector);
   const source = useSelector(modularDrawerSourceSelector);
@@ -69,12 +71,21 @@ const AccountSelectionContent = ({
 
   const renderFooter = useCallback(() => {
     return (
-      <AddAccountButton
-        label={t("addAccounts.addNewOrExisting")}
-        onClick={onAddNewAccountOnClick}
-      />
+      <>
+        {uiUseCase === "perpetuals" && (
+          <Banner
+            appearance="info"
+            title={t("modularDrawer.perpetualsBanner")}
+            lx={{ marginTop: "s16" }}
+          />
+        )}
+        <AddAccountButton
+          label={t("addAccounts.addNewOrExisting")}
+          onClick={onAddNewAccountOnClick}
+        />
+      </>
     );
-  }, [onAddNewAccountOnClick, t]);
+  }, [onAddNewAccountOnClick, t, uiUseCase]);
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
@@ -21,6 +21,7 @@ export type DrawerBaseParams = {
   source?: string;
   areCurrenciesFiltered?: boolean;
   useCase?: string;
+  uiUseCase?: string;
 };
 
 export type DrawerParams<TExtras extends object = DrawerExtras> = DrawerBaseParams & {

--- a/apps/ledger-live-mobile/src/reducers/modularDrawer.ts
+++ b/apps/ledger-live-mobile/src/reducers/modularDrawer.ts
@@ -13,6 +13,7 @@ export interface ModularDrawerState {
   assetsConfiguration?: EnhancedModularDrawerConfiguration["assets"];
   networksConfiguration?: EnhancedModularDrawerConfiguration["networks"];
   useCase?: string;
+  uiUseCase?: string;
   areCurrenciesFiltered?: boolean;
   searchValue: string;
   step: ModularDrawerStep;
@@ -34,6 +35,7 @@ export const INITIAL_STATE: ModularDrawerState = {
     rightElement: "balance",
   },
   useCase: undefined,
+  uiUseCase: undefined,
   areCurrenciesFiltered: undefined,
   searchValue: "",
   step: ModularDrawerStep.Asset,
@@ -64,6 +66,7 @@ const modularDrawerSlice = createSlice({
         assetsConfiguration?: EnhancedModularDrawerConfiguration["assets"];
         networksConfiguration?: EnhancedModularDrawerConfiguration["networks"];
         useCase?: string;
+        uiUseCase?: string;
         areCurrenciesFiltered?: boolean;
         step?: ModularDrawerStep;
       }>,
@@ -79,6 +82,7 @@ const modularDrawerSlice = createSlice({
         assetsConfiguration,
         networksConfiguration,
         useCase,
+        uiUseCase,
         areCurrenciesFiltered,
         step,
       } = action.payload;
@@ -107,6 +111,9 @@ const modularDrawerSlice = createSlice({
       if (useCase !== undefined) {
         state.useCase = useCase;
       }
+      if (uiUseCase !== undefined) {
+        state.uiUseCase = uiUseCase;
+      }
       if (areCurrenciesFiltered !== undefined) {
         state.areCurrenciesFiltered = areCurrenciesFiltered;
       }
@@ -124,6 +131,7 @@ const modularDrawerSlice = createSlice({
       state.assetsConfiguration = INITIAL_STATE.assetsConfiguration;
       state.networksConfiguration = INITIAL_STATE.networksConfiguration;
       state.useCase = undefined;
+      state.uiUseCase = undefined;
       state.areCurrenciesFiltered = undefined;
       state.searchValue = "";
       state.step = ModularDrawerStep.Asset;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _UI-only change: info banner is conditionally rendered based on `uiUseCase` prop. No business logic impacted._
- [x] **Impact of the changes:**
  - Account selection screen in modular drawer (desktop & mobile)
  - Perpetuals flow when selecting an account
  - No impact on other use cases (banner only shows when `uiUseCase === "perpetuals"`)

### 📝 Description

**Problem**: Users entering the perpetuals flow need to be informed that the feature is currently only supported with USDC on the Arbitrum chain. Without this information, users may select an unsupported account and encounter errors later in the flow.

**Solution**: Introduces a new `uiUseCase` prop throughout the modular drawer system (separate from the existing `useCase` which is sent to the API). When `uiUseCase` is set to `"perpetuals"`, an info banner reading "Currently only supported with USDC on Arbitrum chain." is displayed in the account selection step, on both desktop and mobile.

Changes include:
- Added `uiUseCase` to drawer state, types, selectors, and reducers (desktop & mobile)
- Threaded `uiUseCase` through `ModularDrawerFlowManager`, `ModularDialogFlowManager`, and `AssetAndAccountDrawer`
- Conditionally render a `Banner` component in `AccountSelector` (desktop) and `AccountSelection` (mobile)
- Added i18n keys for the banner text

<img width="401" height="548" alt="Screenshot 2026-02-27 at 10 59 28" src="https://github.com/user-attachments/assets/65065875-5791-49ae-836d-a99ac18bb130" />
<img width="401" height="401" alt="image" src="https://github.com/user-attachments/assets/2f2fd285-ece9-47d6-b0c8-c25661901282" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-25515](https://ledgerhq.atlassian.net/browse/LIVE-25515)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-25515]: https://ledgerhq.atlassian.net/browse/LIVE-25515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ