### PR TITLE
chore: add trial rules directory for Cursor

### DIFF
--- a/.cursor/rules/trial/README.md
+++ b/.cursor/rules/trial/README.md
@@ -1,0 +1,5 @@
+# Trial rules
+
+Place rules in this directory that will be ignored by git but picked up by Cursor. 
+
+This is especially useful for trialing `alwaysApply` rules before pushing them to everyone.

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ libs/ui/packages/react/rsbuild.config.js
 libs/ui/packages/react/rsbuild.config.js.map
 .zed
 
-
+.cursor/rules/trial/*
 
 .nx/cache
 .nx/workspace-data


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Config/tooling change; no app logic._
- [x] **Impact of the changes:**
  - Cursor/IDE rules only; no runtime or QA impact on mobile/desktop apps

### 📝 Description

Adds a **trial rules** directory (`.cursor/rules/trial/`) so developers can place Cursor rules that are picked up by the editor but ignored by git. This allows trialing `alwaysApply` or other rules before promoting them into the shared `.cursor/rules/` tree.

**Problem:** There was no supported way to try new Cursor rules locally without committing them or affecting the rest of the team.

**Solution:**
- Added `.cursor/rules/trial/` with a README explaining usage.
- Updated `.gitignore` with `.cursor/rules/trial/*` so files in that folder stay local.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27021](https://ledgerhq.atlassian.net/browse/LIVE-27021)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27021]: https://ledgerhq.atlassian.net/browse/LIVE-27021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ