### PR TITLE
fix(BACK-10812,evm): paginate over blockscout explorer

### DIFF
--- a/.changeset/ten-emus-rest.md
+++ b/.changeset/ten-emus-rest.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Fix evm pagination for Blockscout explorers

--- a/libs/coin-modules/coin-evm/src/api/index.cronos.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.cronos.integ.test.ts
@@ -1,0 +1,47 @@
+import { Api, BufferTxData, MemoNotSupported } from "@ledgerhq/coin-framework/api/types";
+import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { EvmConfig } from "../config";
+import { createApi } from "./index";
+
+describe("EVM Cronos Network (blockscout explorer)", () => {
+  let module: Api<MemoNotSupported, BufferTxData>;
+
+  beforeAll(() => {
+    setupCalClientStore();
+    const config = {
+      node: {
+        type: "external",
+        uri: "https://evm.cronos.org",
+      },
+      explorer: {
+        type: "blockscout",
+        uri: "https://cronos.org/explorer/api",
+      },
+    };
+    module = createApi(config as EvmConfig, "cronos");
+  });
+
+  describe("listOperations", () => {
+    it("paginates with distinct cursors across pages", async () => {
+      const page1 = await module.listOperations("0x24b8bfd98f38322435699595358b4f997ceefd16", {
+        minHeight: 0,
+        order: "asc",
+        limit: 100,
+      });
+
+      expect(page1.items.length).toBeGreaterThan(0);
+      expect(page1.next?.length).toBeGreaterThan(0);
+
+      const page2 = await module.listOperations("0x24b8bfd98f38322435699595358b4f997ceefd16", {
+        minHeight: 0,
+        order: "asc",
+        limit: 100,
+        cursor: page1.next,
+      });
+
+      expect(page2.items.length).toBeGreaterThan(0);
+      expect(page2.next?.length).toBeGreaterThan(0);
+      expect(page2.next).not.toEqual(page1.next);
+    });
+  });
+});

--- a/libs/coin-modules/coin-evm/src/network/explorer/etherscan.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/etherscan.test.ts
@@ -235,8 +235,8 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 0,
-          endBlock: undefined,
+          startblock: 0,
+          endblock: undefined,
         },
       });
     });
@@ -272,8 +272,8 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 50,
-          endBlock: undefined,
+          startblock: 50,
+          endblock: undefined,
         },
       });
     });
@@ -310,8 +310,8 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 50,
-          endBlock: 100,
+          startblock: 50,
+          endblock: 100,
         },
       });
     });
@@ -469,8 +469,8 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 0,
-          endBlock: undefined,
+          startblock: 0,
+          endblock: undefined,
         },
       });
     });
@@ -508,8 +508,8 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 50,
-          endBlock: undefined,
+          startblock: 50,
+          endblock: undefined,
         },
       });
     });
@@ -548,8 +548,8 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 50,
-          endBlock: 100,
+          startblock: 50,
+          endblock: 100,
         },
       });
     });
@@ -707,7 +707,7 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 0,
+          startblock: 0,
         },
       });
     });
@@ -745,7 +745,7 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 50,
+          startblock: 50,
         },
       });
     });
@@ -784,8 +784,8 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 50,
-          endBlock: 100,
+          startblock: 50,
+          endblock: 100,
         },
       });
     });
@@ -943,7 +943,7 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 0,
+          startblock: 0,
         },
       });
     });
@@ -981,7 +981,7 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 50,
+          startblock: 50,
         },
       });
     });
@@ -1020,8 +1020,8 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 50,
-          endBlock: 100,
+          startblock: 50,
+          endblock: 100,
         },
       });
     });
@@ -1312,8 +1312,8 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 0,
-          endBlock: undefined,
+          startblock: 0,
+          endblock: undefined,
         },
       });
     });
@@ -1351,8 +1351,8 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 50,
-          endBlock: undefined,
+          startblock: 50,
+          endblock: undefined,
         },
       });
     });
@@ -1391,8 +1391,8 @@ describe("EVM Family", () => {
           tag: "latest",
           page: 1,
           sort: "desc",
-          startBlock: 50,
-          endBlock: 100,
+          startblock: 50,
+          endblock: 100,
         },
       });
     });
@@ -1600,8 +1600,8 @@ describe("EVM Family", () => {
       return async (config: any) => {
         const url = config.url as string;
         const params = config.params;
-        const startBlock = params.startBlock ?? 0;
-        const endBlock = params.endBlock ?? Infinity;
+        const startBlock = params.startblock ?? 0;
+        const endBlock = params.endblock ?? Infinity;
         const pageLimit = params.offset ?? limit;
         const endpointType = getEndpointType(url);
 

--- a/libs/coin-modules/coin-evm/src/network/explorer/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/etherscan.ts
@@ -128,6 +128,24 @@ function isDone(limitParameter: number | undefined, operationCount: number): boo
   );
 }
 
+function paginationParams(params: FetchOperationsParams): {
+  tag: "latest";
+  page: number;
+  offset?: number;
+  sort: "asc" | "desc";
+  startblock: number;
+  endblock?: number | undefined;
+} {
+  return {
+    tag: "latest",
+    page: params.page ?? 1,
+    ...(params.limit !== undefined && { offset: params.limit }),
+    sort: params.sort,
+    startblock: params.fromBlock,
+    endblock: params.toBlock,
+  };
+}
+
 function groupByHash<T extends { hash: string }>(items: T[]): Record<string, T[]> {
   const byHash: Record<string, T[]> = {};
   for (const item of items) {
@@ -228,14 +246,7 @@ export const getCoinOperations = async (params: FetchOperationsParams): Promise<
   const ops = await fetchWithRetries<EtherscanOperation[]>({
     method: "GET",
     url,
-    params: {
-      tag: "latest",
-      page: params.page ?? 1,
-      ...(params.limit !== undefined && { offset: params.limit }),
-      sort: params.sort,
-      startBlock: params.fromBlock,
-      endBlock: params.toBlock,
-    },
+    params: paginationParams(params),
   });
 
   const operations = ops.flatMap(tx => etherscanOperationToOperations(params.accountId, tx));
@@ -269,14 +280,7 @@ export const getTokenOperations = async (
   const ops = await fetchWithRetries<EtherscanERC20Event[]>({
     method: "GET",
     url,
-    params: {
-      tag: "latest",
-      page: params.page ?? 1,
-      ...(params.limit !== undefined && { offset: params.limit }),
-      sort: params.sort,
-      startBlock: params.fromBlock,
-      endBlock: params.toBlock,
-    },
+    params: paginationParams(params),
   });
 
   // Why this thing ?
@@ -325,14 +329,7 @@ export const getERC721Operations = async (
   const ops = await fetchWithRetries<EtherscanERC721Event[]>({
     method: "GET",
     url,
-    params: {
-      tag: "latest",
-      page: params.page ?? 1,
-      ...(params.limit !== undefined && { offset: params.limit }),
-      sort: params.sort,
-      startBlock: params.fromBlock,
-      endBlock: params.toBlock,
-    },
+    params: paginationParams(params),
   });
 
   // Why this thing ?
@@ -381,14 +378,7 @@ export const getERC1155Operations = async (
   const ops = await fetchWithRetries<EtherscanERC1155Event[]>({
     method: "GET",
     url: `${explorer.uri}?module=account&action=token1155tx&address=${params.address}`,
-    params: {
-      tag: "latest",
-      page: params.page ?? 1,
-      ...(params.limit !== undefined && { offset: params.limit }),
-      sort: params.sort,
-      startBlock: params.fromBlock,
-      endBlock: params.toBlock,
-    },
+    params: paginationParams(params),
   });
 
   // Why this thing ?
@@ -471,14 +461,7 @@ export const getInternalOperations = async (
   const ops = await fetchWithRetries<EtherscanInternalTransaction[]>({
     method: "GET",
     url: `${explorer.uri}?module=account&action=txlistinternal&address=${params.address}`,
-    params: {
-      tag: "latest",
-      page: params.page ?? 1,
-      ...(params.limit !== undefined && { offset: params.limit }),
-      sort: params.sort,
-      startBlock: params.fromBlock,
-      endBlock: params.toBlock,
-    },
+    params: paginationParams(params),
   }).then(ops => ops.map(fixTxHash));
 
   // Why this thing ?


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - bugfix

### 📝 Description

Pagination over Blockscout explorer doesn't work because it uses lowercase for API parameter.
Etherscan supports both lowercase and camelCase parameter name.
https://docs.blockscout.com/devs/apis/rpc/account#get-transactions-by-address

startBlock => startblock
endBlock => endBlock

### ❓ Context

https://ledgerhq.atlassian.net/browse/BACK-10812


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
