### PR TITLE
fix(common): fix app crash when offline due to Hermes catch binding issue

### DIFF
--- a/.changeset/fix-crash-no-internet.md
+++ b/.changeset/fix-crash-no-internet.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix app crash when offline caused by Hermes catch binding issue in RampCatalogProvider and RemoteLiveAppProvider

--- a/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/index.tsx
+++ b/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/index.tsx
@@ -52,18 +52,22 @@ export function RampCatalogProvider({
       error: null,
     }));
 
-    try {
-      const value = await api.fetchRampCatalog();
-      setState(() => ({
-        isLoading: false,
-        value,
-        error: null,
-      }));
-    } catch (error) {
+    const result = await api.fetchRampCatalog().then(
+      (value): { value: RampCatalog; fetchError: null } => ({ value, fetchError: null }),
+      (e): { value: null; fetchError: unknown } => ({ value: null, fetchError: e }),
+    );
+
+    if (result.fetchError !== null) {
       setState(currentState => ({
         ...currentState,
         isLoading: false,
-        error,
+        error: result.fetchError,
+      }));
+    } else {
+      setState(() => ({
+        isLoading: false,
+        value: result.value,
+        error: null,
       }));
     }
   }, []);

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
@@ -119,19 +119,38 @@ export function RemoteLiveAppProvider({
     allowExperimentalApps && branches.push("experimental");
     allowDebugApps && branches.push("debug");
 
-    try {
-      const allManifests = await api.fetchLiveAppManifests(providerURL);
+    const result = await api
+      .fetchLiveAppManifests(providerURL)
+      .then(allManifests =>
+        api
+          .fetchLiveAppManifests(providerURL, {
+            apiVersion,
+            branches,
+            platform,
+            private: false,
+            llVersion,
+            lang: lang ? lang : "en",
+          })
+          .then(catalogManifests => ({ allManifests, catalogManifests })),
+      )
+      .then(
+        (manifests): { manifests: typeof manifests; fetchError: null } => ({
+          manifests,
+          fetchError: null,
+        }),
+        (e): { manifests: null; fetchError: unknown } => ({ manifests: null, fetchError: e }),
+      );
 
-      const catalogManifests = await api.fetchLiveAppManifests(providerURL, {
-        apiVersion,
-        branches,
-        platform,
-        private: false,
-        llVersion,
-        lang: lang ? lang : "en",
-      });
+    if (!isMounted()) return;
 
-      if (!isMounted()) return;
+    if (result.manifests === null) {
+      setState(currentState => ({
+        ...currentState,
+        isLoading: false,
+        error: result.fetchError,
+      }));
+    } else {
+      const { allManifests, catalogManifests } = result.manifests;
       setState(() => ({
         isLoading: false,
         value: {
@@ -147,13 +166,6 @@ export function RemoteLiveAppProvider({
           }, {}),
         },
         error: null,
-      }));
-    } catch (error) {
-      if (!isMounted()) return;
-      setState(currentState => ({
-        ...currentState,
-        isLoading: false,
-        error,
       }));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No test added yet — could add one to verify offline resilience of RampCatalogProvider and RemoteLiveAppProvider._
- [x] **Impact of the changes:**
      - App stability when internet is unavailable
      - RampCatalogProvider and RemoteLiveAppProvider error handling

### 📝 Description

**Problem**: The mobile app crashes immediately when launched without internet connectivity. The crash originates from `RampCatalogProvider` (and potentially `RemoteLiveAppProvider`) where a `catch (error)` block uses the catch binding variable inside a `setState` closure. Hermes (React Native's JS engine) fails to resolve catch binding variables captured by closures, throwing `ReferenceError: Property 'error' doesn't exist`.

**Solution**: Replaced `try/catch` blocks with `.then(onSuccess, onError)` pattern in both providers. The error is now received as a regular function parameter instead of a catch binding, which Hermes handles correctly. This is a minimal, behavior-preserving fix — no functional changes, just a different error-handling mechanism.

**Files changed**:
- `libs/ledger-live-common/src/platform/providers/RampCatalogProvider/index.tsx`
- `libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx`

### ❓ Context

- **JIRA or GitHub link**: N/A — discovered during manual testing

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)