### PR TITLE
chore(common): add version param to stablecoins category API

### DIFF
--- a/.changeset/violet-dancers-hear.md
+++ b/.changeset/violet-dancers-hear.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+fix version for stablecoins category api

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useCategorizedAssets.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useCategorizedAssets.ts
@@ -5,7 +5,7 @@ import { useCategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategoriz
 export function useCategorizedAssetsFromPortfolio() {
   const distribution = useDistribution({ hideEmptyTokenAccount: true });
   const { tickers: stablecoinTickers, isLoading: isLoadingStablecoinTickers } =
-    useStablecoinTickers("lld");
+    useStablecoinTickers("lld", __APP_VERSION__);
   const categorizedAssets = useCategorizedAssets(distribution, stablecoinTickers);
   return {
     categorizedAssets,

--- a/libs/ledger-live-common/src/dada-client/hooks/__tests__/useStablecoinTickers.test.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/__tests__/useStablecoinTickers.test.ts
@@ -11,6 +11,11 @@ jest.mock("../../state-manager/api", () => ({
   useGetAssetsByCategoryQuery: jest.fn(),
 }));
 
+const hookParams = {
+  product: "lld" as const,
+  version: "1.0.0" as const,
+};
+
 const mockUseGetAssetsByCategoryQuery = jest.mocked(useGetAssetsByCategoryQuery);
 
 const defaultMockValues = {
@@ -43,7 +48,9 @@ describe("useStablecoinTickers", () => {
       status: "pending" as const,
     });
 
-    const { result } = renderHook(() => useStablecoinTickers("lld"));
+    const { result } = renderHook(() =>
+      useStablecoinTickers(hookParams.product, hookParams.version),
+    );
 
     expect(result.current.tickers.size).toBe(0);
     expect(result.current.isLoading).toBe(true);
@@ -55,7 +62,9 @@ describe("useStablecoinTickers", () => {
       data: ["usdt", "usdc", "Dai"],
     });
 
-    const { result } = renderHook(() => useStablecoinTickers("lld"));
+    const { result } = renderHook(() =>
+      useStablecoinTickers(hookParams.product, hookParams.version),
+    );
 
     expect(result.current.tickers).toEqual(new Set(["USDT", "USDC", "DAI"]));
     expect(result.current.isLoading).toBe(false);
@@ -64,7 +73,9 @@ describe("useStablecoinTickers", () => {
   it("should return stable reference for empty set across renders", () => {
     mockUseGetAssetsByCategoryQuery.mockReturnValue(defaultMockValues);
 
-    const { result, rerender } = renderHook(() => useStablecoinTickers("lld"));
+    const { result, rerender } = renderHook(() =>
+      useStablecoinTickers(hookParams.product, hookParams.version),
+    );
     const firstRef = result.current.tickers;
 
     rerender();
@@ -75,11 +86,12 @@ describe("useStablecoinTickers", () => {
   it("should pass AssetCategory.Stablecoin to the query", () => {
     mockUseGetAssetsByCategoryQuery.mockReturnValue(defaultMockValues);
 
-    renderHook(() => useStablecoinTickers("lld"));
+    renderHook(() => useStablecoinTickers(hookParams.product, hookParams.version));
 
     expect(mockUseGetAssetsByCategoryQuery).toHaveBeenCalledWith({
       category: AssetCategory.Stablecoin,
-      product: "lld",
+      product: hookParams.product,
+      version: hookParams.version,
     });
   });
 });

--- a/libs/ledger-live-common/src/dada-client/hooks/useStablecoinTickers.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/useStablecoinTickers.ts
@@ -4,10 +4,11 @@ import { AssetCategory } from "../state-manager/types";
 
 const emptySet = new Set<string>();
 
-export function useStablecoinTickers(product: "llm" | "lld") {
+export function useStablecoinTickers(product: "llm" | "lld", version: string) {
   const { data, isLoading } = useGetAssetsByCategoryQuery({
     category: AssetCategory.Stablecoin,
     product,
+    version,
   });
   const tickers = useMemo(
     () => (data ? new Set(data.map(t => t.toUpperCase())) : emptySet),

--- a/libs/ledger-live-common/src/dada-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/api.ts
@@ -109,7 +109,12 @@ export const assetsDataApi = createApi({
         const baseUrl = queryArg.isStaging ? getEnv("DADA_API_STAGING") : getEnv("DADA_API_PROD");
         return {
           url: `${baseUrl}/assets`,
-          params: { category: queryArg.category, product: queryArg.product, pageSize: 100 },
+          params: {
+            category: queryArg.category,
+            product: queryArg.product,
+            pageSize: 100,
+            minVersion: queryArg.version,
+          },
         };
       },
       transformResponse: (response: RawApiResponse) =>

--- a/libs/ledger-live-common/src/dada-client/state-manager/types.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/types.ts
@@ -39,5 +39,6 @@ export const ONE_DAY_IN_SECONDS = 86_400;
 export interface GetAssetsByCategoryParams {
   category: AssetCategory;
   product: "llm" | "lld";
+  version: string;
   isStaging?: boolean;
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No tests added — straightforward parameter pass-through with no new logic._
- [x] **Impact of the changes:**
      - Stablecoin asset categorization in the portfolio/assets view
      - DADA API calls now include `minVersion` query parameter

### 📝 Description

The stablecoins category API was not filtering assets by app version, which could return assets not yet supported by the running release.

This change threads the app version (`__APP_VERSION__`) through `useStablecoinTickers` → `useGetAssetsByCategoryQuery` → DADA `/assets` endpoint as the `minVersion` query parameter, ensuring only version-compatible stablecoins are returned.

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)