### PR TITLE
feat(mobile): add balance refresh shimmer animation

### DIFF
--- a/.changeset/lwm-balance-refresh-animation.md
+++ b/.changeset/lwm-balance-refresh-animation.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add balance refresh shimmer animation on portfolio balance (LIVE-25416)

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from "react";
-import { InfiniteLoader } from "@ledgerhq/native-ui";
 import { AmountDisplay, Box, Pressable, Text } from "@ledgerhq/lumen-ui-rnative";
 import { DiscreetModeIcon } from "./DiscreetModeIcon";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
@@ -23,6 +22,8 @@ export const PortfolioBalanceSectionView = ({
   countervalueChange,
   unit,
   isBalanceAvailable,
+  isLoading,
+  shouldDisplayBalanceRefreshRework,
   onToggleDiscreetMode,
 }: PortfolioBalanceSectionViewProps) => {
   const { t } = useTranslation();
@@ -65,28 +66,26 @@ export const PortfolioBalanceSectionView = ({
           <Box lx={{ flexDirection: "row", alignItems: "baseline", gap: "s14" }}>
             <AmountDisplay
               key={unit.code}
-              value={isBalanceAvailable ? balance : 0}
+              value={balance}
               formatter={formatter}
-              hidden={!isBalanceAvailable || discreet}
+              hidden={discreet || (!shouldDisplayBalanceRefreshRework && !isBalanceAvailable)}
+              loading={shouldDisplayBalanceRefreshRework && isLoading}
               testID="portfolio-balance-amount"
             />
             {discreet && <DiscreetModeIcon />}
           </Box>
         </Pressable>
-        <Box
-          lx={{
-            flexDirection: "row",
-            alignItems: "center",
-            marginTop: "s12",
-            minHeight: isBalanceAvailable ? undefined : "s24",
-          }}
-        >
-          {isBalanceAvailable ? (
+        {isBalanceAvailable && (
+          <Box
+            lx={{
+              flexDirection: "row",
+              alignItems: "center",
+              marginTop: "s12",
+            }}
+          >
             <AnalyticPill valueChange={countervalueChange} />
-          ) : (
-            <InfiniteLoader size={20} />
-          )}
-        </Box>
+          </Box>
+        )}
       </>
     );
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/PortfolioBalanceSectionView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/PortfolioBalanceSectionView.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { getFiatCurrencyByTicker } from "@ledgerhq/live-common/currencies/index";
+import { PortfolioBalanceSectionView } from "../PortfolioBalanceSectionView";
+import { PortfolioBalanceSectionViewProps } from "../types";
+
+const usd = getFiatCurrencyByTicker("USD");
+
+const baseProps: PortfolioBalanceSectionViewProps = {
+  state: "normal",
+  balance: 1000,
+  countervalueChange: { percentage: 1.5, value: 150 },
+  unit: usd.units[0],
+  isBalanceAvailable: true,
+  isLoading: false,
+  shouldDisplayBalanceRefreshRework: false,
+  onToggleDiscreetMode: jest.fn(),
+};
+
+const renderView = (overrides: Partial<PortfolioBalanceSectionViewProps> = {}) =>
+  render(<PortfolioBalanceSectionView {...baseProps} {...overrides} />);
+
+describe("PortfolioBalanceSectionView", () => {
+  describe("state rendering", () => {
+    it("should render balance and analytics pill when state is normal and balance is available", () => {
+      renderView();
+
+      expect(screen.getByTestId("portfolio-balance-normal")).toBeVisible();
+      expect(screen.getByTestId("portfolio-balance-amount")).toBeVisible();
+      expect(screen.getByTestId("portfolio-balance-analytics-pill")).toBeVisible();
+    });
+
+    it("should render noSigner text when state is noSigner", () => {
+      renderView({ state: "noSigner" });
+
+      expect(screen.getByTestId("portfolio-balance-noSigner")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-balance-amount")).toBeNull();
+    });
+
+    it("should render noAccounts text when state is noAccounts", () => {
+      renderView({ state: "noAccounts" });
+
+      expect(screen.getByTestId("portfolio-balance-noAccounts")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-balance-amount")).toBeNull();
+    });
+  });
+
+  describe("loading states", () => {
+    it("should use loading testID and hide analytics pill when balance is not available", () => {
+      renderView({ isBalanceAvailable: false });
+
+      expect(screen.getByTestId("portfolio-balance-loading")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-balance-normal")).toBeNull();
+      expect(screen.queryByTestId("portfolio-balance-analytics-pill")).toBeNull();
+    });
+
+    it("should show shimmer when balance refresh rework is enabled and loading", () => {
+      renderView({
+        isBalanceAvailable: false,
+        isLoading: true,
+        shouldDisplayBalanceRefreshRework: true,
+      });
+
+      expect(screen.getByTestId("portfolio-balance-loading")).toBeVisible();
+      expect(screen.getByTestId("portfolio-balance-amount")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-balance-analytics-pill")).toBeNull();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
@@ -1,5 +1,13 @@
 import { renderHook } from "@tests/test-renderer";
 import { usePortfolioBalanceSectionViewModel } from "../usePortfolioBalanceSectionViewModel";
+import { State } from "~/reducers/types";
+
+const defaultProps = { showAssets: true, isReadOnlyMode: false };
+
+const withRefreshing = (state: State): State => ({
+  ...state,
+  portfolioRefresh: { isRefreshing: true },
+});
 
 describe("usePortfolioBalanceSectionViewModel", () => {
   describe("state determination", () => {
@@ -45,6 +53,22 @@ describe("usePortfolioBalanceSectionViewModel", () => {
       );
 
       expect(result.current.state).toBe("noSigner");
+    });
+  });
+
+  describe("isLoading", () => {
+    it("should be false when balance is available and not refreshing", () => {
+      const { result } = renderHook(() => usePortfolioBalanceSectionViewModel(defaultProps));
+
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("should be true when refreshing", () => {
+      const { result } = renderHook(() => usePortfolioBalanceSectionViewModel(defaultProps), {
+        overrideInitialState: withRefreshing,
+      });
+
+      expect(result.current.isLoading).toBe(true);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/index.tsx
@@ -7,11 +7,19 @@ export const PortfolioBalanceSection = ({
   showAssets,
   isReadOnlyMode = false,
 }: PortfolioBalanceSectionProps) => {
-  const { state, balance, countervalueChange, unit, isBalanceAvailable, onToggleDiscreetMode } =
-    usePortfolioBalanceSectionViewModel({
-      showAssets,
-      isReadOnlyMode,
-    });
+  const {
+    state,
+    balance,
+    countervalueChange,
+    unit,
+    isBalanceAvailable,
+    isLoading,
+    shouldDisplayBalanceRefreshRework,
+    onToggleDiscreetMode,
+  } = usePortfolioBalanceSectionViewModel({
+    showAssets,
+    isReadOnlyMode,
+  });
 
   return (
     <PortfolioBalanceSectionView
@@ -20,6 +28,8 @@ export const PortfolioBalanceSection = ({
       countervalueChange={countervalueChange}
       unit={unit}
       isBalanceAvailable={isBalanceAvailable}
+      isLoading={isLoading}
+      shouldDisplayBalanceRefreshRework={shouldDisplayBalanceRefreshRework}
       onToggleDiscreetMode={onToggleDiscreetMode}
     />
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/types.ts
@@ -14,6 +14,8 @@ export interface PortfolioBalanceSectionViewProps {
   readonly countervalueChange: ValueChange;
   readonly unit: Unit;
   readonly isBalanceAvailable: boolean;
+  readonly isLoading: boolean;
+  readonly shouldDisplayBalanceRefreshRework: boolean;
   readonly onToggleDiscreetMode: () => void;
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
@@ -1,7 +1,9 @@
 import { useMemo } from "react";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useSelector } from "~/context/hooks";
 import { usePortfolioAllAccounts } from "~/hooks/portfolio";
 import { useToggleDiscreetMode } from "~/hooks/useToggleDiscreetMode";
+import { selectIsRefreshing } from "~/reducers/portfolioRefresh";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import {
   PortfolioBalanceState,
@@ -18,6 +20,8 @@ export const usePortfolioBalanceSectionViewModel = ({
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const { toggleDiscreetMode } = useToggleDiscreetMode();
   const portfolio = usePortfolioAllAccounts({ range: DEFAULT_RANGE });
+  const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
+  const isRefreshing = useSelector(selectIsRefreshing);
 
   const { countervalueChange, balanceHistory, balanceAvailable } = portfolio;
   const lastItem = balanceHistory[balanceHistory.length - 1];
@@ -34,12 +38,16 @@ export const usePortfolioBalanceSectionViewModel = ({
     return "normal";
   }, [isReadOnlyMode, showAssets]);
 
+  const isLoading = !balanceAvailable || isRefreshing;
+
   return {
     state,
     balance,
     countervalueChange,
     unit,
     isBalanceAvailable: balanceAvailable,
+    isLoading,
+    shouldDisplayBalanceRefreshRework,
     onToggleDiscreetMode: toggleDiscreetMode,
   };
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio balance section rendering during refresh / cold start
      - Shimmer animation on `AmountDisplay` when `lwmWallet40.params.balanceRefreshRework` is enabled

### 📝 Description

**Problem**: When the user triggers a manual refresh (pull-to-refresh) or opens the app (cold start), there is no visual feedback on the balance amount itself — only a small spinner below it.

**Solution**: Wire the `loading` prop on `AmountDisplay` (from `@ledgerhq/lumen-ui-rnative`) to show a shimmer/pulse animation on the balance during loading states. The animation is gated by the `lwmWallet40` feature flag (`balanceRefreshRework` param).

Changes:
- **ViewModel**: Added `isLoading` (computed from `!balanceAvailable || isRefreshing`) and `shouldDisplayBalanceRefreshRework` from `useWalletFeaturesConfig`
- **View**: Added `loading` prop on `AmountDisplay`, adjusted `hidden` logic to decouple from `isBalanceAvailable` when rework is on, removed `InfiniteLoader` (replaced by shimmer)
- **Types/Connector**: Passed new props through MVVM layers
- **Tests**: Added unit tests for `isLoading` and `shouldDisplayBalanceRefreshRework`

https://github.com/user-attachments/assets/e4fe3317-3367-449b-968e-a15e486d35f4


### ❓ Context

- **JIRA or GitHub link**: [LIVE-25416](https://ledgerhq.atlassian.net/browse/LIVE-25416)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25416]: https://ledgerhq.atlassian.net/browse/LIVE-25416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ