### PR TITLE
test(desktop): add GlobalDialogs integration test

### DIFF
--- a/.changeset/quiet-frogs-clap.md
+++ b/.changeset/quiet-frogs-clap.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add integration test for GlobalDialogs component

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/__integrations__/GlobalDialogs.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/__integrations__/GlobalDialogs.integration.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen, waitFor, act } from "tests/testSetup";
+import GlobalDialogs from "../index";
+import { openReleaseNotes, closeReleaseNotes } from "../../ReleaseNotes/releaseNotesDialog";
+
+jest.mock("../../../../../release-notes.json", () => [
+  { tag_name: "2.80.0", body: "## What's new\n\n- Feature A" },
+]);
+
+describe("GlobalDialogs Integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render without crashing when all dialogs are closed", () => {
+    const { container } = render(<GlobalDialogs />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it("should render ReleaseNotes dialog when opened", async () => {
+    const { store } = render(<GlobalDialogs />);
+
+    act(() => {
+      store.dispatch(openReleaseNotes());
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Release note" })).toBeVisible();
+    });
+    expect(screen.getByText(/Ledger Wallet 2\.80\.0/)).toBeVisible();
+  });
+
+  it("should hide ReleaseNotes dialog when closed", async () => {
+    const { store } = render(<GlobalDialogs />);
+
+    act(() => {
+      store.dispatch(openReleaseNotes());
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Release note" })).toBeVisible();
+    });
+
+    act(() => {
+      store.dispatch(closeReleaseNotes());
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - GlobalDialogs component test coverage

### 📝 Description

Adds an integration test for the `GlobalDialogs` component in ledger-live-desktop.

The test renders the real child components (`ModularDialogRoot`, `SendFlowRoot`, `ReleaseNotes`) with a Redux store, verifying:
- The component mounts without crashing when all dialogs are closed
- The lazy-loaded `ReleaseNotes` dialog renders correctly when opened
- The `ReleaseNotes` dialog is removed from the DOM when closed

### ❓ Context

- **JIRA or GitHub link**: N/A — test coverage improvement

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)