### PR TITLE
ci: connect features folder to SonarCloud coverage

### DIFF
--- a/.changeset/wild-moose-buy.md
+++ b/.changeset/wild-moose-buy.md
@@ -1,0 +1,5 @@
+---
+"@features/market-banner": minor
+---
+
+connect features folder to SonarCloud coverage pipeline

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -87,6 +87,13 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/test-libs-reusable.yml@develop
     secrets: inherit
 
+  test-features:
+    name: "Test Features"
+    needs: determine-affected
+    if: ${{contains(needs.determine-affected.outputs.paths, 'features') && !github.event.pull_request.head.repo.fork}}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-features-reusable.yml@develop
+    secrets: inherit
+
   test-design-system:
     name: "Test UI Libs"
     needs: determine-affected
@@ -129,14 +136,16 @@ jobs:
       - test-desktop
       - test-mobile
       - test-libraries
+      - test-features
       - determine-affected
     uses: LedgerHQ/ledger-live/.github/workflows/scan-sonar-reusable.yml@develop
-    if: ${{ always() && !cancelled() && !github.event.pull_request.head.repo.fork && (needs.test-desktop.result == 'success' || needs.test-mobile.result == 'success' || needs.test-libraries.result == 'success' || contains(needs.determine-affected.outputs.paths, 'e2e')) }}
+    if: ${{ always() && !cancelled() && !github.event.pull_request.head.repo.fork && (needs.test-desktop.result == 'success' || needs.test-mobile.result == 'success' || needs.test-libraries.result == 'success' || needs.test-features.result == 'success' || contains(needs.determine-affected.outputs.paths, 'e2e')) }}
     secrets: inherit
     with:
       should_download_desktop_coverage: ${{ needs.test-desktop.outputs.coverage_generated }}
       should_download_mobile_coverage: ${{ needs.test-mobile.outputs.coverage_generated }}
       should_download_libs_coverage: ${{ needs.test-libraries.outputs.coverage_generated }}
+      should_download_features_coverage: ${{ needs.test-features.outputs.coverage_generated }}
 
   # Final Check required
   ok:
@@ -147,6 +156,7 @@ jobs:
       - test-mobile
       - build-test-mobile
       - test-libraries
+      - test-features
       - test-design-system
       - build-web-tools
       - test-cli

--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -45,6 +45,11 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/test-libs-reusable.yml@develop
     secrets: inherit
 
+  test-features:
+    name: "Test Features"
+    uses: LedgerHQ/ledger-live/.github/workflows/test-features-reusable.yml@develop
+    secrets: inherit
+
   test-design-system:
     name: "Test UI Libs"
     uses: LedgerHQ/ledger-live/.github/workflows/test-design-system-reusable.yml@develop
@@ -69,6 +74,7 @@ jobs:
       - test-mobile
       - build-test-mobile
       - test-libraries
+      - test-features
       - test-design-system
       - build-web-tools
       - test-cli

--- a/.github/workflows/scan-sonar-reusable.yml
+++ b/.github/workflows/scan-sonar-reusable.yml
@@ -15,6 +15,10 @@ on:
         required: false
         default: "false"
         type: string
+      should_download_features_coverage:
+        required: false
+        default: "false"
+        type: string
 
 permissions:
   id-token: write
@@ -67,6 +71,13 @@ jobs:
           name: coverage-libs
           path: coverage-libs
 
+      - name: Download features unit test coverage
+        if: ${{ inputs.should_download_features_coverage == 'true' }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: coverage-features
+          path: coverage-features
+
       - name: Merge coverage files
         run: |
           if [ -d ./coverage-desktop ]; then
@@ -83,6 +94,11 @@ jobs:
             echo "Merging libs coverage files"
             cat ./coverage-libs/lcov.info >> ./lcov.info
             cat ./coverage-libs/sonar-executionTests-report.xml >> ./sonar-executionTests-report.xml
+          fi
+          if [ -d ./coverage-features ]; then
+            echo "Merging features coverage files"
+            cat ./coverage-features/lcov.info >> ./lcov.info
+            cat ./coverage-features/sonar-executionTests-report.xml >> ./sonar-executionTests-report.xml
           fi
           if [ ! -f ./sonar-executionTests-report.xml ]; then
             echo "No report found, creating empty report to avoid sonar scan failing!"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -43,6 +43,7 @@ jobs:
           LANG: en_US.UTF-8
         run: |
           pnpm i --filter="./libs/**" --no-frozen-lockfile --unsafe-perm
+          pnpm i --filter="./features/**" --no-frozen-lockfile --unsafe-perm
           pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
           pnpm i --filter="ledger-live-desktop..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
 
@@ -68,7 +69,7 @@ jobs:
           for package_json in $(find ./libs -name "package.json"); do
             lib=$(dirname "$package_json")
             echo "Processing library at path: $lib"
-            
+
             if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json"; then
               if [ -f "$lib/coverage/lcov.info" ] && [ -f "$lib/coverage/sonar-executionTests-report.xml" ]; then
                 echo "Appending coverage files for $lib"
@@ -82,10 +83,33 @@ jobs:
             fi
           done
 
+      - name: Generate Unit test coverage for features
+        run: |
+          mkdir -p features/coverage
+          touch features/coverage/lcov.info
+          touch features/coverage/sonar-executionTests-report.xml
+
+          pnpm turbo run coverage --filter="./features/**" --concurrency=4 -- --runInBand=1
+
+          for package_json in $(find ./features -name "package.json" -not -path "*/node_modules/*"); do
+            pkg=$(dirname "$package_json")
+            echo "Processing feature at path: $pkg"
+
+            if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json" > /dev/null 2>&1; then
+              if [ -f "$pkg/coverage/lcov.info" ] && [ -f "$pkg/coverage/sonar-executionTests-report.xml" ]; then
+                echo "Appending coverage files for $pkg"
+                cat "$pkg/coverage/lcov.info" >> features/coverage/lcov.info
+                cat "$pkg/coverage/sonar-executionTests-report.xml" >> features/coverage/sonar-executionTests-report.xml
+              fi
+            else
+              echo "No coverage script found for $pkg, skipping."
+            fi
+          done
+
       - name: Merge coverage files
         run: |
-          cat libs/coverage/lcov.info apps/ledger-live-desktop/coverage/lcov.info apps/ledger-live-mobile/coverage/lcov.info > ./lcov.info
-          cat libs/coverage/sonar-executionTests-report.xml apps/ledger-live-desktop/coverage/sonar-executionTests-report.xml apps/ledger-live-mobile/coverage/sonar-executionTests-report.xml > ./sonar-executionTests-report.xml
+          cat libs/coverage/lcov.info features/coverage/lcov.info apps/ledger-live-desktop/coverage/lcov.info apps/ledger-live-mobile/coverage/lcov.info > ./lcov.info
+          cat libs/coverage/sonar-executionTests-report.xml features/coverage/sonar-executionTests-report.xml apps/ledger-live-desktop/coverage/sonar-executionTests-report.xml apps/ledger-live-mobile/coverage/sonar-executionTests-report.xml > ./sonar-executionTests-report.xml
 
       - name: Sonarqube Scan
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6

--- a/.github/workflows/test-features-reusable.yml
+++ b/.github/workflows/test-features-reusable.yml
@@ -1,0 +1,84 @@
+name: "[Features] - Test - Called"
+
+on:
+  workflow_call:
+    outputs:
+      coverage_generated:
+        value: ${{ jobs.test-features.outputs.coverage_generated }}
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: |
+          If you run this manually, and want to run on a PR, the correct ref should be refs/pull/{PR_NUMBER}/merge to
+          have the "normal" scenario involving checking out a merge commit between your branch and the base branch.
+          If you want to run only on a branch or specific commit, you can use either the sha or the branch name instead (prefer the first verion for PRs).
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test-features:
+    name: "Features Test"
+    timeout-minutes: 20
+    env:
+      NODE_OPTIONS: "--max-old-space-size=7168"
+      FORCE_COLOR: 3
+      CI_OS: ubuntu-22.04
+    outputs:
+      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
+
+    runs-on: [ledger-live-linux-8CPU-32RAM]
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup the caches
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        id: setup-caches
+        with:
+          skip-turbo-cache: "false"
+          install-proto: true
+          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+          region: ${{ secrets.AWS_CACHE_REGION }}
+          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm i --filter="./features/**"
+
+      - name: Run coverage on feature packages
+        run: |
+          mkdir -p ${{ github.workspace }}/coverage
+          touch ${{ github.workspace }}/coverage/lcov.info
+          touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
+
+          pnpm turbo run coverage --api="http://127.0.0.1:${{ steps.setup-caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo" --filter="./features/**" --concurrency=4 -- --runInBand=1
+
+      - name: Process coverage files
+        id: process-coverage
+        run: |
+          for package_json in $(find ./features -name "package.json" -not -path "*/node_modules/*"); do
+            pkg=$(dirname "$package_json")
+            echo "Processing feature at path: $pkg"
+            if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json" > /dev/null 2>&1; then
+              if [ -f "$pkg/coverage/lcov.info" ] && [ -f "$pkg/coverage/sonar-executionTests-report.xml" ]; then
+                echo "Appending coverage files for $pkg"
+                cat "$pkg/coverage/lcov.info" >> ${{ github.workspace }}/coverage/lcov.info
+                cat "$pkg/coverage/sonar-executionTests-report.xml" >> ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
+              fi
+            else
+              echo "No coverage script found for $pkg, skipping."
+            fi
+          done
+        shell: bash
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ !cancelled() }}
+        id: generate_coverage
+        with:
+          name: coverage-features
+          path: ${{ github.workspace }}/coverage

--- a/features/market-banner/jest.config.js
+++ b/features/market-banner/jest.config.js
@@ -27,6 +27,7 @@ module.exports = {
   collectCoverage: true,
   reporters: [
     "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
   ],
   projects: [
     // Web tests (Desktop) - uses jsdom environment

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=LedgerHQ_ledger-live
 sonar.projectName=ledger-live
 sonar.sourceEncoding=UTF-8
-sonar.sources=apps,libs,e2e
+sonar.sources=apps,libs,e2e,features
 sonar.exclusions=.pnpm/**,\
 **/node_modules/**,\
 **/coverage/**,\
@@ -34,6 +34,8 @@ libs/**.test.tsx,\
 libs/**/specs.ts,\
 libs/**/e2e/**,\
 libs/coin-tester*/**,\
+features/**.test.ts,\
+features/**.test.tsx,\
 e2e/**/userdata/*.json,\
 **/__mocks__/**,\
 **/__tests__/**,\
@@ -69,7 +71,7 @@ e2e/**/userdata/*.json,\
 sonar.coverage.exclusions=e2e/**/*
 sonar.javascript.lcov.reportPaths=lcov.info
 sonar.testExecutionReportPaths=sonar-executionTests-report.xml
-sonar.typescript.tsconfigPaths=tsconfig.base.json,apps/**/tsconfig.json,e2e/**/tsconfig.json
+sonar.typescript.tsconfigPaths=tsconfig.base.json,apps/**/tsconfig.json,e2e/**/tsconfig.json,features/**/tsconfig.json
 sonar.organization=ledger
 sonar.javascript.node.maxspace=24576
 sonar.c.file.suffixes=-


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _CI/infrastructure changes — verified locally that `jest-sonar` generates the expected `sonar-executionTests-report.xml` and `lcov.info` files._
- [x] **Impact of the changes:**
  - SonarCloud coverage reporting for the `features/` folder
  - CI workflows: new `test-features` job in PR pipeline
  - Scheduled SonarCloud scan now includes features coverage

### 📝 Description

The `features/` folder at the root of the monorepo was not connected to SonarCloud. Code in `features/market-banner` (and any future feature packages) was invisible to coverage analysis and quality gates.

This PR wires the `features/` folder into the SonarCloud pipeline by:

- Adding `features` to `sonar.sources` and `sonar.typescript.tsconfigPaths` in `sonar-project.properties`
- Adding `jest-sonar` reporter to `features/market-banner/jest.config.js` to generate `sonar-executionTests-report.xml`
- Creating a new reusable CI workflow `test-features-reusable.yml` (following the same pattern as `test-libs-reusable.yml`)
- Wiring the new `test-features` job into the PR workflow (`build-and-test-pr.yml`), the sonar scan reusable workflow (`scan-sonar-reusable.yml`), and the scheduled scan (`sonar.yml`)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27064](https://ledgerhq.atlassian.net/browse/LIVE-27064)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27064]: https://ledgerhq.atlassian.net/browse/LIVE-27064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ