### PR TITLE
feat(zcash): hide addresses in operation details when discreet mode is on [LIVE-26509]

### DIFF
--- a/.changeset/rich-hotels-sleep.md
+++ b/.changeset/rich-hotels-sleep.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Hide addresses in operation details for Zcash shielded operations

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/AddressCellShared.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/AddressCellShared.tsx
@@ -41,17 +41,14 @@ const Right = styled.div`
   letter-spacing: 0px;
 `;
 
-export const SplitAddress = ({
-  value,
-  color,
-  ff,
-  fontSize,
-}: {
+export type SplitAddressProps = {
   value: string;
   color?: string;
   ff?: string;
   fontSize?: number;
-}) => {
+};
+
+export const SplitAddress = ({ value, color, ff, fontSize }: SplitAddressProps) => {
   if (!value) {
     return <Box />;
   }

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -19,7 +19,7 @@ import {
   isStuckOperation,
 } from "@ledgerhq/live-common/operation";
 import { getEnv } from "@ledgerhq/live-env";
-import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
+import { CryptoCurrency, CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike, Operation, OperationType } from "@ledgerhq/types-live";
 import { TFunction } from "i18next";
 import invariant from "invariant";
@@ -647,7 +647,12 @@ const OperationD = (props: Props) => {
       {uniqueSenders.length ? (
         <OpDetailsSection data-testid="operation-from">
           <OpDetailsTitle>{t("operationDetails.from")}</OpDetailsTitle>
-          <DataList lines={uniqueSenders} t={t} />
+          <DataList
+            lines={uniqueSenders}
+            t={t}
+            cryptoCurrency={cryptoCurrency}
+            operation={operation}
+          />
         </OpDetailsSection>
       ) : null}
       {recipients.length ? (
@@ -670,7 +675,12 @@ const OperationD = (props: Props) => {
                 </FakeLink>
               </Link>
             ) : null}
-            <DataList lines={recipients} t={t} />
+            <DataList
+              lines={recipients}
+              t={t}
+              cryptoCurrency={cryptoCurrency}
+              operation={operation}
+            />
           </Box>
         </OpDetailsSection>
       ) : null}
@@ -738,6 +748,8 @@ const More = styled(Text).attrs<TextProps>(p => ({
 export class DataList extends Component<{
   lines: string[];
   t: TFunction;
+  cryptoCurrency?: CryptoCurrency;
+  operation?: Operation;
 }> {
   state = {
     numToShow: 2,
@@ -752,14 +764,17 @@ export class DataList extends Component<{
   };
 
   render() {
-    const { lines, t } = this.props;
+    const { lines, t, cryptoCurrency, operation } = this.props;
     const { showMore, numToShow } = this.state;
     // Hardcoded for now
     const shouldShowMore = lines.length > 3;
+    const specific = cryptoCurrency ? getLLDCoinFamily(cryptoCurrency.family) : null;
+    const SplitAddressComponent =
+      specific?.operationDetails?.splitAddress?.[operation?.type as OperationType] || SplitAddress;
     const renderLine = (line: string, index: number) => (
       <OpDetailsData relative horizontal key={line + index}>
         <HashContainer>
-          <SplitAddress value={line} />
+          <SplitAddressComponent value={line} />
         </HashContainer>
         <GradientHover>
           <CopyWithFeedback text={line} />

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/operationDetails.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/operationDetails.test.tsx
@@ -3,10 +3,14 @@ import BigNumber from "bignumber.js";
 import { render, screen } from "tests/testSetup";
 import { createFixtureAccount } from "@ledgerhq/coin-bitcoin/fixtures/common.fixtures";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { TFunction } from "i18next";
 import { Operation } from "@ledgerhq/types-live";
+import { DataList } from "~/renderer/drawers/OperationDetails";
 import operationDetails from "../operationDetails";
 
 const { OperationDetailsExtra, addressCell } = operationDetails;
+
+const mockT = ((key: string) => key) as TFunction;
 
 const ZCASH_OPERATION_TYPES = [
   "SHIELDED_TX_SAPLING_IN",
@@ -146,6 +150,166 @@ describe("addressCell", () => {
       const asterisks = "*".repeat(address.length);
       expect(screen.getByText(asterisks)).toBeInTheDocument();
       expect(container).not.toHaveTextContent(address);
+    });
+  });
+});
+
+const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
+
+describe("splitAddress", () => {
+  describe("Zcash shielded operations", () => {
+    it.each(ZCASH_OPERATION_TYPES)(
+      "should show the address when discreet mode is off for %s",
+      operationType => {
+        const address = "zs1abc123def456";
+        const operation = createOperation(operationType, {
+          senders: operationType.includes("IN") ? [address] : undefined,
+          recipients: operationType.includes("OUT") ? [address] : undefined,
+        });
+
+        const { container } = render(
+          <DataList
+            lines={[address]}
+            t={mockT}
+            cryptoCurrency={zcashCurrency}
+            operation={operation}
+          />,
+          {
+            initialState: {
+              settings: {
+                discreetMode: false,
+              },
+            },
+          },
+        );
+
+        expect(container).toHaveTextContent(address);
+      },
+    );
+
+    it.each(ZCASH_OPERATION_TYPES)(
+      "should show asterisks when discreet mode is on for %s",
+      operationType => {
+        const address = "zs1abc123def456";
+        const operation = createOperation(operationType, {
+          senders: operationType.includes("IN") ? [address] : undefined,
+          recipients: operationType.includes("OUT") ? [address] : undefined,
+        });
+
+        const { container } = render(
+          <DataList
+            lines={[address]}
+            t={mockT}
+            cryptoCurrency={zcashCurrency}
+            operation={operation}
+          />,
+          {
+            initialState: {
+              settings: {
+                discreetMode: true,
+              },
+            },
+          },
+        );
+
+        const asterisks = "*".repeat(address.length);
+        expect(container).toHaveTextContent(asterisks);
+        expect(container).not.toHaveTextContent(address);
+      },
+    );
+  });
+
+  describe("Bitcoin IN and OUT operations", () => {
+    it("should show recipient address for IN operation regardless of discreet mode", () => {
+      const recipientAddress = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh";
+      const operation = createOperation("IN", { recipients: [recipientAddress] });
+
+      const { container } = render(
+        <DataList
+          lines={[recipientAddress]}
+          t={mockT}
+          cryptoCurrency={bitcoinCurrency}
+          operation={operation}
+        />,
+        {
+          initialState: {
+            settings: {
+              discreetMode: false,
+            },
+          },
+        },
+      );
+
+      expect(container).toHaveTextContent(recipientAddress);
+    });
+
+    it("should show recipient address for IN operation when discreet mode is on (no effect)", () => {
+      const recipientAddress = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh";
+      const operation = createOperation("IN", { recipients: [recipientAddress] });
+
+      const { container } = render(
+        <DataList
+          lines={[recipientAddress]}
+          t={mockT}
+          cryptoCurrency={bitcoinCurrency}
+          operation={operation}
+        />,
+        {
+          initialState: {
+            settings: {
+              discreetMode: true,
+            },
+          },
+        },
+      );
+
+      expect(container).toHaveTextContent(recipientAddress);
+    });
+
+    it("should show sender address for OUT operation regardless of discreet mode", () => {
+      const senderAddress = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh";
+      const operation = createOperation("OUT", { senders: [senderAddress] });
+
+      const { container } = render(
+        <DataList
+          lines={[senderAddress]}
+          t={mockT}
+          cryptoCurrency={bitcoinCurrency}
+          operation={operation}
+        />,
+        {
+          initialState: {
+            settings: {
+              discreetMode: false,
+            },
+          },
+        },
+      );
+
+      expect(container).toHaveTextContent(senderAddress);
+    });
+
+    it("should show sender address for OUT operation when discreet mode is on (no effect)", () => {
+      const senderAddress = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh";
+      const operation = createOperation("OUT", { senders: [senderAddress] });
+
+      const { container } = render(
+        <DataList
+          lines={[senderAddress]}
+          t={mockT}
+          cryptoCurrency={bitcoinCurrency}
+          operation={operation}
+        />,
+        {
+          initialState: {
+            settings: {
+              discreetMode: true,
+            },
+          },
+        },
+      );
+
+      expect(container).toHaveTextContent(senderAddress);
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/operationDetails.tsx
@@ -8,9 +8,16 @@ import {
 } from "~/renderer/drawers/OperationDetails/styledComponents";
 import Box from "~/renderer/components/Box";
 import Discreet from "~/renderer/components/Discreet";
-import { Address, Cell } from "~/renderer/components/OperationsList/AddressCellShared";
+import {
+  Address,
+  Cell,
+  SplitAddress,
+  SplitAddressProps,
+} from "~/renderer/components/OperationsList/AddressCellShared";
 import { ZCASH_SHIELDED_TX_TYPES } from "@ledgerhq/zcash-shielded/types";
 import type { AddressCellProps } from "~/renderer/families/types";
+import { discreetModeSelector } from "~/renderer/reducers/settings";
+import { useSelector } from "LLD/hooks/redux";
 
 class AddressCell extends PureComponent<AddressCellProps<Operation>> {
   render() {
@@ -83,6 +90,15 @@ const OperationDetailsExtra = ({
   );
 };
 
+const SplitAddressComponent = (props: SplitAddressProps) => {
+  const useDiscreetMode = useSelector(discreetModeSelector);
+  const newProps: SplitAddressProps = {
+    ...props,
+    value: useDiscreetMode ? "*".repeat(props.value.length) : props.value,
+  };
+  return <SplitAddress {...newProps} />;
+};
+
 export default {
   addressCell: {
     SHIELDED_TX_SAPLING_IN: AddressCell,
@@ -91,4 +107,10 @@ export default {
     SHIELDED_TX_ORCHARD_OUT: AddressCell,
   },
   OperationDetailsExtra,
+  splitAddress: {
+    SHIELDED_TX_SAPLING_IN: SplitAddressComponent,
+    SHIELDED_TX_SAPLING_OUT: SplitAddressComponent,
+    SHIELDED_TX_ORCHARD_IN: SplitAddressComponent,
+    SHIELDED_TX_ORCHARD_OUT: SplitAddressComponent,
+  },
 };

--- a/apps/ledger-live-desktop/src/renderer/families/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/types.ts
@@ -26,6 +26,7 @@ import { StepProps as SendStepProps } from "../modals/Send/types";
 import { StepProps as ReceiveStepProps } from "../modals/Receive/Body";
 import { StepProps as AddAccountsStepProps } from "../modals/AddAccounts";
 import { ModularDrawerAddAccountFlowManagerProps } from "LLD/features/AddAccountDrawer/ModularDrawerAddAccountFlowManager";
+import type { SplitAddressProps } from "../components/OperationsList/AddressCellShared";
 
 export type AddressCellProps<O extends Operation> = {
   operation: O;
@@ -153,6 +154,12 @@ export type LLDCoinFamily<
      * Add custom component at the end in operation details drawer
      */
     OperationDetailsPostAlert?: React.ComponentType<OperationDetailsExtraProps<A, O>>;
+
+    /**
+     * Replace split address component for specific operation type
+     * @default SplitAddress from "~/renderer/components/OperationsList/AddressCellShared"
+     */
+    splitAddress?: Partial<Record<OperationType, React.ComponentType<SplitAddressProps>>>;
   };
 
   accountActions?: {


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ledger-live-desktop

### 📝 Description

Hide recipient and senders addresses for Zcash shielded operations when discreet mode is on.

https://github.com/user-attachments/assets/0dae7766-4b82-4282-aa6b-52b886ba0d10



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26509


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
