### PR TITLE
feat(LIVE-27029): aleo operation details extra

### DIFF
--- a/.changeset/unlucky-timers-matter.md
+++ b/.changeset/unlucky-timers-matter.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aleo": minor
+"ledger-live-desktop": minor
+---
+
+aleo operation details extra

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/operationDetails.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/operationDetails.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import type { AleoOperation } from "@ledgerhq/live-common/families/aleo/types";
+import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
+import operationDetails from "../operationDetails";
+
+const { OperationDetailsExtra } = operationDetails;
+
+describe("OperationDetailsExtra", () => {
+  it("should only render functionId and not expose transactionType or patched", () => {
+    const mockOperation: AleoOperation = {
+      ...ALEO_ACCOUNT_1.operations[0],
+      extra: {
+        functionId: "transfer_public",
+        transactionType: "public",
+        patched: true,
+      },
+    };
+
+    render(<OperationDetailsExtra account={ALEO_ACCOUNT_1} operation={mockOperation} type="OUT" />);
+
+    expect(screen.getByText("transfer_public")).toBeInTheDocument();
+    expect(screen.queryByText("transactionType")).not.toBeInTheDocument();
+    expect(screen.queryByText("public")).not.toBeInTheDocument();
+    expect(screen.queryByText("patched")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/operationDetails.tsx
@@ -1,7 +1,19 @@
 import React from "react";
 import { Trans } from "react-i18next";
 import { Box, Text } from "@ledgerhq/react-ui/index";
-import type { AleoTransactionType } from "@ledgerhq/live-common/families/aleo/types";
+import { getOperationDetailsExtraFields } from "@ledgerhq/live-common/families/aleo/utils";
+import type {
+  AleoAccount,
+  AleoOperation,
+  AleoTransactionType,
+} from "@ledgerhq/live-common/families/aleo/types";
+import Ellipsis from "~/renderer/components/Ellipsis";
+import {
+  OpDetailsData,
+  OpDetailsSection,
+  OpDetailsTitle,
+} from "~/renderer/drawers/OperationDetails/styledComponents";
+import type { OperationDetailsExtraProps } from "~/renderer/families/types";
 import type { AleoFamily } from "./types";
 
 type OperationDetails = NonNullable<AleoFamily["operationDetails"]>;
@@ -28,6 +40,28 @@ const CustomMetadataCell: OperationDetails["customMetadataCell"] = props => {
   );
 };
 
+const OperationDetailsExtra = ({
+  operation,
+}: OperationDetailsExtraProps<AleoAccount, AleoOperation>) => {
+  const extraFields = getOperationDetailsExtraFields(operation.extra);
+
+  return (
+    <>
+      {extraFields.map(item => (
+        <OpDetailsSection key={item.key}>
+          <OpDetailsTitle>
+            <Trans i18nKey={`operationDetails.extra.${item.key}`} defaults={item.key} />
+          </OpDetailsTitle>
+          <OpDetailsData>
+            <Ellipsis>{item.value}</Ellipsis>
+          </OpDetailsData>
+        </OpDetailsSection>
+      ))}
+    </>
+  );
+};
+
 export default {
   customMetadataCell: CustomMetadataCell,
+  OperationDetailsExtra,
 };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -1752,7 +1752,8 @@
       "previousStakingNodeId": "Previous node ID",
       "gasConsumed": "Gas consumed",
       "gasUsed": "Gas used",
-      "gasLimit": "Gas limit"
+      "gasLimit": "Gas limit",
+      "functionId": "Function ID"
     }
   },
   "operationList": {

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -14,7 +14,7 @@ import {
 import { getMockedOperation } from "../__tests__/fixtures/operation.fixture";
 import { getMockedPreparedRequestResponse } from "../__tests__/fixtures/sdk.fixture";
 import { getMockedTransaction } from "../__tests__/fixtures/transaction.fixture";
-import type { ProvableApi, AleoTransactionIntentData } from "../types";
+import type { AleoOperationExtra, ProvableApi, AleoTransactionIntentData } from "../types";
 import {
   getNetworkConfig,
   parseMicrocredits,
@@ -35,6 +35,7 @@ import {
   deserializeTransaction,
   mapTransactionIntentToSdkIntent,
   hasSpecificIntentData,
+  getOperationDetailsExtraFields,
 } from "./utils";
 
 jest.mock("@ledgerhq/cryptoassets/currencies");
@@ -972,5 +973,19 @@ describe("deserializeTransaction", () => {
     const invalidJsonHex = Buffer.from("not json").toString("hex");
 
     expect(() => deserializeTransaction(invalidJsonHex)).toThrow();
+  });
+});
+
+describe("getOperationDetailsExtraFields", () => {
+  it("should return only the functionId field", () => {
+    const extra = {
+      functionId: "transfer_private_to_public",
+      transactionType: "private",
+      patched: true,
+    } satisfies AleoOperationExtra;
+
+    const result = getOperationDetailsExtraFields(extra);
+
+    expect(result).toEqual([{ key: "functionId", value: "transfer_private_to_public" }]);
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -17,6 +17,7 @@ import type {
   AleoOperation,
   AleoTransactionType,
   EnrichedPrivateRecord,
+  OperationDetailsExtraField,
   Transaction,
   TransactionType,
   ProvableApi,
@@ -26,6 +27,7 @@ import type {
   PreparedRequestResponse,
   AleoTransactionIntentData,
   AleoPublicTransaction,
+  AleoOperationExtra,
 } from "../types";
 
 export function parseMicrocredits(microcreditsU64: string): string {
@@ -356,3 +358,9 @@ export function serializeTransaction(tx: PreparedRequestResponse): string {
 export function deserializeTransaction(txHex: string): PreparedRequestResponse {
   return JSON.parse(Buffer.from(txHex, "hex").toString());
 }
+// this function is used to extract the fields that should be displayed in the operation details
+export const getOperationDetailsExtraFields = (
+  extra: AleoOperationExtra,
+): OperationDetailsExtraField[] => {
+  return [{ key: "functionId", value: extra.functionId }];
+};

--- a/libs/coin-modules/coin-aleo/src/types/bridge.ts
+++ b/libs/coin-modules/coin-aleo/src/types/bridge.ts
@@ -84,6 +84,11 @@ export type AleoOperationExtra = {
   patched?: boolean;
 };
 
+export type OperationDetailsExtraField = {
+  key: keyof AleoOperationExtra;
+  value: string | number;
+};
+
 export type AleoOperation = Operation<AleoOperationExtra>;
 
 export type TransactionTransfer = Extract<


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - custom renderer for account.extra for Aleo in operation details 

### 📝 Description

Added custom renderer for account.extra in operation details drawer for Aleo. We want to expose only selected fields from the extra object.   

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [https://ledgerhq.atlassian.net/browse/LIVE-27029](https://ledgerhq.atlassian.net/browse/LIVE-27029)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
