### PR TITLE
feat(mobile): scroll to top when pressing home tab

### DIFF
--- a/.changeset/short-pans-whisper.md
+++ b/.changeset/short-pans-whisper.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wallet screen auto scroll to the top when pressing home tab w4.0

--- a/apps/ledger-live-mobile/src/components/WalletTab/CollapsibleHeaderFlatList.tsx
+++ b/apps/ledger-live-mobile/src/components/WalletTab/CollapsibleHeaderFlatList.tsx
@@ -12,12 +12,14 @@ const DEFAULT_TAB_BAR_HEIGHT = 0;
 type CollapsibleHeaderFlatListProps<T> = AnimatedProps<FlatListProps<T>> & {
   /** When false, skip SafeAreaView (e.g. when parent nav already handles safe area). Default true. */
   useSafeArea?: boolean;
+  onFlatListRef?: (ref: FlatList | null) => void;
 };
 
 function CollapsibleHeaderFlatList<T>({
   children,
   contentContainerStyle,
   useSafeArea = true,
+  onFlatListRef,
   ...otherProps
 }: CollapsibleHeaderFlatListProps<T>) {
   const context = useContext(WalletTabNavigatorScrollContext);
@@ -45,11 +47,12 @@ function CollapsibleHeaderFlatList<T>({
 
   const handleRef = useCallback(
     (ref: FlatList) => {
+      onFlatListRef?.(ref);
       if (onGetRef) {
         onGetRef({ key: route.name, value: ref });
       }
     },
-    [onGetRef, route.name],
+    [onGetRef, onFlatListRef, route.name],
   );
 
   const list = (

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/__tests__/useMainTabBarViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/__tests__/useMainTabBarViewModel.test.ts
@@ -1,0 +1,85 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { NavigatorName } from "~/const";
+import { scrollToTopEvent } from "../scrollToTopEvent";
+import { useMainTabBarViewModel } from "../useMainTabBarViewModel";
+import { track } from "~/analytics";
+
+const TAB_ROUTE_NAMES = [
+  NavigatorName.Portfolio,
+  NavigatorName.Swap,
+  NavigatorName.Earn,
+  NavigatorName.CardTab,
+];
+
+function createState(activeIndex: number) {
+  const routes = TAB_ROUTE_NAMES.map((name, i) => ({ name, key: `tab-${i}` }));
+  return { routes, index: activeIndex };
+}
+
+function createNavigation() {
+  return {
+    emit: () => ({ defaultPrevented: false }),
+    navigate: jest.fn(),
+  };
+}
+
+describe("useMainTabBarViewModel", () => {
+  describe("scroll to top", () => {
+    it("should emit scroll-to-top when re-pressing Home tab while already on Home", () => {
+      const onScrollToTop = jest.fn();
+      const unsubscribe = scrollToTopEvent.subscribe(onScrollToTop);
+
+      const state = createState(0);
+      const navigation = createNavigation();
+      const { result } = renderHook(() =>
+        useMainTabBarViewModel({ state: state as never, navigation: navigation as never }),
+      );
+
+      act(() => {
+        result.current.onTabPress(NavigatorName.Portfolio);
+      });
+
+      expect(onScrollToTop).toHaveBeenCalledTimes(1);
+      expect(track).not.toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it("should not emit scroll-to-top when pressing Home tab while on another tab", () => {
+      const onScrollToTop = jest.fn();
+      const unsubscribe = scrollToTopEvent.subscribe(onScrollToTop);
+
+      const state = createState(1);
+      const navigation = createNavigation();
+      const { result } = renderHook(() =>
+        useMainTabBarViewModel({ state: state as never, navigation: navigation as never }),
+      );
+
+      act(() => {
+        result.current.onTabPress(NavigatorName.Portfolio);
+      });
+
+      expect(onScrollToTop).not.toHaveBeenCalled();
+      expect(track).toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it("should not emit scroll-to-top when pressing a different tab while on Home", () => {
+      const onScrollToTop = jest.fn();
+      const unsubscribe = scrollToTopEvent.subscribe(onScrollToTop);
+
+      const state = createState(0);
+      const navigation = createNavigation();
+      const { result } = renderHook(() =>
+        useMainTabBarViewModel({ state: state as never, navigation: navigation as never }),
+      );
+
+      act(() => {
+        result.current.onTabPress(NavigatorName.Swap);
+      });
+
+      expect(onScrollToTop).not.toHaveBeenCalled();
+      expect(track).toHaveBeenCalled();
+      unsubscribe();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/scrollToTopEvent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/scrollToTopEvent.ts
@@ -1,0 +1,13 @@
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+export const scrollToTopEvent = {
+  emit: () => listeners.forEach(fn => fn()),
+  subscribe: (fn: Listener) => {
+    listeners.add(fn);
+    return () => {
+      listeners.delete(fn);
+    };
+  },
+};

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
@@ -15,6 +15,7 @@ import type { TabItemConfig, MainTabBarViewProps } from "./types";
 import { useTranslation } from "~/context/Locale";
 import { track } from "~/analytics";
 import { LABELKEY_MAP, TRACKING_LABEL_MAP, TRACKING_MENUENTRY_EVENT } from "./constants";
+import { scrollToTopEvent } from "./scrollToTopEvent";
 
 type UseMainTabBarViewModelParams = Pick<BottomTabBarProps, "state" | "navigation">;
 
@@ -39,6 +40,18 @@ const TAB_TEST_IDS: Partial<Record<string, string>> = {
   [NavigatorName.CardTab]: "w40-tab-card",
 };
 
+function trackTabNavigation(targetName: string, sourceName: string, value: string) {
+  const entry = TRACKING_LABEL_MAP[targetName] ?? value;
+  const page = TRACKING_LABEL_MAP[sourceName];
+  track(TRACKING_MENUENTRY_EVENT, { entry, page });
+}
+
+function handleScrollToTop(value: string, activeRouteName: string) {
+  if (value === NavigatorName.Portfolio && activeRouteName === NavigatorName.Portfolio) {
+    scrollToTopEvent.emit();
+  }
+}
+
 export const useMainTabBarViewModel = ({
   state,
   navigation,
@@ -57,19 +70,9 @@ export const useMainTabBarViewModel = ({
     [state.routes, t],
   );
 
-  const onTabPress = useCallback(
-    (value: string) => {
-      const targetRoute = state.routes.find(route => route.name === value);
-      const currentRoute = state.routes[state.index].name;
-      if (!targetRoute) return;
-
-      const trackingLabel = TRACKING_LABEL_MAP[targetRoute.name];
-      const trackingSource = TRACKING_LABEL_MAP[currentRoute];
-
-      track(TRACKING_MENUENTRY_EVENT, {
-        entry: trackingLabel ?? value,
-        page: trackingSource,
-      });
+  const navigateToTab = useCallback(
+    (targetRoute: { key: string; name: string }, value: string) => {
+      trackTabNavigation(targetRoute.name, state.routes[state.index].name, value);
 
       const event = navigation.emit({
         type: "tabPress",
@@ -77,13 +80,25 @@ export const useMainTabBarViewModel = ({
         canPreventDefault: true,
       });
 
-      const isFocused = activeRouteName === value;
-
-      if (!isFocused && !event.defaultPrevented) {
+      if (!event.defaultPrevented) {
         navigation.navigate(value);
       }
     },
-    [state, navigation, activeRouteName],
+    [state, navigation],
+  );
+
+  const onTabPress = useCallback(
+    (value: string) => {
+      const targetRoute = state.routes.find(route => route.name === value);
+      if (!targetRoute) return;
+
+      handleScrollToTop(value, activeRouteName);
+
+      if (activeRouteName !== value) {
+        navigateToTab(targetRoute, value);
+      }
+    },
+    [state.routes, activeRouteName, navigateToTab],
   );
 
   return { activeRouteName, tabItems, onTabPress };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/__tests__/useScrollToTop.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/__tests__/useScrollToTop.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { FlatList } from "react-native";
+import { renderHook, act } from "@tests/test-renderer";
+import { scrollToTopEvent } from "LLM/components/MainTabBar/scrollToTopEvent";
+import WalletTabNavigatorScrollManager from "~/components/WalletTab/WalletTabNavigatorScrollManager";
+import { useScrollToTop } from "../useScrollToTop";
+
+describe("useScrollToTop", () => {
+  it("should scroll to top when event is emitted", () => {
+    const scrollToOffset = jest.fn();
+    const flatListRef = { scrollToOffset };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <WalletTabNavigatorScrollManager currentRouteName={undefined}>
+        {children}
+      </WalletTabNavigatorScrollManager>
+    );
+
+    const { result } = renderHook(() => useScrollToTop(), { wrapper });
+
+    act(() => {
+      result.current.handleFlatListRef(
+        flatListRef as unknown as React.ComponentRef<typeof FlatList>,
+      );
+    });
+
+    act(() => {
+      scrollToTopEvent.emit();
+    });
+
+    expect(scrollToOffset).toHaveBeenCalledWith({ offset: 0, animated: true });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../constants";
 import { getProgressViewOffset } from "../../utils/getProgressViewOffset";
 import usePortfolioViewModel from "./usePortfolioViewModel";
+import { useScrollToTop } from "./useScrollToTop";
 
 import { Box } from "@ledgerhq/native-ui";
 import { QuickActionsCtas, TransferDrawer } from "LLM/features/QuickActions";
@@ -62,6 +63,8 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
   } = usePortfolioViewModel(navigation);
 
   const progressViewOffset = getProgressViewOffset(Platform.OS, shouldDisplayWallet40MainNav);
+
+  const { handleFlatListRef } = useScrollToTop();
 
   const { isDrawerOpen, handleCloseDrawer, closeDrawer, onSlideChange, slides } =
     useWalletV4TourDrawer();
@@ -160,6 +163,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
       <CheckTermOfUseUpdate />
       <Animated.View testID="portfolio-screen" style={{ flex: 1 }}>
         <RefreshableCollapsibleHeaderFlatList
+          onFlatListRef={handleFlatListRef}
           data={data}
           renderItem={renderItem<React.JSX.Element>}
           keyExtractor={(_: unknown, index: number) => String(index)}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/useScrollToTop.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/useScrollToTop.ts
@@ -1,0 +1,22 @@
+import { useCallback, useContext, useEffect, useRef } from "react";
+import { FlatList } from "react-native";
+import { scrollToTopEvent } from "LLM/components/MainTabBar/scrollToTopEvent";
+import { WalletTabNavigatorScrollContext } from "~/components/WalletTab/WalletTabNavigatorScrollManager";
+
+export function useScrollToTop() {
+  const flatListRef = useRef<FlatList | null>(null);
+  const { scrollY } = useContext(WalletTabNavigatorScrollContext);
+
+  const handleFlatListRef = useCallback((ref: FlatList | null) => {
+    flatListRef.current = ref;
+  }, []);
+
+  const scrollToTop = useCallback(() => {
+    scrollY?.setValue(0);
+    flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+  }, [scrollY]);
+
+  useEffect(() => scrollToTopEvent.subscribe(scrollToTop), [scrollToTop]);
+
+  return { handleFlatListRef };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Scroll-to-top behavior when pressing the Home tab (from any tab or re-tapping Home)
      - Background gradient visibility when switching between tabs
      - Tab navigation between all bottom tabs (Home, Swap, Earn, Card)

### 📝 Description

**Scroll to top on Home tab (Wallet 4.0)** — The Portfolio screen scrolls to the top only when the user **re-taps the Home tab while already on the Portfolio screen**. Switching from another tab (Swap, Earn, Card) to Home no longer triggers scroll to top.

- **Logic:** `scrollToTopEvent` is emitted only when `activeRouteName === Portfolio` and the user presses the Portfolio tab (`value === Portfolio`), i.e. re-press on Home.
- **Implementation:** `useMainTabBarViewModel` calls `handleScrollToTop(value, activeRouteName)`; `useScrollToTop` (Portfolio) subscribes to the event and resets `scrollY` + calls `flatListRef.scrollToOffset({ offset: 0, animated: true })`.
- **Tests:** Unit tests for `useMainTabBarViewModel` (real `scrollToTopEvent`, subscribe and assert listener is called only on re-press Home) and for `useScrollToTop` (real `WalletTabNavigatorScrollManager`, event emission triggers scroll).



https://github.com/user-attachments/assets/10762724-e666-4a05-8826-81c404d249b7



### ❓ Context

- **JIRA or GitHub link**: [LIVE-27081](https://ledgerhq.atlassian.net/browse/LIVE-27081)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27081]: https://ledgerhq.atlassian.net/browse/LIVE-27081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ