### PR TITLE
test(desktop): add tests for WalletSync

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/BackupDeleted.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/BackupDeleted.test.tsx
@@ -5,6 +5,13 @@ import React from "react";
 import { render, screen } from "tests/testSetup";
 import BackupDeleted from "../screens/ManageBackup/02-FinalStep";
 
+jest.mock("../hooks/useLedgerSyncAnalytics", () => ({
+  ...jest.requireActual("../hooks/useLedgerSyncAnalytics"),
+  useLedgerSyncAnalytics: () => ({
+    onClickTrack: jest.fn(),
+  }),
+}));
+
 describe("BackupDeleted", () => {
   it("should show delete backup success message, not Sync complete", () => {
     render(<BackupDeleted isSuccessful />);
@@ -12,5 +19,14 @@ describe("BackupDeleted", () => {
     expect(screen.getByText("Your Ledger Wallet apps are no longer synced")).toBeInTheDocument();
     expect(screen.getByText("You can turn on sync anytime")).toBeInTheDocument();
     expect(screen.queryByText("Sync complete")).not.toBeInTheDocument();
+  });
+
+  it("should show error state when isSuccessful is false", () => {
+    render(<BackupDeleted isSuccessful={false} />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Your Ledger Wallet apps are no longer synced"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/Error.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/Error.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import userEvent from "@testing-library/user-event";
+import { Error as WalletSyncError } from "../components/Error";
+
+describe("WalletSync Error component", () => {
+  it("should render title and description", () => {
+    render(<WalletSyncError title="Error title" description="Error description" />);
+    expect(screen.getByText("Error title")).toBeInTheDocument();
+    expect(screen.getByText("Error description")).toBeInTheDocument();
+  });
+
+  it("should render CTA button when cta and onClick provided", async () => {
+    const onClick = jest.fn();
+    render(<WalletSyncError title="Error" description="Desc" cta="Retry" onClick={onClick} />);
+    const button = screen.getByRole("button", { name: "Retry" });
+    await userEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render close link when onClose provided", async () => {
+    const onClose = jest.fn();
+    render(<WalletSyncError title="Error" description="Desc" onClose={onClose} />);
+    const closeLink = screen.getByText("Close");
+    await userEvent.click(closeLink);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/GenericStatusDisplay.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/GenericStatusDisplay.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import userEvent from "@testing-library/user-event";
+import { GenericStatusDisplay } from "../components/GenericStatusDisplay";
+
+describe("GenericStatusDisplay", () => {
+  it("should render title and description with success icon by default", () => {
+    render(<GenericStatusDisplay title="Success title" description="Success description" />);
+    expect(screen.getByText("Success title")).toBeInTheDocument();
+    expect(screen.getByText("Success description")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("should render info icon when type is info", () => {
+    render(<GenericStatusDisplay title="Info" description="Info text" type="info" />);
+    expect(screen.getByText("Info")).toBeInTheDocument();
+  });
+
+  it("should show close button when withClose is true and call onClose when clicked", async () => {
+    const onClose = jest.fn();
+    const { user } = render(
+      <GenericStatusDisplay title="Done" description="All done" withClose onClose={onClose} />,
+    );
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    await user.click(closeButton);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show CTA button when withCta and onClick are provided", async () => {
+    const onClick = jest.fn();
+    render(
+      <GenericStatusDisplay title="Synced" description="Sync complete" withCta onClick={onClick} />,
+    );
+    const ctaButton = screen.getByRole("button", {
+      name: "Sync with another Ledger Wallet app",
+    });
+    await userEvent.click(ctaButton);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should use specificCta when provided", () => {
+    render(
+      <GenericStatusDisplay
+        title="Title"
+        description="Desc"
+        withCta
+        onClick={() => {}}
+        specificCta="Custom CTA"
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Custom CTA" })).toBeInTheDocument();
+  });
+
+  it("should use testId when provided", () => {
+    render(<GenericStatusDisplay title="Title" description="Desc" testId="custom-test-id" />);
+    expect(screen.getByTestId("custom-test-id")).toHaveTextContent("Title");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/WalletSyncContext.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/WalletSyncContext.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, renderHook } from "tests/testSetup";
+import { WalletSyncProvider, useWalletSyncUserState } from "../components/WalletSyncContext";
+
+jest.mock("../hooks/useWatchWalletSync", () => ({
+  useWatchWalletSync: jest.fn(() => ({
+    visualPending: false,
+    walletSyncError: null,
+    onUserRefresh: jest.fn(),
+  })),
+}));
+
+describe("WalletSyncContext", () => {
+  it("should provide default context value when used outside provider", () => {
+    const { result } = renderHook(() => useWalletSyncUserState());
+    expect(result.current.visualPending).toBe(false);
+    expect(result.current.walletSyncError).toBe(null);
+    expect(result.current.onUserRefresh).toEqual(expect.any(Function));
+  });
+
+  it("should provide wallet sync state from useWatchWalletSync when inside provider", () => {
+    const mockOnUserRefresh = jest.fn();
+    const useWatchWalletSync = jest.requireMock("../hooks/useWatchWalletSync").useWatchWalletSync;
+    useWatchWalletSync.mockReturnValue({
+      visualPending: true,
+      walletSyncError: new Error("Sync failed"),
+      onUserRefresh: mockOnUserRefresh,
+    });
+
+    const Consumer = () => {
+      const state = useWalletSyncUserState();
+      return (
+        <>
+          <span data-testid="pending">{String(state.visualPending)}</span>
+          <span data-testid="error">{state.walletSyncError?.message ?? "none"}</span>
+          <button type="button" onClick={state.onUserRefresh}>
+            Refresh
+          </button>
+        </>
+      );
+    };
+
+    render(
+      <WalletSyncProvider>
+        <Consumer />
+      </WalletSyncProvider>,
+    );
+
+    expect(screen.getByTestId("pending")).toHaveTextContent("true");
+    expect(screen.getByTestId("error")).toHaveTextContent("Sync failed");
+    screen.getByRole("button", { name: "Refresh" }).click();
+    expect(mockOnUserRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useFlows.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useFlows.test.ts
@@ -1,12 +1,21 @@
 import { Flow, Step, initialStateWalletSync } from "~/renderer/reducers/walletSync";
 import { act, renderHook } from "tests/testSetup";
-import { FlowOptions, useFlows } from "../hooks/useFlows";
+import { FlowOptions, useFlows, STEPS_WITH_BACK } from "../hooks/useFlows";
+import { simpleTrustChain } from "./shared";
 
 const INITIAL_STATE = {
   walletSync: {
     ...initialStateWalletSync,
     flow: Flow.ManageBackup,
     step: Step.DeleteBackup,
+  },
+};
+
+const INITIAL_STATE_WITH_TRUSTCHAIN = {
+  ...INITIAL_STATE,
+  trustchain: {
+    trustchain: simpleTrustChain,
+    memberCredentials: { pubkey: "pk", privatekey: "sk" },
   },
 };
 
@@ -31,17 +40,42 @@ describe("useFlows", () => {
     expect(result.current.currentStep).toBe(Object.values(steps)[0]);
   });
 
-  it("should reset Flow and Step", async () => {
-    const steps = FlowOptions.ManageBackup.steps;
-
+  it("should reset Flow and Step when no trustchain", async () => {
     const { result, store } = renderHook(() => useFlows(), { initialState: INITIAL_STATE });
-
-    expect(result.current.currentStep).toBe(Object.values(steps)[0]);
 
     act(() => {
       result.current.goToWelcomeScreenWalletSync();
     });
     expect(store.getState().walletSync.step).toBe(Step.CreateOrSynchronize);
     expect(store.getState().walletSync.flow).toBe(Flow.Activation);
+  });
+
+  it("should go to LedgerSyncActivated when trustchain exists", async () => {
+    const { result, store } = renderHook(() => useFlows(), {
+      initialState: INITIAL_STATE_WITH_TRUSTCHAIN,
+    });
+
+    act(() => {
+      result.current.goToWelcomeScreenWalletSync();
+    });
+    expect(store.getState().walletSync.step).toBe(Step.LedgerSyncActivated);
+    expect(store.getState().walletSync.flow).toBe(Flow.LedgerSyncActivated);
+  });
+
+  it("should go to DeviceAction when onboardingNewDevice is true and no trustchain", async () => {
+    const { result, store } = renderHook(() => useFlows(), { initialState: INITIAL_STATE });
+
+    act(() => {
+      result.current.goToWelcomeScreenWalletSync(true);
+    });
+    expect(store.getState().walletSync.step).toBe(Step.DeviceAction);
+    expect(store.getState().walletSync.flow).toBe(Flow.Activation);
+  });
+
+  it("should expose FlowOptions and STEPS_WITH_BACK", () => {
+    const { result } = renderHook(() => useFlows(), { initialState: INITIAL_STATE });
+    expect(result.current.FlowOptions).toBeDefined();
+    expect(result.current.FlowOptions[Flow.ManageBackup].steps).toBeDefined();
+    expect(STEPS_WITH_BACK).toContain(Step.DeleteBackup);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useGetMembers.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useGetMembers.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, waitFor } from "tests/testSetup";
+import { useGetMembers } from "../hooks/useGetMembers";
+import { TrustchainMember } from "@ledgerhq/ledger-key-ring-protocol/types";
+import { simpleTrustChain } from "./shared";
+
+const mockInstances: TrustchainMember[] = [
+  { id: "1", name: "Desktop", permissions: 112 },
+  { id: "2", name: "Mobile", permissions: 112 },
+];
+
+const Mocks = {
+  getMembers: jest.fn().mockResolvedValue(mockInstances),
+  handleError: jest.fn(),
+};
+
+jest.mock("../hooks/useTrustchainSdk", () => ({
+  useTrustchainSdk: () => ({ getMembers: Mocks.getMembers }),
+}));
+
+jest.mock("../hooks/walletSync.hooks", () => ({
+  useLifeCycle: () => ({ handleError: Mocks.handleError }),
+}));
+
+const initialStateWithTrustchain = {
+  trustchain: {
+    trustchain: simpleTrustChain,
+    memberCredentials: { pubkey: "pk", privatekey: "sk" },
+  },
+};
+
+describe("useGetMembers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Mocks.getMembers.mockResolvedValue(mockInstances);
+  });
+
+  it("should return instances when query succeeds", async () => {
+    const { result } = renderHook(() => useGetMembers(), {
+      initialState: initialStateWithTrustchain,
+    });
+
+    await waitFor(() => expect(result.current.isMembersLoading).toBe(false));
+    expect(result.current.instances).toEqual(mockInstances);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should call handleError when query fails", async () => {
+    const err = new Error("Trustchain not found");
+    Mocks.getMembers.mockRejectedValue(err);
+
+    const { result } = renderHook(() => useGetMembers(), {
+      initialState: initialStateWithTrustchain,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(err);
+    expect(Mocks.handleError).toHaveBeenCalledWith(err);
+  });
+
+  it("should not fetch when trustchain or memberCredentials missing", async () => {
+    const { result } = renderHook(() => useGetMembers(), {
+      initialState: {},
+    });
+
+    await waitFor(() => expect(result.current.isMembersLoading).toBe(false));
+    expect(Mocks.getMembers).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useLedgerSyncAnalytics.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useLedgerSyncAnalytics.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, act } from "tests/testSetup";
+import {
+  useLedgerSyncAnalytics,
+  StepMappedToAnalytics,
+  AnalyticsPage,
+  StepsOutsideFlow,
+} from "../hooks/useLedgerSyncAnalytics";
+import { Step } from "~/renderer/reducers/walletSync";
+
+const mockTrack = jest.fn();
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: (event: string, props?: Record<string, unknown>) => mockTrack(event, props),
+  setAnalyticsFeatureFlagMethod: jest.fn(),
+}));
+
+describe("useLedgerSyncAnalytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should call track with button and page on onClickTrack", () => {
+    const { result } = renderHook(() => useLedgerSyncAnalytics());
+
+    act(() => {
+      result.current.onClickTrack({ button: "Turn on", page: AnalyticsPage.Activation });
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith("button_clicked2", {
+      button: "Turn on",
+      page: AnalyticsPage.Activation,
+      flow: undefined,
+    });
+  });
+
+  it("should call track with step mapped to analytics page on onActionTrack", () => {
+    const { result } = renderHook(() => useLedgerSyncAnalytics());
+
+    act(() => {
+      result.current.onActionTrack({
+        button: "Back",
+        step: Step.DeleteBackup,
+        flow: "Ledger Sync",
+      });
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith("button_clicked2", {
+      button: "Back",
+      page: StepMappedToAnalytics[Step.DeleteBackup],
+      flow: "Ledger Sync",
+    });
+  });
+});
+
+describe("StepMappedToAnalytics and StepsOutsideFlow", () => {
+  it("should map Step.DeleteBackup to ConfirmDeleteBackup", () => {
+    expect(StepMappedToAnalytics[Step.DeleteBackup]).toBe(AnalyticsPage.ConfirmDeleteBackup);
+  });
+
+  it("should include LedgerSyncActivated in StepsOutsideFlow", () => {
+    expect(StepsOutsideFlow).toContain(Step.LedgerSyncActivated);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useRemoveMember.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useRemoveMember.test.ts
@@ -1,0 +1,156 @@
+import { renderHook, waitFor } from "tests/testSetup";
+import { Flow, Step } from "~/renderer/reducers/walletSync";
+import { useRemoveMember } from "../hooks/useRemoveMember";
+import { TrustchainMember, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
+import { TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { INITIAL_STATE as INITIAL_STATE_SETTINGS } from "~/renderer/reducers/settings";
+
+const mockDevice = { deviceId: "device-1", modelId: DeviceModelId.stax, wired: true };
+const mockMember: TrustchainMember = { id: "member-1", name: "iPhone", permissions: 112 };
+const mockTrustchain: Trustchain = {
+  rootId: "root",
+  walletSyncEncryptionKey: "0xkey",
+  applicationPath: "m/0'/16'/1'",
+};
+
+const Mocks = {
+  removeMember: jest.fn(),
+  setFlow: jest.fn(),
+  setTrustchain: jest.fn(),
+};
+
+const mockDispatch = jest.fn((action: { type?: string; payload?: unknown }) => {
+  if (action.type === "WALLET_SYNC_CHANGE_FLOW") Mocks.setFlow(action.payload);
+  else Mocks.setTrustchain(action.payload ?? action);
+});
+
+jest.mock("LLD/hooks/redux", () => {
+  const actual = jest.requireActual("LLD/hooks/redux");
+  return {
+    ...actual,
+    useDispatch: () => mockDispatch,
+    useSelector: (selector: (s: unknown) => unknown) => {
+      if (selector.name === "trustchainSelector" || String(selector).includes("trustchain"))
+        return mockTrustchain;
+      if (selector.name === "memberCredentialsSelector" || String(selector).includes("member"))
+        return { pubkey: "pk", privatekey: "sk" };
+      return actual.useSelector(selector);
+    },
+  };
+});
+
+jest.mock("@ledgerhq/ledger-key-ring-protocol/store", () => ({
+  ...jest.requireActual("@ledgerhq/ledger-key-ring-protocol/store"),
+  setTrustchain: (t: Trustchain) => ({ type: "SET_TRUSTCHAIN", payload: t }),
+}));
+
+jest.mock("../hooks/useTrustchainSdk", () => ({
+  useTrustchainSdk: () => ({ removeMember: Mocks.removeMember }),
+}));
+
+const initialState = {
+  trustchain: {
+    trustchain: mockTrustchain,
+    memberCredentials: { pubkey: "pk", privatekey: "sk" },
+  },
+  settings: INITIAL_STATE_SETTINGS,
+};
+
+describe("useRemoveMember", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should call onRetry when device is null", async () => {
+    const { result } = renderHook(() => useRemoveMember({ device: null, member: mockMember }), {
+      initialState,
+    });
+
+    await waitFor(() => {
+      expect(Mocks.setFlow).toHaveBeenCalledWith({
+        flow: Flow.ManageInstances,
+        step: Step.DeviceActionInstance,
+      });
+    });
+    // removeMember also runs and throws "Device not found", so error is set
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.error?.message).toBe("Device not found");
+  });
+
+  it("should call onResetFlow when member is null", async () => {
+    const { result } = renderHook(() => useRemoveMember({ device: mockDevice, member: null }), {
+      initialState,
+    });
+
+    await waitFor(() => {
+      expect(Mocks.setFlow).toHaveBeenCalledWith({
+        flow: Flow.ManageInstances,
+        step: Step.SynchronizedInstances,
+      });
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should remove member and transition to success step on success", async () => {
+    Mocks.removeMember.mockResolvedValue(mockTrustchain);
+
+    const { result } = renderHook(
+      () => useRemoveMember({ device: mockDevice, member: mockMember }),
+      { initialState },
+    );
+
+    await waitFor(() => {
+      expect(Mocks.removeMember).toHaveBeenCalledWith(
+        mockDevice.deviceId,
+        mockTrustchain,
+        expect.any(Object),
+        mockMember,
+        expect.objectContaining({
+          onStartRequestUserInteraction: expect.any(Function),
+          onEndRequestUserInteraction: expect.any(Function),
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(Mocks.setTrustchain).toHaveBeenCalledWith(mockTrustchain);
+      expect(Mocks.setFlow).toHaveBeenCalledWith({
+        flow: Flow.ManageInstances,
+        step: Step.InstanceSuccesfullyDeleted,
+      });
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should set error and dispatch UnsecuredLedger on TrustchainNotAllowed", async () => {
+    Mocks.removeMember.mockRejectedValue(new TrustchainNotAllowed());
+
+    const { result } = renderHook(
+      () => useRemoveMember({ device: mockDevice, member: mockMember }),
+      { initialState },
+    );
+
+    await waitFor(() => expect(Mocks.removeMember).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(Mocks.setFlow).toHaveBeenCalledWith({
+        flow: Flow.ManageInstances,
+        step: Step.UnsecuredLedger,
+      });
+    });
+    expect(result.current.error).toBeInstanceOf(TrustchainNotAllowed);
+  });
+
+  it("should set error on generic error", async () => {
+    Mocks.removeMember.mockRejectedValue(new Error("Device not found"));
+
+    const { result } = renderHook(
+      () => useRemoveMember({ device: mockDevice, member: mockMember }),
+      { initialState },
+    );
+
+    await waitFor(() => expect(Mocks.removeMember).toHaveBeenCalled());
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.error?.message).toBe("Device not found");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/walletSync.hooks.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/walletSync.hooks.test.ts
@@ -1,0 +1,108 @@
+import { renderHook } from "tests/testSetup";
+import { Flow, Step } from "~/renderer/reducers/walletSync";
+import { useLifeCycle } from "../hooks/walletSync.hooks";
+import {
+  TrustchainEjected,
+  TrustchainNotAllowed,
+  TrustchainOutdated,
+} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { ErrorType } from "../hooks/type.hooks";
+
+const Mocks = {
+  dispatch: jest.fn(),
+  resetTrustchainStore: jest.fn(),
+  setFlow: jest.fn(),
+  track: jest.fn(),
+  invalidateJwt: jest.fn(),
+  refetch: jest.fn(),
+};
+
+jest.mock("LLD/hooks/redux", () => ({
+  ...jest.requireActual("LLD/hooks/redux"),
+  useDispatch: () => Mocks.dispatch,
+}));
+
+jest.mock("@ledgerhq/ledger-key-ring-protocol/store", () => ({
+  ...jest.requireActual("@ledgerhq/ledger-key-ring-protocol/store"),
+  resetTrustchainStore: () => Mocks.resetTrustchainStore(),
+}));
+
+jest.mock("~/renderer/actions/walletSync", () => ({
+  setFlow: (payload: unknown) => ({ type: "WALLET_SYNC_CHANGE_FLOW", payload }),
+}));
+
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: (event: string) => Mocks.track(event),
+  setAnalyticsFeatureFlagMethod: jest.fn(),
+}));
+
+jest.mock("../hooks/useTrustchainSdk", () => ({
+  useTrustchainSdk: () => ({ invalidateJwt: Mocks.invalidateJwt }),
+}));
+
+jest.mock("../hooks/useRestoreTrustchain", () => ({
+  useRestoreTrustchain: () => ({ refetch: Mocks.refetch }),
+}));
+
+describe("useLifeCycle", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("should expose handleError function", () => {
+    const { result } = renderHook(() => useLifeCycle());
+    expect(result.current.handleError).toBeInstanceOf(Function);
+  });
+
+  it("should reset and track on TrustchainEjected", () => {
+    const { result } = renderHook(() => useLifeCycle());
+    result.current.handleError(new TrustchainEjected());
+
+    expect(Mocks.resetTrustchainStore).toHaveBeenCalled();
+    expect(Mocks.track).toHaveBeenCalledWith("ledgersync_deactivated");
+    expect(Mocks.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "WALLET_SYNC_CHANGE_FLOW",
+        payload: { flow: Flow.Activation, step: Step.CreateOrSynchronize },
+      }),
+    );
+    expect(Mocks.invalidateJwt).toHaveBeenCalled();
+  });
+
+  it("should reset and track on TrustchainNotAllowed", () => {
+    const { result } = renderHook(() => useLifeCycle());
+    result.current.handleError(new TrustchainNotAllowed());
+
+    expect(Mocks.resetTrustchainStore).toHaveBeenCalled();
+    expect(Mocks.track).toHaveBeenCalledWith("ledgersync_deactivated");
+    expect(Mocks.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "WALLET_SYNC_CHANGE_FLOW",
+        payload: { flow: Flow.Activation, step: Step.CreateOrSynchronize },
+      }),
+    );
+  });
+
+  it("should call restoreTrustchain refetch on TrustchainOutdated", () => {
+    const { result } = renderHook(() => useLifeCycle());
+    result.current.handleError(new TrustchainOutdated());
+
+    expect(Mocks.refetch).toHaveBeenCalled();
+    expect(Mocks.resetTrustchainStore).not.toHaveBeenCalled();
+  });
+
+  it("should reset when error message includes NO_TRUSTCHAIN", () => {
+    const { result } = renderHook(() => useLifeCycle());
+    result.current.handleError(new Error(ErrorType.NO_TRUSTCHAIN));
+
+    expect(Mocks.resetTrustchainStore).toHaveBeenCalled();
+    expect(Mocks.track).toHaveBeenCalledWith("ledgersync_deactivated");
+    expect(Mocks.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "WALLET_SYNC_CHANGE_FLOW",
+        payload: { flow: Flow.Activation, step: Step.CreateOrSynchronize },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - desktop tests

### 📝 Description

- **New tests:** `WalletSyncContext`, `useRemoveMember`, `useGetMembers`, `useLedgerSyncAnalytics`, `walletSync.hooks` (useLifeCycle), `GenericStatusDisplay`, `Error`; extra cases in `useFlows` (goToWelcomeScreenWalletSync branches) and `BackupDeleted` (error path).
- **Fixes:** BackupDeleted mock keeps `AnalyticsPage` export; walletSync.hooks mock returns correct `setFlow` action; useRemoveMember mock uses real `useSelector` for non–wallet-sync selectors and sets `initialState` so countervalues don’t get null; device-null test expects “Device not found” error.



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27070


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
