### PR TITLE
fix: remove press styling on list item in buy device drawer

### DIFF
--- a/.changeset/fair-hounds-reply.md
+++ b/.changeset/fair-hounds-reply.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Remove press styling on list item in buy device drawer

--- a/apps/ledger-live-mobile/src/mvvm/features/Reborn/drawers/RebornBuyDeviceDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Reborn/drawers/RebornBuyDeviceDrawer.tsx
@@ -3,7 +3,6 @@ import { TrackScreen } from "~/analytics";
 import useRebornBuyDeviceViewModel from "./useRebornBuyDeviceViewModel";
 import {
   Text,
-  ListItem,
   ListItemLeading,
   ListItemContent,
   ListItemTitle,
@@ -11,6 +10,7 @@ import {
   Button,
   BottomSheetView,
   BottomSheetHeader,
+  Box,
 } from "@ledgerhq/lumen-ui-rnative";
 import { HandCoins, ShieldLock, Share2 } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { Image } from "react-native";
@@ -64,7 +64,20 @@ function View({ t, setupDevice, buyLedger }: Readonly<Omit<ViewProps, "isOpen" |
       </Text>
 
       {items.map(item => (
-        <ListItem key={item.id}>
+        <Box
+          key={item.id}
+          lx={{
+            flexDirection: "row",
+            alignItems: "center",
+            height: "s64",
+            width: "full",
+            gap: "s16",
+            borderRadius: "md",
+            backgroundColor: "baseTransparent",
+            paddingHorizontal: "s8",
+            paddingVertical: "s12",
+          }}
+        >
           <ListItemLeading>
             <item.Icon size={24} />
 
@@ -73,7 +86,7 @@ function View({ t, setupDevice, buyLedger }: Readonly<Omit<ViewProps, "isOpen" |
               <ListItemDescription>{t(item.desc)}</ListItemDescription>
             </ListItemContent>
           </ListItemLeading>
-        </ListItem>
+        </Box>
       ))}
 
       <Button


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Removes the styling for the list item in buy device drawer so that it does not act like a button and is just styled like a normal view.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27063


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
