### PR TITLE
fix(common): improve resilience when market API returns no data for currency

### DIFF
--- a/.changeset/market-currency-id-resilience.md
+++ b/.changeset/market-currency-id-resilience.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Improve resilience when market API returns no data for a currency id (e.g. unknown or unsupported coin). Prevents "Cannot read property 'id' of undefined" crash in getCurrencyData; query now returns undefined instead of throwing.

--- a/libs/ledger-live-common/src/market/hooks/__tests__/useCurrencyData.test.ts
+++ b/libs/ledger-live-common/src/market/hooks/__tests__/useCurrencyData.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
 import { useCurrencyData } from "../useMarketDataProvider";
 import { countervaluesApi } from "../../state-manager/countervaluesApi";
 import { server } from "@tests/server";
@@ -93,6 +94,21 @@ describe("useCurrencyData", () => {
 
     await waitFor(() => expect(requestCount).toBe(2), { timeout: 2000 });
     await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    unmount();
+  });
+
+  it("should return undefined data when API returns empty array (id not resolving to a currency)", async () => {
+    server.use(http.get("*/v3/markets", () => HttpResponse.json([])));
+    const wrapper = createWrapper(store);
+    const { result, unmount } = renderHook(
+      () => useCurrencyData({ id: "unknown-currency", counterCurrency: "usd" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isError).toBe(false);
 
     unmount();
   });

--- a/libs/ledger-live-common/src/market/state-manager/countervaluesApi.ts
+++ b/libs/ledger-live-common/src/market/state-manager/countervaluesApi.ts
@@ -37,7 +37,7 @@ export const countervaluesApi = createApi({
       transformResponse: (response: MarketItemResponse[]) => response.map(formatPerformer),
       keepUnusedDataFor: REFETCH_TIME_ONE_MINUTE / 1000,
     }),
-    getCurrencyData: build.query<MarketCurrencyData, MarketCurrencyRequestParams>({
+    getCurrencyData: build.query<MarketCurrencyData | undefined, MarketCurrencyRequestParams>({
       query: ({ id, counterCurrency }) => ({
         url: "/v3/markets",
         params: {
@@ -48,7 +48,8 @@ export const countervaluesApi = createApi({
         },
       }),
       providesTags: [MarketDataTags.CurrencyData],
-      transformResponse: (response: MarketItemResponse[]) => format(response[0]),
+      transformResponse: (response: MarketItemResponse[]) =>
+        response?.[0] ? format(response[0]) : undefined,
       keepUnusedDataFor: (REFETCH_TIME_ONE_MINUTE * BASIC_REFETCH) / 1000,
     }),
   }),


### PR DESCRIPTION


### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added test for empty API response in `useCurrencyData.test.ts`.
- **Impact of the changes:**
  - Market: when opening a coin detail for an id that has no market data (e.g. unknown/unsupported), the app no longer crashes; `useCurrencyData` returns `data: undefined`. QA: open Market coin detail for an unsupported/edge currency and confirm no crash and graceful handling.

### 📝 Description


**Problem:** Requesting market data for a currency id that doesn’t exist in the API (e.g. unknown or unsupported coin) returned an empty array. The code did `format(response[0])` without checking, causing `TypeError: Cannot read property 'id' of undefined` in the `getCurrencyData` transformResponse.

**Solution:** Guard the transformResponse: only call `format(response[0])` when `response?.[0]` exists; otherwise return `undefined`. Type the endpoint as `MarketCurrencyData | undefined`. Added a unit test for the empty-response case.

| Before | After |
|--------|--------|
| Crash when API returns `[]` for the requested id | Query succeeds with `data: undefined`; callers can handle “no market data” |

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27094


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
