### PR TITLE
Feat/live 24886 auto refresh

### DIFF
--- a/.changeset/tiny-pigs-sing.md
+++ b/.changeset/tiny-pigs-sing.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): balance refresh - auto sync loading

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
@@ -131,4 +131,20 @@ describe("useActivityIndicator", () => {
     expect(mockTriggerRefresh).toHaveBeenCalledTimes(1);
     expect(track).toHaveBeenCalledWith("SyncRefreshClick");
   });
+
+  it("handleSync dispatches setLastUserSyncClickTimestamp", () => {
+    const before = Date.now();
+    const { result, store } = renderHook(() => useActivityIndicator(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    act(() => {
+      result.current.handleSync();
+    });
+
+    const after = Date.now();
+    const lastUserSyncClickTimestamp = store.getState().syncRefresh.lastUserSyncClickTimestamp;
+    expect(lastUserSyncClickTimestamp).toBeGreaterThanOrEqual(before);
+    expect(lastUserSyncClickTimestamp).toBeLessThanOrEqual(after);
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
@@ -1,6 +1,10 @@
-import { useCallback, useEffect, useReducer, useState } from "react";
-import { useSelector } from "LLD/hooks/redux";
+import { useCallback, useEffect, useReducer } from "react";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { hasAccountsSelector, isUpToDateSelector } from "~/renderer/reducers/accounts";
+import {
+  selectLastUserSyncClickTimestamp,
+  setLastUserSyncClickTimestamp,
+} from "~/renderer/reducers/syncRefresh";
 import { getEnv } from "@ledgerhq/live-env";
 import { track } from "~/renderer/analytics/segment";
 
@@ -13,14 +17,17 @@ import {
   TOOLTIP_UPDATE_INTERVAL_MS,
   USER_CLICK_SPIN_DURATION_MS,
 } from "../utils/constants";
+import { isRecentUserSyncClick } from "../utils/syncRefreshUtils";
 
 /**
  * Activity indicator state for the TopBar sync button.
  * When isRotating is true, the sync action should be non-interactive (disabled).
  */
 export const useActivityIndicator = () => {
+  const dispatch = useDispatch();
   const hasAccounts = useSelector(hasAccountsSelector);
   const accountsWithUpToDateCheck = useSelector(isUpToDateSelector);
+  const lastUserSyncClickTimestamp = useSelector(selectLastUserSyncClickTimestamp);
   const {
     isBalanceLoading,
     stableSyncPending,
@@ -28,7 +35,6 @@ export const useActivityIndicator = () => {
     hasWalletSyncError,
     triggerRefresh,
   } = usePortfolioBalanceSync();
-  const [lastClickTime, setLastClickTime] = useState(0);
   const [, forceTooltipUpdate] = useReducer((tick: number) => tick + 1, 0);
 
   const { allAccounts, listOfErrorAccountNames, areAllAccountsUpToDate } =
@@ -48,7 +54,7 @@ export const useActivityIndicator = () => {
   const userClickSpinMs = isPlaywrightRun
     ? PLAYWRIGHT_CLICK_SPIN_DURATION_MS
     : USER_CLICK_SPIN_DURATION_MS;
-  const isUserClick = Date.now() - lastClickTime < userClickSpinMs;
+  const isUserClick = isRecentUserSyncClick(lastUserSyncClickTimestamp, userClickSpinMs);
   const isRotating = isBalanceLoading || (isUserClick && stableSyncPending);
 
   const icon = getActivityIndicatorIcon(isError, isRotating);
@@ -60,10 +66,11 @@ export const useActivityIndicator = () => {
   });
 
   const handleSync = useCallback(() => {
+    const now = Date.now();
+    dispatch(setLastUserSyncClickTimestamp(now));
     triggerRefresh();
-    setLastClickTime(Date.now());
     track("SyncRefreshClick");
-  }, [triggerRefresh]);
+  }, [dispatch, triggerRefresh]);
 
   return {
     hasAccounts,

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/utils/syncRefreshUtils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/utils/syncRefreshUtils.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns true if the given timestamp is within the last `windowMs` milliseconds.
+ * Used to treat a user sync click as "recent" for manual vs auto refresh loading.
+ */
+export function isRecentUserSyncClick(timestamp: number, windowMs: number): boolean {
+  return Date.now() - timestamp < windowMs;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
@@ -45,6 +45,7 @@ const defaultBalanceSyncReturn = {
   balanceAvailable: true,
   isColdStart: false,
   isBalanceLoading: false,
+  isManualRefreshLoading: false,
   stableSyncPending: false,
   hasCvOrBridgeError: false,
   hasWalletSyncError: false,
@@ -108,7 +109,7 @@ describe("useBalanceViewModel", () => {
     expect(mockUsePortfolioBalanceSync).toHaveBeenCalledWith({ legacyRange: true });
   });
 
-  it("returns isLoading true when isBalanceLoading is true (e.g. countervalues polling)", () => {
+  it("returns isLoading true when isBalanceLoading is true", () => {
     mockUsePortfolioBalanceSync.mockReturnValue({
       ...defaultBalanceSyncReturn,
       isBalanceLoading: true,

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/usePortfolioBalanceSync.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/usePortfolioBalanceSync.test.ts
@@ -96,6 +96,7 @@ describe("usePortfolioBalanceSync", () => {
       balanceAvailable: true,
       isColdStart: false,
       isBalanceLoading: false,
+      isManualRefreshLoading: false,
       stableSyncPending: false,
       hasCvOrBridgeError: false,
       hasWalletSyncError: false,
@@ -164,17 +165,42 @@ describe("usePortfolioBalanceSync", () => {
     expect(result.current.isColdStart).toBe(false);
   });
 
-  it("returns isBalanceLoading true when sync is pending", () => {
+  it("returns isBalanceLoading false and isManualRefreshLoading false when sync pending but no recent user click (auto refresh)", () => {
     jest.spyOn(countervaluesReact, "useCountervaluesPolling").mockReturnValue({
       ...defaultPollingReturn,
       pending: true,
     });
 
     const { result } = renderHook(() => usePortfolioBalanceSync(), {
-      initialState: defaultInitialState,
+      initialState: {
+        ...defaultInitialState,
+        syncRefresh: { lastUserSyncClickTimestamp: 0 },
+      },
     });
 
     expect(result.current.stableSyncPending).toBe(true);
+    expect(result.current.isManualRefreshLoading).toBe(false);
+    expect(result.current.isBalanceLoading).toBe(false);
+  });
+
+  it("returns isManualRefreshLoading true and isBalanceLoading true when sync pending and user clicked recently", () => {
+    const now = 10_000;
+    const recentClickTime = now - 100; // 100ms ago within USER_CLICK_SPIN_DURATION_MS (1000)
+    jest.spyOn(Date, "now").mockReturnValue(now);
+    jest.spyOn(countervaluesReact, "useCountervaluesPolling").mockReturnValue({
+      ...defaultPollingReturn,
+      pending: true,
+    });
+
+    const { result } = renderHook(() => usePortfolioBalanceSync(), {
+      initialState: {
+        ...defaultInitialState,
+        syncRefresh: { lastUserSyncClickTimestamp: recentClickTime },
+      },
+    });
+
+    expect(result.current.stableSyncPending).toBe(true);
+    expect(result.current.isManualRefreshLoading).toBe(true);
     expect(result.current.isBalanceLoading).toBe(true);
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalanceSync.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalanceSync.ts
@@ -10,6 +10,9 @@ import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
 import { useBridgeSync, useGlobalSyncState } from "@ledgerhq/live-common/bridge/react/index";
 import { useWalletSyncUserState } from "LLD/features/WalletSync/components/WalletSyncContext";
 import { useStablePending } from "LLD/hooks/useStablePending";
+import { USER_CLICK_SPIN_DURATION_MS } from "LLD/components/TopBar/utils/constants";
+import { isRecentUserSyncClick } from "LLD/components/TopBar/utils/syncRefreshUtils";
+import { selectLastUserSyncClickTimestamp } from "~/renderer/reducers/syncRefresh";
 import { DEFAULT_PORTFOLIO_RANGE, POLLING_FINISHED_DELAY_MS } from "LLD/utils/constants";
 
 export interface UsePortfolioBalanceSyncOptions {
@@ -24,8 +27,8 @@ export interface UsePortfolioBalanceSyncOptions {
  * - Portfolio: accounts, range, counterValue → balanceAvailable, isColdStart.
  *   Uses usePortfolioThrottled to limit recomputation frequency and avoid heavy work on every render.
  * - Sync state: CV polling + bridge sync + wallet sync → isSyncPending, stableSyncPending, errors
- * - isBalanceLoading = cold start or any sync pending (CV, bridge, wallet) so Balance shows loading
- *   whenever the data that drives it is being refreshed.
+ * - isBalanceLoading = cold start or manual refresh loading (so Balance shows loading only on cold start or after user click when rework is on). TopBar uses this for rotation.
+ * - isManualRefreshLoading = stableSyncPending and user clicked refresh recently (Redux syncRefresh slice).
  * - triggerRefresh = run wallet refresh + CV poll + bridge SYNC_ALL_ACCOUNTS (TopBar calls this on click).
  */
 export function usePortfolioBalanceSync(options: UsePortfolioBalanceSyncOptions = {}) {
@@ -46,13 +49,18 @@ export function usePortfolioBalanceSync(options: UsePortfolioBalanceSyncOptions 
   const globalSyncState = useGlobalSyncState();
   const wsUserState = useWalletSyncUserState();
   const bridgeSync = useBridgeSync();
+  const lastUserSyncClickTimestamp = useSelector(selectLastUserSyncClickTimestamp);
 
   const isSyncPending = cvPolling.pending || globalSyncState.pending || wsUserState.visualPending;
   const stableSyncPending = useStablePending(isSyncPending, POLLING_FINISHED_DELAY_MS);
 
   const balanceAvailable = portfolio.balanceAvailable;
   const isColdStart = hasAccounts && !balanceAvailable;
-  const isBalanceLoading = isColdStart || stableSyncPending;
+  const isManualRefreshLoading =
+    stableSyncPending &&
+    isRecentUserSyncClick(lastUserSyncClickTimestamp, USER_CLICK_SPIN_DURATION_MS);
+
+  const isBalanceLoading = isColdStart || isManualRefreshLoading;
 
   const hasCvOrBridgeError = !isSyncPending && (!!cvPolling.error || !!globalSyncState.error);
   const hasWalletSyncError = !!wsUserState.walletSyncError;
@@ -73,6 +81,7 @@ export function usePortfolioBalanceSync(options: UsePortfolioBalanceSyncOptions 
     balanceAvailable,
     isColdStart,
     isBalanceLoading,
+    isManualRefreshLoading,
     stableSyncPending,
     hasCvOrBridgeError,
     hasWalletSyncError,

--- a/apps/ledger-live-desktop/src/renderer/reducers/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/index.ts
@@ -23,6 +23,7 @@ import { lldRTKApiReducers, LLDRTKApiState } from "./rtkQueryApi";
 import { identitiesSlice, IdentitiesState } from "@ledgerhq/client-ids/store";
 import type { PayloadAction, UnknownAction } from "@reduxjs/toolkit";
 import dialogs, { DialogsState } from "./dialogs";
+import syncRefresh, { SyncRefreshState } from "./syncRefresh";
 
 export type State = LLDRTKApiState & {
   accounts: AccountsState;
@@ -43,6 +44,7 @@ export type State = LLDRTKApiState & {
   wallet: WalletState;
   walletSync: WalletSyncState;
   dialogs: DialogsState;
+  syncRefresh: SyncRefreshState;
 };
 
 const appReducer = combineReducers({
@@ -64,6 +66,7 @@ const appReducer = combineReducers({
   walletSync,
   trustchain,
   dialogs,
+  syncRefresh,
   ...lldRTKApiReducers,
   ...(getEnv("PLAYWRIGHT_RUN") && { lastAction: (_: unknown, action: PayloadAction) => action }),
 });

--- a/apps/ledger-live-desktop/src/renderer/reducers/syncRefresh.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/syncRefresh.ts
@@ -1,0 +1,32 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+/**
+ * Stores the timestamp of the last user-triggered sync (TopBar sync button click).
+ * Used to differentiate manual vs auto refresh loading so the Balance can show
+ * loading (shimmer) only on cold start or after user click, not during background sync.
+ */
+export type SyncRefreshState = {
+  lastUserSyncClickTimestamp: number;
+};
+
+const initialState: SyncRefreshState = {
+  lastUserSyncClickTimestamp: 0,
+};
+
+const syncRefreshSlice = createSlice({
+  name: "syncRefresh",
+  initialState,
+  reducers: {
+    setLastUserSyncClickTimestamp: (state, action: PayloadAction<number>) => {
+      state.lastUserSyncClickTimestamp = action.payload;
+    },
+  },
+});
+
+export const { setLastUserSyncClickTimestamp } = syncRefreshSlice.actions;
+
+/** Select last user sync click timestamp from state (0 = never). */
+export const selectLastUserSyncClickTimestamp = (state: { syncRefresh: SyncRefreshState }) =>
+  state.syncRefresh.lastUserSyncClickTimestamp;
+
+export default syncRefreshSlice.reducer;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a Redux slice to track user-triggered sync actions and refactors balance loading logic to distinguish between manual and automatic refreshes. The changes ensure that the balance loading indicator (shimmer) is shown only on cold start or after a user-initiated sync, improving UX by preventing unnecessary loading states during background syncs. Related tests and components are updated to reflect this logic.

### ❓ Context

[LIVE-24886](https://ledgerhq.atlassian.net/browse/LIVE-24886)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24886]: https://ledgerhq.atlassian.net/browse/LIVE-24886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ