### PR TITLE
feat: scrolls page to top on sidebar Home click

### DIFF
--- a/.changeset/late-crabs-prove.md
+++ b/.changeset/late-crabs-prove.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): scrolls page to top on sidebar Home click

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/usePageViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/usePageViewModel.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "tests/testSetup";
 import { useLocation } from "react-router";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import { SCROLL_TO_TOP_EVENT } from "../constants";
 import { usePageViewModel } from "../usePageViewModel";
 
 jest.mock("react-router", () => ({
@@ -90,6 +91,34 @@ describe("usePageViewModel", () => {
 
     act(() => {
       result.current.onClickScrollUp();
+    });
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+
+  it("scrolls to top with smooth behavior when SCROLL_TO_TOP_EVENT is dispatched", () => {
+    mockedUseLocation.mockReturnValue(createLocation("/"));
+    const { result } = renderHook(() => usePageViewModel(), {
+      initialState: {
+        settings: {
+          ...INITIAL_STATE,
+          overriddenFeatureFlags: wallet40WithRightPanelFlags,
+        },
+      },
+    });
+
+    const scroller = document.createElement("div");
+    scroller.scrollTo = jest.fn();
+
+    act(() => {
+      result.current.pageScrollerRef(scroller);
+    });
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(SCROLL_TO_TOP_EVENT));
     });
 
     expect(scroller.scrollTo).toHaveBeenCalledWith({

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/constants.ts
@@ -7,3 +7,10 @@ export const SCROLL_UP_BUTTON_THRESHOLD = 800;
  * Width of the right panel (swap sidebar) in pixels
  */
 export const RIGHT_PANEL_WIDTH = 375;
+
+/**
+ * Custom event name dispatched when the app should scroll the page to top
+ * (e.g. when user clicks Home in the sidebar while already on home).
+ * usePageViewModel listens for this and scrolls the page scroller element.
+ */
+export const SCROLL_TO_TOP_EVENT = "ledger-live:scroll-to-top";

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/usePageViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/usePageViewModel.ts
@@ -1,7 +1,7 @@
 import { useCallback, useLayoutEffect, useState } from "react";
 import { useLocation } from "react-router";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
-import { SCROLL_UP_BUTTON_THRESHOLD } from "./constants";
+import { SCROLL_UP_BUTTON_THRESHOLD, SCROLL_TO_TOP_EVENT } from "./constants";
 import { shouldDisplayRightPanel as isRightPanelPage } from "./utils";
 import { useRightPanelViewModel } from "LLD/components/RightPanel/useRightPanelViewModel";
 
@@ -45,6 +45,13 @@ export const usePageViewModel = (): PageViewModelResult => {
   );
 
   const onClickScrollUp = useCallback(() => scrollToTop(), [scrollToTop]);
+
+  // When sidebar (or elsewhere) dispatches SCROLL_TO_TOP_EVENT, scroll the page scroller to top
+  useLayoutEffect(() => {
+    const handler = () => scrollToTop(true);
+    globalThis.addEventListener(SCROLL_TO_TOP_EVENT, handler);
+    return () => globalThis.removeEventListener(SCROLL_TO_TOP_EVENT, handler);
+  }, [scrollToTop]);
 
   // Scroll to top when pathname changes
   useLayoutEffect(() => {

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { useSideBarViewModel } from "../useSideBarViewModel";
 import { SIDEBAR_VALUE_TO_PATH, SIDEBAR_VALUE_TO_TRACK_ENTRY } from "../utils/constants";
+import { SCROLL_TO_TOP_EVENT } from "LLD/components/Page/constants";
 import * as segment from "~/renderer/analytics/segment";
 import type { SideBarViewModel } from "../types";
 import { defaultInitialState, withFeatureFlags } from "./testUtils";
@@ -236,6 +237,24 @@ describe("useSideBarViewModel", () => {
       act(() => result.current.handleActiveChange("unknown-value"));
 
       expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it("should dispatch SCROLL_TO_TOP_EVENT when clicking Home while already on home and Wallet 4.0 main nav is enabled", () => {
+      const dispatchEventSpy = jest.spyOn(window, "dispatchEvent");
+      const { result } = renderViewModel(
+        withFeatureFlags({
+          lwdWallet40: { enabled: true, params: { mainNavigation: true } },
+        }),
+      );
+
+      act(() => result.current.handleActiveChange("home"));
+
+      expect(dispatchEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: SCROLL_TO_TOP_EVENT,
+        }),
+      );
+      dispatchEventSpy.mockRestore();
     });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
@@ -23,6 +23,7 @@ import {
   SIDEBAR_SPECIAL_VALUES,
   isSideBarNavValue,
 } from "./utils";
+import { SCROLL_TO_TOP_EVENT } from "LLD/components/Page/constants";
 import type { SideBarViewModel } from "./types";
 
 const MAX_STARRED_ACCOUNTS_DISPLAYED_IN_SMALL_SCREEN = 3;
@@ -187,6 +188,11 @@ export function useSideBarViewModel(): SideBarViewModel {
 
   const openSendFlow = useOpenSendFlow();
 
+  /** Notifies the Page to scroll the main content to top (e.g. when user clicks Home while already on home). */
+  const handleScrollToTop = useCallback(() => {
+    globalThis.dispatchEvent(new CustomEvent(SCROLL_TO_TOP_EVENT));
+  }, []);
+
   const handleClickRefer = useCallback(() => {
     if (referralProgramConfig?.enabled && referralProgramConfig?.params?.path) {
       push(referralProgramConfig.params.path);
@@ -265,11 +271,26 @@ export function useSideBarViewModel(): SideBarViewModel {
         return;
       }
       if (isSideBarNavValue(value)) {
+        if (
+          isWallet40MainNavEnabled &&
+          value === "home" &&
+          location.pathname === SIDEBAR_VALUE_TO_PATH.home
+        ) {
+          handleScrollToTop();
+        }
         push(SIDEBAR_VALUE_TO_PATH[value]);
         trackEntry(SIDEBAR_VALUE_TO_TRACK_ENTRY[value]);
       }
     },
-    [handleClickRefer, handleClickRecover, push, trackEntry],
+    [
+      handleClickRefer,
+      handleClickRecover,
+      handleScrollToTop,
+      push,
+      trackEntry,
+      location.pathname,
+      isWallet40MainNavEnabled,
+    ],
   );
 
   return {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a minor feature to improve the user experience in the Ledger Live Desktop app. Now, when a user clicks "Home" in the sidebar while already on the home page, the app will smoothly scroll the page to the top. This is achieved through a custom event and coordinated updates to the sidebar and page view models.

https://github.com/user-attachments/assets/28ee9a29-98ad-44be-a033-be48e0c71c79


### ❓ Context

[LIVE-27082](https://ledgerhq.atlassian.net/browse/LIVE-27082)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27082]: https://ledgerhq.atlassian.net/browse/LIVE-27082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ