### PR TITLE
fix: only allow redirection once

### DIFF
--- a/.changeset/cool-socks-pump.md
+++ b/.changeset/cool-socks-pump.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: double trigger of recover upsell navigation

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/index.tsx
@@ -285,8 +285,10 @@ function useRedirectToPortfolio({
   useCase: OnboardingUseCase;
 }) {
   const redirectToPostOnboarding = useRedirectToPostOnboardingCallback();
+  const hasRedirected = useRef(false);
   useEffect(() => {
-    if (enabled) {
+    if (enabled && !hasRedirected.current) {
+      hasRedirected.current = true;
       /**
        * There is a lag if we call navigate("/") directly.
        * To improve the UX in that situation, we have to first commit a "loading"


### PR DESCRIPTION
### ✅ Checklist
- [x] npx changeset was attached.
- [ ] Covered by automatic tests.
- [ ] Impact of the changes:
  - Post-onboarding redirect behavior after completing device onboarding
  - QA should verify that completing onboarding correctly navigates to the Recover upsell (not the post-onboarding hub) for eligible devices/use cases

### 📝 Description
Fixes a bug where the post-onboarding redirect was being triggered twice, causing the user to land on the post-onboarding hub instead of the Recover upsell screen.

**Previous behaviour:** After completing onboarding, useRedirectToPortfolio called redirectToPostOnboarding() which correctly navigated to the Recover upsell. However, this call dispatched setHasBeenUpsoldRecover(true), which changed the Redux state and gave the redirectToPostOnboarding callback a new identity. Since that callback was in the useEffect dependency array, the effect re-ran. On the second run, the Recover upsell condition was no longer satisfied (hasBeenUpsoldRecover was now true), but the post-onboarding condition was still true (hasRedirectedToPostOnboarding was still false), so it navigated to the post-onboarding hub — overriding the correct Recover upsell redirect.

**Fix:** Added a useRef guard (hasRedirected) so the redirect only fires once. After the first execution, subsequent re-runs of the effect (triggered by the callback identity changing) are no-ops.

### ❓ Context
JIRA or GitHub link: [LIVE-27102](https://ledgerhq.atlassian.net/browse/LIVE-27102)

[LIVE-27102]: https://ledgerhq.atlassian.net/browse/LIVE-27102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ