### PR TITLE
fix(mobile): fix pull-to-refresh timestamp flicker and remove seconds display

### DIFF
--- a/.changeset/fix-pull-to-refresh-timestamp-flicker.md
+++ b/.changeset/fix-pull-to-refresh-timestamp-flicker.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Fix pull-to-refresh timestamp flicker showing "0 seconds ago" during sync

--- a/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
+++ b/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
@@ -7,8 +7,12 @@ import { useIsFocused, useRoute, useTheme } from "@react-navigation/native";
 import { SYNC_DELAY } from "~/utils/constants";
 import { track } from "~/analytics";
 import { useWalletSyncUserState } from "LLM/features/WalletSync/components/WalletSyncContext";
-import { useDispatch } from "~/context/hooks";
-import { setRefreshStarted, setRefreshCompleted } from "~/reducers/portfolioRefresh";
+import { useDispatch, useStore } from "~/context/hooks";
+import {
+  setRefreshStarted,
+  setRefreshCompleted,
+  selectLastSyncTimestamp,
+} from "~/reducers/portfolioRefresh";
 
 type Props = {
   isError?: boolean;
@@ -33,6 +37,7 @@ function globalSyncRefreshControl<P>(
     const { poll } = useCountervaluesPolling();
     const isFocused = useIsFocused();
     const dispatch = useDispatch();
+    const store = useStore();
     const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
     const route = useRoute();
     const refreshingRef = useRef(refreshing);
@@ -46,7 +51,7 @@ function globalSyncRefreshControl<P>(
         reason: "user-pull-to-refresh",
       });
       setRefreshing(true);
-      dispatch(setRefreshStarted());
+      dispatch(setRefreshStarted(selectLastSyncTimestamp(store.getState())));
       track("button_clicked", {
         button: "pull to refresh",
         page: route.name,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
@@ -6,7 +6,7 @@ const defaultProps = { showAssets: true, isReadOnlyMode: false };
 
 const withRefreshing = (state: State): State => ({
   ...state,
-  portfolioRefresh: { isRefreshing: true },
+  portfolioRefresh: { isRefreshing: true, lastSyncTimestampSnapshot: null },
 });
 
 describe("usePortfolioBalanceSectionViewModel", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
@@ -25,7 +25,8 @@ import { genAccount } from "@ledgerhq/live-common/mock/account";
 import { MINUTE_MS, HOUR_MS, DAY_MS } from "@ledgerhq/live-common/utils/timeAgo";
 import { UP_TO_DATE_VISIBLE_DURATION_MS } from "../usePortfolioRefreshStatusViewModel";
 import { PortfolioRefreshStatus } from "../index";
-import { setRefreshCompleted } from "~/reducers/portfolioRefresh";
+import { setRefreshStarted, setRefreshCompleted } from "~/reducers/portfolioRefresh";
+import { AccountsActionTypes } from "~/actions/types";
 import { State } from "~/reducers/types";
 
 const FIXED_NOW = new Date("2025-08-15T12:00:00Z").getTime();
@@ -39,17 +40,13 @@ const makeAccount = (lastSyncDate: Date) => ({
 });
 
 const withRefreshing =
-  (lastSyncDate?: Date): ((state: State) => State) =>
+  (snapshotTimestamp: number | null = null): ((state: State) => State) =>
   state => ({
     ...state,
-    accounts: {
-      ...state.accounts,
-      active: lastSyncDate ? [makeAccount(lastSyncDate)] : [],
-    },
-    portfolioRefresh: { isRefreshing: true },
+    portfolioRefresh: { isRefreshing: true, lastSyncTimestampSnapshot: snapshotTimestamp },
   });
 
-const withCompleted =
+const withIdle =
   (lastSyncDate: Date): ((state: State) => State) =>
   state => ({
     ...state,
@@ -57,12 +54,12 @@ const withCompleted =
       ...state.accounts,
       active: [makeAccount(lastSyncDate)],
     },
-    portfolioRefresh: { isRefreshing: false },
+    portfolioRefresh: { isRefreshing: false, lastSyncTimestampSnapshot: null },
   });
 
-const renderRefreshing = (lastSyncDate?: Date) =>
+const renderRefreshing = (snapshotTimestamp: number | null = null) =>
   render(<PortfolioRefreshStatus />, {
-    overrideInitialState: withRefreshing(lastSyncDate),
+    overrideInitialState: withRefreshing(snapshotTimestamp),
   });
 
 const completeRefresh = (store: ReturnType<typeof renderRefreshing>["store"]) =>
@@ -88,31 +85,27 @@ describe("PortfolioRefreshStatus", () => {
 
     it("should not show up-to-date when mounted with a completed timestamp but no prior refresh", () => {
       render(<PortfolioRefreshStatus />, {
-        overrideInitialState: withCompleted(new Date(Date.now() - 30_000)),
+        overrideInitialState: withIdle(new Date(Date.now() - 30_000)),
       });
       expect(screen.queryByTestId("portfolio-refresh-status-up-to-date")).toBeNull();
     });
   });
 
   describe("refreshing state", () => {
-    it("should show spinner and 'Refreshing...' when no accounts", () => {
+    it("should show spinner and 'Refreshing...' when no snapshot timestamp", () => {
       renderRefreshing();
       expect(screen.getByTestId("portfolio-refresh-status-spinner")).toBeVisible();
       expect(screen.getByTestId("portfolio-refresh-status-refreshing")).toBeVisible();
       expect(screen.getByText("Refreshing...")).toBeVisible();
     });
 
-    it("should show relative time for a timestamp < 1 minute ago", () => {
-      renderRefreshing(new Date(Date.now() - 30_000));
-      const expected = new Intl.RelativeTimeFormat(TEST_LOCALE, { numeric: "always" }).format(
-        -30,
-        "second",
-      );
-      expect(screen.getByText(`Refreshing - Last update ${expected}`)).toBeVisible();
+    it("should show 'Refreshing...' when snapshot is < 1 minute ago", () => {
+      renderRefreshing(Date.now() - 30_000);
+      expect(screen.getByText("Refreshing...")).toBeVisible();
     });
 
-    it("should show relative time for a timestamp < 1 hour ago", () => {
-      renderRefreshing(new Date(Date.now() - 3 * MINUTE_MS));
+    it("should show relative time for a snapshot < 1 hour ago", () => {
+      renderRefreshing(Date.now() - 3 * MINUTE_MS);
       const expected = new Intl.RelativeTimeFormat(TEST_LOCALE, { numeric: "always" }).format(
         -3,
         "minute",
@@ -120,8 +113,8 @@ describe("PortfolioRefreshStatus", () => {
       expect(screen.getByText(`Refreshing - Last update ${expected}`)).toBeVisible();
     });
 
-    it("should show relative time for a timestamp < 24 hours ago", () => {
-      renderRefreshing(new Date(Date.now() - 2 * HOUR_MS));
+    it("should show relative time for a snapshot < 24 hours ago", () => {
+      renderRefreshing(Date.now() - 2 * HOUR_MS);
       const expected = new Intl.RelativeTimeFormat(TEST_LOCALE, { numeric: "always" }).format(
         -2,
         "hour",
@@ -129,8 +122,8 @@ describe("PortfolioRefreshStatus", () => {
       expect(screen.getByText(`Refreshing - Last update ${expected}`)).toBeVisible();
     });
 
-    it("should show relative time for a timestamp < 7 days ago", () => {
-      renderRefreshing(new Date(Date.now() - 3 * DAY_MS));
+    it("should show relative time for a snapshot < 7 days ago", () => {
+      renderRefreshing(Date.now() - 3 * DAY_MS);
       const expected = new Intl.RelativeTimeFormat(TEST_LOCALE, { numeric: "always" }).format(
         -3,
         "day",
@@ -138,9 +131,9 @@ describe("PortfolioRefreshStatus", () => {
       expect(screen.getByText(`Refreshing - Last update ${expected}`)).toBeVisible();
     });
 
-    it("should show absolute date without year for a timestamp >= 7 days ago in the same year", () => {
+    it("should show absolute date without year for a snapshot >= 7 days ago in the same year", () => {
       const lastSyncDate = new Date(2025, 0, 12);
-      renderRefreshing(lastSyncDate);
+      renderRefreshing(lastSyncDate.getTime());
       const label = screen.getByTestId("portfolio-refresh-status-refreshing");
       expect(label).toBeVisible();
       const expected = new Intl.DateTimeFormat(TEST_LOCALE, {
@@ -150,9 +143,9 @@ describe("PortfolioRefreshStatus", () => {
       expect(label.props.children).toContain(expected);
     });
 
-    it("should show absolute date with year for a timestamp in a previous year", () => {
+    it("should show absolute date with year for a snapshot in a previous year", () => {
       const lastSyncDate = new Date(2024, 0, 12);
-      renderRefreshing(lastSyncDate);
+      renderRefreshing(lastSyncDate.getTime());
       const label = screen.getByTestId("portfolio-refresh-status-refreshing");
       expect(label).toBeVisible();
       const expected = new Intl.DateTimeFormat(TEST_LOCALE, {
@@ -161,6 +154,39 @@ describe("PortfolioRefreshStatus", () => {
         year: "2-digit",
       }).format(lastSyncDate);
       expect(label.props.children).toContain(expected);
+    });
+  });
+
+  describe("snapshot stability during refresh", () => {
+    it("should keep showing the snapshot timestamp even when accounts sync mid-refresh", () => {
+      const oldSyncDate = new Date(Date.now() - 3 * MINUTE_MS);
+      const { store } = render(<PortfolioRefreshStatus />, {
+        overrideInitialState: withIdle(oldSyncDate),
+      });
+
+      const expectedLabel = new Intl.RelativeTimeFormat(TEST_LOCALE, {
+        numeric: "always",
+      }).format(-3, "minute");
+
+      act(() => {
+        store.dispatch(setRefreshStarted(oldSyncDate.getTime()));
+      });
+
+      expect(screen.getByText(`Refreshing - Last update ${expectedLabel}`)).toBeVisible();
+
+      act(() => {
+        store.dispatch({
+          type: AccountsActionTypes.SET_ACCOUNTS,
+          payload: [makeAccount(new Date())],
+        });
+      });
+
+      expect(screen.getByText(`Refreshing - Last update ${expectedLabel}`)).toBeVisible();
+    });
+
+    it("should show 'Refreshing...' when snapshot is < 1 minute old", () => {
+      renderRefreshing(Date.now() - 30_000);
+      expect(screen.getByText("Refreshing...")).toBeVisible();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/usePortfolioRefreshStatusViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/usePortfolioRefreshStatusViewModel.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from "react";
-import { formatTimeAgo } from "@ledgerhq/live-common/utils/timeAgo";
+import { formatTimeAgo, MINUTE_MS } from "@ledgerhq/live-common/utils/timeAgo";
 import { useSelector } from "~/context/hooks";
 import { useTranslation, useLocale } from "~/context/Locale";
-import { selectIsRefreshing, selectLastSyncTimestamp } from "~/reducers/portfolioRefresh";
+import { selectIsRefreshing, selectLastSyncTimestampSnapshot } from "~/reducers/portfolioRefresh";
 
 export const UP_TO_DATE_VISIBLE_DURATION_MS = 3_000;
 
@@ -17,7 +17,7 @@ export const usePortfolioRefreshStatusViewModel = (): UsePortfolioRefreshStatusV
   const { t } = useTranslation();
   const { locale } = useLocale();
   const isRefreshing = useSelector(selectIsRefreshing);
-  const lastRefreshTimestamp = useSelector(selectLastSyncTimestamp);
+  const lastSyncTimestampSnapshot = useSelector(selectLastSyncTimestampSnapshot);
 
   const [showUpToDate, setShowUpToDate] = useState(false);
   const prevIsRefreshing = useRef(isRefreshing);
@@ -32,12 +32,18 @@ export const usePortfolioRefreshStatusViewModel = (): UsePortfolioRefreshStatusV
     prevIsRefreshing.current = isRefreshing;
   }, [isRefreshing]);
 
+  const isStale =
+    lastSyncTimestampSnapshot !== null && Date.now() - lastSyncTimestampSnapshot >= MINUTE_MS;
+
+  const timeAgo =
+    isStale && lastSyncTimestampSnapshot !== null
+      ? formatTimeAgo(lastSyncTimestampSnapshot, locale)
+      : null;
+
   const refreshingLabel =
-    lastRefreshTimestamp === null
+    timeAgo === null
       ? t("portfolio.refreshStatus.refreshingInitial")
-      : t("portfolio.refreshStatus.refreshing", {
-          timeAgo: formatTimeAgo(lastRefreshTimestamp, locale),
-        });
+      : t("portfolio.refreshStatus.refreshing", { timeAgo });
 
   return {
     isVisible: isRefreshing || showUpToDate,

--- a/apps/ledger-live-mobile/src/reducers/portfolioRefresh.ts
+++ b/apps/ledger-live-mobile/src/reducers/portfolioRefresh.ts
@@ -1,24 +1,28 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { createSelector } from "~/context/selectors";
 import { State } from "~/reducers/types";
 
 export interface PortfolioRefreshState {
   isRefreshing: boolean;
+  lastSyncTimestampSnapshot: number | null;
 }
 
 export const INITIAL_STATE: PortfolioRefreshState = {
   isRefreshing: false,
+  lastSyncTimestampSnapshot: null,
 };
 
 const portfolioRefreshSlice = createSlice({
   name: "portfolioRefresh",
   initialState: INITIAL_STATE,
   reducers: {
-    setRefreshStarted: state => {
+    setRefreshStarted: (state, action: PayloadAction<number | null>) => {
       state.isRefreshing = true;
+      state.lastSyncTimestampSnapshot = action.payload;
     },
     setRefreshCompleted: state => {
       state.isRefreshing = false;
+      state.lastSyncTimestampSnapshot = null;
     },
   },
 });
@@ -26,6 +30,9 @@ const portfolioRefreshSlice = createSlice({
 export const { setRefreshStarted, setRefreshCompleted } = portfolioRefreshSlice.actions;
 
 export const selectIsRefreshing = (state: State) => state.portfolioRefresh.isRefreshing;
+
+export const selectLastSyncTimestampSnapshot = (state: State) =>
+  state.portfolioRefresh.lastSyncTimestampSnapshot;
 
 export const selectLastSyncTimestamp = createSelector(
   (state: State) => state.accounts.active,

--- a/libs/ledger-live-common/src/utils/__tests__/timeAgo.test.ts
+++ b/libs/ledger-live-common/src/utils/__tests__/timeAgo.test.ts
@@ -6,17 +6,17 @@ const LOCALE = "en";
 const rtf = new Intl.RelativeTimeFormat(LOCALE, { numeric: "always" });
 
 describe("formatTimeAgo", () => {
-  describe("seconds (< 1 minute)", () => {
-    it("should format 0 seconds ago", () => {
-      expect(formatTimeAgo(NOW, LOCALE, NOW)).toBe(rtf.format(-0, "second"));
+  describe("up to date (< 1 minute)", () => {
+    it("should return null for 0 seconds ago", () => {
+      expect(formatTimeAgo(NOW, LOCALE, NOW)).toBeNull();
     });
 
-    it("should format 30 seconds ago", () => {
-      expect(formatTimeAgo(NOW - 30 * SECOND_MS, LOCALE, NOW)).toBe(rtf.format(-30, "second"));
+    it("should return null for 30 seconds ago", () => {
+      expect(formatTimeAgo(NOW - 30 * SECOND_MS, LOCALE, NOW)).toBeNull();
     });
 
-    it("should format 59 seconds ago", () => {
-      expect(formatTimeAgo(NOW - 59 * SECOND_MS, LOCALE, NOW)).toBe(rtf.format(-59, "second"));
+    it("should return null for 59 seconds ago", () => {
+      expect(formatTimeAgo(NOW - 59 * SECOND_MS, LOCALE, NOW)).toBeNull();
     });
   });
 

--- a/libs/ledger-live-common/src/utils/timeAgo.ts
+++ b/libs/ledger-live-common/src/utils/timeAgo.ts
@@ -8,15 +8,24 @@ export const WEEK_MS = 7 * DAY_MS;
  * Formats a timestamp into a human-readable relative or absolute time label
  * using native Intl APIs (RelativeTimeFormat for < 7 days, DateTimeFormat for older dates).
  *
+ * Returns null when the timestamp is less than 1 minute old (caller should
+ * treat this as "up to date" and display the appropriate message).
+ *
  * @param timestamp - The past timestamp in milliseconds.
  * @param locale - BCP 47 locale string used for formatting (e.g. "en", "fr").
  * @param now - Current time in milliseconds (defaults to Date.now(), injectable for testing).
  */
-export function formatTimeAgo(timestamp: number, locale: string, now: number = Date.now()): string {
+export function formatTimeAgo(
+  timestamp: number,
+  locale: string,
+  now: number = Date.now(),
+): string | null {
   const elapsed = now - timestamp;
+
+  if (elapsed < MINUTE_MS) return null;
+
   const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "always" });
 
-  if (elapsed < MINUTE_MS) return rtf.format(-Math.floor(elapsed / 1000), "second");
   if (elapsed < HOUR_MS) return rtf.format(-Math.floor(elapsed / MINUTE_MS), "minute");
   if (elapsed < DAY_MS) return rtf.format(-Math.floor(elapsed / HOUR_MS), "hour");
   if (elapsed < WEEK_MS) return rtf.format(-Math.floor(elapsed / DAY_MS), "day");


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Pull-to-refresh behavior on Portfolio screen
      - Refresh status label display during sync
      - Time formatting in `formatTimeAgo` utility (< 1 min returns `null` instead of seconds)

### 📝 Description

**Problem**: During pull-to-refresh on mobile, the refresh status label flickers through three states: "Refreshing - Last update 30s ago" → "Refreshing - Last update 0s ago" → "You're up to date". The intermediate "0 seconds ago" state occurs because `selectLastSyncTimestamp` is a live selector that recomputes when bridge sync updates account `lastSyncDate` mid-refresh. Additionally, the design spec states that timestamps under 1 minute should not display seconds.

**Solution**:
- **Redux snapshot**: `setRefreshStarted` now captures the current `lastSyncTimestamp` as a snapshot in the `portfolioRefresh` slice. The ViewModel reads this immutable snapshot during refresh instead of the live selector, preventing mid-sync account updates from causing label flicker.
- **No seconds display**: `formatTimeAgo` now returns `null` for elapsed times < 1 minute (per design spec: "< 1 min = You're up to date"). The ViewModel treats `null` as "Refreshing..." without time info.
- **Defensive guard**: The ViewModel also checks `Date.now() - snapshot >= MINUTE_MS` before calling `formatTimeAgo`, ensuring correct behavior regardless of lib build state.

**Before**: `"30s ago"` → `"0s ago"` → `"You're up to date"`
**After**: `"3 min ago"` → `"You're up to date"` (or `"Refreshing..."` if < 1 min)

https://github.com/user-attachments/assets/9fed53b1-6da0-48bd-ab10-d9165f9efb62


### ❓ Context

- **JIRA or GitHub link**: [LIVE-27077](https://ledgerhq.atlassian.net/browse/LIVE-27077)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27077]: https://ledgerhq.atlassian.net/browse/LIVE-27077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ