### PR TITLE
feat(desktop): add buy button tracking on market pages

### DIFF
--- a/.changeset/clever-walls-cough.md
+++ b/.changeset/clever-walls-cough.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+add tracking for buy button in market

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useMarketActions.ts
@@ -58,9 +58,14 @@ export const useMarketActions = ({ currency, page }: MarketActionsProps) => {
     async (e: React.SyntheticEvent<HTMLButtonElement>) => {
       e.preventDefault();
       e.stopPropagation();
-      setTrackingSource(page);
-
       const ledgerCurrency = await getLedgerCurrency();
+      track("button_clicked2", {
+        button: "buy",
+        currency: ledgerCurrency ? ledgerCurrency.ticker : currency?.ticker,
+        page,
+        flow: "buy",
+      });
+      setTrackingSource(page);
 
       navigateToBuy(ledgerCurrency, currency?.ticker);
     },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Tracking-only change, no business logic impacted._
- [x] **Impact of the changes:**
  - Buy button tracking on Market list page
  - Buy button tracking on Market detail page
  - Analytics event payload correctness

### 📝 Description

**Problem**: The buy button on the Market list and Market detail pages was missing a `button_clicked` tracking event, unlike the swap and stake buttons which already had one.

**Solution**: Added a `button_clicked2` tracking event in the `onBuy` callback of `useMarketActions`, firing before navigation with the currency ticker, page source, and flow. This is consistent with the existing swap and stake tracking patterns in the same hook.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27120](https://ledgerhq.atlassian.net/browse/LIVE-27120)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27120]: https://ledgerhq.atlassian.net/browse/LIVE-27120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ