### PR TITLE
feat: add balance refresh error tracking

### DIFF
--- a/.changeset/shy-eagles-hope.md
+++ b/.changeset/shy-eagles-hope.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): add tracking to balance refresh

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarActionButton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarActionButton.tsx
@@ -11,12 +11,13 @@ export function TopBarActionButton({
   isInteractive,
   onClick,
   icon,
+  onTooltipShow,
 }: TopBarActionButtonProps) {
   const testId = `topbar-action-button-${label.replace(/\s+/g, "-").toLowerCase()}`;
 
   return (
     <div className="flex items-center gap-12">
-      <Tooltip content={tooltip} placement="bottom">
+      <Tooltip content={tooltip} placement="bottom" onShow={onTooltipShow}>
         <IconButton
           appearance="gray"
           size="sm"

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useAccountsSyncStatus.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useAccountsSyncStatus.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "tests/testSetup";
 import { useAccountsSyncStatus } from "../useAccountsSyncStatus";
 import type { AccountWithUpToDateCheck } from "../useAccountsSyncStatus";
+import * as segment from "~/renderer/analytics/segment";
 
 const createAccountWithUpToDateCheck = (
   id: string,
@@ -29,6 +30,29 @@ const mockUseBatchAccountsSyncState = jest.requireMock(
 describe("useAccountsSyncStatus", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it("does not call track when no accounts have problems", () => {
+    const trackSpy = jest.spyOn(segment, "track");
+    const accountsWithUpToDateCheck = [
+      createAccountWithUpToDateCheck("a1", "BTC", true),
+      createAccountWithUpToDateCheck("a2", "ETH", true),
+    ];
+    mockUseBatchAccountsSyncState.mockReturnValue([
+      {
+        syncState: { pending: false, error: null },
+        account: accountsWithUpToDateCheck[0].account,
+      },
+      {
+        syncState: { pending: false, error: null },
+        account: accountsWithUpToDateCheck[1].account,
+      },
+    ]);
+
+    renderHook(() => useAccountsSyncStatus(accountsWithUpToDateCheck));
+
+    expect(trackSpy).not.toHaveBeenCalled();
+    trackSpy.mockRestore();
   });
 
   it("returns empty list and areAllAccountsUpToDate true when no accounts have problems", () => {
@@ -76,6 +100,31 @@ describe("useAccountsSyncStatus", () => {
     expect(result.current.areAllAccountsUpToDate).toBe(false);
   });
 
+  it("calls track SyncError once per account with sync error", () => {
+    const trackSpy = jest.spyOn(segment, "track");
+    const accountsWithUpToDateCheck = [
+      createAccountWithUpToDateCheck("a1", "BTC", false),
+      createAccountWithUpToDateCheck("a2", "ETH", false),
+    ];
+    mockUseBatchAccountsSyncState.mockReturnValue([
+      {
+        syncState: { pending: false, error: new Error() },
+        account: accountsWithUpToDateCheck[0].account,
+      },
+      {
+        syncState: { pending: false, error: new Error() },
+        account: accountsWithUpToDateCheck[1].account,
+      },
+    ]);
+
+    renderHook(() => useAccountsSyncStatus(accountsWithUpToDateCheck));
+
+    expect(trackSpy).toHaveBeenCalledTimes(2);
+    expect(trackSpy).toHaveBeenCalledWith("SyncError", { currency: "BTC" });
+    expect(trackSpy).toHaveBeenCalledWith("SyncError", { currency: "ETH" });
+    trackSpy.mockRestore();
+  });
+
   it("joins multiple error account tickers with /", () => {
     const accountsWithUpToDateCheck = [
       createAccountWithUpToDateCheck("a1", "BTC", false),
@@ -118,6 +167,31 @@ describe("useAccountsSyncStatus", () => {
 
     expect(result.current.listOfErrorAccountNames).toBe("BTC");
     expect(result.current.areAllAccountsUpToDate).toBe(false);
+  });
+
+  it("calls track SyncError twice when two accounts of same currency have sync problems", () => {
+    const trackSpy = jest.spyOn(segment, "track");
+    const accountsWithUpToDateCheck = [
+      createAccountWithUpToDateCheck("a1", "BTC", false),
+      createAccountWithUpToDateCheck("a2", "BTC", false),
+    ];
+    mockUseBatchAccountsSyncState.mockReturnValue([
+      {
+        syncState: { pending: false, error: new Error() },
+        account: accountsWithUpToDateCheck[0].account,
+      },
+      {
+        syncState: { pending: false, error: new Error() },
+        account: accountsWithUpToDateCheck[1].account,
+      },
+    ]);
+
+    renderHook(() => useAccountsSyncStatus(accountsWithUpToDateCheck));
+
+    expect(trackSpy).toHaveBeenCalledTimes(2);
+    expect(trackSpy).toHaveBeenNthCalledWith(1, "SyncError", { currency: "BTC" });
+    expect(trackSpy).toHaveBeenNthCalledWith(2, "SyncError", { currency: "BTC" });
+    trackSpy.mockRestore();
   });
 
   it("excludes accounts that are pending from sync problem list", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
@@ -2,6 +2,7 @@ import { Refresh } from "@ledgerhq/lumen-ui-react/symbols";
 import { renderHook, act } from "tests/testSetup";
 import { useActivityIndicator } from "../useActivityIndicator";
 import { BTC_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
+import * as segment from "~/renderer/analytics/segment";
 
 const mockTriggerRefresh = jest.fn();
 
@@ -38,7 +39,7 @@ describe("useActivityIndicator", () => {
     mockUsePortfolioBalanceSync.mockReturnValue(defaultPortfolioBalanceSync);
   });
 
-  it("returns hasAccounts, handleSync, isError, isRotating, tooltip, icon", () => {
+  it("returns correct values", () => {
     const { result } = renderHook(() => useActivityIndicator(), {
       initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
     });
@@ -53,6 +54,45 @@ describe("useActivityIndicator", () => {
     expect(typeof result.current.tooltip).toBe("string");
     expect(result.current.handleSync).toBeDefined();
     expect(result.current.icon).toBe(Refresh);
+    expect(result.current.onTooltipShow).toBeUndefined();
+  });
+
+  it("returns onTooltipShow when isError is true", () => {
+    mockUsePortfolioBalanceSync.mockReturnValue({
+      ...defaultPortfolioBalanceSync,
+      hasWalletSyncError: true,
+    });
+
+    const { result } = renderHook(() => useActivityIndicator(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    expect(result.current.isError).toBe(true);
+    expect(typeof result.current.onTooltipShow).toBe("function");
+  });
+
+  it("onTooltipShow tracks SyncErrorList with currencies as array", () => {
+    const trackSpy = jest.spyOn(segment, "track");
+    mockUsePortfolioBalanceSync.mockReturnValue({
+      ...defaultPortfolioBalanceSync,
+      hasWalletSyncError: true,
+    });
+
+    const { result } = renderHook(() => useActivityIndicator(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    act(() => {
+      result.current.onTooltipShow?.();
+    });
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      "SyncErrorList",
+      expect.objectContaining({
+        currencies: expect.any(Array),
+      }),
+    );
+    trackSpy.mockRestore();
   });
 
   it("returns isRotating and isDisabled true when balance is loading (e.g. countervalues polling)", () => {
@@ -129,7 +169,9 @@ describe("useActivityIndicator", () => {
     });
 
     expect(mockTriggerRefresh).toHaveBeenCalledTimes(1);
-    expect(track).toHaveBeenCalledWith("SyncRefreshClick");
+    expect(track).toHaveBeenCalledWith("SyncRefreshClick", {
+      triggered_after_sync_error: false,
+    });
   });
 
   it("handleSync dispatches setLastUserSyncClickTimestamp", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
@@ -34,6 +34,7 @@ describe("useTopBarViewModel", () => {
       tooltip: "Refresh",
       icon: Refresh,
       isDisabled: false,
+      onTooltipShow: undefined,
     });
     mockUseSettings.mockReturnValue({
       handleSettings: mockHandleSettings,
@@ -84,6 +85,7 @@ describe("useTopBarViewModel", () => {
       tooltip: "Refresh",
       icon: Refresh,
       isDisabled: false,
+      onTooltipShow: undefined,
     });
 
     const { result } = renderHook(() => useTopBarViewModel());
@@ -99,6 +101,7 @@ describe("useTopBarViewModel", () => {
   });
 
   it("passes isRotating from useActivityIndicator as isInteractive false on sync action", () => {
+    const mockOnTooltipShow = jest.fn();
     mockUseActivityIndicator.mockReturnValue({
       hasAccounts: true,
       handleSync: mockHandleSync,
@@ -107,6 +110,7 @@ describe("useTopBarViewModel", () => {
       tooltip: "Error",
       icon: Refresh,
       isDisabled: true,
+      onTooltipShow: mockOnTooltipShow,
     });
 
     const { result } = renderHook(() => useTopBarViewModel());

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useAccountsSyncStatus.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useAccountsSyncStatus.ts
@@ -1,5 +1,6 @@
 import { useBatchAccountsSyncState } from "@ledgerhq/live-common/bridge/react/index";
 import { Account } from "@ledgerhq/types-live";
+import { track } from "~/renderer/analytics/segment";
 
 export interface AccountWithUpToDateCheck {
   account: Account;
@@ -30,7 +31,11 @@ export function useAccountsSyncStatus(
     if (syncState.pending) continue;
     const isUpToDate = isUpToDateByAccountId.get(account.id);
     if (syncState.error || !isUpToDate) {
-      errorTickersSet.add(account.currency.ticker);
+      const currency = account.currency.ticker;
+      errorTickersSet.add(currency);
+      track("SyncError", {
+        currency,
+      });
     }
   }
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
@@ -69,8 +69,20 @@ export const useActivityIndicator = () => {
     const now = Date.now();
     dispatch(setLastUserSyncClickTimestamp(now));
     triggerRefresh();
-    track("SyncRefreshClick");
-  }, [dispatch, triggerRefresh]);
+    track("SyncRefreshClick", {
+      triggered_after_sync_error: isError,
+    });
+  }, [dispatch, triggerRefresh, isError]);
+
+  const onTooltipShow = useCallback(() => {
+    if (isError) {
+      track("SyncErrorList", {
+        currencies: listOfErrorAccountNames
+          ? listOfErrorAccountNames.split("/").filter(Boolean)
+          : [],
+      });
+    }
+  }, [isError, listOfErrorAccountNames]);
 
   return {
     hasAccounts,
@@ -80,5 +92,6 @@ export const useActivityIndicator = () => {
     isDisabled: isRotating,
     tooltip,
     icon,
+    onTooltipShow: isError ? onTooltipShow : undefined,
   };
 };

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
@@ -12,6 +12,7 @@ const useTopBarViewModel = () => {
     isRotating,
     icon: activityIndicatorIcon,
     tooltip: activityIndicatorTooltip,
+    onTooltipShow: activityIndicatorOnTooltipShow,
   } = useActivityIndicator();
   const { handleSettings, settingsIcon, tooltip: settingsTooltip } = useSettings();
   const { handleMyLedger, tooltip: myLedgerTooltip, icon: myLedgerIcon } = useMyLedger();
@@ -27,6 +28,7 @@ const useTopBarViewModel = () => {
               icon: activityIndicatorIcon,
               isInteractive: !isRotating,
               onClick: handleSync,
+              onTooltipShow: activityIndicatorOnTooltipShow,
             },
           },
         ]

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
@@ -17,6 +17,8 @@ type TopBarAction = {
   isInteractive: boolean;
   onClick: () => void;
   icon: IconComponent;
+  /** Called when the tooltip is shown (e.g. on hover). Used for analytics when showing error tooltip. */
+  onTooltipShow?: () => void;
 };
 
 /** A slot is either a generic action (button) or the notification indicator (button + drawer). */

--- a/apps/ledger-live-desktop/src/renderer/components/Tooltip.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Tooltip.tsx
@@ -41,6 +41,7 @@ type Props = {
   arrow?: boolean;
   hideOnClick?: boolean;
   containerStyle?: React.CSSProperties;
+  onShow?: () => void;
 };
 
 const ToolTip = ({
@@ -54,6 +55,7 @@ const ToolTip = ({
   arrow = true,
   hideOnClick = true,
   containerStyle,
+  onShow,
 }: Props) => {
   const colors = useTheme().colors;
   const bg = tooltipBg === "error-strong" ? colors.error.c50 : colors.neutral.c100;
@@ -67,6 +69,7 @@ const ToolTip = ({
       disabled={!(!!content && enabled)}
       placement={placement}
       hideOnClick={hideOnClick}
+      onShow={onShow}
       // eslint-disable-next-line better-tailwindcss/no-unknown-classes
       className={tooltipBg ? `bg-${tooltipBg}` : "bg-base"}
     >


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces analytics tracking for balance refresh and sync errors in the Ledger Live Desktop application's Top Bar, along with supporting UI and test changes. The main focus is to track user interactions and error states during account and portfolio syncs, enabling better error monitoring and user behavior analysis.


https://github.com/user-attachments/assets/09473192-c1d0-4cd1-ac74-a6a0a74c6385


### ❓ Context

[LIVE-24877](https://ledgerhq.atlassian.net/browse/LIVE-24877)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24877]: https://ledgerhq.atlassian.net/browse/LIVE-24877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ