### PR TITLE
fix(live-countervalues): align status.oldestDateRequested with data cut by selectedTimeRange

### DIFF
--- a/.changeset/fix-countervalues-export-status-oldest-date.md
+++ b/.changeset/fix-countervalues-export-status-oldest-date.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-countervalues": minor
+---
+
+Fix countervalues export: align status.oldestDateRequested with data cut by selectedTimeRange so needOlderReload remains correct after restore

--- a/libs/live-countervalues/src/logic.test.ts
+++ b/libs/live-countervalues/src/logic.test.ts
@@ -283,6 +283,102 @@ describe("exportCountervalues", () => {
     expect(exported["USD bitcoin"]).toEqual({ "2024-01-01": 55000 });
   });
 
+  describe("status.oldestDateRequested correlation with selectedTimeRange cut", () => {
+    test("when data is cut by selectedTimeRange, exported status.oldestDateRequested is at least the cut date (dailyLimit)", () => {
+      const selectedTimeRange = "month"; // 30 days
+      const cutDate = new Date(Date.now() - 30 * DAY);
+      const dailyLimitKey = formatCounterValueDay(cutDate);
+      const oldDailyKey = formatCounterValueDay(new Date(Date.now() - 35 * DAY));
+      const recentDailyKey = formatCounterValueDay(new Date(Date.now() - 15 * DAY));
+
+      const state: CounterValuesState = {
+        data: {
+          "USD bitcoin": new Map([
+            [oldDailyKey, 45000],
+            [recentDailyKey, 50000],
+          ]),
+        },
+        status: {
+          "USD bitcoin": {
+            timestamp: 1234567890,
+            oldestDateRequested: "2020-01-01", // older than cut: we no longer persist that range
+          },
+        },
+        cache: {},
+      };
+
+      const exported = exportCountervalues(state, defaultTrackingPairs, selectedTimeRange);
+
+      expect(exported["USD bitcoin"]).toEqual({ [recentDailyKey]: 50000 });
+      expect(exported.status["USD bitcoin"].oldestDateRequested).toBe(dailyLimitKey);
+    });
+
+    test("when data is cut, status.oldestDateRequested is max(previous, dailyLimit) so we never claim older than persisted", () => {
+      const selectedTimeRange = "week"; // 7 days
+      const cutDate = new Date(Date.now() - 7 * DAY);
+      const dailyLimitKey = formatCounterValueDay(cutDate);
+      const recentDailyKey = formatCounterValueDay(new Date(Date.now() - 3 * DAY));
+
+      const state: CounterValuesState = {
+        data: {
+          "USD bitcoin": new Map([[recentDailyKey, 50000]]),
+        },
+        status: {
+          "USD bitcoin": {
+            timestamp: 1234567890,
+            oldestDateRequested: "2024-06-01", // older than cut
+          },
+        },
+        cache: {},
+      };
+
+      const exported = exportCountervalues(state, defaultTrackingPairs, selectedTimeRange);
+
+      expect(exported.status["USD bitcoin"].oldestDateRequested).toBe(dailyLimitKey);
+    });
+
+    test("when data is not cut (no selectedTimeRange), status.oldestDateRequested is unchanged", () => {
+      const state: CounterValuesState = {
+        data: {
+          "USD bitcoin": new Map([["2024-01-01", 55000]]),
+        },
+        status: {
+          "USD bitcoin": {
+            timestamp: 1234567890,
+            oldestDateRequested: "2024-01-01",
+          },
+        },
+        cache: {},
+      };
+
+      const exported = exportCountervalues(state, defaultTrackingPairs, undefined);
+
+      expect(exported.status["USD bitcoin"].oldestDateRequested).toBe("2024-01-01");
+    });
+
+    test("when data is cut but status.oldestDateRequested is already >= dailyLimit, it is left unchanged", () => {
+      const selectedTimeRange = "year"; // 365 days
+      const recentDailyKey = formatCounterValueDay(new Date(Date.now() - 100 * DAY));
+
+      const state: CounterValuesState = {
+        data: {
+          "USD bitcoin": new Map([[recentDailyKey, 50000]]),
+        },
+        status: {
+          "USD bitcoin": {
+            timestamp: 1234567890,
+            oldestDateRequested: recentDailyKey, // already within range
+          },
+        },
+        cache: {},
+      };
+
+      const exported = exportCountervalues(state, defaultTrackingPairs, selectedTimeRange);
+
+      expect(exported.status["USD bitcoin"].oldestDateRequested).toBe(recentDailyKey);
+    });
+  });
+
   function createState(data: Record<string, unknown>) {
     return { data, status: {}, cache: {} } as CounterValuesState;
   }

--- a/libs/live-countervalues/src/logic.ts
+++ b/libs/live-countervalues/src/logic.ts
@@ -60,12 +60,13 @@ export function hasNewCountervaluesToExport(
 }
 
 // Raw state for db: history + status; no "latest" (so persistence only changes when history changes).
+// When data is cut by selectedTimeRange, status.oldestDateRequested must be aligned so it never
+// claims we have data older than what we actually persist (otherwise needOlderReload would be wrong).
 export function exportCountervalues(
   { data, status }: CounterValuesState,
   trackingPair: TrackingPair[],
   selectedTimeRange?: PortfolioRange,
 ): CounterValuesStateRaw {
-  const out = { status } as CounterValuesStateRaw;
   const hourlyLimit = formatCounterValueDay(new Date(Date.now() - datapointRetention.hourly));
   const pairIds = new Set(trackingPairIds(trackingPair));
 
@@ -76,6 +77,9 @@ export function exportCountervalues(
   const dailyLimit = shouldFilterDaily
     ? formatCounterValueDay(new Date(Date.now() - dailyRetentionDays * 24 * 60 * 60 * 1000))
     : null;
+
+  const exportedPairIds: string[] = [];
+  const out = { status: { ...status } } as CounterValuesStateRaw;
 
   for (const path in data) {
     if (!(data[path] instanceof Map)) continue; // Skip entries that are not maps
@@ -92,7 +96,23 @@ export function exportCountervalues(
       obj[k] = v;
     }
 
-    if (size > 0) out[path] = obj;
+    if (size > 0) {
+      out[path] = obj;
+      if (shouldFilterDaily) exportedPairIds.push(path);
+    }
+  }
+
+  // Correlate status with the cut: oldestDateRequested must not be older than the data we persist.
+  if (shouldFilterDaily && dailyLimit) {
+    for (const path of exportedPairIds) {
+      const s = out.status[path];
+      if (s?.oldestDateRequested && s.oldestDateRequested < dailyLimit) {
+        out.status[path] = {
+          ...s,
+          oldestDateRequested: dailyLimit,
+        };
+      }
+    }
   }
 
   return out;


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ability to refresh countervalues history when going wider time window range. (eg 1M -> 1Y)

### 📝 Description

- **Bug:** When exporting countervalues with `selectedTimeRange`, history was trimmed but `status.oldestDateRequested` was left unchanged. After restore, `needOlderReload` was wrong and the missing range was not refetched.
- **Fix:** In `exportCountervalues`, when filtering by `selectedTimeRange`, set each exported pair’s `oldestDateRequested` to `max(current, dailyLimit)` so the persisted status matches the data we keep.
- **Tests:** Added 4 tests for status/`oldestDateRequested` when data is cut or not.

### ❓ Context

- **JIRA or GitHub link**: ctx: @KVNLS on slack
https://ledgerhq.atlassian.net/browse/LIVE-27579
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
