### PR TITLE
fix(e2e): consolidate waitForQuotesStable into waitForQuotes method

### DIFF
--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -81,6 +81,7 @@ export default class SwapLiveAppPage {
   @Step("Wait for quotes")
   async waitForQuotes() {
     await waitWebElementByTestId(this.numberOfQuotes);
+    await this.waitForQuotesStable();
   }
 
   @Step("verify quotes are displayed")
@@ -100,13 +101,12 @@ export default class SwapLiveAppPage {
     });
     for (const providerName of providersWithoutKYC) {
       const provider = Object.values(Provider).find(p => p.uiName === providerName);
-      if (provider && provider.isNative) {
+      if (provider?.isNative) {
         await waitWebElementByTestId(this.specificQuoteCardProviderName(provider.name));
         const selectedProvider = getWebElementsByIdAndText(
           this.specificQuoteCardProviderName(provider.name),
           provider.uiName,
         );
-        await this.waitForQuotesStable();
         await tapWebElementByElement(selectedProvider);
 
         return provider;
@@ -175,7 +175,6 @@ export default class SwapLiveAppPage {
     const provider: string = Provider.getNameByUiName(providerList[0]);
     const baseProviderLocator = `quote-container-${provider}-`;
     await waitWebElementByTestId(baseProviderLocator + "amount-label");
-    await this.waitForQuotesStable();
     await tapWebElementByTestId(baseProviderLocator + "amount-label");
 
     await detoxExpect(getWebElementByTestId(baseProviderLocator + "amount-label")).toExist();
@@ -318,7 +317,6 @@ export default class SwapLiveAppPage {
     const providerName = Provider.getNameByUiName(provider);
     const providerTestId = this.specificQuoteCardProviderName(providerName);
     await waitWebElementByTestId(providerTestId);
-    await this.waitForQuotesStable();
     await tapWebElementByTestId(providerTestId);
   }
 


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* Move waitForQuotesStable() call into waitForQuotes() instead of calling it separately.
* Also simplify optional chaining.
* Fixes [this](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/37f76105-75ff-4528-a537-6188d0833fb0/#suites/d5f5e953e693ba0aa279c9cb617e7294/369a68542ed1ed40/) flakiness

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- [CI](https://github.com/LedgerHQ/ledger-live/actions/runs/22618737566)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
