### PR TITLE
fix(mobile): use Main navigator for swap when wallet 40 main nav is enabled

### DIFF
--- a/.changeset/rotten-weeks-unite.md
+++ b/.changeset/rotten-weeks-unite.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update swap navigation from the large mover and quick actions when mainNav v4 is ON

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -190,6 +190,8 @@ apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/earn.handler
 apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/swap.handler.ts     @ledgerhq/ptx
 apps/ledger-live-mobile/src/mvvm/features/Card/                                         @ledgerhq/ptx
 apps/ledger-live-desktop/src/mvvm/features/Card/                                        @ledgerhq/ptx
+apps/ledger-live-mobile/src/mvvm/features/Swap/                                         @ledgerhq/ptx
+apps/ledger-live-mobile/src/mvvm/features/Stake/                                        @ledgerhq/ptx
 
 # Wallet API team > coin-integration
 **/PlatformAppProviderWrapper.tsx                        @ledgerhq/coin-integration

--- a/apps/ledger-live-mobile/src/mvvm/features/Swap/__tests__/useOpenSwap.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Swap/__tests__/useOpenSwap.test.ts
@@ -28,6 +28,22 @@ function createBitcoinAccount(id: string): Account {
   return { ...account, id: `mock:1:bitcoin:${id}:` };
 }
 
+const withWallet40MainNav =
+  (show: boolean) =>
+  (state: State): State => ({
+    ...state,
+    settings: {
+      ...state.settings,
+      overriddenFeatureFlags: {
+        ...state.settings.overriddenFeatureFlags,
+        lwmWallet40: {
+          enabled: show,
+          ...(show && { params: { mainNavigation: true } }),
+        },
+      },
+    },
+  });
+
 describe("useOpenSwap (Market / QuickActions origin)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -39,7 +55,7 @@ describe("useOpenSwap (Market / QuickActions origin)", () => {
       () => useOpenSwap({ currency: bitcoin, sourceScreenName: SOURCE_SCREEN }),
       {
         overrideInitialState: (state: State) => ({
-          ...state,
+          ...withWallet40MainNav(false)(state),
           accounts: { ...state.accounts, active: [account] },
         }),
       },
@@ -72,7 +88,7 @@ describe("useOpenSwap (Market / QuickActions origin)", () => {
       () => useOpenSwap({ currency: usdcToken, sourceScreenName: SOURCE_SCREEN }),
       {
         overrideInitialState: (state: State) => ({
-          ...state,
+          ...withWallet40MainNav(false)(state),
           accounts: { ...state.accounts, active: [ethAccount] },
         }),
       },
@@ -96,7 +112,7 @@ describe("useOpenSwap (Market / QuickActions origin)", () => {
       () => useOpenSwap({ currency: usdcToken, sourceScreenName: SOURCE_SCREEN }),
       {
         overrideInitialState: (state: State) => ({
-          ...state,
+          ...withWallet40MainNav(false)(state),
           accounts: { ...state.accounts, active: [] },
         }),
       },
@@ -123,7 +139,7 @@ describe("useOpenSwap (Market / QuickActions origin)", () => {
       () => useOpenSwap({ currency: bitcoin, sourceScreenName: SOURCE_SCREEN }),
       {
         overrideInitialState: (state: State) => ({
-          ...state,
+          ...withWallet40MainNav(false)(state),
           accounts: { ...state.accounts, active: [] },
         }),
       },
@@ -151,7 +167,7 @@ describe("useOpenSwap (Market / QuickActions origin)", () => {
       () => useOpenSwap({ currency: bitcoin, sourceScreenName: SOURCE_SCREEN }),
       {
         overrideInitialState: (state: State) => ({
-          ...state,
+          ...withWallet40MainNav(false)(state),
           accounts: { ...state.accounts, active: [account] },
         }),
       },
@@ -179,7 +195,7 @@ describe("useOpenSwap (Market / QuickActions origin)", () => {
       () => useOpenSwap({ currency: bitcoin, sourceScreenName: SOURCE_SCREEN }),
       {
         overrideInitialState: (state: State) => ({
-          ...state,
+          ...withWallet40MainNav(false)(state),
           accounts: { ...state.accounts, active: [account1, account2] },
         }),
       },
@@ -200,5 +216,118 @@ describe("useOpenSwap (Market / QuickActions origin)", () => {
       }),
     );
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  describe("when shouldDisplayWallet40MainNav is true", () => {
+    test("should navigate via Main → Swap when account for currency exists", () => {
+      const account = createBitcoinAccount("account-1");
+      const { result } = renderHook(
+        () => useOpenSwap({ currency: bitcoin, sourceScreenName: SOURCE_SCREEN }),
+        {
+          overrideInitialState: (state: State) => ({
+            ...withWallet40MainNav(true)(state),
+            accounts: { ...state.accounts, active: [account] },
+          }),
+        },
+      );
+
+      act(() => {
+        result.current.handleOpenSwap();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Main, {
+        screen: NavigatorName.Swap,
+        params: {
+          screen: ScreenName.SwapTab,
+          params: expect.objectContaining({
+            defaultCurrency: bitcoin,
+            fromPath: SOURCE_SCREEN,
+            defaultAccount: account,
+            defaultParentAccount: undefined,
+          }),
+        },
+      });
+      expect(mockOpenDrawer).not.toHaveBeenCalled();
+    });
+
+    test("should navigate via Main → Swap when no account for currency", () => {
+      const { result } = renderHook(
+        () => useOpenSwap({ currency: bitcoin, sourceScreenName: SOURCE_SCREEN }),
+        {
+          overrideInitialState: (state: State) => ({
+            ...withWallet40MainNav(true)(state),
+            accounts: { ...state.accounts, active: [] },
+          }),
+        },
+      );
+
+      act(() => {
+        result.current.handleOpenSwap();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Main, {
+        screen: NavigatorName.Swap,
+        params: {
+          screen: ScreenName.SwapTab,
+          params: expect.objectContaining({
+            defaultCurrency: bitcoin,
+            fromPath: SOURCE_SCREEN,
+          }),
+        },
+      });
+      expect(mockNavigate.mock.calls[0][1].params.params.defaultAccount).toBeUndefined();
+      expect(mockOpenDrawer).not.toHaveBeenCalled();
+    });
+
+    test("should navigate via Main → Swap with toTokenId when no account for token", () => {
+      const { result } = renderHook(
+        () => useOpenSwap({ currency: usdcToken, sourceScreenName: SOURCE_SCREEN }),
+        {
+          overrideInitialState: (state: State) => ({
+            ...withWallet40MainNav(true)(state),
+            accounts: { ...state.accounts, active: [] },
+          }),
+        },
+      );
+
+      act(() => {
+        result.current.handleOpenSwap();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Main, {
+        screen: NavigatorName.Swap,
+        params: {
+          screen: ScreenName.SwapTab,
+          params: expect.objectContaining({
+            defaultCurrency: usdcToken,
+            fromPath: SOURCE_SCREEN,
+            toTokenId: usdcToken.id,
+          }),
+        },
+      });
+      expect(mockOpenDrawer).not.toHaveBeenCalled();
+    });
+
+    test("should open drawer for account selection when multiple accounts (no direct nav)", () => {
+      const account1 = createBitcoinAccount("btc-1");
+      const account2 = createBitcoinAccount("btc-2");
+      const { result } = renderHook(
+        () => useOpenSwap({ currency: bitcoin, sourceScreenName: SOURCE_SCREEN }),
+        {
+          overrideInitialState: (state: State) => ({
+            ...withWallet40MainNav(true)(state),
+            accounts: { ...state.accounts, active: [account1, account2] },
+          }),
+        },
+      );
+
+      act(() => {
+        result.current.handleOpenSwap();
+      });
+
+      expect(mockOpenDrawer).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Swap/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Swap/index.ts
@@ -12,6 +12,7 @@ import { shallowAccountsSelector, flattenAccountsSelector } from "~/reducers/acc
 import { NavigatorName, ScreenName } from "~/const";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { useModularDrawerController } from "../ModularDrawer";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 type UseOpenSwapProps = {
   currency?: CryptoOrTokenCurrency;
@@ -43,6 +44,7 @@ function getAccountsForCurrency(
 
 export function useOpenSwap({ currency, sourceScreenName }: UseOpenSwapProps) {
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
   const shallowAccounts = useSelector(shallowAccountsSelector);
   const flattenedAccounts = useSelector(flattenAccountsSelector);
   const { openDrawer } = useModularDrawerController();
@@ -65,10 +67,20 @@ export function useOpenSwap({ currency, sourceScreenName }: UseOpenSwapProps) {
           ...(currency && isTokenCurrency(currency) && { toTokenId: currency.id }),
         };
 
-        navigation.navigate(NavigatorName.Swap, {
-          screen: ScreenName.SwapTab,
-          params: swapParams,
-        });
+        if (shouldDisplayWallet40MainNav) {
+          navigation.navigate(NavigatorName.Main, {
+            screen: NavigatorName.Swap,
+            params: {
+              screen: ScreenName.SwapTab,
+              params: swapParams,
+            },
+          });
+        } else {
+          navigation.navigate(NavigatorName.Swap, {
+            screen: ScreenName.SwapTab,
+            params: swapParams,
+          });
+        }
         return;
       }
 
@@ -86,12 +98,22 @@ export function useOpenSwap({ currency, sourceScreenName }: UseOpenSwapProps) {
         defaultParentAccount: parentAcc,
       };
 
-      navigation.navigate(NavigatorName.Swap, {
-        screen: ScreenName.SwapTab,
-        params: swapParams,
-      });
+      if (shouldDisplayWallet40MainNav) {
+        navigation.navigate(NavigatorName.Main, {
+          screen: NavigatorName.Swap,
+          params: {
+            screen: ScreenName.SwapTab,
+            params: swapParams,
+          },
+        });
+      } else {
+        navigation.navigate(NavigatorName.Swap, {
+          screen: ScreenName.SwapTab,
+          params: swapParams,
+        });
+      }
     },
-    [currency, sourceScreenName, navigation, shallowAccounts],
+    [currency, sourceScreenName, shallowAccounts, navigation, shouldDisplayWallet40MainNav],
   );
 
   const openAccountSelectionDrawer = useCallback(() => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 
- [x] **Impact of the changes:**
  - Swap entry from large mover landing page and quick actions
  - Behavior with mainNav v4 ON vs OFF (feature flag)

### 📝 Description

When opening Swap from the large mover landing page or quick actions, navigation always used the legacy structure (`NavigatorName.Swap` → `ScreenName.SwapTab`). With Wallet 40 main nav enabled (`shouldDisplayWallet40MainNav`), the app expects Swap to be reached via `NavigatorName.Main` → Swap, so the previous behavior could open the wrong tab or stack.

This fix uses `useWalletFeaturesConfig("mobile").shouldDisplayWallet40MainNav` and branches navigation: when the flag is on, it navigates via `Main` → `Swap` with the same swap params; when off, it keeps the existing `Swap` → `SwapTab` flow. Both code paths (no account / single account and with account selection) are updated.

BEFORE: 

https://github.com/user-attachments/assets/3868db72-2423-4638-a31d-85a212824871




FF OFF:

https://github.com/user-attachments/assets/57fc24ca-b377-4ac4-9b1a-cb2b0e190d04

FF ON:

https://github.com/user-attachments/assets/238baf8e-4bd0-4b12-8c54-ea5cbdf12bef





### ❓ Context

- **JIRA or GitHub link**: [LIVE-27133](https://ledgerhq.atlassian.net/browse/LIVE-27133)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27133]: https://ledgerhq.atlassian.net/browse/LIVE-27133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ