### PR TITLE
test(desktop): improve backgrounds test coverage

### DIFF
--- a/.changeset/rich-lions-sneeze.md
+++ b/.changeset/rich-lions-sneeze.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+add more tests usecase for background

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/backgrounds.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/backgrounds.test.ts
@@ -1,56 +1,39 @@
-import { getPageBackground } from "../backgrounds";
+import { getPageBackground, preloadBackgrounds, PAGE_BACKGROUNDS } from "../backgrounds";
 
-jest.mock("~/renderer/images/backgrounds/light.webp", () => "light.webp");
-jest.mock("~/renderer/images/backgrounds/home.webp", () => "home.webp");
-jest.mock("~/renderer/images/backgrounds/card.webp", () => "card.webp");
-jest.mock("~/renderer/images/backgrounds/swap.webp", () => "swap.webp");
-jest.mock("~/renderer/images/backgrounds/earn.webp", () => "earn.webp");
+const knownRoutes = Object.keys(PAGE_BACKGROUNDS);
 
-describe("getPageBackground", () => {
-  describe("light theme", () => {
-    it("returns light background for supported pages", () => {
-      expect(getPageBackground("/", "light")).toBe("light.webp");
-
-      expect(getPageBackground("/card-new-wallet", "light")).toBe("light.webp");
-      expect(getPageBackground("/swap", "light")).toBe("light.webp");
-      expect(getPageBackground("/swap/bridge", "light")).toBe("light.webp");
-      expect(getPageBackground("/exchange", "light")).toBe("light.webp");
-      expect(getPageBackground("/earn", "light")).toBe("light.webp");
+describe("backgrounds", () => {
+  describe("getPageBackground", () => {
+    it.each(knownRoutes)("should return a background for %s in dark theme", route => {
+      expect(getPageBackground(route, "dark")).toBeDefined();
     });
 
-    it("returns undefined for pages without a background", () => {
-      expect(getPageBackground("/market", "light")).toBeUndefined();
-      expect(getPageBackground("/analytics", "light")).toBeUndefined();
-      expect(getPageBackground("/accounts", "light")).toBeUndefined();
-      expect(getPageBackground("/settings", "light")).toBeUndefined();
+    it.each(knownRoutes)("should return a background for %s in light theme", route => {
+      expect(getPageBackground(route, "light")).toBeDefined();
+    });
+
+    it("should return different backgrounds for light and dark themes", () => {
+      const light = getPageBackground("/", "light");
+      const dark = getPageBackground("/", "dark");
+      expect(light).not.toBe(dark);
+    });
+
+    it("should return undefined for unknown routes", () => {
+      expect(getPageBackground("/settings", "dark")).toBeUndefined();
+      expect(getPageBackground("/accounts", "dark")).toBeUndefined();
+    });
+
+    it("should match route by first segment", () => {
+      expect(getPageBackground("/swap/history", "dark")).toBeDefined();
     });
   });
 
-  describe("dark theme", () => {
-    it("returns page-specific background for home", () => {
-      expect(getPageBackground("/", "dark")).toBe("home.webp");
-    });
-
-    it("returns page-specific background for card", () => {
-      expect(getPageBackground("/card-new-wallet", "dark")).toBe("card.webp");
-    });
-
-    it("returns page-specific background for swap and exchange", () => {
-      expect(getPageBackground("/swap", "dark")).toBe("swap.webp");
-      expect(getPageBackground("/swap/bridge", "dark")).toBe("swap.webp");
-      expect(getPageBackground("/exchange", "dark")).toBe("swap.webp");
-      expect(getPageBackground("/exchange/buy", "dark")).toBe("swap.webp");
-    });
-
-    it("returns page-specific background for earn", () => {
-      expect(getPageBackground("/earn", "dark")).toBe("earn.webp");
-    });
-
-    it("returns undefined for pages without a background", () => {
-      expect(getPageBackground("/market", "dark")).toBeUndefined();
-      expect(getPageBackground("/analytics", "dark")).toBeUndefined();
-      expect(getPageBackground("/accounts", "dark")).toBeUndefined();
-      expect(getPageBackground("/settings", "dark")).toBeUndefined();
+  describe("preloadBackgrounds", () => {
+    it("should create Image instances to preload assets", () => {
+      const spy = jest.spyOn(globalThis, "Image");
+      preloadBackgrounds();
+      expect(spy.mock.instances.length).toBeGreaterThan(0);
+      spy.mockRestore();
     });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/backgrounds.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/backgrounds.ts
@@ -4,7 +4,7 @@ import cardBg from "~/renderer/images/backgrounds/card.webp";
 import swapBg from "~/renderer/images/backgrounds/swap.webp";
 import earnBg from "~/renderer/images/backgrounds/earn.webp";
 
-const PAGE_BACKGROUNDS: Record<string, string> = {
+export const PAGE_BACKGROUNDS: Record<string, string> = {
   "/": homeBg,
   "/earn": earnBg,
   "/card-new-wallet": cardBg,


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - backgrounds test file only, no runtime impact

### Description

Refactor backgrounds tests to loop over `PAGE_BACKGROUNDS` entries with `it.each`, so new routes are automatically covered. Add a test for `preloadBackgrounds`.

- Export `PAGE_BACKGROUNDS` from `backgrounds.ts`
- Replace hardcoded route assertions with `it.each(knownRoutes)`
- Add `preloadBackgrounds` unit test

### Context

- Follow-up to `feat/wallet40-page-backgrounds` (#14940)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)