### PR TITLE
fix(desktop): fix cropped carousel arrows and color in portfolio v4

### DIFF
--- a/.changeset/mean-balloons-applaud.md
+++ b/.changeset/mean-balloons-applaud.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix cropped carousel arrows and background color in portfolio V4

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
@@ -9,22 +9,16 @@ import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/inde
 
 export default PortfolioContentCards;
 
-// Wrapper with animated padding that grows on hover so the content area shrinks to reveal arrows (Wallet 4.0 only)
 const CarouselWrapper = styled.div<{ $isWallet40Enabled: boolean }>`
-  overflow: hidden;
-
-  ${({ $isWallet40Enabled }) =>
-    $isWallet40Enabled &&
-    `
-    padding-left: 0;
-    padding-right: 0;
-    transition: padding 0.25s ease-in-out;
-
-    &:hover {
-      padding-left: 16px;
-      padding-right: 16px;
-    }
-  `}
+  & > div > div > button {
+    ${({ $isWallet40Enabled, theme }) =>
+      $isWallet40Enabled &&
+      `
+      translate: 0 -50%;
+      margin: 0 -12px;
+      background-color: ${theme.colors.neutral.c00};
+    `}
+  }
 `;
 
 function PortfolioContentCards() {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual fix, no unit test applicable._
- [x] **Impact of the changes:**
      - Portfolio carousel arrow visibility and positioning in Wallet 4.0
      - Arrow background color matching V4 page theme
      - Legacy dashboard carousel remains unchanged

### 📝 Description

The portfolio carousel navigation arrows were clipped by parent `overflow-hidden` containers in the Wallet 4.0 layout, and the V4 padding animation was hiding them behind a reveal-on-hover mechanism.

**Fix:** In `CarouselWrapper`, conditionally apply V4-specific overrides:
- `translate: 0 -50%` — removes horizontal protrusion so arrows stay within `overflow-hidden` bounds
- `margin: 0 -12px` — adjusts arrow edge positioning
- `background-color: neutral.c00` — matches the V4 dark page background instead of the default `background.default`

Legacy mode is completely untouched — overrides only apply when `isWallet40Enabled` is true.



https://github.com/user-attachments/assets/10d55699-f91e-43e3-ac41-e8cf97ed7f3d



### ❓ Context

- **JIRA or GitHub link**: [LIVE-27149](https://ledgerhq.atlassian.net/browse/LIVE-27149)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27149]: https://ledgerhq.atlassian.net/browse/LIVE-27149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ