### PR TITLE
fix(mobile): ensure queued drawer cleanup always runs on close

### DIFF
--- a/.changeset/hungry-garlics-cheat.md
+++ b/.changeset/hungry-garlics-cheat.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix queued drawer to always run cleanup and onClose callback on close

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/temp/useQueuedDrawerGorhom.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/temp/useQueuedDrawerGorhom.ts
@@ -51,11 +51,11 @@ const useQueuedDrawerGorhom = ({
   }, []);
 
   const handleClose = useCallback(() => {
-    if (isClosedRef.current) return;
-
-    logDrawer("Closing drawer");
-    isClosedRef.current = true;
-    bottomSheetRef.current?.dismiss();
+    if (!isClosedRef.current) {
+      logDrawer("Closing drawer");
+      isClosedRef.current = true;
+      bottomSheetRef.current?.dismiss();
+    }
     cleanupQueue();
     onCloseRef.current?.();
   }, [cleanupQueue]);

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/useQueuedDrawerBottomSheet.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/useQueuedDrawerBottomSheet.ts
@@ -51,11 +51,11 @@ const useQueuedDrawerBottomSheet = ({
   }, [bottomSheetRef]);
 
   const handleClose = useCallback(() => {
-    if (isClosedRef.current) return;
-
-    logDrawer("Closing drawer");
-    isClosedRef.current = true;
-    bottomSheetRef.current?.dismiss();
+    if (!isClosedRef.current) {
+      logDrawer("Closing drawer");
+      isClosedRef.current = true;
+      bottomSheetRef.current?.dismiss();
+    }
     cleanupQueue();
     onCloseRef.current?.();
   }, [bottomSheetRef, cleanupQueue]);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new tests added — refactor of existing close logic with no behavioral additions._
- [x] **Impact of the changes:**
      - QueuedDrawer close behavior on mobile
      - Ensure `cleanupQueue()` and `onClose` callbacks always execute even if the drawer was already dismissed

### 📝 Description

Previously, the `handleClose` function in both `useQueuedDrawerGorhom` and `useQueuedDrawerBottomSheet` used an early return when `isClosedRef.current` was already true. This meant that `cleanupQueue()` and `onCloseRef.current?.()` were skipped entirely if the drawer had already been flagged as closed.

This fix wraps only the dismiss logic (`logDrawer`, flag set, `dismiss()`) inside the guard, so that cleanup and the onClose callback always run regardless of the drawer's closed state.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27151

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)