### PR TITLE
feat(mobile): add asset section to Portfolio home (lwmWallet40)

### DIFF
--- a/.changeset/lwm-wallet40-asset-section.md
+++ b/.changeset/lwm-wallet40-asset-section.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add asset section to Portfolio home screen under lwmWallet40 feature flag

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/portfolio.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/portfolio.integration.test.tsx
@@ -6,8 +6,8 @@ import {
   overrideInitialStateWithFeatureFlag,
   overrideInitialStateWithGraphReworkEnabled,
   overrideInitialStateWithGraphReworkAndReadOnly,
-  overrideInitialStateWithPerpsEntryPointDisabled,
-  overrideInitialStateWithPerpsEntryPointEnabled,
+  overrideInitialStateWithPerpsEntryPoint,
+  overrideInitialStateWithAssetSection,
 } from "./shared";
 
 describe("Portfolio Screen", () => {
@@ -66,7 +66,7 @@ describe("Portfolio Screen", () => {
   describe("Perps Entry Point", () => {
     it("should show perps entry point when feature flag is enabled", async () => {
       renderWithReactQuery(<PortfolioTest />, {
-        overrideInitialState: overrideInitialStateWithPerpsEntryPointEnabled,
+        overrideInitialState: overrideInitialStateWithPerpsEntryPoint(true),
       });
 
       await screen.findByTestId("PortfolioAccountsList");
@@ -76,12 +76,44 @@ describe("Portfolio Screen", () => {
 
     it("should hide perps entry point when feature flag is disabled", async () => {
       renderWithReactQuery(<PortfolioTest />, {
-        overrideInitialState: overrideInitialStateWithPerpsEntryPointDisabled,
+        overrideInitialState: overrideInitialStateWithPerpsEntryPoint(false),
       });
 
       await screen.findByTestId("PortfolioAccountsList");
 
       expect(screen.queryByTestId("portfolio-perps-entry-point")).toBeNull();
+    });
+  });
+
+  describe("Asset Section Feature", () => {
+    it("should display the cryptos list when assetSection is enabled and user has accounts", async () => {
+      renderWithReactQuery(<PortfolioTest />, {
+        overrideInitialState: overrideInitialStateWithAssetSection(true),
+      });
+
+      await screen.findByTestId("PortfolioAccountsList");
+
+      expect(await screen.findByTestId("PortfolioCryptosList")).toBeVisible();
+    });
+
+    it("should not display the cryptos list when assetSection is disabled", async () => {
+      renderWithReactQuery(<PortfolioTest />, {
+        overrideInitialState: overrideInitialStateWithAssetSection(false),
+      });
+
+      await screen.findByTestId("PortfolioAccountsList");
+
+      expect(screen.queryByTestId("PortfolioCryptosList")).toBeNull();
+    });
+
+    it("should not display the cryptos list when user has no accounts", async () => {
+      renderWithReactQuery(<PortfolioTest />, {
+        overrideInitialState: overrideInitialStateWithFeatureFlag,
+      });
+
+      await screen.findByTestId("PortfolioEmptyList");
+
+      expect(screen.queryByTestId("PortfolioCryptosList")).toBeNull();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/shared.tsx
@@ -24,8 +24,11 @@ export const ReadOnlyPortfolioTest = () => (
   </Stack.Navigator>
 );
 
+export const btcCurrency = getCryptoCurrencyById("bitcoin");
+export const ethCurrency = getCryptoCurrencyById("ethereum");
+
 const mockAccount = {
-  ...genAccount("perpsAccount", { currency: getCryptoCurrencyById("bitcoin") }),
+  ...genAccount("perpsAccount", { currency: btcCurrency }),
   index: 0,
 };
 
@@ -60,32 +63,35 @@ export const overrideInitialStateWithGraphReworkAndReadOnly = (state: State): St
   },
 });
 
-export const overrideInitialStateWithPerpsEntryPointEnabled = (state: State): State => ({
-  ...state,
-  accounts: {
-    active: [mockAccount],
-  },
-  settings: {
-    ...state.settings,
-    overriddenFeatureFlags: {
-      ...state.settings.overriddenFeatureFlags,
-      lwmWallet40: { enabled: true },
-      ptxPerpsLiveAppMobile: { enabled: true },
+export const overrideInitialStateWithPerpsEntryPoint =
+  (enabled: boolean) =>
+  (state: State): State => ({
+    ...state,
+    accounts: {
+      active: [mockAccount],
     },
-  },
-});
+    settings: {
+      ...state.settings,
+      overriddenFeatureFlags: {
+        ...state.settings.overriddenFeatureFlags,
+        lwmWallet40: { enabled: true },
+        ptxPerpsLiveAppMobile: { enabled },
+      },
+    },
+  });
 
-export const overrideInitialStateWithPerpsEntryPointDisabled = (state: State): State => ({
-  ...state,
-  accounts: {
-    active: [mockAccount],
-  },
-  settings: {
-    ...state.settings,
-    overriddenFeatureFlags: {
-      ...state.settings.overriddenFeatureFlags,
-      lwmWallet40: { enabled: true },
-      ptxPerpsLiveAppMobile: { enabled: false },
+export const overrideInitialStateWithAssetSection =
+  (assetSection: boolean) =>
+  (state: State): State => ({
+    ...state,
+    accounts: {
+      active: [mockAccount],
     },
-  },
-});
+    settings: {
+      ...state.settings,
+      overriddenFeatureFlags: {
+        ...state.settings.overriddenFeatureFlags,
+        lwmWallet40: { enabled: true, params: { assetSection } },
+      },
+    },
+  });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/AssetListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/AssetListItem.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback } from "react";
+import {
+  Box,
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import CurrencyIcon from "~/components/CurrencyIcon";
+import { Asset } from "~/types/asset";
+import {
+  useAssetListItemViewModel,
+  type AssetListItemViewModelResult,
+} from "./useAssetListItemViewModel";
+
+interface AssetListItemProps {
+  asset: Asset;
+  onPress: (asset: Asset) => void;
+}
+
+interface AssetListItemViewProps extends AssetListItemViewModelResult {
+  asset: Asset;
+  onPress: () => void;
+}
+
+const AssetListItemView: React.FC<AssetListItemViewProps> = ({
+  asset,
+  onPress,
+  formattedBalance,
+  formattedCounterValue,
+  deltaText,
+  deltaColor,
+}) => (
+  <ListItem
+    onPress={onPress}
+    testID={`assetItem-${asset.currency.name}`}
+    style={{ marginHorizontal: -8 }} // offsets ListItem's internal paddingHorizontal: s8
+  >
+    <ListItemLeading>
+      <CurrencyIcon currency={asset.currency} size={48} />
+      <ListItemContent>
+        <ListItemTitle>{asset.currency.name}</ListItemTitle>
+        <ListItemDescription>{formattedBalance}</ListItemDescription>
+      </ListItemContent>
+    </ListItemLeading>
+    <ListItemTrailing>
+      <Box lx={{ flexDirection: "column", alignItems: "flex-end", gap: "s4" }}>
+        {formattedCounterValue != null && (
+          <Text typography="body2SemiBold" lx={{ color: "base" }}>
+            {formattedCounterValue}
+          </Text>
+        )}
+        <Text typography="body3" lx={{ color: deltaColor }}>
+          {deltaText}
+        </Text>
+      </Box>
+    </ListItemTrailing>
+  </ListItem>
+);
+
+const AssetListItem: React.FC<AssetListItemProps> = ({ asset, onPress }) => {
+  const vmResult = useAssetListItemViewModel(asset);
+  const handlePress = useCallback(() => onPress(asset), [asset, onPress]);
+
+  return <AssetListItemView asset={asset} onPress={handlePress} {...vmResult} />;
+};
+
+export default AssetListItem;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/AssetListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/AssetListItem.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import AssetListItem from "../AssetListItem";
+import {
+  useAssetListItemViewModel,
+  type AssetListItemViewModelResult,
+} from "../useAssetListItemViewModel";
+import { createCryptoAsset, bitcoin } from "./shared";
+
+jest.mock("../useAssetListItemViewModel", () => ({
+  useAssetListItemViewModel: jest.fn(),
+}));
+
+const mockedViewModel = jest.mocked(useAssetListItemViewModel);
+
+const mockAsset = createCryptoAsset(bitcoin, 100000);
+
+const baseViewModelResult: AssetListItemViewModelResult = {
+  formattedBalance: "0.001 BTC",
+  formattedCounterValue: "$45.00",
+  deltaText: "+3.50%",
+  deltaColor: "success",
+};
+
+const renderView = (vmOverrides: Partial<AssetListItemViewModelResult> = {}) => {
+  mockedViewModel.mockReturnValue({ ...baseViewModelResult, ...vmOverrides });
+  return render(<AssetListItem asset={mockAsset} onPress={jest.fn()} />);
+};
+
+describe("AssetListItem", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("leading content", () => {
+    beforeEach(() => {
+      renderView();
+    });
+
+    it("should render the currency name", () => {
+      expect(screen.getByText("Bitcoin")).toBeVisible();
+    });
+
+    it("should render the formatted native balance", () => {
+      expect(screen.getByText("0.001 BTC")).toBeVisible();
+    });
+  });
+
+  describe("trailing content", () => {
+    it("should render the counter value when available", () => {
+      renderView();
+      expect(screen.getByText("$45.00")).toBeVisible();
+    });
+
+    it("should not render the counter value when null", () => {
+      renderView({ formattedCounterValue: null });
+      expect(screen.queryByText("$45.00")).toBeNull();
+    });
+
+    it.each([
+      { deltaText: "+3.50%", deltaColor: "success" as const, label: "positive" },
+      { deltaText: "-1.20%", deltaColor: "error" as const, label: "negative" },
+      { deltaText: "–", deltaColor: "muted" as const, label: "unavailable" },
+    ])("should render the delta with $label variation", ({ deltaText, deltaColor }) => {
+      renderView({ deltaText, deltaColor });
+      expect(screen.getByText(deltaText)).toBeVisible();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/shared.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/shared.ts
@@ -1,0 +1,14 @@
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { Asset } from "~/types/asset";
+
+export const bitcoin = getCryptoCurrencyById("bitcoin");
+export const ethereum = getCryptoCurrencyById("ethereum");
+
+export const createCryptoAsset = (
+  currency: ReturnType<typeof getCryptoCurrencyById>,
+  amount: number,
+): Asset => ({
+  currency,
+  accounts: [],
+  amount,
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/useAssetListItemViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/useAssetListItemViewModel.test.ts
@@ -1,0 +1,47 @@
+import { renderHook } from "@tests/test-renderer";
+import { usePortfolioForAccounts } from "~/hooks/portfolio";
+import { useAssetListItemViewModel } from "../useAssetListItemViewModel";
+import { bitcoin, createCryptoAsset } from "./shared";
+
+jest.mock("~/hooks/portfolio", () => ({
+  ...jest.requireActual("~/hooks/portfolio"),
+  usePortfolioForAccounts: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-countervalues-react", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues-react"),
+  useCalculate: jest.fn(),
+}));
+
+const mockPortfolio = (percentage: number | null) => {
+  (usePortfolioForAccounts as jest.Mock).mockReturnValue({
+    countervalueChange: { percentage },
+  });
+};
+
+const mockAsset = createCryptoAsset(bitcoin, 100_000);
+
+describe("useAssetListItemViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPortfolio(null);
+  });
+
+  describe("delta", () => {
+    it.each([
+      { percentage: null, expectedText: "–", expectedColor: "muted" },
+      { percentage: 0.035, expectedText: "+3.50%", expectedColor: "success" },
+      { percentage: -0.012, expectedText: "-1.20%", expectedColor: "error" },
+      { percentage: 0, expectedText: "0.00%", expectedColor: "muted" },
+    ])(
+      "should return $expectedText / $expectedColor for percentage=$percentage",
+      ({ percentage, expectedText, expectedColor }) => {
+        mockPortfolio(percentage);
+        const { result } = renderHook(() => useAssetListItemViewModel(mockAsset));
+
+        expect(result.current.deltaText).toBe(expectedText);
+        expect(result.current.deltaColor).toBe(expectedColor);
+      },
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/usePortfolioCryptosSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/usePortfolioCryptosSectionViewModel.test.ts
@@ -1,0 +1,123 @@
+import { act } from "@testing-library/react-native";
+import { renderHook } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { useDistribution } from "~/actions/general";
+import { Asset } from "~/types/asset";
+import usePortfolioCryptosSectionViewModel from "../usePortfolioCryptosSectionViewModel";
+import { bitcoin, ethereum, createCryptoAsset } from "./shared";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => ({ name: "Portfolio" }),
+}));
+
+jest.mock("~/actions/general", () => ({
+  ...jest.requireActual("~/actions/general"),
+  useDistribution: jest.fn(),
+}));
+
+const mockDistribution = (list: Asset[] = [], isAvailable = true) => {
+  (useDistribution as jest.Mock).mockReturnValue({ isAvailable, list });
+};
+
+describe("usePortfolioCryptosSectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDistribution();
+  });
+
+  describe("asset filtering and display", () => {
+    it("should return empty assets when distribution is not available", () => {
+      mockDistribution([], false);
+
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel());
+
+      expect(result.current.assetsCount).toBe(0);
+      expect(result.current.assetsToDisplay).toHaveLength(0);
+    });
+
+    it("should return all assets when fewer than 6 are available", () => {
+      const mockAssets = [createCryptoAsset(bitcoin, 100000), createCryptoAsset(ethereum, 2000)];
+      mockDistribution(mockAssets);
+
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel());
+
+      expect(result.current.assetsCount).toBe(2);
+      expect(result.current.assetsToDisplay).toHaveLength(2);
+    });
+
+    it("should limit displayed assets to 6 while showing the total count", () => {
+      const mockAssets = Array.from({ length: 10 }, (_, i) =>
+        createCryptoAsset(bitcoin, 10000 * (10 - i)),
+      );
+      mockDistribution(mockAssets);
+
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel());
+
+      expect(result.current.assetsCount).toBe(10);
+      expect(result.current.assetsToDisplay).toHaveLength(6);
+    });
+  });
+
+  describe("hasMore", () => {
+    it("should be false when there are 6 assets or fewer", () => {
+      const mockAssets = Array.from({ length: 6 }, (_, i) =>
+        createCryptoAsset(bitcoin, 10000 * (6 - i)),
+      );
+      mockDistribution(mockAssets);
+
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel());
+
+      expect(result.current.hasMore).toBe(false);
+    });
+
+    it("should be true when there are more than 6 assets", () => {
+      const mockAssets = Array.from({ length: 7 }, (_, i) =>
+        createCryptoAsset(bitcoin, 10000 * (7 - i)),
+      );
+      mockDistribution(mockAssets);
+
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel());
+
+      expect(result.current.hasMore).toBe(true);
+    });
+  });
+
+  describe("onPressShowAll", () => {
+    it("should navigate to AssetsList screen", () => {
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel());
+
+      act(() => {
+        result.current.onPressShowAll();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Assets, {
+        screen: ScreenName.AssetsList,
+        params: {
+          sourceScreenName: ScreenName.Portfolio,
+          showHeader: true,
+          isSyncEnabled: true,
+        },
+      });
+    });
+  });
+
+  describe("onItemPress", () => {
+    it("should navigate to Asset detail screen with the currency", () => {
+      const mockAsset = createCryptoAsset(ethereum, 5000);
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel());
+
+      act(() => {
+        result.current.onItemPress(mockAsset);
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+        screen: ScreenName.Asset,
+        params: { currency: ethereum },
+      });
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/index.tsx
@@ -3,47 +3,58 @@ import {
   Box,
   Button,
   Subheader,
+  SubheaderCount,
   SubheaderRow,
-  SubheaderTitle,
   SubheaderShowMore,
+  SubheaderTitle,
 } from "@ledgerhq/lumen-ui-rnative";
-import Assets from "~/screens/Portfolio/Assets";
+import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import { useTranslation } from "~/context/Locale";
-import { Asset } from "~/types/asset";
+import AssetListItem from "./AssetListItem";
+import usePortfolioCryptosSectionViewModel from "./usePortfolioCryptosSectionViewModel";
 
-interface PortfolioCryptosSectionProps {
-  readonly assets: Asset[];
-  readonly onPressShowAll: () => void;
-}
-
-export const PortfolioCryptosSection = ({
-  assets,
-  onPressShowAll,
-}: PortfolioCryptosSectionProps) => {
+const PortfolioCryptosSectionComponent: React.FC = () => {
   const { t } = useTranslation();
+  const { assetsCount, hasMore, assetsToDisplay, onPressShowAll, onItemPress } =
+    usePortfolioCryptosSectionViewModel();
+
+  if (assetsCount === 0) return null;
 
   return (
-    <Box key="cryptos">
+    <Box>
       <Subheader>
         <SubheaderRow
-          onPress={onPressShowAll}
+          onPress={hasMore ? onPressShowAll : undefined}
+          accessibilityRole={hasMore ? "button" : undefined}
           lx={{ marginBottom: "s12" }}
-          accessibilityRole="button"
         >
-          <SubheaderTitle>{`${t("wallet.tabs.crypto")} (${String(assets.length)})`}</SubheaderTitle>
-          <SubheaderShowMore />
+          <SubheaderTitle>{t("wallet.tabs.crypto")}</SubheaderTitle>
+          {hasMore && (
+            <>
+              <SubheaderCount value={assetsCount} />
+              <SubheaderShowMore />
+            </>
+          )}
         </SubheaderRow>
       </Subheader>
-      <Assets assets={assets} />
-      <Button
-        appearance="gray"
-        size="lg"
-        isFull
-        onPress={onPressShowAll}
-        lx={{ marginTop: "s24", marginBottom: "s48" }}
-      >
-        {t("portfolio.seeAllAssets")}
-      </Button>
+      <Box testID="PortfolioCryptosList">
+        {assetsToDisplay.map(item => (
+          <AssetListItem key={item.currency.id} asset={item} onPress={onItemPress} />
+        ))}
+      </Box>
+      {hasMore && (
+        <Button
+          appearance="gray"
+          size="lg"
+          isFull
+          onPress={onPressShowAll}
+          lx={{ marginTop: "s24", marginBottom: "s48" }}
+        >
+          {t("portfolio.seeAllAssets")}
+        </Button>
+      )}
     </Box>
   );
 };
+
+export const PortfolioCryptosSection = withDiscreetMode(PortfolioCryptosSectionComponent);

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/useAssetListItemViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/useAssetListItemViewModel.ts
@@ -1,0 +1,78 @@
+import { useMemo } from "react";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { useCalculate } from "@ledgerhq/live-countervalues-react";
+import BigNumber from "bignumber.js";
+import { useLocale } from "~/context/Locale";
+import { useSelector } from "~/context/hooks";
+import { usePortfolioForAccounts } from "~/hooks/portfolio";
+import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/settings";
+import { Asset } from "~/types/asset";
+
+export interface AssetListItemViewModelResult {
+  formattedBalance: string;
+  formattedCounterValue: string | null;
+  deltaText: string;
+  deltaColor: "success" | "error" | "muted";
+}
+
+export const useAssetListItemViewModel = (asset: Asset): AssetListItemViewModelResult => {
+  const { currency } = asset;
+  const balance = BigNumber(asset.amount);
+  const { locale } = useLocale();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const discreet = useSelector(discreetModeSelector);
+  const portfolio = usePortfolioForAccounts(asset.accounts);
+
+  const formattedBalance = useMemo(
+    () =>
+      formatCurrencyUnit(currency.units[0], balance, {
+        showCode: true,
+        locale,
+        discreet,
+      }),
+    [currency, balance, locale, discreet],
+  );
+
+  const countervalueRaw = useCalculate({
+    from: currency,
+    to: counterValueCurrency,
+    value: balance.toNumber(),
+    disableRounding: true,
+  });
+
+  const formattedCounterValue = useMemo(
+    () =>
+      typeof countervalueRaw === "number"
+        ? formatCurrencyUnit(counterValueCurrency.units[0], new BigNumber(countervalueRaw), {
+            locale,
+            showCode: true,
+            discreet,
+          })
+        : null,
+    [countervalueRaw, counterValueCurrency, locale, discreet],
+  );
+
+  const percentage = portfolio.countervalueChange.percentage;
+  // default to – when percentage is null
+  let deltaText = "–";
+  let deltaColor: AssetListItemViewModelResult["deltaColor"] = "muted";
+
+  if (percentage != null) {
+    const sign = percentage > 0 ? "+" : "";
+    deltaText = `${sign}${(percentage * 100).toFixed(2)}%`;
+    if (percentage > 0) {
+      deltaColor = "success";
+    } else if (percentage < 0) {
+      deltaColor = "error";
+    } else {
+      deltaColor = "muted";
+    }
+  }
+
+  return {
+    formattedBalance,
+    formattedCounterValue,
+    deltaText,
+    deltaColor,
+  };
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/usePortfolioCryptosSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/usePortfolioCryptosSectionViewModel.ts
@@ -1,0 +1,97 @@
+import { useCallback, useMemo } from "react";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { useSelector } from "~/context/hooks";
+import { useDistribution } from "~/actions/general";
+import { NavigatorName, ScreenName } from "~/const";
+import { blacklistedTokenIdsSelector } from "~/reducers/settings";
+import { Asset } from "~/types/asset";
+import { track } from "~/analytics";
+
+export const MAX_ASSETS_TO_DISPLAY = 6;
+
+export interface PortfolioCryptosSectionViewModelResult {
+  assetsCount: number;
+  hasMore: boolean;
+  assetsToDisplay: Asset[];
+  onPressShowAll: () => void;
+  onItemPress: (asset: Asset) => void;
+}
+
+const usePortfolioCryptosSectionViewModel = (): PortfolioCryptosSectionViewModelResult => {
+  const hideEmptyTokenAccount = useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
+  const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+
+  const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
+  const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
+
+  const distribution = useDistribution({
+    showEmptyAccounts: true,
+    hideEmptyTokenAccount,
+  });
+
+  const allAssets = useMemo(
+    () => (distribution.isAvailable && distribution.list.length > 0 ? distribution.list : []),
+    [distribution],
+  );
+
+  const filteredAssets = useMemo(
+    () =>
+      allAssets.filter(
+        ({ currency }) =>
+          currency.type !== "TokenCurrency" || !blacklistedTokenIdsSet.has(currency.id),
+      ),
+    [allAssets, blacklistedTokenIdsSet],
+  );
+
+  const assetsCount = filteredAssets.length;
+
+  const assetsToDisplay = useMemo(
+    () => filteredAssets.slice(0, MAX_ASSETS_TO_DISPLAY),
+    [filteredAssets],
+  );
+
+  const onPressShowAll = useCallback(() => {
+    track("button_clicked", {
+      button: "account_cta",
+      type: "view",
+      page: "Wallet",
+    });
+    navigation.navigate(NavigatorName.Assets, {
+      screen: ScreenName.AssetsList,
+      params: {
+        sourceScreenName: ScreenName.Portfolio,
+        showHeader: true,
+        isSyncEnabled: true,
+      },
+    });
+  }, [navigation]);
+
+  const onItemPress = useCallback(
+    (asset: Asset) => {
+      track("asset_clicked", {
+        asset: asset.currency.name,
+        page: "Wallet",
+      });
+      navigation.navigate(NavigatorName.Accounts, {
+        screen: ScreenName.Asset,
+        params: {
+          currency: asset.currency,
+        },
+      });
+    },
+    [navigation],
+  );
+
+  return {
+    assetsCount,
+    hasMore: assetsCount > MAX_ASSETS_TO_DISPLAY,
+    assetsToDisplay,
+    onPressShowAll,
+    onItemPress,
+  };
+};
+
+export default usePortfolioCryptosSectionViewModel;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoSignerContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoSignerContent.tsx
@@ -1,24 +1,21 @@
 import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { QuickActionsCtas, TransferDrawer } from "LLM/features/QuickActions";
-import MarketBanner from "LLM/features/MarketBanner";
 import { ScreenName, NavigatorName } from "~/const";
 import { PortfolioCryptosSection } from "../PortfolioCryptosSection";
 import { PortfolioBannersSection } from "../PortfolioBannersSection";
-import { Asset } from "~/types/asset";
+import MarketBanner from "LLM/features/MarketBanner";
 import TrackScreen from "~/analytics/TrackScreen";
 import { TRACKING_LABEL_MAP } from "LLM/components/MainTabBar/constants";
 
 interface PortfolioNoSignerContentProps {
-  readonly assets: Asset[];
-  readonly goToAssets: () => void;
   readonly isLNSUpsellBannerShown: boolean;
+  readonly shouldDisplayAssetSection?: boolean;
 }
 
 export const PortfolioNoSignerContent = ({
-  assets,
-  goToAssets,
   isLNSUpsellBannerShown,
+  shouldDisplayAssetSection = false,
 }: PortfolioNoSignerContentProps) => (
   <Box lx={{ paddingHorizontal: "s16" }}>
     <TrackScreen name={TRACKING_LABEL_MAP[NavigatorName.Portfolio]} />
@@ -26,6 +23,6 @@ export const PortfolioNoSignerContent = ({
     <TransferDrawer />
     <PortfolioBannersSection isFirst={true} isLNSUpsellBannerShown={isLNSUpsellBannerShown} />
     <MarketBanner />
-    <PortfolioCryptosSection assets={assets} onPressShowAll={goToAssets} />
+    {shouldDisplayAssetSection && <PortfolioCryptosSection />}
   </Box>
 );

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/__integrations__/portfolioEmptySection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/__integrations__/portfolioEmptySection.integration.test.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { render, renderWithReactQuery, screen } from "@tests/test-renderer";
 import { PortfolioEmptySection } from "../index";
 import { State } from "~/reducers/types";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
+import { btcCurrency, ethCurrency } from "../../../__integrations__/shared";
 import { QUICK_ACTIONS_TEST_IDS } from "LLM/features/QuickActions/testIds";
 
 const mockNavigate = jest.fn();
@@ -18,18 +18,22 @@ jest.mock("@react-navigation/native", () => ({
   }),
 }));
 
-const btcCurrency = getCryptoCurrencyById("bitcoin");
-const ethCurrency = getCryptoCurrencyById("ethereum");
-
 const createAccountState = (state: State): State => {
-  const btcAccount = genAccount("btc-1", { currency: btcCurrency, operationsSize: 0 });
-  const ethAccount = genAccount("eth-1", { currency: ethCurrency, operationsSize: 0 });
+  const btcAccount = genAccount("btc-1", { currency: btcCurrency });
+  const ethAccount = genAccount("eth-1", { currency: ethCurrency });
 
   return {
     ...state,
     accounts: {
       ...state.accounts,
       active: [btcAccount, ethAccount],
+    },
+    settings: {
+      ...state.settings,
+      overriddenFeatureFlags: {
+        ...state.settings.overriddenFeatureFlags,
+        lwmWallet40: { enabled: true, params: { assetSection: true } },
+      },
     },
   };
 };
@@ -97,11 +101,11 @@ describe("PortfolioEmptySection", () => {
 
   describe("when user has accounts (NoSignerContent)", () => {
     it("should render the cryptos section with assets", async () => {
-      render(<PortfolioEmptySection isLNSUpsellBannerShown={false} />, {
+      renderWithReactQuery(<PortfolioEmptySection isLNSUpsellBannerShown={false} />, {
         overrideInitialState: createAccountState,
       });
 
-      expect(await screen.findByText(/see all assets/i)).toBeVisible();
+      expect(await screen.findByTestId("PortfolioCryptosList")).toBeVisible();
     });
 
     it("should render quick actions CTAs", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/index.tsx
@@ -8,7 +8,7 @@ interface PortfolioEmptySectionProps {
 }
 
 export const PortfolioEmptySection = ({ isLNSUpsellBannerShown }: PortfolioEmptySectionProps) => {
-  const { hasAccounts, assets, isAddModalOpened, goToAssets, openAddModal, closeAddModal } =
+  const { hasAccounts, shouldDisplayAssetSection, isAddModalOpened, openAddModal, closeAddModal } =
     usePortfolioEmptySectionViewModel();
 
   if (!hasAccounts) {
@@ -24,9 +24,8 @@ export const PortfolioEmptySection = ({ isLNSUpsellBannerShown }: PortfolioEmpty
 
   return (
     <PortfolioNoSignerContent
-      assets={assets}
-      goToAssets={goToAssets}
       isLNSUpsellBannerShown={isLNSUpsellBannerShown}
+      shouldDisplayAssetSection={shouldDisplayAssetSection}
     />
   );
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/usePortfolioEmptySectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/usePortfolioEmptySectionViewModel.ts
@@ -1,58 +1,21 @@
-import { useCallback, useMemo, useState } from "react";
-import { useNavigation } from "@react-navigation/native";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { useReadOnlyCoins } from "~/hooks/useReadOnlyCoins";
-import { NavigatorName, ScreenName } from "~/const";
+import { useCallback, useState } from "react";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { track } from "~/analytics";
-import { Asset } from "~/types/asset";
 import { useSelector } from "~/context/hooks";
 import { flattenAccountsSelector } from "~/reducers/accounts";
 
-const MAX_ASSETS_TO_DISPLAY = 5;
-
 interface UsePortfolioEmptySectionViewModelResult {
   hasAccounts: boolean;
-  assets: Asset[];
+  shouldDisplayAssetSection: boolean;
   isAddModalOpened: boolean;
-  goToAssets: () => void;
   openAddModal: () => void;
   closeAddModal: () => void;
 }
 
 export const usePortfolioEmptySectionViewModel = (): UsePortfolioEmptySectionViewModelResult => {
-  const nav = useNavigation();
   const hasAccounts = useSelector(state => flattenAccountsSelector(state).length > 0);
-  const { sortedCryptoCurrencies } = useReadOnlyCoins({ maxDisplayed: MAX_ASSETS_TO_DISPLAY });
+  const { shouldDisplayAssetSection } = useWalletFeaturesConfig("mobile");
   const [isAddModalOpened, setAddModalOpened] = useState(false);
-  const accountListFF = useFeature("llmAccountListUI");
-  const isAccountListUIEnabled = accountListFF?.enabled ?? false;
-
-  const assets: Asset[] = useMemo(
-    () =>
-      sortedCryptoCurrencies?.map(currency => ({
-        amount: 0,
-        accounts: [],
-        currency,
-      })),
-    [sortedCryptoCurrencies],
-  );
-
-  const goToAssets = useCallback(() => {
-    if (isAccountListUIEnabled) {
-      nav.navigate(NavigatorName.Assets, {
-        screen: ScreenName.AssetsList,
-        params: {
-          sourceScreenName: ScreenName.Portfolio,
-          showHeader: true,
-          isSyncEnabled: true,
-        },
-      });
-    } else {
-      nav.navigate(NavigatorName.Accounts, {
-        screen: ScreenName.Assets,
-      });
-    }
-  }, [nav, isAccountListUIEnabled]);
 
   const openAddModal = useCallback(() => {
     track("button_clicked", {
@@ -65,9 +28,8 @@ export const usePortfolioEmptySectionViewModel = (): UsePortfolioEmptySectionVie
 
   return {
     hasAccounts,
-    assets,
+    shouldDisplayAssetSection,
     isAddModalOpened,
-    goToAssets,
     openAddModal,
     closeAddModal,
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/index.ts
@@ -2,6 +2,7 @@ export { PortfolioAllocationsSection } from "./PortfolioAllocationsSection";
 export { PortfolioAssetsSection } from "./PortfolioAssetsSection";
 export { PortfolioBalanceSection } from "./PortfolioBalanceSection";
 export { PortfolioCarouselSection } from "./PortfolioCarouselSection";
+export { PortfolioCryptosSection } from "./PortfolioCryptosSection";
 export { PortfolioEmptySection } from "./PortfolioEmptySection";
 export { PortfolioHeaderSection } from "./PortfolioHeaderSection";
 export { PortfolioOperationsSection } from "./PortfolioOperationsSection";

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -19,19 +19,20 @@ import { getProgressViewOffset } from "../../utils/getProgressViewOffset";
 import usePortfolioViewModel from "./usePortfolioViewModel";
 import { useScrollToTop } from "./useScrollToTop";
 
-import { Box } from "@ledgerhq/native-ui";
 import { QuickActionsCtas, TransferDrawer } from "LLM/features/QuickActions";
+import MarketBanner from "LLM/features/MarketBanner";
 
 import {
   PortfolioAllocationsSection,
   PortfolioAssetsSection,
   PortfolioCarouselSection,
+  PortfolioCryptosSection,
   PortfolioEmptySection,
   PortfolioHeaderSection,
   PortfolioOperationsSection,
   PortfolioBannersSection,
 } from "../../components";
-
+import { Box } from "@ledgerhq/native-ui";
 type NavigationProps = BaseComposite<
   StackNavigatorProps<WalletTabNavigatorStackParamList, ScreenName.Portfolio>
 >;
@@ -49,6 +50,8 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     isAWalletCardDisplayed,
     isAccountListUIEnabled,
     shouldDisplayQuickActionCtas,
+    shouldDisplayAssetSection,
+    shouldDisplayMarketBanner,
     showAssets,
     isLNSUpsellBannerShown,
     isAddModalOpened,
@@ -115,15 +118,31 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
       />,
     );
 
-    sections.push(
-      <PortfolioAssetsSection
-        key="assets"
-        isAccountListUIEnabled={isAccountListUIEnabled}
-        hideEmptyTokenAccount={hideEmptyTokenAccount}
-        openAddModal={openAddModal}
-        onHeightChange={handleHeightChange}
-      />,
-    );
+    if (shouldDisplayMarketBanner) {
+      sections.push(
+        <Box key="marketBanner" px={6} pt={6}>
+          <MarketBanner />
+        </Box>,
+      );
+    }
+
+    if (shouldDisplayAssetSection) {
+      sections.push(
+        <Box key="cryptos" px={6} pt={6}>
+          <PortfolioCryptosSection />
+        </Box>,
+      );
+    } else {
+      sections.push(
+        <PortfolioAssetsSection
+          key="assets"
+          isAccountListUIEnabled={isAccountListUIEnabled}
+          hideEmptyTokenAccount={hideEmptyTokenAccount}
+          openAddModal={openAddModal}
+          onHeightChange={handleHeightChange}
+        />,
+      );
+    }
 
     if (isAWalletCardDisplayed) {
       sections.push(<PortfolioCarouselSection key="carousel" backgroundColor={backgroundColor} />);
@@ -145,6 +164,8 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
   }, [
     showAssets,
     shouldDisplayGraphRework,
+    shouldDisplayAssetSection,
+    shouldDisplayMarketBanner,
     onBackFromUpdate,
     isLNSUpsellBannerShown,
     shouldDisplayQuickActionCtas,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
@@ -33,6 +33,8 @@ interface UsePortfolioViewModelResult {
   isAccountListUIEnabled: boolean;
   shouldDisplayQuickActionCtas: boolean;
   shouldDisplayWallet40MainNav: boolean;
+  shouldDisplayAssetSection: boolean;
+  shouldDisplayMarketBanner: boolean;
   showAssets: boolean;
   isLNSUpsellBannerShown: boolean;
   isAddModalOpened: boolean;
@@ -53,8 +55,13 @@ const usePortfolioViewModel = (navigation: {
   const [isAddModalOpened, setAddModalOpened] = useState(false);
   const { isAWalletCardDisplayed } = useDynamicContent();
   const accountListFF = useFeature("llmAccountListUI");
-  const { shouldDisplayGraphRework, shouldDisplayQuickActionCtas, shouldDisplayWallet40MainNav } =
-    useWalletFeaturesConfig("mobile");
+  const {
+    shouldDisplayGraphRework,
+    shouldDisplayQuickActionCtas,
+    shouldDisplayWallet40MainNav,
+    shouldDisplayAssetSection,
+    shouldDisplayMarketBanner,
+  } = useWalletFeaturesConfig("mobile");
   const isAccountListUIEnabled = accountListFF?.enabled ?? false;
   const llmDatadog = useFeature("llmDatadog");
   const allAccounts = useSelector(flattenAccountsSelector, shallowEqual);
@@ -138,6 +145,8 @@ const usePortfolioViewModel = (navigation: {
     isAccountListUIEnabled,
     shouldDisplayQuickActionCtas,
     shouldDisplayWallet40MainNav,
+    shouldDisplayAssetSection,
+    shouldDisplayMarketBanner,
     showAssets,
     isLNSUpsellBannerShown,
     isAddModalOpened,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/index.tsx
@@ -23,13 +23,12 @@ type NavigationProps = BaseComposite<
 
 function ReadOnlyPortfolioScreen({ navigation }: NavigationProps) {
   const {
-    assets,
     safeAreaTop,
     shouldDisplayGraphRework,
     shouldDisplayWallet40MainNav,
+    shouldDisplayAssetSection,
     isLNSUpsellBannerShown,
     source,
-    goToAssets,
     onBackFromUpdate,
   } = useReadOnlyPortfolioViewModel(navigation);
 
@@ -56,16 +55,14 @@ function ReadOnlyPortfolioScreen({ navigation }: NavigationProps) {
       ),
       <PortfolioNoSignerContent
         key="noSigner"
-        assets={assets}
-        goToAssets={goToAssets}
         isLNSUpsellBannerShown={isLNSUpsellBannerShown}
+        shouldDisplayAssetSection={shouldDisplayAssetSection}
       />,
     ],
     [
       shouldDisplayGraphRework,
+      shouldDisplayAssetSection,
       isLNSUpsellBannerShown,
-      assets,
-      goToAssets,
       onBackFromUpdate,
       safeAreaTop,
     ],

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/useReadOnlyPortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/useReadOnlyPortfolioViewModel.ts
@@ -1,26 +1,20 @@
-import { useCallback, useContext, useMemo } from "react";
+import { useCallback, useContext } from "react";
 import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { useRefreshAccountsOrdering } from "~/actions/general";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import usePortfolioAnalyticsOptInPrompt from "~/hooks/analyticsOptInPrompt/usePorfolioAnalyticsOptInPrompt";
-import { useReadOnlyCoins } from "~/hooks/useReadOnlyCoins";
 import { AnalyticsContext } from "~/analytics/AnalyticsContext";
-import { NavigatorName, ScreenName } from "~/const";
-import { Asset } from "~/types/asset";
 import { useLNSUpsellBannerState } from "LLM/features/LNSUpsell";
 
-const MAX_ASSETS_TO_DISPLAY = 5;
-
 interface UseReadOnlyPortfolioViewModelResult {
-  assets: Asset[];
   safeAreaTop: number;
   shouldDisplayGraphRework: boolean;
   shouldDisplayWallet40MainNav: boolean;
+  shouldDisplayAssetSection: boolean;
   isLNSUpsellBannerShown: boolean;
   source: string | undefined;
-  goToAssets: () => void;
   onBackFromUpdate: () => void;
 }
 
@@ -28,33 +22,15 @@ const useReadOnlyPortfolioViewModel = (navigation: {
   goBack: () => void;
   navigate: (name: string, params?: object) => void;
 }): UseReadOnlyPortfolioViewModelResult => {
-  const { shouldDisplayGraphRework, shouldDisplayWallet40MainNav } =
+  const { shouldDisplayGraphRework, shouldDisplayWallet40MainNav, shouldDisplayAssetSection } =
     useWalletFeaturesConfig("mobile");
   const { top: safeAreaTop } = useSafeAreaInsets();
   const isLNSUpsellBannerShown = useLNSUpsellBannerState("wallet").isShown;
-
-  const { sortedCryptoCurrencies } = useReadOnlyCoins({ maxDisplayed: MAX_ASSETS_TO_DISPLAY });
-
-  const assets: Asset[] = useMemo(
-    () =>
-      sortedCryptoCurrencies?.map(currency => ({
-        amount: 0,
-        accounts: [],
-        currency,
-      })),
-    [sortedCryptoCurrencies],
-  );
 
   usePortfolioAnalyticsOptInPrompt();
 
   const refreshAccountsOrdering = useRefreshAccountsOrdering();
   useFocusEffect(refreshAccountsOrdering);
-
-  const goToAssets = useCallback(() => {
-    navigation.navigate(NavigatorName.Accounts, {
-      screen: ScreenName.Assets,
-    });
-  }, [navigation]);
 
   const onBackFromUpdate = useCallback(() => {
     navigation.goBack();
@@ -70,13 +46,12 @@ const useReadOnlyPortfolioViewModel = (navigation: {
   useFocusEffect(focusEffect);
 
   return {
-    assets,
     safeAreaTop,
     shouldDisplayGraphRework,
     shouldDisplayWallet40MainNav,
+    shouldDisplayAssetSection,
     isLNSUpsellBannerShown,
     source,
-    goToAssets,
     onBackFromUpdate,
   };
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio home screen rendering (gated behind the \`lwmWallet40\` feature flag with \`assetSection\` param)
  - Cryptos section: displays the top 6 assets by balance, navigation to the full assets list and to asset detail
  - Analytics: tracking \`button_clicked\` (tap on the Cryptos subheader) and \`asset_clicked\` (tap on an asset)

### 📝 Description

As part of the Wallet 4.0 project, this PR implements the "Asset Section" on the Portfolio home screen.

When the \`lwmWallet40\` feature flag is enabled with \`assetSection: true\`, the legacy Assets/Accounts tab section is replaced by a cleaner **"Cryptos (N)"** section displaying the user's top 6 assets sorted by balance.

**Changes:**
- **New ViewModel** \`usePortfolioCryptosSectionViewModel\`: fetches asset distribution, filters blacklisted tokens, limits to 6 items, handles navigation and analytics tracking.
- **Updated View** \`PortfolioCryptosSection\`: uses \`AssetItem\` (Lumen UI) instead of the legacy \`Assets\` component, calls the ViewModel internally (MVVM pattern).
- **Portfolio screen**: conditionally renders \`PortfolioCryptosSection\` (W4.0) or \`PortfolioAssetsSection\` (legacy) based on \`shouldDisplayAssetSection\`.
- **Tests**: 9 ViewModel unit tests + 3 Portfolio screen integration tests.

<img width="300" height="750" alt="simulator_screenshot_0C2DE801-8AA3-4392-AF27-9A7C62A2F43B" src="https://github.com/user-attachments/assets/2f431efe-1292-45e1-a48c-43204fb8b510" />
<img width="300" height="750" alt="simulator_screenshot_F821675D-1E3C-4197-A9AB-2F4C4E09E408" src="https://github.com/user-attachments/assets/dbfcd7fe-ed23-4001-89a4-5bfca2b03a15" />
<img width="396" height="442" alt="image" src="https://github.com/user-attachments/assets/ab2818c1-863b-4ae7-b3ef-c147af2781c7" />
<img width="300" height="750" alt="simulator_screenshot_C529BAD7-7F07-406C-A825-6D8CC49AF9A6" src="https://github.com/user-attachments/assets/58166719-12a9-435f-9eaa-3c96244d98e2" />
### ❓ Context

- **JIRA or GitHub link**: [LIVE-26972](https://ledgerhq.atlassian.net/browse/LIVE-26972)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26972]: https://ledgerhq.atlassian.net/browse/LIVE-26972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ