### PR TITLE
fix(e2e): wait for balance diff element before asserting visibility

### DIFF
--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -118,7 +118,7 @@ export default class PortfolioPage {
 
   @Step("Expect balance diff to be visible")
   async expectBalanceDiffToBeVisible() {
-    await detoxExpect(getElementById(this.graphCardBalanceDiffId)).toBeVisible();
+    await waitForElementById(this.graphCardBalanceDiffId);
   }
 
   @Step("Expect balance diff to have the correct counter value")


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* Replace immediate detoxExpect().toBeVisible() with waitForElementById() for graphCard-balance-delta, since the element is conditionally rendered only after countervalues are fetched and portfolio data is computed
* Fixes [this](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/37f76105-75ff-4528-a537-6188d0833fb0/#/testresult/6d0b025d913b4611) flakiness
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
[@Mobile E2E • Manual • iOS & Android • fix/portfolio-balance-diff-wait • cunhabruno](https://github.com/LedgerHQ/ledger-live/actions/runs/22633226932)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
