### PR TITLE
[LWDM] ci: add shared-lib, desktop-lib, mobile-lib labels to auto-prefix PR titles

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,3 +36,48 @@ coin-modules-api:
 coin-modules:
  - libs/coin-framework/**/*
  - libs/coin-modules/**/*
+
+shared-lib:
+  - libs/asset-aggregation/**/*
+  - libs/client-ids/**/*
+  - libs/coin-modules-monitoring/**/*
+  - libs/coin-tester/**/*
+  - libs/coin-tester-modules/**/*
+  - libs/concordium-core/**/*
+  - libs/deeplink-module/**/*
+  - libs/device-core/**/*
+  - libs/device-react/**/*
+  - libs/disable-network-setup/**/*
+  - libs/domain-service/**/*
+  - libs/env/**/*
+  - libs/ethereum-provider/**/*
+  - libs/evm-tools/**/*
+  - libs/exchange-module/**/*
+  - libs/feature-flag-module/**/*
+  - libs/hw-ledger-key-ring-protocol/**/*
+  - libs/ledger-key-ring-protocol/**/*
+  - libs/ledger-services/**/*
+  - libs/live-config/**/*
+  - libs/live-countervalues/**/*
+  - libs/live-countervalues-react/**/*
+  - libs/live-currency-format/**/*
+  - libs/live-dmk-shared/**/*
+  - libs/live-dmk-speculos/**/*
+  - libs/live-hooks/**/*
+  - libs/live-network/**/*
+  - libs/live-signer-aleo/**/*
+  - libs/live-signer-canton/**/*
+  - libs/live-signer-evm/**/*
+  - libs/live-signer-solana/**/*
+  - libs/live-wallet/**/*
+  - libs/promise/**/*
+  - libs/psbtv2/**/*
+  - libs/speculos-transport/**/*
+  - libs/test-utils/**/*
+  - libs/wallet-api-acre-module/**/*
+
+desktop-lib:
+  - libs/live-dmk-desktop/**/*
+
+mobile-lib:
+  - libs/live-dmk-mobile/**/*

--- a/.github/workflows/pr-title-from-labels.yml
+++ b/.github/workflows/pr-title-from-labels.yml
@@ -30,9 +30,9 @@ jobs:
             // Build prefix from labels
             // If 'common' OR both 'desktop' + 'mobile' are present, use only LWDM
             let prefixes = [];
-            const hasDesktop = labels.includes('desktop');
-            const hasMobile = labels.includes('mobile');
-            const hasCommon = labels.includes('common');
+            const hasDesktop = labels.includes('desktop') || labels.includes('desktop-lib');
+            const hasMobile = labels.includes('mobile') || labels.includes('mobile-lib');
+            const hasCommon = labels.includes('common') || labels.includes('shared-lib');
             const hasCoinModules = labels.includes('coin-modules');
             
             if (hasCommon || (hasDesktop && hasMobile) || hasCoinModules) {


### PR DESCRIPTION
## Summary

- **Labeler**: Added 3 new labels (`shared-lib`, `desktop-lib`, `mobile-lib`) covering all `libs/` directories that were previously unlabeled (excluding `ledgerjs`, `ledger-live-common`, `ui`, and `coin-modules` which already have their own labels).
- **PR title workflow**: Updated `hasCommon`, `hasDesktop`, and `hasMobile` checks to also match the new lib labels, so PRs touching those paths automatically get the correct `[LWDM]`, `[LWD]`, or `[LWM]` prefix.

### Label mapping

| Label | Scope | Libs |
|---|---|---|
| `shared-lib` → `[LWDM]` | Used by both desktop & mobile | 27 libs (e.g. `live-config`, `live-wallet`, `domain-service`, `env`, `live-network`, …) |
| `desktop-lib` → `[LWD]` | Desktop only | `live-dmk-desktop` |
| `mobile-lib` → `[LWM]` | Mobile only | `live-dmk-mobile` |

No changes to existing labels or workflow logic — this is purely additive.

## Test plan

- [ ] Open a PR touching a `shared-lib` path (e.g. `libs/live-config/`) → should get labeled `shared-lib` and title prefixed `[LWDM]`
- [ ] Open a PR touching `libs/live-dmk-desktop/` → should get labeled `desktop-lib` and title prefixed `[LWD]`
- [ ] Open a PR touching `libs/live-dmk-mobile/` → should get labeled `mobile-lib` and title prefixed `[LWM]`
- [ ] Existing labels (`desktop`, `mobile`, `common`, `coin-modules`) still work as before