### PR TITLE
fix(desktop): use lastOnboardedDevice in hasOnboardedDeviceSelector

### DIFF
--- a/.changeset/poor-falcons-explode.md
+++ b/.changeset/poor-falcons-explode.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix: correct hasOnboardedDevice selector by using lastOnboardedDevice in logic check

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
@@ -405,7 +405,11 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true, lastSeenDevice: null },
+          settings: {
+            hasCompletedOnboarding: true,
+            lastSeenDevice: null,
+            lastOnboardedDevice: null,
+          },
         },
       });
 
@@ -419,7 +423,11 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true, lastSeenDevice: null },
+          settings: {
+            hasCompletedOnboarding: true,
+            lastSeenDevice: null,
+            lastOnboardedDevice: null,
+          },
         },
       });
 
@@ -436,7 +444,11 @@ describe("useQuickActions", () => {
       const { result } = renderHook(() => useQuickActions(trackingPageName), {
         initialState: {
           accounts: [createAccountWithFunds()],
-          settings: { hasCompletedOnboarding: true, lastSeenDevice: null },
+          settings: {
+            hasCompletedOnboarding: true,
+            lastSeenDevice: null,
+            lastOnboardedDevice: null,
+          },
         },
       });
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/hasOnboardedDeviceSelector.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/hasOnboardedDeviceSelector.test.ts
@@ -1,44 +1,84 @@
 import { DeviceModelId } from "@ledgerhq/devices";
 import type { DeviceInfo, DeviceModelInfo } from "@ledgerhq/types-live";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { hasOnboardedDeviceSelector, INITIAL_STATE } from "../settings";
 import type { State } from "../index";
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const VALID_DEVICE: DeviceModelInfo = {
+const VALID_LAST_SEEN_DEVICE: DeviceModelInfo = {
   modelId: DeviceModelId.nanoX,
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   deviceInfo: {} as DeviceInfo,
   apps: [],
 };
 
-const createState = (lastSeenDevice: DeviceModelInfo | null | undefined) =>
+const VALID_ONBOARDED_DEVICE: Device = {
+  deviceId: "test-device-id",
+  modelId: DeviceModelId.stax,
+  wired: true,
+};
+
+const createState = ({
+  lastSeenDevice = undefined,
+  lastOnboardedDevice = null,
+}: {
+  lastSeenDevice?: DeviceModelInfo | null;
+  lastOnboardedDevice?: Device | null;
+} = {}) =>
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   ({
     settings: {
       ...INITIAL_STATE,
       lastSeenDevice,
+      lastOnboardedDevice,
     },
   }) as unknown as State;
 
 describe("hasOnboardedDeviceSelector", () => {
-  it("should return false when lastSeenDevice is null", () => {
-    expect(hasOnboardedDeviceSelector(createState(null))).toBe(false);
+  it("should return false when both lastOnboardedDevice and lastSeenDevice are null/undefined", () => {
+    expect(hasOnboardedDeviceSelector(createState())).toBe(false);
+    expect(
+      hasOnboardedDeviceSelector(createState({ lastSeenDevice: null, lastOnboardedDevice: null })),
+    ).toBe(false);
   });
 
-  it("should return true when lastSeenDevice is set with a valid modelId", () => {
-    expect(hasOnboardedDeviceSelector(createState(VALID_DEVICE))).toBe(true);
+  it("should return true when only lastOnboardedDevice is set", () => {
+    expect(
+      hasOnboardedDeviceSelector(
+        createState({ lastOnboardedDevice: VALID_ONBOARDED_DEVICE, lastSeenDevice: null }),
+      ),
+    ).toBe(true);
   });
 
-  it("should return false when lastSeenDevice is undefined", () => {
-    expect(hasOnboardedDeviceSelector(createState(undefined))).toBe(false);
+  it("should return true when only lastSeenDevice is set (backward compat)", () => {
+    expect(
+      hasOnboardedDeviceSelector(
+        createState({ lastSeenDevice: VALID_LAST_SEEN_DEVICE, lastOnboardedDevice: null }),
+      ),
+    ).toBe(true);
   });
 
-  it("should return false when lastSeenDevice has an unrecognized modelId", () => {
+  it("should return true when both lastOnboardedDevice and lastSeenDevice are set", () => {
+    expect(
+      hasOnboardedDeviceSelector(
+        createState({
+          lastOnboardedDevice: VALID_ONBOARDED_DEVICE,
+          lastSeenDevice: VALID_LAST_SEEN_DEVICE,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("should return false when lastSeenDevice has an unrecognized modelId and lastOnboardedDevice is null", () => {
     const invalidDevice: DeviceModelInfo = {
-      ...VALID_DEVICE,
+      ...VALID_LAST_SEEN_DEVICE,
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       modelId: "unknownModel" as DeviceModelId,
     };
-    expect(hasOnboardedDeviceSelector(createState(invalidDevice))).toBe(false);
+    expect(
+      hasOnboardedDeviceSelector(
+        createState({ lastSeenDevice: invalidDevice, lastOnboardedDevice: null }),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -770,7 +770,6 @@ export const lastSeenDeviceSelector = (state: State): DeviceModelInfo | null | u
     return null;
   return lastSeenDevice;
 };
-export const hasOnboardedDeviceSelector = (state: State) => lastSeenDeviceSelector(state) !== null;
 export const devicesModelListSelector = (state: State): DeviceModelId[] =>
   state.settings.devicesModelList;
 export const latestFirmwareSelector = (state: State) => state.settings.latestFirmware;
@@ -801,3 +800,8 @@ export const alwaysShowMemoTagInfoSelector = (state: State) => state.settings.al
 export const anonymousUserNotificationsSelector = (state: State) =>
   state.settings.anonymousUserNotifications;
 export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasSeenWalletV4Tour;
+
+// Last onboarded device is the device set when a user goes through the onboarding flow.
+// Last seen device is the device set when a user performs a device action (e.g. pairing, firmware update, etc.).
+export const hasOnboardedDeviceSelector = (state: State) =>
+  !!lastOnboardedDeviceSelector(state) || lastSeenDeviceSelector(state) !== null;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - `hasOnboardedDeviceSelector` now returns `true` when `lastOnboardedDevice` is set, even if `lastSeenDevice` is still null. This fixes false negatives for users who completed onboarding but haven't yet performed a device action (pairing, firmware update, etc.).

### 📝 Description

`hasOnboardedDeviceSelector` previously relied solely on `lastSeenDevice`, which is only populated after a device action (e.g. pairing or firmware update). Users who completed onboarding without performing such an action were incorrectly treated as not having an onboarded device.

The selector now checks `lastOnboardedDevice` (set at onboarding completion) first, falling back to `lastSeenDevice` for backward compatibility with existing users.

**Changes:**
- Rewrote `hasOnboardedDevicector` to use `lastOnboardedDeviceSelector(state) !== null || lastSeenDeviceSelector(state) !== null`
- Removed leftover debug `console.log` statements
- Removed unused `setLastSeenDevice` import from `Tutorial/index.tsx`
- Rewrote unit tests to cover both `lastOnboardedDevice` and `lastSeenDevice` paths

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27157