### PR TITLE
fix: adds page context to sync error tracking

### DIFF
--- a/.changeset/itchy-geese-poke.md
+++ b/.changeset/itchy-geese-poke.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(lwd): balance refresh tracking page

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useAccountsSyncStatus.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useAccountsSyncStatus.test.ts
@@ -120,8 +120,14 @@ describe("useAccountsSyncStatus", () => {
     renderHook(() => useAccountsSyncStatus(accountsWithUpToDateCheck));
 
     expect(trackSpy).toHaveBeenCalledTimes(2);
-    expect(trackSpy).toHaveBeenCalledWith("SyncError", { currency: "BTC" });
-    expect(trackSpy).toHaveBeenCalledWith("SyncError", { currency: "ETH" });
+    expect(trackSpy).toHaveBeenCalledWith(
+      "SyncError",
+      expect.objectContaining({ currency: "BTC", page: expect.any(String) }),
+    );
+    expect(trackSpy).toHaveBeenCalledWith(
+      "SyncError",
+      expect.objectContaining({ currency: "ETH", page: expect.any(String) }),
+    );
     trackSpy.mockRestore();
   });
 
@@ -189,8 +195,16 @@ describe("useAccountsSyncStatus", () => {
     renderHook(() => useAccountsSyncStatus(accountsWithUpToDateCheck));
 
     expect(trackSpy).toHaveBeenCalledTimes(2);
-    expect(trackSpy).toHaveBeenNthCalledWith(1, "SyncError", { currency: "BTC" });
-    expect(trackSpy).toHaveBeenNthCalledWith(2, "SyncError", { currency: "BTC" });
+    expect(trackSpy).toHaveBeenNthCalledWith(
+      1,
+      "SyncError",
+      expect.objectContaining({ currency: "BTC", page: expect.any(String) }),
+    );
+    expect(trackSpy).toHaveBeenNthCalledWith(
+      2,
+      "SyncError",
+      expect.objectContaining({ currency: "BTC", page: expect.any(String) }),
+    );
     trackSpy.mockRestore();
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
@@ -89,6 +89,7 @@ describe("useActivityIndicator", () => {
     expect(trackSpy).toHaveBeenCalledWith(
       "SyncErrorList",
       expect.objectContaining({
+        page: "/",
         currencies: expect.any(Array),
       }),
     );

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useAccountsSyncStatus.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useAccountsSyncStatus.ts
@@ -1,5 +1,6 @@
 import { useBatchAccountsSyncState } from "@ledgerhq/live-common/bridge/react/index";
 import { Account } from "@ledgerhq/types-live";
+import { useLocation } from "react-router";
 import { track } from "~/renderer/analytics/segment";
 
 export interface AccountWithUpToDateCheck {
@@ -20,6 +21,7 @@ export interface AccountsSyncStatus {
 export function useAccountsSyncStatus(
   accountsWithUpToDateCheck: AccountWithUpToDateCheck[],
 ): AccountsSyncStatus {
+  const location = useLocation();
   const allAccounts = accountsWithUpToDateCheck.map(item => item.account);
   const isUpToDateByAccountId = new Map(
     accountsWithUpToDateCheck.map(item => [item.account.id, item.isUpToDate === true]),
@@ -35,6 +37,7 @@ export function useAccountsSyncStatus(
       errorTickersSet.add(currency);
       track("SyncError", {
         currency,
+        page: location.pathname,
       });
     }
   }

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useReducer } from "react";
+import { useLocation } from "react-router";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { hasAccountsSelector, isUpToDateSelector } from "~/renderer/reducers/accounts";
 import {
@@ -25,6 +26,7 @@ import { isRecentUserSyncClick } from "../utils/syncRefreshUtils";
  */
 export const useActivityIndicator = () => {
   const dispatch = useDispatch();
+  const location = useLocation();
   const hasAccounts = useSelector(hasAccountsSelector);
   const accountsWithUpToDateCheck = useSelector(isUpToDateSelector);
   const lastUserSyncClickTimestamp = useSelector(selectLastUserSyncClickTimestamp);
@@ -77,12 +79,13 @@ export const useActivityIndicator = () => {
   const onTooltipShow = useCallback(() => {
     if (isError) {
       track("SyncErrorList", {
+        page: location.pathname,
         currencies: listOfErrorAccountNames
           ? listOfErrorAccountNames.split("/").filter(Boolean)
           : [],
       });
     }
-  }, [isError, listOfErrorAccountNames]);
+  }, [isError, listOfErrorAccountNames, location.pathname]);
 
   return {
     hasAccounts,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
This pull request introduces improvements to tracking analytics for balance refresh errors in the Ledger Live Desktop application. The main enhancement is the addition of page-level context to error tracking events, which will help provide more granular insights into where sync errors occur in the app. The changes affect both the `useAccountsSyncStatus` and `useActivityIndicator` hooks, as well as their associated tests.


### ❓ Context

[LIVE-24877](https://ledgerhq.atlassian.net/browse/LIVE-24877)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24877]: https://ledgerhq.atlassian.net/browse/LIVE-24877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ