### PR TITLE
feat(mobile): set dark theme as default instead of system

### DIFF
--- a/.changeset/dull-vans-scream.md
+++ b/.changeset/dull-vans-scream.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Set dark theme as default instead of system

--- a/apps/ledger-live-mobile/src/reducers/settings.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.test.ts
@@ -3,12 +3,13 @@ import reducer, {
   lastConnectedDeviceSelector,
   lastSeenDeviceSelector,
   resolvedThemeSelector,
+  themeSelector,
   INITIAL_STATE as SETTINGS_INITIAL_STATE,
   filterValidSettings,
 } from "./settings";
 import { State, Theme, SettingsState } from "./types";
 import { aDeviceInfoBuilder } from "@ledgerhq/live-common/mock/fixtures/aDeviceInfo";
-import { importSettings } from "../actions/settings";
+import { importSettings, setTheme } from "../actions/settings";
 
 const invalidDeviceModelIds = ["nanoFTS", undefined, "whatever"];
 const validDeviceModelIds: DeviceModelId[] = Object.values(DeviceModelId);
@@ -133,6 +134,41 @@ describe("resolvedThemeSelector", () => {
       expect(resolvedThemeSelector(createState("system", null))).toBe("dark");
       expect(resolvedThemeSelector(createState("system", undefined))).toBe("dark");
     });
+  });
+});
+
+describe("default theme", () => {
+  it("should have theme set to 'dark' in initial state", () => {
+    expect(SETTINGS_INITIAL_STATE.theme).toBe("dark");
+  });
+});
+
+describe("SETTINGS_SET_THEME", () => {
+  it("should update theme when setTheme action is dispatched", () => {
+    const stateAfterLight = reducer(SETTINGS_INITIAL_STATE, setTheme("light"));
+    expect(stateAfterLight.theme).toBe("light");
+
+    const stateAfterDark = reducer(stateAfterLight, setTheme("dark"));
+    expect(stateAfterDark.theme).toBe("dark");
+
+    const stateAfterSystem = reducer(stateAfterDark, setTheme("system"));
+    expect(stateAfterSystem.theme).toBe("system");
+  });
+
+  it("should reflect theme change in resolvedThemeSelector", () => {
+    const stateWithLight: State = {
+      ...({} as State),
+      settings: reducer(SETTINGS_INITIAL_STATE, setTheme("light")),
+    };
+    expect(themeSelector(stateWithLight)).toBe("light");
+    expect(resolvedThemeSelector(stateWithLight)).toBe("light");
+
+    const stateWithDark: State = {
+      ...({} as State),
+      settings: reducer(SETTINGS_INITIAL_STATE, setTheme("dark")),
+    };
+    expect(themeSelector(stateWithDark)).toBe("dark");
+    expect(resolvedThemeSelector(stateWithDark)).toBe("dark");
   });
 });
 

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -109,7 +109,7 @@ export const INITIAL_STATE: SettingsState = {
   blacklistedTokenIds: [],
   dismissedBanners: [],
   hasAvailableUpdate: false,
-  theme: "system",
+  theme: "dark",
   osTheme: undefined,
   customLockScreenType: null,
   lastSeenCustomImage: {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Theme/appearance on first app launch (new users see dark by default)
  - Theme selector behavior (light/dark/system still works as before)

### 📝 Description

**Problem:** The app previously defaulted to the system theme. For consistency and to match product requirements, the default should be dark.

**Solution:** The settings reducer initial state now uses `theme: "dark"` instead of `theme: "system"`. Users can still switch to light or system via the theme selector; only the initial value changes.

Tests added for:
- Default theme in initial state
- `SETTINGS_SET_THEME` reducer and `resolvedThemeSelector` for light/dark/system

https://github.com/user-attachments/assets/663a4a48-08e7-4cfd-9950-30dac2951ffa


### ❓ Context

- **JIRA or GitHub link**: [LIVE-27181](https://ledgerhq.atlassian.net/browse/LIVE-27181)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27181]: https://ledgerhq.atlassian.net/browse/LIVE-27181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ