### PR TITLE
fix(desktop): exchange back button

### DIFF
--- a/.changeset/fix-exchange-back-return-to.md
+++ b/.changeset/fix-exchange-back-return-to.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix exchange back button to use returnTo and persist across webview navigation
+
+- Exchange header back now navigates to the route passed as `returnTo` in location state (or `/` as fallback) instead of `navigate(-1)`, so back leaves the exchange in desktop context instead of stepping within WebPTXPlayer history
+- Initial `returnTo` is stored in a ref so it survives in-webview navigations that overwrite `location.state`
+- All entry points that navigate to `/exchange` (Market buy/sell, FundAccount, QuickActions, account/asset headers, etc.) now pass `returnTo: location.pathname` in state

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/FundAccount/components/ActionsContainer.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/FundAccount/components/ActionsContainer.tsx
@@ -4,7 +4,7 @@ import { Account } from "@ledgerhq/types-live";
 import React, { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "LLD/hooks/redux";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import styled from "styled-components";
 import { openModal } from "~/renderer/actions/modals";
 import { setDrawer } from "~/renderer/drawers/Provider";
@@ -43,6 +43,7 @@ interface Props {
 
 const ActionsContainer = ({ account, currencyId }: Props) => {
   const { t } = useTranslation();
+  const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { isCurrencyAvailable } = useRampCatalog();
@@ -56,7 +57,7 @@ const ActionsContainer = ({ account, currencyId }: Props) => {
     setDrawer();
     if (location.pathname === "/manager") navigate("/accounts");
     dispatch(openModal("MODAL_RECEIVE", { account }));
-  }, [account, dispatch, navigate, trackAddAccountEvent]);
+  }, [account, dispatch, location.pathname, navigate, trackAddAccountEvent]);
 
   const handleBuy = useCallback(() => {
     trackAddAccountEvent(ADD_ACCOUNT_EVENTS_NAME.ADD_ACCOUNT_BUTTON_CLICKED, {
@@ -65,9 +66,14 @@ const ActionsContainer = ({ account, currencyId }: Props) => {
     });
     setDrawer();
     navigate("/exchange", {
-      state: { currency: currencyId, account: account.id, mode: "buy" },
+      state: {
+        currency: currencyId,
+        account: account.id,
+        mode: "buy",
+        returnTo: location.pathname,
+      },
     });
-  }, [currencyId, account.id, navigate, trackAddAccountEvent]);
+  }, [currencyId, account.id, location.pathname, navigate, trackAddAccountEvent]);
 
   const actions = useMemo(() => {
     const baseActions = [

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useBuySellNavigation.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/__tests__/useBuySellNavigation.test.ts
@@ -13,6 +13,7 @@ const mockOpenAssetAndAccount = jest.fn();
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
   useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: "/market" }),
 }));
 
 jest.mock("LLD/features/ModularDialog/Web3AppWebview/AssetAndAccountDrawer", () => ({
@@ -63,7 +64,7 @@ describe.each(cases)(
 
       expect(mockNavigate).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
-        state: { mode: rampMode, defaultTicker: "BTC" },
+        state: { mode: rampMode, defaultTicker: "BTC", returnTo: "/market" },
       });
       expect(mockOpenAssetAndAccount).not.toHaveBeenCalled();
     });
@@ -79,7 +80,7 @@ describe.each(cases)(
 
       expect(mockNavigate).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
-        state: { mode: rampMode, defaultTicker: "ETH" },
+        state: { mode: rampMode, defaultTicker: "ETH", returnTo: "/market" },
       });
       expect(mockOpenAssetAndAccount).not.toHaveBeenCalled();
     });
@@ -95,7 +96,7 @@ describe.each(cases)(
 
       expect(mockNavigate).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
-        state: { currency: bitcoin.id, mode },
+        state: { currency: bitcoin.id, mode, returnTo: "/market" },
       });
       expect(mockOpenAssetAndAccount).not.toHaveBeenCalled();
     });
@@ -112,7 +113,7 @@ describe.each(cases)(
 
       expect(mockNavigate).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
-        state: { currency: bitcoin.id, account: account.id, mode },
+        state: { currency: bitcoin.id, account: account.id, mode, returnTo: "/market" },
       });
       expect(mockOpenAssetAndAccount).not.toHaveBeenCalled();
     });
@@ -136,6 +137,7 @@ describe.each(cases)(
       expect(callState.currency).toBe(usdcToken.id);
       expect(callState.account).toBe(ethAccount.id);
       expect(callState.mode).toBe(mode);
+      expect(callState.returnTo).toBe("/market");
       expect(mockOpenAssetAndAccount).not.toHaveBeenCalled();
     });
 
@@ -189,7 +191,7 @@ describe.each(cases)(
 
       expect(mockNavigate).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
-        state: { currency: bitcoin.id, account: account1.id, mode },
+        state: { currency: bitcoin.id, account: account1.id, mode, returnTo: "/market" },
       });
     });
   },

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useBuyNavigation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useBuyNavigation.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useSelector } from "LLD/hooks/redux";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { flattenAccounts, isTokenAccount } from "@ledgerhq/live-common/account/index";
 import { getAvailableAccountsById } from "@ledgerhq/live-common/exchange/swap/utils/index";
@@ -19,6 +19,7 @@ interface UseBuyNavigationResult {
 
 export function useBuyNavigation(): UseBuyNavigationResult {
   const navigate = useNavigate();
+  const location = useLocation();
   const allAccounts = useSelector(accountsSelector);
   const flattenedAccounts = flattenAccounts(allAccounts);
   const { openAssetAndAccount } = useOpenAssetAndAccount();
@@ -29,6 +30,7 @@ export function useBuyNavigation(): UseBuyNavigationResult {
         const onRampState: BuyNavigationOnRampState = {
           mode: "onRamp",
           defaultTicker: ticker?.toUpperCase(),
+          returnTo: location.pathname,
         };
         navigate("/exchange", { state: onRampState });
         return;
@@ -39,7 +41,7 @@ export function useBuyNavigation(): UseBuyNavigationResult {
 
       if (!hasAccounts) {
         navigate("/exchange", {
-          state: buildBuyNavigationState({ ledgerCurrency }),
+          state: buildBuyNavigationState({ ledgerCurrency, returnTo: location.pathname }),
         });
         return;
       }
@@ -55,6 +57,7 @@ export function useBuyNavigation(): UseBuyNavigationResult {
             ledgerCurrency,
             account,
             parentAccount,
+            returnTo: location.pathname,
           }),
         });
         return;
@@ -71,12 +74,13 @@ export function useBuyNavigation(): UseBuyNavigationResult {
               ledgerCurrency,
               account,
               parentAccount,
+              returnTo: location.pathname,
             }),
           });
         },
       });
     },
-    [navigate, flattenedAccounts, allAccounts, openAssetAndAccount],
+    [navigate, flattenedAccounts, allAccounts, openAssetAndAccount, location.pathname],
   );
 
   return { navigateToBuy };

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useSellNavigation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/hooks/useSellNavigation.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useSelector } from "LLD/hooks/redux";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { flattenAccounts, isTokenAccount } from "@ledgerhq/live-common/account/index";
 import { getAvailableAccountsById } from "@ledgerhq/live-common/exchange/swap/utils/index";
@@ -19,6 +19,7 @@ interface UseSellNavigationResult {
 
 export function useSellNavigation(): UseSellNavigationResult {
   const navigate = useNavigate();
+  const location = useLocation();
   const allAccounts = useSelector(accountsSelector);
   const flattenedAccounts = flattenAccounts(allAccounts);
   const { openAssetAndAccount } = useOpenAssetAndAccount();
@@ -29,6 +30,7 @@ export function useSellNavigation(): UseSellNavigationResult {
         const offRampState: SellNavigationOffRampState = {
           mode: "offRamp",
           defaultTicker: ticker?.toUpperCase(),
+          returnTo: location.pathname,
         };
         navigate("/exchange", { state: offRampState });
         return;
@@ -39,7 +41,7 @@ export function useSellNavigation(): UseSellNavigationResult {
 
       if (!hasAccounts) {
         navigate("/exchange", {
-          state: buildSellNavigationState({ ledgerCurrency }),
+          state: buildSellNavigationState({ ledgerCurrency, returnTo: location.pathname }),
         });
         return;
       }
@@ -55,6 +57,7 @@ export function useSellNavigation(): UseSellNavigationResult {
             ledgerCurrency,
             account,
             parentAccount,
+            returnTo: location.pathname,
           }),
         });
         return;
@@ -71,12 +74,13 @@ export function useSellNavigation(): UseSellNavigationResult {
               ledgerCurrency,
               account,
               parentAccount,
+              returnTo: location.pathname,
             }),
           });
         },
       });
     },
-    [navigate, flattenedAccounts, allAccounts, openAssetAndAccount],
+    [navigate, flattenedAccounts, allAccounts, openAssetAndAccount, location.pathname],
   );
 
   return { navigateToSell };

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/utils/buyNavigation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/utils/buyNavigation.ts
@@ -6,27 +6,32 @@ export interface BuyNavigationState {
   currency: string;
   account?: string;
   mode: "buy";
+  returnTo?: string;
 }
 
 export interface BuyNavigationOnRampState {
   mode: "onRamp";
   defaultTicker?: string;
+  returnTo?: string;
 }
 
 interface BuildBuyStateParams {
   ledgerCurrency: CryptoOrTokenCurrency;
   account?: AccountLike;
   parentAccount?: Account;
+  returnTo?: string;
 }
 
 export function buildBuyNavigationState({
   ledgerCurrency,
   account,
   parentAccount,
+  returnTo,
 }: BuildBuyStateParams): BuyNavigationState {
   const state: BuyNavigationState = {
     currency: ledgerCurrency.id,
     mode: "buy",
+    returnTo,
   };
 
   if (account) {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/utils/sellNavigation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/utils/sellNavigation.ts
@@ -6,27 +6,32 @@ export interface SellNavigationState {
   currency: string;
   account?: string;
   mode: "sell";
+  returnTo?: string;
 }
 
 export interface SellNavigationOffRampState {
   mode: "offRamp";
   defaultTicker?: string;
+  returnTo?: string;
 }
 
 interface BuildSellStateParams {
   ledgerCurrency: CryptoOrTokenCurrency;
   account?: AccountLike;
   parentAccount?: Account;
+  returnTo?: string;
 }
 
 export function buildSellNavigationState({
   ledgerCurrency,
   account,
   parentAccount,
+  returnTo,
 }: BuildSellStateParams): SellNavigationState {
   const state: SellNavigationState = {
     currency: ledgerCurrency.id,
     mode: "sell",
+    returnTo,
   };
 
   if (account) {

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/__tests__/useQuickActions.test.ts
@@ -287,7 +287,7 @@ describe("useQuickActions", () => {
       });
 
       expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
-        state: { mode: "buy" },
+        state: { mode: "buy", returnTo: "/accounts" },
       });
     });
   });
@@ -306,7 +306,7 @@ describe("useQuickActions", () => {
       });
 
       expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
-        state: { mode: "sell" },
+        state: { mode: "sell", returnTo: "/accounts" },
       });
     });
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
@@ -83,9 +83,10 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
     navigate("/exchange", {
       state: {
         mode: "buy",
+        returnTo: location.pathname,
       },
     });
-  }, [navigate, trackingPageName]);
+  }, [navigate, trackingPageName, location.pathname]);
 
   const onSell = useCallback(() => {
     track("button_clicked", {
@@ -96,9 +97,10 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
     navigate("/exchange", {
       state: {
         mode: "sell",
+        returnTo: location.pathname,
       },
     });
-  }, [navigate, trackingPageName]);
+  }, [navigate, trackingPageName, location.pathname]);
 
   const onConnect = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
 import { getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
 import { useFlowWizard } from "LLD/features/FlowWizard/FlowWizardContext";
@@ -37,7 +37,7 @@ export function useAmountScreen(): AmountScreenViewModel {
   const { transaction: transactionActions, close } = useSendFlowActions();
   const { navigation } = useFlowWizard();
   const navigate = useNavigate();
-
+  const location = useLocation();
   const { account, parentAccount } = state.account;
   const { bridgePending, bridgeError, status, transaction } = state.transaction;
 
@@ -51,10 +51,11 @@ export function useAmountScreen(): AmountScreenViewModel {
         currency: currencyId,
         account: mainAccount.id,
         mode: "buy",
+        returnTo: location.pathname,
       },
     });
     close();
-  }, [account, close, navigate, parentAccount]);
+  }, [account, close, navigate, parentAccount, location.pathname]);
 
   const onReview = useCallback(() => {
     navigation.goToStep(SEND_FLOW_STEP.SIGNATURE);

--- a/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
@@ -167,10 +167,11 @@ export default function BalanceInfos({
     setTrackingSource("Page Portfolio");
     navigate("/exchange", {
       state: {
-        mode: "buy", // buy or sell
+        mode: "buy",
+        returnTo: location.pathname,
       },
     });
-  }, [navigate]);
+  }, [navigate, location.pathname]);
   const onSwap = useCallback(() => {
     setTrackingSource("Page Portfolio");
     navigate("/swap", {

--- a/apps/ledger-live-desktop/src/renderer/components/BuyButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BuyButton.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import Button from "~/renderer/components/Button";
-import { useNavigate } from "react-router";
+import { useNavigate, useLocation } from "react-router";
 import { closeAllModal } from "~/renderer/actions/modals";
 import { useDispatch } from "LLD/hooks/redux";
 import { Account } from "@ledgerhq/types-live";
@@ -12,7 +12,7 @@ import { isCurrencySupported } from "~/renderer/screens/exchange/config";
 const BuyButton = ({ currency, account }: { currency: CryptoCurrency; account: Account }) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
-
+  const location = useLocation();
   const onClick = useCallback(() => {
     dispatch(closeAllModal());
     setTrackingSource("send flow");
@@ -20,10 +20,11 @@ const BuyButton = ({ currency, account }: { currency: CryptoCurrency; account: A
       state: {
         currency: currency.id,
         account: account.id,
-        mode: "buy", // buy or sell
+        mode: "buy",
+        returnTo: location.pathname,
       },
     });
-  }, [account, currency, dispatch, navigate]);
+  }, [account, currency, dispatch, navigate, location.pathname]);
 
   if (!isCurrencySupported("BUY", currency)) {
     return null;

--- a/apps/ledger-live-desktop/src/renderer/components/ContextMenu/AccountContextMenu.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ContextMenu/AccountContextMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import { openModal } from "~/renderer/actions/modals";
@@ -41,6 +41,7 @@ export default function AccountContextMenu({
   withStar,
 }: Props) {
   const navigate = useNavigate();
+  const location = useLocation();
   const dispatch = useDispatch();
   const refreshAccountsOrdering = useRefreshAccountsOrdering();
   const swapSelectableCurrencies = useSelector(swapSelectableCurrenciesSelector);
@@ -90,7 +91,8 @@ export default function AccountContextMenu({
             state: {
               currency: currency?.id,
               account: mainAccount?.id,
-              mode: "buy", // buy or sell
+              mode: "buy",
+              returnTo: location.pathname,
             },
           });
         },
@@ -107,7 +109,8 @@ export default function AccountContextMenu({
             state: {
               currency: currency?.id,
               account: mainAccount?.id,
-              mode: "sell", // buy or sell
+              mode: "sell",
+              returnTo: location.pathname,
             },
           });
         },
@@ -197,6 +200,7 @@ export default function AccountContextMenu({
     openSendFlow,
     isStarred,
     refreshAccountsOrdering,
+    location.pathname,
   ]);
   const currency = getAccountCurrency(account);
   return (

--- a/apps/ledger-live-desktop/src/renderer/components/LowGasAlertBuyMore.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/LowGasAlertBuyMore.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { isCurrencySupported } from "~/renderer/screens/exchange/config";
 import Alert from "~/renderer/components/Alert";
@@ -38,7 +38,7 @@ const LowGasAlertBuyMore = ({
   trackingSource,
 }: LowGasAlertBuyMoreProps) => {
   const navigate = useNavigate();
-
+  const location = useLocation();
   const onBuyClick = useCallback(() => {
     handleRequestClose();
     setTrackingSource(trackingSource);
@@ -47,9 +47,17 @@ const LowGasAlertBuyMore = ({
         currency: account.currency.id,
         account: account.id,
         mode: "buy",
+        returnTo: location.pathname,
       },
     });
-  }, [account.currency.id, account.id, navigate, handleRequestClose, trackingSource]);
+  }, [
+    account.currency.id,
+    account.id,
+    navigate,
+    handleRequestClose,
+    trackingSource,
+    location.pathname,
+  ]);
 
   if (!gasPriceError) return null;
   return (

--- a/apps/ledger-live-desktop/src/renderer/components/NotEnoughFundsToUnstake/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/NotEnoughFundsToUnstake/index.tsx
@@ -59,10 +59,11 @@ const NotEnoughFundsToUnstake = ({
         currency: currency.id,
         account: account.id,
         mode: "buy",
+        returnTo: location.pathname,
       },
     });
     onClose();
-  }, [buttonSharedTrackingFields, navigate, currency.id, account?.id, onClose]);
+  }, [buttonSharedTrackingFields, navigate, currency.id, account?.id, onClose, location.pathname]);
 
   const onPressSwap = useCallback(() => {
     track("button_clicked2", {

--- a/apps/ledger-live-desktop/src/renderer/modals/NoFundsStake/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/NoFundsStake/index.tsx
@@ -78,6 +78,7 @@ const NoFundsStakeModal = ({ account, parentAccount, entryPoint }: NoFundsStakeM
         account: isTokenAccount(account) ? parentAccount?.id : account.id,
         currency: currency.id,
         mode: "buy",
+        returnTo: location.pathname,
       },
     });
   }, [location, dispatch, navigate, account, parentAccount?.id, currency.id]);

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
@@ -263,11 +263,12 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
         state: {
           currency: currency?.id,
           account: mainAccount?.id,
-          mode, // buy or sell
+          mode,
+          returnTo: location.pathname,
         },
       });
     },
-    [currency, navigate, mainAccount.id, buttonSharedTrackingFields],
+    [currency, navigate, mainAccount.id, buttonSharedTrackingFields, location.pathname],
   );
 
   const onSwap = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/screens/account/EmptyStateAccount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/EmptyStateAccount.tsx
@@ -15,7 +15,7 @@ import darkEmptyStateAccount from "~/renderer/images/dark-empty-state-account.sv
 import Text from "~/renderer/components/Text";
 import Button from "~/renderer/components/Button";
 import styled from "styled-components";
-import { useNavigate } from "react-router";
+import { useNavigate, useLocation } from "react-router";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
@@ -35,7 +35,7 @@ function EmptyStateAccount({ t, account, parentAccount, openModal }: Props) {
   const currency = getAccountCurrency(account);
   const { isCurrencyAvailable } = useRampCatalog();
   const navigate = useNavigate();
-
+  const location = useLocation();
   const availableOnBuy = !!currency && isCurrencyAvailable(currency.id, "onRamp");
 
   const hasTokens =
@@ -48,10 +48,11 @@ function EmptyStateAccount({ t, account, parentAccount, openModal }: Props) {
       state: {
         currency: currency?.id,
         account: mainAccount?.id,
-        mode: "buy", // buy or sell
+        mode: "buy",
+        returnTo: location.pathname,
       },
     });
-  }, [currency, navigate, mainAccount]);
+  }, [currency, navigate, mainAccount, location.pathname]);
   if (!mainAccount) return null;
   return (
     <Box mt={10} alignItems="center" selectable>

--- a/apps/ledger-live-desktop/src/renderer/screens/asset/AssetBalanceSummaryHeader.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/asset/AssetBalanceSummaryHeader.tsx
@@ -112,9 +112,10 @@ export default function AssetBalanceSummaryHeader({
       state: {
         currency: currency?.id,
         mode: "buy",
+        returnTo: location.pathname,
       },
     });
-  }, [currency.id, navigate, currency?.ticker]);
+  }, [currency.id, navigate, currency?.ticker, location.pathname]);
 
   const onSell = useCallback(() => {
     track("button_clicked2", {
@@ -127,9 +128,10 @@ export default function AssetBalanceSummaryHeader({
       state: {
         currency: currency?.id,
         mode: "sell",
+        returnTo: location.pathname,
       },
     });
-  }, [currency.id, navigate, currency?.ticker]);
+  }, [currency.id, navigate, currency?.ticker, location.pathname]);
 
   const onSwap = useCallback(() => {
     track("button_clicked2", {

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import semver from "semver";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
@@ -36,8 +36,7 @@ import PageHeader from "LLD/components/PageHeader";
 import { getWallet40HeaderKey } from "./helpers";
 import Box from "~/renderer/components/Box/Box";
 
-type ExchangeState = { account?: string } | undefined;
-
+type ExchangeState = { account?: string; returnTo?: string };
 const LiveAppExchange = ({ appId }: { appId: string }) => {
   const location = useLocation();
   const urlParams = location.state as ExchangeState;
@@ -63,6 +62,16 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
   const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("desktop");
   const { t } = useTranslation();
   const navigate = useNavigate();
+  // Persist initial returnTo in a ref so it survives in-webview navigations that push
+  // new React Router locations and overwrite location.state.
+  const returnToRef = useRef<string | null>(null);
+  useEffect(() => {
+    const value = urlParams?.returnTo;
+    if (returnToRef.current === null && value != null && value !== "") {
+      returnToRef.current = value;
+    }
+  }, [urlParams?.returnTo]);
+  const returnTo = returnToRef.current ?? urlParams?.returnTo ?? "/";
   const providerInterstitialEnabled = useProviderInterstitalEnabled({
     manifest,
   });
@@ -112,7 +121,7 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
   return (
     <>
       {shouldDisplayWallet40MainNav && headerKey ? (
-        <PageHeader title={t(headerKey)} onBack={() => navigate(-1)} />
+        <PageHeader title={t(headerKey)} onBack={() => navigate(returnTo, { replace: true })} />
       ) : null}
       <Box
         grow


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 

### 📝 Description

**Problem:** On the Exchange screen (buy/sell WebPTXPlayer), the desktop PageHeader back button used `navigate(-1)`. React Router history is shared with in-webview flows that push new locations, so "back" often stepped within the webview (e.g. provider flow) instead of leaving the exchange and returning to the previous desktop screen (e.g. Market, account).

**Solution:**

1. **Explicit return path**  
   The header back button now calls `navigate(returnTo)` where `returnTo` comes from `location.state.returnTo` (fallback `"/"`) instead of `navigate(-1)`, so back always leaves the exchange in desktop context.

2. **Persist returnTo across in-webview navigation**  
   The initial `returnTo` from state is stored in a ref. When in-webview navigations push new React Router locations and overwrite `location.state`, the ref still holds the original path so the back button continues to work.

3. **Call sites pass returnTo**  
   All entry points that navigate to `/exchange` now pass `returnTo: location.pathname` in state: Market (useBuyNavigation / useSellNavigation), Add Account FundAccount (ActionsContainer), QuickActions, useAmountScreen, BalanceInfos, AccountContextMenu, LowGasAlertBuyMore, NotEnoughFundsToUnstake, NoFundsStake, AccountHeaderActions, AssetBalanceSummaryHeader. ActionsContainer also uses `useLocation()` from react-router so returnTo is correct.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-27186

Before:

https://github.com/user-attachments/assets/5f2322f0-02d2-4ebf-97c0-73416597c99e

After:

https://github.com/user-attachments/assets/3815da99-bca3-4023-b1b5-bb9fdba5e17c



---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
