### PR TITLE
fix(desktop): reliable balance refresh loading for all 4 sync scenarios

### DIFF
--- a/.changeset/heavy-fireants-mix.md
+++ b/.changeset/heavy-fireants-mix.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix balance refresh loading for all 4 sync scenarios (cold start, initial sync, manual click, auto sync)

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
@@ -48,7 +48,6 @@ describe("useActivityIndicator", () => {
       hasAccounts: true,
       isError: false,
       isRotating: false,
-      isDisabled: false,
     });
     expect(result.current.tooltip).toBeDefined();
     expect(typeof result.current.tooltip).toBe("string");
@@ -69,6 +68,42 @@ describe("useActivityIndicator", () => {
 
     expect(result.current.isError).toBe(true);
     expect(typeof result.current.onTooltipShow).toBe("function");
+  });
+
+  it("returns isError false when stableSyncPending is true even if sync has errors", () => {
+    mockUsePortfolioBalanceSync.mockReturnValue({
+      ...defaultPortfolioBalanceSync,
+      stableSyncPending: true,
+      hasWalletSyncError: true,
+    });
+
+    const { result } = renderHook(() => useActivityIndicator(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("returns isError false when accounts are not up-to-date but have never been (cold start)", () => {
+    const mockUseBatchAccountsSyncState = jest.requireMock(
+      "@ledgerhq/live-common/bridge/react/index",
+    ).useBatchAccountsSyncState;
+    mockUseBatchAccountsSyncState.mockReturnValue([
+      {
+        syncState: { pending: false, error: null },
+        account: {
+          ...BTC_ACCOUNT,
+          currency: { ...BTC_ACCOUNT.currency, blockAvgTime: 600 },
+          lastSyncDate: new Date(0),
+        },
+      },
+    ]);
+
+    const { result } = renderHook(() => useActivityIndicator(), {
+      initialState: { ...defaultInitialState, accounts: [BTC_ACCOUNT] },
+    });
+
+    expect(result.current.isError).toBe(false);
   });
 
   it("onTooltipShow tracks SyncErrorList with currencies as array", () => {
@@ -96,7 +131,7 @@ describe("useActivityIndicator", () => {
     trackSpy.mockRestore();
   });
 
-  it("returns isRotating and isDisabled true when balance is loading (e.g. countervalues polling)", () => {
+  it("returns isRotating true when balance is loading (e.g. countervalues polling)", () => {
     mockUsePortfolioBalanceSync.mockReturnValue({
       ...defaultPortfolioBalanceSync,
       isBalanceLoading: true,
@@ -107,7 +142,6 @@ describe("useActivityIndicator", () => {
     });
 
     expect(result.current.isRotating).toBe(true);
-    expect(result.current.isDisabled).toBe(true);
   });
 
   it("returns isRotating true on cold start when portfolio balance is not available", () => {
@@ -124,10 +158,9 @@ describe("useActivityIndicator", () => {
     expect(result.current.tooltip).toBeNull();
   });
 
-  it("returns isRotating true when sync is pending", () => {
+  it("returns isRotating true when balance is loading during sync", () => {
     mockUsePortfolioBalanceSync.mockReturnValue({
       ...defaultPortfolioBalanceSync,
-      stableSyncPending: true,
       isBalanceLoading: true,
     });
 
@@ -138,10 +171,9 @@ describe("useActivityIndicator", () => {
     expect(result.current.isRotating).toBe(true);
   });
 
-  it("returns isRotating true after user click when sync is pending", () => {
+  it("returns isRotating true after user click when balance is loading", () => {
     mockUsePortfolioBalanceSync.mockReturnValue({
       ...defaultPortfolioBalanceSync,
-      stableSyncPending: true,
       isBalanceLoading: true,
     });
 
@@ -156,7 +188,6 @@ describe("useActivityIndicator", () => {
     });
 
     expect(result.current.isRotating).toBe(true);
-    expect(result.current.isDisabled).toBe(true);
   });
 
   it("handleSync calls triggerRefresh and track", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
@@ -33,7 +33,6 @@ describe("useTopBarViewModel", () => {
       isError: false,
       tooltip: "Refresh",
       icon: Refresh,
-      isDisabled: false,
       onTooltipShow: undefined,
     });
     mockUseSettings.mockReturnValue({
@@ -84,7 +83,6 @@ describe("useTopBarViewModel", () => {
       isError: false,
       tooltip: "Refresh",
       icon: Refresh,
-      isDisabled: false,
       onTooltipShow: undefined,
     });
 
@@ -109,7 +107,6 @@ describe("useTopBarViewModel", () => {
       isError: true,
       tooltip: "Error",
       icon: Refresh,
-      isDisabled: true,
       onTooltipShow: mockOnTooltipShow,
     });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
@@ -1,24 +1,15 @@
-import { useCallback, useEffect, useReducer } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 import { useLocation } from "react-router";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { hasAccountsSelector, isUpToDateSelector } from "~/renderer/reducers/accounts";
-import {
-  selectLastUserSyncClickTimestamp,
-  setLastUserSyncClickTimestamp,
-} from "~/renderer/reducers/syncRefresh";
-import { getEnv } from "@ledgerhq/live-env";
+import { setLastUserSyncClickTimestamp } from "~/renderer/reducers/syncRefresh";
 import { track } from "~/renderer/analytics/segment";
 
 import { usePortfolioBalanceSync } from "LLD/hooks/usePortfolioBalanceSync";
 import { useAccountsSyncStatus } from "./useAccountsSyncStatus";
 import { useActivityIndicatorTooltip } from "./useActivityIndicatorTooltip";
 import { getActivityIndicatorIcon } from "../utils/getActivityIndicatorIcon";
-import {
-  PLAYWRIGHT_CLICK_SPIN_DURATION_MS,
-  TOOLTIP_UPDATE_INTERVAL_MS,
-  USER_CLICK_SPIN_DURATION_MS,
-} from "../utils/constants";
-import { isRecentUserSyncClick } from "../utils/syncRefreshUtils";
+import { TOOLTIP_UPDATE_INTERVAL_MS } from "../utils/constants";
 
 /**
  * Activity indicator state for the TopBar sync button.
@@ -29,7 +20,6 @@ export const useActivityIndicator = () => {
   const location = useLocation();
   const hasAccounts = useSelector(hasAccountsSelector);
   const accountsWithUpToDateCheck = useSelector(isUpToDateSelector);
-  const lastUserSyncClickTimestamp = useSelector(selectLastUserSyncClickTimestamp);
   const {
     isBalanceLoading,
     stableSyncPending,
@@ -51,13 +41,18 @@ export const useActivityIndicator = () => {
     return () => clearInterval(id);
   }, [needsTooltipUpdates]);
 
-  const isError = hasCvOrBridgeError || !areAllAccountsUpToDate || hasWalletSyncError;
-  const isPlaywrightRun = getEnv("PLAYWRIGHT_RUN");
-  const userClickSpinMs = isPlaywrightRun
-    ? PLAYWRIGHT_CLICK_SPIN_DURATION_MS
-    : USER_CLICK_SPIN_DURATION_MS;
-  const isUserClick = isRecentUserSyncClick(lastUserSyncClickTimestamp, userClickSpinMs);
-  const isRotating = isBalanceLoading || (isUserClick && stableSyncPending);
+  const hasEverBeenUpToDate = useRef(areAllAccountsUpToDate);
+  useEffect(() => {
+    if (areAllAccountsUpToDate) {
+      hasEverBeenUpToDate.current = true;
+    }
+  }, [areAllAccountsUpToDate]);
+
+  const isSyncSettled = !isBalanceLoading && !stableSyncPending;
+  const hasAccountDegradation = hasEverBeenUpToDate.current && !areAllAccountsUpToDate;
+  const hasAnySyncError = hasCvOrBridgeError || hasAccountDegradation || hasWalletSyncError;
+  const isError = isSyncSettled && hasAnySyncError;
+  const isRotating = isBalanceLoading;
 
   const icon = getActivityIndicatorIcon(isError, isRotating);
   const tooltip = useActivityIndicatorTooltip({
@@ -92,7 +87,6 @@ export const useActivityIndicator = () => {
     handleSync,
     isError,
     isRotating,
-    isDisabled: isRotating,
     tooltip,
     icon,
     onTooltipShow: isError ? onTooltipShow : undefined,

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/utils/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/utils/constants.ts
@@ -1,6 +1,4 @@
 export const TOOLTIP_UPDATE_INTERVAL_MS = 60_000;
-export const USER_CLICK_SPIN_DURATION_MS = 1000;
-export const PLAYWRIGHT_CLICK_SPIN_DURATION_MS = 10_000;
 
 export const MANAGER_PATH = "/manager";
 export const MANAGER_TRACK_ENTRY = "manager";

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/utils/syncRefreshUtils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/utils/syncRefreshUtils.ts
@@ -1,7 +1,0 @@
-/**
- * Returns true if the given timestamp is within the last `windowMs` milliseconds.
- * Used to treat a user sync click as "recent" for manual vs auto refresh loading.
- */
-export function isRecentUserSyncClick(timestamp: number, windowMs: number): boolean {
-  return Date.now() - timestamp < windowMs;
-}

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
@@ -44,6 +44,7 @@ const defaultBalanceSyncReturn = {
   counterValue: mockCounterValue,
   balanceAvailable: true,
   isColdStart: false,
+  isInitialLoading: false,
   isBalanceLoading: false,
   isManualRefreshLoading: false,
   stableSyncPending: false,
@@ -133,6 +134,36 @@ describe("useBalanceViewModel", () => {
     });
 
     expect(result.current.isColdStart).toBe(true);
+  });
+
+  it("freezes balance during loading and unfreezes when loading completes", () => {
+    mockUsePortfolioBalanceSync.mockReturnValue({
+      ...defaultBalanceSyncReturn,
+      isBalanceLoading: false,
+      portfolio: { ...mockPortfolio, balanceHistory: [{ date: new Date(), value: 1500 }] },
+    });
+
+    const { result, rerender } = renderHook(() => useBalanceViewModel(), { initialState });
+
+    expect(result.current.balance).toBe(1500);
+
+    mockUsePortfolioBalanceSync.mockReturnValue({
+      ...defaultBalanceSyncReturn,
+      isBalanceLoading: true,
+      portfolio: { ...mockPortfolio, balanceHistory: [{ date: new Date(), value: 2000 }] },
+    });
+    rerender();
+
+    expect(result.current.balance).toBe(1500);
+
+    mockUsePortfolioBalanceSync.mockReturnValue({
+      ...defaultBalanceSyncReturn,
+      isBalanceLoading: false,
+      portfolio: { ...mockPortfolio, balanceHistory: [{ date: new Date(), value: 2000 }] },
+    });
+    rerender();
+
+    expect(result.current.balance).toBe(2000);
   });
 
   it("returns shouldDisplayBalanceRefreshRework false when lwdWallet40 has balanceRefreshRework false", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useSelector } from "LLD/hooks/redux";
 import {
   hasOnboardedDeviceSelector,
@@ -37,6 +37,16 @@ export const useBalanceViewModel = (
 
   const latestBalanceValue =
     portfolio.balanceHistory[portfolio.balanceHistory.length - 1]?.value ?? 0;
+
+  const frozenBalanceRef = useRef(latestBalanceValue);
+  useEffect(() => {
+    if (!isBalanceLoading) {
+      frozenBalanceRef.current = latestBalanceValue;
+    }
+  }, [isBalanceLoading, latestBalanceValue]);
+  const shouldFreezeBalance = shouldDisplayBalanceRefreshRework && isBalanceLoading;
+  const displayedBalance = shouldFreezeBalance ? frozenBalanceRef.current : latestBalanceValue;
+
   const unit = counterValue.units[0];
   const valueChange = portfolio.countervalueChange;
 
@@ -70,7 +80,7 @@ export const useBalanceViewModel = (
   );
 
   return {
-    balance: latestBalanceValue,
+    balance: displayedBalance,
     formatter,
     discreet,
     valueChange,

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useManualRefreshLoading.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useManualRefreshLoading.test.ts
@@ -1,0 +1,135 @@
+import { renderHook } from "tests/testSetup";
+import { useManualRefreshLoading } from "../useManualRefreshLoading";
+
+interface Props {
+  stableSyncPending: boolean;
+  lastUserSyncClickTimestamp: number;
+}
+
+function renderManualRefresh(initialProps: Props) {
+  return renderHook(
+    (props: Props) =>
+      useManualRefreshLoading(props.stableSyncPending, props.lastUserSyncClickTimestamp),
+    { initialProps },
+  );
+}
+
+describe("useManualRefreshLoading", () => {
+  it("returns false on initial render when no click has happened", () => {
+    const { result } = renderManualRefresh({
+      stableSyncPending: false,
+      lastUserSyncClickTimestamp: 0,
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when timestamp changes (user clicks refresh)", () => {
+    const { result, rerender } = renderManualRefresh({
+      stableSyncPending: false,
+      lastUserSyncClickTimestamp: 0,
+    });
+
+    rerender({ stableSyncPending: true, lastUserSyncClickTimestamp: 1000 });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("does not trigger on mount when timestamp is already non-zero", () => {
+    const { result, rerender } = renderManualRefresh({
+      stableSyncPending: false,
+      lastUserSyncClickTimestamp: 5000,
+    });
+
+    expect(result.current).toBe(false);
+
+    rerender({ stableSyncPending: true, lastUserSyncClickTimestamp: 6000 });
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when sync is pending but no click occurred", () => {
+    const { result } = renderManualRefresh({
+      stableSyncPending: true,
+      lastUserSyncClickTimestamp: 0,
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("stays true while sync is still pending after click", () => {
+    const { result, rerender } = renderManualRefresh({
+      stableSyncPending: false,
+      lastUserSyncClickTimestamp: 0,
+    });
+
+    rerender({ stableSyncPending: true, lastUserSyncClickTimestamp: 1000 });
+    expect(result.current).toBe(true);
+
+    rerender({ stableSyncPending: true, lastUserSyncClickTimestamp: 1000 });
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false after sync completes (pending: true → false) following a click", () => {
+    const { result, rerender } = renderManualRefresh({
+      stableSyncPending: false,
+      lastUserSyncClickTimestamp: 0,
+    });
+
+    rerender({ stableSyncPending: true, lastUserSyncClickTimestamp: 1000 });
+    expect(result.current).toBe(true);
+
+    rerender({ stableSyncPending: false, lastUserSyncClickTimestamp: 1000 });
+    expect(result.current).toBe(false);
+  });
+
+  it("does not release until sync has been pending at least once after click", () => {
+    const { result, rerender } = renderManualRefresh({
+      stableSyncPending: false,
+      lastUserSyncClickTimestamp: 0,
+    });
+
+    rerender({ stableSyncPending: false, lastUserSyncClickTimestamp: 1000 });
+    expect(result.current).toBe(true);
+
+    rerender({ stableSyncPending: false, lastUserSyncClickTimestamp: 1000 });
+    expect(result.current).toBe(true);
+
+    rerender({ stableSyncPending: true, lastUserSyncClickTimestamp: 1000 });
+    expect(result.current).toBe(true);
+
+    rerender({ stableSyncPending: false, lastUserSyncClickTimestamp: 1000 });
+    expect(result.current).toBe(false);
+  });
+
+  it("re-triggers on a second click after the first cycle completes", () => {
+    const { result, rerender } = renderManualRefresh({
+      stableSyncPending: false,
+      lastUserSyncClickTimestamp: 0,
+    });
+
+    rerender({ stableSyncPending: true, lastUserSyncClickTimestamp: 1000 });
+    expect(result.current).toBe(true);
+
+    rerender({ stableSyncPending: false, lastUserSyncClickTimestamp: 1000 });
+    expect(result.current).toBe(false);
+
+    rerender({ stableSyncPending: true, lastUserSyncClickTimestamp: 2000 });
+    expect(result.current).toBe(true);
+  });
+
+  it("stays loading through a second click while sync is still running", () => {
+    const { result, rerender } = renderManualRefresh({
+      stableSyncPending: false,
+      lastUserSyncClickTimestamp: 0,
+    });
+
+    rerender({ stableSyncPending: true, lastUserSyncClickTimestamp: 1000 });
+    expect(result.current).toBe(true);
+
+    rerender({ stableSyncPending: true, lastUserSyncClickTimestamp: 2000 });
+    expect(result.current).toBe(true);
+
+    rerender({ stableSyncPending: false, lastUserSyncClickTimestamp: 2000 });
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/usePortfolioBalanceSync.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/usePortfolioBalanceSync.test.ts
@@ -3,11 +3,12 @@ import { usePortfolioBalanceSync } from "../usePortfolioBalanceSync";
 import { BTC_ACCOUNT, ETH_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
 import * as walletSyncContext from "LLD/features/WalletSync/components/WalletSyncContext";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
-import { DEFAULT_PORTFOLIO_RANGE } from "LLD/utils/constants";
+import { DEFAULT_PORTFOLIO_RANGE, POLLING_FINISHED_DELAY_MS } from "LLD/utils/constants";
 import type { PortfolioRange } from "@ledgerhq/types-live";
 import * as portfolioReact from "@ledgerhq/live-countervalues-react/portfolio";
 import * as countervaluesReact from "@ledgerhq/live-countervalues-react";
 import * as bridgeReact from "@ledgerhq/live-common/bridge/react/index";
+import { setLastUserSyncClickTimestamp } from "~/renderer/reducers/syncRefresh";
 
 const dayRange: PortfolioRange = "day";
 
@@ -165,6 +166,80 @@ describe("usePortfolioBalanceSync", () => {
     expect(result.current.isColdStart).toBe(false);
   });
 
+  it("returns isInitialLoading true when hasAccounts and initial sync not completed", () => {
+    jest.spyOn(countervaluesReact, "useCountervaluesPolling").mockReturnValue({
+      ...defaultPollingReturn,
+      pending: true,
+    });
+
+    const { result } = renderHook(() => usePortfolioBalanceSync(), {
+      initialState: {
+        ...defaultInitialState,
+        accounts: [BTC_ACCOUNT],
+        syncRefresh: { lastUserSyncClickTimestamp: 0, hasCompletedInitialSync: false },
+      },
+    });
+
+    expect(result.current.isInitialLoading).toBe(true);
+    expect(result.current.isBalanceLoading).toBe(true);
+  });
+
+  it("returns isInitialLoading false after initial sync completes (after stableSyncPending delay)", () => {
+    jest.useFakeTimers();
+    const pollingMock = jest
+      .spyOn(countervaluesReact, "useCountervaluesPolling")
+      .mockReturnValue({ ...defaultPollingReturn, pending: true });
+
+    const { result, rerender } = renderHook(() => usePortfolioBalanceSync(), {
+      initialState: {
+        ...defaultInitialState,
+        accounts: [BTC_ACCOUNT],
+        syncRefresh: { lastUserSyncClickTimestamp: 0, hasCompletedInitialSync: false },
+      },
+    });
+
+    expect(result.current.isInitialLoading).toBe(true);
+
+    pollingMock.mockReturnValue({ ...defaultPollingReturn, pending: false });
+    mockUseGlobalSyncState.mockReturnValue({ pending: false, error: null });
+
+    act(() => {
+      rerender();
+    });
+
+    expect(result.current.isInitialLoading).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(POLLING_FINISHED_DELAY_MS);
+    });
+
+    expect(result.current.isInitialLoading).toBe(false);
+    jest.useRealTimers();
+  });
+
+  it("returns isBalanceLoading true during initial loading even with cached balance", () => {
+    jest.spyOn(portfolioReact, "usePortfolioThrottled").mockReturnValue({
+      ...defaultPortfolio,
+      balanceAvailable: true,
+    });
+    jest.spyOn(countervaluesReact, "useCountervaluesPolling").mockReturnValue({
+      ...defaultPollingReturn,
+      pending: true,
+    });
+
+    const { result } = renderHook(() => usePortfolioBalanceSync(), {
+      initialState: {
+        ...defaultInitialState,
+        accounts: [BTC_ACCOUNT],
+        syncRefresh: { lastUserSyncClickTimestamp: 0, hasCompletedInitialSync: false },
+      },
+    });
+
+    expect(result.current.isColdStart).toBe(false);
+    expect(result.current.isInitialLoading).toBe(true);
+    expect(result.current.isBalanceLoading).toBe(true);
+  });
+
   it("returns isBalanceLoading false and isManualRefreshLoading false when sync pending but no recent user click (auto refresh)", () => {
     jest.spyOn(countervaluesReact, "useCountervaluesPolling").mockReturnValue({
       ...defaultPollingReturn,
@@ -174,7 +249,7 @@ describe("usePortfolioBalanceSync", () => {
     const { result } = renderHook(() => usePortfolioBalanceSync(), {
       initialState: {
         ...defaultInitialState,
-        syncRefresh: { lastUserSyncClickTimestamp: 0 },
+        syncRefresh: { lastUserSyncClickTimestamp: 0, hasCompletedInitialSync: true },
       },
     });
 
@@ -183,20 +258,23 @@ describe("usePortfolioBalanceSync", () => {
     expect(result.current.isBalanceLoading).toBe(false);
   });
 
-  it("returns isManualRefreshLoading true and isBalanceLoading true when sync pending and user clicked recently", () => {
-    const now = 10_000;
-    const recentClickTime = now - 100; // 100ms ago within USER_CLICK_SPIN_DURATION_MS (1000)
-    jest.spyOn(Date, "now").mockReturnValue(now);
+  it("returns isManualRefreshLoading true and isBalanceLoading true when user clicks refresh while sync is pending", () => {
     jest.spyOn(countervaluesReact, "useCountervaluesPolling").mockReturnValue({
       ...defaultPollingReturn,
       pending: true,
     });
 
-    const { result } = renderHook(() => usePortfolioBalanceSync(), {
+    const { result, store } = renderHook(() => usePortfolioBalanceSync(), {
       initialState: {
         ...defaultInitialState,
-        syncRefresh: { lastUserSyncClickTimestamp: recentClickTime },
+        syncRefresh: { lastUserSyncClickTimestamp: 0, hasCompletedInitialSync: true },
       },
+    });
+
+    expect(result.current.isManualRefreshLoading).toBe(false);
+
+    act(() => {
+      store.dispatch(setLastUserSyncClickTimestamp(Date.now()));
     });
 
     expect(result.current.stableSyncPending).toBe(true);

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useManualRefreshLoading.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useManualRefreshLoading.ts
@@ -1,0 +1,47 @@
+import { useEffect, useReducer, useRef } from "react";
+
+type Phase = "idle" | "waitingForSync" | "syncing";
+type Event = "click" | "syncStarted" | "syncDone";
+
+/**
+ * State machine for manual refresh lifecycle:
+ *   idle → (click) → waitingForSync → (syncStarted) → syncing → (syncDone) → idle
+ */
+function reducer(phase: Phase, event: Event): Phase {
+  switch (event) {
+    case "click":
+      return "waitingForSync";
+    case "syncStarted":
+      return phase === "waitingForSync" ? "syncing" : phase;
+    case "syncDone":
+      return phase === "syncing" || phase === "waitingForSync" ? "idle" : phase;
+    default:
+      return phase;
+  }
+}
+
+/**
+ * Tracks whether a user-triggered manual refresh is in progress.
+ *
+ * Latches on when a click is detected and releases once the sync completes.
+ */
+export function useManualRefreshLoading(
+  stableSyncPending: boolean,
+  lastUserSyncClickTimestamp: number,
+): boolean {
+  const [phase, send] = useReducer(reducer, "idle");
+  const prevTimestampRef = useRef(lastUserSyncClickTimestamp);
+
+  useEffect(() => {
+    if (lastUserSyncClickTimestamp !== prevTimestampRef.current) {
+      prevTimestampRef.current = lastUserSyncClickTimestamp;
+      send("click");
+    }
+  }, [lastUserSyncClickTimestamp]);
+
+  useEffect(() => {
+    send(stableSyncPending ? "syncStarted" : "syncDone");
+  }, [stableSyncPending]);
+
+  return phase !== "idle";
+}

--- a/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalanceSync.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalanceSync.ts
@@ -1,5 +1,5 @@
-import { useCallback } from "react";
-import { useSelector } from "LLD/hooks/redux";
+import { useCallback, useEffect, useRef } from "react";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { accountsSelector, hasAccountsSelector } from "~/renderer/reducers/accounts";
 import {
   counterValueCurrencySelector,
@@ -10,9 +10,12 @@ import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
 import { useBridgeSync, useGlobalSyncState } from "@ledgerhq/live-common/bridge/react/index";
 import { useWalletSyncUserState } from "LLD/features/WalletSync/components/WalletSyncContext";
 import { useStablePending } from "LLD/hooks/useStablePending";
-import { USER_CLICK_SPIN_DURATION_MS } from "LLD/components/TopBar/utils/constants";
-import { isRecentUserSyncClick } from "LLD/components/TopBar/utils/syncRefreshUtils";
-import { selectLastUserSyncClickTimestamp } from "~/renderer/reducers/syncRefresh";
+import { useManualRefreshLoading } from "LLD/hooks/useManualRefreshLoading";
+import {
+  selectLastUserSyncClickTimestamp,
+  selectHasCompletedInitialSync,
+  setHasCompletedInitialSync,
+} from "~/renderer/reducers/syncRefresh";
 import { DEFAULT_PORTFOLIO_RANGE, POLLING_FINISHED_DELAY_MS } from "LLD/utils/constants";
 
 export interface UsePortfolioBalanceSyncOptions {
@@ -27,11 +30,13 @@ export interface UsePortfolioBalanceSyncOptions {
  * - Portfolio: accounts, range, counterValue → balanceAvailable, isColdStart.
  *   Uses usePortfolioThrottled to limit recomputation frequency and avoid heavy work on every render.
  * - Sync state: CV polling + bridge sync + wallet sync → isSyncPending, stableSyncPending, errors
- * - isBalanceLoading = cold start or manual refresh loading (so Balance shows loading only on cold start or after user click when rework is on). TopBar uses this for rotation.
- * - isManualRefreshLoading = stableSyncPending and user clicked refresh recently (Redux syncRefresh slice).
+ * - isBalanceLoading = cold start OR initial loading (first sync not done) OR manual refresh.
+ *   TopBar uses this for rotation and to suppress error state during loading.
+ * - isManualRefreshLoading = latched on user click, released when sync actually completes.
  * - triggerRefresh = run wallet refresh + CV poll + bridge SYNC_ALL_ACCOUNTS (TopBar calls this on click).
  */
 export function usePortfolioBalanceSync(options: UsePortfolioBalanceSyncOptions = {}) {
+  const dispatch = useDispatch();
   const { legacyRange = false } = options;
   const accounts = useSelector(accountsSelector);
   const counterValue = useSelector(counterValueCurrencySelector);
@@ -50,17 +55,31 @@ export function usePortfolioBalanceSync(options: UsePortfolioBalanceSyncOptions 
   const wsUserState = useWalletSyncUserState();
   const bridgeSync = useBridgeSync();
   const lastUserSyncClickTimestamp = useSelector(selectLastUserSyncClickTimestamp);
+  const hasCompletedInitialSync = useSelector(selectHasCompletedInitialSync);
 
   const isSyncPending = cvPolling.pending || globalSyncState.pending || wsUserState.visualPending;
   const stableSyncPending = useStablePending(isSyncPending, POLLING_FINISHED_DELAY_MS);
 
+  const prevStablePending = useRef(false);
+
+  useEffect(() => {
+    const wasPending = prevStablePending.current;
+    prevStablePending.current = stableSyncPending;
+
+    if (!hasCompletedInitialSync && wasPending && !stableSyncPending) {
+      dispatch(setHasCompletedInitialSync(true));
+    }
+  }, [stableSyncPending, hasCompletedInitialSync, dispatch]);
+
   const balanceAvailable = portfolio.balanceAvailable;
   const isColdStart = hasAccounts && !balanceAvailable;
-  const isManualRefreshLoading =
-    stableSyncPending &&
-    isRecentUserSyncClick(lastUserSyncClickTimestamp, USER_CLICK_SPIN_DURATION_MS);
+  const isInitialLoading = hasAccounts && !hasCompletedInitialSync;
+  const isManualRefreshLoading = useManualRefreshLoading(
+    stableSyncPending,
+    lastUserSyncClickTimestamp,
+  );
 
-  const isBalanceLoading = isColdStart || isManualRefreshLoading;
+  const isBalanceLoading = isColdStart || isInitialLoading || isManualRefreshLoading;
 
   const hasCvOrBridgeError = !isSyncPending && (!!cvPolling.error || !!globalSyncState.error);
   const hasWalletSyncError = !!wsUserState.walletSyncError;
@@ -80,6 +99,7 @@ export function usePortfolioBalanceSync(options: UsePortfolioBalanceSyncOptions 
     counterValue,
     balanceAvailable,
     isColdStart,
+    isInitialLoading,
     isBalanceLoading,
     isManualRefreshLoading,
     stableSyncPending,

--- a/apps/ledger-live-desktop/src/renderer/reducers/syncRefresh.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/syncRefresh.ts
@@ -1,16 +1,19 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
 /**
- * Stores the timestamp of the last user-triggered sync (TopBar sync button click).
- * Used to differentiate manual vs auto refresh loading so the Balance can show
- * loading (shimmer) only on cold start or after user click, not during background sync.
+ * Stores sync-related UI state that must survive component remounts within a session:
+ * - lastUserSyncClickTimestamp: differentiates manual vs auto refresh loading.
+ * - hasCompletedInitialSync: tracks whether the first sync cycle after app start finished.
+ *   Resets on app restart (not persisted to disk).
  */
 export type SyncRefreshState = {
   lastUserSyncClickTimestamp: number;
+  hasCompletedInitialSync: boolean;
 };
 
 const initialState: SyncRefreshState = {
   lastUserSyncClickTimestamp: 0,
+  hasCompletedInitialSync: false,
 };
 
 const syncRefreshSlice = createSlice({
@@ -20,13 +23,20 @@ const syncRefreshSlice = createSlice({
     setLastUserSyncClickTimestamp: (state, action: PayloadAction<number>) => {
       state.lastUserSyncClickTimestamp = action.payload;
     },
+    setHasCompletedInitialSync: (state, action: PayloadAction<boolean>) => {
+      state.hasCompletedInitialSync = action.payload;
+    },
   },
 });
 
-export const { setLastUserSyncClickTimestamp } = syncRefreshSlice.actions;
+export const { setLastUserSyncClickTimestamp, setHasCompletedInitialSync } =
+  syncRefreshSlice.actions;
 
 /** Select last user sync click timestamp from state (0 = never). */
 export const selectLastUserSyncClickTimestamp = (state: { syncRefresh: SyncRefreshState }) =>
   state.syncRefresh.lastUserSyncClickTimestamp;
+
+export const selectHasCompletedInitialSync = (state: { syncRefresh: SyncRefreshState }) =>
+  state.syncRefresh.hasCompletedInitialSync;
 
 export default syncRefreshSlice.reducer;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Balance shimmer/loading behavior during cold start, initial sync, manual refresh click, and auto background sync
      - TopBar activity indicator rotation and error state transitions
      - Balance freeze during loading (no flickering)

### 📝 Description

**Problem**: The previous balance refresh implementation used a fragile 1-second time-window to detect manual refresh clicks. This caused unreliable loading states across the 4 sync scenarios: cold start, initial sync after app launch, manual user click, and automatic background sync. The balance could flicker during loading, and error indicators could flash prematurely before sync completed.

**Solution**:
- Replace the time-window approach with a deterministic `useReducer` state machine (`idle → waitingForSync → syncing → idle`) in `useManualRefreshLoading`
- Add `hasCompletedInitialSync` to Redux to properly track first-sync lifecycle after app start
- Suppress error indicators during loading and initial sync (via `hasEverBeenUpToDate` latch)
- Freeze displayed balance during loading to prevent flickering
- Simplify `usePortfolioBalanceSync` by moving ref mutations from render into `useEffect`
- Remove Playwright-specific spin duration workaround (`PLAYWRIGHT_CLICK_SPIN_DURATION_MS`)
- Delete unused `syncRefreshUtils.ts` and associated constants

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27180](https://ledgerhq.atlassian.net/browse/LIVE-27180)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27180]: https://ledgerhq.atlassian.net/browse/LIVE-27180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ