### PR TITLE
feat(desktop): change default theme to dark

### DIFF
--- a/.changeset/chilly-clouds-camp.md
+++ b/.changeset/chilly-clouds-camp.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+change default theme to dark

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
@@ -95,6 +95,12 @@ describe("lastSeenDeviceSelector", () => {
   });
 });
 
+describe("INITIAL_STATE defaults", () => {
+  it("should default theme to dark", () => {
+    expect(SETTINGS_INITIAL_STATE.theme).toBe("dark");
+  });
+});
+
 describe("action: purgeAnonymousUserNotifications", () => {
   it("should remove notifications older than cutoff but keep newer ones", () => {
     const now = new Date();

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -157,7 +157,7 @@ export const INITIAL_STATE: SettingsState = {
   hasCompletedOnboarding: false,
   counterValue: "USD",
   ...getInitialLanguageAndLocale(),
-  theme: null,
+  theme: "dark",
   region: null,
   orderAccounts: "balance|desc",
   countervalueFirst: false,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Default theme at first launch (new users or fresh install)
      - Users who already have a persisted theme setting are not affected

### 📝 Description

**Problem**: The default theme was set to `null`, which could cause an inconsistent initial experience for new users before the theme is resolved.

**Solution**: Set the default theme to `"dark"` in `INITIAL_STATE` so new users get dark mode out of the box. Added a unit test to protect this default.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27123

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)