### PR TITLE
refactor(desktop): remove background feature flag and rely on mainnav

### DIFF
--- a/.changeset/forty-rivers-train.md
+++ b/.changeset/forty-rivers-train.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+remove custom background feature flag and relay on mainnav

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -275,17 +275,15 @@ export const MainAppLayout = () => {
   } = useWalletFeaturesConfig("desktop");
   const shouldShowDeferredModals = useShouldShowDeferredModals();
 
-  //TODO: Remove this once testing is done
-  const walletFeatureFlag = useFeature("lwdWallet40");
-  const walletParams = walletFeatureFlag?.params;
-  const backgroundEnabled = isWallet40Enabled && Boolean(walletParams?.background);
-  const backgroundImage = backgroundEnabled ? getPageBackground(pathname, theme) : undefined;
+  const backgroundImage = shouldDisplayWallet40MainNav
+    ? getPageBackground(pathname, theme)
+    : undefined;
 
   const useWallet40Layout = isWallet40Enabled && isWallet40Page(pathname);
 
   useEffect(() => {
-    if (backgroundEnabled) preloadBackgrounds();
-  }, [backgroundEnabled]);
+    if (shouldDisplayWallet40MainNav) preloadBackgrounds();
+  }, [shouldDisplayWallet40MainNav]);
 
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
@@ -9,7 +9,6 @@ export const WALLET_FEATURES_PARAMS = [
   { key: "mainNavigation", label: "Main Navigation" },
   { key: "tour", label: "Tour" },
   { key: "newReceiveDialog", label: "New Receive Dialog" },
-  { key: "background", label: "Background" },
   { key: "balanceRefreshRework", label: "Balance Refresh Rework" },
   { key: "assetSection", label: "Asset Section" },
 ] as const;

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -826,7 +826,6 @@ type Feature_Wallet40_Params = {
 
   // Specifics
   newReceiveDialog?: boolean;
-  background?: boolean;
 };
 
 export type Feature_LwmWallet40 = Feature<Feature_Wallet40_Params>;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No tests added — this is a small config/logic simplification with no new behavior._
- [x] **Impact of the changes:**
  - Background image display logic in the main app layout
  - Wallet 4.0 developer settings panel (removed "Background" toggle)

### 📝 Description

The `background` parameter in the `lwdWallet40` feature flag was a temporary toggle used during development. Now that the background feature is stable, it no longer needs its own flag.

This PR removes the dedicated `background` feature flag parameter and ties background image display to `shouldDisplayWallet40MainNav` instead, simplifying the gating logic.

### ❓ Context

- **JIRA or GitHub link**: No ticket

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)