### PR TITLE
test(mobile): add unit tests for market feature hooks, components and utils

### DIFF
--- a/.changeset/thick-ducks-run.md
+++ b/.changeset/thick-ducks-run.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+add unit tests for market feature hooks, components and utils

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__tests__/Navigators.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__tests__/Navigators.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { renderWithReactQuery, screen, waitFor } from "@tests/test-renderer";
+import { server, http, HttpResponse } from "@tests/server";
+import { MOCK_MARKET_PERFORMERS } from "@ledgerhq/live-common/market/utils/fixtures";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { ScreenName } from "~/const";
+import MarketNavigator from "../Navigator";
+import MarketWalletTabNavigator from "../WalletTabNavigator";
+
+const COUNTERVALUES_API = "https://countervalues.live.ledger.com";
+
+const Stack = createNativeStackNavigator<BaseNavigatorStackParamList>();
+
+const NavigatorWrapper = () => (
+  <Stack.Navigator initialRouteName={ScreenName.MarketList}>
+    {MarketNavigator({ Stack })}
+  </Stack.Navigator>
+);
+
+describe("Market Navigators", () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`${COUNTERVALUES_API}/v3/markets`, () => HttpResponse.json(MOCK_MARKET_PERFORMERS)),
+    );
+  });
+
+  describe("MarketNavigator", () => {
+    it("should render MarketList as initial screen", async () => {
+      renderWithReactQuery(<NavigatorWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("market-list")).toBeOnTheScreen();
+      });
+    });
+  });
+
+  describe("MarketWalletTabNavigator", () => {
+    it("should render MarketList as initial screen", async () => {
+      renderWithReactQuery(<MarketWalletTabNavigator />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("market-list")).toBeOnTheScreen();
+      });
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__tests__/helpers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__tests__/helpers.ts
@@ -1,0 +1,19 @@
+import { State } from "~/reducers/types";
+
+type MarketOverrides = Omit<Partial<State["market"]>, "marketParams"> & {
+  marketParams?: Partial<State["market"]["marketParams"]>;
+};
+
+export const withMarketState = (overrides: MarketOverrides = {}) => ({
+  overrideInitialState: (state: State) => ({
+    ...state,
+    market: {
+      ...state.market,
+      ...overrides,
+      marketParams: {
+        ...state.market.marketParams,
+        ...overrides.marketParams,
+      },
+    },
+  }),
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/components/DeltaVariation/__tests__/DeltaVariation.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/components/DeltaVariation/__tests__/DeltaVariation.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import DeltaVariation from "../index";
+
+describe("DeltaVariation", () => {
+  it("should render nothing when value is NaN", () => {
+    const { toJSON } = render(<DeltaVariation value={NaN} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it("should render minus sign when rounded delta is 0", () => {
+    render(<DeltaVariation value={0.001} />);
+    expect(screen.getByText("−")).toBeOnTheScreen();
+  });
+
+  it("should render positive percentage with percent prop", () => {
+    render(<DeltaVariation value={5.25} percent />);
+    expect(screen.getByText("5.25%")).toBeOnTheScreen();
+  });
+
+  it("should render negative percentage with percent prop", () => {
+    render(<DeltaVariation value={-3.14} percent />);
+    expect(screen.getByText("3.14%")).toBeOnTheScreen();
+  });
+
+  it("should render positive absolute value without percent prop", () => {
+    render(<DeltaVariation value={42} />);
+    expect(screen.getByText("+42")).toBeOnTheScreen();
+  });
+
+  it("should render negative absolute value without percent prop", () => {
+    render(<DeltaVariation value={-7.5} />);
+    expect(screen.getByText("-7.5")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/components/MarketListHeader/__tests__/MarketListHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/components/MarketListHeader/__tests__/MarketListHeader.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { MarketListHeaderLeft, MarketListHeaderTitle } from "../index";
+import { State } from "~/reducers/types";
+
+const withMarketBanner = (enabled: boolean) => ({
+  overrideInitialState: (state: State) => ({
+    ...state,
+    settings: {
+      ...state.settings,
+      overriddenFeatureFlags: {
+        lwmWallet40: { enabled: true, params: { marketBanner: enabled } },
+      },
+    },
+  }),
+});
+
+const components = [
+  {
+    name: "MarketListHeaderLeft",
+    Component: MarketListHeaderLeft,
+    testID: "market-list-header-left",
+  },
+  {
+    name: "MarketListHeaderTitle",
+    Component: MarketListHeaderTitle,
+    testID: "market-list-header-title",
+  },
+];
+
+describe.each(components)("$name", ({ Component, testID }) => {
+  it("should render null when marketBanner flag is disabled", () => {
+    render(<Component />, withMarketBanner(false));
+    expect(screen.queryByTestId(testID)).toBeNull();
+  });
+
+  it("should render when marketBanner flag is enabled", () => {
+    render(<Component />, withMarketBanner(true));
+    expect(screen.getByTestId(testID)).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/components/MarketListHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/components/MarketListHeader/index.tsx
@@ -20,5 +20,5 @@ export function MarketListHeaderTitle() {
     return null;
   }
 
-  return <HeaderTitle titleKey="market.title" />;
+  return <HeaderTitle testID="market-list-header-title" titleKey="market.title" />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/components/MarketRowItem/__tests__/MarketRowItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/components/MarketRowItem/__tests__/MarketRowItem.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import MarketRowItem from "../index";
+import { MOCK_MARKET_CURRENCY_DATA } from "@ledgerhq/live-common/market/utils/fixtures";
+
+const bitcoinItem = MOCK_MARKET_CURRENCY_DATA[0];
+
+describe("MarketRowItem", () => {
+  it("should render item details", () => {
+    render(<MarketRowItem item={bitcoinItem} index={0} counterCurrency="usd" range="24h" />);
+    expect(screen.getByText("Bitcoin (BTC)")).toBeOnTheScreen();
+    expect(screen.getByText("1")).toBeOnTheScreen();
+    expect(screen.getByText("2.50%")).toBeOnTheScreen();
+  });
+
+  it("should render fallback image when no ledgerIds", () => {
+    const item = { ...bitcoinItem, ledgerIds: [] };
+    render(<MarketRowItem item={item} index={0} counterCurrency="usd" range="24h" />);
+    expect(screen.getByLabelText("currency logo")).toBeOnTheScreen();
+  });
+
+  it("should not render fallback image when ledgerIds and ticker are available", () => {
+    render(<MarketRowItem item={bitcoinItem} index={0} counterCurrency="usd" range="24h" />);
+    expect(screen.queryByLabelText("currency logo")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/useMarket.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/useMarket.test.ts
@@ -1,0 +1,60 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { useMarket } from "../useMarket";
+import { State } from "~/reducers/types";
+import { Order } from "@ledgerhq/live-common/market/utils/types";
+import { withMarketState } from "../../__tests__/helpers";
+
+describe("useMarket", () => {
+  it("should return default market params from Redux state", () => {
+    const { result } = renderHook(() => useMarket());
+
+    expect(result.current.marketParams).toBeDefined();
+    expect(result.current.marketParams.counterCurrency).toBeDefined();
+    expect(result.current.marketCurrentPage).toBeDefined();
+  });
+
+  it("should return starredMarketCoins from settings", () => {
+    const { result } = renderHook(() => useMarket(), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          starredMarketCoins: ["bitcoin", "ethereum"],
+        },
+      }),
+    });
+
+    expect(result.current.starredMarketCoins).toEqual(["bitcoin", "ethereum"]);
+  });
+
+  it("should return filterByStarredCurrencies from market state", () => {
+    const { result } = renderHook(
+      () => useMarket(),
+      withMarketState({ marketFilterByStarredCurrencies: true }),
+    );
+
+    expect(result.current.filterByStarredCurrencies).toBe(true);
+  });
+
+  it("should dispatch setMarketRequestParams when updateMarketParams is called", () => {
+    const { result, store } = renderHook(() => useMarket());
+
+    act(() => {
+      result.current.updateMarketParams({ range: "7d", order: Order.MarketCapAsc });
+    });
+
+    expect(store.getState().market.marketParams.range).toBe("7d");
+    expect(store.getState().market.marketParams.order).toBe(Order.MarketCapAsc);
+  });
+
+  it("should dispatch empty object when updateMarketParams is called without args", () => {
+    const { result, store } = renderHook(() => useMarket());
+    const prevParams = { ...store.getState().market.marketParams };
+
+    act(() => {
+      result.current.updateMarketParams();
+    });
+
+    expect(store.getState().market.marketParams.range).toBe(prevParams.range);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/useMarketCoinData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/useMarketCoinData.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from "@tests/test-renderer";
+import { useMarketCoinData, useMarketCoinDataWithChart } from "../useMarketCoinData";
+import { withMarketState } from "../../__tests__/helpers";
+
+describe("useMarketCoinData hooks", () => {
+  it.each([
+    { counterCurrency: "eur", expected: "eur" },
+    { counterCurrency: undefined, expected: "usd" },
+  ])(
+    "useMarketCoinData should return counterCurrency=$expected when Redux value is $counterCurrency",
+    ({ counterCurrency, expected }) => {
+      const { result } = renderHook(
+        () => useMarketCoinData({ currencyId: "bitcoin" }),
+        withMarketState({ marketParams: { counterCurrency } }),
+      );
+
+      expect(result.current.counterCurrency).toBe(expected);
+    },
+  );
+
+  it.each([
+    { range: "7d" as const, expected: "7d" },
+    { range: undefined, expected: "24h" },
+  ])(
+    "useMarketCoinDataWithChart should return range=$expected when Redux value is $range",
+    ({ range, expected }) => {
+      const { result } = renderHook(
+        () => useMarketCoinDataWithChart({ currencyId: "bitcoin" }),
+        withMarketState({ marketParams: { range } }),
+      );
+
+      expect(result.current.range).toBe(expected);
+    },
+  );
+
+  it("useMarketCoinData should expose loading state and refetch", async () => {
+    const { result } = renderHook(() => useMarketCoinData({ currencyId: "bitcoin" }));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.refetch).toBeInstanceOf(Function);
+  });
+
+  it("useMarketCoinDataWithChart should expose marketParams and counterCurrency from Redux", () => {
+    const { result } = renderHook(
+      () => useMarketCoinDataWithChart({ currencyId: "bitcoin" }),
+      withMarketState({ marketParams: { counterCurrency: "eur" } }),
+    );
+
+    expect(result.current.counterCurrency).toBe("eur");
+    expect(result.current.marketParams).toEqual(
+      expect.objectContaining({ counterCurrency: "eur" }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/usePullToRefresh.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/hooks/__tests__/usePullToRefresh.test.ts
@@ -1,0 +1,83 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { track } from "~/analytics";
+import usePullToRefresh from "../usePullToRefresh";
+
+const mockedTrack = jest.mocked(track);
+
+describe("usePullToRefresh", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should initialise with refreshControlVisible as false", () => {
+    const refetch = jest.fn();
+    const { result } = renderHook(() => usePullToRefresh({ loading: false, refetch }));
+
+    expect(result.current.refreshControlVisible).toBe(false);
+  });
+
+  it("should call refetch and set refreshControlVisible to true on pull", () => {
+    const refetch = jest.fn();
+    const { result } = renderHook(() => usePullToRefresh({ loading: false, refetch }));
+
+    act(() => {
+      result.current.handlePullToRefresh();
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(result.current.refreshControlVisible).toBe(true);
+  });
+
+  it("should track button_clicked analytics event on pull", () => {
+    const refetch = jest.fn();
+    const { result } = renderHook(() => usePullToRefresh({ loading: false, refetch }));
+
+    act(() => {
+      result.current.handlePullToRefresh();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", { button: "pull to refresh" });
+  });
+
+  it("should reset refreshControlVisible when loading cycle completes", () => {
+    let loading = false;
+    const refetch = jest.fn();
+    const { result, rerender } = renderHook(() => usePullToRefresh({ loading, refetch }));
+
+    act(() => {
+      result.current.handlePullToRefresh();
+    });
+
+    expect(result.current.refreshControlVisible).toBe(true);
+
+    loading = true;
+    rerender({});
+
+    loading = false;
+    rerender({});
+
+    expect(result.current.refreshControlVisible).toBe(false);
+  });
+
+  it("should reset refreshControlVisible via timeout fallback when loading never starts", () => {
+    const refetch = jest.fn();
+    const { result } = renderHook(() => usePullToRefresh({ loading: false, refetch }));
+
+    act(() => {
+      result.current.handlePullToRefresh();
+    });
+
+    expect(result.current.refreshControlVisible).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(result.current.refreshControlVisible).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/components/BottomSection/__tests__/useBottomSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/components/BottomSection/__tests__/useBottomSectionViewModel.test.ts
@@ -1,0 +1,104 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { track } from "~/analytics";
+import { Order } from "@ledgerhq/live-common/market/utils/types";
+import useBottomSectionViewModel from "../useBottomSectionViewModel";
+import { withMarketState } from "LLM/features/Market/__tests__/helpers";
+
+const mockedTrack = jest.mocked(track);
+
+describe("useBottomSectionViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return range, order and counterCurrency from Redux market state", () => {
+    const { result } = renderHook(
+      () => useBottomSectionViewModel(),
+      withMarketState({
+        marketParams: {
+          range: "7d",
+          order: Order.MarketCapAsc,
+          counterCurrency: "eur",
+        },
+      }),
+    );
+
+    expect(result.current.range).toBe("7d");
+    expect(result.current.order).toBe(Order.MarketCapAsc);
+    expect(result.current.counterCurrency).toBe("eur");
+  });
+
+  it("should toggle filterByStarredCurrencies and reset page", () => {
+    const { result, store } = renderHook(
+      () => useBottomSectionViewModel(),
+      withMarketState({ marketFilterByStarredCurrencies: false }),
+    );
+
+    expect(result.current.filterByStarredCurrencies).toBe(false);
+
+    act(() => {
+      result.current.toggleFilterByStarredCurrencies();
+    });
+
+    expect(store.getState().market.marketFilterByStarredCurrencies).toBe(true);
+    expect(store.getState().market.marketCurrentPage).toBe(1);
+    expect(store.getState().market.marketParams.page).toBe(1);
+  });
+
+  it("should track analytics when enabling starred filter", () => {
+    const { result } = renderHook(
+      () => useBottomSectionViewModel(),
+      withMarketState({ marketFilterByStarredCurrencies: false }),
+    );
+
+    act(() => {
+      result.current.toggleFilterByStarredCurrencies();
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith(
+      "Page Market Favourites",
+      expect.objectContaining({ access: false }),
+    );
+  });
+
+  it("should not track analytics when disabling starred filter", () => {
+    const { result } = renderHook(
+      () => useBottomSectionViewModel(),
+      withMarketState({ marketFilterByStarredCurrencies: true }),
+    );
+
+    act(() => {
+      result.current.toggleFilterByStarredCurrencies();
+    });
+
+    expect(mockedTrack).not.toHaveBeenCalled();
+  });
+
+  it("should dispatch new params and reset page on onFilterChange", () => {
+    const { result, store } = renderHook(() => useBottomSectionViewModel(), withMarketState());
+
+    act(() => {
+      result.current.onFilterChange({ range: "30d" });
+    });
+
+    expect(store.getState().market.marketParams.range).toBe("30d");
+    expect(store.getState().market.marketCurrentPage).toBe(1);
+    expect(store.getState().market.marketParams.page).toBe(1);
+  });
+
+  it("should track analytics with merged params on onFilterChange", () => {
+    const { result } = renderHook(() => useBottomSectionViewModel(), withMarketState());
+
+    act(() => {
+      result.current.onFilterChange({ range: "7d" });
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith(
+      "Page Market",
+      expect.objectContaining({
+        access: false,
+        "%change": "7d",
+      }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.test.ts
@@ -1,6 +1,13 @@
 import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
-import { counterValueFormatter } from ".";
+import {
+  counterValueFormatter,
+  getDateFormatter,
+  getAnalyticsProperties,
+  isDataStale,
+  getCurrentPage,
+} from ".";
+import { Order } from "@ledgerhq/live-common/market/utils/types";
 import en from "~/locales/en/common.json";
 
 beforeAll(async () => {
@@ -233,5 +240,151 @@ describe("counterValueFormatter", () => {
       });
       expect(result).toBeDefined();
     });
+  });
+});
+
+describe("getDateFormatter", () => {
+  it("should return a DateTimeFormat for 24h interval", () => {
+    const formatter = getDateFormatter("en-US", "24h");
+    expect(formatter).toBeInstanceOf(Intl.DateTimeFormat);
+    const parts = formatter.formatToParts(new Date(2024, 0, 15, 14, 30));
+    const partTypes = parts.map(p => p.type);
+    expect(partTypes).toContain("hour");
+    expect(partTypes).toContain("minute");
+  });
+
+  it("should return a DateTimeFormat for 7d interval", () => {
+    const formatter = getDateFormatter("en-US", "7d");
+    const parts = formatter.formatToParts(new Date(2024, 0, 15, 14, 30));
+    const partTypes = parts.map(p => p.type);
+    expect(partTypes).toContain("year");
+    expect(partTypes).toContain("month");
+    expect(partTypes).toContain("day");
+    expect(partTypes).toContain("hour");
+  });
+
+  it("should return a DateTimeFormat for 30d interval", () => {
+    const formatter = getDateFormatter("en-US", "30d");
+    const parts = formatter.formatToParts(new Date(2024, 0, 15));
+    const partTypes = parts.map(p => p.type);
+    expect(partTypes).toContain("month");
+    expect(partTypes).toContain("day");
+  });
+
+  it("should fall back to default formatter for unknown intervals", () => {
+    const formatter = getDateFormatter("en-US", "unknown");
+    const defaultFormatter = getDateFormatter("en-US", "default");
+    expect(formatter).toBe(defaultFormatter);
+  });
+
+  it("should cache formatters per locale", () => {
+    const first = getDateFormatter("en-US", "24h");
+    const second = getDateFormatter("en-US", "24h");
+    expect(first).toBe(second);
+  });
+
+  it("should create separate formatters for different locales", () => {
+    const usFormatter = getDateFormatter("en-US", "24h");
+    const frFormatter = getDateFormatter("fr-FR", "24h");
+    expect(usFormatter).not.toBe(frFormatter);
+  });
+});
+
+describe("getAnalyticsProperties", () => {
+  it("should return correct shape with order and range", () => {
+    const result = getAnalyticsProperties({
+      order: Order.MarketCapDesc,
+      range: "24h",
+      counterCurrency: "usd",
+      liveCompatible: false,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        access: false,
+        sort: expect.any(String),
+        "%change": "24h",
+        countervalue: "usd",
+        view: "All coins",
+      }),
+    );
+  });
+
+  it("should set view to 'Only Live Supported' when liveCompatible is true", () => {
+    const result = getAnalyticsProperties({
+      order: Order.MarketCapDesc,
+      range: "24h",
+      counterCurrency: "usd",
+      liveCompatible: true,
+    });
+
+    expect(result.view).toBe("Only Live Supported");
+  });
+
+  it("should not include sort when order is missing", () => {
+    const result = getAnalyticsProperties({
+      range: "24h",
+      counterCurrency: "usd",
+    });
+
+    expect(result).not.toHaveProperty("sort");
+  });
+
+  it("should not include sort when range is missing", () => {
+    const result = getAnalyticsProperties({
+      order: Order.MarketCapDesc,
+      counterCurrency: "usd",
+    });
+
+    expect(result).not.toHaveProperty("sort");
+  });
+
+  it("should merge otherProperties into the result", () => {
+    const result = getAnalyticsProperties(
+      { order: Order.MarketCapDesc, range: "24h", counterCurrency: "usd" },
+      { currencies: ["bitcoin", "ethereum"] },
+    );
+
+    expect(result).toHaveProperty("currencies", ["bitcoin", "ethereum"]);
+  });
+});
+
+describe("isDataStale", () => {
+  it("should return true when elapsed time exceeds refreshRate", () => {
+    const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
+    const threeMinuteRate = 3 * 60 * 1000;
+    expect(isDataStale(fiveMinutesAgo, threeMinuteRate)).toBe(true);
+  });
+
+  it("should return false when elapsed time is within refreshRate", () => {
+    const oneMinuteAgo = Date.now() - 1 * 60 * 1000;
+    const threeMinuteRate = 3 * 60 * 1000;
+    expect(isDataStale(oneMinuteAgo, threeMinuteRate)).toBe(false);
+  });
+
+  it("should return false when lastUpdate is now", () => {
+    expect(isDataStale(Date.now(), 60000)).toBe(false);
+  });
+});
+
+describe("getCurrentPage", () => {
+  it("should return page 1 for index 0", () => {
+    expect(getCurrentPage(0, 50)).toBe(1);
+  });
+
+  it("should return page 1 for index 49 with pageSize 50", () => {
+    expect(getCurrentPage(49, 50)).toBe(1);
+  });
+
+  it("should return page 2 for index 50 with pageSize 50", () => {
+    expect(getCurrentPage(50, 50)).toBe(2);
+  });
+
+  it("should return page 3 for index 100 with pageSize 50", () => {
+    expect(getCurrentPage(100, 50)).toBe(3);
+  });
+
+  it("should handle pageSize of 10", () => {
+    expect(getCurrentPage(25, 10)).toBe(3);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/marketIdResolver.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/marketIdResolver.test.ts
@@ -1,0 +1,30 @@
+import { resolveMarketId, tokenToMarketIdMap } from "./marketIdResolver";
+
+describe("resolveMarketId", () => {
+  it("should resolve known ERC20 USDT token to tether", () => {
+    expect(resolveMarketId("ethereum/erc20/usd_tether__erc20_")).toBe("tether");
+  });
+
+  it("should resolve known ERC20 USDC token to usd-coin", () => {
+    expect(resolveMarketId("ethereum/erc20/usd__coin")).toBe("usd-coin");
+  });
+
+  it("should return the original id for unknown tokens", () => {
+    expect(resolveMarketId("bitcoin")).toBe("bitcoin");
+  });
+
+  it("should return the original id for unmapped token paths", () => {
+    expect(resolveMarketId("ethereum/erc20/some_unknown_token")).toBe(
+      "ethereum/erc20/some_unknown_token",
+    );
+  });
+});
+
+describe("tokenToMarketIdMap", () => {
+  it("should contain the expected entries", () => {
+    expect(tokenToMarketIdMap).toEqual({
+      "ethereum/erc20/usd_tether__erc20_": "tether",
+      "ethereum/erc20/usd__coin": "usd-coin",
+    });
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Market feature test coverage for hooks (`useMarket`, `useMarketCoinData`, `usePullToRefresh`)
      - Market feature test coverage for components (`DeltaVariation`, `MarketListHeader`, `MarketRowItem`)
      - Market feature test coverage for utils (`counterValueFormatter`, `getDateFormatter`, `getAnalyticsProperties`, `isDataStale`, `getCurrentPage`, `marketIdResolver`)
      - Market feature test coverage for view models (`useBottomSectionViewModel`)
      - Market feature test coverage for navigators (`MarketNavigator`, `MarketWalletTabNavigator`)

### 📝 Description

This PR adds comprehensive unit tests for the Market feature in Ledger Live Mobile, covering hooks, components, utils, view models, and navigators.

A shared test helper (`withMarketState`) has been extracted to `Market/__tests__/helpers.ts` to avoid duplicating Redux state override boilerplate across test files.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27066](https://ledgerhq.atlassian.net/browse/LIVE-27066)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27066]: https://ledgerhq.atlassian.net/browse/LIVE-27066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ