### PR TITLE
Fix/live 27100 change currency

### DIFF
--- a/.changeset/nervous-crabs-lick.md
+++ b/.changeset/nervous-crabs-lick.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(lwd): skeleton while balance unavailable

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -327,10 +327,11 @@ describe("PortfolioView", () => {
       expect(screen.getByTestId("portfolio-balance")).toBeVisible();
     });
 
-    it("should display loading state when balance is not yet available", () => {
+    it("should display placeholder when balance is not yet available", () => {
       mockUsePortfolioThrottled.mockReturnValue({
         ...defaultPortfolioMock,
         balanceAvailable: false,
+        balanceHistory: [],
       });
 
       render(<PortfolioView {...defaultProps} shouldDisplayGraphRework={true} />, {
@@ -352,6 +353,7 @@ describe("PortfolioView", () => {
       });
 
       expect(screen.getByTestId("portfolio-balance")).toBeVisible();
+      expect(screen.getByTestId("portfolio-placeholder-balance")).toBeVisible();
       expect(screen.queryByTestId("portfolio-trend")).toBeNull();
     });
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/BalanceView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/BalanceView.tsx
@@ -1,13 +1,17 @@
 import React from "react";
-import { AmountDisplay } from "@ledgerhq/lumen-ui-react";
+import { AmountDisplay, Skeleton } from "@ledgerhq/lumen-ui-react";
 import { useSelector } from "LLD/hooks/redux";
 import { cn } from "LLD/utils/cn";
 import { themeSelector } from "~/renderer/actions/general";
 import { BalanceViewProps } from "./types";
 import { Trend } from "../Trend";
 
+const showPlaceholder = (balance: number, balanceAvailable: boolean) =>
+  balance === 0 && !balanceAvailable;
+
 export const BalanceView = ({
   balance,
+  balanceAvailable,
   formatter,
   discreet,
   valueChange,
@@ -38,14 +42,18 @@ export const BalanceView = ({
           theme === "dark" && "group-hover:brightness-85",
         )}
       >
-        <AmountDisplay
-          value={balance}
-          formatter={formatter}
-          hidden={discreet}
-          animate={shouldDisplayBalanceRefreshRework}
-          loading={shouldDisplayBalanceRefreshRework && isLoading}
-          data-testid="portfolio-total-balance"
-        />
+        {showPlaceholder(balance, balanceAvailable) ? (
+          <Skeleton data-testid="portfolio-placeholder-balance" className="h-48 w-256 rounded-md" />
+        ) : (
+          <AmountDisplay
+            value={balance}
+            formatter={formatter}
+            hidden={discreet}
+            animate={shouldDisplayBalanceRefreshRework}
+            loading={shouldDisplayBalanceRefreshRework && isLoading}
+            data-testid="portfolio-total-balance"
+          />
+        )}
         {!isColdStart && <Trend valueChange={valueChange} />}
       </span>
     </button>

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
@@ -3,6 +3,7 @@ import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
 
 export interface BalanceViewProps {
   readonly balance: number;
+  readonly balanceAvailable: boolean;
   readonly formatter: (value: number) => FormattedValue;
   readonly discreet: boolean;
   readonly valueChange: ValueChange;

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
@@ -73,6 +73,7 @@ describe("useBalanceViewModel", () => {
     const { result } = renderHook(() => useBalanceViewModel(), { initialState });
 
     expect(result.current.balance).toBe(1500);
+    expect(result.current.balanceAvailable).toBe(true);
     expect(result.current.formatter).toBeDefined();
     expect(result.current.formatter(result.current.balance).integerPart).toContain("15");
     expect(result.current.valueChange).toEqual(mockPortfolio.countervalueChange);

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -31,9 +31,10 @@ export const useBalanceViewModel = (
   const discreet = useSelector(discreetModeSelector);
   const hasOnboardedDevice = useSelector(hasOnboardedDeviceSelector);
   const { hasAccount } = useAccountStatus();
-  const { portfolio, counterValue, isBalanceLoading, isColdStart } = usePortfolioBalanceSync({
-    legacyRange,
-  });
+  const { portfolio, counterValue, isBalanceLoading, isColdStart, balanceAvailable } =
+    usePortfolioBalanceSync({
+      legacyRange,
+    });
 
   const latestBalanceValue =
     portfolio.balanceHistory[portfolio.balanceHistory.length - 1]?.value ?? 0;
@@ -81,6 +82,7 @@ export const useBalanceViewModel = (
 
   return {
     balance: displayedBalance,
+    balanceAvailable,
     formatter,
     discreet,
     valueChange,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a placeholder skeleton UI for the portfolio balance when the balance is zero and not available, improving the user experience during loading or unavailable states. It also updates the related tests and type definitions to support this new feature.

https://github.com/user-attachments/assets/05377cc5-d980-4607-bf57-b7429fd7b288


### ❓ Context

[LIVE-27100](https://ledgerhq.atlassian.net/browse/LIVE-27100)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27100]: https://ledgerhq.atlassian.net/browse/LIVE-27100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ