### PR TITLE
fix(desktop): mark wallet v4 tour as seen at onboarding start

### DIFF
--- a/.changeset/four-masks-tease.md
+++ b/.changeset/four-masks-tease.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix(desktop): mark wallet v4 tour as seen at onboarding start

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletV4Tour/hooks/useMarkWalletV4TourSeenAtOnboardingStart.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletV4Tour/hooks/useMarkWalletV4TourSeenAtOnboardingStart.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useDispatch } from "LLD/hooks/redux";
+import { setHasSeenWalletV4Tour } from "~/renderer/actions/settings";
+
+/**
+ * Call on the first screen of the onboarding flow (Welcome).
+ * Marks the Wallet V4 tour as "seen" so the tour dialog does not open after onboarding.
+ */
+export function useMarkWalletV4TourSeenAtOnboardingStart(): void {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(setHasSeenWalletV4Tour(true));
+  }, [dispatch]);
+}

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Welcome/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Welcome/index.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { WelcomeNew as WelcomeNewMVVM } from "LLD/features/Onboarding/screens/WelcomeNew";
+import { useMarkWalletV4TourSeenAtOnboardingStart } from "LLD/features/WalletV4Tour/hooks/useMarkWalletV4TourSeenAtOnboardingStart";
 import { WelcomeOld } from "./WelcomeOld";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 export function Welcome() {
   const welcomeScreenVideoCarouselFeature = useFeature("welcomeScreenVideoCarousel");
+  useMarkWalletV4TourSeenAtOnboardingStart();
 
   return welcomeScreenVideoCarouselFeature?.enabled ? <WelcomeNewMVVM /> : <WelcomeOld />;
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
  - No new automated test added for this small hook wiring change.
- [x] **Impact of the changes:**
  - Users who enter onboarding on desktop will now have `hasSeenWalletV4Tour` set at onboarding start, so the Wallet V4 Tour dialog does not auto-open after onboarding.
  - Applies to both `WelcomeNew` and `WelcomeOld` onboarding variants.
  - Includes the lazy onboarding path (user reaches dashboard first, then onboards a device later).

### 📝 Description

This fixes a desktop parity gap with mobile for Wallet V4 Tour behavior.

A new desktop hook (`useMarkWalletV4TourSeenAtOnboardingStart`) now dispatches `setHasSeenWalletV4Tour(true)` on onboarding welcome mount, and the hook is called from the shared onboarding `Welcome` entry component. This ensures users who go through onboarding are not shown the Wallet V4 Tour afterward.

A changeset is included for `ledger-live-desktop`.

### ❓ Context

- **JIRA or GitHub link**: LIVE-27171

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)