### PR TITLE
feat(desktop): add horizontal scroll arrows to market banner trending assets

### DIFF
--- a/.changeset/lucky-terms-doubt.md
+++ b/.changeset/lucky-terms-doubt.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+add horizontal scroll arrows to market banner trending assets list

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__integrations__/MarketBanner.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__integrations__/MarketBanner.integration.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { render, screen, waitFor, act } from "tests/testSetup";
+import { useNavigate } from "react-router";
+import MarketBanner from "../index";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(() => mockNavigate),
+}));
+
+const mockedUseNavigate = jest.mocked(useNavigate);
+
+function simulateScrollLayout(
+  container: Element,
+  scrollLeft: number,
+  clientWidth: number,
+  scrollWidth: number,
+) {
+  Object.defineProperty(container, "scrollLeft", {
+    value: scrollLeft,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(container, "clientWidth", {
+    value: clientWidth,
+    configurable: true,
+  });
+  Object.defineProperty(container, "scrollWidth", {
+    value: scrollWidth,
+    configurable: true,
+  });
+  container.dispatchEvent(new Event("scroll"));
+}
+
+describe("MarketBanner integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseNavigate.mockReturnValue(mockNavigate);
+  });
+
+  it("should render loading skeleton then display trending assets", async () => {
+    render(<MarketBanner />, { withRampCatalog: true });
+
+    expect(screen.getByTestId("skeleton-list")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("trending-assets-list")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("skeleton-list")).not.toBeInTheDocument();
+    expect(screen.getByText("BTC")).toBeInTheDocument();
+  });
+
+  it("should show and hide scroll arrows based on scroll position", async () => {
+    render(<MarketBanner />, { withRampCatalog: true });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("trending-assets-list")).toBeInTheDocument();
+    });
+
+    const scrollContainer = screen.getByTestId("scroll-container");
+
+    await act(async () => simulateScrollLayout(scrollContainer, 0, 500, 1000));
+    expect(screen.queryByTestId("scroll-arrow-left")).not.toBeInTheDocument();
+    expect(screen.getByTestId("scroll-arrow-right")).toBeInTheDocument();
+
+    await act(async () => simulateScrollLayout(scrollContainer, 200, 500, 1000));
+    expect(screen.getByTestId("scroll-arrow-left")).toBeInTheDocument();
+    expect(screen.getByTestId("scroll-arrow-right")).toBeInTheDocument();
+
+    await act(async () => simulateScrollLayout(scrollContainer, 500, 500, 1000));
+    expect(screen.getByTestId("scroll-arrow-left")).toBeInTheDocument();
+    expect(screen.queryByTestId("scroll-arrow-right")).not.toBeInTheDocument();
+  });
+
+  it("should navigate to market page when header is clicked", async () => {
+    const { user } = render(<MarketBanner />, { withRampCatalog: true });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("market-banner-button")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("market-banner-button"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/market");
+  });
+
+  it("should navigate to asset detail when an asset tile is clicked", async () => {
+    const { user } = render(<MarketBanner />, { withRampCatalog: true });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("market-banner-asset-bitcoin")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("market-banner-asset-bitcoin"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/market/bitcoin");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/ScrollArrowButton.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/ScrollArrowButton.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { ScrollArrowButton } from "../components/ScrollArrowButton";
+
+describe("ScrollArrowButton", () => {
+  it("should render a left scroll arrow", () => {
+    render(<ScrollArrowButton direction="left" onClick={jest.fn()} />);
+
+    expect(screen.getByLabelText("Scroll left")).toBeVisible();
+    expect(screen.getByTestId("scroll-arrow-left")).toBeVisible();
+  });
+
+  it("should render a right scroll arrow", () => {
+    render(<ScrollArrowButton direction="right" onClick={jest.fn()} />);
+
+    expect(screen.getByLabelText("Scroll right")).toBeVisible();
+    expect(screen.getByTestId("scroll-arrow-right")).toBeVisible();
+  });
+
+  it("should trigger the callback on click", async () => {
+    const onClick = jest.fn();
+    const { user } = render(<ScrollArrowButton direction="right" onClick={onClick} />);
+
+    await user.click(screen.getByLabelText("Scroll right"));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetsList.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetsList.test.tsx
@@ -3,35 +3,78 @@ import { render, screen } from "tests/testSetup";
 import { TrendingAssetsList } from "../components/TrendingAssetsList";
 import { useNavigate } from "react-router";
 import { MOCK_MARKET_PERFORMERS } from "@ledgerhq/live-common/market/utils/fixtures";
+import { useHorizontalScroll } from "../hooks/useHorizontalScroll";
 
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
   useNavigate: jest.fn(),
 }));
 
+jest.mock("../hooks/useHorizontalScroll");
+
 const mockNavigate = jest.fn();
 (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+
+const mockScrollLeft = jest.fn();
+const mockScrollRight = jest.fn();
+const mockUseHorizontalScroll = useHorizontalScroll as jest.Mock;
+
+const defaultScrollState = {
+  scrollContainerRef: { current: null },
+  isAtStart: true,
+  isAtEnd: false,
+  scrollLeft: mockScrollLeft,
+  scrollRight: mockScrollRight,
+};
 
 describe("TrendingAssetsList", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseHorizontalScroll.mockReturnValue(defaultScrollState);
   });
 
-  it("should render the list with all assets", () => {
-    render(<TrendingAssetsList items={MOCK_MARKET_PERFORMERS} />);
+  it("should render assets, hide left arrow, show right arrow and handle scroll right at start position", async () => {
+    const { user } = render(<TrendingAssetsList items={MOCK_MARKET_PERFORMERS} />);
 
     expect(screen.getByTestId("trending-assets-list")).toBeVisible();
     expect(screen.getByText("BTC")).toBeVisible();
     expect(screen.getByText("ETH")).toBeVisible();
+    expect(screen.queryByTestId("scroll-arrow-left")).not.toBeInTheDocument();
+    expect(screen.getByTestId("scroll-arrow-right")).toBeVisible();
+
+    await user.click(screen.getByLabelText("Scroll right"));
+    expect(mockScrollRight).toHaveBeenCalledTimes(1);
   });
 
   it("should navigate to asset detail page when asset is clicked", async () => {
     const { user } = render(<TrendingAssetsList items={MOCK_MARKET_PERFORMERS} />);
 
-    const bitcoinTile = screen.getByText("BTC").closest("div[role='button']");
-    if (bitcoinTile) {
-      await user.click(bitcoinTile);
-      expect(mockNavigate).toHaveBeenCalledWith(`/market/bitcoin`);
-    }
+    await user.click(screen.getByTestId("market-banner-asset-bitcoin"));
+    expect(mockNavigate).toHaveBeenCalledWith("/market/bitcoin");
+  });
+
+  it("should show left arrow and handle scroll left when not at start", async () => {
+    mockUseHorizontalScroll.mockReturnValue({
+      ...defaultScrollState,
+      isAtStart: false,
+    });
+
+    const { user } = render(<TrendingAssetsList items={MOCK_MARKET_PERFORMERS} />);
+
+    expect(screen.getByTestId("scroll-arrow-left")).toBeVisible();
+
+    await user.click(screen.getByLabelText("Scroll left"));
+    expect(mockScrollLeft).toHaveBeenCalledTimes(1);
+  });
+
+  it("should hide right arrow when at end of list", () => {
+    mockUseHorizontalScroll.mockReturnValue({
+      ...defaultScrollState,
+      isAtEnd: true,
+    });
+
+    render(<TrendingAssetsList items={MOCK_MARKET_PERFORMERS} />);
+
+    expect(screen.queryByTestId("scroll-arrow-right")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useHorizontalScroll.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/useHorizontalScroll.test.ts
@@ -1,0 +1,50 @@
+import { renderHook, act } from "tests/testSetup";
+import { useHorizontalScroll } from "../hooks/useHorizontalScroll";
+
+describe("useHorizontalScroll", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return isAtStart true and isAtEnd false by default", () => {
+    const { result } = renderHook(() => useHorizontalScroll());
+
+    expect(result.current.isAtStart).toBe(true);
+    expect(result.current.isAtEnd).toBe(false);
+  });
+
+  it("should expose a scrollContainerRef", () => {
+    const { result } = renderHook(() => useHorizontalScroll());
+
+    expect(result.current.scrollContainerRef).toBeDefined();
+    expect(result.current.scrollContainerRef.current).toBeNull();
+  });
+
+  it("should call scrollBy with negative offset when scrollLeft is called", () => {
+    const mockScrollBy = jest.fn();
+    const { result } = renderHook(() => useHorizontalScroll());
+
+    Object.defineProperty(result.current.scrollContainerRef, "current", {
+      value: { scrollBy: mockScrollBy },
+      writable: true,
+    });
+
+    act(() => result.current.scrollLeft());
+
+    expect(mockScrollBy).toHaveBeenCalledWith({ left: -300, behavior: "smooth" });
+  });
+
+  it("should call scrollBy with positive offset when scrollRight is called", () => {
+    const mockScrollBy = jest.fn();
+    const { result } = renderHook(() => useHorizontalScroll());
+
+    Object.defineProperty(result.current.scrollContainerRef, "current", {
+      value: { scrollBy: mockScrollBy },
+      writable: true,
+    });
+
+    act(() => result.current.scrollRight());
+
+    expect(mockScrollBy).toHaveBeenCalledWith({ left: 300, behavior: "smooth" });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/ScrollArrowButton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/ScrollArrowButton.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { IconButton } from "@ledgerhq/lumen-ui-react";
+import { ChevronLeft, ChevronRight } from "@ledgerhq/lumen-ui-react/symbols";
+import { cn } from "LLD/utils/cn";
+
+type ScrollArrowButtonProps = {
+  readonly direction: "left" | "right";
+  readonly onClick: () => void;
+};
+
+const config = {
+  left: {
+    icon: ChevronLeft,
+    translationKey: "marketBanner.scrollLeft",
+    className: "left-0 pl-8",
+    gradientClassName: "left-0 bg-gradient-to-r from-gradient-70 via-gradient-0",
+  },
+  right: {
+    icon: ChevronRight,
+    translationKey: "marketBanner.scrollRight",
+    className: "right-0 pr-8",
+    gradientClassName: "right-0 bg-gradient-to-l from-gradient-70 via-gradient-0",
+  },
+} as const;
+
+export const ScrollArrowButton = ({ direction, onClick }: ScrollArrowButtonProps) => {
+  const { t } = useTranslation();
+  const { icon, translationKey, className, gradientClassName } = config[direction];
+
+  return (
+    <div
+      className={cn("absolute inset-y-0 z-10 flex items-center", className)}
+      data-testid={`scroll-arrow-${direction}`}
+    >
+      <div className={cn("pointer-events-none absolute inset-y-0 w-48", gradientClassName)} />
+      <div className="relative">
+        <IconButton
+          icon={icon}
+          size="sm"
+          appearance="gray"
+          aria-label={t(translationKey)}
+          onClick={onClick}
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
@@ -8,6 +8,8 @@ import { AssetIcon } from "./AssetIcon";
 import { track } from "~/renderer/analytics/segment";
 import { TRACKING_PAGE_NAME } from "../utils/constants";
 import FearAndGreed from "LLD/features/FearAndGreed";
+import { useHorizontalScroll } from "../hooks/useHorizontalScroll";
+import { ScrollArrowButton } from "./ScrollArrowButton";
 
 type TrendingAssetsListProps = {
   readonly items: MarketItemPerformer[];
@@ -15,6 +17,7 @@ type TrendingAssetsListProps = {
 
 export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
   const navigate = useNavigate();
+  const { scrollContainerRef, isAtStart, isAtEnd, scrollLeft, scrollRight } = useHorizontalScroll();
 
   const onAssetClick = useCallback(
     (id: string) => () => {
@@ -31,33 +34,38 @@ export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
   const getCapitalizedTicker = (item: MarketItemPerformer) => item.ticker.toUpperCase();
 
   return (
-    <div
-      className="scrollbar-none flex flex-col overflow-x-scroll py-2"
-      data-testid="trending-assets-list"
-    >
-      <div className="flex items-stretch gap-8">
-        <FearAndGreed />
-        {items.map(item => (
-          <Tile
-            className="w-[98px]"
-            key={item.id}
-            appearance="card"
-            onClick={onAssetClick(item.id)}
-            data-testid={`market-banner-asset-${item.id}`}
-          >
-            <TileSpot
-              size={40}
-              appearance="icon"
-              icon={() => <AssetIcon item={item} getCapitalizedTicker={getCapitalizedTicker} />}
-            />
-            <TileContent>
-              <TileTitle>{getCapitalizedTicker(item)}</TileTitle>
-              <PerformanceIndicator value={item} />
-            </TileContent>
-          </Tile>
-        ))}
-        <ViewAllTile />
+    <div className="relative" data-testid="trending-assets-list">
+      {!isAtStart && <ScrollArrowButton direction="left" onClick={scrollLeft} />}
+      <div
+        ref={scrollContainerRef}
+        data-testid="scroll-container"
+        className="scrollbar-none flex flex-col overflow-x-scroll py-2"
+      >
+        <div className="flex items-stretch gap-8">
+          <FearAndGreed />
+          {items.map(item => (
+            <Tile
+              className="w-[98px]"
+              key={item.id}
+              appearance="card"
+              onClick={onAssetClick(item.id)}
+              data-testid={`market-banner-asset-${item.id}`}
+            >
+              <TileSpot
+                size={40}
+                appearance="icon"
+                icon={() => <AssetIcon item={item} getCapitalizedTicker={getCapitalizedTicker} />}
+              />
+              <TileContent>
+                <TileTitle>{getCapitalizedTicker(item)}</TileTitle>
+                <PerformanceIndicator value={item} />
+              </TileContent>
+            </Tile>
+          ))}
+          <ViewAllTile />
+        </div>
       </div>
+      {!isAtEnd && <ScrollArrowButton direction="right" onClick={scrollRight} />}
     </div>
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useHorizontalScroll.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/hooks/useHorizontalScroll.ts
@@ -1,0 +1,52 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+
+const SCROLL_STEP = 300;
+const SCROLL_END_THRESHOLD = 2;
+
+export const useHorizontalScroll = () => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [isAtStart, setIsAtStart] = useState(true);
+  const [isAtEnd, setIsAtEnd] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const atStart = container.scrollLeft <= SCROLL_END_THRESHOLD;
+    const atEnd =
+      container.scrollLeft + container.clientWidth >= container.scrollWidth - SCROLL_END_THRESHOLD;
+
+    setIsAtStart(prev => (prev === atStart ? prev : atStart));
+    setIsAtEnd(prev => (prev === atEnd ? prev : atEnd));
+  }, []);
+
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    container.addEventListener("scroll", updateScrollState, { passive: true });
+
+    const resizeObserver = new ResizeObserver(updateScrollState);
+    resizeObserver.observe(container);
+    if (container.firstElementChild) {
+      resizeObserver.observe(container.firstElementChild);
+    }
+
+    updateScrollState();
+
+    return () => {
+      container.removeEventListener("scroll", updateScrollState);
+      resizeObserver.disconnect();
+    };
+  }, [updateScrollState]);
+
+  const scrollLeft = useCallback(() => {
+    scrollContainerRef.current?.scrollBy({ left: -SCROLL_STEP, behavior: "smooth" });
+  }, []);
+
+  const scrollRight = useCallback(() => {
+    scrollContainerRef.current?.scrollBy({ left: SCROLL_STEP, behavior: "smooth" });
+  }, []);
+
+  return { scrollContainerRef, isAtStart, isAtEnd, scrollLeft, scrollRight };
+};

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8045,6 +8045,8 @@
     "title": "Explore market",
     "genericError": "Connection failed",
     "cta": "View all",
+    "scrollLeft": "Scroll left",
+    "scrollRight": "Scroll right",
     "fearAndGreed": {
       "title": "Mood"
     }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Horizontal scroll behavior on the MarketBanner trending assets list
      - Scroll arrow buttons visibility (left/right) based on scroll position
      - Gradient fade effect on list edges

### 📝 Description

Users with many trending assets in the MarketBanner had no way to discover or navigate to off-screen items beyond manual scrolling.

Added horizontal scroll navigation arrows with gradient fade indicators to the trending assets list. The implementation includes:
- A `useHorizontalScroll` hook tracking scroll position with `ResizeObserver` for responsive updates
- A `ScrollArrowButton` component with directional gradient overlays and chevron icons
- Conditional rendering of left/right arrows based on scroll boundaries
- Unit tests for the hook, component, and updated list behavior
- Integration test with simulated scroll layout verification


https://github.com/user-attachments/assets/35e7b9d2-ca4c-4807-bb9a-a0560a4498c4



### ❓ Context

- **JIRA or GitHub link**: [LIVE-27173](https://ledgerhq.atlassian.net/browse/LIVE-27173)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27173]: https://ledgerhq.atlassian.net/browse/LIVE-27173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ