### PR TITLE
chore: decouple coin-concordium module from CryptoCurrency 

### DIFF
--- a/.changeset/grumpy-llamas-trade.md
+++ b/.changeset/grumpy-llamas-trade.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-concordium": minor
+"ledger-live-desktop": minor
+---
+
+Decouple coin-concordium module from CryptoCurrency type, using currencyId: string throughout network, logic, bridge, and API layers.

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
@@ -148,7 +148,7 @@ describe("OnboardModal", () => {
     expect(agreeButton).toBeVisible();
 
     await user.click(agreeButton);
-    expect(mockPairWalletConnect).toHaveBeenCalledWith(currency, mockDevice.deviceId);
+    expect(mockPairWalletConnect).toHaveBeenCalledWith(currency.id, mockDevice.deviceId);
 
     await waitFor(() => {
       expect(screen.getByText(/scan the qr code/i)).toBeVisible();
@@ -160,7 +160,7 @@ describe("OnboardModal", () => {
 
     await user.click(screen.getByRole("button", { name: /continue/i }));
     expect(mockOnboardAccount).toHaveBeenCalledWith(
-      currency,
+      currency.id,
       mockDevice.deviceId,
       creatableAccount,
     );

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/index.tsx
@@ -242,7 +242,7 @@ class OnboardModal extends PureComponent<Props, State> {
     });
 
     this.pairingSubscription = this.concordiumBridge
-      .pairWalletConnect(currency, device.deviceId)
+      .pairWalletConnect(currency.id, device.deviceId)
       .subscribe({
         next: (data: ConcordiumPairingProgress) => {
           const stateUpdate = handlePairingProgress(data);
@@ -350,7 +350,7 @@ class OnboardModal extends PureComponent<Props, State> {
     });
 
     this.onboardingSubscription = this.concordiumBridge
-      .onboardAccount(currency, device.deviceId, creatableAccount)
+      .onboardAccount(currency.id, device.deviceId, creatableAccount)
       .subscribe({
         next: data => {
           const stateUpdate = handleOnboardingProgress(data);

--- a/libs/coin-modules/coin-concordium/src/api/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-concordium/src/api/craftTransaction.test.ts
@@ -24,8 +24,8 @@ describe("api/craftTransaction", () => {
   });
 
   it("should craft transaction with memo", async () => {
-    const api = createApi(mockConfig);
-    getNextValidSequenceMock.mockResolvedValue(BigInt(5));
+    const api = createApi(mockConfig, "concordium_testnet");
+    getNextValidSequenceMock.mockResolvedValue(5);
     craftTransactionMock.mockResolvedValue({
       type: 22, // TransferWithMemo
       header: {
@@ -51,10 +51,10 @@ describe("api/craftTransaction", () => {
 
     expect(getNextValidSequenceMock).toHaveBeenCalledWith(
       transactionIntent.sender,
-      expect.objectContaining({ id: "concordium" }),
+      "concordium_testnet",
     );
     expect(craftTransactionMock).toHaveBeenCalledWith(
-      { address: transactionIntent.sender, nextSequenceNumber: BigInt(5) },
+      { address: transactionIntent.sender, nextSequenceNumber: 5 },
       expect.objectContaining({
         recipient: transactionIntent.recipient,
         memo: "test memo",
@@ -65,8 +65,8 @@ describe("api/craftTransaction", () => {
   });
 
   it("should craft transaction without memo", async () => {
-    const api = createApi(mockConfig);
-    getNextValidSequenceMock.mockResolvedValue(BigInt(10));
+    const api = createApi(mockConfig, "concordium_testnet");
+    getNextValidSequenceMock.mockResolvedValue(10);
     craftTransactionMock.mockResolvedValue({
       type: 3, // Transfer
       header: {

--- a/libs/coin-modules/coin-concordium/src/api/estimateFees.test.ts
+++ b/libs/coin-modules/coin-concordium/src/api/estimateFees.test.ts
@@ -24,7 +24,7 @@ describe("api/estimateFees", () => {
   });
 
   it("should estimate fees for transaction with memo", async () => {
-    const api = createApi(mockConfig);
+    const api = createApi(mockConfig, "concordium_testnet");
     craftTransactionMock.mockResolvedValue({
       type: 22, // TransferWithMemo
       header: {
@@ -49,15 +49,12 @@ describe("api/estimateFees", () => {
 
     const result = await api.estimateFees(transactionIntent);
 
-    expect(estimateFeesMock).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "concordium" }),
-      "fee test",
-    );
+    expect(estimateFeesMock).toHaveBeenCalledWith("concordium_testnet", "fee test");
     expect(result).toEqual({ value: BigInt(1500) });
   });
 
   it("should estimate fees for transaction without memo", async () => {
-    const api = createApi(mockConfig);
+    const api = createApi(mockConfig, "concordium_testnet");
     craftTransactionMock.mockResolvedValue({
       type: 3, // Transfer
       header: {

--- a/libs/coin-modules/coin-concordium/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/api/index.integ.test.ts
@@ -18,13 +18,16 @@ describe("Concordium Api (testnet)", () => {
   const PUBLIC_KEY = "aa".repeat(32);
 
   beforeAll(() => {
-    api = createApi({
-      networkType: "testnet",
-      grpcUrl: "grpc.testnet.concordium.com",
-      grpcPort: 20000,
-      proxyUrl: "https://wallet-proxy.testnet.concordium.com",
-      minReserve: 100000,
-    });
+    api = createApi(
+      {
+        networkType: "testnet",
+        grpcUrl: "grpc.testnet.concordium.com",
+        grpcPort: 20000,
+        proxyUrl: "https://wallet-proxy.testnet.concordium.com",
+        minReserve: 100000,
+      },
+      "concordium_testnet",
+    );
   });
 
   describe("estimateFees", () => {

--- a/libs/coin-modules/coin-concordium/src/api/index.test.ts
+++ b/libs/coin-modules/coin-concordium/src/api/index.test.ts
@@ -39,7 +39,7 @@ describe("api/index", () => {
   });
 
   it("should return every api methods", () => {
-    expect(createApi(mockConfig)).toEqual({
+    expect(createApi(mockConfig, "concordium_testnet")).toEqual({
       broadcast: expect.any(Function),
       combine: expect.any(Function),
       craftRawTransaction: expect.any(Function),
@@ -58,53 +58,47 @@ describe("api/index", () => {
 
   describe("broadcast", () => {
     it("should call broadcast with transaction and currency", async () => {
-      const api = createApi(mockConfig);
+      const api = createApi(mockConfig, "concordium_testnet");
       broadcastMock.mockResolvedValue("tx-hash-123");
 
       const result = await api.broadcast("signed-tx-data");
 
-      expect(broadcastMock).toHaveBeenCalledWith(
-        "signed-tx-data",
-        expect.objectContaining({ id: "concordium" }),
-      );
+      expect(broadcastMock).toHaveBeenCalledWith("signed-tx-data", "concordium_testnet");
       expect(result).toBe("tx-hash-123");
     });
   });
 
   describe("getBalance", () => {
     it("should call getBalance with address and currency", async () => {
-      const api = createApi(mockConfig);
-      getBalanceMock.mockResolvedValue(BigInt(5000000));
+      const api = createApi(mockConfig, "concordium_testnet");
+      const mockBalances = [{ asset: { type: "native" }, value: BigInt(5000000) }];
+      getBalanceMock.mockResolvedValue(mockBalances);
 
       const result = await api.getBalance(VALID_ADDRESS);
 
-      expect(getBalanceMock).toHaveBeenCalledWith(
-        VALID_ADDRESS,
-        expect.objectContaining({ id: "concordium" }),
-      );
-      expect(result).toBe(BigInt(5000000));
+      expect(getBalanceMock).toHaveBeenCalledWith(VALID_ADDRESS, "concordium_testnet");
+      expect(result).toEqual(mockBalances);
     });
   });
 
   describe("lastBlock", () => {
     it("should call lastBlock with currency", async () => {
-      const api = createApi(mockConfig);
+      const api = createApi(mockConfig, "concordium_testnet");
       const mockBlockInfo = { height: 1000, hash: "block-hash", time: new Date() };
       lastBlockMock.mockResolvedValue(mockBlockInfo);
 
       const result = await api.lastBlock();
 
-      expect(lastBlockMock).toHaveBeenCalledWith(expect.objectContaining({ id: "concordium" }));
+      expect(lastBlockMock).toHaveBeenCalledWith("concordium_testnet");
       expect(result).toEqual(mockBlockInfo);
     });
   });
 
   describe("listOperations", () => {
     it("should call listOperations with address, pagination and currency", async () => {
-      const api = createApi(mockConfig);
-      const mockOperations = [{ id: "op1" }, { id: "op2" }];
-      const mockCursor = "";
-      listOperationsMock.mockResolvedValue([mockOperations, mockCursor]);
+      const api = createApi(mockConfig, "concordium_testnet");
+      const mockPage = { items: [{ id: "op1" }, { id: "op2" }], next: undefined };
+      listOperationsMock.mockResolvedValue(mockPage);
       const pagination = { minHeight: 100 };
 
       const result = await api.listOperations(VALID_ADDRESS, pagination);
@@ -112,54 +106,51 @@ describe("api/index", () => {
       expect(listOperationsMock).toHaveBeenCalledWith(
         VALID_ADDRESS,
         pagination,
-        expect.objectContaining({ id: "concordium" }),
+        "concordium_testnet",
       );
-      expect(result).toEqual([mockOperations, mockCursor]);
+      expect(result).toEqual(mockPage);
     });
   });
 
   describe("getBlock", () => {
     it("should call getBlock with height and currency", async () => {
-      const api = createApi(mockConfig);
+      const api = createApi(mockConfig, "concordium_testnet");
       const mockBlock = { height: 500, hash: "block-500", transactions: [] };
       getBlockMock.mockResolvedValue(mockBlock);
 
       const result = await api.getBlock(500);
 
-      expect(getBlockMock).toHaveBeenCalledWith(500, expect.objectContaining({ id: "concordium" }));
+      expect(getBlockMock).toHaveBeenCalledWith(500, "concordium_testnet");
       expect(result).toEqual(mockBlock);
     });
   });
 
   describe("getBlockInfo", () => {
     it("should call getBlockInfo with height and currency", async () => {
-      const api = createApi(mockConfig);
+      const api = createApi(mockConfig, "concordium_testnet");
       const mockBlockInfo = { height: 600, hash: "block-600", time: new Date() };
       getBlockInfoMock.mockResolvedValue(mockBlockInfo);
 
       const result = await api.getBlockInfo(600);
 
-      expect(getBlockInfoMock).toHaveBeenCalledWith(
-        600,
-        expect.objectContaining({ id: "concordium" }),
-      );
+      expect(getBlockInfoMock).toHaveBeenCalledWith(600, "concordium_testnet");
       expect(result).toEqual(mockBlockInfo);
     });
   });
 
   describe("unsupported methods", () => {
     it("should throw error for getStakes", () => {
-      const api = createApi(mockConfig);
+      const api = createApi(mockConfig, "concordium_testnet");
       expect(() => api.getStakes("address")).toThrow("getStakes is not supported");
     });
 
     it("should throw error for getRewards", () => {
-      const api = createApi(mockConfig);
+      const api = createApi(mockConfig, "concordium_testnet");
       expect(() => api.getRewards("address")).toThrow("getRewards is not supported");
     });
 
     it("should throw error for getValidators", () => {
-      const api = createApi(mockConfig);
+      const api = createApi(mockConfig, "concordium_testnet");
       expect(() => api.getValidators()).toThrow("getValidators is not supported");
     });
   });

--- a/libs/coin-modules/coin-concordium/src/api/index.ts
+++ b/libs/coin-modules/coin-concordium/src/api/index.ts
@@ -10,8 +10,6 @@ import type {
   TransactionIntent,
   Validator,
 } from "@ledgerhq/coin-framework/api/index";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import {
   serializeTransfer,
@@ -34,24 +32,23 @@ import {
 import coinConfig from "../config";
 import type { ConcordiumConfig, ConcordiumMemo } from "../types";
 
-export function createApi(config: ConcordiumConfig): AlpacaApi<ConcordiumMemo> {
+export function createApi(config: ConcordiumConfig, currencyId: string): AlpacaApi<ConcordiumMemo> {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
-  const currency = getCryptoCurrencyById("concordium");
 
   return {
-    broadcast: (tx: string) => broadcast(tx, currency),
+    broadcast: (tx: string) => broadcast(tx, currencyId),
     combine,
     craftTransaction: (transactionIntent: TransactionIntent<ConcordiumMemo>) =>
-      craftTransaction(transactionIntent, currency),
+      craftTransaction(transactionIntent, currencyId),
     craftRawTransaction,
     estimateFees: (transactionIntent: TransactionIntent<ConcordiumMemo>) =>
-      estimateFees(transactionIntent, currency),
-    getBalance: (address: string) => getBalance(address, currency),
-    lastBlock: () => lastBlock(currency),
+      estimateFees(transactionIntent, currencyId),
+    getBalance: (address: string) => getBalance(address, currencyId),
+    lastBlock: () => lastBlock(currencyId),
     listOperations: (address: string, options: ListOperationsOptions) =>
-      listOperations(address, options, currency),
-    getBlock: (height: number) => getBlock(height, currency),
-    getBlockInfo: (height: number) => getBlockInfo(height, currency),
+      listOperations(address, options, currencyId),
+    getBlock: (height: number) => getBlock(height, currencyId),
+    getBlockInfo: (height: number) => getBlockInfo(height, currencyId),
     getStakes(_address: string, _cursor?: Cursor): Promise<Page<Stake>> {
       throw new Error("getStakes is not supported");
     },
@@ -66,9 +63,9 @@ export function createApi(config: ConcordiumConfig): AlpacaApi<ConcordiumMemo> {
 
 async function craftTransaction(
   transactionIntent: TransactionIntent<ConcordiumMemo>,
-  currency: CryptoCurrency,
+  currencyId: string,
 ): Promise<CraftedTransaction> {
-  const nextSequenceNumber = await getNextValidSequence(transactionIntent.sender, currency);
+  const nextSequenceNumber = await getNextValidSequence(transactionIntent.sender, currencyId);
   const memo =
     "memo" in transactionIntent && transactionIntent.memo?.type === "string"
       ? transactionIntent.memo.value
@@ -90,14 +87,14 @@ async function craftTransaction(
 
 async function estimateFees(
   transactionIntent: TransactionIntent<ConcordiumMemo>,
-  currency: CryptoCurrency,
+  currencyId: string,
 ): Promise<FeeEstimation> {
   const memo =
     "memo" in transactionIntent && transactionIntent.memo?.type === "string"
       ? transactionIntent.memo.value
       : undefined;
 
-  const estimation = await estimateFeesLogic(currency, memo);
+  const estimation = await estimateFeesLogic(currencyId, memo);
 
   return { value: estimation.cost };
 }

--- a/libs/coin-modules/coin-concordium/src/bridge/broadcast.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/broadcast.ts
@@ -7,6 +7,6 @@ export const broadcast: AccountBridge<Transaction>["broadcast"] = async ({
   account,
   signedOperation: { signature, operation },
 }) => {
-  const hash = await broadcastLogic(signature, account.currency);
+  const hash = await broadcastLogic(signature, account.currency.id);
   return patchOperationWithHash(operation, hash);
 };

--- a/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.ts
@@ -78,7 +78,7 @@ export const getTransactionStatus: AccountBridge<
   const warnings: Record<string, Error> = {};
 
   // reserveAmount is the minimum amount of currency that an account must hold in order to stay activated
-  const reserveAmount = new BigNumber(coinConfig.getCoinConfig(account.currency).minReserve);
+  const reserveAmount = new BigNumber(coinConfig.getCoinConfig(account.currency.id).minReserve);
   const estimatedFees = new BigNumber(transaction.fee || 0);
 
   // Calculate amount based on useAllAmount flag

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.integ.test.ts
@@ -94,7 +94,7 @@ describe("onboard (testnet integration)", () => {
       const currency = createFixtureCurrency();
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
       const events = await firstValueFrom(observable.pipe(toArray()));
 
       const statuses = events.filter(e => "status" in e).map(e => e.status);
@@ -120,7 +120,7 @@ describe("onboard (testnet integration)", () => {
       const currency = createFixtureCurrency();
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
 
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
         "No active WalletConnect session",
@@ -140,7 +140,7 @@ describe("onboard (testnet integration)", () => {
       const currency = createFixtureCurrency();
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
 
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
         "IDApp create_account failed",
@@ -160,7 +160,7 @@ describe("onboard (testnet integration)", () => {
       const currency = createFixtureCurrency();
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
       await firstValueFrom(observable.pipe(toArray()));
 
       expect(getPublicKey).toHaveBeenCalled();
@@ -179,7 +179,7 @@ describe("onboard (testnet integration)", () => {
       const pairWalletConnect = buildPairWalletConnect();
       const currency = createFixtureCurrency();
 
-      const observable = pairWalletConnect(currency, "test-device");
+      const observable = pairWalletConnect(currency.id, "test-device");
       const events = await firstValueFrom(observable.pipe(toArray()));
 
       const statuses = events.filter(e => "status" in e).map(e => e.status);
@@ -207,7 +207,7 @@ describe("onboard (testnet integration)", () => {
       const pairWalletConnect = buildPairWalletConnect();
       const currency = createFixtureCurrency();
 
-      const observable = pairWalletConnect(currency, "test-device");
+      const observable = pairWalletConnect(currency.id, "test-device");
 
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
         "WalletConnect connect() returned no URI",
@@ -228,7 +228,7 @@ describe("onboard (testnet integration)", () => {
       const pairWalletConnect = buildPairWalletConnect();
       const currency = createFixtureCurrency();
 
-      const observable = pairWalletConnect(currency, "test-device");
+      const observable = pairWalletConnect(currency.id, "test-device");
 
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow();
     }, 15000);
@@ -268,10 +268,10 @@ describe("onboard (testnet integration)", () => {
       const currency = createFixtureCurrency();
       const mockData = { v: 0, value: {} } as never;
 
-      const result = await submitCredential(currency, mockData);
+      const result = await submitCredential(currency.id, mockData);
 
       expect(result).toEqual({ submissionId: "test-submission-123" });
-      expect(mockSubmitCredential).toHaveBeenCalledWith(currency, mockData);
+      expect(mockSubmitCredential).toHaveBeenCalledWith(currency.id, mockData);
     }, 15000);
 
     it("should use correct testnet configuration", () => {

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.test.ts
@@ -34,8 +34,14 @@ jest.mock("../signer", () => ({
   signCredentialDeployment: jest.fn().mockResolvedValue("bb".repeat(64)),
 }));
 
+jest.mock("../config", () => ({
+  __esModule: true,
+  default: {
+    getCoinConfig: jest.fn().mockReturnValue({ networkType: "mainnet" }),
+  },
+}));
+
 jest.mock("../network/utils", () => ({
-  getConcordiumNetwork: jest.fn().mockReturnValue("Mainnet"),
   buildSubmitCredentialData: jest.fn().mockReturnValue({ v: 0, value: {} }),
   deserializeCredentialDeploymentTransaction: jest.fn().mockReturnValue({
     // 96 hex chars = 48 bytes, credential ID
@@ -74,7 +80,7 @@ describe("onboard", () => {
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
       const events = await firstValueFrom(observable.pipe(toArray()));
 
       // THEN
@@ -96,7 +102,7 @@ describe("onboard", () => {
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
       const events = await firstValueFrom(observable.pipe(toArray()));
 
       // THEN
@@ -123,7 +129,7 @@ describe("onboard", () => {
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
 
       // THEN
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
@@ -141,7 +147,7 @@ describe("onboard", () => {
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
 
       // THEN
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
@@ -163,7 +169,7 @@ describe("onboard", () => {
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
 
       // THEN
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
@@ -185,7 +191,7 @@ describe("onboard", () => {
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
 
       // THEN
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
@@ -205,7 +211,7 @@ describe("onboard", () => {
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
 
       // THEN
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
@@ -226,7 +232,7 @@ describe("onboard", () => {
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
 
       // THEN
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(UserRefusedOnDevice);
@@ -245,7 +251,7 @@ describe("onboard", () => {
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
 
       // THEN
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(LockedDeviceError);
@@ -264,7 +270,7 @@ describe("onboard", () => {
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
 
       // THEN
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
@@ -284,7 +290,7 @@ describe("onboard", () => {
       account.freshAddressPath = "m/1105'/0'/1'/2'/3'/4'";
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
       await firstValueFrom(observable.pipe(toArray()));
 
       // THEN
@@ -308,11 +314,11 @@ describe("onboard", () => {
       const account = createFixtureAccount({ freshAddress: "", xpub: "" });
 
       // WHEN
-      const observable = onboardAccount(currency, "test-device", account);
+      const observable = onboardAccount(currency.id, "test-device", account);
       await firstValueFrom(observable.pipe(toArray()));
 
       // THEN
-      expect(submitCredential).toHaveBeenCalledWith(currency, { v: 0, value: { test: "data" } });
+      expect(submitCredential).toHaveBeenCalledWith(currency.id, { v: 0, value: { test: "data" } });
     });
   });
 
@@ -327,7 +333,7 @@ describe("onboard", () => {
       const currency = createFixtureCurrency();
 
       // WHEN
-      const observable = pairWalletConnect(currency, "test-device");
+      const observable = pairWalletConnect(currency.id, "test-device");
       const events = await firstValueFrom(observable.pipe(toArray()));
 
       // THEN
@@ -351,7 +357,7 @@ describe("onboard", () => {
       const currency = createFixtureCurrency();
 
       // WHEN
-      const observable = pairWalletConnect(currency, "test-device");
+      const observable = pairWalletConnect(currency.id, "test-device");
 
       // THEN
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
@@ -369,7 +375,7 @@ describe("onboard", () => {
       const currency = createFixtureCurrency();
 
       // WHEN
-      const observable = pairWalletConnect(currency, "test-device");
+      const observable = pairWalletConnect(currency.id, "test-device");
 
       // THEN
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
@@ -385,7 +391,7 @@ describe("onboard", () => {
       const currency = createFixtureCurrency();
 
       // WHEN
-      const observable = pairWalletConnect(currency, "test-device");
+      const observable = pairWalletConnect(currency.id, "test-device");
       const events: unknown[] = [];
       await new Promise<void>((resolve, reject) => {
         observable.subscribe({
@@ -412,7 +418,7 @@ describe("onboard", () => {
       const currency = createFixtureCurrency();
 
       // WHEN
-      const observable = pairWalletConnect(currency, "test-device");
+      const observable = pairWalletConnect(currency.id, "test-device");
       const events = await firstValueFrom(observable.pipe(toArray()));
 
       // THEN
@@ -425,22 +431,22 @@ describe("onboard", () => {
       expect(prepareEvent.walletConnectUri).toContain(`encodedUri=${encodedUri}`);
     });
 
-    it("should call getConcordiumNetwork with currency", async () => {
+    it("should call coinConfig.getCoinConfig with currencyId", async () => {
       // GIVEN
       mockInitiatePairing.mockResolvedValue({
         uri: "wc:test",
         approval: jest.fn().mockResolvedValue({ topic: "topic" }),
       });
-      const { getConcordiumNetwork } = jest.requireMock("../network/utils");
+      const coinConfig = jest.requireMock("../config").default;
       const pairWalletConnect = buildPairWalletConnect();
       const currency = createFixtureCurrency();
 
       // WHEN
-      const observable = pairWalletConnect(currency, "test-device");
+      const observable = pairWalletConnect(currency.id, "test-device");
       await firstValueFrom(observable.pipe(toArray()));
 
       // THEN
-      expect(getConcordiumNetwork).toHaveBeenCalledWith(currency);
+      expect(coinConfig.getCoinConfig).toHaveBeenCalledWith(currency.id);
     });
   });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
@@ -1,12 +1,11 @@
 import type { SignerContext } from "@ledgerhq/coin-framework/signer";
 import { LockedDeviceError, TransportStatusError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
 import { Observable } from "rxjs";
 import { CONCORDIUM_CHAIN_IDS, CONCORDIUM_ID_APP_MOBILE_HOST } from "../constants";
+import coinConfig from "../config";
 import {
-  getConcordiumNetwork,
   buildSubmitCredentialData,
   deserializeCredentialDeploymentTransaction,
 } from "../network/utils";
@@ -44,7 +43,7 @@ const withTimeout = <T>(promise: Promise<T>, errorMessage: string): Promise<T> =
 export const buildOnboardAccount =
   (signerContext: SignerContext<ConcordiumSigner>) =>
   (
-    currency: CryptoCurrency,
+    currencyId: string,
     deviceId: string,
     account: Account,
   ): Observable<ConcordiumOnboardProgress | ConcordiumOnboardResult> =>
@@ -64,7 +63,7 @@ export const buildOnboardAccount =
 
           o.next({ status: AccountOnboardStatus.PREPARE });
 
-          const network = getConcordiumNetwork(currency);
+          const network = coinConfig.getCoinConfig(currencyId).networkType;
           const chainId = CONCORDIUM_CHAIN_IDS[network];
 
           const session = await walletConnect.getSession(network);
@@ -124,7 +123,7 @@ export const buildOnboardAccount =
 
           const data = buildSubmitCredentialData(credentialDeploymentTransaction, signature);
 
-          await submitCredential(currency, data);
+          await submitCredential(currencyId, data);
 
           const onboardResult: ConcordiumOnboardResult = {
             account: {
@@ -172,7 +171,7 @@ export const buildOnboardAccount =
 
 export const buildPairWalletConnect =
   () =>
-  (currency: CryptoCurrency, _deviceId: string): Observable<ConcordiumPairingProgress> =>
+  (currencyId: string, _deviceId: string): Observable<ConcordiumPairingProgress> =>
     new Observable(o => {
       async function main() {
         o.next({ status: ConcordiumPairingStatus.INIT });
@@ -183,7 +182,7 @@ export const buildPairWalletConnect =
             throw new Error("WalletConnect context is not available");
           }
 
-          const network = getConcordiumNetwork(currency);
+          const network = coinConfig.getCoinConfig(currencyId).networkType;
           const chainId = CONCORDIUM_CHAIN_IDS[network];
 
           const { uri: encodedUri, approval } = await walletConnect.initiatePairing(

--- a/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.test.ts
@@ -67,7 +67,7 @@ describe("prepareTransaction", () => {
       await prepareTransaction(account, tx);
 
       // THEN
-      expect(estimateFees).toHaveBeenCalledWith(account.currency, undefined);
+      expect(estimateFees).toHaveBeenCalledWith(account.currency.id, undefined);
     });
 
     it("should call estimateFees with memo when memo is present", async () => {
@@ -79,7 +79,7 @@ describe("prepareTransaction", () => {
       await prepareTransaction(account, tx);
 
       // THEN
-      expect(estimateFees).toHaveBeenCalledWith(account.currency, "test memo");
+      expect(estimateFees).toHaveBeenCalledWith(account.currency.id, "test memo");
     });
   });
 

--- a/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.ts
@@ -7,7 +7,7 @@ export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"
   account,
   transaction,
 ) => {
-  const estimation = await estimateFees(account.currency, transaction.memo);
+  const estimation = await estimateFees(account.currency.id, transaction.memo);
 
   if (!transaction.fee?.isEqualTo(new BigNumber(estimation.cost.toString()))) {
     return { ...transaction, fee: new BigNumber(estimation.cost.toString()) };

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
@@ -25,10 +25,10 @@ export const buildSignOperation =
 
         const nextSequenceNumber = await getNextValidSequence(
           account.freshAddress,
-          account.currency,
+          account.currency.id,
         );
 
-        const estimation = await estimateFees(account.currency, transaction.memo);
+        const estimation = await estimateFees(account.currency.id, transaction.memo);
 
         const signature = await signerContext(deviceId, async signer => {
           const { freshAddressPath: derivationPath } = account;

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
@@ -186,7 +186,7 @@ describe("sync", () => {
       });
 
       // THEN
-      expect(getAccountsByPublicKey).toHaveBeenCalledWith(currency, PUBLIC_KEY);
+      expect(getAccountsByPublicKey).toHaveBeenCalledWith(currency.id, PUBLIC_KEY);
     });
 
     it("should merge operations with existing operations", async () => {

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.ts
@@ -64,7 +64,7 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async info =>
   let spendableBalance = new BigNumber(0);
 
   try {
-    const accountsResponse = await getAccountsByPublicKey(currency, publicKey);
+    const accountsResponse = await getAccountsByPublicKey(currency.id, publicKey);
 
     if (!accountsResponse?.length) {
       return {
@@ -90,7 +90,7 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async info =>
     const account = accountsResponse[0];
 
     const { finalizedBalance: { accountAmount, accountAtDisposal } = {} } = await getAccountBalance(
-      currency,
+      currency.id,
       account.address,
     ).catch(error => {
       // If balance request fails, log the error and return zeros,
@@ -104,7 +104,7 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async info =>
 
     balance = valueToBigNumber(accountAmount);
 
-    const minReserve = coinConfig.getCoinConfig(currency).minReserve;
+    const minReserve = coinConfig.getCoinConfig(currency.id).minReserve;
     spendableBalance = accountAtDisposal
       ? valueToBigNumber(accountAtDisposal)
       : balance.minus(minReserve);
@@ -112,7 +112,7 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async info =>
 
     const oldOperations = initialAccount?.operations ?? [];
 
-    const proxyOperations = await getOperations(currency, {
+    const proxyOperations = await getOperations(currency.id, {
       address: account.address,
       accountId,
       size: 100,

--- a/libs/coin-modules/coin-concordium/src/config.ts
+++ b/libs/coin-modules/coin-concordium/src/config.ts
@@ -1,12 +1,12 @@
-import buildCoinConfig, { type CoinConfig } from "@ledgerhq/coin-framework/config";
+import buildCoinConfig from "@ledgerhq/coin-framework/config";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { ConcordiumCoinConfig } from "./types/config";
 
 export type { ConcordiumCoinConfig } from "./types/config";
 
-const coinConfig: {
-  setCoinConfig: (config: CoinConfig<ConcordiumCoinConfig>) => void;
-  getCoinConfig: (currency?: CryptoCurrency) => ConcordiumCoinConfig;
-} = buildCoinConfig<ConcordiumCoinConfig>();
+const { setCoinConfig, getCoinConfig: _getCoinConfig } = buildCoinConfig<ConcordiumCoinConfig>();
 
-export default coinConfig;
+const getCoinConfig = (currencyId?: string): ConcordiumCoinConfig =>
+  _getCoinConfig(currencyId ? ({ id: currencyId } as CryptoCurrency) : undefined);
+
+export default { setCoinConfig, getCoinConfig };

--- a/libs/coin-modules/coin-concordium/src/constants.ts
+++ b/libs/coin-modules/coin-concordium/src/constants.ts
@@ -5,8 +5,8 @@ export { MAX_MEMO_LENGTH } from "@ledgerhq/concordium-core";
  * These identify Concordium Mainnet and Testnet in WalletConnect sessions
  */
 export const CONCORDIUM_CHAIN_IDS = {
-  Mainnet: "ccd:9dd9ca4d19e9393877d2c44b70f89acb",
-  Testnet: "ccd:4221332d34e1694168c2a0c0b3fd0f27",
+  mainnet: "ccd:9dd9ca4d19e9393877d2c44b70f89acb",
+  testnet: "ccd:4221332d34e1694168c2a0c0b3fd0f27",
 } as const;
 
 export const CONCORDIUM_ID_APP_MOBILE_HOST = "concordiumidapp://";

--- a/libs/coin-modules/coin-concordium/src/logic/account/account.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/account/account.test.ts
@@ -1,4 +1,3 @@
-import { createTestCryptoCurrency } from "../../test/testHelpers";
 import { getBalance } from "./getBalance";
 import { getNextValidSequence } from "./getNextSequence";
 
@@ -16,12 +15,6 @@ jest.mock("../../network/proxyClient", () => ({
 
 const VALID_ADDRESS = "3a9gh23nNY3kH4k3ajaCqAbM8rcbWMor2VhEzQ6qkn2r17UU7w";
 
-const createMockCurrency = () =>
-  createTestCryptoCurrency({
-    id: "concordium",
-    name: "Concordium",
-  });
-
 describe("logic/account", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -29,9 +22,7 @@ describe("logic/account", () => {
 
   describe("getBalance", () => {
     it("should return balance as native asset", async () => {
-      const currency = createMockCurrency();
-
-      const result = await getBalance(VALID_ADDRESS, currency);
+      const result = await getBalance(VALID_ADDRESS, "concordium_testnet");
 
       expect(result).toHaveLength(1);
       expect(result[0].asset).toEqual({ type: "native" });
@@ -40,11 +31,10 @@ describe("logic/account", () => {
 
     it("should call getAccountBalance with correct parameters", async () => {
       const { getAccountBalance } = jest.requireMock("../../network/proxyClient");
-      const currency = createMockCurrency();
 
-      await getBalance(VALID_ADDRESS, currency);
+      await getBalance(VALID_ADDRESS, "concordium_testnet");
 
-      expect(getAccountBalance).toHaveBeenCalledWith(currency, VALID_ADDRESS);
+      expect(getAccountBalance).toHaveBeenCalledWith("concordium_testnet", VALID_ADDRESS);
     });
 
     it("should handle zero balance", async () => {
@@ -53,9 +43,7 @@ describe("logic/account", () => {
         finalizedBalance: { accountAmount: "0" },
       });
 
-      const currency = createMockCurrency();
-
-      const result = await getBalance(VALID_ADDRESS, currency);
+      const result = await getBalance(VALID_ADDRESS, "concordium_testnet");
 
       expect(result[0].value).toBe(BigInt(0));
     });
@@ -66,9 +54,7 @@ describe("logic/account", () => {
         finalizedBalance: { accountAmount: "999999999999999999" },
       });
 
-      const currency = createMockCurrency();
-
-      const result = await getBalance(VALID_ADDRESS, currency);
+      const result = await getBalance(VALID_ADDRESS, "concordium_testnet");
 
       expect(result[0].value).toBe(BigInt("999999999999999999"));
     });
@@ -77,37 +63,32 @@ describe("logic/account", () => {
       const { getAccountBalance } = jest.requireMock("../../network/proxyClient");
       getAccountBalance.mockRejectedValueOnce(new Error("Account not found"));
 
-      const currency = createMockCurrency();
-
-      await expect(getBalance(VALID_ADDRESS, currency)).rejects.toThrow("Account not found");
+      await expect(getBalance(VALID_ADDRESS, "concordium_testnet")).rejects.toThrow(
+        "Account not found",
+      );
     });
   });
 
   describe("getNextValidSequence", () => {
     it("should return nonce from network", async () => {
-      const currency = createMockCurrency();
-
-      const result = await getNextValidSequence(VALID_ADDRESS, currency);
+      const result = await getNextValidSequence(VALID_ADDRESS, "concordium_testnet");
 
       expect(result).toBe(42);
     });
 
     it("should call getAccountNonce with correct parameters", async () => {
       const { getAccountNonce } = jest.requireMock("../../network/proxyClient");
-      const currency = createMockCurrency();
 
-      await getNextValidSequence(VALID_ADDRESS, currency);
+      await getNextValidSequence(VALID_ADDRESS, "concordium_testnet");
 
-      expect(getAccountNonce).toHaveBeenCalledWith(currency, VALID_ADDRESS);
+      expect(getAccountNonce).toHaveBeenCalledWith("concordium_testnet", VALID_ADDRESS);
     });
 
     it("should handle nonce of 0", async () => {
       const { getAccountNonce } = jest.requireMock("../../network/proxyClient");
       getAccountNonce.mockResolvedValueOnce({ nonce: 0 });
 
-      const currency = createMockCurrency();
-
-      const result = await getNextValidSequence(VALID_ADDRESS, currency);
+      const result = await getNextValidSequence(VALID_ADDRESS, "concordium_testnet");
 
       expect(result).toBe(0);
     });
@@ -116,9 +97,7 @@ describe("logic/account", () => {
       const { getAccountNonce } = jest.requireMock("../../network/proxyClient");
       getAccountNonce.mockResolvedValueOnce({ nonce: 999999999 });
 
-      const currency = createMockCurrency();
-
-      const result = await getNextValidSequence(VALID_ADDRESS, currency);
+      const result = await getNextValidSequence(VALID_ADDRESS, "concordium_testnet");
 
       expect(result).toBe(999999999);
     });
@@ -127,9 +106,7 @@ describe("logic/account", () => {
       const { getAccountNonce } = jest.requireMock("../../network/proxyClient");
       getAccountNonce.mockRejectedValueOnce(new Error("Network timeout"));
 
-      const currency = createMockCurrency();
-
-      await expect(getNextValidSequence(VALID_ADDRESS, currency)).rejects.toThrow(
+      await expect(getNextValidSequence(VALID_ADDRESS, "concordium_testnet")).rejects.toThrow(
         "Network timeout",
       );
     });

--- a/libs/coin-modules/coin-concordium/src/logic/account/getBalance.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/account/getBalance.integ.test.ts
@@ -1,10 +1,7 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import coinConfig from "../../config";
 import { getBalance } from "./getBalance";
 
 describe("getBalance", () => {
-  const currency = getCryptoCurrencyById("concordium");
-
   beforeAll(() => {
     coinConfig.setCoinConfig(() => ({
       status: {
@@ -22,7 +19,7 @@ describe("getBalance", () => {
     // Account with some balance on testnet
     const address = "3U6m951FWryY56SKFFHgMLGVHtJtk4VaxN7V2F9hjkR7Sg1FUx";
 
-    const balances = await getBalance(address, currency);
+    const balances = await getBalance(address, "concordium_testnet");
 
     expect(balances).toBeInstanceOf(Array);
     expect(balances.length).toBeGreaterThanOrEqual(1);
@@ -35,7 +32,7 @@ describe("getBalance", () => {
     // Pristine account with no transactions
     const address = "4ox4d7b4S9Mi3qA696v3yYjBQB4f6GDEVATrH9oFnoHUd5zLgh";
 
-    const result = await getBalance(address, currency);
+    const result = await getBalance(address, "concordium_testnet");
 
     expect(result).toEqual([{ asset: { type: "native" }, value: BigInt(0) }]);
   });

--- a/libs/coin-modules/coin-concordium/src/logic/account/getBalance.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/account/getBalance.ts
@@ -1,9 +1,8 @@
 import type { Balance } from "@ledgerhq/coin-framework/api/types";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getAccountBalance } from "../../network/proxyClient";
 
-export async function getBalance(address: string, currency: CryptoCurrency): Promise<Balance[]> {
-  const balanceResponse = await getAccountBalance(currency, address);
+export async function getBalance(address: string, currencyId: string): Promise<Balance[]> {
+  const balanceResponse = await getAccountBalance(currencyId, address);
   return [
     { asset: { type: "native" }, value: BigInt(balanceResponse.finalizedBalance.accountAmount) },
   ];

--- a/libs/coin-modules/coin-concordium/src/logic/account/getNextSequence.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/account/getNextSequence.ts
@@ -1,10 +1,6 @@
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getAccountNonce } from "../../network/proxyClient";
 
-export async function getNextValidSequence(
-  address: string,
-  currency: CryptoCurrency,
-): Promise<number> {
-  const result = await getAccountNonce(currency, address);
+export async function getNextValidSequence(address: string, currencyId: string): Promise<number> {
+  const result = await getAccountNonce(currencyId, address);
   return result.nonce;
 }

--- a/libs/coin-modules/coin-concordium/src/logic/history/getBlock.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/getBlock.ts
@@ -1,7 +1,6 @@
 import type { Block } from "@ledgerhq/coin-framework/api/index";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getBlockByHeight } from "../../network/grpcClient";
 
-export async function getBlock(height: number, currency: CryptoCurrency): Promise<Block> {
-  return getBlockByHeight(currency, height);
+export async function getBlock(height: number, currencyId: string): Promise<Block> {
+  return getBlockByHeight(currencyId, height);
 }

--- a/libs/coin-modules/coin-concordium/src/logic/history/getBlockInfo.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/getBlockInfo.ts
@@ -1,7 +1,6 @@
 import type { BlockInfo } from "@ledgerhq/coin-framework/api/index";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getBlockInfoByHeight } from "../../network/grpcClient";
 
-export async function getBlockInfo(height: number, currency: CryptoCurrency): Promise<BlockInfo> {
-  return getBlockInfoByHeight(currency, height);
+export async function getBlockInfo(height: number, currencyId: string): Promise<BlockInfo> {
+  return getBlockInfoByHeight(currencyId, height);
 }

--- a/libs/coin-modules/coin-concordium/src/logic/history/history.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/history.test.ts
@@ -1,5 +1,4 @@
 import { VALID_ADDRESS } from "../../test/fixtures";
-import { createTestCryptoCurrency } from "../../test/testHelpers";
 import { lastBlock } from "./lastBlock";
 import { getBlock } from "./getBlock";
 import { getBlockInfo } from "./getBlockInfo";
@@ -25,11 +24,6 @@ const {
 
 const { getOperations: getOperationsProxyMock } = jest.requireMock("../../network/proxyClient");
 
-const mockCurrency = createTestCryptoCurrency({
-  id: "concordium",
-  name: "Concordium",
-});
-
 describe("history", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -46,10 +40,10 @@ describe("history", () => {
       });
 
       // WHEN
-      const result = await lastBlock(mockCurrency);
+      const result = await lastBlock("concordium_testnet");
 
       // THEN
-      expect(getLastBlockMock).toHaveBeenCalledWith(mockCurrency);
+      expect(getLastBlockMock).toHaveBeenCalledWith("concordium_testnet");
       expect(result).toEqual({
         height: 12345,
         hash: "abc123hash",
@@ -70,10 +64,10 @@ describe("history", () => {
       getBlockByHeightMock.mockResolvedValue(mockBlock);
 
       // WHEN
-      const result = await getBlock(1000, mockCurrency);
+      const result = await getBlock(1000, "concordium_testnet");
 
       // THEN
-      expect(getBlockByHeightMock).toHaveBeenCalledWith(mockCurrency, 1000);
+      expect(getBlockByHeightMock).toHaveBeenCalledWith("concordium_testnet", 1000);
       expect(result).toEqual(mockBlock);
     });
   });
@@ -89,10 +83,10 @@ describe("history", () => {
       getBlockInfoByHeightMock.mockResolvedValue(mockBlockInfo);
 
       // WHEN
-      const result = await getBlockInfo(2000, mockCurrency);
+      const result = await getBlockInfo(2000, "concordium_testnet");
 
       // THEN
-      expect(getBlockInfoByHeightMock).toHaveBeenCalledWith(mockCurrency, 2000);
+      expect(getBlockInfoByHeightMock).toHaveBeenCalledWith("concordium_testnet", 2000);
       expect(result).toEqual(mockBlockInfo);
     });
   });
@@ -111,16 +105,16 @@ describe("history", () => {
           recipients: ["recipient1"],
         },
       ];
-      getOperationsGrpcMock.mockResolvedValue([mockOperations, ""]);
+      getOperationsGrpcMock.mockResolvedValue({ items: mockOperations, next: undefined });
 
       // WHEN
-      const result = await listOperations(VALID_ADDRESS, { minHeight: 100 }, mockCurrency);
+      const result = await listOperations(VALID_ADDRESS, { minHeight: 100 }, "concordium_testnet");
 
       // THEN
-      expect(getOperationsGrpcMock).toHaveBeenCalledWith(mockCurrency, VALID_ADDRESS, {
+      expect(getOperationsGrpcMock).toHaveBeenCalledWith("concordium_testnet", VALID_ADDRESS, {
         minHeight: 100,
       });
-      expect(result).toEqual([mockOperations, ""]);
+      expect(result).toEqual({ items: mockOperations, next: undefined });
     });
 
     it("should use proxy client when minHeight is 0", async () => {
@@ -142,10 +136,10 @@ describe("history", () => {
       getOperationsProxyMock.mockResolvedValue(mockLiveOperations);
 
       // WHEN
-      const result = await listOperations(VALID_ADDRESS, { minHeight: 0 }, mockCurrency);
+      const result = await listOperations(VALID_ADDRESS, { minHeight: 0 }, "concordium_testnet");
 
       // THEN
-      expect(getOperationsProxyMock).toHaveBeenCalledWith(mockCurrency, {
+      expect(getOperationsProxyMock).toHaveBeenCalledWith("concordium_testnet", {
         address: VALID_ADDRESS,
         accountId: expect.stringContaining("concordium"),
       });
@@ -177,7 +171,7 @@ describe("history", () => {
       getOperationsProxyMock.mockResolvedValue(mockLiveOperations);
 
       // WHEN
-      const result = await listOperations(VALID_ADDRESS, { minHeight: 0 }, mockCurrency);
+      const result = await listOperations(VALID_ADDRESS, { minHeight: 0 }, "concordium_testnet");
 
       // THEN
       const { items: operations } = result;
@@ -222,7 +216,7 @@ describe("history", () => {
       getOperationsProxyMock.mockResolvedValue(mockLiveOperations);
 
       // WHEN
-      const result = await listOperations(VALID_ADDRESS, { minHeight: 0 }, mockCurrency);
+      const result = await listOperations(VALID_ADDRESS, { minHeight: 0 }, "concordium_testnet");
 
       // THEN
       const { items: operations } = result;
@@ -238,7 +232,7 @@ describe("history", () => {
       getOperationsProxyMock.mockResolvedValue([]);
 
       // WHEN
-      const result = await listOperations(VALID_ADDRESS, { minHeight: 0 }, mockCurrency);
+      const result = await listOperations(VALID_ADDRESS, { minHeight: 0 }, "concordium_testnet");
 
       // THEN
       expect(result).toEqual({ items: [], next: undefined });

--- a/libs/coin-modules/coin-concordium/src/logic/history/lastBlock.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/lastBlock.integ.test.ts
@@ -1,10 +1,7 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import coinConfig from "../../config";
 import { lastBlock } from "./lastBlock";
 
 describe("lastBlock", () => {
-  const currency = getCryptoCurrencyById("concordium");
-
   beforeAll(() => {
     coinConfig.setCoinConfig(() => ({
       status: {
@@ -19,7 +16,7 @@ describe("lastBlock", () => {
   });
 
   it("returns last block info", async () => {
-    const result = await lastBlock(currency);
+    const result = await lastBlock("concordium_testnet");
 
     expect(result.hash).toMatch(/^[A-Fa-f0-9]{64}$/);
     expect(result.height).toBeGreaterThan(0);

--- a/libs/coin-modules/coin-concordium/src/logic/history/lastBlock.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/lastBlock.ts
@@ -1,7 +1,6 @@
 import type { BlockInfo } from "@ledgerhq/coin-framework/api/index";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getLastBlock } from "../../network/grpcClient";
 
-export async function lastBlock(currency: CryptoCurrency): Promise<BlockInfo> {
-  return getLastBlock(currency);
+export async function lastBlock(currencyId: string): Promise<BlockInfo> {
+  return getLastBlock(currencyId);
 }

--- a/libs/coin-modules/coin-concordium/src/logic/history/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/listOperations.integ.test.ts
@@ -1,10 +1,8 @@
 import type { Operation } from "@ledgerhq/coin-framework/api/types";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import coinConfig from "../../config";
 import { listOperations } from "./listOperations";
 
 describe("listOperations", () => {
-  const currency = getCryptoCurrencyById("concordium");
   const ADDRESS_WITH_BALANCE = "3U6m951FWryY56SKFFHgMLGVHtJtk4VaxN7V2F9hjkR7Sg1FUx";
   const ADDRESS_PRISTINE = "4ox4d7b4S9Mi3qA696v3yYjBQB4f6GDEVATrH9oFnoHUd5zLgh";
 
@@ -26,7 +24,7 @@ describe("listOperations", () => {
       const { items: operations, next: cursor } = await listOperations(
         ADDRESS_PRISTINE,
         { minHeight: 0 },
-        currency,
+        "concordium_testnet",
       );
 
       expect(Array.isArray(operations)).toBe(true);
@@ -40,7 +38,11 @@ describe("listOperations", () => {
     let cursor: string | undefined;
 
     beforeAll(async () => {
-      const page = await listOperations(ADDRESS_WITH_BALANCE, { minHeight: 0 }, currency);
+      const page = await listOperations(
+        ADDRESS_WITH_BALANCE,
+        { minHeight: 0 },
+        "concordium_testnet",
+      );
       operations = page.items;
       cursor = page.next;
     });
@@ -124,7 +126,11 @@ describe("listOperations", () => {
     let operations: Operation[];
 
     beforeAll(async () => {
-      const page = await listOperations(ADDRESS_WITH_BALANCE, { minHeight: 0 }, currency);
+      const page = await listOperations(
+        ADDRESS_WITH_BALANCE,
+        { minHeight: 0 },
+        "concordium_testnet",
+      );
       operations = page.items;
     });
 

--- a/libs/coin-modules/coin-concordium/src/logic/history/listOperations.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/listOperations.ts
@@ -1,6 +1,5 @@
 import { encodeAccountId } from "@ledgerhq/coin-framework/account/accountId";
 import type { Operation, ListOperationsOptions, Page } from "@ledgerhq/coin-framework/api/index";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getOperations as getOperationsGrpc } from "../../network/grpcClient";
 import {
   getOperations as getOperationsProxy,
@@ -11,27 +10,27 @@ import {
  * Returns list of operations associated to an account.
  * @param address Account address
  * @param options Pagination/filtering options
- * @param currency The cryptocurrency
+ * @param currencyId The cryptocurrency ID
  * @returns Operations found and the next "id" or "index" to use for pagination (i.e. `start` property).\
  */
 export async function listOperations(
   address: string,
   options: ListOperationsOptions,
-  currency: CryptoCurrency,
+  currencyId: string,
 ): Promise<Page<Operation>> {
   const accountId = encodeAccountId({
     type: "js",
     version: "2",
-    currencyId: currency.id,
+    currencyId,
     xpubOrAddress: address,
     derivationMode: "",
   });
 
   if (options.minHeight > 0) {
-    return getOperationsGrpc(currency, address, options);
+    return getOperationsGrpc(currencyId, address, options);
   }
 
-  const operations = await getOperationsProxy(currency, { address, accountId });
+  const operations = await getOperationsProxy(currencyId, { address, accountId });
 
   return {
     items: operations.map(

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/broadcast.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/broadcast.ts
@@ -1,11 +1,10 @@
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { submitTransfer } from "../../network/proxyClient";
 import { buildSubmitTransferData } from "../../network/utils";
 
-export async function broadcast(signedTx: string, currency: CryptoCurrency): Promise<string> {
+export async function broadcast(signedTx: string, currencyId: string): Promise<string> {
   const { transactionBody, signature } = JSON.parse(signedTx);
   const data = buildSubmitTransferData(transactionBody, signature);
 
-  const result = await submitTransfer(currency, data);
+  const result = await submitTransfer(currencyId, data);
   return result.submissionId;
 }

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.integ.test.ts
@@ -1,10 +1,7 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import coinConfig from "../../config";
 import { estimateFees } from "./estimateFees";
 
 describe("estimateFees", () => {
-  const currency = getCryptoCurrencyById("concordium");
-
   beforeAll(() => {
     coinConfig.setCoinConfig(() => ({
       status: {
@@ -20,7 +17,7 @@ describe("estimateFees", () => {
 
   describe("Simple transfer", () => {
     it("should return fee estimation for simple transfer", async () => {
-      const result = await estimateFees(currency);
+      const result = await estimateFees("concordium_testnet");
 
       expect(result).toHaveProperty("cost");
       expect(result).toHaveProperty("energy");
@@ -31,8 +28,8 @@ describe("estimateFees", () => {
     });
 
     it("should return consistent results for same parameters", async () => {
-      const result1 = await estimateFees(currency);
-      const result2 = await estimateFees(currency);
+      const result1 = await estimateFees("concordium_testnet");
+      const result2 = await estimateFees("concordium_testnet");
 
       expect(result1.cost).toBe(result2.cost);
       expect(result1.energy).toBe(result2.energy);
@@ -43,8 +40,8 @@ describe("estimateFees", () => {
     it("should return higher fee for transfer with memo", async () => {
       const memo = "Test memo";
 
-      const resultWithoutMemo = await estimateFees(currency);
-      const resultWithMemo = await estimateFees(currency, memo);
+      const resultWithoutMemo = await estimateFees("concordium_testnet");
+      const resultWithMemo = await estimateFees("concordium_testnet", memo);
 
       expect(resultWithMemo.cost).toBeGreaterThan(resultWithoutMemo.cost);
       expect(resultWithMemo.energy).toBeGreaterThan(resultWithoutMemo.energy);
@@ -54,8 +51,8 @@ describe("estimateFees", () => {
       const shortMemo = "Hi";
       const longMemo = "This is a longer memo with more characters";
 
-      const resultShort = await estimateFees(currency, shortMemo);
-      const resultLong = await estimateFees(currency, longMemo);
+      const resultShort = await estimateFees("concordium_testnet", shortMemo);
+      const resultLong = await estimateFees("concordium_testnet", longMemo);
 
       expect(resultLong.cost).toBeGreaterThanOrEqual(resultShort.cost);
       expect(resultLong.energy).toBeGreaterThanOrEqual(resultShort.energy);
@@ -64,21 +61,21 @@ describe("estimateFees", () => {
 
   describe("Fee estimation structure", () => {
     it("should return bigint values for precision", async () => {
-      const result = await estimateFees(currency);
+      const result = await estimateFees("concordium_testnet");
 
       expect(typeof result.cost).toBe("bigint");
       expect(typeof result.energy).toBe("bigint");
     });
 
     it("should have reasonable cost values", async () => {
-      const result = await estimateFees(currency);
+      const result = await estimateFees("concordium_testnet");
 
       expect(result.cost).toBeGreaterThan(BigInt(100));
       expect(result.cost).toBeLessThan(BigInt(10000000));
     });
 
     it("should have reasonable energy values", async () => {
-      const result = await estimateFees(currency);
+      const result = await estimateFees("concordium_testnet");
 
       expect(result.energy).toBeGreaterThan(BigInt(100));
       expect(result.energy).toBeLessThan(BigInt(10000000));
@@ -98,7 +95,7 @@ describe("estimateFees", () => {
         minReserve: 100000,
       }));
 
-      const result = await estimateFees(currency);
+      const result = await estimateFees("concordium_testnet");
 
       expect(typeof result.cost).toBe("bigint");
       expect(typeof result.energy).toBe("bigint");

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.ts
@@ -1,4 +1,3 @@
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { log } from "@ledgerhq/logs";
 import { memoEncodedSize } from "@ledgerhq/concordium-core";
 import { CONCORDIUM_ENERGY } from "../../constants";
@@ -9,12 +8,9 @@ export interface FeeEstimation {
   energy: bigint;
 }
 
-export async function estimateFees(
-  currency: CryptoCurrency,
-  memo?: string,
-): Promise<FeeEstimation> {
+export async function estimateFees(currencyId: string, memo?: string): Promise<FeeEstimation> {
   try {
-    const result = await getTransactionCost(currency, {
+    const result = await getTransactionCost(currencyId, {
       numSignatures: 1,
       ...(memo ? { memoSize: memoEncodedSize(memo) } : {}),
     });

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/transaction.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/transaction.test.ts
@@ -1,7 +1,6 @@
 import BigNumber from "bignumber.js";
 import { TransactionType } from "@ledgerhq/concordium-core";
 import { CONCORDIUM_ENERGY } from "../../constants";
-import { createTestCryptoCurrency } from "../../test/testHelpers";
 import { craftTransaction } from "./craftTransaction";
 import { estimateFees } from "./estimateFees";
 import { combine } from "./combine";
@@ -24,12 +23,6 @@ jest.mock("../../network/grpcClient", () => ({
 }));
 
 const VALID_ADDRESS = "3a9gh23nNY3kH4k3ajaCqAbM8rcbWMor2VhEzQ6qkn2r17UU7w";
-
-const createMockCurrency = () =>
-  createTestCryptoCurrency({
-    id: "concordium",
-    name: "Concordium",
-  });
 
 describe("logic/transaction", () => {
   beforeEach(() => {
@@ -197,9 +190,7 @@ describe("logic/transaction", () => {
 
   describe("estimateFees", () => {
     it("should return fee estimation for simple transfer", async () => {
-      const currency = createMockCurrency();
-
-      const result = await estimateFees(currency);
+      const result = await estimateFees("concordium_testnet");
 
       expect(result).toHaveProperty("cost");
       expect(result).toHaveProperty("energy");
@@ -208,18 +199,14 @@ describe("logic/transaction", () => {
     });
 
     it("should use fixed energy for simple transfer without payload", async () => {
-      const currency = createMockCurrency();
-
-      const result = await estimateFees(currency);
+      const result = await estimateFees("concordium_testnet");
 
       // Simple transfer has fixed energy cost
       expect(result.energy).toBe(CONCORDIUM_ENERGY.SIMPLE_TRANSFER);
     });
 
     it("should calculate energy for transfer with payload", async () => {
-      const currency = createMockCurrency();
-
-      const result = await estimateFees(currency);
+      const result = await estimateFees("concordium_testnet");
 
       expect(result.energy).toBeGreaterThan(0n);
     });
@@ -228,9 +215,7 @@ describe("logic/transaction", () => {
       const { getTransactionCost } = jest.requireMock("../../network/proxyClient");
       getTransactionCost.mockRejectedValueOnce(new Error("Network error"));
 
-      const currency = createMockCurrency();
-
-      const result = await estimateFees(currency);
+      const result = await estimateFees("concordium_testnet");
 
       expect(result.cost).toBe(CONCORDIUM_ENERGY.DEFAULT_COST);
       expect(result.energy).toBe(CONCORDIUM_ENERGY.DEFAULT);
@@ -240,9 +225,7 @@ describe("logic/transaction", () => {
       const { getTransactionCost } = jest.requireMock("../../network/proxyClient");
       getTransactionCost.mockRejectedValueOnce(new Error("Network error"));
 
-      const currency = createMockCurrency();
-
-      const result = await estimateFees(currency, "some memo");
+      const result = await estimateFees("concordium_testnet", "some memo");
 
       expect(result.cost).toBe(CONCORDIUM_ENERGY.DEFAULT_COST);
       expect(result.energy).toBe(CONCORDIUM_ENERGY.TRANSFER_WITH_MEMO_MAX);
@@ -250,20 +233,21 @@ describe("logic/transaction", () => {
 
     it("should call getTransactionCost with correct parameters", async () => {
       const { getTransactionCost } = jest.requireMock("../../network/proxyClient");
-      const currency = createMockCurrency();
 
-      await estimateFees(currency);
+      await estimateFees("concordium_testnet");
 
-      expect(getTransactionCost).toHaveBeenCalledWith(currency, { numSignatures: 1 });
+      expect(getTransactionCost).toHaveBeenCalledWith("concordium_testnet", { numSignatures: 1 });
     });
 
     it("should call getTransactionCost with memoSize when memo provided", async () => {
       const { getTransactionCost } = jest.requireMock("../../network/proxyClient");
-      const currency = createMockCurrency();
 
-      await estimateFees(currency, "test");
+      await estimateFees("concordium_testnet", "test");
 
-      expect(getTransactionCost).toHaveBeenCalledWith(currency, { numSignatures: 1, memoSize: 5 });
+      expect(getTransactionCost).toHaveBeenCalledWith("concordium_testnet", {
+        numSignatures: 1,
+        memoSize: 5,
+      });
     });
   });
 
@@ -290,16 +274,15 @@ describe("logic/transaction", () => {
   describe("broadcast", () => {
     it("should broadcast transaction and return submission ID", async () => {
       const { submitTransfer } = jest.requireMock("../../network/proxyClient");
-      const currency = createMockCurrency();
       const signedTx = JSON.stringify({
         transactionBody: "aabbccdd",
         signature: "11223344",
       });
 
-      const result = await broadcast(signedTx, currency);
+      const result = await broadcast(signedTx, "concordium_testnet");
 
       expect(result).toBe("test-submission-id");
-      expect(submitTransfer).toHaveBeenCalledWith(currency, {
+      expect(submitTransfer).toHaveBeenCalledWith("concordium_testnet", {
         transaction: "aabbccdd",
         signatures: { "0": { "0": "11223344" } },
       });
@@ -307,37 +290,33 @@ describe("logic/transaction", () => {
 
     it("should parse signed transaction JSON correctly", async () => {
       const { submitTransfer } = jest.requireMock("../../network/proxyClient");
-      const currency = createMockCurrency();
       const signedTx = JSON.stringify({
         transactionBody: "deadbeef",
         signature: "cafebabe",
       });
 
-      await broadcast(signedTx, currency);
+      await broadcast(signedTx, "concordium_testnet");
 
-      expect(submitTransfer).toHaveBeenCalledWith(currency, {
+      expect(submitTransfer).toHaveBeenCalledWith("concordium_testnet", {
         transaction: "deadbeef",
         signatures: { "0": { "0": "cafebabe" } },
       });
     });
 
     it("should throw on invalid JSON", async () => {
-      const currency = createMockCurrency();
-
-      await expect(broadcast("not-json", currency)).rejects.toThrow();
+      await expect(broadcast("not-json", "concordium_testnet")).rejects.toThrow();
     });
 
     it("should propagate network errors", async () => {
       const { submitTransfer } = jest.requireMock("../../network/proxyClient");
       submitTransfer.mockRejectedValueOnce(new Error("Network error"));
 
-      const currency = createMockCurrency();
       const signedTx = JSON.stringify({
         transactionBody: "aabbccdd",
         signature: "11223344",
       });
 
-      await expect(broadcast(signedTx, currency)).rejects.toThrow("Network error");
+      await expect(broadcast(signedTx, "concordium_testnet")).rejects.toThrow("Network error");
     });
   });
 });

--- a/libs/coin-modules/coin-concordium/src/network/grpcClient.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/network/grpcClient.integ.test.ts
@@ -1,9 +1,8 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import coinConfig from "../config";
 import { getLastBlock, getBlockInfoByHeight, getBlockByHeight } from "./grpcClient";
 
 describe("grpcClient", () => {
-  const currency = getCryptoCurrencyById("concordium");
+  const currencyId = "concordium_testnet";
 
   beforeAll(() => {
     coinConfig.setCoinConfig(() => ({
@@ -20,7 +19,7 @@ describe("grpcClient", () => {
 
   describe("getLastBlock", () => {
     it("should return last block info", async () => {
-      const result = await getLastBlock(currency);
+      const result = await getLastBlock(currencyId);
 
       expect(result).toHaveProperty("height");
       expect(result).toHaveProperty("hash");
@@ -31,10 +30,10 @@ describe("grpcClient", () => {
     });
 
     it("should return increasing block height on subsequent calls", async () => {
-      const result1 = await getLastBlock(currency);
+      const result1 = await getLastBlock(currencyId);
       // Wait a bit for potential new block
       await new Promise(resolve => setTimeout(resolve, 1000));
-      const result2 = await getLastBlock(currency);
+      const result2 = await getLastBlock(currencyId);
 
       expect(result2.height).toBeGreaterThanOrEqual(result1.height);
     });
@@ -42,10 +41,10 @@ describe("grpcClient", () => {
 
   describe("getBlockInfoByHeight", () => {
     it("should return block info for specific height", async () => {
-      const lastBlock = await getLastBlock(currency);
+      const lastBlock = await getLastBlock(currencyId);
       const targetHeight = lastBlock.height - 10;
 
-      const result = await getBlockInfoByHeight(currency, targetHeight);
+      const result = await getBlockInfoByHeight(currencyId, targetHeight);
 
       expect(result.height).toBe(targetHeight);
       expect(result.hash).toMatch(/^[A-Fa-f0-9]{64}$/);
@@ -53,11 +52,11 @@ describe("grpcClient", () => {
     });
 
     it("should return consistent info for same height", async () => {
-      const lastBlock = await getLastBlock(currency);
+      const lastBlock = await getLastBlock(currencyId);
       const targetHeight = lastBlock.height - 10;
 
-      const result1 = await getBlockInfoByHeight(currency, targetHeight);
-      const result2 = await getBlockInfoByHeight(currency, targetHeight);
+      const result1 = await getBlockInfoByHeight(currencyId, targetHeight);
+      const result2 = await getBlockInfoByHeight(currencyId, targetHeight);
 
       expect(result1.height).toBe(result2.height);
       expect(result1.hash).toBe(result2.hash);
@@ -65,10 +64,10 @@ describe("grpcClient", () => {
     });
 
     it("should handle recent blocks", async () => {
-      const lastBlock = await getLastBlock(currency);
+      const lastBlock = await getLastBlock(currencyId);
       const recentHeight = lastBlock.height - 1;
 
-      const result = await getBlockInfoByHeight(currency, recentHeight);
+      const result = await getBlockInfoByHeight(currencyId, recentHeight);
 
       expect(result.height).toBe(recentHeight);
       expect(result.hash).toMatch(/^[A-Fa-f0-9]{64}$/);
@@ -77,10 +76,10 @@ describe("grpcClient", () => {
 
   describe("getBlockByHeight", () => {
     it("should return block with transaction info", async () => {
-      const lastBlock = await getLastBlock(currency);
+      const lastBlock = await getLastBlock(currencyId);
       const targetHeight = lastBlock.height - 10;
 
-      const result = await getBlockByHeight(currency, targetHeight);
+      const result = await getBlockByHeight(currencyId, targetHeight);
 
       expect(result.info.height).toBe(targetHeight);
       expect(result.info.hash).toMatch(/^[A-Fa-f0-9]{64}$/);
@@ -89,10 +88,10 @@ describe("grpcClient", () => {
     });
 
     it("should return transactions with valid structure", async () => {
-      const lastBlock = await getLastBlock(currency);
+      const lastBlock = await getLastBlock(currencyId);
       const targetHeight = lastBlock.height - 10;
 
-      const result = await getBlockByHeight(currency, targetHeight);
+      const result = await getBlockByHeight(currencyId, targetHeight);
 
       result.transactions.forEach(tx => {
         expect(tx).toHaveProperty("hash");
@@ -104,11 +103,11 @@ describe("grpcClient", () => {
     });
 
     it("should return consistent block data", async () => {
-      const lastBlock = await getLastBlock(currency);
+      const lastBlock = await getLastBlock(currencyId);
       const targetHeight = lastBlock.height - 10;
 
-      const result1 = await getBlockByHeight(currency, targetHeight);
-      const result2 = await getBlockByHeight(currency, targetHeight);
+      const result1 = await getBlockByHeight(currencyId, targetHeight);
+      const result2 = await getBlockByHeight(currencyId, targetHeight);
 
       expect(result1.info.height).toBe(result2.info.height);
       expect(result1.info.hash).toBe(result2.info.hash);
@@ -119,12 +118,16 @@ describe("grpcClient", () => {
   describe("Network connectivity", () => {
     it("should successfully connect to gRPC endpoint", async () => {
       // This test verifies the gRPC connection works
-      const result = await getLastBlock(currency);
+      const result = await getLastBlock(currencyId);
       expect(result.height).toBeGreaterThan(0);
     });
 
     it("should handle multiple concurrent requests", async () => {
-      const promises = [getLastBlock(currency), getLastBlock(currency), getLastBlock(currency)];
+      const promises = [
+        getLastBlock(currencyId),
+        getLastBlock(currencyId),
+        getLastBlock(currencyId),
+      ];
 
       const results = await Promise.all(promises);
 

--- a/libs/coin-modules/coin-concordium/src/network/grpcClient.native.ts
+++ b/libs/coin-modules/coin-concordium/src/network/grpcClient.native.ts
@@ -6,7 +6,6 @@
  * and node:path. The bridge layer (sync, broadcast, sign) uses only
  * proxyClient (HTTP REST) and never reaches these functions at runtime.
  */
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type {
   Block,
   BlockInfo,
@@ -17,35 +16,35 @@ import type {
 
 type GRPCClient = never;
 
-export function getClient(_currency: CryptoCurrency): GRPCClient {
+export function getClient(_currencyId: string): GRPCClient {
   throw new Error("gRPC client is not available in React Native");
 }
 
 export async function withClient<T>(
-  _currency: CryptoCurrency,
+  _currencyId: string,
   _execute: (client: GRPCClient) => Promise<T>,
   _retries?: number,
 ): Promise<T> {
   throw new Error("gRPC client is not available in React Native");
 }
 
-export async function getLastBlock(_currency: CryptoCurrency): Promise<BlockInfo> {
+export async function getLastBlock(_currencyId: string): Promise<BlockInfo> {
   throw new Error("gRPC getLastBlock() method is not available in React Native");
 }
 
 export async function getBlockInfoByHeight(
-  _currency: CryptoCurrency,
+  _currencyId: string,
   _height: number,
 ): Promise<BlockInfo> {
   throw new Error("gRPC getBlockInfoByHeight() method is not available in React Native");
 }
 
-export async function getBlockByHeight(_currency: CryptoCurrency, _height: number): Promise<Block> {
+export async function getBlockByHeight(_currencyId: string, _height: number): Promise<Block> {
   throw new Error("gRPC getBlockByHeight() method is not available in React Native");
 }
 
 export async function getOperations(
-  _currency: CryptoCurrency,
+  _currencyId: string,
   _address: string,
   _options: ListOperationsOptions,
 ): Promise<Page<Operation>> {

--- a/libs/coin-modules/coin-concordium/src/network/grpcClient.test.ts
+++ b/libs/coin-modules/coin-concordium/src/network/grpcClient.test.ts
@@ -1,4 +1,3 @@
-import { createTestCryptoCurrency } from "../test/testHelpers";
 import {
   getClient,
   withClient,
@@ -80,11 +79,7 @@ jest.mock("../config", () => ({
   },
 }));
 
-const createMockCurrency = () =>
-  createTestCryptoCurrency({
-    id: "concordium",
-    family: "concordium",
-  });
+const currencyId = "concordium_testnet";
 
 describe("grpcClient", () => {
   beforeEach(() => {
@@ -93,16 +88,14 @@ describe("grpcClient", () => {
 
   describe("getClient", () => {
     it("should create a new client for currency", () => {
-      const currency = createMockCurrency();
-      const client = getClient(currency);
+      const client = getClient(currencyId);
 
       expect(client).not.toBeUndefined();
     });
 
     it("should return cached client on subsequent calls", () => {
-      const currency = createMockCurrency();
-      const client1 = getClient(currency);
-      const client2 = getClient(currency);
+      const client1 = getClient(currencyId);
+      const client2 = getClient(currencyId);
 
       expect(client1).toBe(client2);
     });
@@ -110,41 +103,37 @@ describe("grpcClient", () => {
 
   describe("withClient", () => {
     it("should execute function with client", async () => {
-      const currency = createMockCurrency();
       const mockFn = jest.fn().mockResolvedValue("result");
 
-      const result = await withClient(currency, mockFn);
+      const result = await withClient(currencyId, mockFn);
 
       expect(result).toBe("result");
       expect(mockFn).toHaveBeenCalledTimes(1);
     });
 
     it("should retry on failure", async () => {
-      const currency = createMockCurrency();
       const mockFn = jest
         .fn()
         .mockRejectedValueOnce(new Error("First failure"))
         .mockResolvedValueOnce("success");
 
-      const result = await withClient(currency, mockFn, 1);
+      const result = await withClient(currencyId, mockFn, 1);
 
       expect(result).toBe("success");
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
     it("should throw after all retries exhausted", async () => {
-      const currency = createMockCurrency();
       const mockFn = jest.fn().mockRejectedValue(new Error("Always fails"));
 
-      await expect(withClient(currency, mockFn, 1)).rejects.toThrow("Always fails");
+      await expect(withClient(currencyId, mockFn, 1)).rejects.toThrow("Always fails");
       expect(mockFn).toHaveBeenCalledTimes(2); // initial + 1 retry
     });
 
     it("should use default retries when not specified", async () => {
-      const currency = createMockCurrency();
       const mockFn = jest.fn().mockRejectedValue(new Error("Fails"));
 
-      await expect(withClient(currency, mockFn)).rejects.toThrow("Fails");
+      await expect(withClient(currencyId, mockFn)).rejects.toThrow("Fails");
       expect(mockFn).toHaveBeenCalledTimes(2); // DEFAULT_RETRIES = 1
     });
   });
@@ -158,8 +147,7 @@ describe("grpcClient", () => {
         lastFinalizedTime: { value: "1700000000000" },
       });
 
-      const currency = createMockCurrency();
-      const result = await getLastBlock(currency);
+      const result = await getLastBlock(currencyId);
 
       expect(result).toEqual({
         height: 1000,
@@ -175,8 +163,7 @@ describe("grpcClient", () => {
         lastFinalizedTime: { value: "1000" },
       });
 
-      const currency = createMockCurrency();
-      await getLastBlock(currency);
+      await getLastBlock(currencyId);
 
       expect(mockGetConsensusStatusResponse).toHaveBeenCalled();
     });
@@ -193,8 +180,7 @@ describe("grpcClient", () => {
         blockSlotTime: new Date("2024-01-01"),
       });
 
-      const currency = createMockCurrency();
-      const result = await getBlockInfoByHeight(currency, 500);
+      const result = await getBlockInfoByHeight(currencyId, 500);
 
       expect(result.height).toBe(500);
       expect(result.hash).toBe("abc456abc456abc456abc456abc456abc456abc456abc456abc456abc456abc4");
@@ -203,9 +189,7 @@ describe("grpcClient", () => {
     it("should throw error when no blocks found at height", async () => {
       mockGetBlocksAtHeightResponse.mockReturnValue([]);
 
-      const currency = createMockCurrency();
-
-      await expect(getBlockInfoByHeight(currency, 999)).rejects.toThrow(
+      await expect(getBlockInfoByHeight(currencyId, 999)).rejects.toThrow(
         "No blocks found at height 999",
       );
     });
@@ -231,8 +215,7 @@ describe("grpcClient", () => {
           blockSlotTime: new Date("2024-01-01"),
         });
 
-      const currency = createMockCurrency();
-      const result = await getBlockInfoByHeight(currency, 500);
+      const result = await getBlockInfoByHeight(currencyId, 500);
 
       expect(result.parent).not.toBeUndefined();
       expect(result.parent?.height).toBe(499);
@@ -251,8 +234,7 @@ describe("grpcClient", () => {
         blockSlotTime: new Date("2024-01-01"),
       });
 
-      const currency = createMockCurrency();
-      const result = await getBlockInfoByHeight(currency, 0);
+      const result = await getBlockInfoByHeight(currencyId, 0);
 
       expect(result.parent).toBeUndefined();
     });
@@ -270,8 +252,7 @@ describe("grpcClient", () => {
       });
       mockGetBlockTransactionEventsStream.mockReturnValue((async function* () {})());
 
-      const currency = createMockCurrency();
-      const result = await getBlockByHeight(currency, 100);
+      const result = await getBlockByHeight(currencyId, 100);
 
       expect(result.info.height).toBe(100);
       expect(result.transactions).toEqual([]);
@@ -306,8 +287,7 @@ describe("grpcClient", () => {
         })(),
       );
 
-      const currency = createMockCurrency();
-      const result = await getBlockByHeight(currency, 100);
+      const result = await getBlockByHeight(currencyId, 100);
 
       expect(result.transactions).toHaveLength(1);
       expect(result.transactions[0].hash).toBe("txhash");
@@ -337,8 +317,7 @@ describe("grpcClient", () => {
         })(),
       );
 
-      const currency = createMockCurrency();
-      const result = await getBlockByHeight(currency, 100);
+      const result = await getBlockByHeight(currencyId, 100);
 
       expect(result.transactions).toHaveLength(1);
       expect(result.transactions[0].failed).toBe(true);
@@ -375,8 +354,7 @@ describe("grpcClient", () => {
         })(),
       );
 
-      const currency = createMockCurrency();
-      const result = await getBlockByHeight(currency, 100);
+      const result = await getBlockByHeight(currencyId, 100);
 
       expect(result.transactions).toHaveLength(1);
     });
@@ -392,8 +370,7 @@ describe("grpcClient", () => {
     });
 
     it("should return empty array when minHeight exceeds current height", async () => {
-      const currency = createMockCurrency();
-      const result = await getOperations(currency, "address", { minHeight: 2000 });
+      const result = await getOperations(currencyId, "address", { minHeight: 2000 });
 
       expect(result).toEqual({ items: [], next: undefined });
     });
@@ -427,8 +404,9 @@ describe("grpcClient", () => {
         })(),
       );
 
-      const currency = createMockCurrency();
-      const { items: operations } = await getOperations(currency, "my-address", { minHeight: 100 });
+      const { items: operations } = await getOperations(currencyId, "my-address", {
+        minHeight: 100,
+      });
 
       expect(operations.length).toBeGreaterThanOrEqual(0);
     });
@@ -462,8 +440,9 @@ describe("grpcClient", () => {
         })(),
       );
 
-      const currency = createMockCurrency();
-      const { items: operations } = await getOperations(currency, "my-address", { minHeight: 100 });
+      const { items: operations } = await getOperations(currencyId, "my-address", {
+        minHeight: 100,
+      });
 
       // Should not include transactions not involving my-address
       expect(
@@ -489,8 +468,7 @@ describe("grpcClient", () => {
       });
       mockGetBlockTransactionEventsStream.mockReturnValue((async function* () {})());
 
-      const currency = createMockCurrency();
-      const { next: cursor } = await getOperations(currency, "my-address", { minHeight: 100 });
+      const { next: cursor } = await getOperations(currencyId, "my-address", { minHeight: 100 });
 
       expect(cursor).toBeUndefined();
     });
@@ -511,9 +489,8 @@ describe("grpcClient", () => {
       });
       mockGetBlockTransactionEventsStream.mockReturnValue((async function* () {})());
 
-      const currency = createMockCurrency();
       // Scan from height 100, will hit MAX_BLOCKS_TO_SCAN (1000) limit at height 1100
-      const { next: cursor } = await getOperations(currency, "my-address", { minHeight: 100 });
+      const { next: cursor } = await getOperations(currencyId, "my-address", { minHeight: 100 });
 
       // Next height should be 1101 (endHeight + 1 where endHeight = 100 + 1000)
       expect(cursor).toBe(JSON.stringify(1101));
@@ -535,9 +512,8 @@ describe("grpcClient", () => {
       });
       mockGetBlockTransactionEventsStream.mockReturnValue((async function* () {})());
 
-      const currency = createMockCurrency();
       // Scan from 100 to 150 (current height)
-      const { next: cursor } = await getOperations(currency, "my-address", { minHeight: 100 });
+      const { next: cursor } = await getOperations(currencyId, "my-address", { minHeight: 100 });
 
       // At chain tip, should return empty cursor
       expect(cursor).toBeUndefined();
@@ -548,17 +524,13 @@ describe("grpcClient", () => {
     it("should handle and throw getLastBlock errors", async () => {
       mockGetConsensusStatusResponse.mockReturnValue(new Error("Connection failed"));
 
-      const currency = createMockCurrency();
-
-      await expect(getLastBlock(currency)).rejects.toThrow("Connection failed");
+      await expect(getLastBlock(currencyId)).rejects.toThrow("Connection failed");
     });
 
     it("should handle and throw getBlockInfoByHeight errors when GetBlocksAtHeight fails", async () => {
       mockGetBlocksAtHeightResponse.mockReturnValue(new Error("Network error"));
 
-      const currency = createMockCurrency();
-
-      await expect(getBlockInfoByHeight(currency, 100)).rejects.toThrow("Network error");
+      await expect(getBlockInfoByHeight(currencyId, 100)).rejects.toThrow("Network error");
     });
 
     it("should handle and throw getBlockInfoByHeight errors when GetBlockInfo fails", async () => {
@@ -567,9 +539,7 @@ describe("grpcClient", () => {
       ]);
       mockGetBlockInfoResponse.mockReturnValue(new Error("Block not found"));
 
-      const currency = createMockCurrency();
-
-      await expect(getBlockInfoByHeight(currency, 100)).rejects.toThrow("Block not found");
+      await expect(getBlockInfoByHeight(currencyId, 100)).rejects.toThrow("Block not found");
     });
 
     it("should handle and throw getBlockByHeight errors", async () => {
@@ -585,9 +555,7 @@ describe("grpcClient", () => {
         throw new Error("Stream error");
       });
 
-      const currency = createMockCurrency();
-
-      await expect(getBlockByHeight(currency, 100)).rejects.toThrow("Stream error");
+      await expect(getBlockByHeight(currencyId, 100)).rejects.toThrow("Stream error");
     });
   });
 
@@ -630,8 +598,7 @@ describe("grpcClient", () => {
         })(),
       );
 
-      const currency = createMockCurrency();
-      const result = await getBlockByHeight(currency, 100);
+      const result = await getBlockByHeight(currencyId, 100);
 
       expect(result.transactions).toHaveLength(1);
       expect(result.transactions[0].hash).toBe("txhash");
@@ -658,8 +625,7 @@ describe("grpcClient", () => {
         })(),
       );
 
-      const currency = createMockCurrency();
-      const result = await getBlockByHeight(currency, 100);
+      const result = await getBlockByHeight(currencyId, 100);
 
       expect(result.transactions).toHaveLength(1);
       expect(result.transactions[0].hash).toBe("encrypted-tx");
@@ -685,8 +651,7 @@ describe("grpcClient", () => {
         })(),
       );
 
-      const currency = createMockCurrency();
-      const result = await getBlockByHeight(currency, 100);
+      const result = await getBlockByHeight(currencyId, 100);
 
       expect(result.transactions).toHaveLength(1);
     });

--- a/libs/coin-modules/coin-concordium/src/network/grpcClient.ts
+++ b/libs/coin-modules/coin-concordium/src/network/grpcClient.ts
@@ -9,7 +9,6 @@ import { join } from "node:path";
 import * as grpc from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
 import { retry } from "@ledgerhq/live-promise";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type {
   Block,
   BlockInfo,
@@ -129,8 +128,8 @@ const DEFAULT_RETRIES = 1;
 const RETRY_DELAY = 1000;
 const MAX_BLOCKS_TO_SCAN = 1000;
 
-function createGrpcClient(currency: CryptoCurrency): GRPCClient {
-  const { grpcUrl: address, grpcPort: port } = coinConfig.getCoinConfig(currency);
+function createGrpcClient(currencyId: string): GRPCClient {
+  const { grpcUrl: address, grpcPort: port } = coinConfig.getCoinConfig(currencyId);
 
   try {
     const protoPath = join(__dirname, "proto/v2/concordium/service.proto");
@@ -157,23 +156,23 @@ function createGrpcClient(currency: CryptoCurrency): GRPCClient {
   }
 }
 
-const CLIENTS_BY_CURRENCY = new Map<CryptoCurrency["id"], GRPCClient>();
+const CLIENTS_BY_CURRENCY = new Map<string, GRPCClient>();
 
-export function getClient(currency: CryptoCurrency): GRPCClient {
-  const existing = CLIENTS_BY_CURRENCY.get(currency.id);
+export function getClient(currencyId: string): GRPCClient {
+  const existing = CLIENTS_BY_CURRENCY.get(currencyId);
   if (existing) return existing;
 
-  const client = createGrpcClient(currency);
-  CLIENTS_BY_CURRENCY.set(currency.id, client);
+  const client = createGrpcClient(currencyId);
+  CLIENTS_BY_CURRENCY.set(currencyId, client);
   return client;
 }
 
 export async function withClient<T>(
-  currency: CryptoCurrency,
+  currencyId: string,
   execute: (client: GRPCClient) => Promise<T>,
   retries = DEFAULT_RETRIES,
 ): Promise<T> {
-  const client = getClient(currency);
+  const client = getClient(currencyId);
 
   return retry(() => execute(client), {
     maxRetry: retries,
@@ -201,12 +200,12 @@ async function streamToList<T>(stream: AsyncIterable<T>): Promise<T[]> {
  *
  * Used by: history/lastBlock.ts
  *
- * @param currency - The cryptocurrency configuration
+ * @param currencyId - The cryptocurrency ID
  * @returns Block metadata (height, hash, time) of the last finalized block
  */
-export async function getLastBlock(currency: CryptoCurrency): Promise<BlockInfo> {
+export async function getLastBlock(currencyId: string): Promise<BlockInfo> {
   try {
-    return await withClient(currency, async client => {
+    return await withClient(currencyId, async client => {
       return new Promise<BlockInfo>((resolve, reject) => {
         client.GetConsensusInfo({}, (error, response) => {
           if (error) {
@@ -253,7 +252,7 @@ function handleBlocksResponse(
  * Note: Concordium can have multiple blocks at the same height (forks),
  * but we typically use the first one as the canonical block.
  */
-async function getBlockHashesAtHeight(currency: CryptoCurrency, height: number): Promise<string[]> {
+async function getBlockHashesAtHeight(currencyId: string, height: number): Promise<string[]> {
   const fetchBlocks = (client: GRPCClient): Promise<string[]> => {
     return new Promise<string[]>((resolve, reject) => {
       client.GetBlocksAtHeight(
@@ -264,7 +263,7 @@ async function getBlockHashesAtHeight(currency: CryptoCurrency, height: number):
   };
 
   try {
-    return await withClient(currency, fetchBlocks);
+    return await withClient(currencyId, fetchBlocks);
   } catch (error) {
     log("concordium-grpc", "getBlockHashesAtHeight", { error });
     throw error;
@@ -278,9 +277,9 @@ async function getBlockHashesAtHeight(currency: CryptoCurrency, height: number):
  *
  * Converts gRPC response types to Ledger Live BlockInfo format.
  */
-async function getBlockInfo(currency: CryptoCurrency, blockHash: string): Promise<BlockInfo> {
+async function getBlockInfo(currencyId: string, blockHash: string): Promise<BlockInfo> {
   try {
-    return await withClient(currency, async client => {
+    return await withClient(currencyId, async client => {
       return new Promise<BlockInfo>((resolve, reject) => {
         client.GetBlockInfo(
           { given: { value: Buffer.from(blockHash, "hex") } },
@@ -314,29 +313,26 @@ async function getBlockInfo(currency: CryptoCurrency, blockHash: string): Promis
  *
  * Composes: getBlockHashesAtHeight + getBlockInfo (for block and parent)
  *
- * @param currency - The cryptocurrency configuration
+ * @param currencyId - The cryptocurrency ID
  * @param height - Block height to query
  * @returns Block metadata with parent block reference (if height > 0)
  */
-export async function getBlockInfoByHeight(
-  currency: CryptoCurrency,
-  height: number,
-): Promise<BlockInfo> {
+export async function getBlockInfoByHeight(currencyId: string, height: number): Promise<BlockInfo> {
   try {
-    const blockHashes = await getBlockHashesAtHeight(currency, height);
+    const blockHashes = await getBlockHashesAtHeight(currencyId, height);
 
     if (blockHashes.length === 0) {
       throw new Error(`No blocks found at height ${height}`);
     }
 
     const blockHash = blockHashes[0];
-    const result = await getBlockInfo(currency, blockHash);
+    const result = await getBlockInfo(currencyId, blockHash);
 
     if (height > 0) {
-      const parentHashes = await getBlockHashesAtHeight(currency, height - 1);
+      const parentHashes = await getBlockHashesAtHeight(currencyId, height - 1);
 
       if (parentHashes.length > 0) {
-        const parentBlockInfo = await getBlockInfo(currency, parentHashes[0]);
+        const parentBlockInfo = await getBlockInfo(currencyId, parentHashes[0]);
         result.parent = {
           height: parentBlockInfo.height,
           hash: parentBlockInfo.hash!,
@@ -360,11 +356,11 @@ export async function getBlockInfoByHeight(
  * filtering out non-account transactions and processing transfer effects.
  */
 async function getBlockTransactionEvents(
-  currency: CryptoCurrency,
+  currencyId: string,
   blockHash: string,
 ): Promise<AsyncIterable<BlockTransactionEvent>> {
   try {
-    return await withClient(currency, async client => {
+    return await withClient(currencyId, async client => {
       const request = {
         given: { value: Buffer.from(blockHash, "hex") },
       };
@@ -446,26 +442,26 @@ async function getBlockTransactionEvents(
  * Parses transaction events into Ledger Live Block format with operations
  * (transfers IN/OUT). Filters to account transactions only.
  *
- * @param currency - The cryptocurrency configuration
+ * @param currencyId - The cryptocurrency ID
  * @param height - Block height to query
  * @returns Full block with metadata and parsed transactions
  */
-export async function getBlockByHeight(currency: CryptoCurrency, height: number): Promise<Block> {
+export async function getBlockByHeight(currencyId: string, height: number): Promise<Block> {
   try {
-    const blockHashes = await getBlockHashesAtHeight(currency, height);
+    const blockHashes = await getBlockHashesAtHeight(currencyId, height);
 
     if (blockHashes.length === 0) {
       throw new Error(`No blocks found at height ${height}`);
     }
 
     const blockHash = blockHashes[0];
-    const info = await getBlockInfo(currency, blockHash);
+    const info = await getBlockInfo(currencyId, blockHash);
 
     if (height > 0) {
-      const parentHashes = await getBlockHashesAtHeight(currency, height - 1);
+      const parentHashes = await getBlockHashesAtHeight(currencyId, height - 1);
 
       if (parentHashes.length > 0) {
-        const parentBlockInfo = await getBlockInfo(currency, parentHashes[0]);
+        const parentBlockInfo = await getBlockInfo(currencyId, parentHashes[0]);
         info.parent = {
           height: parentBlockInfo.height,
           hash: parentBlockInfo.hash!,
@@ -473,7 +469,7 @@ export async function getBlockByHeight(currency: CryptoCurrency, height: number)
       }
     }
 
-    const transactionStream = await getBlockTransactionEvents(currency, blockHash);
+    const transactionStream = await getBlockTransactionEvents(currencyId, blockHash);
     const transactionEvents = await streamToList(transactionStream);
 
     const transactions: BlockTransaction[] = transactionEvents
@@ -629,18 +625,18 @@ function processTransactionForAddress(
  * filtering for transactions where the address is sender or recipient.
  * Returns operations sorted by date (newest first).
  *
- * @param currency - The cryptocurrency configuration
+ * @param currencyId - The cryptocurrency ID
  * @param address - The account address to filter operations for
  * @param options - Pagination/filtering parameters (minHeight determines scan start)
- * @returns Array of operations and cursor (stringified next block height if more results, empty string otherwise)
+ * @returns Page containing matching operations and an optional cursor for pagination
  */
 export async function getOperations(
-  currency: CryptoCurrency,
+  currencyId: string,
   address: string,
   options: ListOperationsOptions,
 ): Promise<Page<Operation>> {
   try {
-    const { height: currentHeight } = await getLastBlock(currency);
+    const { height: currentHeight } = await getLastBlock(currencyId);
 
     if (options.minHeight > currentHeight) {
       return { items: [], next: undefined };
@@ -654,14 +650,14 @@ export async function getOperations(
     const operations: Operation[] = [];
 
     for (let height = startHeight; height <= endHeight; height++) {
-      const blockHashes = await getBlockHashesAtHeight(currency, height);
+      const blockHashes = await getBlockHashesAtHeight(currencyId, height);
 
       if (blockHashes.length === 0) continue;
 
       const blockHash = blockHashes[0];
-      const blockInfo = await getBlockInfo(currency, blockHash);
+      const blockInfo = await getBlockInfo(currencyId, blockHash);
 
-      const transactionStream = await getBlockTransactionEvents(currency, blockHash);
+      const transactionStream = await getBlockTransactionEvents(currencyId, blockHash);
       const transactionEvents = await streamToList(transactionStream);
 
       for (const event of transactionEvents) {

--- a/libs/coin-modules/coin-concordium/src/network/proxyClient.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/network/proxyClient.integ.test.ts
@@ -1,4 +1,3 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import coinConfig from "../config";
 import {
   getAccountsByPublicKey,
@@ -10,7 +9,7 @@ import {
 } from "./proxyClient";
 
 describe("proxyClient", () => {
-  const currency = getCryptoCurrencyById("concordium");
+  const currencyId = "concordium_testnet";
   const ADDRESS_WITH_BALANCE = "3U6m951FWryY56SKFFHgMLGVHtJtk4VaxN7V2F9hjkR7Sg1FUx";
   const ADDRESS_PRISTINE = "4ox4d7b4S9Mi3qA696v3yYjBQB4f6GDEVATrH9oFnoHUd5zLgh";
   const PUBLIC_KEY = "aa".repeat(32);
@@ -32,14 +31,14 @@ describe("proxyClient", () => {
   describe("getAccountsByPublicKey", () => {
     it("should return accounts for valid public key", async () => {
       // Note: This will return empty for test public key, but should not error
-      const result = await getAccountsByPublicKey(currency, PUBLIC_KEY);
+      const result = await getAccountsByPublicKey(currencyId, PUBLIC_KEY);
 
       expect(Array.isArray(result)).toBe(true);
     });
 
     it("should return array even for unknown public key", async () => {
       const unknownPubKey = "bb".repeat(32);
-      const result = await getAccountsByPublicKey(currency, unknownPubKey);
+      const result = await getAccountsByPublicKey(currencyId, unknownPubKey);
 
       expect(Array.isArray(result)).toBe(true);
     });
@@ -47,7 +46,7 @@ describe("proxyClient", () => {
 
   describe("getAccountBalance", () => {
     it("should return balance for existing account", async () => {
-      const result = await getAccountBalance(currency, ADDRESS_WITH_BALANCE);
+      const result = await getAccountBalance(currencyId, ADDRESS_WITH_BALANCE);
 
       expect(result).toHaveProperty("finalizedBalance");
       expect(result.finalizedBalance).toHaveProperty("accountAmount");
@@ -58,7 +57,7 @@ describe("proxyClient", () => {
 
     it("should return balance structure for pristine account", async () => {
       try {
-        const result = await getAccountBalance(currency, ADDRESS_PRISTINE);
+        const result = await getAccountBalance(currencyId, ADDRESS_PRISTINE);
         expect(result).toHaveProperty("finalizedBalance");
       } catch (error) {
         // Pristine accounts may not exist yet, which is expected
@@ -67,7 +66,7 @@ describe("proxyClient", () => {
     });
 
     it("should parse balance as valid numbers", async () => {
-      const result = await getAccountBalance(currency, ADDRESS_WITH_BALANCE);
+      const result = await getAccountBalance(currencyId, ADDRESS_WITH_BALANCE);
 
       const amount = BigInt(result.finalizedBalance.accountAmount);
       const atDisposal = BigInt(result.finalizedBalance.accountAtDisposal);
@@ -80,7 +79,7 @@ describe("proxyClient", () => {
 
   describe("getAccountNonce", () => {
     it("should return nonce for existing account", async () => {
-      const result = await getAccountNonce(currency, ADDRESS_WITH_BALANCE);
+      const result = await getAccountNonce(currencyId, ADDRESS_WITH_BALANCE);
 
       expect(result).toHaveProperty("nonce");
       expect(typeof result.nonce).toBe("number");
@@ -89,7 +88,7 @@ describe("proxyClient", () => {
 
     it("should handle pristine account", async () => {
       try {
-        const result = await getAccountNonce(currency, ADDRESS_PRISTINE);
+        const result = await getAccountNonce(currencyId, ADDRESS_PRISTINE);
         expect(result).toHaveProperty("nonce");
       } catch (error) {
         // Pristine accounts may not exist yet, which is expected
@@ -98,8 +97,8 @@ describe("proxyClient", () => {
     });
 
     it("should return consistent nonce for same account", async () => {
-      const result1 = await getAccountNonce(currency, ADDRESS_WITH_BALANCE);
-      const result2 = await getAccountNonce(currency, ADDRESS_WITH_BALANCE);
+      const result1 = await getAccountNonce(currencyId, ADDRESS_WITH_BALANCE);
+      const result2 = await getAccountNonce(currencyId, ADDRESS_WITH_BALANCE);
 
       // Nonce should be the same or higher (if transactions were sent in between)
       expect(result2.nonce).toBeGreaterThanOrEqual(result1.nonce);
@@ -108,7 +107,7 @@ describe("proxyClient", () => {
 
   describe("getTransactions", () => {
     it("should return transactions for account", async () => {
-      const result = await getTransactions(currency, ADDRESS_WITH_BALANCE);
+      const result = await getTransactions(currencyId, ADDRESS_WITH_BALANCE);
 
       expect(result).toHaveProperty("transactions");
       expect(Array.isArray(result.transactions)).toBe(true);
@@ -116,13 +115,13 @@ describe("proxyClient", () => {
 
     it("should respect limit parameter", async () => {
       const limit = 5;
-      const result = await getTransactions(currency, ADDRESS_WITH_BALANCE, { limit });
+      const result = await getTransactions(currencyId, ADDRESS_WITH_BALANCE, { limit });
 
       expect(result.transactions.length).toBeLessThanOrEqual(limit);
     });
 
     it("should respect order parameter", async () => {
-      const resultDesc = await getTransactions(currency, ADDRESS_WITH_BALANCE, {
+      const resultDesc = await getTransactions(currencyId, ADDRESS_WITH_BALANCE, {
         limit: 10,
         order: "d",
       });
@@ -138,7 +137,7 @@ describe("proxyClient", () => {
     });
 
     it("should return transactions with valid structure", async () => {
-      const result = await getTransactions(currency, ADDRESS_WITH_BALANCE, { limit: 5 });
+      const result = await getTransactions(currencyId, ADDRESS_WITH_BALANCE, { limit: 5 });
 
       if (result.transactions.length > 0) {
         result.transactions.forEach(tx => {
@@ -156,7 +155,7 @@ describe("proxyClient", () => {
   describe("getTransactionCost", () => {
     it("should return cost estimation for simple transfer", async () => {
       const numSignatures = 1;
-      const result = await getTransactionCost(currency, { numSignatures });
+      const result = await getTransactionCost(currencyId, { numSignatures });
 
       expect(result).toHaveProperty("cost");
       expect(result).toHaveProperty("energy");
@@ -173,8 +172,8 @@ describe("proxyClient", () => {
       const numSignatures = 1;
       const memoSize = 50;
 
-      const resultWithoutMemo = await getTransactionCost(currency, { numSignatures });
-      const resultWithMemo = await getTransactionCost(currency, { numSignatures, memoSize });
+      const resultWithoutMemo = await getTransactionCost(currencyId, { numSignatures });
+      const resultWithMemo = await getTransactionCost(currencyId, { numSignatures, memoSize });
 
       const costWithoutMemo = BigInt(resultWithoutMemo.cost);
       const costWithMemo = BigInt(resultWithMemo.cost);
@@ -185,8 +184,11 @@ describe("proxyClient", () => {
     it("should scale with memo size", async () => {
       const numSignatures = 1;
 
-      const resultSmallMemo = await getTransactionCost(currency, { numSignatures, memoSize: 10 });
-      const resultLargeMemo = await getTransactionCost(currency, { numSignatures, memoSize: 100 });
+      const resultSmallMemo = await getTransactionCost(currencyId, { numSignatures, memoSize: 10 });
+      const resultLargeMemo = await getTransactionCost(currencyId, {
+        numSignatures,
+        memoSize: 100,
+      });
 
       const costSmall = BigInt(resultSmallMemo.cost);
       const costLarge = BigInt(resultLargeMemo.cost);
@@ -197,8 +199,8 @@ describe("proxyClient", () => {
     it("should return consistent results for same parameters", async () => {
       const numSignatures = 1;
 
-      const result1 = await getTransactionCost(currency, { numSignatures });
-      const result2 = await getTransactionCost(currency, { numSignatures });
+      const result1 = await getTransactionCost(currencyId, { numSignatures });
+      const result2 = await getTransactionCost(currencyId, { numSignatures });
 
       expect(result1.cost).toBe(result2.cost);
       expect(result1.energy).toBe(result2.energy);
@@ -207,7 +209,7 @@ describe("proxyClient", () => {
 
   describe("getOperations", () => {
     it("should return operations for account", async () => {
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: ADDRESS_WITH_BALANCE,
         accountId: ACCOUNT_ID,
       });
@@ -216,7 +218,7 @@ describe("proxyClient", () => {
     });
 
     it("should return empty array for pristine account", async () => {
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: ADDRESS_PRISTINE,
         accountId: ACCOUNT_ID,
       });
@@ -226,7 +228,7 @@ describe("proxyClient", () => {
 
     it("should respect size parameter", async () => {
       const size = 5;
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: ADDRESS_WITH_BALANCE,
         accountId: ACCOUNT_ID,
         size,
@@ -236,7 +238,7 @@ describe("proxyClient", () => {
     });
 
     it("should return operations with valid structure", async () => {
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: ADDRESS_WITH_BALANCE,
         accountId: ACCOUNT_ID,
         size: 10,
@@ -262,7 +264,7 @@ describe("proxyClient", () => {
     });
 
     it("should filter transactions by type", async () => {
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: ADDRESS_WITH_BALANCE,
         accountId: ACCOUNT_ID,
         size: 100,
@@ -279,7 +281,7 @@ describe("proxyClient", () => {
     it("should handle network errors gracefully", async () => {
       // Even with invalid address, should return empty array instead of throwing
       const invalidAddress = "invalid-address";
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: invalidAddress,
         accountId: ACCOUNT_ID,
       });
@@ -290,16 +292,16 @@ describe("proxyClient", () => {
 
   describe("Network connectivity", () => {
     it("should successfully connect to proxy endpoint", async () => {
-      await expect(getTransactionCost(currency, { numSignatures: 1 })).resolves.toHaveProperty(
+      await expect(getTransactionCost(currencyId, { numSignatures: 1 })).resolves.toHaveProperty(
         "cost",
       );
     });
 
     it("should handle multiple concurrent requests", async () => {
       const promises = [
-        getTransactionCost(currency, { numSignatures: 1 }),
-        getTransactionCost(currency, { numSignatures: 1 }),
-        getTransactionCost(currency, { numSignatures: 1 }),
+        getTransactionCost(currencyId, { numSignatures: 1 }),
+        getTransactionCost(currencyId, { numSignatures: 1 }),
+        getTransactionCost(currencyId, { numSignatures: 1 }),
       ];
 
       const results = await Promise.all(promises);

--- a/libs/coin-modules/coin-concordium/src/network/proxyClient.test.ts
+++ b/libs/coin-modules/coin-concordium/src/network/proxyClient.test.ts
@@ -1,4 +1,3 @@
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import {
   withClient,
@@ -28,11 +27,7 @@ jest.mock("../config", () => ({
   },
 }));
 
-const createMockCurrency = (): CryptoCurrency =>
-  ({
-    id: "concordium",
-    family: "concordium",
-  }) as CryptoCurrency;
+const currencyId = "concordium_testnet";
 
 describe("proxyClient", () => {
   beforeEach(() => {
@@ -43,9 +38,8 @@ describe("proxyClient", () => {
   describe("withClient", () => {
     it("should execute function with client", async () => {
       mockNetwork.mockResolvedValue({ data: "result" });
-      const currency = createMockCurrency();
 
-      const result = await withClient(currency, async client => {
+      const result = await withClient(currencyId, async client => {
         return client.request({ method: "GET", url: "/test" });
       });
 
@@ -57,10 +51,8 @@ describe("proxyClient", () => {
         .mockRejectedValueOnce(new Error("First failure"))
         .mockResolvedValueOnce({ data: "success" });
 
-      const currency = createMockCurrency();
-
       const result = await withClient(
-        currency,
+        currencyId,
         async client => client.request({ method: "GET", url: "/test" }),
         1,
       );
@@ -71,38 +63,37 @@ describe("proxyClient", () => {
 
     it("should throw after all retries exhausted", async () => {
       mockNetwork.mockRejectedValue(new Error("Always fails"));
-      const currency = createMockCurrency();
 
       await expect(
-        withClient(currency, async client => client.request({ method: "GET", url: "/test" }), 1),
+        withClient(currencyId, async client => client.request({ method: "GET", url: "/test" }), 1),
       ).rejects.toThrow("Always fails");
       expect(mockNetwork).toHaveBeenCalledTimes(2);
     }, 10000);
 
     it("should use default retries when not specified", async () => {
       mockNetwork.mockRejectedValue(new Error("Fails"));
-      const currency = createMockCurrency();
 
       await expect(
-        withClient(currency, async client => client.request({ method: "GET", url: "/test" })),
+        withClient(currencyId, async client => client.request({ method: "GET", url: "/test" })),
       ).rejects.toThrow("Fails");
       expect(mockNetwork).toHaveBeenCalledTimes(3); // DEFAULT_RETRIES = 2
     }, 10000);
 
     it("should throw when URL is not provided", async () => {
-      const currency = createMockCurrency();
-
       await expect(
-        withClient(currency, async client => client.request({ method: "GET" } as any)),
+        withClient(currencyId, async client => client.request({ method: "GET" } as any)),
       ).rejects.toThrow("URL is required for proxy client requests");
     });
 
     it("should cache client by currency id", async () => {
       mockNetwork.mockResolvedValue({ data: "result" });
-      const currency = createMockCurrency();
 
-      await withClient(currency, async client => client.request({ method: "GET", url: "/test1" }));
-      await withClient(currency, async client => client.request({ method: "GET", url: "/test2" }));
+      await withClient(currencyId, async client =>
+        client.request({ method: "GET", url: "/test1" }),
+      );
+      await withClient(currencyId, async client =>
+        client.request({ method: "GET", url: "/test2" }),
+      );
 
       // Both calls should use same base URL (client was cached)
       expect(mockNetwork).toHaveBeenCalledTimes(2);
@@ -115,9 +106,8 @@ describe("proxyClient", () => {
     it("should fetch accounts by public key", async () => {
       const mockResponse = [{ address: "3a9gh23nNY3kH4k3ajaCqAbM8rcbWMor2VhEzQ6qkn2r17UU7w" }];
       mockNetwork.mockResolvedValue({ data: mockResponse });
-      const currency = createMockCurrency();
 
-      const result = await getAccountsByPublicKey(currency, "aa".repeat(32));
+      const result = await getAccountsByPublicKey(currencyId, "aa".repeat(32));
 
       expect(result).toEqual(mockResponse);
       expect(mockNetwork).toHaveBeenCalledWith(
@@ -138,9 +128,8 @@ describe("proxyClient", () => {
         },
       };
       mockNetwork.mockResolvedValue({ data: mockResponse });
-      const currency = createMockCurrency();
 
-      const result = await getAccountBalance(currency, "test-address");
+      const result = await getAccountBalance(currencyId, "test-address");
 
       expect(result).toEqual(mockResponse);
       expect(mockNetwork).toHaveBeenCalledWith(
@@ -156,9 +145,8 @@ describe("proxyClient", () => {
     it("should fetch account nonce", async () => {
       const mockResponse = { nonce: 5 };
       mockNetwork.mockResolvedValue({ data: mockResponse });
-      const currency = createMockCurrency();
 
-      const result = await getAccountNonce(currency, "test-address");
+      const result = await getAccountNonce(currencyId, "test-address");
 
       expect(result).toEqual({ nonce: 5 });
       expect(mockNetwork).toHaveBeenCalledWith(
@@ -174,9 +162,8 @@ describe("proxyClient", () => {
     it("should fetch transactions without params", async () => {
       const mockResponse = { transactions: [] };
       mockNetwork.mockResolvedValue({ data: mockResponse });
-      const currency = createMockCurrency();
 
-      const result = await getTransactions(currency, "test-address");
+      const result = await getTransactions(currencyId, "test-address");
 
       expect(result).toEqual({ transactions: [] });
       expect(mockNetwork).toHaveBeenCalledWith(
@@ -190,9 +177,8 @@ describe("proxyClient", () => {
     it("should fetch transactions with params", async () => {
       const mockResponse = { transactions: [] };
       mockNetwork.mockResolvedValue({ data: mockResponse });
-      const currency = createMockCurrency();
 
-      await getTransactions(currency, "test-address", { limit: 50, order: "d" });
+      await getTransactions(currencyId, "test-address", { limit: 50, order: "d" });
 
       expect(mockNetwork).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -205,9 +191,8 @@ describe("proxyClient", () => {
   describe("getTransactionCost", () => {
     it("should fetch transaction cost", async () => {
       mockNetwork.mockResolvedValue({ data: { cost: "1000", energy: "500" } });
-      const currency = createMockCurrency();
 
-      const result = await getTransactionCost(currency, { numSignatures: 1 });
+      const result = await getTransactionCost(currencyId, { numSignatures: 1 });
 
       expect(result).toEqual({ cost: "1000", energy: "500" });
       expect(mockNetwork).toHaveBeenCalledWith(
@@ -223,9 +208,8 @@ describe("proxyClient", () => {
   describe("submitTransfer", () => {
     it("should submit transfer transaction", async () => {
       mockNetwork.mockResolvedValue({ data: { submissionId: "tx-123" } });
-      const currency = createMockCurrency();
 
-      const result = await submitTransfer(currency, {
+      const result = await submitTransfer(currencyId, {
         transaction: "transaction-body-hex",
         signatures: { "0": { "0": "signature-hex" } },
       });
@@ -251,12 +235,11 @@ describe("proxyClient", () => {
   describe("submitCredential", () => {
     it("should submit credential deployment", async () => {
       mockNetwork.mockResolvedValue({ data: { submissionId: "cred-123" } });
-      const currency = createMockCurrency();
       const credentialData = {
         credential: { value: { credential: {} } },
       } as any;
 
-      const result = await submitCredential(currency, credentialData);
+      const result = await submitCredential(currencyId, credentialData);
 
       expect(result).toEqual({ submissionId: "cred-123" });
       expect(mockNetwork).toHaveBeenCalledWith(
@@ -272,9 +255,8 @@ describe("proxyClient", () => {
   describe("getOperations", () => {
     it("should return empty array on network error", async () => {
       mockNetwork.mockRejectedValue(new Error("Network error"));
-      const currency = createMockCurrency();
 
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: "test-address",
         accountId: "account-id",
       });
@@ -284,9 +266,8 @@ describe("proxyClient", () => {
 
     it("should return empty array for non-transaction response", async () => {
       mockNetwork.mockResolvedValue({ data: { error: "something" } });
-      const currency = createMockCurrency();
 
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: "test-address",
         accountId: "account-id",
       });
@@ -309,9 +290,7 @@ describe("proxyClient", () => {
         },
       };
       mockNetwork.mockResolvedValue({ data: { transactions: [mockTx] } });
-      const currency = createMockCurrency();
-
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: "test-address",
         accountId: "account-id",
       });
@@ -337,9 +316,7 @@ describe("proxyClient", () => {
         },
       };
       mockNetwork.mockResolvedValue({ data: { transactions: [mockTx] } });
-      const currency = createMockCurrency();
-
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: "test-address",
         accountId: "account-id",
       });
@@ -367,9 +344,7 @@ describe("proxyClient", () => {
         },
       };
       mockNetwork.mockResolvedValue({ data: { transactions: [mockTx] } });
-      const currency = createMockCurrency();
-
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: "test-address",
         accountId: "account-id",
       });
@@ -408,9 +383,7 @@ describe("proxyClient", () => {
         },
       ];
       mockNetwork.mockResolvedValue({ data: { transactions: mockTxs } });
-      const currency = createMockCurrency();
-
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: "test-address",
         accountId: "account-id",
       });
@@ -439,9 +412,7 @@ describe("proxyClient", () => {
         },
       };
       mockNetwork.mockResolvedValue({ data: { transactions: [mockTx] } });
-      const currency = createMockCurrency();
-
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: "test-address",
         accountId: "account-id",
       });
@@ -464,9 +435,7 @@ describe("proxyClient", () => {
         },
       };
       mockNetwork.mockResolvedValue({ data: { transactions: [mockTx] } });
-      const currency = createMockCurrency();
-
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: "test-address",
         accountId: "account-id",
       });
@@ -476,9 +445,7 @@ describe("proxyClient", () => {
 
     it("should use default size when not specified", async () => {
       mockNetwork.mockResolvedValue({ data: { transactions: [] } });
-      const currency = createMockCurrency();
-
-      await getOperations(currency, { address: "test-address", accountId: "account-id" });
+      await getOperations(currencyId, { address: "test-address", accountId: "account-id" });
 
       expect(mockNetwork).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -489,9 +456,11 @@ describe("proxyClient", () => {
 
     it("should use provided size param", async () => {
       mockNetwork.mockResolvedValue({ data: { transactions: [] } });
-      const currency = createMockCurrency();
-
-      await getOperations(currency, { address: "test-address", accountId: "account-id", size: 50 });
+      await getOperations(currencyId, {
+        address: "test-address",
+        accountId: "account-id",
+        size: 50,
+      });
 
       expect(mockNetwork).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -514,9 +483,7 @@ describe("proxyClient", () => {
         },
       };
       mockNetwork.mockResolvedValue({ data: { transactions: [mockTx] } });
-      const currency = createMockCurrency();
-
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: "test-address",
         accountId: "account-id",
       });
@@ -539,9 +506,7 @@ describe("proxyClient", () => {
         },
       };
       mockNetwork.mockResolvedValue({ data: { transactions: [mockTx] } });
-      const currency = createMockCurrency();
-
-      const result = await getOperations(currency, {
+      const result = await getOperations(currencyId, {
         address: "test-address",
         accountId: "account-id",
       });

--- a/libs/coin-modules/coin-concordium/src/network/proxyClient.ts
+++ b/libs/coin-modules/coin-concordium/src/network/proxyClient.ts
@@ -3,7 +3,6 @@ import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
 import network from "@ledgerhq/live-network";
 import type { LiveNetworkRequest } from "@ledgerhq/live-network/network";
 import { retry } from "@ledgerhq/live-promise";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { log } from "@ledgerhq/logs";
 import { decodeMemoFromCbor } from "@ledgerhq/concordium-core";
 import coinConfig from "../config";
@@ -28,13 +27,8 @@ const PROXY_TIMEOUT = 30000;
 const DEFAULT_RETRIES = 2;
 const RETRY_DELAY = 1000;
 
-function getProxyUrl(currency: CryptoCurrency): string {
-  const config = coinConfig.getCoinConfig(currency);
-  return config.proxyUrl;
-}
-
-function createProxyClient(currency: CryptoCurrency): ProxyClient {
-  const baseUrl = getProxyUrl(currency);
+function createProxyClient(currencyId: string): ProxyClient {
+  const baseUrl = coinConfig.getCoinConfig(currencyId).proxyUrl;
 
   const request = async <TResponse, TRequest = unknown>(
     config: LiveNetworkRequest<TRequest>,
@@ -58,31 +52,31 @@ function createProxyClient(currency: CryptoCurrency): ProxyClient {
   return { baseUrl, request };
 }
 
-const CLIENTS_BY_CURRENCY = new Map<CryptoCurrency["id"], ProxyClient>();
+const CLIENTS_BY_CURRENCY = new Map<string, ProxyClient>();
 
-function getClient(currency: CryptoCurrency): ProxyClient {
-  const existing = CLIENTS_BY_CURRENCY.get(currency.id);
+function getClient(currencyId: string): ProxyClient {
+  const existing = CLIENTS_BY_CURRENCY.get(currencyId);
   if (existing) return existing;
 
-  const client = createProxyClient(currency);
-  CLIENTS_BY_CURRENCY.set(currency.id, client);
+  const client = createProxyClient(currencyId);
+  CLIENTS_BY_CURRENCY.set(currencyId, client);
   return client;
 }
 
 /**
  * Executes a function with a proxy client, handling retries and error handling
  *
- * @param currency - The Concordium currency
+ * @param currencyId - The Concordium currency ID
  * @param execute - Function to execute with the client
  * @param retries - Number of retries (default: 2)
  * @returns Result of the execute function
  */
 export async function withClient<T>(
-  currency: CryptoCurrency,
+  currencyId: string,
   execute: (client: ProxyClient) => Promise<T>,
   retries = DEFAULT_RETRIES,
 ): Promise<T> {
-  const client = getClient(currency);
+  const client = getClient(currencyId);
 
   return retry(() => execute(client), {
     maxRetry: retries,
@@ -93,16 +87,13 @@ export async function withClient<T>(
 
 /**
  * Retrieves all accounts associated with a given public key from the Concordium network.
- *
- * @param currency - The cryptocurrency configuration for the Concordium network
- * @param publicKey - The public key to query for associated accounts
- * @returns A promise that resolves to a response containing the list of accounts associated with the public key
+ * GET /v0/keyAccounts/{publicKey}
  */
 export function getAccountsByPublicKey(
-  currency: CryptoCurrency,
+  currencyId: string,
   publicKey: string,
 ): Promise<PublicKeyAccountsResponse> {
-  return withClient(currency, async client =>
+  return withClient(currencyId, async client =>
     client.request<PublicKeyAccountsResponse>({
       method: "GET",
       url: `/v0/keyAccounts/${publicKey}`,
@@ -115,10 +106,10 @@ export function getAccountsByPublicKey(
  * GET /v2/accBalance/{address}
  */
 export async function getAccountBalance(
-  currency: CryptoCurrency,
+  currencyId: string,
   accountAddress: string,
 ): Promise<AccountBalanceResponse> {
-  return withClient(currency, async client =>
+  return withClient(currencyId, async client =>
     client.request<AccountBalanceResponse>({
       method: "GET",
       url: `/v2/accBalance/${accountAddress}`,
@@ -131,10 +122,10 @@ export async function getAccountBalance(
  * GET /v0/accNonce/{address}
  */
 export async function getAccountNonce(
-  currency: CryptoCurrency,
+  currencyId: string,
   accountAddress: string,
 ): Promise<{ nonce: number }> {
-  return withClient(currency, async client =>
+  return withClient(currencyId, async client =>
     client.request<{ nonce: number }>({
       method: "GET",
       url: `/v0/accNonce/${accountAddress}`,
@@ -147,11 +138,11 @@ export async function getAccountNonce(
  * GET /v3/accTransactions/{address}
  */
 export async function getTransactions(
-  currency: CryptoCurrency,
+  currencyId: string,
   accountAddress: string,
   params?: TransactionQueryParams,
 ): Promise<TransactionsResponse> {
-  return withClient(currency, async client =>
+  return withClient(currencyId, async client =>
     client.request<TransactionsResponse>({
       method: "GET",
       url: `/v3/accTransactions/${accountAddress}`,
@@ -168,10 +159,10 @@ export async function getTransactions(
  * Memo overhead is calculated via the optional memoSize parameter.
  */
 export async function getTransactionCost(
-  currency: CryptoCurrency,
+  currencyId: string,
   { numSignatures, memoSize }: GetTransactionCostParams,
 ): Promise<{ cost: string; energy: number }> {
-  return withClient(currency, async client =>
+  return withClient(currencyId, async client =>
     client.request<{ cost: string; energy: number }>({
       method: "GET",
       url: "/v0/transactionCost",
@@ -188,15 +179,15 @@ export async function getTransactionCost(
  * Submit a signed transfer transaction to the network
  * PUT /v0/submitTransfer/
  *
- * @param currency - The Concordium currency
+ * @param currencyId - The Concordium currency ID
  * @param data - The transfer payload (hex-encoded transaction body and signatures)
  * @returns Submission ID
  */
 export async function submitTransfer(
-  currency: CryptoCurrency,
+  currencyId: string,
   data: SubmitTransferData,
 ): Promise<{ submissionId: string }> {
-  return withClient(currency, async client => {
+  return withClient(currencyId, async client => {
     const request: LiveNetworkRequest<SubmitTransferData> = {
       method: "PUT",
       url: "/v0/submitTransfer/",
@@ -210,15 +201,15 @@ export async function submitTransfer(
  * Submit a credential deployment transaction to the network
  * PUT /v0/submitCredential/
  *
- * @param currency - The Concordium currency
+ * @param currencyId - The Concordium currency ID
  * @param data - The credential deployment data in proxy format
  * @returns Submission ID
  */
 export async function submitCredential(
-  currency: CryptoCurrency,
+  currencyId: string,
   data: SubmitCredentialData,
 ): Promise<{ submissionId: string }> {
-  return withClient(currency, async client => {
+  return withClient(currencyId, async client => {
     const request: LiveNetworkRequest<SubmitCredentialData> = {
       method: "PUT",
       url: "/v0/submitCredential/",
@@ -307,7 +298,7 @@ function operationAdapter(
  * Filters and converts wallet-proxy transactions to network operation format
  */
 export async function getOperations(
-  currency: CryptoCurrency,
+  currencyId: string,
   { address, accountId, size }: GetOperationsParams,
 ): Promise<ProxyOperation[]> {
   try {
@@ -316,7 +307,7 @@ export async function getOperations(
       order: "d",
     };
 
-    const response = await getTransactions(currency, address, proxyParams);
+    const response = await getTransactions(currencyId, address, proxyParams);
 
     if (!("transactions" in response) || !Array.isArray(response.transactions)) {
       return [];

--- a/libs/coin-modules/coin-concordium/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-concordium/src/network/utils.test.ts
@@ -4,33 +4,14 @@ import {
   insertAccountOwnershipProofs,
 } from "@ledgerhq/concordium-core";
 import type { SerializedCredentialDeploymentTransaction } from "../types";
-import { createTestCryptoCurrency, createTestCommitmentsRandomness } from "../test/testHelpers";
+import { createTestCommitmentsRandomness } from "../test/testHelpers";
 import {
-  getConcordiumNetwork,
   buildSubmitTransferData,
   buildSubmitCredentialData,
   deserializeCredentialDeploymentTransaction,
 } from "./utils";
 
 describe("network/utils", () => {
-  describe("getConcordiumNetwork", () => {
-    it("should return Mainnet for mainnet currency", () => {
-      const currency = createTestCryptoCurrency({
-        isTestnetFor: undefined,
-      });
-
-      expect(getConcordiumNetwork(currency)).toBe("Mainnet");
-    });
-
-    it("should return Testnet for testnet currency", () => {
-      const currency = createTestCryptoCurrency({
-        isTestnetFor: "concordium",
-      });
-
-      expect(getConcordiumNetwork(currency)).toBe("Testnet");
-    });
-  });
-
   describe("buildSubmitTransferData", () => {
     it("should build correct submit transfer request", () => {
       const result = buildSubmitTransferData("aabbccdd", "11223344");

--- a/libs/coin-modules/coin-concordium/src/network/utils.ts
+++ b/libs/coin-modules/coin-concordium/src/network/utils.ts
@@ -3,16 +3,11 @@ import {
   type IdOwnershipProofs,
   insertAccountOwnershipProofs,
 } from "@ledgerhq/concordium-core";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type {
   SubmitCredentialData,
   SubmitTransferData,
   SerializedCredentialDeploymentTransaction,
 } from "../types";
-
-export function getConcordiumNetwork(currency: CryptoCurrency): "Mainnet" | "Testnet" {
-  return currency.isTestnetFor ? "Testnet" : "Mainnet";
-}
 
 /**
  * Structure of parsed unsignedCdi from ID App

--- a/libs/coin-modules/coin-concordium/src/network/walletConnect.test.ts
+++ b/libs/coin-modules/coin-concordium/src/network/walletConnect.test.ts
@@ -33,7 +33,7 @@ const createMockSession = (overrides: Partial<SessionTypes.Struct> = {}): Sessio
     expiry: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
     namespaces: {
       ccd: {
-        chains: [CONCORDIUM_CHAIN_IDS.Mainnet],
+        chains: [CONCORDIUM_CHAIN_IDS.mainnet],
         methods: ["create_account"],
         events: [],
         accounts: [],
@@ -111,7 +111,7 @@ describe("walletConnect", () => {
         mockSessionGetAll.mockReturnValue([]);
         const wc = new ConcordiumWalletConnect();
 
-        const session = await wc.getSession("Mainnet");
+        const session = await wc.getSession("mainnet");
 
         expect(session).toBeNull();
       });
@@ -121,7 +121,7 @@ describe("walletConnect", () => {
           topic: "mainnet-session",
           namespaces: {
             ccd: {
-              chains: [CONCORDIUM_CHAIN_IDS.Mainnet],
+              chains: [CONCORDIUM_CHAIN_IDS.mainnet],
               methods: [],
               events: [],
               accounts: [],
@@ -131,7 +131,7 @@ describe("walletConnect", () => {
         mockSessionGetAll.mockReturnValue([mainnetSession]);
         const wc = new ConcordiumWalletConnect();
 
-        const session = await wc.getSession("Mainnet");
+        const session = await wc.getSession("mainnet");
 
         expect(session?.topic).toBe("mainnet-session");
       });
@@ -141,7 +141,7 @@ describe("walletConnect", () => {
           topic: "testnet-session",
           namespaces: {
             ccd: {
-              chains: [CONCORDIUM_CHAIN_IDS.Testnet],
+              chains: [CONCORDIUM_CHAIN_IDS.testnet],
               methods: [],
               events: [],
               accounts: [],
@@ -151,7 +151,7 @@ describe("walletConnect", () => {
         mockSessionGetAll.mockReturnValue([testnetSession]);
         const wc = new ConcordiumWalletConnect();
 
-        const session = await wc.getSession("Mainnet");
+        const session = await wc.getSession("mainnet");
 
         expect(session).toBeNull();
       });
@@ -168,7 +168,7 @@ describe("walletConnect", () => {
         mockSessionGetAll.mockReturnValue([expiredSession, validSession]);
         const wc = new ConcordiumWalletConnect();
 
-        const session = await wc.getSession("Mainnet");
+        const session = await wc.getSession("mainnet");
 
         expect(session?.topic).toBe("valid");
       });
@@ -185,7 +185,7 @@ describe("walletConnect", () => {
         mockSessionGetAll.mockReturnValue([olderSession, newerSession]);
         const wc = new ConcordiumWalletConnect();
 
-        const session = await wc.getSession("Mainnet");
+        const session = await wc.getSession("mainnet");
 
         expect(session?.topic).toBe("newer");
       });
@@ -195,7 +195,7 @@ describe("walletConnect", () => {
           topic: "testnet-session",
           namespaces: {
             ccd: {
-              chains: [CONCORDIUM_CHAIN_IDS.Testnet],
+              chains: [CONCORDIUM_CHAIN_IDS.testnet],
               methods: [],
               events: [],
               accounts: [],
@@ -205,7 +205,7 @@ describe("walletConnect", () => {
         mockSessionGetAll.mockReturnValue([testnetSession]);
         const wc = new ConcordiumWalletConnect();
 
-        const session = await wc.getSession("Testnet");
+        const session = await wc.getSession("testnet");
 
         expect(session?.topic).toBe("testnet-session");
       });
@@ -262,7 +262,7 @@ describe("walletConnect", () => {
 
         const params = {
           topic: "test-topic",
-          chainId: CONCORDIUM_CHAIN_IDS.Mainnet,
+          chainId: CONCORDIUM_CHAIN_IDS.mainnet,
           params: { identityIndex: 0, credNumber: 0, ipIdentity: 1 },
         };
 
@@ -271,7 +271,7 @@ describe("walletConnect", () => {
         expect(result).toEqual(mockResponse);
         expect(mockRequest).toHaveBeenCalledWith({
           topic: "test-topic",
-          chainId: CONCORDIUM_CHAIN_IDS.Mainnet,
+          chainId: CONCORDIUM_CHAIN_IDS.mainnet,
           request: {
             method: "create_account",
             params: { identityIndex: 0, credNumber: 0, ipIdentity: 1 },
@@ -292,7 +292,7 @@ describe("walletConnect", () => {
         mockConnect.mockResolvedValue({ uri: "wc:test", approval: jest.fn() });
         const wc = new ConcordiumWalletConnect();
 
-        await wc.initiatePairing("Mainnet", CONCORDIUM_CHAIN_IDS.Mainnet);
+        await wc.initiatePairing("mainnet", CONCORDIUM_CHAIN_IDS.mainnet);
 
         expect(mockPairingDelete).toHaveBeenCalledWith("expired-pairing", {
           code: 6001,
@@ -309,7 +309,7 @@ describe("walletConnect", () => {
         mockConnect.mockResolvedValue({ uri: "wc:test", approval: jest.fn() });
         const wc = new ConcordiumWalletConnect();
 
-        await wc.initiatePairing("Mainnet", CONCORDIUM_CHAIN_IDS.Mainnet);
+        await wc.initiatePairing("mainnet", CONCORDIUM_CHAIN_IDS.mainnet);
 
         expect(mockPairingDelete).not.toHaveBeenCalled();
       });
@@ -318,14 +318,14 @@ describe("walletConnect", () => {
         mockConnect.mockResolvedValue({ uri: "wc:test-uri", approval: jest.fn() });
         const wc = new ConcordiumWalletConnect();
 
-        const result = await wc.initiatePairing("Mainnet", CONCORDIUM_CHAIN_IDS.Mainnet);
+        const result = await wc.initiatePairing("mainnet", CONCORDIUM_CHAIN_IDS.mainnet);
 
         expect(result.uri).toBe("wc:test-uri");
         expect(mockConnect).toHaveBeenCalledWith({
           requiredNamespaces: {
             ccd: {
               methods: ["create_account"],
-              chains: [CONCORDIUM_CHAIN_IDS.Mainnet],
+              chains: [CONCORDIUM_CHAIN_IDS.mainnet],
               events: [],
             },
           },
@@ -336,7 +336,7 @@ describe("walletConnect", () => {
         mockConnect.mockRejectedValue(new Error("Connect failed"));
         const wc = new ConcordiumWalletConnect();
 
-        await expect(wc.initiatePairing("Mainnet", CONCORDIUM_CHAIN_IDS.Mainnet)).rejects.toThrow(
+        await expect(wc.initiatePairing("mainnet", CONCORDIUM_CHAIN_IDS.mainnet)).rejects.toThrow(
           "Connect failed",
         );
       });

--- a/libs/coin-modules/coin-concordium/src/network/walletConnect.ts
+++ b/libs/coin-modules/coin-concordium/src/network/walletConnect.ts
@@ -46,12 +46,12 @@ export class ConcordiumWalletConnect {
     const chains = session.namespaces[this.namespace]?.chains;
     const networks: ConcordiumNetwork[] = [];
 
-    if (chains?.includes(CONCORDIUM_CHAIN_IDS.Mainnet)) {
-      networks.push("Mainnet");
+    if (chains?.includes(CONCORDIUM_CHAIN_IDS.mainnet)) {
+      networks.push("mainnet");
     }
 
-    if (chains?.includes(CONCORDIUM_CHAIN_IDS.Testnet)) {
-      networks.push("Testnet");
+    if (chains?.includes(CONCORDIUM_CHAIN_IDS.testnet)) {
+      networks.push("testnet");
     }
 
     return networks;

--- a/libs/coin-modules/coin-concordium/src/test/fixtures.ts
+++ b/libs/coin-modules/coin-concordium/src/test/fixtures.ts
@@ -23,11 +23,11 @@ export const CRED_ID = "cc".repeat(48);
 export function createFixtureCurrency(overrides?: Partial<CryptoCurrency>): CryptoCurrency {
   return {
     type: "CryptoCurrency",
-    id: "concordium",
+    id: "concordium_testnet",
     name: "Concordium",
     family: "concordium",
     ticker: "CCD",
-    scheme: "concordium",
+    scheme: "concordium_testnet",
     color: "#000000",
     units: [{ name: "CCD", code: "CCD", magnitude: 6 }],
     managerAppName: "Concordium",
@@ -38,7 +38,7 @@ export function createFixtureCurrency(overrides?: Partial<CryptoCurrency>): Cryp
 export function createFixtureAccount(overrides?: Partial<Account>): Account {
   return {
     type: "Account",
-    id: "js:2:concordium:3a9gh23nNY3kH4k3ajaCqAbM8rcbWMor2VhEzQ6qkn2r17UU7w:",
+    id: "js:2:concordium_testnet:3a9gh23nNY3kH4k3ajaCqAbM8rcbWMor2VhEzQ6qkn2r17UU7w:",
     seedIdentifier: PUBLIC_KEY,
     xpub: PUBLIC_KEY,
     derivationMode: "",
@@ -79,7 +79,7 @@ export function createFixtureTransaction(overrides?: Partial<Transaction>): Tran
 
 export function createFixtureOperation(overrides?: Partial<Operation>): Operation {
   return {
-    id: "js:2:concordium:addr:tx-1",
+    id: "js:2:concordium_testnet:addr:tx-1",
     hash: "tx-hash-1",
     type: "OUT",
     value: new BigNumber(1000000),
@@ -88,7 +88,7 @@ export function createFixtureOperation(overrides?: Partial<Operation>): Operatio
     recipients: [VALID_ADDRESS_2],
     blockHeight: 1000,
     blockHash: "block-hash-1",
-    accountId: "js:2:concordium:addr:",
+    accountId: "js:2:concordium_testnet:addr:",
     date: new Date("2024-01-01"),
     extra: {},
     transactionSequenceNumber: new BigNumber(1),

--- a/libs/coin-modules/coin-concordium/src/test/testHelpers.ts
+++ b/libs/coin-modules/coin-concordium/src/test/testHelpers.ts
@@ -90,12 +90,12 @@ export function createTestAccount(overrides?: Partial<Account>): Account {
     blockHeight: 0,
     currency: {
       type: "CryptoCurrency",
-      id: "concordium",
+      id: "concordium_testnet",
       coinType: 919,
       name: "Concordium",
       managerAppName: "Concordium",
       ticker: "CCD",
-      scheme: "concordium",
+      scheme: "concordium_testnet",
       color: "#000000",
       family: "concordium",
       units: [
@@ -159,7 +159,7 @@ export function createTestAccountRaw(
     operationsCount: 0,
     operations: [],
     pendingOperations: [],
-    currencyId: "concordium",
+    currencyId: "concordium_testnet",
     balance: "0",
     spendableBalance: "0",
     lastSyncDate: new Date().toISOString(),
@@ -180,7 +180,7 @@ export function createTestConcordiumAccountRaw(
   overrides?: Partial<import("../types").ConcordiumAccountRaw>,
 ): import("../types").ConcordiumAccountRaw {
   return {
-    ...createTestAccountRaw({ currencyId: "concordium" }),
+    ...createTestAccountRaw({ currencyId: "concordium_testnet" }),
     concordiumResources: {
       isOnboarded: false,
       credId: "",
@@ -201,12 +201,12 @@ export function createTestCryptoCurrency(
 ): import("@ledgerhq/types-cryptoassets").CryptoCurrency {
   return {
     type: "CryptoCurrency",
-    id: "concordium",
+    id: "concordium_testnet",
     coinType: 919,
     name: "Concordium",
     managerAppName: "Concordium",
     ticker: "CCD",
-    scheme: "concordium",
+    scheme: "concordium_testnet",
     color: "#000000",
     family: "concordium",
     units: [

--- a/libs/coin-modules/coin-concordium/src/types/bridge.ts
+++ b/libs/coin-modules/coin-concordium/src/types/bridge.ts
@@ -1,4 +1,3 @@
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type {
   Account,
   AccountRaw,
@@ -18,11 +17,11 @@ import type {
 
 export interface ConcordiumCurrencyBridge extends CurrencyBridge {
   pairWalletConnect: (
-    currency: CryptoCurrency,
+    currencyId: string,
     deviceId: string,
   ) => Observable<ConcordiumPairingProgress>;
   onboardAccount: (
-    currency: CryptoCurrency,
+    currencyId: string,
     deviceId: string,
     creatableAccount: Account,
   ) => Observable<ConcordiumOnboardProgress | ConcordiumOnboardResult>;

--- a/libs/coin-modules/coin-concordium/src/types/config.ts
+++ b/libs/coin-modules/coin-concordium/src/types/config.ts
@@ -1,15 +1,13 @@
 import type { CurrencyConfig } from "@ledgerhq/coin-framework/config";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 
-export type ConcordiumNetwork = "Mainnet" | "Testnet";
+export type ConcordiumNetwork = "mainnet" | "testnet";
 
 export type ConcordiumConfig = {
-  networkType: "mainnet" | "testnet";
+  networkType: ConcordiumNetwork;
   grpcUrl: string;
   grpcPort: number;
   proxyUrl: string;
   minReserve: number;
-  currency?: CryptoCurrency;
 };
 
 export type ConcordiumCoinConfig = CurrencyConfig & ConcordiumConfig;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** no functional changes, no new functionality added
  - ...

### 📝 Description

Replaced `CryptoCurrency` dependency with `currencyId: string` across all layers of the coin-concordium module (network, logic, bridge, API). 
Added a temporary shim in `config.ts` that casts `{ id: currencyId }` to satisfy the coin-framework's `getCoinConfig()` signature — single place to remove once the framework aligns.

Aligned `ConcordiumNetwork` type to lowercase `"mainnet" | "testnet"` matching config values and removed the redundant `getConcordiumNetwork()` wrapper. 

UpdatedConcordiumCurrencyBridge interface and desktop app call sites accordingly.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26400](https://ledgerhq.atlassian.net/browse/LIVE-26400)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26400]: https://ledgerhq.atlassian.net/browse/LIVE-26400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ