### PR TITLE
fix(coin-polkadot): bypass cache get tx material

### DIFF
--- a/.changeset/neat-schools-begin.md
+++ b/.changeset/neat-schools-begin.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-polkadot": patch
+---
+
+fix(coin-polkadot): bypass the cache when fetching tx materials

--- a/libs/coin-modules/coin-polkadot/src/bridge/buildTransaction.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/buildTransaction.ts
@@ -22,18 +22,12 @@ export const extractExtrinsicArg = (
  *
  * @param {Account} account
  * @param {Transaction} transaction
- * @param {boolean} forceLatestParams - forces the use of latest transaction params
  */
-export const buildTransaction = async (
-  account: PolkadotAccount,
-  transaction: Transaction,
-  forceLatestParams = false,
-) => {
+export const buildTransaction = async (account: PolkadotAccount, transaction: Transaction) => {
   return craftTransaction(
     account.freshAddress,
     getNonce(account),
     extractExtrinsicArg(account, transaction),
-    forceLatestParams,
     getCryptoCurrencyById(account.currency.id),
   );
 };

--- a/libs/coin-modules/coin-polkadot/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/logic/craftTransaction.test.ts
@@ -82,7 +82,7 @@ describe("craftTransaction", () => {
 
     expect(mockGetTransactionParams).toHaveBeenCalledTimes(1);
     expect(mockGetTransactionParams.mock.lastCall[0]).toEqual(undefined);
-    expect(mockGetTransactionParams.mock.lastCall[1]).toEqual(false);
+    expect(mockGetTransactionParams.mock.lastCall[1]).toEqual(true);
 
     const expectedResult = {
       address: "5D4yQHKfqCQYThhHmTfN1JEDi47uyDJc1xg9eZfAG1R7FC7J",
@@ -131,7 +131,7 @@ describe("craftTransaction", () => {
 
     expect(mockGetTransactionParams).toHaveBeenCalledTimes(1);
     expect(mockGetTransactionParams.mock.lastCall[0]).toEqual(undefined);
-    expect(mockGetTransactionParams.mock.lastCall[1]).toEqual(false);
+    expect(mockGetTransactionParams.mock.lastCall[1]).toEqual(true);
   });
 
   it.each([
@@ -170,7 +170,7 @@ describe("craftTransaction", () => {
 
       expect(mockGetTransactionParams).toHaveBeenCalledTimes(1);
       expect(mockGetTransactionParams.mock.lastCall[0]).toEqual(undefined);
-      expect(mockGetTransactionParams.mock.lastCall[1]).toEqual(false);
+      expect(mockGetTransactionParams.mock.lastCall[1]).toEqual(true);
     },
   );
 
@@ -204,7 +204,7 @@ describe("craftTransaction", () => {
 
     expect(mockGetTransactionParams).toHaveBeenCalledTimes(1);
     expect(mockGetTransactionParams.mock.lastCall[0]).toEqual(undefined);
-    expect(mockGetTransactionParams.mock.lastCall[1]).toEqual(false);
+    expect(mockGetTransactionParams.mock.lastCall[1]).toEqual(true);
   });
 
   it('returns an unsigned with first validator when transaction has mode "chill"', async () => {
@@ -237,6 +237,6 @@ describe("craftTransaction", () => {
 
     expect(mockGetTransactionParams).toHaveBeenCalledTimes(1);
     expect(mockGetTransactionParams.mock.lastCall[0]).toEqual(undefined);
-    expect(mockGetTransactionParams.mock.lastCall[1]).toEqual(false);
+    expect(mockGetTransactionParams.mock.lastCall[1]).toEqual(true);
   });
 });

--- a/libs/coin-modules/coin-polkadot/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-polkadot/src/logic/craftTransaction.ts
@@ -173,13 +173,15 @@ export async function craftTransaction(
   address: string,
   nonceToUse: number,
   extractExtrinsicArg: CreateExtrinsicArg,
-  forceLatestParams: boolean = false,
   currency?: CryptoCurrency,
 ): Promise<CoreTransaction> {
   await loadPolkadotCrypto();
   const { extrinsics, registry } = await polkadotAPI.getRegistry(currency);
+  // Embedding outdated params inside transactions results in `Transaction has a bad signature`.
+  // We bypass the cache to fetch fresh parameters and avoid the issue, especially since the endpoint
+  // POST /transaction/material?noMeta=true returns a pretty small payload (content-length=284)
   const info = await polkadotAPI.getTransactionParams(currency, {
-    force: forceLatestParams,
+    force: true,
   });
   // Get the correct extrinsics params depending on transaction
   const extrinsicParams = getExtrinsicParams(extractExtrinsicArg);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - coin polkadot

### 📝 Description

Bypass cache in get transaction params to fetch fresh data before broadcast

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
