### PR TITLE
[LWDM] feat(validate transaction evm): :sparkles: add validate transaction before broadcast

### DIFF
--- a/.changeset/silent-laws-glow.md
+++ b/.changeset/silent-laws-glow.md
@@ -1,18 +1,5 @@
 ---
-"@ledgerhq/coin-module-boilerplate": minor
-"@ledgerhq/coin-concordium": minor
-"@ledgerhq/coin-algorand": minor
-"@ledgerhq/coin-polkadot": minor
-"@ledgerhq/coin-stellar": minor
-"@ledgerhq/coin-canton": minor
-"@ledgerhq/coin-hedera": minor
-"@ledgerhq/coin-aptos": minor
-"@ledgerhq/coin-tezos": minor
-"@ledgerhq/coin-aleo": minor
-"@ledgerhq/coin-tron": minor
 "@ledgerhq/coin-evm": minor
-"@ledgerhq/coin-sui": minor
-"@ledgerhq/coin-xrp": minor
 "ledger-live-desktop": minor
 "live-mobile": minor
 "@ledgerhq/live-common": minor

--- a/libs/coin-framework/src/api/types.ts
+++ b/libs/coin-framework/src/api/types.ts
@@ -675,14 +675,6 @@ export type AlpacaApi<
    * @throws if the transaction is rejected by the network (e.g., invalid signature, insufficient funds)
    */
   broadcast: (tx: string, broadcastConfig?: BroadcastConfig) => Promise<string>;
-
-  /**
-   * Validate a transaction signature.
-   *
-   * @param signature the transaction signature
-   * @returns { error: Error | undefined } object with the error if the transaction is invalid, undefined if the transaction is valid
-   */
-  validateTransaction: (signature: string) => Promise<{ error: Error | undefined }>;
 };
 
 export type ChainSpecificRules = {
@@ -707,7 +699,7 @@ export type BridgeApi<
   getAssetFromToken?: (token: TokenCurrency, owner: string) => AssetInfo;
   computeIntentType?: (transaction: Record<string, unknown>) => string;
   refreshOperations?: (operations: LiveOperation[]) => Promise<LiveOperation[]>;
-  // validateTransaction?: (signature: string) => Promise<{ error: Error | undefined }>;
+  validateTransaction?: (signature: string) => Promise<{ error: Error | undefined }>;
 };
 
 export type Api<

--- a/libs/coin-modules/coin-aleo/src/api/index.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.ts
@@ -101,8 +101,5 @@ export function createApi(
     getSequence: async (_address: string) => {
       throw new Error("getSequence is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }

--- a/libs/coin-modules/coin-algorand/src/api/index.ts
+++ b/libs/coin-modules/coin-algorand/src/api/index.ts
@@ -59,8 +59,5 @@ export function createApi(config: AlgorandCoinConfig): Api<AlgorandMemo> {
     ): Promise<CraftedTransaction> => {
       throw new Error("craftRawTransaction is not supported for Algorand");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }

--- a/libs/coin-modules/coin-aptos/src/api/index.ts
+++ b/libs/coin-modules/coin-aptos/src/api/index.ts
@@ -54,8 +54,5 @@ export function createApi(config: AptosConfigApi): AlpacaApi {
     getValidators(_cursor?: Cursor): Promise<Page<Validator>> {
       throw new Error("getValidators is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }

--- a/libs/coin-modules/coin-canton/src/api/index.ts
+++ b/libs/coin-modules/coin-canton/src/api/index.ts
@@ -63,8 +63,5 @@ export function createApi(config: CantonConfig): AlpacaApi {
     getValidators(_cursor?: Cursor): Promise<Page<Validator>> {
       throw new Error("getValidators is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }

--- a/libs/coin-modules/coin-concordium/src/api/index.ts
+++ b/libs/coin-modules/coin-concordium/src/api/index.ts
@@ -58,9 +58,6 @@ export function createApi(config: ConcordiumConfig, currencyId: string): AlpacaA
     getValidators(_cursor?: Cursor): Promise<Page<Validator>> {
       throw new Error("getValidators is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }
 

--- a/libs/coin-modules/coin-hedera/src/api/index.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.ts
@@ -231,8 +231,5 @@ export function createApi(config: HederaConfig, currencyId: string): Api<HederaM
     getSequence: async (_address): Promise<bigint> => {
       throw new Error("getSequence is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }

--- a/libs/coin-modules/coin-module-boilerplate/src/api/index.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/api/index.ts
@@ -58,9 +58,6 @@ export function createApi(config: BoilerplateConfig): AlpacaApi {
     getValidators(_cursor?: Cursor): Promise<Page<Validator>> {
       throw new Error("getValidators is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }
 

--- a/libs/coin-modules/coin-polkadot/src/api/index.ts
+++ b/libs/coin-modules/coin-polkadot/src/api/index.ts
@@ -63,9 +63,6 @@ export function createApi(config: PolkadotConfig): AlpacaApi {
     getValidators(_cursor?: Cursor): Promise<Page<Validator>> {
       throw new Error("getValidators is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }
 

--- a/libs/coin-modules/coin-stellar/src/api/index.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.ts
@@ -87,9 +87,6 @@ export function createApi(config: StellarConfig): Api<StellarMemo> {
     getValidators(_cursor?: Cursor): Promise<Page<Validator>> {
       throw new Error("getValidators is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }
 

--- a/libs/coin-modules/coin-sui/src/api/index.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.ts
@@ -44,9 +44,6 @@ export function createApi(config: SuiConfig): AlpacaApi {
     getStakes,
     getRewards,
     getValidators: logicGetValidators,
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }
 

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -79,9 +79,6 @@ export function createApi(config: TezosConfig): TezosApi {
     getValidators(_cursor?: Cursor): Promise<Page<Validator>> {
       throw new Error("getValidators is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }
 

--- a/libs/coin-modules/coin-tron/src/api/index.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.ts
@@ -60,9 +60,6 @@ export function createApi(config: TronConfig): AlpacaApi<TronMemo> {
     getValidators(_cursor?: Cursor): Promise<Page<Validator>> {
       throw new Error("getValidators is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }
 

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -60,9 +60,6 @@ export function createApi(config: XrpConfig): Api<XrpMapMemo> {
     getValidators(_cursor?: Cursor): Promise<Page<Validator>> {
       throw new Error("getValidators is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-      throw new Error("validateTransaction is not supported");
-    },
   };
 }
 

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/network/network-alpaca.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/network/network-alpaca.ts
@@ -210,7 +210,4 @@ export const getNetworkAlpacaApi = (networkFamily: string) =>
     getValidators(_cursor?: Cursor): Promise<Page<Validator>> {
       throw new Error("getValidators is not supported");
     },
-    validateTransaction: (_signature: string): Promise<{ error: Error | undefined }> => {
-       throw new Error("validateTransaction is not supported");
-    },
   }) satisfies Api<any>;

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/broadcast.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/broadcast.ts
@@ -10,13 +10,11 @@ export const genericBroadcast: (
   (_network, kind) =>
   async ({ signedOperation: { signature, operation }, account, broadcastConfig }) => {
     const api = getAlpacaApi(account.currency.id, kind);
-    try {
+    if (api.validateTransaction) {
       const validation = await api.validateTransaction(signature);
       if (validation.error !== undefined) {
         throw validation.error;
       }
-    } catch {
-      // eslint-disable-next-line no-empty
     }
     const hash = await api.broadcast(signature, broadcastConfig);
 


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Create a new hook that happens just before the broadcast, which allows the coin-module to check if a tx is still valid or not.
if tx is invalid, we ask the user to start the flow again

| desktop | mobile |
|-----|----|
| <img width="554" height="543" alt="Screenshot 2026-03-05 at 14 15 49" src="https://github.com/user-attachments/assets/2e8d9044-d946-49db-9a00-dd8c442d1478" /> | <img width="401" height="843" alt="Screenshot 2026-03-05 at 13 49 51" src="https://github.com/user-attachments/assets/52ec7f31-f53b-4d74-873b-5f5d68563249" /> |


### ❓ Context

- **JIRA or GitHub link**:  [LIVE-26161](https://ledgerhq.atlassian.net/browse/LIVE-26161)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26161]: https://ledgerhq.atlassian.net/browse/LIVE-26161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ