### PR TITLE
fix(common): return validated amount in getTransactionStatus

### DIFF
--- a/.changeset/giant-months-tickle.md
+++ b/.changeset/giant-months-tickle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix(common): return validated amount in getTransactionStatus when useAllAmount

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/getTransactionStatus.ts
@@ -72,7 +72,7 @@ export function genericGetTransactionStatus(
         !transaction.fees || transaction.fees.isZero()
           ? new BigNumber(estimatedFees.toString())
           : transaction.fees,
-      amount: transaction.amount.eq(0) ? new BigNumber(amount.toString()) : transaction.amount,
+      amount: new BigNumber(amount.toString()),
       totalSpent: new BigNumber(totalSpent.toString()),
     };
   };

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/tests/getTransactionStatus.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/tests/getTransactionStatus.test.ts
@@ -1,0 +1,71 @@
+import BigNumber from "bignumber.js";
+import { genericGetTransactionStatus } from "../getTransactionStatus";
+import { getAlpacaApi } from "../alpaca";
+import * as utils from "../utils";
+
+jest.mock("../alpaca", () => ({
+  getAlpacaApi: jest.fn(),
+}));
+
+jest.mock("../utils", () => ({
+  ...jest.requireActual("../utils"),
+  transactionToIntent: jest.fn(),
+  applyMemoToIntent: jest.fn(),
+  extractBalances: jest.fn(),
+}));
+
+const mockTransactionToIntent = utils.transactionToIntent as jest.Mock;
+const mockApplyMemoToIntent = utils.applyMemoToIntent as jest.Mock;
+const mockExtractBalances = utils.extractBalances as jest.Mock;
+
+describe("genericGetTransactionStatus", () => {
+  const account = {
+    id: "test-account",
+    currency: { id: "ethereum" },
+    pendingOperations: [],
+  } as any;
+
+  const validatedAmount = 1000n;
+  const validateIntentResult = {
+    errors: {},
+    warnings: {},
+    estimatedFees: 50n,
+    amount: validatedAmount,
+    totalSpent: 1050n,
+    totalFees: 50n,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTransactionToIntent.mockReturnValue({ intent: true });
+    mockApplyMemoToIntent.mockImplementation((intent: unknown) => intent);
+    mockExtractBalances.mockReturnValue({});
+    (getAlpacaApi as jest.Mock).mockReturnValue({
+      validateIntent: jest.fn().mockResolvedValue(validateIntentResult),
+    });
+  });
+
+  it.each([
+    ["useAllAmount is true", new BigNumber(999), true, new BigNumber(validatedAmount.toString())],
+    ["amount is 0", new BigNumber(0), false, new BigNumber(validatedAmount.toString())],
+    [
+      "useAllAmount is false and amount > 0",
+      new BigNumber(500),
+      false,
+      new BigNumber(validatedAmount.toString()),
+    ],
+  ])(
+    "returns validated amount from validateIntent when %s",
+    async (_label, txAmount, useAllAmount, expected) => {
+      const getStatus = genericGetTransactionStatus("mainnet", "evm");
+      const result = await getStatus(account, {
+        amount: txAmount,
+        useAllAmount,
+        recipient: "0x",
+        family: "evm",
+      } as any);
+
+      expect(result.amount).toEqual(expected);
+    },
+  );
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

With "Send max" on, changing fees (Standard presets or Custom/Advanced) did not update the displayed amount. The UI could show amount + fees > balance without an error

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-27209)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
