### PR TITLE
chore: opt out ownership of copilot-intructions.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -311,6 +311,7 @@ apps/ledger-live-mobile/e2e/                                                @led
 tools/actions/composites/merge-e2e-detox-timings/                           @ledgerhq/qaa
 
 # Cross-team generic files can be opted out (no strict ownership when it concerns everyone)
+.github/copilot-instructions.md
 libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
 libs/ledgerjs/packages/types-live/src/feature.ts
 libs/ledger-live-common/src/modularDrawer/hooks/useCurrenciesUnderFeatureFlag.ts


### PR DESCRIPTION

.github/copilot-instructions.md is wrongly assigned to wallet-ci team (because general ownership of .github/ actions)
i think this file is a legit case to not have any CODEOWNERS so this PR adds it in the opted out case
