### PR TITLE
fix(e2e): set hasSeenWalletV4Tour in all e2e userdata fixtures

### DIFF
--- a/.changeset/grumpy-schools-pretend.md
+++ b/.changeset/grumpy-schools-pretend.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+Set hasSeenWalletV4Tour to true in all E2E userdata fixtures to prevent the WalletV4Tour dialog from blocking tests

--- a/e2e/desktop/tests/userdata/1AccountBTC1AccountETH.json
+++ b/e2e/desktop/tests/userdata/1AccountBTC1AccountETH.json
@@ -42,7 +42,8 @@
       "swapProviders": [],
       "showClearCacheBanner": false,
       "starredAccountIds": [],
-      "hasPassword": false
+      "hasPassword": false,
+      "hasSeenWalletV4Tour": true
     },
     "user": {
       "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"

--- a/e2e/desktop/tests/userdata/1AccountDOT.json
+++ b/e2e/desktop/tests/userdata/1AccountDOT.json
@@ -5,7 +5,7 @@
         "acceptedTermsVersion": "2042-01-01"
       }
     },
-    "settings": { "hasCompletedOnboarding": true },
+    "settings": { "hasCompletedOnboarding": true, "hasSeenWalletV4Tour": true },
     "accounts": [
       {
         "data": {

--- a/e2e/desktop/tests/userdata/erc20-0-balance.json
+++ b/e2e/desktop/tests/userdata/erc20-0-balance.json
@@ -3067,7 +3067,8 @@
       ],
       "dismissedContentCards": {},
       "anonymousBrazeId": "anonymous_id_1",
-      "starredMarketCoins": []
+      "starredMarketCoins": [],
+      "hasSeenWalletV4Tour": true
     },
     "accounts": [
       {

--- a/e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json
+++ b/e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json
@@ -46,7 +46,8 @@
       "swapProviders": [],
       "showClearCacheBanner": false,
       "starredAccountIds": [],
-      "hasPassword": false
+      "hasPassword": false,
+      "hasSeenWalletV4Tour": true
     },
     "user": {
       "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"

--- a/e2e/desktop/tests/userdata/skip-onboarding.json
+++ b/e2e/desktop/tests/userdata/skip-onboarding.json
@@ -42,7 +42,8 @@
       "swapProviders": [],
       "showClearCacheBanner": false,
       "starredAccountIds": [],
-      "hasPassword": false
+      "hasPassword": false,
+      "hasSeenWalletV4Tour": true
     },
     "user": {
       "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"

--- a/e2e/desktop/tests/userdata/speculos-subAccount.json
+++ b/e2e/desktop/tests/userdata/speculos-subAccount.json
@@ -73,7 +73,7 @@
       "lastOnboardedDevice": null,
       "alwaysShowMemoTagInfo": true,
       "anonymousUserNotifications": {},
-      "hasSeenWalletV4Tour": false
+      "hasSeenWalletV4Tour": true
     },
     "user": { "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971" },
     "accounts": [

--- a/e2e/desktop/tests/userdata/speculos-tests-app.json
+++ b/e2e/desktop/tests/userdata/speculos-tests-app.json
@@ -94,7 +94,8 @@
       "swapAcceptedProviderIds": [],
       "swapProviders": [],
       "starredAccountIds": [],
-      "hasPassword": false
+      "hasPassword": false,
+      "hasSeenWalletV4Tour": true
     },
     "trustchain": {
       "trustchain": null,

--- a/e2e/desktop/tests/userdata/swap-history.json
+++ b/e2e/desktop/tests/userdata/swap-history.json
@@ -77,7 +77,8 @@
       "swapAcceptedProviderIds": [],
       "swapProviders": [],
       "starredAccountIds": [],
-      "hasPassword": false
+      "hasPassword": false,
+      "hasSeenWalletV4Tour": true
     },
     "wallet": {
       "walletSyncState": { "data": null, "version": 0 },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Desktop E2E test stability on Portfolio page
      - No functional or UI changes to the application

### 📝 Description

The WalletV4Tour dialog was appearing during E2E tests when landing on the Portfolio page, blocking test interactions and causing CI failures.

This PR sets `hasSeenWalletV4Tour: true` in all 8 affected E2E userdata fixtures to prevent the tour dialog from auto-opening during tests.

### ❓ Context

- **GitHub link**: https://github.com/LedgerHQ/ledger-live/actions/runs/22680060063/job/65747740433

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)