### PR TITLE
refactor(e2e): extract lwdWallet40 flags into shared constant

### DIFF
--- a/.changeset/grumpy-schools-pretend.md
+++ b/.changeset/grumpy-schools-pretend.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+Extract lwdWallet40 feature flags into shared constant and fix navigation selectors

--- a/e2e/desktop/tests/specs/main.navigation.spec.ts
+++ b/e2e/desktop/tests/specs/main.navigation.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "tests/fixtures/common";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
+import { LWD_WALLET_40_FLAGS } from "tests/utils/featureFlagUtils";
 
 const DEVICE_TAGS = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"] as const;
 
@@ -8,15 +9,7 @@ test.describe("Main navigation", () => {
   test.use({
     userdata: "1AccountBTC1AccountETH",
     featureFlags: {
-      lwdWallet40: {
-        enabled: true,
-        params: {
-          marketBanner: true,
-          graphRework: true,
-          quickActionCtas: true,
-          mainNavigation: true,
-        },
-      },
+      ...LWD_WALLET_40_FLAGS,
       referralProgramDesktopSidebar: {
         enabled: true,
         params: {

--- a/e2e/desktop/tests/specs/market.spec.ts
+++ b/e2e/desktop/tests/specs/market.spec.ts
@@ -2,19 +2,13 @@ import { test } from "tests/fixtures/common";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { LWD_WALLET_40_FLAGS } from "tests/utils/featureFlagUtils";
 
 test.describe("Market", () => {
   test.use({
     //TODO: remove feature flag when market banner is enabled for all users
     userdata: "speculos-tests-app",
-    featureFlags: {
-      lwdWallet40: {
-        enabled: true,
-        params: {
-          marketBanner: true,
-        },
-      },
-    },
+    featureFlags: LWD_WALLET_40_FLAGS,
   });
 
   test(

--- a/e2e/desktop/tests/specs/marketBanner.spec.ts
+++ b/e2e/desktop/tests/specs/marketBanner.spec.ts
@@ -2,20 +2,12 @@ import { test } from "tests/fixtures/common";
 import { expect } from "@playwright/test";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
+import { LWD_WALLET_40_FLAGS } from "tests/utils/featureFlagUtils";
 
 test.describe("Market Banner", () => {
   test.use({
     userdata: "speculos-tests-app",
-    featureFlags: {
-      lwdWallet40: {
-        enabled: true,
-        params: {
-          marketBanner: true,
-          graphRework: true,
-          quickActionCtas: true,
-        },
-      },
-    },
+    featureFlags: LWD_WALLET_40_FLAGS,
   });
 
   test(
@@ -30,7 +22,7 @@ test.describe("Market Banner", () => {
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-      await app.layout.goToPortfolio();
+      await app.mainNavigation.openTargetFromMainNavigation("home");
 
       await app.marketBanner.expectMarketBannerToBeVisible();
 
@@ -50,7 +42,7 @@ test.describe("Market Banner", () => {
 
       await expect(app.layout.getPage()).toHaveURL(new RegExp(`/market/${assetId}`));
 
-      await app.layout.goToPortfolio();
+      await app.mainNavigation.openTargetFromMainNavigation("home");
 
       await app.marketBanner.clickExploreMarketHeader();
 
@@ -58,7 +50,7 @@ test.describe("Market Banner", () => {
       await app.market.openCoinPage("BTC");
       await expect(app.layout.getPage()).toHaveURL(new RegExp(`/market/bitcoin`));
 
-      await app.layout.goToPortfolio();
+      await app.mainNavigation.openTargetFromMainNavigation("home");
 
       await app.marketBanner.scrollToAndClickViewAllTile();
 

--- a/e2e/desktop/tests/specs/portfolio.spec.ts
+++ b/e2e/desktop/tests/specs/portfolio.spec.ts
@@ -3,6 +3,7 @@ import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { CLI } from "tests/utils/cliUtils";
+import { LWD_WALLET_40_FLAGS } from "tests/utils/featureFlagUtils";
 
 test.describe("Portfolio", () => {
   test.use({
@@ -36,17 +37,7 @@ test.describe("Portfolio Wallet 4.0 - Zero balance state", () => {
     userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: currency.speculosApp,
     // to-do remove when wallet 4.0 is default
-    featureFlags: {
-      lwdWallet40: {
-        enabled: true,
-        params: {
-          marketBanner: true,
-          graphRework: true,
-          quickActionCtas: true,
-          mainNavigation: true,
-        },
-      },
-    },
+    featureFlags: LWD_WALLET_40_FLAGS,
   });
 
   test(
@@ -93,17 +84,7 @@ test.describe("Portfolio Wallet 4.0 - With Account", () => {
       },
     ],
     // to-do remove when wallet 4.0 is default
-    featureFlags: {
-      lwdWallet40: {
-        enabled: true,
-        params: {
-          marketBanner: true,
-          graphRework: true,
-          quickActionCtas: true,
-          mainNavigation: true,
-        },
-      },
-    },
+    featureFlags: LWD_WALLET_40_FLAGS,
   });
 
   test(
@@ -136,17 +117,7 @@ test.describe("Portfolio Wallet 4.0 - No seen device (Reborn mode)", () => {
   test.use({
     userdata: "skip-onboarding",
     // to-do remove when wallet 4.0 is default
-    featureFlags: {
-      lwdWallet40: {
-        enabled: true,
-        params: {
-          marketBanner: true,
-          graphRework: true,
-          quickActionCtas: true,
-          mainNavigation: true,
-        },
-      },
-    },
+    featureFlags: LWD_WALLET_40_FLAGS,
   });
 
   test(

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -1,0 +1,14 @@
+import { OptionalFeatureMap } from "@ledgerhq/types-live";
+
+// TODO: remove when wallet 4.0 is default
+export const LWD_WALLET_40_FLAGS: OptionalFeatureMap = {
+  lwdWallet40: {
+    enabled: true,
+    params: {
+      marketBanner: true,
+      graphRework: true,
+      quickActionCtas: true,
+      mainNavigation: true,
+    },
+  },
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Desktop E2E test maintainability
      - No functional or UI changes to the application

### 📝 Description

The `lwdWallet40` feature flag configuration was duplicated across 4 E2E spec files with slightly different param subsets. This PR:

- Extracts a shared `LWD_WALLET_40_FLAGS` constant into `e2e/desktop/tests/utils/featureFlagUtils.ts`
- Replaces all inline `lwdWallet40` configurations in `main.navigation.spec.ts`, `portfolio.spec.ts`, `market.spec.ts`, and `marketBanner.spec.ts`
- Fixes `marketBanner.spec.ts` to use `app.mainNavigation.openTargetFromMainNavigation("home")` instead of the legacy `app.layout.goToPortfolio()` selector, which doesn't exist when `mainNavigation: true`

This makes it easier to update `lwdWallet40` params in one place when needed, and prepares for the eventual removal of the flag when wallet 4.0 becomes default.

### ❓ Context

- Cleanup of duplicated E2E feature flag configuration https://ledgerhq.atlassian.net/browse/LIVE-27347

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)