### PR TITLE
fix(desktop): use resolved theme selector in add account overlay

### DIFF
--- a/.changeset/quick-spiders-wait.md
+++ b/.changeset/quick-spiders-wait.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix system theme not applied in Add Account loading overlay

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/index.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import { useTheme } from "styled-components";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
-import { userThemeSelector } from "~/renderer/reducers/settings";
+import { themeSelector } from "~/renderer/actions/general";
 import { ADD_ACCOUNT_FLOW_NAME, ADD_ACCOUNT_PAGE_NAME } from "../../analytics/addAccount.types";
 import { TrackAddAccountScreen } from "../../analytics/TrackAddAccountScreen";
 import { ScrollContainer } from "../../components/ScrollContainer";
@@ -36,7 +36,7 @@ const ScanAccounts = ({
 }: Props) => {
   const source = useSelector(modularDrawerSourceSelector);
   const { colors } = useTheme();
-  const currentTheme = useSelector(userThemeSelector);
+  const currentTheme = useSelector(themeSelector);
   const { t } = useTranslation();
 
   const {
@@ -98,7 +98,7 @@ const ScanAccounts = ({
         source={source}
         flow={ADD_ACCOUNT_FLOW_NAME}
       />
-      {scanning ? <LoadingOverlay theme={currentTheme || "dark"} /> : null}
+      {scanning ? <LoadingOverlay theme={currentTheme} /> : null}
       <Flex marginBottom={24}>
         <Text
           color="neutral.c100"


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Single selector swap with no new logic to unit-test._
- [x] **Impact of the changes:**
  - Add Account loading overlay theme when "System" theme is selected
  - No impact on users who explicitly select Dark or Light theme

### 📝 Description

**Problem**: When the user selects the "System" theme in Settings, the Add Account loading overlay always renders with a dark background, even if the OS is in light mode. This happens because `userThemeSelector` returns `null` for the system theme, and the fallback `currentTheme || "dark"` always defaults to dark.

**Solution**: Replace `userThemeSelector` with `themeSelector` in the `ScanAccounts` component. `themeSelector` resolves the system preference by combining the user setting with the OS dark-mode state, always returning `"light"` or `"dark"` — never `null`. This ensures the `LoadingOverlay` correctly follows the system theme.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27226](https://ledgerhq.atlassian.net/browse/LIVE-27226)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27226]: https://ledgerhq.atlassian.net/browse/LIVE-27226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ