### PR TITLE
chore: rename marketApi

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/reducers/rtkQueryApi.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/rtkQueryApi.ts
@@ -1,7 +1,7 @@
 import type { Middleware, Reducer, Tuple } from "@reduxjs/toolkit";
 import { ofacGeoBlockApi } from "@ledgerhq/live-common/api/ofacGeoBlockApi";
 import { assetsDataApi } from "@ledgerhq/live-common/dada-client/state-manager/api";
-import { countervaluesApi } from "@ledgerhq/live-common/market/state-manager/api";
+import { marketApi } from "@ledgerhq/live-common/market/state-manager/api";
 import { cgApi } from "@ledgerhq/live-common/cg-client/state-manager/api";
 import { cryptoAssetsApi } from "@ledgerhq/cryptoassets/cal-client/state-manager/api";
 import { pushDevicesApi } from "@ledgerhq/client-ids/api";
@@ -12,7 +12,7 @@ const APIs = {
   [assetsDataApi.reducerPath]: assetsDataApi,
   [cmcApi.reducerPath]: cmcApi,
   [cryptoAssetsApi.reducerPath]: cryptoAssetsApi,
-  [countervaluesApi.reducerPath]: countervaluesApi,
+  [marketApi.reducerPath]: marketApi,
   [cgApi.reducerPath]: cgApi,
   [ofacGeoBlockApi.reducerPath]: ofacGeoBlockApi,
   [pushDevicesApi.reducerPath]: pushDevicesApi,

--- a/apps/ledger-live-mobile/src/context/rtkQueryApi.ts
+++ b/apps/ledger-live-mobile/src/context/rtkQueryApi.ts
@@ -1,7 +1,7 @@
 import type { Middleware, Reducer, Tuple } from "@reduxjs/toolkit";
 import { ofacGeoBlockApi } from "@ledgerhq/live-common/api/ofacGeoBlockApi";
 import { assetsDataApi } from "@ledgerhq/live-common/dada-client/state-manager/api";
-import { countervaluesApi } from "@ledgerhq/live-common/market/state-manager/api";
+import { marketApi } from "@ledgerhq/live-common/market/state-manager/api";
 import { cgApi } from "@ledgerhq/live-common/cg-client/state-manager/api";
 import { cryptoAssetsApi } from "@ledgerhq/cryptoassets/cal-client/state-manager/api";
 import { firebaseRemoteConfigApi } from "LLM/api/firebaseRemoteConfigApi";
@@ -15,7 +15,7 @@ const APIs = {
   [cryptoAssetsApi.reducerPath]: cryptoAssetsApi,
   [firebaseRemoteConfigApi.reducerPath]: firebaseRemoteConfigApi,
   [cgApi.reducerPath]: cgApi,
-  [countervaluesApi.reducerPath]: countervaluesApi,
+  [marketApi.reducerPath]: marketApi,
   [ofacGeoBlockApi.reducerPath]: ofacGeoBlockApi,
   [pushDevicesApi.reducerPath]: pushDevicesApi,
 };

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -490,7 +490,7 @@
     "src/market/hooks/useMarketDataProvider.ts",
     "src/market/hooks/useMarketPerformers.ts",
     "src/market/state-manager/api.ts",
-    "src/market/state-manager/countervaluesApi.ts",
+    "src/market/state-manager/marketApi.ts",
     "src/market/state-manager/types.ts",
     "src/market/utils/currencyFormatter.ts",
     "src/market/utils/fixtures.ts",

--- a/libs/ledger-live-common/src/market/hooks/__tests__/useCurrencyData.test.ts
+++ b/libs/ledger-live-common/src/market/hooks/__tests__/useCurrencyData.test.ts
@@ -6,7 +6,7 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { useCurrencyData } from "../useMarketDataProvider";
-import { countervaluesApi } from "../../state-manager/countervaluesApi";
+import { marketApi } from "../../state-manager/marketApi";
 import { server } from "@tests/server";
 import { createTestStore, createWrapper } from "@tests/test-helpers/testUtils";
 
@@ -27,13 +27,13 @@ describe("useCurrencyData", () => {
   afterEach(() => {
     server.events.removeListener("request:start", requestListener);
     server.resetHandlers();
-    store.dispatch(countervaluesApi.util.resetApiState());
+    store.dispatch(marketApi.util.resetApiState());
   });
 
   afterAll(() => server.close());
 
   beforeEach(() => {
-    store = createTestStore([countervaluesApi], { disableSerializableCheck: true });
+    store = createTestStore([marketApi], { disableSerializableCheck: true });
     requestCount = 0;
     lastRequestUrl = null;
     requestListener = ({ request }: { request: Request }) => {

--- a/libs/ledger-live-common/src/market/state-manager/api.ts
+++ b/libs/ledger-live-common/src/market/state-manager/api.ts
@@ -1,1 +1,1 @@
-export * from "./countervaluesApi";
+export * from "./marketApi";

--- a/libs/ledger-live-common/src/market/state-manager/marketApi.ts
+++ b/libs/ledger-live-common/src/market/state-manager/marketApi.ts
@@ -11,8 +11,8 @@ import { REFETCH_TIME_ONE_MINUTE, BASIC_REFETCH } from "../utils/timers";
 import { MarketDataTags, MarketPerformersQueryParams } from "./types";
 import { format, formatPerformer } from "../utils/currencyFormatter";
 
-export const countervaluesApi = createApi({
-  reducerPath: "countervaluesApi",
+export const marketApi = createApi({
+  reducerPath: "marketApi",
   baseQuery: fetchBaseQuery({
     baseUrl: getEnv("LEDGER_COUNTERVALUES_API"),
   }),
@@ -55,4 +55,4 @@ export const countervaluesApi = createApi({
   }),
 });
 
-export const { useGetMarketPerformersQuery, useGetCurrencyDataQuery } = countervaluesApi;
+export const { useGetMarketPerformersQuery, useGetCurrencyDataQuery } = marketApi;


### PR DESCRIPTION

### ✅ Checklist


- ~`npx changeset`~ n/a
- ~ **Covered by automatic tests.**~ n/a (rename only)
- **Impact of the changes:**
    - **In scope:** Rename the RTK Query API object, its file, reducerPath, and all imports/references.
    - **Out of scope:** The i18n key `troubleshootNetwork.countervaluesApi` and the network-troubleshooting entry -- these refer to the actual Countervalues API endpoint health check, not the RTK Query API. They are correctly named.
    - **Also out of scope:** `CounterValuesAPI` type in `libs/live-countervalues/` -- this is a completely separate concept (the countervalues data fetching interface).

### 📝 Description

Ticket: [LIVE-26226](https://ledgerhq.atlassian.net/browse/LIVE-26226) -- The RTK Query API at `libs/ledger-live-common/src/market/state-manager/countervaluesApi.ts` is misnamed. It serves the **market** feature, not **counterValues**. 

Renaming it to `marketApi` unblocks creating a real `counterValuesApi`.


### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-26226


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26226]: https://ledgerhq.atlassian.net/browse/LIVE-26226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ