### PR TITLE
chore: (rules) rebuild deps and rerun install

### DIFF
--- a/.cursor/rules/rebuild-to-fix-lib-import-errors.mdc
+++ b/.cursor/rules/rebuild-to-fix-lib-import-errors.mdc
@@ -1,0 +1,25 @@
+---
+description: When typecheck finds an error importing from a lib in the monorepo, rebuild the lib
+alwaysApply: false
+---
+
+When typecheck finds an error importing from a lib in the monorepo rebuild the lib using the command below:
+
+```shell
+pnpm turbo build --filter=@ledgerhq/name_of_lib_here
+```
+
+## Example
+
+### `live-countervalues-react` has been updated and the import in `live-common` is erroring
+
+We run `typecheck` and get the following error:
+
+> src/currencies/hooks.ts:1:10 - error TS2305: Module '"@ledgerhq/live-countervalues-react"' has no exported member 'useMarketcapIds'.
+> 1 import { useMarketcapIds } from "@ledgerhq/live-countervalues-react";
+
+We need to rebuild `@ledgerhq/live-countervalues-react`
+
+```shell
+pnpm turbo build --filter=@ledgerhq/live-countervalues-react
+```


### PR DESCRIPTION
### ✅ Checklist

- ~`npx changeset`~ n/a (rules only)
- ~ **Covered by automatic tests.**~ n/a (rules only)
- **Impact of the changes:**
    - New agent applied rule to help recover from import related typecheck errors

### 📝 Description

Whilst working on a rename task the agent struggled with an import error. The dependencies needed to be rebuilt.

~As often happens, the build task then ran into issues because I had not run `pnpm i` recently enough.~ 
☝️ _Removed after comments that it wasn't needed_

These rule provide a way to address this.

### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-27230


### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
