### PR TITLE
refactor(desktop): migrate topbar tooltip to lumen-ui-react compound component

### DIFF
--- a/.changeset/shiny-eggs-type.md
+++ b/.changeset/shiny-eggs-type.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Migrate TopBar tooltip to lumen-ui-react Tooltip compound component

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarActionButton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarActionButton.tsx
@@ -1,6 +1,5 @@
-import React from "react";
-import { IconButton } from "@ledgerhq/lumen-ui-react";
-import Tooltip from "~/renderer/components/Tooltip";
+import React, { useCallback } from "react";
+import { IconButton, Tooltip, TooltipTrigger, TooltipContent } from "@ledgerhq/lumen-ui-react";
 import type { TopBarAction } from "../types";
 
 type TopBarActionButtonProps = TopBarAction;
@@ -15,18 +14,28 @@ export function TopBarActionButton({
 }: TopBarActionButtonProps) {
   const testId = `topbar-action-button-${label.replace(/\s+/g, "-").toLowerCase()}`;
 
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) onTooltipShow?.();
+    },
+    [onTooltipShow],
+  );
+
   return (
     <div className="flex items-center gap-12">
-      <Tooltip content={tooltip} placement="bottom" onShow={onTooltipShow}>
-        <IconButton
-          appearance="gray"
-          size="sm"
-          aria-label={label}
-          icon={icon}
-          onClick={onClick}
-          data-testid={testId}
-          disabled={!isInteractive}
-        />
+      <Tooltip onOpenChange={handleOpenChange}>
+        <TooltipTrigger asChild>
+          <IconButton
+            appearance="gray"
+            size="sm"
+            aria-label={label}
+            icon={icon}
+            onClick={onClick}
+            data-testid={testId}
+            disabled={!isInteractive}
+          />
+        </TooltipTrigger>
+        {tooltip && <TooltipContent side="bottom">{tooltip}</TooltipContent>}
       </Tooltip>
     </div>
   );

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
@@ -155,7 +155,7 @@ describe("useActivityIndicator", () => {
     });
 
     expect(result.current.isRotating).toBe(true);
-    expect(result.current.tooltip).toBeNull();
+    expect(result.current.tooltip).toBeUndefined();
   });
 
   it("returns isRotating true when balance is loading during sync", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicatorTooltip.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicatorTooltip.test.ts
@@ -4,7 +4,7 @@ import { useActivityIndicatorTooltip } from "../useActivityIndicatorTooltip";
 const enUsState = { settings: { locale: "en-US" } };
 
 describe("useActivityIndicatorTooltip", () => {
-  it("returns null when isRotating is true", () => {
+  it("returns undefined when isRotating is true", () => {
     const { result } = renderHook(() =>
       useActivityIndicatorTooltip({
         isRotating: true,
@@ -13,7 +13,7 @@ describe("useActivityIndicatorTooltip", () => {
         lastSyncMs: 0,
       }),
     );
-    expect(result.current).toBeNull();
+    expect(result.current).toBeUndefined();
   });
 
   it("returns emptyErrorToolTip when isError is true and no account names", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicatorTooltip.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicatorTooltip.ts
@@ -18,12 +18,12 @@ export function useActivityIndicatorTooltip({
   isError,
   listOfErrorAccountNames,
   lastSyncMs,
-}: ActivityIndicatorTooltipParams): string | null {
+}: ActivityIndicatorTooltipParams): string | undefined {
   const { t } = useTranslation();
   const locale = useSelector(localeSelector);
 
   if (isRotating) {
-    return null;
+    return undefined;
   }
 
   if (isError) {

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
@@ -13,7 +13,7 @@ type IconComponent =
 
 type TopBarAction = {
   label: string;
-  tooltip: string | null;
+  tooltip?: string;
   isInteractive: boolean;
   onClick: () => void;
   icon: IconComponent;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - TopBar action buttons tooltip rendering and hover behavior
  - `onTooltipShow` callback (used for sync error analytics tracking)

### 📝 Description

The `TopBarActionButton` was using a legacy `Tooltip` wrapper from `~/renderer/components/Tooltip` which is not part of the lumen-ui-react design system. The `onTooltipShow` callback needed to be wired through the tooltip lifecycle to fire analytics events when the sync error tooltip is displayed.

**Solution**: Replaced the legacy Tooltip with lumen-ui-react's `Tooltip`, `TooltipTrigger`, and `TooltipContent` compound component. The `onTooltipShow` callback is now connected via Radix UI's `onOpenChange` handler. Also aligned the tooltip type from `string | null` to `string | undefined` across the TopBar module for consistency, and fixed corresponding test assertions.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27236](https://ledgerhq.atlassian.net/browse/LIVE-27236)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27236]: https://ledgerhq.atlassian.net/browse/LIVE-27236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ