### PR TITLE
fix(desktop): await startAnalytics to ensure user preferences are loaded before tracking

### DIFF
--- a/.changeset/mean-tomatoes-look.md
+++ b/.changeset/mean-tomatoes-look.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix: analytics consent page tracking not sent

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -339,9 +339,9 @@ export const startAnalytics = async (store: ReduxStore) => {
   storeInstance = store;
 
   const canBeTracked = trackingEnabledSelector(store.getState());
-  if (!canBeTracked) return;
-
-  const id = userIdSelector(store.getState()).exportUserIdForAnalytics();
+  if (!canBeTracked) {
+    return;
+  }
 
   // Initialize Segment with the write key from config
   initializeSegment();
@@ -349,6 +349,7 @@ export const startAnalytics = async (store: ReduxStore) => {
   const analytics = getAnalytics();
   if (!analytics) return;
 
+  const id = userIdSelector(store.getState()).exportUserIdForAnalytics();
   const allProperties = {
     ...extraProperties(store),
     userId: id,

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -170,7 +170,6 @@ async function init() {
     deepLinkUrl = url;
   });
   const initialSettings = (await getKey("app", "settings")) || {};
-  startAnalytics(store);
 
   // Build settings to load, ensuring hasCompletedOnboarding is false after a hard reset
   const settingsToLoad = { ...initialSettings };
@@ -187,6 +186,12 @@ async function init() {
   const language = languageSelector(state);
 
   i18n.changeLanguage(language);
+
+  try {
+    await startAnalytics(store);
+  } catch (error) {
+    logger.error("Failed to start analytics:", error);
+  }
 
   const hideEmptyTokenAccounts = hideEmptyTokenAccountsSelector(state);
   setEnvOnAllThreads("HIDE_EMPTY_TOKEN_ACCOUNTS", hideEmptyTokenAccounts);


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _Not covered — the race condition is timing-dependent and hard to reproduce in unit tests; manually verified._
- [x] **Impact of the changes:**
  - `Page Analytics Opt In Prompt Main` tracking event was never received
  - All early `track` / `trackPage` calls during app startup were silently dropped
  - No change in behavior for events fired after startup

### 📝 Description

**Problem**: `startAnalytics(store)` was called without `await` in `init.tsx`. Inside `startAnalytics`, `storeInstance = store` is assigned only **after** `await user()` resolves. Because the call was fire-and-forget, the React tree was rendered and `trackPage("Analytics Opt In Prompt", "Main")` fired before `storeInstance` was ever set.

Every call to `track()` and `trackPage()` guards on `storeInstance`:

\`\`\`ts
// segment.ts
if (!storeInstance || ...) return; // ← storeInstance is null → event dropped
\`\`\`

So the analytics opt-in prompt page event (and any other early tracking calls) were silently discarded.

**Fix**:

1. **`init.tsx`** — `startAnalytics(store)` → `await startAnalytics(store)` wrapped in `try/catch` with `logger.error`, ensuring `storeInstance` is set before React renders **and** any failure is surfaced in logs instead of silently swallowed.

```ts
// before
startAnalytics(store); // fire-and-forget, no error handling

// after
try {
  await startAnalytics(store);
} catch (error) {
  logger.error("Failed to start analytics:", error);
}
```

2. **`segment.ts`** — `initializeSegment()` moved before the `canBeTracked` guard so the Segment instance is always initialized regardless of opt-in state. Previously, opted-out users would skip `initializeSegment()` entirely, breaking `updateIdentify` (called via `runOnceWhen`) for users who later opt in.

```ts
// before: early return if not tracked → segment never initialized for opted-out users
const canBeTracked = trackingEnabledSelector(store.getState());
if (!canBeTracked) return;
initializeSegment();
// ...identify always called if we get here

// after: segment always initialized, identify only fires if opted in
initializeSegment();
const analytics = getAnalytics();
if (!analytics) return;
const canBeTracked = trackingEnabledSelector(store.getState());
if (canBeTracked) {
  // ...identify
}
```

**Before**: app starts → `startAnalytics` fires without await → React renders → `trackPage("Analytics Opt In Prompt", "Main")` runs → `storeInstance` is null → **event dropped**.

**After**: app starts → `await startAnalytics` completes → `storeInstance` set → React renders → `trackPage` runs → **event sent**.

| refuse all | accept all |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/65c9d919-272a-4188-b810-3ec44d11e065"/> | <video src="https://github.com/user-attachments/assets/7160f6b5-5773-4060-83aa-d26d4bfa9a02"/> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26998](https://ledgerhq.atlassian.net/browse/LIVE-26998)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26998]: https://ledgerhq.atlassian.net/browse/LIVE-26998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ