### PR TITLE
fix: tracking metadata casing for sync refresh

### DIFF
--- a/.changeset/purple-trains-jog.md
+++ b/.changeset/purple-trains-jog.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+fix: tracking metadata for SyncRefreshClick

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
@@ -202,7 +202,7 @@ describe("useActivityIndicator", () => {
 
     expect(mockTriggerRefresh).toHaveBeenCalledTimes(1);
     expect(track).toHaveBeenCalledWith("SyncRefreshClick", {
-      triggered_after_sync_error: false,
+      triggeredAfterSyncError: false,
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicator.ts
@@ -67,7 +67,7 @@ export const useActivityIndicator = () => {
     dispatch(setLastUserSyncClickTimestamp(now));
     triggerRefresh();
     track("SyncRefreshClick", {
-      triggered_after_sync_error: isError,
+      triggeredAfterSyncError: isError,
     });
   }, [dispatch, triggerRefresh, isError]);
 

--- a/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
+++ b/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
@@ -55,7 +55,7 @@ function globalSyncRefreshControl<P>(
       track("button_clicked", {
         button: "pull to refresh",
         page: route.name,
-        triggered_after_sync_error: isError ?? false,
+        triggeredAfterSyncError: isError ?? false,
       });
       onUserRefresh();
     }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a minor update to both the desktop and mobile apps, focusing on improving tracking metadata for the "SyncRefreshClick" event. The main change is a refactor of the tracking property name from `triggered_after_sync_error` to `triggeredAfterSyncError` to standardize naming conventions across the codebase.

### ❓ Context

[LIVE-27265](https://ledgerhq.atlassian.net/browse/LIVE-27265)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27265]: https://ledgerhq.atlassian.net/browse/LIVE-27265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ