### PR TITLE
ci: fix errors with bot replacement

### DIFF
--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -51,7 +51,7 @@ jobs:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const isManual = context.eventName === 'workflow_dispatch';
-            const { owner, repo } = context.repo();
+            const { owner, repo } = context.repo;
 
             let command, commentId, login, issueNumber;
             if (isManual) {


### PR DESCRIPTION
Fix of an error within the slashcommands that could not be tested until the initial PR was merged.

Test Run: https://github.com/LedgerHQ/ledger-live/actions/runs/22723305330