### PR TITLE
refactor(desktop): add allow list and keepLegacy for app namespace

### DIFF
--- a/.changeset/app-json-allow-list-keep-legacy.md
+++ b/.changeset/app-json-allow-list-keep-legacy.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add allow list and keepLegacy for app namespace: only allowed keyPaths are loaded and persisted; legacy "user" is kept until "identities" is written, then dropped at save time. Unknown keys are dropped on load and never written back.

--- a/apps/ledger-live-desktop/src/main/db/index.test.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const readFileMock = jest.fn<(path: string) => Promise<Buffer>>();
+const writeFileMock = jest.fn<(path: string, data: string) => Promise<void>>();
+
+jest.mock("~/main/db/fsHelper", () => ({
+  readFile: (path: string) => readFileMock(path),
+  writeFile: (path: string, data: string) => writeFileMock(path, data),
+}));
+
+describe("db (app namespace allow list + keepLegacy)", () => {
+  let db: typeof import("./index").default;
+  const testDir = "/tmp/db-test";
+
+  beforeEach(async () => {
+    jest.resetModules();
+    readFileMock.mockReset();
+    writeFileMock.mockReset();
+    writeFileMock.mockResolvedValue(undefined);
+    db = (await import("./index")).default;
+    db.init(testDir);
+  });
+
+  function appJson(data: Record<string, unknown>) {
+    return Buffer.from(JSON.stringify({ data }), "utf-8");
+  }
+
+  function getWrittenData(): Record<string, unknown> {
+    expect(writeFileMock).toHaveBeenCalled();
+    const call = writeFileMock.mock.calls[writeFileMock.mock.calls.length - 1];
+    const content = call[1];
+    const parsed = JSON.parse(content);
+    return parsed.data as Record<string, unknown>;
+  }
+
+  it("drops unknown keys at load and does not write them back", async () => {
+    readFileMock.mockResolvedValueOnce(
+      appJson({
+        settings: { loaded: true },
+        _this_is_not_valid_field_: "junk",
+      }),
+    );
+    const settings = await db.getKey("app", "settings", undefined);
+    expect(settings).toEqual({ loaded: true });
+    const unknown = await db.getKey("app", "_this_is_not_valid_field_", undefined);
+    expect(unknown).toBeUndefined();
+
+    await db.setKey("app", "settings", { loaded: true });
+
+    const written = getWrittenData();
+    expect(written.settings).toEqual({ loaded: true });
+    expect((written as Record<string, unknown>)._this_is_not_valid_field_).toBeUndefined();
+  });
+
+  it("keeps user in file until identities is written", async () => {
+    readFileMock.mockResolvedValueOnce(
+      appJson({
+        user: { id: "legacy-user-id" },
+      }),
+    );
+    const user = await db.getKey("app", "user", undefined);
+    expect(user).toEqual({ id: "legacy-user-id" });
+
+    await db.setKey("app", "settings", {});
+
+    let written = getWrittenData();
+    expect(written.user).toEqual({ id: "legacy-user-id" });
+
+    await db.setKey("app", "identities", { userId: "new-id" });
+
+    written = getWrittenData();
+    expect(written.identities).toEqual({ userId: "new-id" });
+    expect(written.user).toBeUndefined();
+  });
+
+  it("preserves allowed and keepLegacy keys on load", async () => {
+    readFileMock.mockResolvedValueOnce(
+      appJson({
+        settings: { a: 1 },
+        identities: { userId: "u" },
+        user: { id: "legacy" },
+      }),
+    );
+    expect(await db.getKey("app", "settings", undefined)).toEqual({ a: 1 });
+    expect(await db.getKey("app", "identities", undefined)).toEqual({ userId: "u" });
+    expect(await db.getKey("app", "user", undefined)).toEqual({ id: "legacy" });
+  });
+});

--- a/apps/ledger-live-desktop/src/main/db/index.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.ts
@@ -3,6 +3,7 @@ import path from "path";
 import cloneDeep from "lodash/cloneDeep";
 import get from "lodash/get";
 import set from "lodash/set";
+import pick from "lodash/pick";
 import fs from "fs/promises";
 import { getEnv } from "@ledgerhq/live-env";
 import { NoDBPathGiven, DBWrongPassword } from "@ledgerhq/errors";
@@ -45,6 +46,27 @@ const save = debounce(saveToDisk, DEBOUNCE_MS);
 // Track which keyPaths triggered saves for each namespace
 const saveTriggers: Map<string, Set<string>> = new Map();
 
+/** Allow list for app namespace: only these + keepLegacy keys are loaded and can be persisted. */
+const APP_NAMESPACE_ALLOWED_KEY_PATHS: ReadonlySet<string> = new Set([
+  "accounts",
+  "countervalues",
+  "postOnboarding",
+  "settings",
+  "trustchain",
+  "wallet",
+  "market",
+  "cryptoAssets",
+  "identities",
+  "discover",
+  "ptx",
+  "PLAYWRIGHT_RUN", // e2e fixtures: localStorage seed (e.g. acceptedTermsVersion) and env overrides
+]);
+
+/** Legacy keys we keep in memory and on disk until their replacement is written. */
+const APP_NAMESPACE_KEEP_LEGACY: Record<string, { replacedBy: string }> = {
+  user: { replacedBy: "identities" },
+};
+
 /**
  * Reset memory state, db path, encryption keys, transforms..
  */
@@ -57,6 +79,7 @@ function init(_DBPath: string) {
 
 /**
  * Load a namespace, using <file>.json
+ * For app: keep only allowed + keepLegacy keys (unknown keys are dropped).
  */
 async function load(ns: string): Promise<unknown> {
   try {
@@ -64,7 +87,17 @@ async function load(ns: string): Promise<unknown> {
     const filePath = path.resolve(DBPath, `${ns}.json`);
     const fileContent = await readFile(filePath);
     const { data } = JSON.parse(fileContent.toString());
-    memoryNamespaces[ns] = data;
+    const dataObj = data as Record<string, unknown>;
+
+    if (ns === "app") {
+      const keysToKeep = [
+        ...APP_NAMESPACE_ALLOWED_KEY_PATHS,
+        ...Object.keys(APP_NAMESPACE_KEEP_LEGACY),
+      ];
+      memoryNamespaces[ns] = pick(dataObj, keysToKeep) as Record<string, unknown>;
+    } else {
+      memoryNamespaces[ns] = dataObj;
+    }
   } catch (err) {
     if ((err as { code?: string })?.code === "ENOENT") {
       memoryNamespaces[ns] = {};
@@ -204,6 +237,19 @@ async function hasBeenDecrypted(): Promise<boolean> {
 }
 
 /**
+ * Build payload for app namespace: allowed keys + keepLegacy keys only when replacement not written.
+ */
+function buildAppNamespacePayload(memory: Record<string, unknown>): Record<string, unknown> {
+  const payload = pick(memory, [...APP_NAMESPACE_ALLOWED_KEY_PATHS]) as Record<string, unknown>;
+  for (const [legacyKey, { replacedBy }] of Object.entries(APP_NAMESPACE_KEEP_LEGACY)) {
+    if (payload[replacedBy] === undefined && memory[legacyKey] !== undefined) {
+      payload[legacyKey] = memory[legacyKey];
+    }
+  }
+  return payload;
+}
+
+/**
  * Save given namespace to corresponding file, in atomic way
  */
 async function saveToDisk(ns: string) {
@@ -214,8 +260,11 @@ async function saveToDisk(ns: string) {
   const triggersSet = saveTriggers.get(ns);
   const triggers = triggersSet ? Array.from(triggersSet) : [];
 
-  // cloning because we are mutating the obj
-  const clone = cloneDeep(memoryNamespaces[ns]);
+  const raw =
+    ns === "app"
+      ? buildAppNamespacePayload(memoryNamespaces[ns] as Record<string, unknown>)
+      : memoryNamespaces[ns];
+  const clone = cloneDeep(raw);
 
   // encrypt fields
   const namespacedEncryptionKeys = encryptionKeys[ns];

--- a/apps/ledger-live-desktop/src/main/index.ts
+++ b/apps/ledger-live-desktop/src/main/index.ts
@@ -26,7 +26,6 @@ import { UserDataCleanup } from "./cleanupUserData";
 import debounce from "lodash/debounce";
 import sentry, { setTags } from "~/sentry/main";
 import type { SettingsState } from "~/renderer/reducers/settings";
-import type { User } from "~/renderer/storage";
 import {
   installExtension,
   REDUX_DEVTOOLS,
@@ -119,9 +118,10 @@ app.on("ready", async () => {
   // Measure database initialization and first reads
   console.time("T-db");
   const settings = (await db.getKey("app", "settings")) as SettingsState;
-  const user: User = (await db.getKey("app", "user")) as User;
+  const identities = (await db.getKey("app", "identities")) as { userId?: string } | undefined;
+  const user = (await db.getKey("app", "user")) as { id?: string } | undefined;
   console.timeEnd("T-db");
-  const userId = user?.id;
+  const userId = identities?.userId ?? user?.id;
   if (userId) {
     sentry(() => settings?.sentryLogs, userId);
   }

--- a/e2e/desktop/tests/specs/app.spec.ts
+++ b/e2e/desktop/tests/specs/app.spec.ts
@@ -32,8 +32,10 @@ test.describe("Identities migration from legacy user", () => {
   test(
     "after boot with skip-onboarding userdata, user id is in store identities (same value), deviceIds [], new datadogId",
     { tag: ["@smoke", "@NanoSP", "@NanoX", "@LNS"] },
-    async ({ app, page, userdataFile }) => {
-      const initial = JSON.parse(await readFile(userdataFile, "utf-8"));
+    async ({ app, page, userdataFile, userdataOriginalFile }) => {
+      // Read legacy user id from the original fixture: the app overwrites app.json
+      // and drops "user" when it saves identities, so userdataFile no longer has it.
+      const initial = JSON.parse(await readFile(userdataOriginalFile!, "utf-8"));
       const legacyUserId = initial?.data?.user?.id;
       expect(legacyUserId).toBeDefined();
       expect(typeof legacyUserId).toBe("string");
@@ -49,6 +51,27 @@ test.describe("Identities migration from legacy user", () => {
       expect(identities.deviceIds).toEqual([]);
       expect(identities.datadogId).toBeDefined();
       expect(identities.datadogId).not.toBe("");
+    },
+  );
+});
+
+test.describe("App namespace allow list", () => {
+  test.use({ userdata: "app-allowlist-cleanup" });
+
+  test(
+    "invalid keys in app.json are dropped on load and not written back",
+    { tag: ["@smoke", "@NanoSP", "@NanoX", "@LNS"] },
+    async ({ app, userdataFile }) => {
+      await app.layout.goToSettings();
+
+      await app.portfolio.expectIdentitiesPersistedInAppJson(userdataFile, 15000);
+
+      const content = await readFile(userdataFile, "utf-8");
+      const parsed = JSON.parse(content);
+      expect(parsed.data).toBeDefined();
+      expect(parsed.data._this_is_not_valid_field_).toBeUndefined();
+      expect(parsed.data.user).toBeUndefined();
+      expect(parsed.data.identities).toBeDefined();
     },
   );
 });

--- a/e2e/desktop/tests/userdata/app-allowlist-cleanup.json
+++ b/e2e/desktop/tests/userdata/app-allowlist-cleanup.json
@@ -1,0 +1,53 @@
+{
+  "data": {
+    "PLAYWRIGHT_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2042-01-01"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": null,
+      "region": null,
+      "locale": "en-US",
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "selectedTimeRange": "month",
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sentryLogs": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "nanoSP",
+      "hasInstalledApps": true,
+      "hasAcceptedSwapKYC": false,
+      "lastSeenDevice": null,
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [],
+    "countervalues": {},
+    "_this_is_not_valid_field_": "should be dropped on load and not written back"
+  }
+}


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no impact for users
  - but otherwise it only concerns Desktop

### 📝 Description

- Only allowed keyPaths loaded and persisted; unknown keys dropped on load
- Legacy 'user' kept until 'identities' is written, then dropped at save time
- Main: read identities + user for Sentry userId
- Unit tests (db): unknown key drop, user/identities save-time drop, allowed keys preserved
- E2E app.spec: fixture with invalid key, assert removed after load and save

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
