### PR TITLE
test(mobile): improve ModularDrawer test coverage

### DIFF
--- a/.changeset/loud-moles-remain.md
+++ b/.changeset/loud-moles-remain.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+add new tests on the MAD

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/Debug/__tests__/utils.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/Debug/__tests__/utils.test.ts
@@ -1,0 +1,55 @@
+import { getElement, isOneOf, makeOnValueChange } from "../utils";
+
+describe("Debug/utils", () => {
+  describe("getElement", () => {
+    it('should return undefined when value is "undefined"', () => {
+      expect(getElement("undefined")).toBeUndefined();
+    });
+
+    it("should return undefined when value is undefined", () => {
+      expect(getElement(undefined)).toBeUndefined();
+    });
+
+    it("should return the value when it is a valid string", () => {
+      expect(getElement("balance")).toBe("balance");
+      expect(getElement("numberOfAccounts")).toBe("numberOfAccounts");
+    });
+  });
+
+  describe("isOneOf", () => {
+    const allowed = ["balance", "apy", "marketTrend"] as const;
+
+    it("should return true when value is in allowed list", () => {
+      expect(isOneOf("balance", allowed)).toBe(true);
+      expect(isOneOf("apy", allowed)).toBe(true);
+    });
+
+    it("should return false when value is not in allowed list", () => {
+      expect(isOneOf("unknown", allowed)).toBe(false);
+      expect(isOneOf("", allowed)).toBe(false);
+    });
+  });
+
+  describe("makeOnValueChange", () => {
+    const allowed = ["balance", "apy", "marketTrend"] as const;
+
+    it("should call setter when value is allowed", () => {
+      const setter = jest.fn();
+      const handler = makeOnValueChange(allowed, setter);
+
+      handler("balance");
+      expect(setter).toHaveBeenCalledWith("balance");
+
+      handler("apy");
+      expect(setter).toHaveBeenCalledWith("apy");
+    });
+
+    it("should not call setter when value is not allowed", () => {
+      const setter = jest.fn();
+      const handler = makeOnValueChange(allowed, setter);
+
+      handler("unknown");
+      expect(setter).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useDetailedAccounts.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useDetailedAccounts.test.ts
@@ -1,0 +1,84 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { useDetailedAccounts } from "../useDetailedAccounts";
+import { mockEthCryptoCurrency } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
+import { ETH_ACCOUNT } from "@ledgerhq/live-common/modularDrawer/__mocks__/accounts.mock";
+import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
+import BigNumber from "bignumber.js";
+import { State } from "~/reducers/types";
+
+describe("useDetailedAccounts", () => {
+  it("should return an empty list when no accounts exist for the asset", () => {
+    const { result } = renderHook(() =>
+      useDetailedAccounts(mockEthCryptoCurrency, "test_flow", "test_source", undefined),
+    );
+
+    expect(result.current.detailedAccounts).toHaveLength(0);
+  });
+
+  it("should format balance with currency ticker and fiatValue as non-empty string", () => {
+    const { result } = renderHook(
+      () => useDetailedAccounts(mockEthCryptoCurrency, "test_flow", "test_source", undefined),
+      {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          accounts: { active: [ETH_ACCOUNT] },
+        }),
+      },
+    );
+
+    expect(result.current.detailedAccounts.length).toBeGreaterThan(0);
+    const { balance, fiatValue } = result.current.detailedAccounts[0];
+    expect(balance).toContain(mockEthCryptoCurrency.ticker);
+    expect(fiatValue.trim().length).toBeGreaterThan(0);
+  });
+
+  it("should sort accounts by balance descending", () => {
+    const highBalanceAccount = {
+      ...genAccount("high_balance_eth", { currency: mockEthCryptoCurrency }),
+      balance: new BigNumber("1000000000000000000000"),
+    };
+    const lowBalanceAccount = {
+      ...genAccount("low_balance_eth", { currency: mockEthCryptoCurrency }),
+      balance: new BigNumber("1"),
+    };
+
+    const { result } = renderHook(
+      () => useDetailedAccounts(mockEthCryptoCurrency, "test_flow", "test_source", undefined),
+      {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          accounts: { active: [lowBalanceAccount, highBalanceAccount] },
+        }),
+      },
+    );
+
+    expect(result.current.accounts).toHaveLength(2);
+    expect(
+      result.current.accounts[0].account.balance.isGreaterThanOrEqualTo(
+        result.current.accounts[1].account.balance,
+      ),
+    ).toBe(true);
+  });
+
+  it("should forward account and parentAccount to onAccountSelected", () => {
+    const onAccountSelected = jest.fn();
+    const { result } = renderHook(
+      () =>
+        useDetailedAccounts(mockEthCryptoCurrency, "test_flow", "test_source", onAccountSelected),
+      {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          accounts: { active: [ETH_ACCOUNT] },
+        }),
+      },
+    );
+
+    const rawAccount = result.current.detailedAccounts[0];
+
+    act(() => {
+      result.current.handleAccountSelected(rawAccount);
+    });
+
+    expect(onAccountSelected).toHaveBeenCalledWith(rawAccount.account, rawAccount.parentAccount);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
@@ -1,0 +1,119 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { useModularDrawerController } from "../useModularDrawerController";
+import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
+import { AccountLike } from "@ledgerhq/types-live";
+
+const mockAccount = genAccount("test_account");
+const mockParentAccount = genAccount("parent_account");
+
+jest.mock("../../utils/callbackIdGenerator", () => ({
+  generateCallbackId: jest.fn(() => "generated-id"),
+}));
+
+describe("useModularDrawerController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should initialize with drawer closed", () => {
+    const { result } = renderHook(() => useModularDrawerController());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("should open drawer and set state correctly when called with params", () => {
+    const { result, store } = renderHook(() => useModularDrawerController());
+
+    act(() => {
+      result.current.openDrawer({
+        flow: "receive_flow",
+        source: "test_source",
+        enableAccountSelection: true,
+        currencies: ["bitcoin"],
+      });
+    });
+
+    const state = store.getState().modularDrawer;
+    expect(state.isOpen).toBe(true);
+    expect(state.flow).toBe("receive_flow");
+    expect(state.source).toBe("test_source");
+    expect(state.enableAccountSelection).toBe(true);
+    expect(state.preselectedCurrencies).toEqual(["bitcoin"]);
+  });
+
+  it("should close the drawer when closeDrawer is called", () => {
+    const { result, store } = renderHook(() => useModularDrawerController());
+
+    act(() => {
+      result.current.openDrawer({ flow: "test_flow", source: "test_source" });
+    });
+
+    act(() => {
+      result.current.closeDrawer();
+    });
+
+    expect(store.getState().modularDrawer.isOpen).toBe(false);
+  });
+
+  describe("handleAccountSelected", () => {
+    it("should invoke registered onAccountSelected callback and close the drawer", () => {
+      const onAccountSelected = jest.fn();
+      const { result, store } = renderHook(() => useModularDrawerController());
+
+      act(() => {
+        result.current.openDrawer({
+          flow: "receive_flow",
+          source: "test_source",
+          onAccountSelected,
+        });
+      });
+
+      expect(store.getState().modularDrawer.callbackId).toBe("generated-id");
+
+      act(() => {
+        result.current.handleAccountSelected(mockAccount);
+      });
+
+      expect(onAccountSelected).toHaveBeenCalledWith(mockAccount, undefined);
+      expect(store.getState().modularDrawer.isOpen).toBe(false);
+    });
+
+    it("should pass through parentAccount when it has derivationMode", () => {
+      const onAccountSelected = jest.fn();
+      const { result } = renderHook(() => useModularDrawerController());
+
+      act(() => {
+        result.current.openDrawer({
+          flow: "receive_flow",
+          source: "test_source",
+          onAccountSelected,
+        });
+      });
+
+      act(() => {
+        result.current.handleAccountSelected(mockAccount, mockParentAccount);
+      });
+
+      expect(onAccountSelected).toHaveBeenCalledWith(mockAccount, mockParentAccount);
+    });
+
+    it("should narrow parentAccount to undefined when it lacks derivationMode", () => {
+      const onAccountSelected = jest.fn();
+      const tokenLikeParent = { id: "token-parent", type: "TokenAccount" } as AccountLike;
+      const { result } = renderHook(() => useModularDrawerController());
+
+      act(() => {
+        result.current.openDrawer({
+          flow: "receive_flow",
+          source: "test_source",
+          onAccountSelected,
+        });
+      });
+
+      act(() => {
+        result.current.handleAccountSelected(mockAccount, tokenLikeParent);
+      });
+
+      expect(onAccountSelected).toHaveBeenCalledWith(mockAccount, undefined);
+    });
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - ModularDrawer Debug utilities (`getElement`, `isOneOf`, `makeOnValueChange`)
  - `useModularDrawerController` hook (open/close drawer, callback handling, currencies)
  - `useDetailedAccounts` hook (formatted output, sorting, callback forwarding)

### 📝 Description

The `ModularDrawer` feature had a global coverage of **79.9% on new code**, with several uncovered areas including the Debug utilities (0%) and key hooks.

This PR adds unit tests targeting the most impactful gaps:

- **`Debug/__tests__/utils.test.ts`** — Tests for the pure utility functions (`getElement`, `isOneOf`, `makeOnValueChange`)
- **`hooks/__tests__/useModularDrawerController.test.ts`** — Tests for opening/closing the drawer, state dispatch, currency preselection, and callback handling
- **`hooks/__tests__/useDetailedAccounts.test.ts`** — Tests for the mobile-specific formatting of `balance` and `fiatValue` as strings, descending balance sort, and correct forwarding of `account`/`parentAccount` to the selection callback

Tests follow project conventions: shared mocks from `@ledgerhq/live-common/modularDrawer/__mocks__`, `overrideInitialState` for Redux state, no mocking of feature flags or already-mocked globals (segment analytics).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27068](https://ledgerhq.atlassian.net/browse/LIVE-27068)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27068]: https://ledgerhq.atlassian.net/browse/LIVE-27068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ