### PR TITLE
fix(mobile): prevent Modular Drawer Asset Selection crash (LIVE-27193)

### DIFF
--- a/.changeset/rich-mirrors-kiss.md
+++ b/.changeset/rich-mirrors-kiss.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Disable LumenBottomSheet in the MAD

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawer.tsx
@@ -3,9 +3,9 @@ import ModularDrawerFlowManager from "./ModularDrawerFlowManager";
 import { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
 import { useAssets } from "./hooks/useAssets";
 import { useModularDrawerState } from "./hooks/useModularDrawerState";
-import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+//import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
-import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+//import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import QueuedDrawerGorhom from "LLM/components/QueuedDrawer/temp/QueuedDrawerGorhom";
 
 import { AccountLike } from "@ledgerhq/types-live";
@@ -64,7 +64,8 @@ export function ModularDrawer({
   uiUseCase,
   areCurrenciesFiltered,
 }: ModularDrawerProps) {
-  const { isEnabled } = useWalletFeaturesConfig("mobile");
+  // TODO: Re-enable it for LIVE-27294
+  // const { isEnabled } = useWalletFeaturesConfig("mobile");
 
   const {
     assetsConfiguration: assetsConfigurationSanitized,
@@ -129,21 +130,22 @@ export function ModularDrawer({
     },
   };
 
-  if (isEnabled) {
-    return (
-      <QueuedDrawerBottomSheet
-        isRequestingToBeOpened={(!hasOneCurrency || enableAccountSelection) && isOpen}
-        onClose={handleCloseButton}
-        enableBlurKeyboardOnGesture={true}
-        snapPoints={SNAP_POINTS}
-        hasBackButton={shouldShowBackButton}
-        onBack={handleBackButton}
-        enablePanDownToClose
-      >
-        <ModularDrawerFlowManager {...flowManagerProps} />
-      </QueuedDrawerBottomSheet>
-    );
-  }
+  // TODO: Re-enable it for LIVE-27294
+  // if (isEnabled) {
+  //   return (
+  //     <QueuedDrawerBottomSheet
+  //       isRequestingToBeOpened={(!hasOneCurrency || enableAccountSelection) && isOpen}
+  //       onClose={handleCloseButton}
+  //       enableBlurKeyboardOnGesture={true}
+  //       snapPoints={SNAP_POINTS}
+  //       hasBackButton={shouldShowBackButton}
+  //       onBack={handleBackButton}
+  //       enablePanDownToClose
+  //     >
+  //       <ModularDrawerFlowManager {...flowManagerProps} />
+  //     </QueuedDrawerBottomSheet>
+  //   );
+  // }
 
   return (
     <QueuedDrawerGorhom

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlowManager/ModularDrawerFlowView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlowManager/ModularDrawerFlowView.tsx
@@ -10,7 +10,7 @@ import { ModularDrawerFlowProps } from ".";
 import useScreenTransition from "./useScreenTransition";
 import { useSelector } from "~/context/hooks";
 import { modularDrawerStepSelector } from "~/reducers/modularDrawer";
-import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+//import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 export function ModularDrawerFlowView({
   assetsViewModel,
@@ -18,18 +18,19 @@ export function ModularDrawerFlowView({
   accountsViewModel,
 }: ModularDrawerFlowProps) {
   const currentStep = useSelector(modularDrawerStepSelector);
-  const { isEnabled } = useWalletFeaturesConfig("mobile");
+  // TODO: Re-enable it for LIVE-27294:
+  // const { isEnabled } = useWalletFeaturesConfig("mobile");
 
   const { activeSteps, getStepAnimations } = useScreenTransition(currentStep);
 
   const renderStepContent = (step: ModularDrawerStep) => {
     switch (step) {
       case ModularDrawerStep.Asset:
-        return <AssetSelection {...assetsViewModel} useLumenBottomSheet={isEnabled} />;
+        return <AssetSelection {...assetsViewModel} useLumenBottomSheet={false} />;
       case ModularDrawerStep.Network:
-        return <NetworkSelection {...networksViewModel} useLumenBottomSheet={isEnabled} />;
+        return <NetworkSelection {...networksViewModel} useLumenBottomSheet={false} />;
       case ModularDrawerStep.Account:
-        return <AccountSelection {...accountsViewModel} useLumenBottomSheet={isEnabled} />;
+        return <AccountSelection {...accountsViewModel} useLumenBottomSheet={false} />;
       default:
         return null;
     }
@@ -45,7 +46,8 @@ export function ModularDrawerFlowView({
         style={[{ flex: 1 }, stepAnimations.animatedStyle]}
         testID={`${step}-screen`}
       >
-        {!isEnabled && <Title step={step} />}
+        {/* TODO: Re-enable it for LIVE-27294: {!isEnabled && <Title step={step} />} */}
+        <Title step={step} />
         {renderStepContent(step)}
       </Animated.View>
     );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing createAssetConfiguration Jest tests pass; fix ensures stable hook order and safe array handling.
- [x] **Impact of the changes:**
  - Modular Drawer → Asset Selection screen (no crash when opening or when config changes)
  - Swap/Receive/Add Account flows that use the asset selector drawer


### 📝 Description

Fixes the asset selection crash in the Modular Asset Drawer (MAD).

**Approach:** LumenBottomSheet has been temporarily deactivated in the MAD to fix the crash:
- The MAD now uses `QueuedDrawerGorhom` instead of `QueuedDrawerBottomSheet` (Lumen bottom sheet).
- Asset, Network, and Account selection screens are rendered with `useLumenBottomSheet={false}`.

Re-enabling LumenBottomSheet in the MAD will be investigated later (follow-up: LIVE-27294).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27193](https://ledgerhq.atlassian.net/browse/LIVE-27193)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27193]: https://ledgerhq.atlassian.net/browse/LIVE-27193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ