### PR TITLE
fix(lwdm): fix warning blocking on recipient step new send flow

### DIFF
--- a/.changeset/polite-weeks-compare.md
+++ b/.changeset/polite-weeks-compare.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+fix(lwdm): fix warning blocking on recipient step new send flow

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientAddressModalView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientAddressModalView.tsx
@@ -109,7 +109,7 @@ export function RecipientAddressModalView({
           onSelect={onAddressSelect}
           isSanctioned={isSanctioned}
           isAddressComplete={isAddressComplete}
-          hasBridgeError={showBridgeRecipientError || showBridgeRecipientWarning}
+          hasBridgeError={showBridgeRecipientError}
         />
       )}
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -1,5 +1,6 @@
 import { isAddressSanctioned } from "@ledgerhq/coin-framework/sanction/index";
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
 import {
   getAccountCurrency,
   getMainAccount,
@@ -341,6 +342,30 @@ describe("useAddressValidation", () => {
     );
 
     expect(result.current.result.bridgeWarnings?.recipient).toBe(recipientWarning);
+  });
+
+  it("injects a self-transfer error when policy is impossible and recipient is the current account", () => {
+    mockedSendFeatures.getSelfTransferPolicy.mockReturnValue("impossible");
+    mockedUseBridgeRecipientValidation.mockReturnValue({
+      errors: {},
+      warnings: {},
+      isLoading: false,
+      status: null,
+      cleanup: jest.fn(),
+    });
+
+    const { result } = renderHook(() =>
+      useAddressValidation({
+        searchValue: mockAccount.freshAddress,
+        currency: mockAccount.currency,
+        account: mockAccount,
+        currentAccountId: mockAccount.id,
+      }),
+    );
+
+    expect(result.current.result.bridgeErrors?.recipient).toBeInstanceOf(
+      InvalidAddressBecauseDestinationIsAlsoSource,
+    );
   });
 
   it("shows loading during bridge validation", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -2,7 +2,7 @@ import { isAddressSanctioned } from "@ledgerhq/coin-framework/sanction/index";
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { isLoaded } from "@ledgerhq/domain-service/hooks/logic";
 import type { DomainServiceStatus } from "@ledgerhq/domain-service/hooks/types";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
 import {
   getAccountCurrency,
   getMainAccount,
@@ -84,6 +84,11 @@ export function useAddressValidation({
     return ensResolution?.address ?? searchValue;
   }, [ensResolution?.address, searchValue]);
 
+  const mainAccount = useMemo(
+    () => (account ? getMainAccount(account, parentAccount) : null),
+    [account, parentAccount],
+  );
+
   // Bridge validation for recipient/sender errors and warnings
   const bridgeValidation = useBridgeRecipientValidation({
     recipient: addressForBridgeValidation,
@@ -154,14 +159,13 @@ export function useAddressValidation({
     });
   }, [searchValue, userAccountsForCurrency, accountNames]);
 
-  const currentAccountName = useMaybeAccountName(
-    account ? getMainAccount(account, parentAccount) : null,
-  );
+  const currentAccountName = useMaybeAccountName(mainAccount);
 
   const currentAccountMatch = useMemo(() => {
     if (!searchValue || !account) return null;
 
-    const mainAccount = getMainAccount(account, parentAccount);
+    if (!mainAccount) return null;
+
     const addressToCheck = ensResolution?.address ?? searchValue;
     const selfTransferPolicy = sendFeatures.getSelfTransferPolicy(currency);
 
@@ -177,7 +181,7 @@ export function useAddressValidation({
     }
 
     return null;
-  }, [searchValue, account, parentAccount, currency, ensResolution?.address, currentAccountName]);
+  }, [searchValue, account, mainAccount, currency, ensResolution?.address, currentAccountName]);
 
   const matchedLedgerAccount = currentAccountMatch ?? matchedLedgerAccounts[0];
 
@@ -273,6 +277,15 @@ export function useAddressValidation({
       delete filteredBridgeErrors.recipient;
     }
 
+    const isImpossibleSelfTransferAttempt =
+      mainAccount &&
+      sendFeatures.getSelfTransferPolicy(currency) === "impossible" &&
+      addressForBridgeValidation.toLowerCase() === mainAccount.freshAddress.toLowerCase();
+
+    if (isImpossibleSelfTransferAttempt && !filteredBridgeErrors.recipient) {
+      filteredBridgeErrors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
+    }
+
     return {
       status: validationState.status,
       error: validationState.error,
@@ -298,6 +311,9 @@ export function useAddressValidation({
     formattedBalance,
     formattedCounterValue,
     accountName,
+    mainAccount,
+    currency,
+    addressForBridgeValidation,
     bridgeValidation.errors,
     bridgeValidation.warnings,
   ]);

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useTranslatedBridgeError.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useTranslatedBridgeError.ts
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 
 type TranslatedErrorMessages = {
   title: string;
-  description: string;
+  description?: string;
 };
 
 /**
@@ -35,12 +35,19 @@ export function useTranslatedBridgeError(error: Error | undefined): TranslatedEr
     const genericTitleKey = "errors.generic.title";
     const genericDescriptionKey = "errors.generic.description";
 
+    const hasSpecificTitle = title !== titleKey;
+    const hasSpecificDescription = description !== descriptionKey;
+    let translatedDescription: string | undefined;
+
+    if (hasSpecificDescription) {
+      translatedDescription = description;
+    } else if (!hasSpecificTitle) {
+      translatedDescription = t(genericDescriptionKey, args as Record<string, unknown>);
+    }
+
     return {
-      title: title === titleKey ? t(genericTitleKey, args as Record<string, unknown>) : title,
-      description:
-        description === descriptionKey
-          ? t(genericDescriptionKey, args as Record<string, unknown>)
-          : description,
+      title: hasSpecificTitle ? title : t(genericTitleKey, args as Record<string, unknown>),
+      description: translatedDescription,
     };
   }, [error, t]);
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -112,7 +112,7 @@ export const RecipientScreenView = ({
               onSelect={handleAddressSelect}
               isSanctioned={showSanctionedBanner}
               isAddressComplete={isAddressComplete}
-              hasBridgeError={showBridgeRecipientError || showBridgeRecipientWarning}
+              hasBridgeError={showBridgeRecipientError}
             />
           )}
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -3,6 +3,7 @@ import { useAddressValidation } from "../useAddressValidation";
 import { useSelector } from "~/context/hooks";
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { isAddressSanctioned } from "@ledgerhq/coin-framework/sanction/index";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
 import {
   getRecentAddressesStore,
   getMainAccount,
@@ -338,6 +339,30 @@ describe("useAddressValidation", () => {
     );
 
     expect(result.current.result.bridgeWarnings?.recipient).toBe(recipientWarning);
+  });
+
+  it("injects a self-transfer error when policy is impossible and recipient is the current account", () => {
+    mockedSendFeatures.getSelfTransferPolicy.mockReturnValue("impossible");
+    mockedUseBridgeRecipientValidation.mockReturnValue({
+      errors: {},
+      warnings: {},
+      isLoading: false,
+      status: null,
+      cleanup: jest.fn(),
+    });
+
+    const { result } = renderHook(() =>
+      useAddressValidation({
+        searchValue: mockAccount.freshAddress,
+        currency: mockAccount.currency,
+        account: mockAccount,
+        currentAccountId: mockAccount.id,
+      }),
+    );
+
+    expect(result.current.result.bridgeErrors?.recipient).toBeInstanceOf(
+      InvalidAddressBecauseDestinationIsAlsoSource,
+    );
   });
 
   it("shows loading during bridge validation", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -2,7 +2,7 @@ import { isAddressSanctioned } from "@ledgerhq/coin-framework/sanction/index";
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { isLoaded } from "@ledgerhq/domain-service/hooks/logic";
 import type { DomainServiceStatus } from "@ledgerhq/domain-service/hooks/types";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
 import {
   getAccountCurrency,
   getMainAccount,
@@ -85,6 +85,11 @@ export function useAddressValidation({
     return ensResolution?.address ?? searchValue;
   }, [ensResolution?.address, searchValue]);
 
+  const mainAccount = useMemo(
+    () => (account ? getMainAccount(account, parentAccount) : null),
+    [account, parentAccount],
+  );
+
   // Bridge validation for recipient/sender errors and warnings
   const bridgeValidation = useBridgeRecipientValidation({
     recipient: addressForBridgeValidation,
@@ -155,14 +160,13 @@ export function useAddressValidation({
     });
   }, [searchValue, userAccountsForCurrency, accountNames]);
 
-  const currentAccountName = useMaybeAccountName(
-    account ? getMainAccount(account, parentAccount) : null,
-  );
+  const currentAccountName = useMaybeAccountName(mainAccount);
 
   const currentAccountMatch = useMemo(() => {
     if (!searchValue || !account) return null;
 
-    const mainAccount = getMainAccount(account, parentAccount);
+    if (!mainAccount) return null;
+
     const addressToCheck = ensResolution?.address ?? searchValue;
     const selfTransferPolicy = sendFeatures.getSelfTransferPolicy(currency);
 
@@ -178,7 +182,7 @@ export function useAddressValidation({
     }
 
     return null;
-  }, [searchValue, account, parentAccount, currency, ensResolution?.address, currentAccountName]);
+  }, [searchValue, account, mainAccount, currency, ensResolution?.address, currentAccountName]);
 
   const matchedLedgerAccount = currentAccountMatch ?? matchedLedgerAccounts[0];
 
@@ -274,6 +278,15 @@ export function useAddressValidation({
       delete filteredBridgeErrors.recipient;
     }
 
+    const isImpossibleSelfTransferAttempt =
+      mainAccount &&
+      sendFeatures.getSelfTransferPolicy(currency) === "impossible" &&
+      addressForBridgeValidation.toLowerCase() === mainAccount.freshAddress.toLowerCase();
+
+    if (isImpossibleSelfTransferAttempt && !filteredBridgeErrors.recipient) {
+      filteredBridgeErrors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
+    }
+
     return {
       status: validationState.status,
       error: validationState.error,
@@ -299,6 +312,9 @@ export function useAddressValidation({
     formattedBalance,
     formattedCounterValue,
     accountName,
+    mainAccount,
+    currency,
+    addressForBridgeValidation,
     bridgeValidation.errors,
     bridgeValidation.warnings,
   ]);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useTranslatedBridgeError.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useTranslatedBridgeError.ts
@@ -3,7 +3,7 @@ import { useTranslation } from "~/context/Locale";
 
 type TranslatedErrorMessages = {
   title: string;
-  description: string;
+  description?: string;
 };
 
 /**
@@ -35,12 +35,19 @@ export function useTranslatedBridgeError(error: Error | undefined): TranslatedEr
     const genericTitleKey = "errors.generic.title";
     const genericDescriptionKey = "errors.generic.description";
 
+    const hasSpecificTitle = title !== titleKey;
+    const hasSpecificDescription = description !== descriptionKey;
+    let translatedDescription: string | undefined;
+
+    if (hasSpecificDescription) {
+      translatedDescription = description;
+    } else if (!hasSpecificTitle) {
+      translatedDescription = t(genericDescriptionKey, args as Record<string, unknown>);
+    }
+
     return {
-      title: title === titleKey ? t(genericTitleKey, args as Record<string, unknown>) : title,
-      description:
-        description === descriptionKey
-          ? t(genericDescriptionKey, args as Record<string, unknown>)
-          : description,
+      title: hasSpecificTitle ? title : t(genericTitleKey, args as Record<string, unknown>),
+      description: translatedDescription,
     };
   }, [error, t]);
 }

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
@@ -332,6 +332,30 @@ describe("useRecipientSearchState", () => {
     expect(result.current.bridgeRecipientError).toBe(recipientError);
   });
 
+  it("should show bridge recipient error even when a recent address matches", () => {
+    const recipientError = new InvalidAddressBecauseDestinationIsAlsoSource();
+    const recent = {
+      address: "tz1self",
+      currency: {} as never,
+      lastUsedAt: new Date(),
+    };
+    const { result } = renderHook(() =>
+      useRecipientSearchState({
+        ...defaultProps,
+        searchValue: "tz1self",
+        result: createDefaultResult({
+          status: "valid",
+          matchedRecentAddress: recent,
+          bridgeErrors: { recipient: recipientError },
+        }),
+      }),
+    );
+
+    expect(result.current.showMatchedAddress).toBe(true);
+    expect(result.current.showBridgeRecipientError).toBe(true);
+    expect(result.current.bridgeRecipientError).toBe(recipientError);
+  });
+
   it("should show bridge recipient warning when no recipient error and no address validation error", () => {
     const warning = new Error("Warning");
     const { result } = renderHook(() =>

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
@@ -79,11 +79,7 @@ export function useRecipientSearchState({
   }, [result.error, isBridgeInvalidAddress, searchValue]);
 
   const showBridgeRecipientError =
-    showSearchResults &&
-    !!bridgeRecipientError &&
-    !isBridgeInvalidAddress &&
-    !showSanctionedBanner &&
-    !hasAnyMatches;
+    showSearchResults && hasBridgeRecipientError && !showAddressValidationError;
 
   const showBridgeRecipientWarning =
     showSearchResults &&


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Warning messages used to block the user on the recipient step (which should only be the errors that are blocking)
Simultaneity this lead to an issue with errors to appears properly

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-27303)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
