### PR TITLE
fix(concordium): stub coin-module gRPC client for web environments

### DIFF
--- a/.changeset/tame-hotels-boil.md
+++ b/.changeset/tame-hotels-boil.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-concordium": minor
+"@ledgerhq/web-tools": minor
+---
+
+coin-concordium: add grpcClient.web.ts stub and browser field override to prevent @grpc/grpc-js from being bundled in web environments.

--- a/apps/web-tools/rsbuild.config.ts
+++ b/apps/web-tools/rsbuild.config.ts
@@ -52,11 +52,7 @@ export default defineConfig({
         http2: false,
         dns: false,
       };
-      appendPlugins([
-        new rspack.IgnorePlugin({ resourceRegExp: /^electron$/ }),
-        new rspack.IgnorePlugin({ resourceRegExp: /@grpc\/grpc-js/ }),
-        new rspack.IgnorePlugin({ resourceRegExp: /@grpc\/proto-loader/ }),
-      ]);
+      appendPlugins([new rspack.IgnorePlugin({ resourceRegExp: /^electron$/ })]);
     },
   },
 });

--- a/libs/coin-modules/coin-concordium/.unimportedrc.json
+++ b/libs/coin-modules/coin-concordium/.unimportedrc.json
@@ -19,13 +19,14 @@
     "jest-message-util"
   ],
   "ignoreUnimported": [
+    "src/network/grpcClient.native.ts",
+    "src/network/grpcClient.web.ts",
     "src/test/bot-specs.ts",
     "src/test/concordiumTestUtils.ts",
     "src/test/fixtures.ts",
     "src/test/testHelpers.ts",
     "src/test/walletConnectFixtures.ts",
-    "src/types/errors.ts",
-    "src/network/grpcClient.native.ts"
+    "src/types/errors.ts"
   ],
   "ignoreUnused": []
 }

--- a/libs/coin-modules/coin-concordium/package.json
+++ b/libs/coin-modules/coin-concordium/package.json
@@ -160,6 +160,10 @@
     },
     "./package.json": "./package.json"
   },
+  "browser": {
+    "./lib/network/grpcClient.js": "./lib/network/grpcClient.web.js",
+    "./lib-es/network/grpcClient.js": "./lib-es/network/grpcClient.web.js"
+  },
   "license": "Apache-2.0",
   "dependencies": {
     "@grpc/grpc-js": "^1.9.15",

--- a/libs/coin-modules/coin-concordium/src/network/grpcClient.web.ts
+++ b/libs/coin-modules/coin-concordium/src/network/grpcClient.web.ts
@@ -1,0 +1,52 @@
+/**
+ * Concordium gRPC Client — Web stub
+ *
+ * Rspack resolves this file instead of grpcClient.ts for web builds,
+ * severing the dependency chain to @grpc/grpc-js, @grpc/proto-loader,
+ * and node:path. The bridge layer (sync, broadcast, sign) uses only
+ * proxyClient (HTTP REST) and never reaches these functions at runtime.
+ */
+import type {
+  Block,
+  BlockInfo,
+  Operation,
+  ListOperationsOptions,
+  Page,
+} from "@ledgerhq/coin-framework/api/index";
+
+type GRPCClient = never;
+
+export function getClient(_currencyId: string): GRPCClient {
+  throw new Error("gRPC client is not available in web");
+}
+
+export async function withClient<T>(
+  _currencyId: string,
+  _execute: (client: GRPCClient) => Promise<T>,
+  _retries?: number,
+): Promise<T> {
+  throw new Error("gRPC client is not available in web");
+}
+
+export async function getLastBlock(_currencyId: string): Promise<BlockInfo> {
+  throw new Error("gRPC getLastBlock() method is not available in web");
+}
+
+export async function getBlockInfoByHeight(
+  _currencyId: string,
+  _height: number,
+): Promise<BlockInfo> {
+  throw new Error("gRPC getBlockInfoByHeight() method is not available in web");
+}
+
+export async function getBlockByHeight(_currencyId: string, _height: number): Promise<Block> {
+  throw new Error("gRPC getBlockByHeight() method is not available in web");
+}
+
+export async function getOperations(
+  _currencyId: string,
+  _address: string,
+  _options: ListOperationsOptions,
+): Promise<Page<Operation>> {
+  throw new Error("gRPC getOperations() method is not available in web");
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** addresses runtime errors in web-tools; no new functionality added; doesn't affect existing integration in desktop app.
  - ...

### 📝 Description

Adds a web stub for the Concordium gRPC client (grpcClient.web.ts) mirroring the existing React Native stub pattern. The browser field in package.json redirects any bundler targeting web environments from the real grpcClient.js (which depends on Node.js-only @grpc/grpc-js) to the stub, which throws descriptive errors if gRPC functions are called. This fix is safe for desktop (LLD renderer never imports grpcClient — the bridge layer uses proxyClient exclusively) and mobile (Metro ignores the browser field entirely).

### ❓ Context

- reported by @lewisd5 via [Slack](https://ledger.slack.com/archives/C08FSSUBVTP/p1772789774820439) 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
