### PR TITLE
fix: missing mantra balances

### DIFF
--- a/.changeset/nervous-apes-worry.md
+++ b/.changeset/nervous-apes-worry.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/cryptoassets": minor
+"@ledgerhq/live-currency-format": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+fix: missing mantra balances

--- a/apps/ledger-live-desktop/tests/fixtures/wallet-api.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/wallet-api.ts
@@ -1125,11 +1125,11 @@ export const expectedCurrencyList = [
   {
     type: "CryptoCurrency",
     id: "mantra",
-    ticker: "OM",
+    ticker: "MANTRA",
     name: "Mantra",
     family: "cosmos",
     color: "#ffb386",
-    decimals: 6,
+    decimals: 18,
   },
   {
     type: "CryptoCurrency",

--- a/libs/ledger-live-common/src/currencies/mock.ts
+++ b/libs/ledger-live-common/src/currencies/mock.ts
@@ -487,19 +487,19 @@ export const CURRENCIES_LIST: CryptoCurrency[] = [
     coinType: 118,
     name: "Mantra",
     managerAppName: "Cosmos",
-    ticker: "OM",
+    ticker: "MANTRA",
     scheme: "mantra",
     color: "#ffb386",
     family: "cosmos",
     units: [
       {
         name: "Mantra",
-        code: "OM",
-        magnitude: 6,
+        code: "MANTRA",
+        magnitude: 18,
       },
       {
         name: "Micro-Mantra",
-        code: "uom",
+        code: "amantra",
         magnitude: 0,
       },
     ],

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cosmos.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cosmos.integration.test.ts.snap
@@ -12,7 +12,7 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "0388459b2653519948b12492f1a0b464720110c147a8155d23d423a5cc3c21d89a",
-    "spendableBalance": "1991321",
+    "spendableBalance": "3351996",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/mantra.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/mantra.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`mantra currency bridge scanAccounts mantra seed 1 1`] = `
 [
   {
-    "balance": "714932",
+    "balance": "2859728000000000000",
     "currencyId": "mantra",
     "derivationMode": "",
     "freshAddress": "mantra1gyauvl44q2apn3u3aujm36q8zrj74vry7n5nvn",
@@ -12,7 +12,7 @@ exports[`mantra currency bridge scanAccounts mantra seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "03d5e0ebb3f1ae2afe87e5d5a24b5029a59cc12f8fd1056840091b2f0b97e54e83",
-    "spendableBalance": "204932",
+    "spendableBalance": "819728000000000000",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -4817,19 +4817,19 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     coinType: CoinType.ATOM,
     name: "Mantra",
     managerAppName: "Cosmos",
-    ticker: "OM",
+    ticker: "MANTRA",
     scheme: "mantra",
     color: "#ffb386",
     family: "cosmos",
     units: [
       {
         name: "Mantra",
-        code: "OM",
-        magnitude: 6,
+        code: "MANTRA",
+        magnitude: 18,
       },
       {
         name: "Micro-Mantra",
-        code: "uom",
+        code: "amantra",
         magnitude: 0,
       },
     ],

--- a/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
+++ b/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
@@ -218,7 +218,7 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format MIX Blockchain unit (MIX) 1`] = `"123.456.789,00000000- -MIX"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Mantra unit (Mantra) 1`] = `"12.345.678.900,000000- -OM"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Mantra unit (Mantra) 1`] = `"0,012345678900000000- -MANTRA"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Metis unit (METIS) 1`] = `"0,012345678900000000- -METIS"`;
 
@@ -622,7 +622,7 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format MIX Blockchain unit (MIX) 1`] = `"123,456,789.00000000- -MIX"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Mantra unit (Mantra) 1`] = `"12,345,678,900.000000- -OM"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Mantra unit (Mantra) 1`] = `"0.012345678900000000- -MANTRA"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Metis unit (METIS) 1`] = `"0.012345678900000000- -METIS"`;
 
@@ -1026,7 +1026,7 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format MIX Blockchain unit (MIX) 1`] = `"123.456.789,00000000- -MIX"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Mantra unit (Mantra) 1`] = `"12.345.678.900,000000- -OM"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Mantra unit (Mantra) 1`] = `"0,012345678900000000- -MANTRA"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Metis unit (METIS) 1`] = `"0,012345678900000000- -METIS"`;
 
@@ -1430,7 +1430,7 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format MIX Blockchain unit (MIX) 1`] = `"123 456 789,00000000- -MIX"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Mantra unit (Mantra) 1`] = `"12 345 678 900,000000- -OM"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Mantra unit (Mantra) 1`] = `"0,012345678900000000- -MANTRA"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Metis unit (METIS) 1`] = `"0,012345678900000000- -METIS"`;
 
@@ -1834,7 +1834,7 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format MIX Blockchain unit (MIX) 1`] = `"123,456,789.00000000- -MIX"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Mantra unit (Mantra) 1`] = `"12,345,678,900.000000- -OM"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Mantra unit (Mantra) 1`] = `"0.012345678900000000- -MANTRA"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Metis unit (METIS) 1`] = `"0.012345678900000000- -METIS"`;
 
@@ -2238,7 +2238,7 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format MIX Blockchain unit (MIX) 1`] = `"123,456,789.00000000- -MIX"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Mantra unit (Mantra) 1`] = `"12,345,678,900.000000- -OM"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Mantra unit (Mantra) 1`] = `"0.012345678900000000- -MANTRA"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Metis unit (METIS) 1`] = `"0.012345678900000000- -METIS"`;
 
@@ -2642,7 +2642,7 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format MIX Blockchain unit (MIX) 1`] = `"123.456.789,00000000- -MIX"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Mantra unit (Mantra) 1`] = `"12.345.678.900,000000- -OM"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Mantra unit (Mantra) 1`] = `"0,012345678900000000- -MANTRA"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Metis unit (METIS) 1`] = `"0,012345678900000000- -METIS"`;
 
@@ -3046,7 +3046,7 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format MIX Blockchain unit (MIX) 1`] = `"123 456 789,00000000- -MIX"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Mantra unit (Mantra) 1`] = `"12 345 678 900,000000- -OM"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Mantra unit (Mantra) 1`] = `"0,012345678900000000- -MANTRA"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Metis unit (METIS) 1`] = `"0,012345678900000000- -METIS"`;
 
@@ -3450,7 +3450,7 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format MIX Blockchain unit (MIX) 1`] = `"123.456.789,00000000- -MIX"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Mantra unit (Mantra) 1`] = `"12.345.678.900,000000- -OM"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Mantra unit (Mantra) 1`] = `"0,012345678900000000- -MANTRA"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Metis unit (METIS) 1`] = `"0,012345678900000000- -METIS"`;
 
@@ -3854,7 +3854,7 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format MIX Blockchain unit (MIX) 1`] = `"123,456,789.00000000- -MIX"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Mantra unit (Mantra) 1`] = `"12,345,678,900.000000- -OM"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Mantra unit (Mantra) 1`] = `"0.012345678900000000- -MANTRA"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Metis unit (METIS) 1`] = `"0.012345678900000000- -METIS"`;
 
@@ -4258,7 +4258,7 @@ exports[`formatCurrencyUnit with default options should correctly format Lukso u
 
 exports[`formatCurrencyUnit with default options should correctly format MIX Blockchain unit (MIX) 1`] = `"123,456,789"`;
 
-exports[`formatCurrencyUnit with default options should correctly format Mantra unit (Mantra) 1`] = `"12,345,678,900"`;
+exports[`formatCurrencyUnit with default options should correctly format Mantra unit (Mantra) 1`] = `"0.0123456"`;
 
 exports[`formatCurrencyUnit with default options should correctly format Metis unit (METIS) 1`] = `"0.0123456"`;
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

Following an [update](https://mantrachain.io/resources/announcements/mantra-chain-coin-upgrade-timeline-and-key-details), Mantra’s denomination changed.

However, [in the code](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts#L227), if the denomination does not match, we return `0`.
So I updated Mantra’s denomination as well as the magnitude.


| Before        | After         |
|--------- | ------------- |
|     <img width="765" height="703" alt="Screenshot 2026-03-06 at 13 33 11" src="https://github.com/user-attachments/assets/13a78640-4ef5-4103-a550-fd08cd4874cd" />      |     <img width="765" height="703" alt="Screenshot 2026-03-06 at 13 41 49" src="https://github.com/user-attachments/assets/18072bba-3219-4078-9954-46566611214a" />         |


### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-27308

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
