### PR TITLE
fix(mobile): adapt portfolio spacing when OS update banner is visible (lwmWallet40)

### DIFF
--- a/.changeset/portfolio-banner-spacing-lw40.md
+++ b/.changeset/portfolio-banner-spacing-lw40.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Adapt spacing on portfolio page when OS update banner is visible (lwmWallet40)

--- a/apps/ledger-live-mobile/src/mvvm/components/ScreenHeroSection/ScreenHeroSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/ScreenHeroSection/ScreenHeroSectionView.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { CONTENT_AREA_HEIGHT } from "./constants";
 
 interface ScreenHeroSectionViewProps {
   readonly children: React.ReactNode;
   readonly ctas?: React.ReactNode;
   readonly testID?: string;
+  readonly minContentHeight?: number;
 }
-
-const CONTENT_AREA_HEIGHT = 208;
 
 const contentAreaStyle: LumenViewStyle = {
   justifyContent: "center",
@@ -20,9 +20,14 @@ const ctasStyle: LumenViewStyle = {
   paddingHorizontal: "s16",
 };
 
-export const ScreenHeroSectionView = ({ children, ctas, testID }: ScreenHeroSectionViewProps) => (
+export const ScreenHeroSectionView = ({
+  children,
+  ctas,
+  testID,
+  minContentHeight,
+}: ScreenHeroSectionViewProps) => (
   <Box lx={{ gap: "s12" }} testID={testID}>
-    <Box lx={contentAreaStyle} style={{ minHeight: CONTENT_AREA_HEIGHT }}>
+    <Box lx={contentAreaStyle} style={{ minHeight: minContentHeight ?? CONTENT_AREA_HEIGHT }}>
       {children}
     </Box>
     {ctas && <Box lx={ctasStyle}>{ctas}</Box>}

--- a/apps/ledger-live-mobile/src/mvvm/components/ScreenHeroSection/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/ScreenHeroSection/constants.ts
@@ -1,0 +1,1 @@
+export const CONTENT_AREA_HEIGHT = 208;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioHeaderSection/__tests__/usePortfolioHeaderSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioHeaderSection/__tests__/usePortfolioHeaderSectionViewModel.test.ts
@@ -1,0 +1,37 @@
+import { renderHook, act } from "@tests/test-renderer";
+import { usePortfolioHeaderSectionViewModel } from "../usePortfolioHeaderSectionViewModel";
+import { CONTENT_AREA_HEIGHT } from "LLM/components/ScreenHeroSection/constants";
+
+describe("usePortfolioHeaderSectionViewModel", () => {
+  describe("minContentHeight", () => {
+    it.each([
+      { bannerHeight: 0, expected: undefined },
+      { bannerHeight: 48, expected: CONTENT_AREA_HEIGHT - 48 },
+      { bannerHeight: 300, expected: 0 },
+    ])("is $expected when banner height is $bannerHeight", ({ bannerHeight, expected }) => {
+      const { result } = renderHook(() => usePortfolioHeaderSectionViewModel());
+
+      act(() => {
+        result.current.onBannerHeightChange(bannerHeight);
+      });
+
+      expect(result.current.minContentHeight).toBe(expected);
+    });
+
+    it("resets to undefined when banner height goes back to 0 (banner dismissed)", () => {
+      const { result } = renderHook(() => usePortfolioHeaderSectionViewModel());
+
+      act(() => {
+        result.current.onBannerHeightChange(48);
+      });
+
+      expect(result.current.minContentHeight).toBe(CONTENT_AREA_HEIGHT - 48);
+
+      act(() => {
+        result.current.onBannerHeightChange(0);
+      });
+
+      expect(result.current.minContentHeight).toBeUndefined();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioHeaderSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioHeaderSection/index.tsx
@@ -1,7 +1,6 @@
-import React from "react";
-import { View } from "react-native";
+import React, { useCallback } from "react";
+import { View, type LayoutChangeEvent } from "react-native";
 import { Flex } from "@ledgerhq/native-ui";
-import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import FirmwareUpdateBanner from "LLM/features/FirmwareUpdate/components/UpdateBanner";
 import PortfolioGraphCard from "~/screens/Portfolio/PortfolioGraphCard";
 import { PortfolioBalanceSection } from "../PortfolioBalanceSection";
@@ -24,17 +23,26 @@ export const PortfolioHeaderSection = ({
   isReadOnlyMode = false,
   ctas,
 }: PortfolioHeaderSectionProps) => {
-  const { safeAreaTop } = usePortfolioHeaderSectionViewModel();
-  const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
+  const { safeAreaTop, shouldDisplayBalanceRefreshRework, onBannerHeightChange, minContentHeight } =
+    usePortfolioHeaderSectionViewModel();
+
+  const onBannerLayout = useCallback(
+    (e: LayoutChangeEvent) => {
+      onBannerHeightChange(e.nativeEvent.layout.height);
+    },
+    [onBannerHeightChange],
+  );
 
   if (hideGraph) {
     return (
       <View key="portfolioHeaderElements" style={{ paddingTop: safeAreaTop }}>
         {shouldDisplayBalanceRefreshRework && <PortfolioRefreshStatus />}
-        <Flex px={6} key="FirmwareUpdateBanner">
-          <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
-        </Flex>
-        <ScreenHeroSectionView ctas={ctas}>
+        <View onLayout={onBannerLayout}>
+          <Flex px={6} key="FirmwareUpdateBanner">
+            <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
+          </Flex>
+        </View>
+        <ScreenHeroSectionView ctas={ctas} minContentHeight={minContentHeight}>
           <PortfolioBalanceSection showAssets={showAssets} isReadOnlyMode={isReadOnlyMode} />
         </ScreenHeroSectionView>
       </View>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioHeaderSection/usePortfolioHeaderSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioHeaderSection/usePortfolioHeaderSectionViewModel.ts
@@ -1,10 +1,28 @@
+import { useState, useCallback } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { CONTENT_AREA_HEIGHT } from "LLM/components/ScreenHeroSection/constants";
 
 interface PortfolioHeaderSectionViewModel {
   readonly safeAreaTop: number;
+  readonly shouldDisplayBalanceRefreshRework: boolean;
+  readonly onBannerHeightChange: (height: number) => void;
+  readonly minContentHeight: number | undefined;
 }
 
 export function usePortfolioHeaderSectionViewModel(): PortfolioHeaderSectionViewModel {
   const { top: safeAreaTop } = useSafeAreaInsets();
-  return { safeAreaTop };
+  const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
+
+  const [bannerHeight, setBannerHeight] = useState(0);
+  const onBannerHeightChange = useCallback((height: number) => {
+    setBannerHeight(height);
+  }, []);
+
+  // When the OS update banner is visible, shrink the hero section by the banner's actual height
+  // so the total portfolio header height (banner + hero) stays constant at CONTENT_AREA_HEIGHT.
+  const minContentHeight =
+    bannerHeight > 0 ? Math.max(0, CONTENT_AREA_HEIGHT - bannerHeight) : undefined;
+
+  return { safeAreaTop, shouldDisplayBalanceRefreshRework, onBannerHeightChange, minContentHeight };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _Visual/layout change — covered manually via the \`DEV_FORCE_SHOW_BANNER\` dev flag._
- [x] **Impact of the changes:**
  - Portfolio header section layout (balance & performance pill vertical spacing)
  - Only activates when \`lwmWallet40\` flag + \`mainNavigation\` sub-param are enabled

### 📝 Description

When the `Wallet40PortfolioBanner` (OS update pill) appears on the portfolio screen, the `ScreenHeroSectionView` was keeping its fixed `minHeight: 208` with `justifyContent: center`, causing the balance amount to float in a large centered block regardless of the banner above it. This created too much whitespace between the banner and the balance/performance pill section.

<img width="300" height="750" alt="simulator_screenshot_F1100EBA-B3D4-4A04-AF3E-EEF40103E80A" src="https://github.com/user-attachments/assets/5acb475c-31a7-4f52-83b6-44daf7c5adcf" />

**Solution:**
- Added an `onBannerVisibilityChange` callback to `FirmwareUpdateBanner` so the parent (`PortfolioHeaderSection`) is notified when the banner becomes visible/hidden.
- When the Wallet 4.0 OS update banner is active, `ScreenHeroSectionView` switches to a reduced `minContentHeight` (160px instead of 208px), keeping the balance section compact and directly below the banner.
- When the banner is absent, the original 208px height is preserved — no visual change.
- Added `DEV_FORCE_SHOW_BANNER = __DEV__ && true` in `useUpdateBannerViewModel` to allow visual testing without a physical device with pending firmware. **Remove/set to false after visual validation.**

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26964](https://ledgerhq.atlassian.net/browse/LIVE-26964)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26964]: https://ledgerhq.atlassian.net/browse/LIVE-26964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ