### PR TITLE
fix(mobile): enable Lumen BottomSheet for ModularDrawer and fix crash on asset selection

### DIFF
--- a/.changeset/fix-modular-drawer-lumen-crash.md
+++ b/.changeset/fix-modular-drawer-lumen-crash.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Enable Lumen BottomSheet for ModularDrawer under lwmWallet40 feature flag and fix crash when opening the asset selection drawer

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawer.tsx
@@ -3,9 +3,9 @@ import ModularDrawerFlowManager from "./ModularDrawerFlowManager";
 import { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
 import { useAssets } from "./hooks/useAssets";
 import { useModularDrawerState } from "./hooks/useModularDrawerState";
-//import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
-//import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import QueuedDrawerGorhom from "LLM/components/QueuedDrawer/temp/QueuedDrawerGorhom";
 
 import { AccountLike } from "@ledgerhq/types-live";
@@ -64,8 +64,7 @@ export function ModularDrawer({
   uiUseCase,
   areCurrenciesFiltered,
 }: ModularDrawerProps) {
-  // TODO: Re-enable it for LIVE-27294
-  // const { isEnabled } = useWalletFeaturesConfig("mobile");
+  const { isEnabled } = useWalletFeaturesConfig("mobile");
 
   const {
     assetsConfiguration: assetsConfigurationSanitized,
@@ -106,6 +105,7 @@ export function ModularDrawer({
   });
 
   const flowManagerProps = {
+    useLumenBottomSheet: isEnabled,
     assetsViewModel: {
       availableAssets: sortedCryptoCurrencies,
       onAssetSelected: handleAsset,
@@ -130,22 +130,21 @@ export function ModularDrawer({
     },
   };
 
-  // TODO: Re-enable it for LIVE-27294
-  // if (isEnabled) {
-  //   return (
-  //     <QueuedDrawerBottomSheet
-  //       isRequestingToBeOpened={(!hasOneCurrency || enableAccountSelection) && isOpen}
-  //       onClose={handleCloseButton}
-  //       enableBlurKeyboardOnGesture={true}
-  //       snapPoints={SNAP_POINTS}
-  //       hasBackButton={shouldShowBackButton}
-  //       onBack={handleBackButton}
-  //       enablePanDownToClose
-  //     >
-  //       <ModularDrawerFlowManager {...flowManagerProps} />
-  //     </QueuedDrawerBottomSheet>
-  //   );
-  // }
+  if (isEnabled) {
+    return (
+      <QueuedDrawerBottomSheet
+        isRequestingToBeOpened={(!hasOneCurrency || enableAccountSelection) && isOpen}
+        onClose={handleCloseButton}
+        enableBlurKeyboardOnGesture={true}
+        snapPoints={SNAP_POINTS}
+        hasBackButton={shouldShowBackButton}
+        onBack={handleBackButton}
+        enablePanDownToClose
+      >
+        <ModularDrawerFlowManager {...flowManagerProps} />
+      </QueuedDrawerBottomSheet>
+    );
+  }
 
   return (
     <QueuedDrawerGorhom

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlowManager/ModularDrawerFlowView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlowManager/ModularDrawerFlowView.tsx
@@ -10,27 +10,29 @@ import { ModularDrawerFlowProps } from ".";
 import useScreenTransition from "./useScreenTransition";
 import { useSelector } from "~/context/hooks";
 import { modularDrawerStepSelector } from "~/reducers/modularDrawer";
-//import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 export function ModularDrawerFlowView({
   assetsViewModel,
   networksViewModel,
   accountsViewModel,
+  useLumenBottomSheet,
 }: ModularDrawerFlowProps) {
   const currentStep = useSelector(modularDrawerStepSelector);
-  // TODO: Re-enable it for LIVE-27294:
-  // const { isEnabled } = useWalletFeaturesConfig("mobile");
 
   const { activeSteps, getStepAnimations } = useScreenTransition(currentStep);
 
   const renderStepContent = (step: ModularDrawerStep) => {
     switch (step) {
       case ModularDrawerStep.Asset:
-        return <AssetSelection {...assetsViewModel} useLumenBottomSheet={false} />;
+        return <AssetSelection {...assetsViewModel} useLumenBottomSheet={useLumenBottomSheet} />;
       case ModularDrawerStep.Network:
-        return <NetworkSelection {...networksViewModel} useLumenBottomSheet={false} />;
+        return (
+          <NetworkSelection {...networksViewModel} useLumenBottomSheet={useLumenBottomSheet} />
+        );
       case ModularDrawerStep.Account:
-        return <AccountSelection {...accountsViewModel} useLumenBottomSheet={false} />;
+        return (
+          <AccountSelection {...accountsViewModel} useLumenBottomSheet={useLumenBottomSheet} />
+        );
       default:
         return null;
     }
@@ -46,8 +48,7 @@ export function ModularDrawerFlowView({
         style={[{ flex: 1 }, stepAnimations.animatedStyle]}
         testID={`${step}-screen`}
       >
-        {/* TODO: Re-enable it for LIVE-27294: {!isEnabled && <Title step={step} />} */}
-        <Title step={step} />
+        {!useLumenBottomSheet && <Title step={step} />}
         {renderStepContent(step)}
       </Animated.View>
     );

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlowManager/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlowManager/index.tsx
@@ -8,6 +8,7 @@ export interface ModularDrawerFlowProps {
   assetsViewModel: AssetSelectionStepProps;
   networksViewModel: NetworkSelectionStepProps;
   accountsViewModel: AccountSelectionStepProps;
+  useLumenBottomSheet: boolean;
 }
 
 /**
@@ -25,6 +26,7 @@ export default function ModularDrawerFlow(props: ModularDrawerFlowProps) {
       assetsViewModel={props.assetsViewModel}
       networksViewModel={props.networksViewModel}
       accountsViewModel={props.accountsViewModel}
+      useLumenBottomSheet={props.useLumenBottomSheet}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
@@ -68,218 +68,272 @@ const setNetInfoState = (override?: NetInfoOverride) => {
   jest.mocked(useNetInfo).mockReturnValue(buildNetInfoState(override));
 };
 
-describe("ModularDrawer integration", () => {
+const advanceTimers = () => {
+  act(() => {
+    jest.advanceTimersByTime(500);
+  });
+};
+
+type DrawerVariant = {
+  label: string;
+  backButtonTestId: string;
+  renderOptions: Parameters<typeof render>[1];
+};
+
+const DRAWER_VARIANTS: DrawerVariant[] = [
+  {
+    label: "Gorhom (legacy)",
+    backButtonTestId: "drawer-back-button",
+    renderOptions: undefined,
+  },
+  {
+    label: "Lumen BottomSheet (lwmWallet40)",
+    backButtonTestId: "bottom-sheet-header-back-button",
+    renderOptions: {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          overriddenFeatureFlags: {
+            ...mockedFF,
+            lwmWallet40: { enabled: true },
+          },
+        },
+      }),
+    },
+  },
+];
+
+describe.each(DRAWER_VARIANTS)(
+  "ModularDrawer integration [$label]",
+  ({ backButtonTestId, renderOptions }) => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      setNetInfoState();
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should allow full navigation: asset → network → Device Selection, with back navigation at each step", async () => {
+      const { getByText, getByTestId, user } = render(
+        <ModularDrawerSharedNavigator />,
+        renderOptions,
+      );
+
+      await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
+      advanceTimers();
+
+      await user.press(getByText(/ethereum/i));
+      advanceTimers();
+
+      expect(getByText(/select network/i)).toBeVisible();
+      advanceTimers();
+
+      await user.press(getByTestId(backButtonTestId));
+      advanceTimers();
+
+      expect(getByText(/select asset/i)).toBeVisible();
+
+      await user.press(getByText(/ethereum/i));
+      advanceTimers();
+
+      expect(getByText(/select network/i)).toBeVisible();
+
+      await user.press(getByText(/arbitrum/i));
+      advanceTimers();
+
+      expect(getByText(/Connect Device/i)).toBeVisible();
+    });
+
+    it("should go directly to Device selection for Bitcoin", async () => {
+      const { getByText, user } = render(<ModularDrawerSharedNavigator />, renderOptions);
+
+      await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
+      advanceTimers();
+
+      await user.press(getByText(/bitcoin/i));
+      advanceTimers();
+
+      expect(getByText(/Connect Device/i)).toBeVisible();
+    });
+
+    it("should allow searching for assets", async () => {
+      const { getByText, queryByText, getByPlaceholderText, user } = render(
+        <ModularDrawerSharedNavigator />,
+        renderOptions,
+      );
+
+      await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
+      advanceTimers();
+
+      expect(getByText(/bitcoin/i)).toBeVisible();
+
+      const searchInput = getByPlaceholderText(/search/i);
+      await user.type(searchInput, "bitc");
+
+      await waitFor(() => expect(queryByText(/ethereum/i)).not.toBeVisible());
+      await waitFor(() => expect(getByText(/bitcoin/i)).toBeVisible());
+    });
+
+    it("should show the empty state when no assets are found", async () => {
+      const { getByText, queryByText, getByPlaceholderText, user } = render(
+        <ModularDrawerSharedNavigator />,
+        renderOptions,
+      );
+
+      await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
+      advanceTimers();
+
+      await user.type(getByPlaceholderText(/search/i), "ttttttt");
+
+      await waitFor(() => expect(queryByText(/no assets found/i)).toBeVisible());
+    });
+
+    it("should not crash when tapping search input with empty asset list", async () => {
+      const { getByText, getByPlaceholderText, getByTestId, user } = render(
+        <ModularDrawerSharedNavigator />,
+        renderOptions,
+      );
+
+      await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
+      advanceTimers();
+
+      const searchInput = getByPlaceholderText(/search/i);
+      await user.type(searchInput, "zzzzzzz");
+
+      await waitFor(() => expect(getByText(/no assets found/i)).toBeVisible());
+
+      await user.press(searchInput);
+      advanceTimers();
+
+      expect(getByTestId("modular-drawer-search-input")).toBeVisible();
+      expect(getByText(/no assets found/i)).toBeVisible();
+    });
+
+    it("should expand to full height when tapping search input with non-empty list", async () => {
+      const { getByText, getByPlaceholderText, user } = render(
+        <ModularDrawerSharedNavigator />,
+        renderOptions,
+      );
+
+      await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
+      advanceTimers();
+
+      await waitFor(() => expect(getByText(/bitcoin/i)).toBeVisible());
+
+      const searchInput = getByPlaceholderText(/search/i);
+      await user.press(searchInput);
+      advanceTimers();
+
+      expect(searchInput).toBeVisible();
+    });
+
+    it("should allow full navigation: asset → network → account", async () => {
+      const { getByText, user } = render(<ModularDrawerSharedNavigator />, {
+        ...INITIAL_STATE,
+        overrideInitialState: (state: State) => ({
+          ...state,
+          accounts: { active: mockedAccounts },
+          settings: {
+            ...state.settings,
+            overriddenFeatureFlags: {
+              ...mockedFF,
+              ...(renderOptions?.overrideInitialState
+                ? { lwmWallet40: { enabled: true } }
+                : undefined),
+            },
+          },
+          wallet: {
+            ...state.wallet,
+            accountNames: new Map([[ARB_ACCOUNT.id, "Arbitrum One"]]),
+          },
+        }),
+      });
+
+      await user.press(getByText(WITH_ACCOUNT_SELECTION));
+      advanceTimers();
+
+      await waitFor(() => expect(getByText(/select asset/i)).toBeVisible());
+
+      await user.press(getByText(/ethereum/i));
+      advanceTimers();
+
+      expect(getByText(/select network/i)).toBeVisible();
+
+      await user.press(getByText(/arbitrum/i));
+      advanceTimers();
+
+      expect(getByText(/select account/i)).toBeVisible();
+      expect(getByText(/Arbitrum One/i)).toBeVisible();
+      expect(getByText(/add new or existing account/i)).toBeVisible();
+
+      await user.press(getByText(/add new or existing account/i));
+      advanceTimers();
+
+      expect(getByText(/Connect Device/i)).toBeVisible();
+    });
+
+    it("should display generic error when a Backend error occurs", async () => {
+      server.use(http.get("https://dada.api.ledger.com/v1/assets", () => HttpResponse.error()));
+      const { getByText, user } = render(<ModularDrawerSharedNavigator />, renderOptions);
+      advanceTimers();
+
+      await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
+
+      expect(
+        await screen.findByText(/Something went wrong on our end\. Please try again later/i),
+      ).toBeVisible();
+    });
+
+    it("should display generic error when an internet error occurs", async () => {
+      setNetInfoState({
+        isConnected: false,
+        isInternetReachable: false,
+        type: NetInfoStateType.none,
+      });
+
+      const { getByText, user } = render(<ModularDrawerSharedNavigator />, renderOptions);
+
+      await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
+      advanceTimers();
+
+      await waitFor(() =>
+        expect(getByText(/No internet connection. Please try again/i)).toBeVisible(),
+      );
+    });
+  },
+);
+
+describe("ModularDrawer — Lumen BottomSheet specific", () => {
+  const lumenOverride = {
+    overrideInitialState: (state: State) => ({
+      ...state,
+      settings: {
+        ...state.settings,
+        overriddenFeatureFlags: { ...mockedFF, lwmWallet40: { enabled: true } },
+      },
+    }),
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     setNetInfoState();
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-  const advanceTimers = () => {
-    act(() => {
-      jest.advanceTimersByTime(500);
-    });
-  };
-
-  it("should allow full navigation: asset → network → Device Selection, with back navigation at each step", async () => {
-    const { getByText, getByTestId, user } = render(<ModularDrawerSharedNavigator />);
-
-    await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
-
-    advanceTimers();
-
-    // Select Ethereum (should go to network selection)
-    await user.press(getByText(/ethereum/i));
-
-    advanceTimers();
-
-    expect(getByText(/select network/i)).toBeVisible();
-
-    advanceTimers();
-
-    await user.press(getByTestId("drawer-back-button"));
-
-    advanceTimers();
-
-    expect(getByText(/select asset/i)).toBeVisible();
-
-    await user.press(getByText(/ethereum/i));
-
-    advanceTimers();
-
-    expect(getByText(/select network/i)).toBeVisible();
-
-    // Select Arbitrum (Network) (should go to account selection)
-    await user.press(getByText(/arbitrum/i));
-
-    advanceTimers();
-
-    expect(getByText(/Connect Device/i)).toBeVisible();
-  });
-
-  it("should go directly to Device selection for Bitcoin, and allow back to asset and forward again", async () => {
-    const { getByText, user } = render(<ModularDrawerSharedNavigator />);
-
-    await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
-
-    // Wait for the assets to be loaded (MSW mock))
-    advanceTimers();
-
-    // Select Bitcoin (should go directly to Device Selection)
-    await user.press(getByText(/bitcoin/i));
-
-    advanceTimers();
-
-    expect(getByText(/Connect Device/i)).toBeVisible();
-  });
-
-  it("should allow searching for assets", async () => {
-    const { getByText, queryByText, getByPlaceholderText, user } = render(
+  it("should show BottomSheetHeader title and hide legacy Title when Lumen path is active", async () => {
+    const { getByText, queryByTestId, getByTestId, user } = render(
       <ModularDrawerSharedNavigator />,
+      lumenOverride,
     );
 
     await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
+    act(() => jest.advanceTimersByTime(500));
 
-    advanceTimers();
-    expect(getByText(/bitcoin/i)).toBeVisible();
+    await waitFor(() => expect(getByText(/bitcoin/i)).toBeVisible());
 
-    const searchInput = getByPlaceholderText(/search/i);
-    expect(searchInput).toBeVisible();
-
-    await user.type(searchInput, "bitc");
-
-    await waitFor(() => {
-      expect(queryByText(/ethereum/i)).not.toBeVisible();
-    });
-
-    await waitFor(() => {
-      expect(getByText(/bitcoin/i)).toBeVisible();
-    });
-  });
-
-  it("should show the empty state when no assets are found", async () => {
-    const { getByText, queryByText, getByPlaceholderText, user } = render(
-      <ModularDrawerSharedNavigator />,
-    );
-
-    await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
-    advanceTimers();
-    const searchInput = getByPlaceholderText(/search/i);
-    expect(searchInput).toBeVisible();
-
-    await user.type(searchInput, "ttttttt");
-
-    await waitFor(() => {
-      expect(queryByText(/no assets found/i)).toBeVisible();
-    });
-  });
-
-  it("should not crash when tapping search input with empty asset list", async () => {
-    const { getByText, getByPlaceholderText, getByTestId, user } = render(
-      <ModularDrawerSharedNavigator />,
-    );
-
-    await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
-    advanceTimers();
-
-    const searchInput = getByPlaceholderText(/search/i);
-
-    // First, search for something that returns no results
-    await user.type(searchInput, "zzzzzzz");
-
-    await waitFor(() => {
-      expect(getByText(/no assets found/i)).toBeVisible();
-    });
-
-    // Now tap on the search input again - this should not crash
-    await user.press(searchInput);
-
-    advanceTimers();
-
-    // Verify the drawer is still visible and functional
-    expect(getByTestId("modular-drawer-search-input")).toBeVisible();
-    expect(getByText(/no assets found/i)).toBeVisible();
-  });
-
-  it("should allow full navigation: asset → network → account", async () => {
-    const { getByText, user } = render(<ModularDrawerSharedNavigator />, {
-      ...INITIAL_STATE,
-      overrideInitialState: (state: State) => ({
-        ...state,
-        accounts: {
-          active: mockedAccounts,
-        },
-        settings: {
-          ...state.settings,
-          overriddenFeatureFlags: mockedFF,
-        },
-        wallet: {
-          ...state.wallet,
-          accountNames: new Map([[ARB_ACCOUNT.id, "Arbitrum One"]]),
-        },
-      }),
-    });
-
-    await user.press(getByText(WITH_ACCOUNT_SELECTION));
-    advanceTimers();
-
-    // Wait for the assets to be loaded (MSW mock))
-    await waitFor(() => expect(getByText(/select asset/i)).toBeVisible());
-
-    // Select Ethereum (should go to network selection)
-    await user.press(getByText(/ethereum/i));
-
-    advanceTimers();
-
-    expect(getByText(/select network/i)).toBeVisible();
-
-    // Select Arbitrum (Network) (should go to account selection)
-    await user.press(getByText(/arbitrum/i));
-
-    advanceTimers();
-
-    expect(getByText(/select account/i)).toBeVisible();
-    expect(getByText(/Arbitrum One/i)).toBeVisible();
-
-    expect(getByText(/add new or existing account/i)).toBeVisible();
-
-    // Select new account (should go to Device Selection)
-    await user.press(getByText(/add new or existing account/i));
-
-    advanceTimers();
-
-    expect(getByText(/Connect Device/i)).toBeVisible();
-  });
-
-  it("should display generic error when a Backend error occurs", async () => {
-    server.use(http.get("https://dada.api.ledger.com/v1/assets", () => HttpResponse.error()));
-    const { getByText, user } = render(<ModularDrawerSharedNavigator />);
-    advanceTimers();
-
-    await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
-
-    expect(
-      await screen.findByText(/Something went wrong on our end\. Please try again later/i),
-    ).toBeVisible();
-  });
-
-  it("should display generic error when an internet error occurs", async () => {
-    setNetInfoState({
-      isConnected: false,
-      isInternetReachable: false,
-      type: NetInfoStateType.none,
-    });
-
-    const { getByText, user } = render(<ModularDrawerSharedNavigator />);
-
-    await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
-
-    advanceTimers();
-
-    await waitFor(() =>
-      expect(getByText(/No internet connection. Please try again/i)).toBeVisible(),
-    );
+    expect(queryByTestId("modular-drawer-step-title")).toBeNull();
+    expect(getByTestId("modular-drawer-Asset-title")).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -75,8 +75,8 @@ const AssetSelection = ({
   const listRef = useRef<FlatList>(null);
 
   const expandToFullHeight = () => {
-    snapToIndex(1);
     if (formattedAssets.length > 0) {
+      snapToIndex(1);
       listRef.current?.scrollToIndex({ index: 0 });
     }
   };


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _The crash reproduced at runtime when the feature flag is enabled; existing integration tests are blocked by a pre-existing \`marketApi\` issue unrelated to this change._
- [x] **Impact of the changes:**
  - ModularDrawer opening under `lwmWallet40` feature flag (Lumen BottomSheet path)
  - Asset selection screen: pressing the search input while assets are loading
  - Network and Account selection screens: visual header rendering under the feature flag

### 📝 Description

The `QueuedDrawerBottomSheet` (Lumen-based drawer) was developed as a migration target for `QueuedDrawerGorhom`, gated behind the `lwmWallet40` feature flag. The feature had been disabled with a `// TODO: Re-enable it for LIVE-27294` comment after a crash was discovered.

**Problem (LIVE-27193):** When the Lumen BottomSheet was active and the user pressed the search input in the asset selection screen before assets had finished loading, `snapToIndex(1)` was called unconditionally — crashing when the list was empty. The root cause was in `expandToFullHeight`:

```ts
// Before — crash when assets not yet loaded
const expandToFullHeight = () => {
  snapToIndex(1); // ← always called, even on empty list
  if (formattedAssets.length > 0) {
    listRef.current?.scrollToIndex({ index: 0 });
  }
};

// After — safe guard covers both calls
const expandToFullHeight = () => {
  if (formattedAssets.length > 0) {
    snapToIndex(1);
    listRef.current?.scrollToIndex({ index: 0 });
  }
};
```

**Fix (LIVE-27294):**
1. Re-enabled the `lwmWallet40` feature flag gating in `ModularDrawer.tsx` and `ModularDrawerFlowView.tsx`.
2. Fixed `expandToFullHeight` in `AssetSelection` to guard both `snapToIndex` and `scrollToIndex` on a non-empty list.

### ❓ Context

- **JIRA**: [LIVE-27294](https://ledgerhq.atlassian.net/browse/LIVE-27294) — Fix crash & re-enable Lumen BottomSheet
- **JIRA**: [LIVE-27316](https://ledgerhq.atlassian.net/browse/LIVE-27316)
- **Original crash report**: [LIVE-27193](https://ledgerhq.atlassian.net/browse/LIVE-27193)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-27294]: https://ledgerhq.atlassian.net/browse/LIVE-27294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ