### PR TITLE
fix(mobile): replace withTranslation HOC with useTranslation hook

### DIFF
--- a/.changeset/wild-mayflies-raise.md
+++ b/.changeset/wild-mayflies-raise.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix translation keys displayed as raw strings instead of translated text by replacing withTranslation HOC with useTranslation hook

--- a/apps/ledger-live-mobile/src/context/AuthPass/AuthScreen.tsx
+++ b/apps/ledger-live-mobile/src/context/AuthPass/AuthScreen.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useCallback } from "react";
-import { withTranslation } from "react-i18next";
+
 import { useTranslation } from "~/context/Locale";
 import { StyleSheet } from "react-native";
 import { compose } from "redux";
 import { Flex, Logos } from "@ledgerhq/native-ui";
 import { useTheme } from "styled-components/native";
-import type { TFunction } from "i18next";
 import type { Privacy } from "~/reducers/types";
 import LText from "~/components/LText";
 import TranslatedError from "~/components/TranslatedError";
@@ -30,7 +29,6 @@ type OwnProps = {
 };
 
 type Props = OwnProps & {
-  t: TFunction;
   colors: Theme["colors"];
 };
 
@@ -89,7 +87,8 @@ const FormFooter = ({
   );
 };
 
-const AuthScreen: React.FC<Props> = ({ t, privacy, biometricsError, lock, unlock, colors }) => {
+const AuthScreen: React.FC<Props> = ({ privacy, biometricsError, lock, unlock, colors }) => {
+  const { t } = useTranslation();
   const [passwordError, setPasswordError] = useState<Error | null | undefined>(null);
   const [password, setPassword] = useState<string>("");
   const [passwordFocused, setPasswordFocused] = useState<boolean>(false);
@@ -193,7 +192,7 @@ const AuthScreen: React.FC<Props> = ({ t, privacy, biometricsError, lock, unlock
   );
 };
 
-export default compose<React.ComponentType<OwnProps>>(withTranslation(), withTheme)(AuthScreen);
+export default compose<React.ComponentType<OwnProps>>(withTheme)(AuthScreen);
 
 const styles = StyleSheet.create({
   root: {

--- a/apps/ledger-live-mobile/src/screens/Settings/CryptoAssets/Currencies/CurrencySettings.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/CryptoAssets/Currencies/CurrencySettings.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { compose } from "redux";
-import { withTranslation } from "react-i18next";
 import { Trans, useTranslation } from "~/context/Locale";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
@@ -130,7 +129,6 @@ function EachCurrencySettings({
 
 export default compose<React.ComponentType<NavigationProps>>(
   connect(mapStateToProps, mapDispatchToProps),
-  withTranslation(),
   withTheme,
 )(EachCurrencySettings);
 

--- a/apps/ledger-live-mobile/src/screens/Settings/General/PasswordRemove.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/PasswordRemove.tsx
@@ -1,11 +1,9 @@
-import React, { PureComponent } from "react";
+import React, { memo, useCallback, useState } from "react";
 import * as Keychain from "react-native-keychain";
-import { connect } from "react-redux";
-import { compose } from "redux";
-import type { TFunction } from "i18next";
-import { withTranslation } from "react-i18next";
 import { PasswordsDontMatchError } from "@ledgerhq/errors";
 import { Vibration } from "react-native";
+import { useDispatch } from "~/context/hooks";
+import { useTranslation } from "~/context/Locale";
 import { disablePrivacy } from "~/actions/settings";
 import PasswordForm from "./PasswordForm";
 import { VIBRATION_PATTERN_ERROR } from "~/utils/constants";
@@ -15,34 +13,20 @@ import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpe
 
 type NavigationProps = StackNavigatorProps<PasswordModifyFlowParamList, ScreenName.PasswordRemove>;
 
-type Props = {
-  t: TFunction;
-  disablePrivacy: () => void;
-} & NavigationProps;
+const PasswordRemove = ({ navigation }: NavigationProps) => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const [error, setError] = useState<Error | null>(null);
+  const [confirmPassword, setConfirmPassword] = useState("");
 
-type State = {
-  error?: Error | null;
-  confirmPassword: string;
-};
+  const onChange = useCallback((password: string) => {
+    setConfirmPassword(password);
+    setError(null);
+  }, []);
 
-const mapDispatchToProps = {
-  disablePrivacy,
-};
-
-class PasswordRemove extends PureComponent<Props, State> {
-  state = {
-    error: null,
-    confirmPassword: "",
-  };
-
-  onChange = (confirmPassword: string) => {
-    this.setState({ confirmPassword, error: null });
-  };
-
-  async submit() {
-    const { confirmPassword } = this.state;
+  const submit = useCallback(async () => {
     if (!confirmPassword) return;
-    const { disablePrivacy, navigation } = this.props;
+
     try {
       const credentials = await Keychain.getGenericPassword();
       if (credentials) {
@@ -50,36 +34,33 @@ class PasswordRemove extends PureComponent<Props, State> {
           Vibration.vibrate(VIBRATION_PATTERN_ERROR);
           throw new PasswordsDontMatchError();
         }
+
         await Keychain.resetGenericPassword();
       }
-      disablePrivacy();
-      const n = navigation.getParent();
-      if (n) n.goBack();
+
+      dispatch(disablePrivacy());
+
+      const parentNavigation = navigation.getParent();
+      if (parentNavigation) parentNavigation.goBack();
     } catch (error) {
-      this.setState({ error: error as Error, confirmPassword: "" });
+      setError(error instanceof Error ? error : new Error("Could not remove password"));
+      setConfirmPassword("");
     }
-  }
+  }, [confirmPassword, dispatch, navigation]);
 
-  onSubmit = () => {
-    this.submit();
-  };
+  const onSubmit = useCallback(() => {
+    submit();
+  }, [submit]);
 
-  render() {
-    const { t } = this.props;
-    const { error, confirmPassword } = this.state;
-    return (
-      <PasswordForm
-        placeholder={t("auth.confirmPassword.placeholder")}
-        onChange={this.onChange}
-        onSubmit={this.onSubmit}
-        error={error}
-        value={confirmPassword}
-      />
-    );
-  }
-}
+  return (
+    <PasswordForm
+      placeholder={t("auth.confirmPassword.placeholder")}
+      onChange={onChange}
+      onSubmit={onSubmit}
+      error={error}
+      value={confirmPassword}
+    />
+  );
+};
 
-export default compose<React.ComponentType<NavigationProps>>(
-  connect(null, mapDispatchToProps),
-  withTranslation(),
-)(PasswordRemove);
+export default memo(PasswordRemove);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new tests added — this is a HOC-to-hook migration with no behavior change._
- [x] **Impact of the changes:**
  - Password unlock screen translation rendering
  - Currency settings screen
  - Password removal screen

### 📝 Description

Translation keys like `auth.unlock.inputPlaceholder` were displayed as raw strings instead of translated text in the password field on LWM. This was caused by components using `react-i18next`'s `withTranslation` HOC, which does not integrate with the app's locale context.

**Fix:** Replaced `withTranslation()` HOC with `useTranslation()` hook from `~/context/Locale` across three components:
- **AuthScreen** — removed `withTranslation` and `TFunction` prop, added `useTranslation` hook
- **CurrencySettings** — removed unused `withTranslation` from the `compose` chain (already using the hook internally)
- **PasswordRemove** — converted from class component to functional component, replaced `withTranslation` + `connect` with `useTranslation` + `useDispatch` hooks

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27319](https://ledgerhq.atlassian.net/browse/LIVE-27319)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27319]: https://ledgerhq.atlassian.net/browse/LIVE-27319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ