### PR TITLE
fix(mobile): contentcard_clicked & dismissed

### DIFF
--- a/.changeset/fix-mobile-content-card-click-tracking.md
+++ b/.changeset/fix-mobile-content-card-click-tracking.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Flush mobile content card click analytics before opening links so Mixpanel events are not lost when the app backgrounds.

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -547,9 +547,7 @@ export const trackWithRoute = (
   track(event, newProperties, mandatory);
 };
 
-export const flush = () => {
-  segmentClient?.flush();
-};
+export const flush = async () => segmentClient?.flush();
 
 export const useTrack = () => {
   const route = useRoute();

--- a/apps/ledger-live-mobile/src/components/Carousel/CarouselCard.tsx
+++ b/apps/ledger-live-mobile/src/components/Carousel/CarouselCard.tsx
@@ -17,11 +17,11 @@ const CarouselCard = ({ id, cardProps, index, width }: CarouselCardProps) => {
   const { theme } = useTheme();
   const { logClickCard, dismissCard, trackContentCardEvent } = useDynamicContent();
 
-  const onPress = useCallback(() => {
+  const onPress = useCallback(async () => {
     if (!cardProps) return;
     if (!cardProps.link) return;
 
-    trackContentCardEvent("contentcard_clicked", {
+    await trackContentCardEvent("contentcard_clicked", {
       ...cardProps.extras,
       screen: cardProps.location,
       campaign: cardProps.id,
@@ -29,7 +29,7 @@ const CarouselCard = ({ id, cardProps, index, width }: CarouselCardProps) => {
 
     // Notify Braze that the card has been clicked by the user
     logClickCard(cardProps.id);
-    Linking.openURL(cardProps.link);
+    await Linking.openURL(cardProps.link);
   }, [cardProps, logClickCard, trackContentCardEvent]);
 
   const onHide = useCallback(() => {

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
@@ -70,8 +70,8 @@ type LayoutProps = {
 const Layout = ({ category, cards }: LayoutProps) => {
   const { logClickCard, dismissCard, trackContentCardEvent } = useDynamicContent();
 
-  const onCardCick = (card: AnyContentCard, displayedPosition?: number) => {
-    trackContentCardEvent("contentcard_clicked", {
+  const onCardClick = async (card: AnyContentCard, displayedPosition?: number) => {
+    await trackContentCardEvent("contentcard_clicked", {
       ...card.extras,
       page: card.location,
       campaign: card.id,
@@ -83,7 +83,10 @@ const Layout = ({ category, cards }: LayoutProps) => {
 
     logClickCard(card.id);
     if (card.link) {
-      Linking.canOpenURL(card.link).then(() => Linking.openURL(card.link as string));
+      const canOpenLink = await Linking.canOpenURL(card.link);
+      if (canOpenLink) {
+        await Linking.openURL(card.link as string);
+      }
     }
   };
 
@@ -120,7 +123,7 @@ const Layout = ({ category, cards }: LayoutProps) => {
         displayedPosition: index,
 
         actions: {
-          onClick: card.link ? () => onCardCick(card, index) : undefined,
+          onClick: card.link ? () => onCardClick(card, index) : undefined,
           onDismiss: category.isDismissable ? () => onCardDismiss(card, index) : undefined,
         },
       },

--- a/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.test.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.test.ts
@@ -1,0 +1,158 @@
+import { act, renderHook } from "@tests/test-renderer";
+import type { ContentCard } from "@braze/react-native-sdk";
+import useDynamicContent from "./useDynamicContent";
+import { flush, track } from "../analytics";
+
+jest.mock("./brazeContentCard", () => ({
+  useBrazeContentCard: jest.fn(() => ({
+    logClickCard: jest.fn(),
+    logDismissCard: jest.fn(),
+    logImpressionCard: jest.fn(),
+    refreshDynamicContent: jest.fn(),
+  })),
+}));
+
+jest.mock("../analytics", () => ({
+  flush: jest.fn(() => Promise.resolve()),
+  track: jest.fn(() => Promise.resolve()),
+}));
+
+const mockedTrack = jest.mocked(track);
+const mockedFlush = jest.mocked(flush);
+const localCard: ContentCard = {
+  id: "local-card",
+  created: 1690112400,
+  expiresAt: -1,
+  viewed: false,
+  clicked: false,
+  pinned: false,
+  dismissed: false,
+  dismissible: true,
+  openURLInWebView: true,
+  isControl: false,
+  extras: {},
+  type: "Classic",
+  title: "Local card",
+  cardDescription: "Local test card",
+};
+
+describe("useDynamicContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should flush clicked events after tracking resolves", async () => {
+    let resolveTrack: (() => void) | undefined;
+    let resolveFlush: (() => void) | undefined;
+    mockedTrack.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveTrack = resolve;
+        }),
+    );
+    mockedFlush.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveFlush = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useDynamicContent());
+
+    let trackingPromise: Promise<void> | undefined;
+    act(() => {
+      trackingPromise = result.current.trackContentCardEvent("contentcard_clicked", {
+        campaign: "card-1",
+        contentcard: "Card title",
+      });
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("contentcard_clicked", {
+      campaign: "card-1",
+      contentcard: "Card title",
+    });
+    expect(mockedFlush).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveTrack?.();
+    });
+
+    expect(mockedFlush).toHaveBeenCalledTimes(1);
+    await expect(Promise.race([trackingPromise, Promise.resolve("pending")])).resolves.toBe(
+      "pending",
+    );
+
+    await act(async () => {
+      resolveFlush?.();
+      await trackingPromise;
+    });
+  });
+
+  it("should not flush dismissed events after tracking resolves", async () => {
+    let resolveTrack: (() => void) | undefined;
+    mockedTrack.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveTrack = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useDynamicContent());
+
+    let trackingPromise: Promise<void> | undefined;
+    act(() => {
+      trackingPromise = result.current.trackContentCardEvent("contentcard_dismissed", {
+        campaign: "card-1",
+        contentcard: "Card title",
+      });
+    });
+
+    expect(mockedTrack).toHaveBeenCalledWith("contentcard_dismissed", {
+      campaign: "card-1",
+      contentcard: "Card title",
+    });
+    expect(mockedFlush).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveTrack?.();
+      await trackingPromise;
+    });
+
+    expect(mockedFlush).not.toHaveBeenCalled();
+  });
+
+  it("should skip tracking for local cards", async () => {
+    const { result } = renderHook(() => useDynamicContent(), {
+      overrideInitialState: state => ({
+        ...state,
+        dynamicContent: {
+          ...state.dynamicContent,
+          localMobileCards: [localCard],
+        },
+      }),
+    });
+
+    await act(async () => {
+      await result.current.trackContentCardEvent("contentcard_clicked", {
+        campaign: "local-card",
+      });
+    });
+
+    expect(mockedTrack).not.toHaveBeenCalled();
+    expect(mockedFlush).not.toHaveBeenCalled();
+  });
+
+  it("should swallow analytics errors", async () => {
+    mockedTrack.mockRejectedValueOnce(new Error("track failed"));
+
+    const { result } = renderHook(() => useDynamicContent());
+
+    await expect(
+      result.current.trackContentCardEvent("contentcard_clicked", {
+        campaign: "card-1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockedFlush).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.tsx
@@ -19,7 +19,7 @@ import {
   LandingPageUseCase,
   WalletContentCard,
 } from "./types";
-import { track } from "../analytics";
+import { flush, track } from "../analytics";
 import { setDismissedDynamicCards } from "../actions/settings";
 import { setDynamicContentMobileCards, removeLocalCard } from "~/actions/dynamicContent";
 
@@ -87,13 +87,22 @@ const useDynamicContent = () => {
   );
 
   const trackContentCardEvent = useCallback(
-    (
+    async (
       event: "contentcard_clicked" | "contentcard_dismissed",
       params: Record<string, string | number | undefined>,
     ) => {
       const cardId = params.campaign;
       if (typeof cardId === "string" && localMobileCards.some(c => c.id === cardId)) return;
-      track(event, params);
+      try {
+        await track(event, params);
+        if (event === "contentcard_clicked") {
+          // Flush immediately because content card clicks often open a link
+          // and background the app before Segment flushes queued events itself.
+          await flush();
+        }
+      } catch {
+        // Analytics must never block the user action that follows.
+      }
     },
     [localMobileCards],
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/__integrations__/genericLandingPage.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/__integrations__/genericLandingPage.integration.test.tsx
@@ -18,15 +18,15 @@ const Linking = {
   openURL: jest.fn(),
 };
 
-const openLinkMock = jest.fn((card: LandingPageStickyCtaContentCard) => {
-  trackContentCardEvent("contentcard_clicked", {
+const openLinkMock = jest.fn(async (card: LandingPageStickyCtaContentCard) => {
+  await trackContentCardEvent("contentcard_clicked", {
     ...card.extras,
     campaign: card.id,
     contentcard: card.cta,
     landingPage: useCase,
   });
   logClickCard(card.id);
-  Linking.openURL(card.link);
+  await Linking.openURL(card.link);
 });
 
 jest.mock("~/dynamicContent/useDynamicContent", () => ({

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/GenericLandingPage/useGeneralLandingPageViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/GenericLandingPage/useGeneralLandingPageViewModel.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { Linking } from "react-native";
+import useDynamicContent from "~/dynamicContent/useDynamicContent";
+import { LandingPageUseCase } from "~/dynamicContent/types";
+import { useGeneralLandingPage } from "./useGeneralLandingPageViewModel";
+import { fakeCategoryContentCards, landingPageStickyCtaCard } from "../../__integrations__/shared";
+
+jest.mock("~/dynamicContent/useDynamicContent", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockedUseDynamicContent = jest.mocked(useDynamicContent);
+
+describe("useGeneralLandingPage", () => {
+  const logClickCard = jest.fn();
+  const trackContentCardEvent = jest.fn();
+  const goBack = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+
+    mockedUseDynamicContent.mockReturnValue({
+      categoriesCards: fakeCategoryContentCards,
+      getStickyCtaCardByLandingPage: jest.fn(() => landingPageStickyCtaCard),
+      logClickCard,
+      trackContentCardEvent,
+    } as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should wait for tracking before opening the sticky CTA link", async () => {
+    let resolveTracking: (() => void) | undefined;
+    trackContentCardEvent.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveTracking = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      useGeneralLandingPage({
+        route: {
+          params: { useCase: LandingPageUseCase.LP_Generic },
+        },
+        navigation: { goBack },
+      } as never),
+    );
+
+    let openLinkPromise: Promise<void> | undefined;
+    act(() => {
+      openLinkPromise = result.current.openLink(landingPageStickyCtaCard);
+    });
+
+    expect(trackContentCardEvent).toHaveBeenCalledWith("contentcard_clicked", {
+      campaign: "stickyCta001",
+      cta: "Sign Up Now",
+      link: "https://example.com/signup",
+      contentcard: "Sign Up Now",
+      landingPage: "LP_Generic",
+      location: "landing_page_sticky_cta",
+    });
+    expect(logClickCard).not.toHaveBeenCalled();
+    expect(Linking.openURL).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveTracking?.();
+      await openLinkPromise;
+    });
+
+    expect(logClickCard).toHaveBeenCalledWith("stickyCta001");
+    expect(Linking.openURL).toHaveBeenCalledWith("https://example.com/signup");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/GenericLandingPage/useGeneralLandingPageViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/GenericLandingPage/useGeneralLandingPageViewModel.ts
@@ -19,7 +19,7 @@ export type NavigationProps = BaseComposite<
 
 export type HookResult = {
   isLoading: boolean;
-  openLink: (card: LandingPageStickyCtaContentCard) => void;
+  openLink: (card: LandingPageStickyCtaContentCard) => Promise<void>;
   categoriesCards: CategoryContentCard[];
   landingStickyCTA?: LandingPageStickyCtaContentCard;
   useCase: LandingPageUseCase;
@@ -33,15 +33,15 @@ export const useGeneralLandingPage = (props: NavigationProps) => {
 
   const landingStickyCTA = getStickyCtaCardByLandingPage(useCase);
 
-  const openLink = (card: LandingPageStickyCtaContentCard) => {
-    trackContentCardEvent("contentcard_clicked", {
+  const openLink = async (card: LandingPageStickyCtaContentCard) => {
+    await trackContentCardEvent("contentcard_clicked", {
       ...card.extras,
       campaign: card.id,
       contentcard: card.cta,
       landingPage: useCase,
     });
     logClickCard(card.id);
-    Linking.openURL(card.link);
+    await Linking.openURL(card.link);
   };
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/screens/NotificationCenter/Notifications.tsx
+++ b/apps/ledger-live-mobile/src/screens/NotificationCenter/Notifications.tsx
@@ -85,10 +85,10 @@ export default function NotificationCenter() {
 
   // ----- Utils Functions ----------
   const onPress = useCallback(
-    (item: NotificationContentCard) => {
+    async (item: NotificationContentCard) => {
       if (!item) return;
 
-      trackContentCardEvent("contentcard_clicked", {
+      await trackContentCardEvent("contentcard_clicked", {
         ...item.extras,
         screen: item.location,
         campaign: item.id,
@@ -99,7 +99,7 @@ export default function NotificationCenter() {
 
       // Notify Braze that the card has been clicked by the user
       logClickCard(item.id);
-      Linking.openURL(item.link);
+      await Linking.openURL(item.link);
     },
     [logClickCard, trackContentCardEvent],
   );

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetDynamicContent.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetDynamicContent.tsx
@@ -14,11 +14,11 @@ const AssetDynamicContent: React.FC<Props> = ({ currency }) => {
     useDynamicContent();
   const dynamicContentCard = getAssetCardByIdOrTicker(currency);
 
-  const onClickLink = useCallback(() => {
+  const onClickLink = useCallback(async () => {
     if (!dynamicContentCard) return;
     if (!dynamicContentCard.link) return;
 
-    trackContentCardEvent("contentcard_clicked", {
+    await trackContentCardEvent("contentcard_clicked", {
       ...dynamicContentCard.extras,
       screen: dynamicContentCard.location,
       campaign: dynamicContentCard.id,
@@ -26,7 +26,7 @@ const AssetDynamicContent: React.FC<Props> = ({ currency }) => {
 
     // Notify Braze that the card has been clicked by the user
     logClickCard(dynamicContentCard.id);
-    Linking.openURL(dynamicContentCard.link);
+    await Linking.openURL(dynamicContentCard.link);
   }, [dynamicContentCard, logClickCard, trackContentCardEvent]);
 
   const onPressDismiss = useCallback(() => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Mobile content cards that open links from wallet carousels, asset banners, notification center cards, and landing page sticky CTAs
      - Mixpanel `contentcard_clicked` reliability when tapping a card backgrounds the app or hands off to an external URL
      - No change to Braze click logging behavior

### 📝 Description

This PR fixes `LIVE-25759`, where mobile `contentcard_clicked` analytics were significantly undercounted in Mixpanel compared with Braze for the same content cards.

The root cause was the mobile Segment tracking path being asynchronous while several content card click handlers immediately opened a deep link or external URL afterward. The app could background before the event was reliably queued and flushed. The fix makes the shared mobile content card tracking helper await `track(...)`, flush only click events before link handoff, and swallow analytics errors so tracking never blocks the user action. The affected mobile click handlers now wait for tracking before opening links.

Test coverage now includes the shared helper behavior for click flush, dismiss without flush, local cards being skipped, analytics errors being swallowed, and the landing page sticky CTA flow waiting for tracking before opening the link.

<table>
<tr>
 <td>before
 <td>after
<tr>
 <td><video src="https://github.com/user-attachments/assets/caa9fba6-3de4-4879-8115-25ed9734eb3c"/>
 <td><video src="https://github.com/user-attachments/assets/0d505d38-3d17-4621-8300-33168622370e"/>
</table>

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25759](https://ledgerhq.atlassian.net/browse/LIVE-25759)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25759]: https://ledgerhq.atlassian.net/browse/LIVE-25759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ