### PR TITLE
[LWD] feat(desktop): add experimental and feature flags buttons to topbar

### DIFF
--- a/.changeset/many-moose-fetch.md
+++ b/.changeset/many-moose-fetch.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+add experimental features and feature flags buttons to topbar

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarActionButton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarActionButton.tsx
@@ -10,6 +10,7 @@ export function TopBarActionButton({
   isInteractive,
   onClick,
   icon,
+  appearance = "gray",
   onTooltipShow,
 }: TopBarActionButtonProps) {
   const testId = `topbar-action-button-${label.replace(/\s+/g, "-").toLowerCase()}`;
@@ -26,7 +27,7 @@ export function TopBarActionButton({
       <Tooltip onOpenChange={handleOpenChange}>
         <TooltipTrigger asChild>
           <IconButton
-            appearance="gray"
+            appearance={appearance}
             size="sm"
             aria-label={label}
             icon={icon}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useExperimentalFeatures.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useExperimentalFeatures.test.ts
@@ -1,0 +1,85 @@
+import { Experiment } from "@ledgerhq/lumen-ui-react/symbols";
+import { renderHook, act } from "tests/testSetup";
+import { useExperimentalFeatures } from "../useExperimentalFeatures";
+import { useNavigate, useLocation } from "react-router";
+import useExperimental from "~/renderer/hooks/useExperimental";
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(),
+  useLocation: jest.fn(),
+}));
+
+jest.mock("~/renderer/hooks/useExperimental");
+
+const mockNavigate = jest.fn();
+const mockUseNavigate = jest.mocked(useNavigate);
+const mockUseLocation = jest.mocked(useLocation);
+const mockUseExperimental = jest.mocked(useExperimental);
+
+const createLocation = (pathname: string) => ({
+  pathname,
+  state: null,
+  key: "default",
+  search: "",
+  hash: "",
+});
+
+describe("useExperimentalFeatures", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+    mockUseLocation.mockReturnValue(createLocation("/"));
+    mockUseExperimental.mockReturnValue(false);
+  });
+
+  it("returns handleExperimental, icon, and translated tooltip", () => {
+    const { result } = renderHook(() => useExperimentalFeatures());
+
+    expect(result.current.handleExperimental).toBeDefined();
+    expect(typeof result.current.handleExperimental).toBe("function");
+    expect(result.current.icon).toBe(Experiment);
+    expect(result.current.tooltip).toBeDefined();
+    expect(typeof result.current.tooltip).toBe("string");
+  });
+
+  it("returns isVisible false when no experimental features are enabled", () => {
+    mockUseExperimental.mockReturnValue(false);
+
+    const { result } = renderHook(() => useExperimentalFeatures());
+
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("returns isVisible true when experimental features are enabled", () => {
+    mockUseExperimental.mockReturnValue(true);
+
+    const { result } = renderHook(() => useExperimentalFeatures());
+
+    expect(result.current.isVisible).toBe(true);
+  });
+
+  it("navigates to /settings/experimental when not already on that page", () => {
+    mockUseLocation.mockReturnValue(createLocation("/accounts"));
+
+    const { result } = renderHook(() => useExperimentalFeatures());
+
+    act(() => {
+      result.current.handleExperimental();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/settings/experimental");
+  });
+
+  it("does not navigate when already on /settings/experimental", () => {
+    mockUseLocation.mockReturnValue(createLocation("/settings/experimental"));
+
+    const { result } = renderHook(() => useExperimentalFeatures());
+
+    act(() => {
+      result.current.handleExperimental();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useFeatureFlags.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useFeatureFlags.test.ts
@@ -1,0 +1,103 @@
+import { Tools } from "@ledgerhq/lumen-ui-react/symbols";
+import { renderHook, act } from "tests/testSetup";
+import { useFeatureFlags } from "../useFeatureFlags";
+import { useNavigate, useLocation } from "react-router";
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(),
+  useLocation: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+const mockUseNavigate = jest.mocked(useNavigate);
+const mockUseLocation = jest.mocked(useLocation);
+
+const createLocation = (pathname: string) => ({
+  pathname,
+  state: null,
+  key: "default",
+  search: "",
+  hash: "",
+});
+
+describe("useFeatureFlags", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+    mockUseLocation.mockReturnValue(createLocation("/"));
+  });
+
+  it("returns handleFeatureFlags, icon, and translated tooltip", () => {
+    const { result } = renderHook(() => useFeatureFlags());
+
+    expect(result.current.handleFeatureFlags).toBeDefined();
+    expect(typeof result.current.handleFeatureFlags).toBe("function");
+    expect(result.current.icon).toBe(Tools);
+    expect(result.current.tooltip).toBeDefined();
+    expect(typeof result.current.tooltip).toBe("string");
+  });
+
+  it("returns isVisible false when button is not visible and no overridden flags", () => {
+    const { result } = renderHook(() => useFeatureFlags(), {
+      initialState: {
+        settings: {
+          featureFlagsButtonVisible: false,
+          overriddenFeatureFlags: {},
+        },
+      },
+    });
+
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("returns isVisible true when featureFlagsButtonVisible is true", () => {
+    const { result } = renderHook(() => useFeatureFlags(), {
+      initialState: {
+        settings: {
+          featureFlagsButtonVisible: true,
+          overriddenFeatureFlags: {},
+        },
+      },
+    });
+
+    expect(result.current.isVisible).toBe(true);
+  });
+
+  it("returns isVisible true when overridden feature flags exist", () => {
+    const { result } = renderHook(() => useFeatureFlags(), {
+      initialState: {
+        settings: {
+          featureFlagsButtonVisible: false,
+          overriddenFeatureFlags: { currencyAvalancheCChain: { enabled: true } },
+        },
+      },
+    });
+
+    expect(result.current.isVisible).toBe(true);
+  });
+
+  it("navigates to /settings/developer when not already on that page", () => {
+    mockUseLocation.mockReturnValue(createLocation("/accounts"));
+
+    const { result } = renderHook(() => useFeatureFlags());
+
+    act(() => {
+      result.current.handleFeatureFlags();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/settings/developer");
+  });
+
+  it("does not navigate when already on /settings/developer", () => {
+    mockUseLocation.mockReturnValue(createLocation("/settings/developer"));
+
+    const { result } = renderHook(() => useFeatureFlags());
+
+    act(() => {
+      result.current.handleFeatureFlags();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
@@ -1,22 +1,32 @@
-import { Eye, Refresh, Settings } from "@ledgerhq/lumen-ui-react/symbols";
+import { Eye, Experiment, Refresh, Settings, Tools } from "@ledgerhq/lumen-ui-react/symbols";
 import { renderHook } from "tests/testSetup";
 import useTopBarViewModel from "../useTopBarViewModel";
 import * as useActivityIndicatorModule from "../useActivityIndicator";
 import * as useDiscreetModeModule from "../useDiscreetMode";
+import * as useExperimentalFeaturesModule from "../useExperimentalFeatures";
+import * as useFeatureFlagsModule from "../useFeatureFlags";
 import * as useSettingsModule from "../useSettings";
 
 jest.mock("../useActivityIndicator");
 jest.mock("../useDiscreetMode");
+jest.mock("../useExperimentalFeatures");
+jest.mock("../useFeatureFlags");
 jest.mock("../useSettings");
 
 const mockUseActivityIndicator = jest.mocked(useActivityIndicatorModule.useActivityIndicator);
 const mockUseDiscreetMode = jest.mocked(useDiscreetModeModule.useDiscreetMode);
+const mockUseExperimentalFeatures = jest.mocked(
+  useExperimentalFeaturesModule.useExperimentalFeatures,
+);
+const mockUseFeatureFlags = jest.mocked(useFeatureFlagsModule.useFeatureFlags);
 const mockUseSettings = jest.mocked(useSettingsModule.useSettings);
 
 describe("useTopBarViewModel", () => {
   const mockHandleSync = jest.fn();
   const mockHandleDiscreet = jest.fn();
   const mockHandleSettings = jest.fn();
+  const mockHandleExperimental = jest.fn();
+  const mockHandleFeatureFlags = jest.fn();
   const mockDiscreetIcon = Eye;
 
   beforeEach(() => {
@@ -39,6 +49,18 @@ describe("useTopBarViewModel", () => {
       handleSettings: mockHandleSettings,
       settingsIcon: Settings,
       tooltip: "Settings",
+    });
+    mockUseExperimentalFeatures.mockReturnValue({
+      isVisible: false,
+      handleExperimental: mockHandleExperimental,
+      icon: Experiment,
+      tooltip: "Experimental",
+    });
+    mockUseFeatureFlags.mockReturnValue({
+      isVisible: false,
+      handleFeatureFlags: mockHandleFeatureFlags,
+      icon: Tools,
+      tooltip: "Feature flags",
     });
   });
 
@@ -96,6 +118,54 @@ describe("useTopBarViewModel", () => {
       s.type === "action" ? s.action.label : "notification",
     );
     expect(slotLabels).toEqual(["notification", "discreet", "settings", "my ledger"]);
+  });
+
+  it("includes experimental and feature flags slots with accent appearance when visible", () => {
+    mockUseExperimentalFeatures.mockReturnValue({
+      isVisible: true,
+      handleExperimental: mockHandleExperimental,
+      icon: Experiment,
+      tooltip: "Experimental",
+    });
+    mockUseFeatureFlags.mockReturnValue({
+      isVisible: true,
+      handleFeatureFlags: mockHandleFeatureFlags,
+      icon: Tools,
+      tooltip: "Feature flags",
+    });
+
+    const { result } = renderHook(() => useTopBarViewModel());
+
+    const slotLabels = result.current.topBarSlots.map(s =>
+      s.type === "action" ? s.action.label : "notification",
+    );
+    expect(slotLabels).toEqual([
+      "experimental",
+      "feature flags",
+      "synchronize",
+      "notification",
+      "discreet",
+      "settings",
+      "my ledger",
+    ]);
+
+    const experimentalSlot = result.current.topBarSlots.find(
+      s => s.type === "action" && s.action.label === "experimental",
+    );
+    expect(experimentalSlot).toBeDefined();
+    if (experimentalSlot?.type === "action") {
+      expect(experimentalSlot.action.appearance).toBe("accent");
+      expect(experimentalSlot.action.onClick).toBe(mockHandleExperimental);
+    }
+
+    const featureFlagsSlot = result.current.topBarSlots.find(
+      s => s.type === "action" && s.action.label === "feature flags",
+    );
+    expect(featureFlagsSlot).toBeDefined();
+    if (featureFlagsSlot?.type === "action") {
+      expect(featureFlagsSlot.action.appearance).toBe("accent");
+      expect(featureFlagsSlot.action.onClick).toBe(mockHandleFeatureFlags);
+    }
   });
 
   it("passes isRotating from useActivityIndicator as isInteractive false on sync action", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useExperimentalFeatures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useExperimentalFeatures.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+import { useNavigate, useLocation } from "react-router";
+import { useTranslation } from "react-i18next";
+import { Experiment } from "@ledgerhq/lumen-ui-react/symbols";
+import useExperimental from "~/renderer/hooks/useExperimental";
+
+export const useExperimentalFeatures = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isExperimental = useExperimental();
+
+  const handleExperimental = useCallback(() => {
+    const url = "/settings/experimental";
+    if (location.pathname !== url) {
+      navigate(url);
+    }
+  }, [navigate, location.pathname]);
+
+  return {
+    isVisible: isExperimental,
+    handleExperimental,
+    icon: Experiment,
+    tooltip: t("common.experimentalFeature"),
+  };
+};

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useFeatureFlags.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useFeatureFlags.ts
@@ -1,0 +1,34 @@
+import { useCallback } from "react";
+import { useNavigate, useLocation } from "react-router";
+import { useTranslation } from "react-i18next";
+import { useSelector } from "LLD/hooks/redux";
+import { Tools } from "@ledgerhq/lumen-ui-react/symbols";
+import {
+  featureFlagsButtonVisibleSelector,
+  overriddenFeatureFlagsSelector,
+} from "~/renderer/reducers/settings";
+
+export const useFeatureFlags = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isFeatureFlagsButtonVisible = useSelector(featureFlagsButtonVisibleSelector);
+  const overriddenFeatureFlags = useSelector(overriddenFeatureFlagsSelector);
+
+  const isVisible =
+    isFeatureFlagsButtonVisible || Object.keys(overriddenFeatureFlags ?? {}).length !== 0;
+
+  const handleFeatureFlags = useCallback(() => {
+    const url = "/settings/developer";
+    if (location.pathname !== url) {
+      navigate(url);
+    }
+  }, [navigate, location.pathname]);
+
+  return {
+    isVisible,
+    handleFeatureFlags,
+    icon: Tools,
+    tooltip: t("common.featureFlags"),
+  };
+};

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
@@ -2,6 +2,8 @@ import { useLocation } from "react-router";
 import { TopBarSlot } from "../types";
 import { useActivityIndicator } from "./useActivityIndicator";
 import { useDiscreetMode } from "./useDiscreetMode";
+import { useExperimentalFeatures } from "./useExperimentalFeatures";
+import { useFeatureFlags } from "./useFeatureFlags";
 import { useMyLedger } from "./useMyLedger";
 import { useSettings } from "./useSettings";
 
@@ -17,10 +19,52 @@ const useTopBarViewModel = () => {
   } = useActivityIndicator();
   const { handleSettings, settingsIcon, tooltip: settingsTooltip } = useSettings();
   const { handleMyLedger, tooltip: myLedgerTooltip, icon: myLedgerIcon } = useMyLedger();
+  const {
+    isVisible: isExperimentalVisible,
+    handleExperimental,
+    icon: experimentalIcon,
+    tooltip: experimentalTooltip,
+  } = useExperimentalFeatures();
+  const {
+    isVisible: isFeatureFlagsVisible,
+    handleFeatureFlags,
+    icon: featureFlagsIcon,
+    tooltip: featureFlagsTooltip,
+  } = useFeatureFlags();
   const location = useLocation();
   const inManager = location.pathname === "/manager";
 
   const topBarSlots: TopBarSlot[] = [
+    ...(isExperimentalVisible
+      ? [
+          {
+            type: "action" as const,
+            action: {
+              label: "experimental",
+              tooltip: experimentalTooltip,
+              icon: experimentalIcon,
+              isInteractive: true,
+              onClick: handleExperimental,
+              appearance: "accent" as const,
+            },
+          },
+        ]
+      : []),
+    ...(isFeatureFlagsVisible
+      ? [
+          {
+            type: "action" as const,
+            action: {
+              label: "feature flags",
+              tooltip: featureFlagsTooltip,
+              icon: featureFlagsIcon,
+              isInteractive: true,
+              onClick: handleFeatureFlags,
+              appearance: "accent" as const,
+            },
+          },
+        ]
+      : []),
     ...(hasAccounts
       ? [
           {

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
@@ -1,4 +1,12 @@
-import { Bell, BellNotification, Eye, EyeCross, Settings } from "@ledgerhq/lumen-ui-react/symbols";
+import {
+  Bell,
+  BellNotification,
+  Eye,
+  EyeCross,
+  Experiment,
+  Settings,
+  Tools,
+} from "@ledgerhq/lumen-ui-react/symbols";
 import { DeviceIconComponent } from "LLD/utils/getDeviceIcon";
 import { ActivityIndicatorIcon } from "./utils/getActivityIndicatorIcon";
 
@@ -7,9 +15,13 @@ type IconComponent =
   | typeof BellNotification
   | typeof Eye
   | typeof EyeCross
+  | typeof Experiment
   | typeof Settings
+  | typeof Tools
   | ActivityIndicatorIcon
   | DeviceIconComponent;
+
+type TopBarActionAppearance = "gray" | "accent";
 
 type TopBarAction = {
   label: string;
@@ -17,6 +29,8 @@ type TopBarAction = {
   isInteractive: boolean;
   onClick: () => void;
   icon: IconComponent;
+  /** Visual appearance of the button. Defaults to "gray". */
+  appearance?: TopBarActionAppearance;
   /** Called when the tooltip is shown (e.g. on hover). Used for analytics when showing error tooltip. */
   onTooltipShow?: () => void;
 };
@@ -29,4 +43,4 @@ type TopBarViewProps = {
   shouldShowFirmwareUpdateBanner: boolean;
 };
 
-export type { TopBarAction, TopBarSlot, TopBarViewProps };
+export type { TopBarAction, TopBarActionAppearance, TopBarSlot, TopBarViewProps };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - TopBar action buttons rendering
      - Experimental features and feature flags visibility in the top bar

### 📝 Description

The MVVM TopBar was missing the experimental features and feature flags buttons that exist in the legacy TopBar.

Added two new hooks (`useExperimentalFeatures`, `useFeatureFlags`) and integrated them into `useTopBarViewModel` so the buttons appear conditionally with an `accent` appearance. Also updated `TopBarActionButton` to support the `appearance` prop and extended the `TopBarAction` type accordingly.

<img width="430" height="92" alt="Screenshot 2026-03-09 at 14 15 56" src="https://github.com/user-attachments/assets/2391ae0a-3746-4ab4-9ec2-2e042928489d" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27379](https://ledgerhq.atlassian.net/browse/LIVE-27379)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27379]: https://ledgerhq.atlassian.net/browse/LIVE-27379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ