### PR TITLE
[LWM] refactor(mobile): update quick action CTA button click tracking

### DIFF
--- a/.changeset/update-quick-action-cta-tracking.md
+++ b/.changeset/update-quick-action-cta-tracking.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update quick action CTA button click tracking to use buttonLocation instead of flow

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
@@ -24,6 +24,8 @@ import { QUICK_ACTIONS_TEST_IDS } from "../../testIds";
 import { useTranslation } from "~/context/Locale";
 import useBuyDeviceAction from "LLM/features/Reborn/hooks/useBuyDeviceAction";
 
+const BUTTON_LOCATION = "quick_action";
+
 interface UseQuickActionsCtasViewModelProps {
   sourceScreenName?: string;
 }
@@ -65,8 +67,8 @@ export const useQuickActionsCtasViewModel = ({
   // Handlers for standard CTAs (Transfer, Swap, Buy)
   const handleTransferPress = useCallback(() => {
     track("button_clicked", {
-      button: "quick_action",
-      flow: "transfer",
+      button: "transfer",
+      buttonLocation: BUTTON_LOCATION,
       page: pageName,
     });
     openTransferDrawer({ sourceScreenName: pageName });
@@ -74,8 +76,8 @@ export const useQuickActionsCtasViewModel = ({
 
   const handleSwapPress = useCallback(() => {
     track("button_clicked", {
-      button: "quick_action",
-      flow: "swap",
+      button: "swap",
+      buttonLocation: BUTTON_LOCATION,
       page: pageName,
     });
     navigation.navigate(NavigatorName.Swap);
@@ -83,8 +85,8 @@ export const useQuickActionsCtasViewModel = ({
 
   const handleBuyPress = useCallback(() => {
     track("button_clicked", {
-      button: "quick_action",
-      flow: "buy",
+      button: "buy",
+      buttonLocation: BUTTON_LOCATION,
       page: pageName,
     });
     navigation.navigate(NavigatorName.Exchange, {
@@ -95,8 +97,8 @@ export const useQuickActionsCtasViewModel = ({
   // Handlers for no-signer CTAs (Connect, Buy a Ledger)
   const handleConnectPress = useCallback(() => {
     track("button_clicked", {
-      button: "quick_action",
-      flow: "connect",
+      button: "connect",
+      buttonLocation: BUTTON_LOCATION,
       page: pageName,
     });
     navigation.navigate(NavigatorName.BaseOnboarding, {
@@ -112,8 +114,8 @@ export const useQuickActionsCtasViewModel = ({
 
   const handleBuyLedgerPress = useCallback(() => {
     track("button_clicked", {
-      button: "quick_action",
-      flow: "buy_ledger",
+      button: "buy_ledger",
+      buttonLocation: BUTTON_LOCATION,
       page: pageName,
     });
     handleBuyDeviceAction();

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
@@ -58,8 +58,8 @@ describe("TransferDrawer Navigation", () => {
       screen: ScreenName.SendCoin,
     });
     expect(track).toHaveBeenCalledWith("button_clicked", {
-      button: "quick_action_transfer",
-      flow: "send",
+      button: "send",
+      buttonLocation: "quick_action_transfer",
       page: SOURCE_SCREEN,
     });
   });
@@ -74,8 +74,8 @@ describe("TransferDrawer Navigation", () => {
       params: { manifestId: "noah" },
     });
     expect(track).toHaveBeenCalledWith("button_clicked", {
-      button: "quick_action_transfer",
-      flow: "bank_transfer",
+      button: "bank_transfer",
+      buttonLocation: "quick_action_transfer",
       page: SOURCE_SCREEN,
     });
   });
@@ -88,8 +88,8 @@ describe("TransferDrawer Navigation", () => {
     expect(mockHandleOpenReceiveDrawer).toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(track).toHaveBeenCalledWith("button_clicked", {
-      button: "quick_action_transfer",
-      flow: "receive",
+      button: "receive",
+      buttonLocation: "quick_action_transfer",
       page: SOURCE_SCREEN,
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -19,7 +19,7 @@ import { useReceiveNoahEntry } from "LLM/features/Noah/useNoahEntryPoint";
 // Fiat provider manifest ID for Noah integration
 const FIAT_PROVIDER_MANIFEST_ID = "noah";
 
-const BUTTON_ID = "quick_action_transfer";
+const BUTTON_LOCATION = "quick_action_transfer";
 
 interface TransferDrawerViewModel {
   isOpen: boolean;
@@ -49,8 +49,8 @@ export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
 
   const handleReceivePress = useCallback(() => {
     track("button_clicked", {
-      button: BUTTON_ID,
-      flow: "receive",
+      button: "receive",
+      buttonLocation: BUTTON_LOCATION,
       page: sourceScreenName,
     });
     closeDrawer();
@@ -59,8 +59,8 @@ export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
 
   const handleSendPress = useCallback(() => {
     track("button_clicked", {
-      button: BUTTON_ID,
-      flow: "send",
+      button: "send",
+      buttonLocation: BUTTON_LOCATION,
       page: sourceScreenName,
     });
     closeDrawer();
@@ -71,8 +71,8 @@ export const useTransferDrawerViewModel = (): TransferDrawerViewModel => {
 
   const handleBankTransferPress = useCallback(() => {
     track("button_clicked", {
-      button: BUTTON_ID,
-      flow: "bank_transfer",
+      button: "bank_transfer",
+      buttonLocation: BUTTON_LOCATION,
       page: sourceScreenName,
     });
     closeDrawer();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Quick action CTA analytics events on mobile (button_clicked tracking properties)
      - No UI or functional behavior changes

### 📝 Description

The mobile quick action CTA tracking events used a `flow` property to identify the action and a static `button: "quick_action"` value, which was inconsistent with the desktop tracking pattern.

This PR aligns mobile tracking with desktop by:
- Moving the action identifier (e.g. `"transfer"`, `"swap"`, `"buy"`) into the `button` property
- Renaming `flow` to `buttonLocation` with the value `"quick_action"` (or `"quick_action_transfer"` for transfer drawer sub-actions)

**Before:**
```json
{ "button": "quick_action", "flow": "transfer", "page": "Portfolio" }
```

**After:**
```json
{ "button": "transfer", "buttonLocation": "quick_action", "page": "Portfolio" }
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27234](https://ledgerhq.atlassian.net/browse/LIVE-27234)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27234]: https://ledgerhq.atlassian.net/browse/LIVE-27234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ