### PR TITLE
fix(desktop): os update banner design refinement

### DIFF
--- a/.changeset/smooth-tigers-enjoy.md
+++ b/.changeset/smooth-tigers-enjoy.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix(desktop): refine OS update banner design using Lumen UI Card components

--- a/apps/ledger-live-desktop/src/renderer/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/FirmwareUpdateBanner.tsx
@@ -2,7 +2,16 @@ import React, { useContext, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import { useLocation, useNavigate } from "react-router";
-import { Button as NewButton } from "@ledgerhq/lumen-ui-react";
+import {
+  Card,
+  CardHeader,
+  CardLeading,
+  CardContent,
+  CardContentTitle,
+  CardContentDescription,
+  CardTrailing,
+  Button as NewButton,
+} from "@ledgerhq/lumen-ui-react";
 import { latestFirmwareSelector } from "~/renderer/reducers/settings";
 import { UpdaterContext } from "~/renderer/components/Updater/UpdaterContext";
 import { VISIBLE_STATUS } from "./Updater/Banner";
@@ -33,43 +42,41 @@ const FirmwareUpdateBannerNew = ({
   onClick,
 }: BannerContentProps) => {
   const { t } = useTranslation();
-  const { colors } = useTheme();
 
   return (
-    <TopBanner
-      id={"fw-update-banner"}
-      testId="fw-update-banner"
-      containerStyle={{
-        background: `${colors.primary}`,
-        borderRadius: radii[2],
-        padding: "12px 16px",
-      }}
-      content={{
-        message: (
-          <Box>
-            <Text fontFamily="Inter|Bold" fontSize={5} color="neutral.c00">
-              {t(
-                old
-                  ? "manager.firmware.banner.old.warning"
-                  : "manager.firmware.banner.wallet40.warning.manager",
-              )}
-            </Text>
-            {old ? null : (
-              <Text color="neutral.c00">
-                {t("manager.firmware.banner.version", {
-                  latestFirmware: visibleFirmwareVersion,
-                })}
-              </Text>
-            )}
-          </Box>
-        ),
-        right: right ?? (
-          <NewButton size="sm" appearance="gray" onClick={onClick}>
-            {t("manager.firmware.banner.cta")}
-          </NewButton>
-        ),
-      }}
-    />
+    <Card type="info" className="bg-accent" data-testid="fw-update-banner">
+      <CardHeader>
+        <CardLeading>
+          <CardContent>
+            <CardContentTitle>
+              <span className="text-black">
+                {t(
+                  old
+                    ? "manager.firmware.banner.old.warning"
+                    : "manager.firmware.banner.wallet40.warning.manager",
+                )}
+              </span>
+            </CardContentTitle>
+            <CardContentDescription>
+              <span className="text-black">
+                {old
+                  ? null
+                  : t("manager.firmware.banner.version", {
+                      latestFirmware: visibleFirmwareVersion,
+                    })}
+              </span>
+            </CardContentDescription>
+          </CardContent>
+        </CardLeading>
+        <CardTrailing>
+          {right ?? (
+            <NewButton appearance="base" size="sm" onClick={onClick}>
+              {t("manager.firmware.banner.cta")}
+            </NewButton>
+          )}
+        </CardTrailing>
+      </CardHeader>
+    </Card>
   );
 };
 

--- a/apps/ledger-live-desktop/src/renderer/components/__tests__/FirmwareUpdateBannerEntry.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/__tests__/FirmwareUpdateBannerEntry.test.tsx
@@ -2,6 +2,13 @@ import React from "react";
 import { render, screen } from "tests/testSetup";
 import FirmwareUpdateBannerEntry from "../FirmwareUpdateBanner";
 import type { FirmwareUpdateContext } from "@ledgerhq/types-live";
+import { track } from "~/renderer/analytics/segment";
+
+const firmwareWithVersion = (name = "2.2.0") => ({
+  osu: {},
+  final: { name },
+  shouldFlashMCU: false,
+});
 
 describe("FirmwareUpdateBannerEntry", () => {
   describe("When wallet40 feature flag is enabled", () => {
@@ -35,37 +42,103 @@ describe("FirmwareUpdateBannerEntry", () => {
       it("renders OS update button when latestFirmware is set", () => {
         render(<FirmwareUpdateBannerEntry />, {
           initialState: initialState({
-            settings: {
-              latestFirmware: {
-                osu: {},
-                final: { name: "2.2.0" },
-                shouldFlashMCU: false,
-              },
-            },
+            settings: { latestFirmware: firmwareWithVersion() },
           }),
           initialRoute: "/",
         });
 
         expect(screen.getByTestId("topbar-os-update-button")).toBeVisible();
       });
+
+      it("tracks banner_impression on portfolio page", () => {
+        jest.mocked(track).mockClear();
+        render(<FirmwareUpdateBannerEntry />, {
+          initialState: initialState({
+            settings: { latestFirmware: firmwareWithVersion() },
+          }),
+          initialRoute: "/",
+        });
+
+        expect(track).toHaveBeenCalledWith("banner_impression", {
+          banner: "OS update",
+          page: "portfolio",
+        });
+      });
+
+      it("tracks button_clicked and navigates when topbar button is clicked", async () => {
+        jest.mocked(track).mockClear();
+        const { user } = render(<FirmwareUpdateBannerEntry />, {
+          initialState: initialState({
+            settings: { latestFirmware: firmwareWithVersion() },
+          }),
+          initialRoute: "/",
+        });
+
+        await user.click(screen.getByTestId("topbar-os-update-button"));
+
+        expect(track).toHaveBeenCalledWith("button_clicked", {
+          page: "portfolio",
+          banner: "OS update",
+          button: "click(update)",
+        });
+      });
     });
 
     describe("When user is on manager page", () => {
-      it("renders legacy banner with CTA", () => {
+      it("renders new Card banner with update warning and version", () => {
         render(<FirmwareUpdateBannerEntry right={<button>OSUpdate</button>} />, {
           initialState: initialState({
-            settings: {
-              latestFirmware: {
-                osu: {},
-                final: { name: "2.2.0" },
-                shouldFlashMCU: false,
-              },
-            },
+            settings: { latestFirmware: firmwareWithVersion("2.2.0") },
           }),
           initialRoute: "/manager",
         });
 
         expect(screen.getByTestId("fw-update-banner")).toBeVisible();
+        expect(screen.getByText("Ledger OS update available")).toBeVisible();
+        expect(screen.getByText("Version 2.2.0")).toBeVisible();
+      });
+
+      it("renders old warning text and hides version when old prop is true", () => {
+        render(<FirmwareUpdateBannerEntry old right={<button>OSUpdate</button>} />, {
+          initialState: initialState({
+            settings: { latestFirmware: firmwareWithVersion("2.2.0") },
+          }),
+          initialRoute: "/manager",
+        });
+
+        expect(screen.getByTestId("fw-update-banner")).toBeVisible();
+        expect(
+          screen.getByText(
+            "Device firmware version too old to be updated. Contact Ledger Support for a replacement.",
+          ),
+        ).toBeVisible();
+        expect(screen.queryByText("Version 2.2.0")).toBeNull();
+      });
+
+      it("renders custom right content when provided", () => {
+        render(<FirmwareUpdateBannerEntry right={<button>CustomCTA</button>} />, {
+          initialState: initialState({
+            settings: { latestFirmware: firmwareWithVersion() },
+          }),
+          initialRoute: "/manager",
+        });
+
+        expect(screen.getByRole("button", { name: "CustomCTA" })).toBeVisible();
+      });
+
+      it("tracks banner_impression on my ledger page", () => {
+        jest.mocked(track).mockClear();
+        render(<FirmwareUpdateBannerEntry right={<button>OSUpdate</button>} />, {
+          initialState: initialState({
+            settings: { latestFirmware: firmwareWithVersion() },
+          }),
+          initialRoute: "/manager",
+        });
+
+        expect(track).toHaveBeenCalledWith("banner_impression", {
+          banner: "OS update",
+          page: "my ledger",
+        });
       });
     });
   });
@@ -94,21 +167,13 @@ describe("FirmwareUpdateBannerEntry", () => {
         initialState: initialState(),
         initialRoute: "/",
       });
-      expect(
-        screen.queryByRole("button", { name: /manager\.firmware\.banner\.cta|Update/i }),
-      ).toBeNull();
+      expect(screen.queryByRole("button", { name: /Go to My Ledger/i })).toBeNull();
     });
 
     it("renders legacy banner with CTA when latestFirmware is set and not in manager", () => {
       render(<FirmwareUpdateBannerEntry />, {
         initialState: initialState({
-          settings: {
-            latestFirmware: {
-              osu: {},
-              final: { name: "2.2.0" },
-              shouldFlashMCU: false,
-            },
-          },
+          settings: { latestFirmware: firmwareWithVersion() },
         }),
         initialRoute: "/",
       });
@@ -120,13 +185,7 @@ describe("FirmwareUpdateBannerEntry", () => {
     it("legacy CTA button triggers onClick without throwing", async () => {
       const { user } = render(<FirmwareUpdateBannerEntry />, {
         initialState: initialState({
-          settings: {
-            latestFirmware: {
-              osu: {},
-              final: { name: "2.2.0" },
-              shouldFlashMCU: false,
-            },
-          },
+          settings: { latestFirmware: firmwareWithVersion() },
         }),
         initialRoute: "/",
       });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Visual change to the OS update banner on the portfolio and My Ledger pages (Wallet 4.0 nav only)
  - QA should verify the banner renders correctly with proper borders, background color, title, description, and CTA button

### 📝 Description

Refine OS update banner design using Lumen UI Card components

| Before        | After         |
| ------------- | ------------- |
| <img width="1253" height="778" alt="Screenshot 2026-03-09 at 18 34 15" src="https://github.com/user-attachments/assets/0268d9f0-4149-4034-9e60-0e546aed5c6b" /> | <img width="1254" height="787" alt="Screenshot 2026-03-09 at 18 32 22" src="https://github.com/user-attachments/assets/3d38ff35-568c-4bc6-842e-37961f7545e8" /> |


### ❓ Context

- **JIRA link**: [LIVE-27387](https://ledgerhq.atlassian.net/browse/LIVE-27387) 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27387]: https://ledgerhq.atlassian.net/browse/LIVE-27387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ