### PR TITLE
refactor(tooling): extract changeset creation into a standalone Cursor skill

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -45,25 +45,7 @@ $HAS_UI_CHANGES
 
 ### Step 2: Create the changeset
 
-Run `npx changeset` interactively OR create a changeset file manually:
-
-```bash
-# Interactive mode (recommended)
-npx changeset
-
-# Or create manually in .changeset/ with format:
-# ---
-# "package-name": minor | major
-# ---
-#
-# Description of the change
-```
-
-**Changeset naming convention:**
-
-- Use the change description from the ticket
-- Keep it concise but descriptive
-- Format: `<verb> <what>` (e.g., "Add dark mode toggle", "Fix transaction signing issue")
+Use the `create-changeset` skill to add a changeset for the modified packages.
 
 ### Step 3: Prepare the PR
 
@@ -192,33 +174,9 @@ After creating the PR, use the URL from the `gh pr create` output to generate a 
    - JIRA: `[LIVE-1234](https://ledgerhq.atlassian.net/browse/LIVE-1234)`
    - GitHub: `#123`
 
-## Changeset Guidelines
-
-From CONTRIBUTING.md:
-
-- Always add a changeset with `pnpm changeset`
-- Package names must match exactly (check package.json):
-  - `live-mobile` for mobile app
-  - `ledger-live-desktop` for desktop app
-  - `@ledgerhq/live-common` for common lib
-- Impact levels:
-  - `minor`: New features, bug fixes, non-breaking changes
-  - `major`: Breaking changes (rare, requires discussion)
-
 ## Example Output
 
 For a feature adding portfolio analytics:
-
-**Changeset** (`.changeset/blue-tigers-smile.md`):
-
-```markdown
----
-"live-mobile": minor
-"ledger-live-desktop": minor
----
-
-Add portfolio analytics dashboard with performance metrics
-```
 
 **PR Title**: `feat(portfolio): add analytics dashboard`
 

--- a/.cursor/skills/create-changeset/SKILL.md
+++ b/.cursor/skills/create-changeset/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: create-changeset
+description: Create changesets for the ledger-live monorepo using @changesets/cli. Use when the user asks to add a changeset, prepare a release, or document package changes for a PR.
+---
+
+# Create Changeset
+
+Create a `.changeset/<adjective-noun-verb>.md` file (human-readable random identifier, matching `@changesets/cli` convention) with this format:
+
+```markdown
+---
+"package-name": minor
+---
+
+Short description of the change
+```
+
+## Package Names
+
+Package names **must match exactly** what's in each `package.json`:
+
+| App / Lib | Package name |
+|-----------|-------------|
+| Mobile app | `live-mobile` |
+| Desktop app | `ledger-live-desktop` |
+| Common lib | `@ledgerhq/live-common` |
+| Coin modules | `@ledgerhq/coin-<name>` (e.g. `@ledgerhq/coin-sui`) |
+| Other libs | Check the lib's `package.json` `name` field |
+
+## Impact Levels
+
+| Level | When to use |
+|-------|-------------|
+| `minor` | New features, bug fixes, non-breaking changes |
+| `major` | Breaking changes (rare, requires discussion) |
+| `patch` | Internal-only changes, dependency bumps |
+
+## Description
+
+- One line, concise but descriptive
+- Format: `<verb> <what>` or conventional commit style
+- Examples:
+  - `Add portfolio analytics dashboard with performance metrics`
+  - `Fix transaction signing issue on mobile`
+  - `Flush mobile content card click analytics before opening links`


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _No packages affected — IDE tooling changes only._
- [ ] **Covered by automatic tests.** _Config/tooling files, no runtime code._
- [x] **Impact of the changes:**
  - Cursor `/create-pr` command behavior (Step 2 now delegates to the `create-changeset` skill)
  - New `create-changeset` skill available independently

### 📝 Description

The `/create-pr` Cursor command contained inline changeset creation instructions, making it long and preventing reuse of that knowledge in other contexts.

This PR extracts the changeset creation logic into a dedicated Cursor skill (`.cursor/skills/create-changeset/SKILL.md`) and replaces the inline instructions in `create-pr.md` with a one-line reference to the skill. The skill is now independently discoverable and reusable.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27409](https://ledgerhq.atlassian.net/browse/LIVE-27409)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27409]: https://ledgerhq.atlassian.net/browse/LIVE-27409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ