### PR TITLE
[LWM] feat(mobile): simplify pull-to-refresh status and add animated checkmark

### DIFF
--- a/.changeset/simplify-refresh-status-checkmark.md
+++ b/.changeset/simplify-refresh-status-checkmark.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Simplify pull-to-refresh status and add animated checkmark on completion

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2759,8 +2759,7 @@
       }
     },
     "refreshStatus": {
-      "refreshing": "Refreshing - Last update {{timeAgo}}",
-      "refreshingInitial": "Refreshing...",
+      "refreshing": "Refreshing...",
       "upToDate": "You're up to date"
     }
   },

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/AnimatedCheckmark.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/AnimatedCheckmark.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { CheckmarkCircleFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  withSpring,
+} from "react-native-reanimated";
+
+export const CONTENT_FADE_MS = 150;
+
+export const AnimatedCheckmark = () => {
+  const scale = useSharedValue(0.5);
+  const checkOpacity = useSharedValue(0);
+
+  React.useEffect(() => {
+    checkOpacity.value = withTiming(1, { duration: CONTENT_FADE_MS });
+    scale.value = withSpring(1, { damping: 15, stiffness: 600 });
+  }, [scale, checkOpacity]);
+
+  const animatedCheckStyle = useAnimatedStyle(
+    () => ({
+      opacity: checkOpacity.value,
+      transform: [{ scale: scale.value }],
+    }),
+    [scale, checkOpacity],
+  );
+
+  return (
+    <Animated.View style={animatedCheckStyle} testID="portfolio-refresh-status-checkmark">
+      <CheckmarkCircleFill size={16} color="success" />
+    </Animated.View>
+  );
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
@@ -15,6 +15,7 @@ jest.mock("react-native-reanimated", () => {
     useAnimatedReaction: () => {},
     withTiming: (toValue: unknown) => toValue,
     withDelay: (_delay: number, animation: unknown) => animation,
+    withSpring: (toValue: unknown) => toValue,
     default: {
       View: RN.View,
       Text: RN.Text,
@@ -28,15 +29,12 @@ jest.mock("react-native-reanimated", () => {
 import React from "react";
 import { render, screen, act } from "@tests/test-renderer";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
-import { MINUTE_MS, HOUR_MS, DAY_MS } from "@ledgerhq/live-common/utils/timeAgo";
 import { UP_TO_DATE_VISIBLE_DURATION_MS } from "../usePortfolioRefreshStatusViewModel";
 import { PortfolioRefreshStatus } from "../index";
-import { setRefreshStarted, setRefreshCompleted } from "~/reducers/portfolioRefresh";
-import { AccountsActionTypes } from "~/actions/types";
+import { setRefreshCompleted } from "~/reducers/portfolioRefresh";
 import { State } from "~/reducers/types";
 
 const FIXED_NOW = new Date("2025-08-15T12:00:00Z").getTime();
-const TEST_LOCALE = "en";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -45,12 +43,10 @@ const makeAccount = (lastSyncDate: Date) => ({
   lastSyncDate,
 });
 
-const withRefreshing =
-  (snapshotTimestamp: number | null = null): ((state: State) => State) =>
-  state => ({
-    ...state,
-    portfolioRefresh: { isRefreshing: true, lastSyncTimestampSnapshot: snapshotTimestamp },
-  });
+const withRefreshing = (): ((state: State) => State) => state => ({
+  ...state,
+  portfolioRefresh: { isRefreshing: true, lastSyncTimestampSnapshot: null },
+});
 
 const withIdle =
   (lastSyncDate: Date): ((state: State) => State) =>
@@ -63,9 +59,9 @@ const withIdle =
     portfolioRefresh: { isRefreshing: false, lastSyncTimestampSnapshot: null },
   });
 
-const renderRefreshing = (snapshotTimestamp: number | null = null) =>
+const renderRefreshing = () =>
   render(<PortfolioRefreshStatus />, {
-    overrideInitialState: withRefreshing(snapshotTimestamp),
+    overrideInitialState: withRefreshing(),
   });
 
 const completeRefresh = (store: ReturnType<typeof renderRefreshing>["store"]) =>
@@ -98,111 +94,22 @@ describe("PortfolioRefreshStatus", () => {
   });
 
   describe("refreshing state", () => {
-    it("should show spinner and 'Refreshing...' when no snapshot timestamp", () => {
+    it("should show spinner and 'Refreshing...' label", () => {
       renderRefreshing();
       expect(screen.getByTestId("portfolio-refresh-status-spinner")).toBeVisible();
       expect(screen.getByTestId("portfolio-refresh-status-refreshing")).toBeVisible();
       expect(screen.getByText("Refreshing...")).toBeVisible();
     });
-
-    it("should show 'Refreshing...' when snapshot is < 1 minute ago", () => {
-      renderRefreshing(Date.now() - 30_000);
-      expect(screen.getByText("Refreshing...")).toBeVisible();
-    });
-
-    it("should show relative time for a snapshot < 1 hour ago", () => {
-      renderRefreshing(Date.now() - 3 * MINUTE_MS);
-      const expected = new Intl.RelativeTimeFormat(TEST_LOCALE, { numeric: "always" }).format(
-        -3,
-        "minute",
-      );
-      expect(screen.getByText(`Refreshing - Last update ${expected}`)).toBeVisible();
-    });
-
-    it("should show relative time for a snapshot < 24 hours ago", () => {
-      renderRefreshing(Date.now() - 2 * HOUR_MS);
-      const expected = new Intl.RelativeTimeFormat(TEST_LOCALE, { numeric: "always" }).format(
-        -2,
-        "hour",
-      );
-      expect(screen.getByText(`Refreshing - Last update ${expected}`)).toBeVisible();
-    });
-
-    it("should show relative time for a snapshot < 7 days ago", () => {
-      renderRefreshing(Date.now() - 3 * DAY_MS);
-      const expected = new Intl.RelativeTimeFormat(TEST_LOCALE, { numeric: "always" }).format(
-        -3,
-        "day",
-      );
-      expect(screen.getByText(`Refreshing - Last update ${expected}`)).toBeVisible();
-    });
-
-    it("should show absolute date without year for a snapshot >= 7 days ago in the same year", () => {
-      const lastSyncDate = new Date(2025, 0, 12);
-      renderRefreshing(lastSyncDate.getTime());
-      const label = screen.getByTestId("portfolio-refresh-status-refreshing");
-      expect(label).toBeVisible();
-      const expected = new Intl.DateTimeFormat(TEST_LOCALE, {
-        day: "numeric",
-        month: "short",
-      }).format(lastSyncDate);
-      expect(label.props.children).toContain(expected);
-    });
-
-    it("should show absolute date with year for a snapshot in a previous year", () => {
-      const lastSyncDate = new Date(2024, 0, 12);
-      renderRefreshing(lastSyncDate.getTime());
-      const label = screen.getByTestId("portfolio-refresh-status-refreshing");
-      expect(label).toBeVisible();
-      const expected = new Intl.DateTimeFormat(TEST_LOCALE, {
-        day: "numeric",
-        month: "short",
-        year: "2-digit",
-      }).format(lastSyncDate);
-      expect(label.props.children).toContain(expected);
-    });
-  });
-
-  describe("snapshot stability during refresh", () => {
-    it("should keep showing the snapshot timestamp even when accounts sync mid-refresh", () => {
-      const oldSyncDate = new Date(Date.now() - 3 * MINUTE_MS);
-      const { store } = render(<PortfolioRefreshStatus />, {
-        overrideInitialState: withIdle(oldSyncDate),
-      });
-
-      const expectedLabel = new Intl.RelativeTimeFormat(TEST_LOCALE, {
-        numeric: "always",
-      }).format(-3, "minute");
-
-      act(() => {
-        store.dispatch(setRefreshStarted(oldSyncDate.getTime()));
-      });
-
-      expect(screen.getByText(`Refreshing - Last update ${expectedLabel}`)).toBeVisible();
-
-      act(() => {
-        store.dispatch({
-          type: AccountsActionTypes.SET_ACCOUNTS,
-          payload: [makeAccount(new Date())],
-        });
-      });
-
-      expect(screen.getByText(`Refreshing - Last update ${expectedLabel}`)).toBeVisible();
-    });
-
-    it("should show 'Refreshing...' when snapshot is < 1 minute old", () => {
-      renderRefreshing(Date.now() - 30_000);
-      expect(screen.getByText("Refreshing...")).toBeVisible();
-    });
   });
 
   describe("up-to-date state", () => {
-    it("should show 'You're up to date' without spinner right after refresh completes", () => {
+    it("should show checkmark and 'You're up to date' without spinner right after refresh completes", () => {
       const { store } = renderRefreshing();
       completeRefresh(store);
 
       expect(screen.getByTestId("portfolio-refresh-status-up-to-date")).toBeVisible();
       expect(screen.getByText("You're up to date")).toBeVisible();
+      expect(screen.getByTestId("portfolio-refresh-status-checkmark")).toBeTruthy();
       expect(screen.queryByTestId("portfolio-refresh-status-spinner")).toBeNull();
     });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/index.tsx
@@ -8,9 +8,9 @@ import Animated, {
   withDelay,
 } from "react-native-reanimated";
 import { usePortfolioRefreshStatusViewModel } from "./usePortfolioRefreshStatusViewModel";
+import { AnimatedCheckmark, CONTENT_FADE_MS } from "./AnimatedCheckmark";
 
 const FADE_DURATION_MS = 300;
-const CONTENT_FADE_MS = 150;
 const VISIBLE_HEIGHT = 60;
 
 const innerStyle = {
@@ -85,7 +85,12 @@ export const PortfolioRefreshStatus = () => {
     }
 
     if (isVisible) {
-      return <StatusText testID="portfolio-refresh-status-up-to-date">{upToDateLabel}</StatusText>;
+      return (
+        <>
+          <AnimatedCheckmark />
+          <StatusText testID="portfolio-refresh-status-up-to-date">{upToDateLabel}</StatusText>
+        </>
+      );
     }
 
     return null;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/usePortfolioRefreshStatusViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/usePortfolioRefreshStatusViewModel.ts
@@ -1,8 +1,7 @@
 import { useState, useEffect, useRef } from "react";
-import { formatTimeAgo, MINUTE_MS } from "@ledgerhq/live-common/utils/timeAgo";
 import { useSelector } from "~/context/hooks";
-import { useTranslation, useLocale } from "~/context/Locale";
-import { selectIsRefreshing, selectLastSyncTimestampSnapshot } from "~/reducers/portfolioRefresh";
+import { useTranslation } from "~/context/Locale";
+import { selectIsRefreshing } from "~/reducers/portfolioRefresh";
 
 export const UP_TO_DATE_VISIBLE_DURATION_MS = 3_000;
 
@@ -15,9 +14,7 @@ interface UsePortfolioRefreshStatusViewModelResult {
 
 export const usePortfolioRefreshStatusViewModel = (): UsePortfolioRefreshStatusViewModelResult => {
   const { t } = useTranslation();
-  const { locale } = useLocale();
   const isRefreshing = useSelector(selectIsRefreshing);
-  const lastSyncTimestampSnapshot = useSelector(selectLastSyncTimestampSnapshot);
 
   const [showUpToDate, setShowUpToDate] = useState(false);
   const prevIsRefreshing = useRef(isRefreshing);
@@ -32,23 +29,10 @@ export const usePortfolioRefreshStatusViewModel = (): UsePortfolioRefreshStatusV
     prevIsRefreshing.current = isRefreshing;
   }, [isRefreshing]);
 
-  const isStale =
-    lastSyncTimestampSnapshot !== null && Date.now() - lastSyncTimestampSnapshot >= MINUTE_MS;
-
-  const timeAgo =
-    isStale && lastSyncTimestampSnapshot !== null
-      ? formatTimeAgo(lastSyncTimestampSnapshot, locale)
-      : null;
-
-  const refreshingLabel =
-    timeAgo === null
-      ? t("portfolio.refreshStatus.refreshingInitial")
-      : t("portfolio.refreshStatus.refreshing", { timeAgo });
-
   return {
     isVisible: isRefreshing || showUpToDate,
     isRefreshing,
-    refreshingLabel,
+    refreshingLabel: t("portfolio.refreshStatus.refreshing"),
     upToDateLabel: t("portfolio.refreshStatus.upToDate"),
   };
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Pull-to-refresh status banner on the Portfolio screen (under `lwmWallet40` feature flag)
      - Refresh status text display during and after refresh
      - Visual appearance of the "You're up to date" completion state

### 📝 Description

**Problem**: The pull-to-refresh status banner displayed time-based information ("Refreshing - Last update X ago") which was noisy and not aligned with the desired UX. The completion state ("You're up to date") lacked a visual indicator to reinforce the message.

**Solution**:
- Simplified the refreshing label to always show "Refreshing..." without time information
- Added an animated `CheckmarkCircleFill` icon (from Lumen UI) next to the "You're up to date" text
- The checkmark animates in with a spring scale effect for a polished, lively feel
- Removed unused time formatting logic and translation keys
- Updated integration tests to match the simplified behavior

https://github.com/user-attachments/assets/cb623f13-dcbb-4bcf-8a5f-6de72f179e71


### ❓ Context

- **JIRA or GitHub link**: [LIVE-27247](https://ledgerhq.atlassian.net/browse/LIVE-27247)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27247]: https://ledgerhq.atlassian.net/browse/LIVE-27247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ