### PR TITLE
[LWDM] feat(mobile): enforce manifest domain whitelist on webview navigation [LIVE-25032]

### DIFF
--- a/.changeset/famous-singers-sit.md
+++ b/.changeset/famous-singers-sit.md
@@ -1,0 +1,24 @@
+---
+"@ledgerhq/types-live": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat(mobile): enforce manifest domain whitelist on webview navigation
+
+Add `llmWebviewManifestDomainCheck` feature flag that, when enabled,
+replaces the native `originWhitelist` (whose regex is unanchored) with
+`isUrlAllowedByManifestDomains`-based JS-level checks on mobile.
+
+- Register `llmWebviewManifestDomainCheck` in `feature.ts` and
+  `defaultFeatures.ts`
+- Wire the check in mobile `useWebviewState` to gate the initial URL,
+  `loadURL` calls, and `onShouldStartLoadWithRequest` navigation requests
+- Expose `isBlockedByDomainCheck` from `useWebviewState` and `useWebView`
+  so components can react to a fully blocked manifest
+- Extend `WebviewState` with `isAppUnavailable` to surface the blocked
+  state to parent screens via `onStateChange`
+- Show `NetworkError` immediately in `WalletAPIWebview` and
+  `PlatformAPIWebview` when blocked, avoiding an infinite loading spinner
+- Apply the same pattern to both `WalletAPIWebview` and
+  `PlatformAPIWebview`

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -36,6 +36,7 @@ import trackingWrapper from "@ledgerhq/live-common/platform/tracking";
 import { INTERNAL_APP_IDS } from "@ledgerhq/live-common/wallet-api/constants";
 import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 import { safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useCurrenciesUnderFeatureFlag } from "@ledgerhq/live-common/modularDrawer/hooks/useCurrenciesUnderFeatureFlag";
 import { NavigatorName, ScreenName } from "~/const";
 import { broadcastSignedTx } from "~/logic/screenTransactionHooks";
@@ -46,6 +47,7 @@ import { RootNavigationComposite, StackNavigatorNavigation } from "../RootNaviga
 import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigator";
 import { WebviewAPI, WebviewProps } from "./types";
 import { useWebviewState } from "./helpers";
+import { NetworkError } from "./NetworkError";
 import { currentRouteNameRef } from "~/analytics/screenRefs";
 import { walletSelector } from "~/reducers/wallet";
 import { WebViewOpenWindowEvent } from "react-native-webview/lib/WebViewTypes";
@@ -78,14 +80,18 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       [],
     );
 
-    const { webviewProps, webviewRef } = useWebviewState(
-      {
-        manifest,
-        inputs,
-      },
-      ref,
-      onStateChange,
-    );
+    const manifestDomainCheckEnabled = useFeature("llmWebviewManifestDomainCheck")?.enabled;
+
+    const { webviewProps, webviewRef, onShouldStartLoadWithRequest, isBlockedByDomainCheck } =
+      useWebviewState(
+        {
+          manifest,
+          inputs,
+          manifestDomainCheckEnabled,
+        },
+        ref,
+        onStateChange,
+      );
 
     const walletState = useSelector(walletSelector);
 
@@ -478,6 +484,10 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
 
     const javaScriptCanOpenWindowsAutomatically = internalAppIds.includes(manifest.id);
 
+    if (isBlockedByDomainCheck) {
+      return <NetworkError handleTryAgain={() => {}} />;
+    }
+
     return (
       <RNWebView
         ref={webviewRef}
@@ -488,7 +498,10 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}
         renderLoading={renderLoading}
-        originWhitelist={manifest.domains}
+        originWhitelist={manifestDomainCheckEnabled ? undefined : manifest.domains}
+        onShouldStartLoadWithRequest={
+          manifestDomainCheckEnabled ? onShouldStartLoadWithRequest : undefined
+        }
         allowsInlineMediaPlayback
         onMessage={handleMessage}
         onError={handleError}

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -8,6 +8,7 @@ import { useWebView } from "./helpers";
 import { NetworkError } from "./NetworkError";
 import { INTERNAL_APP_IDS, WC_ID } from "@ledgerhq/live-common/wallet-api/constants";
 import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { INJECTED_JAVASCRIPT } from "./dappInject";
 import { NoAccountScreen } from "./NoAccountScreen";
 
@@ -27,10 +28,14 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
     },
     ref,
   ) => {
+    const manifestDomainCheckEnabled = useFeature("llmWebviewManifestDomainCheck")?.enabled;
+
     const {
       onMessage,
       onLoadError,
       onOpenWindow,
+      onShouldStartLoadWithRequest,
+      isBlockedByDomainCheck,
       webviewProps,
       webviewRef,
       webviewCacheOptions,
@@ -41,6 +46,7 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         inputs,
         customHandlers,
         currentAccountHistDb,
+        manifestDomainCheckEnabled,
       },
       ref,
       onStateChange,
@@ -61,6 +67,10 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       return <NoAccountScreen manifest={manifest} currentAccountHistDb={currentAccountHistDb} />;
     }
 
+    if (isBlockedByDomainCheck) {
+      return <NetworkError handleTryAgain={() => {}} />;
+    }
+
     return (
       <RNWebView
         ref={webviewRef}
@@ -71,7 +81,10 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         allowsBackForwardNavigationGestures={allowsBackForwardNavigationGestures}
         showsVerticalScrollIndicator={false}
         renderLoading={Loader}
-        originWhitelist={manifest.domains}
+        originWhitelist={manifestDomainCheckEnabled ? undefined : manifest.domains}
+        onShouldStartLoadWithRequest={
+          manifestDomainCheckEnabled ? onShouldStartLoadWithRequest : undefined
+        }
         allowsInlineMediaPlayback
         onMessage={onMessage}
         onError={() => {

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
@@ -1,5 +1,6 @@
 import { AppManifest, WalletAPIServer } from "@ledgerhq/live-common/wallet-api/types";
 import { getClientHeaders, getInitialURL } from "@ledgerhq/live-common/wallet-api/helpers";
+import { isUrlAllowedByManifestDomains } from "@ledgerhq/live-common/wallet-api/manifestDomainUtils";
 import {
   safeGetRefValue,
   ExchangeType,
@@ -36,7 +37,11 @@ import { sendWalletAPIResponse } from "../../../e2e/bridge/client";
 import Config from "react-native-config";
 import { currentRouteNameRef } from "../../analytics/screenRefs";
 import { walletSelector } from "~/reducers/wallet";
-import { CacheMode, WebViewOpenWindowEvent } from "react-native-webview/lib/WebViewTypes";
+import {
+  CacheMode,
+  ShouldStartLoadRequest,
+  WebViewOpenWindowEvent,
+} from "react-native-webview/lib/WebViewTypes";
 import { Linking } from "react-native";
 import { useCacheBustedLiveAppsDB } from "~/screens/Platform/v2/hooks";
 import { useModularDrawerController } from "LLM/features/ModularDrawer";
@@ -47,7 +52,10 @@ export function useWebView(
     currentAccountHistDb,
     inputs,
     customHandlers,
-  }: Pick<WebviewProps, "manifest" | "inputs" | "customHandlers" | "currentAccountHistDb">,
+    manifestDomainCheckEnabled,
+  }: Pick<WebviewProps, "manifest" | "inputs" | "customHandlers" | "currentAccountHistDb"> & {
+    manifestDomainCheckEnabled?: boolean;
+  },
   ref: React.ForwardedRef<WebviewAPI>,
   onStateChange: WebviewProps["onStateChange"],
 ) {
@@ -67,15 +75,17 @@ export function useWebView(
     [],
   );
 
-  const { webviewProps, webviewRef } = useWebviewState(
-    {
-      manifest: manifest satisfies AppManifest,
-      inputs,
-    },
-    ref,
-    onStateChange,
-    serverRef,
-  );
+  const { webviewProps, webviewRef, onShouldStartLoadWithRequest, isBlockedByDomainCheck } =
+    useWebviewState(
+      {
+        manifest: manifest satisfies AppManifest,
+        inputs,
+        manifestDomainCheckEnabled,
+      },
+      ref,
+      onStateChange,
+      serverRef,
+    );
 
   const accounts = useSelector(flattenAccountsSelector);
   const mevProtected = useSelector(mevProtectionSelector);
@@ -220,6 +230,8 @@ export function useWebView(
     onLoadError,
     onMessage,
     onOpenWindow,
+    onShouldStartLoadWithRequest,
+    isBlockedByDomainCheck,
     webviewCacheOptions,
     webviewProps,
     webviewRef,
@@ -233,24 +245,54 @@ export const initialWebviewState: WebviewState = {
   canGoForward: false,
   title: "",
   loading: false,
+  isAppUnavailable: false,
 };
 
 export function useWebviewState(
-  params: Pick<WebviewProps, "manifest" | "inputs">,
+  params: Pick<WebviewProps, "manifest" | "inputs"> & { manifestDomainCheckEnabled?: boolean },
   WebviewAPIRef: React.ForwardedRef<WebviewAPI>,
   onStateChange: WebviewProps["onStateChange"],
   serverRef?: React.RefObject<WalletAPIServer | undefined>,
 ) {
   const webviewRef = useRef<WebView>(null);
-  const { manifest, inputs } = params;
+  const { manifest, inputs, manifestDomainCheckEnabled } = params;
   const initialURL = useMemo(() => getInitialURL(inputs, manifest), [manifest, inputs]);
   const [state, setState] = useState<WebviewState>(initialWebviewState);
 
-  useEffect(() => {
-    setURI(initialURL);
-  }, [initialURL]);
+  // Mirror desktop's originWhitelist logic: when the flag is on, validate the initial URL
+  // against manifest.domains, falling back to manifest.url.
+  // When neither passes, webviewSrc is "" — the WebView is not navigated and we derive
+  // isBlockedByDomainCheck to push isAppUnavailable directly into state, avoiding any
+  // URL load that could crash (e.g. about:blank on iOS).
+  const webviewSrc = useMemo(() => {
+    if (!manifestDomainCheckEnabled) {
+      return initialURL;
+    }
+    const domains = manifest.domains ?? [];
+    if (isUrlAllowedByManifestDomains(initialURL, domains)) {
+      return initialURL;
+    }
+    if (isUrlAllowedByManifestDomains(manifest.url.toString(), domains)) {
+      return manifest.url.toString();
+    }
+    return "";
+  }, [initialURL, manifest.domains, manifest.url, manifestDomainCheckEnabled]);
 
-  const [currentURI, setURI] = useState(initialURL);
+  const isBlockedByDomainCheck = manifestDomainCheckEnabled && webviewSrc === "";
+
+  useEffect(() => {
+    setURI(webviewSrc);
+  }, [webviewSrc]);
+
+  const [currentURI, setURI] = useState(webviewSrc);
+
+  // When blocked, immediately surface isAppUnavailable without waiting for WebView load
+  // events (which would hang on an empty URI).
+  useEffect(() => {
+    if (isBlockedByDomainCheck) {
+      setState(s => ({ ...s, loading: false, isAppUnavailable: true }));
+    }
+  }, [isBlockedByDomainCheck]);
   const { theme } = useTheme();
 
   const source = useMemo(
@@ -292,6 +334,12 @@ export function useWebviewState(
           webview.goForward();
         },
         loadURL: (url: string): void => {
+          if (
+            manifestDomainCheckEnabled &&
+            !isUrlAllowedByManifestDomains(url, manifest.domains ?? [])
+          ) {
+            return;
+          }
           setURI(url);
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -301,48 +349,52 @@ export function useWebviewState(
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    [manifest.domains, manifestDomainCheckEnabled],
   );
 
   const onLoad: Required<WebViewProps>["onLoad"] = useCallback(({ nativeEvent }) => {
-    setState({
+    setState(oldState => ({
       title: nativeEvent.title,
       url: nativeEvent.url,
       canGoBack: nativeEvent.canGoBack,
       canGoForward: nativeEvent.canGoForward,
       loading: nativeEvent.loading,
-    });
+      isAppUnavailable: oldState.isAppUnavailable,
+    }));
   }, []);
 
   const onLoadStart: Required<WebViewProps>["onLoadStart"] = useCallback(({ nativeEvent }) => {
-    setState({
+    setState(oldState => ({
       title: nativeEvent.title,
       url: nativeEvent.url,
       canGoBack: nativeEvent.canGoBack,
       canGoForward: nativeEvent.canGoForward,
       loading: nativeEvent.loading,
-    });
+      isAppUnavailable: oldState.isAppUnavailable,
+    }));
   }, []);
 
   const onLoadEnd: Required<WebViewProps>["onLoadEnd"] = useCallback(({ nativeEvent }) => {
-    setState({
+    setState(oldState => ({
       title: nativeEvent.title,
       url: nativeEvent.url,
       canGoBack: nativeEvent.canGoBack,
       canGoForward: nativeEvent.canGoForward,
       loading: nativeEvent.loading,
-    });
+      isAppUnavailable: oldState.isAppUnavailable,
+    }));
   }, []);
 
   const onNavigationStateChange: Required<WebViewProps>["onNavigationStateChange"] = useCallback(
     event => {
-      setState({
+      setState(oldState => ({
         title: event.title,
         url: event.url,
         canGoBack: event.canGoBack,
         canGoForward: event.canGoForward,
         loading: event.loading,
-      });
+        isAppUnavailable: oldState.isAppUnavailable,
+      }));
     },
     [],
   );
@@ -352,6 +404,14 @@ export function useWebviewState(
       onStateChange(state);
     }
   }, [state, onStateChange]);
+
+  const onShouldStartLoadWithRequest = useCallback(
+    (request: ShouldStartLoadRequest): boolean => {
+      if (!manifestDomainCheckEnabled) return true;
+      return isUrlAllowedByManifestDomains(request.url, manifest.domains ?? []);
+    },
+    [manifestDomainCheckEnabled, manifest.domains],
+  );
 
   const props: Partial<WebViewProps> = useMemo(
     () => ({
@@ -367,6 +427,8 @@ export function useWebviewState(
   return {
     webviewProps: props,
     webviewRef,
+    onShouldStartLoadWithRequest,
+    isBlockedByDomainCheck,
   };
 }
 

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/types.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/types.ts
@@ -21,6 +21,7 @@ export type WebviewState = {
   canGoForward: boolean;
   title: string;
   loading: boolean;
+  isAppUnavailable: boolean;
 };
 
 export type WebviewAPI = Pick<WebView, "reload" | "goBack" | "goForward"> & {

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -693,6 +693,7 @@ export const DEFAULT_FEATURES: Features = {
     },
   },
   lldWebviewManifestDomainCheck: DEFAULT_FEATURE,
+  llmWebviewManifestDomainCheck: DEFAULT_FEATURE,
   llmModularDrawer: {
     ...DEFAULT_FEATURE,
     params: {

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -255,6 +255,7 @@ export type Features = CurrencyFeatures & {
   llmMmkvMigration: Feature_LlmMmkvMigration;
   lldModularDrawer: Feature_ModularDrawer;
   lldWebviewManifestDomainCheck: DefaultFeature;
+  llmWebviewManifestDomainCheck: DefaultFeature;
   llmModularDrawer: Feature_ModularDrawer;
   llNftEntryPoint: Feature_LlNftEntryPoint;
   ldmkSolanaSigner: DefaultFeature;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - mobile webviews but behind a FF

### 📝 Description

Add `llmWebviewManifestDomainCheck` feature flag that, when enabled, replaces the native `originWhitelist` (whose regex is unanchored) with `isUrlAllowedByManifestDomains`-based JS-level checks on mobile.

- Register `llmWebviewManifestDomainCheck` in `feature.ts` and `defaultFeatures.ts`
- Wire the check in mobile `useWebviewState` to gate the initial URL, `loadURL` calls, and `onShouldStartLoadWithRequest` navigation requests
- Apply the same pattern to both `WalletAPIWebview` and `PlatformAPIWebview`

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25032](https://ledgerhq.atlassian.net/browse/LIVE-25032)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25032]: https://ledgerhq.atlassian.net/browse/LIVE-25032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ