### PR TITLE
chore(tooling): extract slack message generation into dedicated skill

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -135,20 +135,7 @@ open "$PR_URL"
 
 ### Step 5: Generate Slack Message
 
-After creating the PR, use the URL from the `gh pr create` output to generate a Slack message:
-
-```
-:pr-open: {{SLACK_PREFIX}} - {{SHORT_DESCRIPTION}}
-<PR_URL from gh pr create output>
-```
-
-**Slack prefix rules:**
-
-- `LWM` for Ledger Live Mobile changes
-- `LWD` for Ledger Live Desktop changes
-- `Common` for @ledgerhq/live-common or shared libs
-- `Tooling` for CI, scripts, or developer tooling
-- `LWM + LWD` if both apps are impacted
+Use the `slack-pr-message` skill (`.cursor/skills/slack-pr-message/SKILL.md`) to generate the Slack announcement message for the PR.
 
 ## Template Fill Rules
 
@@ -251,9 +238,4 @@ This PR introduces a new analytics dashboard to the portfolio feature, providing
 - **JIRA or GitHub link**: [LIVE-5678](https://ledgerhq.atlassian.net/browse/LIVE-5678)
 ```
 
-**Slack Message**:
-
-```
-:pr-open: LWM + LWD - Add portfolio analytics dashboard
-https://github.com/LedgerHQ/ledger-live/pull/1234
-```
+**Slack Message**: Generated via the `slack-pr-message` skill.

--- a/.cursor/skills/slack-pr-message/SKILL.md
+++ b/.cursor/skills/slack-pr-message/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: slack-pr-message
+description: Generate a formatted Slack message to share a pull request with the team. Use when the user asks to generate a Slack message for a PR, share a PR on Slack, or after creating a pull request.
+---
+
+# Slack PR Message
+
+Generate a formatted Slack message to announce a pull request.
+
+## Instructions
+
+1. Determine the PR URL and short description from the current context (branch, PR title, or user input).
+2. Determine the correct prefix based on impacted packages.
+3. Output the formatted message.
+
+## Format
+
+```
+:pr-open: {{PREFIX}} - {{SHORT_DESCRIPTION}}
+{{PR_URL}}
+```
+
+## Prefix Rules
+
+| Impacted packages | Prefix |
+|---|---|
+| `live-mobile` only | `LWM` |
+| `ledger-live-desktop` only | `LWD` |
+| `@ledgerhq/live-common` or shared libs | `Common` |
+| CI, scripts, developer tooling | `Tooling` |
+| Both `live-mobile` and `ledger-live-desktop` | `LWM + LWD` |
+
+When multiple non-app packages are impacted alongside an app, use the app prefix. Combine prefixes only when both apps are affected.
+
+## Example
+
+```
+:pr-open: LWM - Add portfolio analytics dashboard
+https://github.com/LedgerHQ/ledger-live/pull/1234
+```


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _N/A — no npm packages impacted, only `.cursor/` config files._
- [ ] **Covered by automatic tests.** _N/A — Cursor IDE configuration only, no runtime code changed._
- [x] **Impact of the changes:**
  - Slack message generation is now a standalone reusable skill (`.cursor/skills/slack-pr-message/`)
  - `create-pr` command delegates to the skill instead of embedding the logic

### 📝 Description

The Slack message generation instructions were previously inlined in the `create-pr` Cursor command. This made the command longer and the Slack formatting logic non-reusable outside of PR creation.

This PR extracts the Slack PR announcement formatting into a dedicated Cursor skill (`slack-pr-message`), making it independently invocable and keeping the `create-pr` command focused on PR creation.

**Changes:**
- **New**: `.cursor/skills/slack-pr-message/SKILL.md` — standalone skill with format template, prefix rules, and example
- **Updated**: `.cursor/commands/create-pr.md` — Step 5 now delegates to the skill; example section simplified

### ❓ Context

- **JIRA or GitHub link**: N/A — internal tooling improvement

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)