### PR TITLE
[LWM] feat(mobile): allow reborn lazy onboarding users to access walled features

### DIFF
--- a/.changeset/afraid-rivers-learn.md
+++ b/.changeset/afraid-rivers-learn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Allow lazy onboarding reborn users to access screens

--- a/apps/ledger-live-mobile/src/components/FabActions/index.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions/index.tsx
@@ -14,6 +14,7 @@ import { NavigatorName } from "~/const";
 import { useRebornFlow } from "LLM/features/Reborn/hooks/useRebornFlow";
 import { useSelector } from "~/context/hooks";
 import { hasOrderedNanoSelector, readOnlyModeEnabledSelector } from "~/reducers/settings";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 export type ModalOnDisabledClickComponentProps = {
   account?: AccountLike;
@@ -100,6 +101,7 @@ export const FabButtonBarProvider = ({
     useNavigation<NativeStackNavigationProp<ParamListBase, string, NavigatorName>>();
 
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("mobile");
   const hasOrderedNano = useSelector(hasOrderedNanoSelector);
   const { navigateToRebornFlow } = useRebornFlow();
 
@@ -149,7 +151,8 @@ export const FabButtonBarProvider = ({
         customHandler,
       } = data;
 
-      if (readOnlyModeEnabled && !hasOrderedNano) {
+      const shouldUseLegacyRebornFlow = readOnlyModeEnabled && !shouldUseLazyOnboarding;
+      if (shouldUseLegacyRebornFlow && !hasOrderedNano) {
         navigateToRebornFlow();
         return;
       }
@@ -187,6 +190,7 @@ export const FabButtonBarProvider = ({
       router.name,
       globalEventProperties,
       onNavigate,
+      shouldUseLazyOnboarding,
     ],
   );
 

--- a/apps/ledger-live-mobile/src/components/FabActions/modals/ZeroBalanceDisabledModalContent.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions/modals/ZeroBalanceDisabledModalContent.tsx
@@ -3,7 +3,6 @@ import { Flex } from "@ledgerhq/native-ui";
 import { useTranslation } from "~/context/Locale";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { useNavigation } from "@react-navigation/native";
-import { Currency } from "@ledgerhq/types-cryptoassets";
 import { ModalOnDisabledClickComponentProps } from "../index";
 import CurrencyIcon from "../../CurrencyIcon";
 import { NavigatorName, ScreenName } from "~/const";
@@ -17,7 +16,9 @@ import QueuedDrawer from "../../QueuedDrawer";
 import { useRebornFlow } from "LLM/features/Reborn/hooks/useRebornFlow";
 import { useSelector } from "~/context/hooks";
 import { readOnlyModeEnabledSelector, hasOrderedNanoSelector } from "~/reducers/settings";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
+import { Currency } from "@ledgerhq/types-cryptoassets";
 
 function ZeroBalanceDisabledModalContent({
   account,
@@ -33,6 +34,7 @@ function ZeroBalanceDisabledModalContent({
   const { navigateToRebornFlow } = useRebornFlow();
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const hasOrderedNano = useSelector(hasOrderedNanoSelector);
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("mobile");
 
   const actionCurrency = account ? getAccountCurrency(account) : currency;
 
@@ -40,9 +42,10 @@ function ZeroBalanceDisabledModalContent({
     sourceScreenName: "zero-balance-disabled-modal",
     currency,
   });
+  const shouldUseLegacyRebornFlow = readOnlyModeEnabled && !shouldUseLazyOnboarding;
 
   const goToBuy = useCallback(() => {
-    if (readOnlyModeEnabled && !hasOrderedNano) {
+    if (shouldUseLegacyRebornFlow && !hasOrderedNano) {
       navigateToRebornFlow();
       return;
     }
@@ -61,11 +64,11 @@ function ZeroBalanceDisabledModalContent({
     navigateToRebornFlow,
     navigation,
     onClose,
-    readOnlyModeEnabled,
+    shouldUseLegacyRebornFlow,
   ]);
 
   const goToReceive = useCallback(() => {
-    if (readOnlyModeEnabled && !hasOrderedNano) {
+    if (shouldUseLegacyRebornFlow && !hasOrderedNano) {
       navigateToRebornFlow();
       return;
     }
@@ -84,7 +87,6 @@ function ZeroBalanceDisabledModalContent({
     }
     onClose();
   }, [
-    readOnlyModeEnabled,
     hasOrderedNano,
     account,
     onClose,
@@ -93,6 +95,7 @@ function ZeroBalanceDisabledModalContent({
     actionCurrency,
     parentAccount?.id,
     handleOpenReceiveDrawer,
+    shouldUseLegacyRebornFlow,
   ]);
 
   return (

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/Wallet40TabNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/Wallet40TabNavigator.tsx
@@ -16,12 +16,7 @@ function Wallet40SwapTabHeader() {
 export function Wallet40TabNavigator({
   tabBar,
   screenOptions,
-  rebornFlowListener,
-}: Readonly<
-  Wallet40TabNavigatorProps & {
-    rebornFlowListener: (e: { preventDefault: () => void }) => void;
-  }
->): React.JSX.Element {
+}: Readonly<Wallet40TabNavigatorProps>): React.JSX.Element {
   return (
     <Tab.Navigator tabBar={tabBar} screenOptions={screenOptions}>
       <Tab.Screen name={NavigatorName.Portfolio} component={PortfolioNavigator} />
@@ -32,11 +27,8 @@ export function Wallet40TabNavigator({
           header: Wallet40SwapTabHeader,
         }}
         listeners={() => ({
-          tabPress: e => {
-            // Prevent stale opaque header state when re-entering the Swap tab.
-            resetSwapWallet40HeaderState();
-            rebornFlowListener(e);
-          },
+          // Prevent stale opaque header state when re-entering the Swap tab.
+          tabPress: resetSwapWallet40HeaderState,
         })}
       />
       <Tab.Screen name={NavigatorName.Earn} component={EarnLiveAppNavigator} />

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import { useTheme } from "styled-components/native";
 import { useSelector } from "~/context/hooks";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -50,24 +50,8 @@ export default function MainNavigator() {
     [managerNavLockCallback],
   );
 
-  const rebornFlowListener = useMemo(() => {
-    if (!readOnlyModeEnabled) {
-      return (_: { preventDefault: () => void }) => {};
-    }
-    return (e: { preventDefault: () => void }) => {
-      e.preventDefault();
-      managerLockAwareCallback(navigateToRebornFlow);
-    };
-  }, [readOnlyModeEnabled, navigateToRebornFlow, managerLockAwareCallback]);
-
   if (shouldDisplayWallet40MainNav) {
-    return (
-      <Wallet40TabNavigator
-        tabBar={tabBar}
-        screenOptions={screenOptions}
-        rebornFlowListener={rebornFlowListener}
-      />
-    );
+    return <Wallet40TabNavigator tabBar={tabBar} screenOptions={screenOptions} />;
   }
 
   return (

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SwapNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SwapNavigator.tsx
@@ -155,18 +155,24 @@ export default function SwapNavigator(
     [noNanoBuyNanoWallScreenOptions],
   );
 
-  const swapComponent = isLwm40Enabled ? SwapLiveAppWallet40 : SwapLiveApp;
-  const swapOptions = isLwm40Enabled ? wallet40Options : oldDesignOptions;
-
   return (
     <Stack.Navigator screenOptions={{ ...stackNavigationConfig, headerShown: shouldDisplayHeader }}>
-      <Stack.Screen
-        name={ScreenName.SwapTab}
-        component={swapComponent}
-        {...noNanoBuyNanoWallScreenOptions}
-        options={swapOptions}
-        initialParams={initialSwapParams}
-      />
+      {isLwm40Enabled ? (
+        <Stack.Screen
+          name={ScreenName.SwapTab}
+          component={SwapLiveAppWallet40}
+          options={wallet40Options}
+          initialParams={initialSwapParams}
+        />
+      ) : (
+        <Stack.Screen
+          name={ScreenName.SwapTab}
+          component={SwapLiveApp}
+          {...noNanoBuyNanoWallScreenOptions}
+          options={oldDesignOptions}
+          initialParams={initialSwapParams}
+        />
+      )}
 
       <Stack.Screen
         name={ScreenName.SwapPendingOperation}

--- a/apps/ledger-live-mobile/src/context/NoNanoBuyNanoWall.test.tsx
+++ b/apps/ledger-live-mobile/src/context/NoNanoBuyNanoWall.test.tsx
@@ -1,0 +1,129 @@
+import { renderHook } from "@tests/test-renderer";
+import type { State } from "~/reducers/types";
+import BuyDeviceNavigator from "~/components/RootNavigator/BuyDeviceNavigator";
+import PostBuyDeviceSetupNanoWallScreen from "~/screens/PostBuyDeviceSetupNanoWallScreen";
+import { useNoNanoBuyNanoWallScreenOptions } from "./NoNanoBuyNanoWall";
+
+type TestStateOverrides = {
+  hasCompletedOnboarding?: boolean;
+  hasOrderedNano?: boolean;
+  readOnlyModeEnabled?: boolean;
+  lazyOnboarding?: boolean;
+};
+
+const overrideInitialState =
+  ({
+    hasCompletedOnboarding = true,
+    hasOrderedNano = false,
+    readOnlyModeEnabled = true,
+    lazyOnboarding = false,
+  }: TestStateOverrides = {}) =>
+  (state: State): State => ({
+    ...state,
+    settings: {
+      ...state.settings,
+      hasCompletedOnboarding,
+      hasOrderedNano,
+      readOnlyModeEnabled,
+      overriddenFeatureFlags: {
+        ...state.settings.overriddenFeatureFlags,
+        lwmWallet40: {
+          enabled: true,
+          params: {
+            lazyOnboarding,
+          },
+        },
+      },
+    },
+  });
+
+describe("useNoNanoBuyNanoWallScreenOptions", () => {
+  it("should not gate when onboarding is not completed and read only mode is disabled", () => {
+    const { result } = renderHook(() => useNoNanoBuyNanoWallScreenOptions(), {
+      overrideInitialState: overrideInitialState({
+        hasCompletedOnboarding: false,
+        readOnlyModeEnabled: false,
+      }),
+    });
+
+    expect(result.current).toEqual({});
+  });
+
+  it("should not gate when onboarding is not completed and read only mode is enabled", () => {
+    const { result } = renderHook(() => useNoNanoBuyNanoWallScreenOptions(), {
+      overrideInitialState: overrideInitialState({
+        hasCompletedOnboarding: false,
+        readOnlyModeEnabled: true,
+      }),
+    });
+
+    expect(result.current).toEqual({});
+  });
+
+  it("should not gate when onboarding is completed and read only mode is disabled", () => {
+    const { result } = renderHook(() => useNoNanoBuyNanoWallScreenOptions(), {
+      overrideInitialState: overrideInitialState({
+        hasCompletedOnboarding: true,
+        readOnlyModeEnabled: false,
+      }),
+    });
+
+    expect(result.current).toEqual({});
+  });
+
+  it("should not gate when onboarding is completed, read only mode is enabled, and lazy onboarding is enabled", () => {
+    const { result } = renderHook(() => useNoNanoBuyNanoWallScreenOptions(), {
+      overrideInitialState: overrideInitialState({
+        hasCompletedOnboarding: true,
+        lazyOnboarding: true,
+        readOnlyModeEnabled: true,
+      }),
+    });
+
+    expect(result.current).toEqual({});
+  });
+
+  it("should gate to buy device when onboarding is completed, read only mode is enabled, lazy onboarding is disabled, and no nano was ordered", () => {
+    const { result } = renderHook(() => useNoNanoBuyNanoWallScreenOptions(), {
+      overrideInitialState: overrideInitialState({
+        hasCompletedOnboarding: true,
+        hasOrderedNano: false,
+        lazyOnboarding: false,
+        readOnlyModeEnabled: true,
+      }),
+    });
+
+    expect(result.current).toEqual({
+      component: BuyDeviceNavigator,
+      options: {
+        headerShown: false,
+        presentation: "transparentModal",
+        animation: "slide_from_bottom",
+      },
+    });
+  });
+
+  it("should gate to post buy setup when onboarding is completed, read only mode is enabled, lazy onboarding is disabled, and a nano was ordered", () => {
+    const { result } = renderHook(() => useNoNanoBuyNanoWallScreenOptions(), {
+      overrideInitialState: overrideInitialState({
+        hasCompletedOnboarding: true,
+        hasOrderedNano: true,
+        lazyOnboarding: false,
+        readOnlyModeEnabled: true,
+      }),
+    });
+
+    expect(result.current).toEqual({
+      component: PostBuyDeviceSetupNanoWallScreen,
+      options: expect.objectContaining({
+        headerShown: false,
+        presentation: "transparentModal",
+        contentStyle: { opacity: 1 },
+        gestureEnabled: true,
+        headerTitle: "",
+        headerBackButtonDisplayMode: "minimal",
+        title: undefined,
+      }),
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/context/NoNanoBuyNanoWall.tsx
+++ b/apps/ledger-live-mobile/src/context/NoNanoBuyNanoWall.tsx
@@ -7,6 +7,7 @@ import {
   readOnlyModeEnabledSelector,
 } from "~/reducers/settings";
 import PostBuyDeviceSetupNanoWallScreen from "~/screens/PostBuyDeviceSetupNanoWallScreen";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 /**
  * Get options to spread in a Stack.Screen you want to have a wall preventing
@@ -18,31 +19,40 @@ export const useNoNanoBuyNanoWallScreenOptions = ():
       options: NativeStackNavigationOptions;
     }
   | object => {
-  const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const hasOrderedNano = useSelector(hasOrderedNanoSelector);
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("mobile");
+  const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
+
+  const shouldUseLegacyRebornFlow = readOnlyModeEnabled && !shouldUseLazyOnboarding;
+
   if (!hasCompletedOnboarding || !readOnlyModeEnabled) return {};
-  if (hasOrderedNano) {
+
+  if (!shouldUseLegacyRebornFlow) return {};
+
+  if (!hasOrderedNano) {
     return {
-      component: PostBuyDeviceSetupNanoWallScreen,
+      component: BuyDeviceNavigator,
       options: {
         headerShown: false,
         presentation: "transparentModal",
-        contentStyle: { opacity: 1 },
-        gestureEnabled: true,
-        headerTitle: "",
-        headerRight: () => null,
-        headerBackButtonDisplayMode: "minimal",
-        title: undefined,
+        animation: "slide_from_bottom",
       },
     };
   }
+
   return {
-    component: BuyDeviceNavigator,
+    component: PostBuyDeviceSetupNanoWallScreen,
     options: {
       headerShown: false,
       presentation: "transparentModal",
-      animation: "slide_from_bottom",
+      contentStyle: { opacity: 1 },
+      gestureEnabled: true,
+      headerTitle: "",
+      headerRight: () => null,
+      headerBackButtonDisplayMode: "minimal",
+      title: undefined,
     },
   };
 };

--- a/apps/ledger-live-mobile/src/hooks/useQuickActions.ts
+++ b/apps/ledger-live-mobile/src/hooks/useQuickActions.ts
@@ -20,6 +20,7 @@ import { useOpenStakeDrawer } from "LLM/features/Stake";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import { useOpenSwap } from "LLM/features/Swap";
 import { useOpenBuy } from "LLM/features/Buy";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 export type QuickAction = {
   disabled: boolean;
@@ -110,7 +111,11 @@ function useQuickActions({ currency, accounts }: QuickActionProps = {}) {
   const { handleOpenSwap } = useOpenSwap({ currency, sourceScreenName: route.name });
   const { handleOpenBuy } = useOpenBuy({ currency, sourceScreenName: route.name });
 
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("mobile");
+
   const quickActionsList = useMemo(() => {
+    const isLegacyRebornFlow = readOnlyModeEnabled && !shouldUseLazyOnboarding;
+
     const list: Partial<Record<Actions, QuickAction>> = {
       SEND: {
         disabled: readOnlyModeEnabled || !hasCurrency,
@@ -124,12 +129,12 @@ function useQuickActions({ currency, accounts }: QuickActionProps = {}) {
         icon: IconsLegacy.ArrowTopMedium,
       },
       RECEIVE: {
-        disabled: readOnlyModeEnabled,
+        disabled: isLegacyRebornFlow,
         customHandler: handleOpenReceiveDrawer,
         icon: IconsLegacy.ArrowBottomMedium,
       },
       SWAP: {
-        disabled: isPtxServiceCtaExchangeDrawerDisabled || readOnlyModeEnabled || !hasFunds,
+        disabled: isPtxServiceCtaExchangeDrawerDisabled || isLegacyRebornFlow || !hasFunds,
         customHandler: handleOpenSwap,
         icon: IconsLegacy.BuyCryptoMedium,
       },
@@ -137,7 +142,7 @@ function useQuickActions({ currency, accounts }: QuickActionProps = {}) {
 
     if (canBeBought) {
       list.BUY = {
-        disabled: isPtxServiceCtaExchangeDrawerDisabled || readOnlyModeEnabled,
+        disabled: isPtxServiceCtaExchangeDrawerDisabled || isLegacyRebornFlow,
         customHandler: handleOpenBuy,
         icon: IconsLegacy.PlusMedium,
       };
@@ -145,7 +150,7 @@ function useQuickActions({ currency, accounts }: QuickActionProps = {}) {
 
     if (canBeSold) {
       list.SELL = {
-        disabled: isPtxServiceCtaExchangeDrawerDisabled || readOnlyModeEnabled || !hasCurrency,
+        disabled: isPtxServiceCtaExchangeDrawerDisabled || isLegacyRebornFlow || !hasCurrency,
         route: [
           NavigatorName.Exchange,
           {
@@ -161,7 +166,7 @@ function useQuickActions({ currency, accounts }: QuickActionProps = {}) {
     if (partnerStakeRoute) {
       const { screen, params } = partnerStakeRoute;
       list.STAKE = {
-        disabled: readOnlyModeEnabled,
+        disabled: isLegacyRebornFlow,
         // @ts-expect-error - cannot infer screen & params type correctly. But this will go away if we do not return the NoFundsFlow when account is empty, or narrow the conditions of the return type.
         route: [screen, params],
         icon: IconsLegacy.CoinsMedium,
@@ -170,14 +175,14 @@ function useQuickActions({ currency, accounts }: QuickActionProps = {}) {
 
     if (canStakeCurrencyUsingLedgerLive || !currency) {
       list.STAKE = {
-        disabled: readOnlyModeEnabled,
+        disabled: isLegacyRebornFlow,
         customHandler: handleOpenStakeDrawer,
         icon: IconsLegacy.CoinsMedium,
       };
     }
 
     list.WALLET_CONNECT = {
-      disabled: readOnlyModeEnabled,
+      disabled: isLegacyRebornFlow,
       route: [
         NavigatorName.WalletConnect,
         {
@@ -190,7 +195,7 @@ function useQuickActions({ currency, accounts }: QuickActionProps = {}) {
 
     if (canBeRecovered) {
       list.RECOVER = {
-        disabled: readOnlyModeEnabled,
+        disabled: isLegacyRebornFlow,
         route: [
           NavigatorName.Main,
           {
@@ -205,6 +210,7 @@ function useQuickActions({ currency, accounts }: QuickActionProps = {}) {
     return list;
   }, [
     readOnlyModeEnabled,
+    shouldUseLazyOnboarding,
     hasCurrency,
     currency,
     handleOpenReceiveDrawer,

--- a/apps/ledger-live-mobile/src/screens/Assets/AssetsNavigationHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Assets/AssetsNavigationHeader.tsx
@@ -6,6 +6,7 @@ import AddAccount from "../Accounts/AddAccount";
 import Touchable from "~/components/Touchable";
 import { track } from "~/analytics";
 import { useRebornFlow } from "LLM/features/Reborn/hooks/useRebornFlow";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 type Props = {
   readOnly?: boolean;
@@ -15,11 +16,14 @@ function AssetsNavigationHeader({ readOnly }: Props) {
   const navigation = useNavigation();
   const { navigateToRebornFlow } = useRebornFlow();
 
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("mobile");
+  const shouldUseLegacyRebornFlow = readOnly && !shouldUseLazyOnboarding;
   const handleOnReadOnlyAddAccountPress = useCallback(() => {
     track("button_clicked", {
       button: "Add Account '+'",
       page: "Assets",
     });
+
     navigateToRebornFlow();
   }, [navigateToRebornFlow]);
 
@@ -39,7 +43,7 @@ function AssetsNavigationHeader({ readOnly }: Props) {
         </TouchableOpacity>
       </Flex>
       <Flex flexDirection="row" alignItems={"center"}>
-        {readOnly ? (
+        {shouldUseLegacyRebornFlow ? (
           <Touchable onPress={handleOnReadOnlyAddAccountPress}>
             <Flex
               bg={"neutral.c100"}

--- a/apps/ledger-live-mobile/src/screens/Platform/v2/hooks.ts
+++ b/apps/ledger-live-mobile/src/screens/Platform/v2/hooks.ts
@@ -21,6 +21,7 @@ import { DiscoverDB, AppManifest } from "@ledgerhq/live-common/wallet-api/types"
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { useSelector } from "~/context/hooks";
 import { useSearch } from "@ledgerhq/live-common/hooks/useSearch";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useDB } from "../../../db";
 import { NavigatorName, ScreenName } from "~/const";
 import { useBanner } from "~/components/banners/hooks";
@@ -106,6 +107,7 @@ export type Disclaimer = DisclaimerRaw & {
 function useDisclaimer(appendRecentlyUsed: (manifest: AppManifest) => void): Disclaimer {
   const isReadOnly = useSelector(readOnlyModeEnabledSelector);
   const hasOrderedNano = useSelector(hasOrderedNanoSelector);
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("mobile");
 
   const [isDismissed, dismiss] = useBanner(DAPP_DISCLAIMER_ID);
 
@@ -130,8 +132,9 @@ function useDisclaimer(appendRecentlyUsed: (manifest: AppManifest) => void): Dis
       }
 
       const isLedgerShopApp = manifest.id === LEDGER_SHOP_ID;
+      const shouldUseLegacyRebornFlow = isReadOnly && !shouldUseLazyOnboarding;
 
-      if (isReadOnly && !hasOrderedNano && !isLedgerShopApp) {
+      if (shouldUseLegacyRebornFlow && !hasOrderedNano && !isLedgerShopApp) {
         navigateToRebornFlow();
         return;
       }
@@ -145,7 +148,7 @@ function useDisclaimer(appendRecentlyUsed: (manifest: AppManifest) => void): Dis
         },
       });
     },
-    [hasOrderedNano, isReadOnly, navigateToRebornFlow, navigation, params],
+    [hasOrderedNano, shouldUseLazyOnboarding, isReadOnly, navigateToRebornFlow, navigation, params],
   );
 
   const toggleCheck = useCallback(() => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _`pnpm mobile typecheck` passed. Added dedicated coverage for `NoNanoBuyNanoWall` and ran related mobile Jest suites, but not every affected entrypoint has direct automated coverage yet._
- [x] **Impact of the changes:**
  - Reborn users with lazy onboarding can access legacy-walled mobile entrypoints while in read-only mode
  - Legacy read-only users without lazy onboarding keep the existing reborn flow and no-device wall protections
  - Quick actions and other mobile entrypoints now rely on the legacy-flow check instead of gating all read-only users

### 📝 Description

https://github.com/user-attachments/assets/de7bfc32-e810-4f60-abfd-7bab735f3b96

Reborn users in lazy onboarding were still being treated like legacy no-device users in several mobile entrypoints. That created inconsistent behavior: some Wallet 4.0 paths allowed access as expected, while older wall logic still redirected users to the reborn flow or showed the no-device wall.

This PR updates the mobile gating logic so the legacy reborn flow is only used when the user is read-only and lazy onboarding is disabled. Users in the reborn lazy-onboarding flow are no longer blocked by the legacy wall behavior, while legacy read-only users keep the existing protections. The PR also adds targeted unit coverage for `useNoNanoBuyNanoWallScreenOptions` to lock down the gate versus not-gate decision matrix.

### 🔎 QA Focus Areas

- Validate swap, buy, earn/stake, discover live apps, card, and quick action entrypoints for reborn users with lazy onboarding enabled
- Confirm these users no longer get redirected to the reborn flow or blocked by the no-device wall where access should be allowed
- Confirm legacy read-only users still hit the existing wall behavior when lazy onboarding is disabled and when Nano order state changes the destination wall

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25798](https://ledgerhq.atlassian.net/browse/LIVE-25798)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25798]: https://ledgerhq.atlassian.net/browse/LIVE-25798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ