### PR TITLE
test(e2e): re-enable hedera swap test

### DIFF
--- a/.changeset/rare-guests-collect.md
+++ b/.changeset/rare-guests-collect.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+test: re-enable hedera swap e2e test

--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -173,14 +173,22 @@ const swaps = [
   //   xrayTicket: "B2CQA-3081, B2CQA-3450, B2CQA-3281",
   //   tag: ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@aptos", "@solana", "@family-solana","@family-aptos"],
   // },
-  //ToDo: enable once Hedera Swap E2E test issue fixed
-  // Task https://ledgerhq.atlassian.net/browse/LIVE-21744
-  //{
-  //  fromAccount: Account.HEDERA_1,
-  //  toAccount: Account.XRP_1,
-  //  xrayTicket: "B2CQA-3753",
-  //  tag: ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@hedera", "@xrp", "@family-xrp", "@family-hedera"],
-  //},
+  {
+    fromAccount: Account.HEDERA_1,
+    toAccount: Account.XRP_1,
+    xrayTicket: "B2CQA-3753",
+    tag: [
+      "@NanoSP",
+      "@NanoX",
+      "@Stax",
+      "@Flex",
+      "@NanoGen5",
+      "@hedera",
+      "@xrp",
+      "@family-xrp",
+      "@family-hedera",
+    ],
+  },
   {
     fromAccount: TokenAccount.SUI_USDC_1,
     toAccount: Account.SOL_1,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Hedera swap E2E test

### 📝 Description

This PR restores E2E test for Hedera swaps.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-21744

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
