### PR TITLE
[LWD] fix(desktop): display scroll indicator only on hover on market banner

### DIFF
--- a/.changeset/odd-numbers-add.md
+++ b/.changeset/odd-numbers-add.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+display scroll indicator on hover on market banner

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/ScrollArrowButton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/ScrollArrowButton.tsx
@@ -30,7 +30,10 @@ export const ScrollArrowButton = ({ direction, onClick }: ScrollArrowButtonProps
 
   return (
     <div
-      className={cn("absolute inset-y-0 z-10 flex items-center", className)}
+      className={cn(
+        "absolute inset-y-0 z-10 flex items-center opacity-0 transition-opacity group-hover:opacity-100",
+        className,
+      )}
       data-testid={`scroll-arrow-${direction}`}
     >
       <div className={cn("pointer-events-none absolute inset-y-0 w-48", gradientClassName)} />

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
@@ -34,7 +34,7 @@ export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
   const getCapitalizedTicker = (item: MarketItemPerformer) => item.ticker.toUpperCase();
 
   return (
-    <div className="relative" data-testid="trending-assets-list">
+    <div className="group relative" data-testid="trending-assets-list">
       {!isAtStart && <ScrollArrowButton direction="left" onClick={scrollLeft} />}
       <div
         ref={scrollContainerRef}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _CSS-only behavior change — no functional logic modified._
- [x] **Impact of the changes:**
      - Scroll arrow visibility on hover over the market banner
      - Scroll left/right functionality still works correctly

### 📝 Description

The scroll indicator arrows on the market banner were always visible, cluttering the UI.

This fix uses Tailwind's `group-hover` pattern to hide the scroll arrows by default (`opacity-0`) and reveal them with a smooth transition only when the user hovers over the trending assets list (`group-hover:opacity-100`).

https://github.com/user-attachments/assets/cb52bc84-2e3e-49e9-a030-8a49dcf01593



### ❓ Context

- **JIRA or GitHub link**: [LIVE-27444](https://ledgerhq.atlassian.net/browse/LIVE-27444)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27444]: https://ledgerhq.atlassian.net/browse/LIVE-27444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ