### PR TITLE
[LWDM] chore(perps): add deeplink custom handlers to perps webview

### DIFF
--- a/.changeset/gentle-perps-deeplink.md
+++ b/.changeset/gentle-perps-deeplink.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add deeplink custom handlers to Perps WebView

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsWebView/PerpsWebView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsWebView/PerpsWebView.tsx
@@ -1,5 +1,5 @@
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
-import React, { type RefObject } from "react";
+import React, { useMemo, type RefObject } from "react";
 import { Web3AppWebview } from "~/renderer/components/Web3AppWebview";
 import {
   WebviewAPI,
@@ -10,6 +10,8 @@ import {
 import { TopBar } from "~/renderer/components/WebPlatformPlayer/TopBar";
 import { PerpsLoader } from "LLD/features/Perps/components/PerpsLoader";
 import type { PerpsWebviewInputs } from "../PerpsApp/usePerpsAppViewModel";
+import { useDeeplinkCustomHandlers } from "~/renderer/components/WebPlatformPlayer/CustomHandlers";
+import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
 
 export type PerpsWebProps = {
   manifest: LiveAppManifest;
@@ -30,6 +32,12 @@ export const PerpsWebView = ({
   enablePlatformDevTools,
   Loader = PerpsLoader,
 }: PerpsWebProps) => {
+  const customDeeplinkHandlers = useDeeplinkCustomHandlers();
+  const customHandlers = useMemo<WalletAPICustomHandlers>(() => {
+    return {
+      ...customDeeplinkHandlers,
+    };
+  }, [customDeeplinkHandlers]);
   return (
     <>
       {enablePlatformDevTools && (
@@ -42,6 +50,7 @@ export const PerpsWebView = ({
           inputs={{
             ...inputs,
           }}
+          customHandlers={customHandlers}
           onStateChange={onStateChange}
           ref={webviewAPIRef}
           Loader={Loader}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/components/PerpsWebView/PerpsWebView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/components/PerpsWebView/PerpsWebView.tsx
@@ -1,9 +1,11 @@
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
-import React, { forwardRef } from "react";
+import React, { forwardRef, useMemo } from "react";
 import { Web3AppWebview } from "~/components/Web3AppWebview";
 import { WebviewAPI, WebviewState } from "~/components/Web3AppWebview/types";
 import SafeAreaView from "~/components/SafeAreaView";
 import type { PerpsWebviewInputs } from "LLM/features/Perps/screens/PerpsLiveApp/usePerpsLiveAppViewModel";
+import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
+import { useDeeplinkCustomHandlers } from "~/components/WebPlatformPlayer/CustomHandlers";
 
 type Props = {
   manifest: LiveAppManifest;
@@ -13,6 +15,13 @@ type Props = {
 
 export const PerpsWebView = forwardRef<WebviewAPI, Props>(
   ({ manifest, setWebviewState, inputs }, ref) => {
+    const customDeeplinkHandlers = useDeeplinkCustomHandlers();
+    const customHandlers = useMemo<WalletAPICustomHandlers>(() => {
+      return {
+        ...customDeeplinkHandlers,
+      };
+    }, [customDeeplinkHandlers]);
+
     return (
       <SafeAreaView edges={["bottom"]} isFlex>
         <Web3AppWebview
@@ -20,6 +29,7 @@ export const PerpsWebView = forwardRef<WebviewAPI, Props>(
           manifest={manifest}
           onStateChange={setWebviewState}
           inputs={inputs}
+          customHandlers={customHandlers}
         />
       </SafeAreaView>
     );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new tests — change wires existing `useDeeplinkCustomHandlers` hook into the Perps WebView components with no new logic._
- [x] **Impact of the changes:**
      - Deeplink handling from within the Perps WebView on desktop and mobile
      - Verify that deeplinks triggered from the Perps live app navigate correctly to the target screens

### 📝 Description

**Problem**: The Perps WebView did not handle deeplinks, so any deeplink triggered from within the Perps live app was silently ignored instead of navigating to the appropriate screen in the host app.

**Solution**: Wire the existing `useDeeplinkCustomHandlers` hook into the `PerpsWebView` component on both desktop and mobile, passing `customHandlers` to the `Web3AppWebview`. This follows the same pattern already used by other live-app webviews (Swap, Web3Hub).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27318](https://ledgerhq.atlassian.net/browse/LIVE-27318)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-27318]: https://ledgerhq.atlassian.net/browse/LIVE-27318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ