### PR TITLE
[LWM] Migrate sync onboarding first step to MVVM architecture

### DIFF
--- a/.changeset/quick-sheep-move.md
+++ b/.changeset/quick-sheep-move.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Migrate sync onboarding first step component to MVVM architecture

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__integrations__/FirstStepSyncOnboarding.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__integrations__/FirstStepSyncOnboarding.integration.test.tsx
@@ -1,0 +1,214 @@
+import React, { createRef } from "react";
+import { render, screen } from "@tests/test-renderer";
+import FirstStepSyncOnboarding from "../components/FirstStepSyncOnboarding";
+import * as viewModelModule from "../components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { ScrollView } from "react-native";
+import { FirstStepCompanionStepKey } from "~/screens/SyncOnboarding/TwoStepStepper/types";
+
+jest.mock("react-native-reanimated", () => {
+  const RN = require("react-native");
+  return {
+    __esModule: true,
+    default: {
+      View: RN.View,
+      ScrollView: RN.ScrollView,
+    },
+    useSharedValue: jest.fn(() => ({ value: 0 })),
+    useAnimatedStyle: jest.fn(() => ({})),
+    withTiming: jest.fn(value => value),
+  };
+});
+
+const mockHandleNextStep = jest.fn();
+
+jest.mock("../components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel", () => ({
+  FirstStepCompanionStepKey: {
+    Pin: 0,
+    Seed: 1,
+    Ready: 2,
+  },
+  useFirstStepSyncOnboardingViewModel: jest.fn(() => ({
+    companionSteps: {
+      activeStep: 0,
+      steps: [
+        { title: "Pin step", status: "active" },
+        { title: "Seed step", status: "inactive" },
+      ],
+    },
+    hasFinishedExitAnimation: false,
+    isFinishedStep: false,
+    formatEstimatedTime: jest.fn((time: number) => `${time} min`),
+    animatedStyle: { height: undefined, opacity: 1 },
+    handleLayout: jest.fn(),
+    handleNextStep: mockHandleNextStep,
+  })),
+}));
+
+const mockDevice = {
+  deviceId: "device-123",
+  modelId: DeviceModelId.nanoX,
+  wired: false,
+};
+
+const defaultProps = {
+  device: mockDevice,
+  productName: "Nano X",
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  navigation: { navigate: jest.fn() } as any,
+  onLostDevice: jest.fn(),
+  handleSeedGenerationDelay: jest.fn(),
+  notifyEarlySecurityCheckShouldReset: jest.fn(),
+  handlePollingError: jest.fn(),
+  isPollingOn: true,
+  setIsPollingOn: jest.fn(),
+  handleFinishStep: jest.fn(),
+  parentRef: createRef<ScrollView | null>(),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  analyticsSeedConfiguration: { current: "setup" as any },
+};
+
+describe("FirstStepSyncOnboarding", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the component with initial step (Pin)", () => {
+    render(<FirstStepSyncOnboarding {...defaultProps} />);
+
+    expect(screen.getByText(/syncOnboarding.title/)).toBeDefined();
+  });
+
+  it("renders VerticalTimeline when not on Ready step", () => {
+    render(<FirstStepSyncOnboarding {...defaultProps} />);
+
+    expect(screen.getByText("Pin step")).toBeDefined();
+    expect(screen.getByText("Seed step")).toBeDefined();
+  });
+
+  it("renders DeviceSeededSuccessPanel when on Ready step and not finished", () => {
+    const useFirstStepSyncOnboardingViewModel =
+      viewModelModule.useFirstStepSyncOnboardingViewModel as jest.Mock;
+
+    useFirstStepSyncOnboardingViewModel.mockReturnValue({
+      companionSteps: {
+        activeStep: FirstStepCompanionStepKey.Ready,
+        steps: [],
+      },
+      hasFinishedExitAnimation: false,
+      isFinishedStep: false,
+      formatEstimatedTime: jest.fn(),
+      animatedStyle: { height: undefined, opacity: 1 },
+      handleLayout: jest.fn(),
+      handleNextStep: mockHandleNextStep,
+    });
+
+    render(<FirstStepSyncOnboarding {...defaultProps} />);
+
+    expect(screen.getByText(/syncOnboarding.firstStepReadyTitle/)).toBeDefined();
+  });
+
+  it("shows complete status when activeStep is Ready or beyond", () => {
+    const useFirstStepSyncOnboardingViewModel =
+      viewModelModule.useFirstStepSyncOnboardingViewModel as jest.Mock;
+
+    useFirstStepSyncOnboardingViewModel.mockReturnValue({
+      companionSteps: {
+        activeStep: FirstStepCompanionStepKey.Ready,
+        steps: [],
+        setStep: jest.fn(),
+        hasSyncStep: false,
+        isLedgerSyncActive: false,
+      },
+      hasFinishedExitAnimation: false,
+      isFinishedStep: false,
+      formatEstimatedTime: jest.fn(),
+      animatedStyle: { height: undefined, opacity: 1 },
+      handleLayout: jest.fn(),
+      handleNextStep: mockHandleNextStep,
+    });
+
+    render(<FirstStepSyncOnboarding {...defaultProps} />);
+
+    expect(screen.getByText(/syncOnboarding.firstStepReadyTitle/)).toBeDefined();
+  });
+
+  it("collapses when hasFinishedExitAnimation is true", () => {
+    const useFirstStepSyncOnboardingViewModel =
+      viewModelModule.useFirstStepSyncOnboardingViewModel as jest.Mock;
+
+    useFirstStepSyncOnboardingViewModel.mockReturnValue({
+      companionSteps: {
+        activeStep: FirstStepCompanionStepKey.Ready,
+        steps: [],
+        setStep: jest.fn(),
+        hasSyncStep: false,
+        isLedgerSyncActive: false,
+      },
+      hasFinishedExitAnimation: true,
+      isFinishedStep: true,
+      formatEstimatedTime: jest.fn(),
+      animatedStyle: { height: undefined, opacity: 1 },
+      handleLayout: jest.fn(),
+      handleNextStep: mockHandleNextStep,
+    });
+
+    render(<FirstStepSyncOnboarding {...defaultProps} />);
+
+    expect(screen.getByText(/syncOnboarding.firstStepReadyTitle/)).toBeDefined();
+  });
+
+  it("does not render VerticalTimeline when on Ready step", () => {
+    const useFirstStepSyncOnboardingViewModel =
+      viewModelModule.useFirstStepSyncOnboardingViewModel as jest.Mock;
+
+    useFirstStepSyncOnboardingViewModel.mockReturnValue({
+      companionSteps: {
+        activeStep: FirstStepCompanionStepKey.Ready,
+        steps: [],
+        setStep: jest.fn(),
+        hasSyncStep: false,
+        isLedgerSyncActive: false,
+      },
+      hasFinishedExitAnimation: false,
+      isFinishedStep: false,
+      formatEstimatedTime: jest.fn(),
+      animatedStyle: { height: undefined, opacity: 1 },
+      handleLayout: jest.fn(),
+      handleNextStep: mockHandleNextStep,
+    });
+
+    render(<FirstStepSyncOnboarding {...defaultProps} />);
+
+    expect(screen.queryByText("Pin step")).toBeNull();
+    expect(screen.queryByText("Seed step")).toBeNull();
+  });
+
+  it("does not render DeviceSeededSuccessPanel when isFinishedStep is true", () => {
+    const useFirstStepSyncOnboardingViewModel =
+      viewModelModule.useFirstStepSyncOnboardingViewModel as jest.Mock;
+
+    useFirstStepSyncOnboardingViewModel.mockReturnValue({
+      companionSteps: {
+        activeStep: FirstStepCompanionStepKey.Ready,
+        steps: [],
+      },
+      hasFinishedExitAnimation: false,
+      isFinishedStep: true,
+      formatEstimatedTime: jest.fn(),
+      animatedStyle: { height: undefined, opacity: 1 },
+      handleLayout: jest.fn(),
+      handleNextStep: mockHandleNextStep,
+    });
+
+    render(<FirstStepSyncOnboarding {...defaultProps} />);
+
+    expect(screen.queryByTestId("device-seeded-success-panel")).toBeNull();
+  });
+
+  it("passes correct productName to title", () => {
+    render(<FirstStepSyncOnboarding {...defaultProps} productName="Stax" />);
+
+    expect(screen.getByText(/syncOnboarding.title/)).toBeDefined();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__integrations__/useFirstStepSyncOnboardingViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__integrations__/useFirstStepSyncOnboardingViewModel.test.ts
@@ -1,0 +1,266 @@
+import { renderHook, waitFor } from "@tests/test-renderer";
+import { useOnboardingStatePolling } from "@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useIsFocused } from "@react-navigation/core";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { useTranslation } from "~/context/Locale";
+import useCompanionSteps from "LLM/features/Onboarding/screens/SyncOnboardingCompanion/hooks/useCompanionSteps";
+import useFirstStepCompanionState from "~/screens/SyncOnboarding/TwoStepStepper/useFirstStepCompanionState";
+import { useTrackOnboardingFlow } from "~/analytics/hooks/useTrackOnboardingFlow";
+import { OnboardingStep } from "@ledgerhq/live-common/hw/extractOnboardingState";
+import { FirstStepCompanionStepKey } from "~/screens/SyncOnboarding/TwoStepStepper/types";
+import {
+  SEED_STATE,
+  useFirstStepSyncOnboardingViewModel,
+} from "../components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel";
+
+jest.mock("@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling");
+jest.mock("@ledgerhq/live-common/featureFlags/index");
+jest.mock("@react-navigation/core");
+jest.mock("~/context/hooks");
+jest.mock("~/context/Locale");
+jest.mock("LLM/features/Onboarding/screens/SyncOnboardingCompanion/hooks/useCompanionSteps");
+jest.mock("~/screens/SyncOnboarding/TwoStepStepper/useFirstStepCompanionState");
+jest.mock("~/analytics/hooks/useTrackOnboardingFlow");
+
+const mockDevice = {
+  deviceId: "test-device-123",
+  deviceName: "Test Device",
+  modelId: "nanoS",
+};
+
+const createDefaultProps = (overrides = {}) => ({
+  device: mockDevice,
+  productName: "Nano S",
+  navigation: {
+    navigate: jest.fn(),
+  } as any,
+  handleSeedGenerationDelay: jest.fn(),
+  onLostDevice: jest.fn(),
+  notifyEarlySecurityCheckShouldReset: jest.fn(),
+  handlePollingError: jest.fn(() => undefined),
+  isPollingOn: true,
+  setIsPollingOn: jest.fn(),
+  handleFinishStep: jest.fn(),
+  parentRef: null,
+  analyticsSeedConfiguration: { current: undefined },
+  ...overrides,
+});
+
+describe("useFirstStepSyncOnboardingViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useTranslation as jest.Mock).mockReturnValue({ t: jest.fn() });
+    (useIsFocused as jest.Mock).mockReturnValue(true);
+    (useDispatch as jest.Mock).mockReturnValue(jest.fn());
+    (useSelector as jest.Mock).mockReturnValue(false);
+    (useFeature as jest.Mock).mockReturnValue({ enabled: false });
+    (useOnboardingStatePolling as jest.Mock).mockReturnValue({
+      onboardingState: null,
+      allowedError: null,
+      fatalError: null,
+    });
+    (useCompanionSteps as jest.Mock).mockReturnValue({
+      activeStep: FirstStepCompanionStepKey.Start,
+      setStep: jest.fn(),
+      hasSyncStep: false,
+      isLedgerSyncActive: false,
+    });
+    (useFirstStepCompanionState as jest.Mock).mockReturnValue(undefined);
+    (useTrackOnboardingFlow as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it("should initialize with correct default state", () => {
+    const props = createDefaultProps();
+    const { result } = renderHook(() => useFirstStepSyncOnboardingViewModel(props));
+
+    expect(result.current.seedPathStatus).toBe("choice_new_or_restore");
+    expect(result.current.hasFinishedExitAnimation).toBe(false);
+    expect(result.current.isFinishedStep).toBe(false);
+  });
+
+  it("should call handlePollingError when allowedError changes", () => {
+    const handlePollingError = jest.fn(() => undefined);
+    const props = createDefaultProps({ handlePollingError });
+    const testError = new Error("Test error");
+
+    (useOnboardingStatePolling as jest.Mock).mockReturnValue({
+      onboardingState: null,
+      allowedError: testError,
+      fatalError: null,
+    });
+
+    renderHook(() => useFirstStepSyncOnboardingViewModel(props));
+
+    expect(handlePollingError).toHaveBeenCalledWith(testError);
+  });
+
+  it("should call onLostDevice and setIsPollingOn when fatalError occurs", async () => {
+    const onLostDevice = jest.fn();
+    const setIsPollingOn = jest.fn();
+    const props = createDefaultProps({ onLostDevice, setIsPollingOn });
+    const fatalError = new Error("Fatal error");
+
+    const { rerender } = renderHook(() => useFirstStepSyncOnboardingViewModel(props), {
+      initialProps: props,
+    });
+
+    (useOnboardingStatePolling as jest.Mock).mockReturnValue({
+      onboardingState: null,
+      allowedError: null,
+      fatalError: null,
+    });
+
+    rerender(props);
+
+    (useOnboardingStatePolling as jest.Mock).mockReturnValue({
+      onboardingState: null,
+      allowedError: null,
+      fatalError,
+    });
+
+    rerender(props);
+
+    await waitFor(() => {
+      expect(onLostDevice).toHaveBeenCalled();
+      expect(setIsPollingOn).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("should add device to known devices when activeStep is greater than Ready", async () => {
+    const dispatchRedux = jest.fn();
+    const setIsPollingOn = jest.fn();
+    const props = createDefaultProps({ setIsPollingOn });
+
+    (useDispatch as jest.Mock).mockReturnValue(dispatchRedux);
+    (useCompanionSteps as jest.Mock).mockReturnValue({
+      activeStep: FirstStepCompanionStepKey.Seed,
+      setStep: jest.fn(),
+      hasSyncStep: false,
+      isLedgerSyncActive: false,
+    });
+
+    const { rerender } = renderHook(() => useFirstStepSyncOnboardingViewModel(props));
+
+    (useCompanionSteps as jest.Mock).mockReturnValue({
+      activeStep: FirstStepCompanionStepKey.Sync,
+      setStep: jest.fn(),
+      hasSyncStep: false,
+      isLedgerSyncActive: false,
+    });
+
+    rerender(props);
+
+    await waitFor(() => {
+      expect(setIsPollingOn).toHaveBeenCalledWith(false);
+      expect(dispatchRedux).toHaveBeenCalled();
+    });
+  });
+
+  it("should stop polling when activeStep is greater than Ready", async () => {
+    const setIsPollingOn = jest.fn();
+    const props = createDefaultProps({ setIsPollingOn });
+
+    (useCompanionSteps as jest.Mock).mockReturnValue({
+      activeStep: FirstStepCompanionStepKey.Ready,
+      setStep: jest.fn(),
+      hasSyncStep: false,
+      isLedgerSyncActive: false,
+    });
+
+    renderHook(() => useFirstStepSyncOnboardingViewModel(props));
+
+    await waitFor(() => {
+      expect(setIsPollingOn).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("should call handleSeedGenerationDelay when seed phrase generation is near completion", async () => {
+    const handleSeedGenerationDelay = jest.fn();
+    const props = createDefaultProps({ handleSeedGenerationDelay });
+
+    (useOnboardingStatePolling as jest.Mock).mockReturnValue({
+      onboardingState: {
+        seedPhraseType: 24,
+        currentOnboardingStep: OnboardingStep.NewDeviceConfirming,
+        currentSeedWordIndex: 22,
+        isOnboarded: false,
+      },
+      allowedError: null,
+      fatalError: null,
+    });
+
+    renderHook(() => useFirstStepSyncOnboardingViewModel(props));
+
+    await waitFor(() => {
+      expect(handleSeedGenerationDelay).toHaveBeenCalled();
+    });
+  });
+
+  it("should initialize deviceInitiallyOnboarded from onboardingState", async () => {
+    const props = createDefaultProps();
+
+    (useOnboardingStatePolling as jest.Mock).mockReturnValue({
+      onboardingState: {
+        isOnboarded: false,
+        seedPhraseType: 12,
+        currentOnboardingStep: OnboardingStep.NewDeviceConfirming,
+        currentSeedWordIndex: 0,
+      },
+      allowedError: null,
+      fatalError: null,
+    });
+
+    const { result } = renderHook(() => useFirstStepSyncOnboardingViewModel(props));
+
+    expect(result.current).toBeDefined();
+  });
+
+  it("should call handleNextStep and trigger exit animation", async () => {
+    const handleFinishStep = jest.fn();
+    const setStep = jest.fn();
+    const props = createDefaultProps({
+      handleFinishStep,
+      analyticsSeedConfiguration: { current: SEED_STATE.NEW_SEED },
+    });
+
+    (useCompanionSteps as jest.Mock).mockReturnValue({
+      activeStep: FirstStepCompanionStepKey.Seed,
+      setStep,
+      hasSyncStep: false,
+      isLedgerSyncActive: false,
+    });
+
+    const { result } = renderHook(() => useFirstStepSyncOnboardingViewModel(props));
+
+    result.current.handleNextStep();
+
+    expect(result.current.isFinishedStep).toBe(true);
+    expect(handleFinishStep).toHaveBeenCalledWith(SEED_STATE.NEW_SEED);
+  });
+
+  it("should return formatEstimatedTime function", () => {
+    const props = createDefaultProps();
+    const { result } = renderHook(() => useFirstStepSyncOnboardingViewModel(props));
+
+    expect(typeof result.current.formatEstimatedTime).toBe("function");
+  });
+
+  it("should return handleLayout function", () => {
+    const props = createDefaultProps();
+    const { result } = renderHook(() => useFirstStepSyncOnboardingViewModel(props));
+
+    expect(typeof result.current.handleLayout).toBe("function");
+  });
+
+  it("should stop polling on unmount", () => {
+    const setIsPollingOn = jest.fn();
+    const props = createDefaultProps({ setIsPollingOn });
+
+    const { unmount } = renderHook(() => useFirstStepSyncOnboardingViewModel(props));
+
+    unmount();
+
+    expect(setIsPollingOn).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/assets/BackgroundGreen.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/assets/BackgroundGreen.tsx
@@ -49,7 +49,7 @@ const BackgroundGreen = () => {
         </Mask>
       </Defs>
 
-      {/* 4a. purple base */}
+      {/* 4a. green base */}
       <Rect width="100%" height="100%" fill="#6EC85C" mask="url(#fadeMask1)" opacity={0.3} />
 
       <Rect width="100%" height="100%" fill="#6EC85C" mask="url(#fadeMask2)" opacity={0.2} />

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/DeviceSeededSuccessPanel.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/DeviceSeededSuccessPanel.tsx
@@ -2,24 +2,18 @@ import React, { useEffect, useRef } from "react";
 import { BoxedIcon, Flex, Icons, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "~/context/Locale";
 
-/*
- * Constants
- */
+const READY_REDIRECT_DELAY_MS = 2_500;
 
-const READY_REDIRECT_DELAY_MS = 2500;
+type DeviceSeededSuccessPanelProps = {
+  handleNextStep: () => void;
+  productName: string;
+};
 
 const DeviceSeededSuccessPanel = ({
   handleNextStep,
   productName,
-}: {
-  handleNextStep: () => void;
-  productName: string;
-}) => {
+}: DeviceSeededSuccessPanelProps) => {
   const { t } = useTranslation();
-
-  /*
-   * Refs
-   */
   const readyRedirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Handle move to second step
@@ -35,7 +29,13 @@ const DeviceSeededSuccessPanel = ({
   }, [handleNextStep]);
 
   return (
-    <Flex height="264px" justifyContent="center" alignItems="center" marginX="16px">
+    <Flex
+      height="264px"
+      justifyContent="center"
+      alignItems="center"
+      marginX="16px"
+      testID="device-seeded-success-panel"
+    >
       <BoxedIcon
         backgroundColor="opacityDefault.c10"
         borderColor="transparent"

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/index.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import Animated from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Flex, VerticalTimeline } from "@ledgerhq/native-ui";
+import { TrackScreen } from "~/analytics";
+import { useTranslation } from "~/context/Locale";
+import { FirstStepCompanionStepKey } from "~/screens/SyncOnboarding/TwoStepStepper/types";
+import BackgroundGreen from "LLM/features/Onboarding/screens/SyncOnboardingCompanion/assets/BackgroundGreen";
+import CollapsibleStep from "LLM/features/Onboarding/screens/SyncOnboardingCompanion/components/CollapsibleStep";
+import DeviceSeededSuccessPanel from "./DeviceSeededSuccessPanel";
+import {
+  FirstStepSyncOnboardingProps,
+  useFirstStepSyncOnboardingViewModel,
+} from "./useFirstStepSyncOnboardingViewModel";
+
+const FirstStepSyncOnboarding = ({
+  device,
+  productName,
+  navigation,
+  onLostDevice,
+  handleSeedGenerationDelay,
+  notifyEarlySecurityCheckShouldReset,
+  handlePollingError,
+  isPollingOn,
+  setIsPollingOn,
+  handleFinishStep,
+  parentRef,
+  analyticsSeedConfiguration,
+}: FirstStepSyncOnboardingProps) => {
+  const { t } = useTranslation();
+  const safeAreaInsets = useSafeAreaInsets();
+
+  const {
+    companionSteps,
+    hasFinishedExitAnimation,
+    isFinishedStep,
+    formatEstimatedTime,
+    animatedStyle,
+    handleLayout,
+    handleNextStep,
+  } = useFirstStepSyncOnboardingViewModel({
+    device,
+    productName,
+    navigation,
+    onLostDevice,
+    handleSeedGenerationDelay,
+    notifyEarlySecurityCheckShouldReset,
+    handlePollingError,
+    isPollingOn,
+    setIsPollingOn,
+    handleFinishStep,
+    parentRef,
+    analyticsSeedConfiguration,
+  });
+
+  return (
+    <CollapsibleStep
+      isFirst
+      isCollapsed={hasFinishedExitAnimation}
+      title={
+        companionSteps.activeStep <= FirstStepCompanionStepKey.Seed
+          ? t("syncOnboarding.title", { productName })
+          : t("syncOnboarding.firstStepReadyTitle", { productName })
+      }
+      status={
+        companionSteps.activeStep >= FirstStepCompanionStepKey.Ready ? "complete" : "unfinished"
+      }
+      hideTitle={!isFinishedStep && companionSteps.activeStep === FirstStepCompanionStepKey.Ready}
+      background={
+        companionSteps.activeStep === FirstStepCompanionStepKey.Ready && !isFinishedStep ? (
+          <Animated.View
+            style={[{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }, animatedStyle]}
+          >
+            <BackgroundGreen />
+          </Animated.View>
+        ) : null
+      }
+    >
+      {companionSteps.activeStep !== FirstStepCompanionStepKey.Ready && (
+        <Flex mt={3}>
+          <VerticalTimeline
+            steps={companionSteps.steps}
+            formatEstimatedTime={formatEstimatedTime}
+            contentContainerStyle={{ paddingBottom: safeAreaInsets.bottom }}
+            parentScrollRef={parentRef}
+          />
+        </Flex>
+      )}
+      <Animated.ScrollView style={animatedStyle} showsVerticalScrollIndicator={false}>
+        <Animated.View onLayout={handleLayout}>
+          {companionSteps.activeStep === FirstStepCompanionStepKey.Ready && !isFinishedStep ? (
+            <>
+              <TrackScreen
+                category="Set up device: Final Step Your device is ready"
+                flow="onboarding"
+                seedConfiguration={analyticsSeedConfiguration.current}
+              />
+
+              <DeviceSeededSuccessPanel handleNextStep={handleNextStep} productName={productName} />
+            </>
+          ) : null}
+        </Animated.View>
+      </Animated.ScrollView>
+    </CollapsibleStep>
+  );
+};
+
+export default FirstStepSyncOnboarding;

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding/useFirstStepSyncOnboardingViewModel.ts
@@ -1,43 +1,48 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Flex, VerticalTimeline } from "@ledgerhq/native-ui";
-import CollapsibleStep from "LLM/features/Onboarding/screens/SyncOnboardingCompanion/components/CollapsibleStep";
-import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { useTranslation } from "~/context/Locale";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { SyncOnboardingScreenProps } from "../SyncOnboardingScreenProps";
-import { NavigatorName, ScreenName } from "~/const";
-import { useSelector, useDispatch } from "~/context/hooks";
-import { useOnboardingStatePolling } from "@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling";
-import { isAllowedOnboardingStatePollingErrorDmk } from "@ledgerhq/live-dmk-mobile";
-import { SeedOriginType, SeedPhraseType } from "@ledgerhq/types-live";
-import { setIsReborn, setLastConnectedDevice, setOnboardingHasDevice } from "~/actions/settings";
-import { addKnownDevice } from "~/actions/ble";
-import { screen, TrackScreen } from "~/analytics";
-import { hasCompletedOnboardingSelector } from "~/reducers/settings";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { LayoutChangeEvent, ScrollView } from "react-native";
 import {
-  OnboardingStep as DeviceOnboardingStep,
-  fromSeedPhraseTypeToNbOfSeedWords,
-} from "@ledgerhq/live-common/hw/extractOnboardingState";
-import useFirstStepCompanionState from "./useFirstStepCompanionState";
-import { useTrackOnboardingFlow } from "~/analytics/hooks/useTrackOnboardingFlow";
-import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
-import DeviceSeededSuccessPanel from "./DeviceSeededSuccessPanel";
-import BackgroundGreen from "../assets/BackgroundGreen";
-import Animated, {
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
-import { LayoutChangeEvent, ScrollView } from "react-native";
-import { SEED_STATE, SeedPathStatus, FirstStepCompanionStepKey } from "./types";
 import { useIsFocused } from "@react-navigation/core";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import {
+  OnboardingStep,
+  fromSeedPhraseTypeToNbOfSeedWords,
+} from "@ledgerhq/live-common/hw/extractOnboardingState";
+import { useOnboardingStatePolling } from "@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling";
+import { isAllowedOnboardingStatePollingErrorDmk } from "@ledgerhq/live-dmk-mobile";
+import { Device } from "@ledgerhq/types-devices";
+import { SeedOriginType, SeedPhraseType } from "@ledgerhq/types-live";
+import { addKnownDevice } from "~/actions/ble";
+import { setIsReborn, setLastConnectedDevice, setOnboardingHasDevice } from "~/actions/settings";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { useTranslation } from "~/context/Locale";
+import { NavigatorName, ScreenName } from "~/const";
+import { hasCompletedOnboardingSelector } from "~/reducers/settings";
+import { FirstStepCompanionStepKey } from "~/screens/SyncOnboarding/TwoStepStepper/types";
+import { SyncOnboardingScreenProps } from "~/screens/SyncOnboarding/SyncOnboardingScreenProps";
+import useFirstStepCompanionState from "~/screens/SyncOnboarding/TwoStepStepper/useFirstStepCompanionState";
 import useCompanionSteps from "LLM/features/Onboarding/screens/SyncOnboardingCompanion/hooks/useCompanionSteps";
+import { screen } from "~/analytics";
+import { useTrackOnboardingFlow } from "~/analytics/hooks/useTrackOnboardingFlow";
+import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 
-/*
- * Constants
- */
+export enum SEED_STATE {
+  NEW_SEED = "new_seed",
+  RESTORE = "restore",
+}
+
+export type SeedPathStatus =
+  | "choice_new_or_restore"
+  | "new_seed"
+  | "choice_restore_direct_or_recover"
+  | "restore_seed"
+  | "recover_seed"
+  | "backup_charon"
+  | "restore_charon";
 
 const POLLING_PERIOD_MS = 1000;
 const OPACITY_DURATION = 400;
@@ -48,11 +53,7 @@ const fromSeedPhraseTypeToAnalyticsPropertyString = new Map<SeedPhraseType, stri
   [SeedPhraseType.Twelve, "Twelve"],
 ]);
 
-/*
- * Types
- */
-
-interface FirstStepSyncOnboardingProps {
+export interface FirstStepSyncOnboardingProps {
   device: Device;
   productName: string;
   navigation: SyncOnboardingScreenProps["navigation"];
@@ -77,12 +78,12 @@ interface FirstStepSyncOnboardingProps {
   analyticsSeedConfiguration: React.RefObject<SeedOriginType | undefined>;
 }
 
-const FirstStepSyncOnboarding = ({
+export const useFirstStepSyncOnboardingViewModel = ({
   device,
   productName,
   navigation,
-  onLostDevice,
   handleSeedGenerationDelay,
+  onLostDevice,
   notifyEarlySecurityCheckShouldReset,
   handlePollingError,
   isPollingOn,
@@ -92,25 +93,14 @@ const FirstStepSyncOnboarding = ({
   analyticsSeedConfiguration,
 }: FirstStepSyncOnboardingProps) => {
   const { t } = useTranslation();
-  const safeAreaInsets = useSafeAreaInsets();
   const isFocused = useIsFocused();
-
-  /*
-   * Local State
-   */
 
   const [seedPathStatus, setSeedPathStatus] = useState<SeedPathStatus>("choice_new_or_restore");
   const [hasFinishedExitAnimation, setHasFinishedExitAnimation] = useState<boolean>(false);
   const [isFinishedStep, setIsFinishedStep] = useState<boolean>(false);
 
-  /*
-   * Feature Flags
-   */
   const servicesConfig = useFeature("protectServicesMobile");
 
-  /*
-   * Refs
-   */
   const lastCompanionStepKey = useRef<FirstStepCompanionStepKey | undefined>(undefined);
   const analyticsSeedingTracked = useRef(false);
   const addedToKnownDevices = useRef(false);
@@ -252,11 +242,6 @@ const FirstStepSyncOnboarding = ({
   ]);
 
   /*
-   * useEffects
-   * Divided into three lifecycle events as logic is complex
-   */
-
-  /*
    * Initial effects
    */
 
@@ -391,7 +376,7 @@ const FirstStepSyncOnboarding = ({
   useEffect(() => {
     if (
       deviceOnboardingState?.seedPhraseType &&
-      [DeviceOnboardingStep.NewDeviceConfirming, DeviceOnboardingStep.RestoreSeed].includes(
+      [OnboardingStep.NewDeviceConfirming, OnboardingStep.RestoreSeed].includes(
         deviceOnboardingState?.currentOnboardingStep,
       )
     ) {
@@ -463,56 +448,15 @@ const FirstStepSyncOnboarding = ({
     analyticsSeedConfiguration,
   ]);
 
-  return (
-    <CollapsibleStep
-      isFirst
-      isCollapsed={hasFinishedExitAnimation}
-      title={
-        companionSteps.activeStep <= FirstStepCompanionStepKey.Seed
-          ? t("syncOnboarding.title", { productName })
-          : t("syncOnboarding.firstStepReadyTitle", { productName })
-      }
-      status={
-        companionSteps.activeStep >= FirstStepCompanionStepKey.Ready ? "complete" : "unfinished"
-      }
-      hideTitle={!isFinishedStep && companionSteps.activeStep === FirstStepCompanionStepKey.Ready}
-      background={
-        showSuccess && !isFinishedStep ? (
-          <Animated.View
-            style={[{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }, animatedStyle]}
-          >
-            <BackgroundGreen />
-          </Animated.View>
-        ) : null
-      }
-    >
-      {!showSuccess && (
-        <Flex mt={3}>
-          <VerticalTimeline
-            steps={companionSteps.steps}
-            formatEstimatedTime={formatEstimatedTime}
-            contentContainerStyle={{ paddingBottom: safeAreaInsets.bottom }}
-            parentScrollRef={parentRef}
-          />
-        </Flex>
-      )}
-      <Animated.ScrollView style={animatedStyle} showsVerticalScrollIndicator={false}>
-        <Animated.View onLayout={handleLayout}>
-          {showSuccess ? (
-            <>
-              <TrackScreen
-                category="Set up device: Final Step Your device is ready"
-                flow="onboarding"
-                seedConfiguration={analyticsSeedConfiguration.current}
-              />
-
-              <DeviceSeededSuccessPanel handleNextStep={handleNextStep} productName={productName} />
-            </>
-          ) : null}
-        </Animated.View>
-      </Animated.ScrollView>
-    </CollapsibleStep>
-  );
+  return {
+    animatedStyle,
+    handleLayout,
+    formatEstimatedTime,
+    handleNextStep,
+    seedPathStatus,
+    setSeedPathStatus,
+    hasFinishedExitAnimation,
+    isFinishedStep,
+    companionSteps,
+  };
 };
-
-export default FirstStepSyncOnboarding;

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/TwoStepStepper/TwoStepSyncOnboardingCompanion.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/TwoStepStepper/TwoStepSyncOnboardingCompanion.tsx
@@ -20,7 +20,7 @@ import {
   setIsOnboardingFlowReceiveSuccess,
   setReadOnlyMode,
 } from "~/actions/settings";
-import FirstStepSyncOnboarding from "./FirstStepSyncOnboarding";
+import FirstStepSyncOnboarding from "LLM/features/Onboarding/screens/SyncOnboardingCompanion/components/FirstStepSyncOnboarding";
 import SecondStepSyncOnboarding from "./SecondStepSyncOnboarding";
 import { useTranslation } from "~/context/Locale";
 import { ScrollView } from "react-native";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Migrate `FirstStepSyncOnboarding` component to new MVVM architecture.

### 📝 Description
This pull request refactors and modularizes the onboarding companion's first step components, improves test coverage, and introduces a new background visual. The changes move logic and UI components from legacy locations to a new MVVM structure, enhance maintainability, and add a dedicated integration test suite. The most important changes are grouped below by theme:

**Component Refactoring and Modularization**

* Migrated and refactored `FirstStepSyncOnboarding` logic and UI from legacy files to a new MVVM structure, splitting out the view model (`useFirstStepSyncOnboardingViewModel.ts`) and updating type definitions for clarity and maintainability. [[1]](diffhunk://#diff-3ae45cad378ecf9266d619b67c771c4f2247975d210b9086541dcea1282c115bL1-R53) [[2]](diffhunk://#diff-3ae45cad378ecf9266d619b67c771c4f2247975d210b9086541dcea1282c115bL51-R64) [[3]](diffhunk://#diff-3ae45cad378ecf9266d619b67c771c4f2247975d210b9086541dcea1282c115bL80-R94) [[4]](diffhunk://#diff-3ae45cad378ecf9266d619b67c771c4f2247975d210b9086541dcea1282c115bL95-L113) [[5]](diffhunk://#diff-3ae45cad378ecf9266d619b67c771c4f2247975d210b9086541dcea1282c115bL254-L258) [[6]](diffhunk://#diff-3ae45cad378ecf9266d619b67c771c4f2247975d210b9086541dcea1282c115bL394-R387)
* Created a new `FirstStepSyncOnboarding` component (`index.tsx`) that cleanly separates UI rendering, background visuals, and step logic, using the new view model and improved props structure.
* Updated and clarified the props and types for `DeviceSeededSuccessPanel` to use a dedicated type, improving readability and reducing inline type definitions.

**Visual Improvements**

* Introduced a new `BackgroundGreen` SVG component for enhanced step background visuals, using gradients and patterns for a modern look.

**Testing Enhancements**

* Added a comprehensive integration test suite for `FirstStepSyncOnboarding`, covering step rendering, transitions, and UI state under various conditions.

These changes collectively improve the onboarding experience's maintainability, testability, and visual polish.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-22507]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-22507]: https://ledgerhq.atlassian.net/browse/LIVE-22507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ