### PR TITLE
docs(e2e): add mobile E2E onboarding command and update README

### DIFF
--- a/.cursor/commands/e2e-mobile-onboard.md
+++ b/.cursor/commands/e2e-mobile-onboard.md
@@ -8,6 +8,8 @@ You are an interactive setup wizard that checks the developer's machine and guid
 
 Work through each phase sequentially. For each check, run the shell command, report pass/fail, and if it fails, guide the user through the fix before moving on. Use TodoWrite to track progress across phases.
 
+**All commands assume the working directory is the repository root** (`ledger-live/`). Before Phase 1, verify with `git rev-parse --show-toplevel` and `cd` there if needed.
+
 **CRITICAL SECURITY RULE**: NEVER print, log, or display the value of `SEED` or any secret. Only confirm whether it is set or not.
 
 **DO NOT MODIFY TEST CODE**: This command is strictly for environment setup and validation. Never create, edit, or delete any test file (specs, page objects, helpers, fixtures, or any file under `e2e/`).
@@ -55,8 +57,8 @@ First, read the config files to determine expected versions. Then run these chec
 
 `.prototools` is the source of truth for the **recommended** versions. The check should:
 - **PASS** if the active version matches the pinned version exactly.
-- **WARN** if the active major version matches but the minor/patch differs (e.g. pinned `22.13.1`, active `22.14.0`). This is acceptable and should not block the setup.
-- **FAIL** only if the active major version is different or older than the pinned major version (e.g. pinned Node 22, active Node 20).
+- **WARN** if the active major version matches but the minor/patch differs (e.g. pinned `22.13.1`, active `22.14.0`). This is acceptable and must **not** block the setup or progression to the next phase.
+- **FAIL** only if the active major version is different or older than the pinned major version (e.g. pinned Node 22, active Node 20). Only **FAIL** results are hard blockers that must be resolved before proceeding.
 
 Do not fail just because the binary path is not under `~/.proto/`. The version is what matters, not the install method. If Proto is installed, suggest running `proto use` from the repo root to align versions.
 
@@ -98,7 +100,7 @@ Do not fail just because the binary path is not under `~/.proto/`. The version i
   export PATH=$PATH:$ANDROID_HOME/emulator:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin
   ```
 
-**Do not proceed to Phase 2 until all relevant checks pass.**
+**Do not proceed to Phase 2 until all relevant FAIL-level checks are resolved.** WARN-only results (Proto absence, `sdkmanager` missing, Node/pnpm minor/patch drift) should be surfaced but must not block progression.
 
 ---
 

--- a/e2e/mobile/README.md
+++ b/e2e/mobile/README.md
@@ -48,7 +48,7 @@ export SEED=$(op read "op://Vault/Item/field")
 
 ### 3. Build
 
-Install dependencies and build the app for testing:
+All build commands below are run from the **repo root** (`ledger-live/`).
 
 ```bash
 pnpm clean


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not applicable — changes are developer tooling (Cursor command) and documentation only. No published package is affected._
- [ ] **Covered by automatic tests.** _No automated tests — this is a Cursor command prompt file and a README update. Validated by running the onboarding flow end-to-end on a local machine (iOS + Android)._
- [x] **Impact of the changes:**
      - Running `/e2e-mobile-onboard` in Cursor to validate the interactive setup wizard
      - Accuracy of the updated `e2e/mobile/README.md` build and test commands

### 📝 Description

**Problem**: Setting up a local machine for mobile E2E (Detox) testing requires following scattered documentation across the wiki, README, and tribal knowledge. Developers frequently hit environment issues (wrong architecture, missing env vars, incorrect simulator names) that take hours to debug.

**Solution**: 

1. **New Cursor command** (`.cursor/commands/e2e-mobile-onboard.md`): An interactive setup wizard that checks every prerequisite on the developer's machine, validates environment variables, and guides through fixes step by step. It covers:
   - Platform selection (iOS / Android / Both) to skip irrelevant checks
   - System tools with version policy (warn vs fail based on compatibility, not exact match)
   - Environment variables with secure SEED handling (1Password CLI recommended, manual export accepted)
   - Simulator/emulator setup with auto-create offers
   - CI ambient variable detection to prevent wrong-ABI builds on Apple Silicon
   - Emulator free-space preflight checks
   - Dependency install, lib build, CLI build, platform-specific app build
   - Smoke test with failure classification (setup vs project vs test-flow issues)

2. **Updated `e2e/mobile/README.md`**:
   - Android now uses **release** builds (debug is broken due to a known Detox/Espresso `eventInjector` bug)
   - iOS stays on debug (requires Metro bundler)
   - SEED guidance updated to use 1Password CLI, never show plaintext placeholder
   - Fixed incorrect `pnpm e2e:mobile` commands to correct `pnpm test:android` / `pnpm test:ios:debug` form
   - Added reference to the `/e2e-mobile-onboard` Cursor command

### ❓ Context

- **JIRA or GitHub link**: [QAA-1000](https://ledgerhq.atlassian.net/browse/QAA-1000)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1000]: https://ledgerhq.atlassian.net/browse/QAA-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ