### PR TITLE
[LWDM] fix(LIVE-27295): remove staking reward suffix from hedera operations in alpaca

### DIFF
--- a/.changeset/beige-ducks-count.md
+++ b/.changeset/beige-ducks-count.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix: remove staking reward suffix from hedera operations in alpaca

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -13,7 +13,7 @@ import type { FeeEstimation } from "@ledgerhq/coin-framework/api/types";
 import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
 import invariant from "invariant";
 import { createApi } from "../api";
-import { HEDERA_TRANSACTION_MODES, TINYBAR_SCALE } from "../constants";
+import { HEDERA_TRANSACTION_MODES, STAKING_REWARD_HASH_SUFFIX, TINYBAR_SCALE } from "../constants";
 import { getSyntheticBlock, toEVMAddress } from "../logic/utils";
 import { rpcClient } from "../network/rpc";
 import { MAINNET_TEST_ACCOUNTS } from "../test/fixtures/account.fixture";
@@ -873,6 +873,7 @@ describe("createApi", () => {
       });
       expect(rewardOp?.value).toBeGreaterThan(BigInt(0));
       expect(rewardOp?.tx.fees).toBe(BigInt(0));
+      expect(rewardOp?.tx.hash).not.toContain(STAKING_REWARD_HASH_SUFFIX);
       // every staking operation should have a fees payer
       expect(ops.every(op => /^0\.0\.\d+$/.test(op.tx.feesPayer ?? ""))).toBe(true);
     });

--- a/libs/coin-modules/coin-hedera/src/api/index.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.ts
@@ -9,7 +9,11 @@ import type { Operation as LiveOperation } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import coinConfig, { type HederaConfig } from "../config";
-import { HARDCODED_BLOCK_HEIGHT, HEDERA_OPERATION_TYPES } from "../constants";
+import {
+  HARDCODED_BLOCK_HEIGHT,
+  HEDERA_OPERATION_TYPES,
+  STAKING_REWARD_HASH_SUFFIX,
+} from "../constants";
 import {
   broadcast as logicBroadcast,
   combine,
@@ -184,6 +188,12 @@ export function createApi(config: HederaConfig, currencyId: string): Api<HederaM
           ? extractFeesPayer(liveOp.extra.transactionId)
           : undefined;
 
+        // REWARD operations append a suffix to the tx.hash to ensure uniqueness
+        const hash =
+          liveOp.type === "REWARD"
+            ? liveOp.hash.replace(STAKING_REWARD_HASH_SUFFIX, "")
+            : liveOp.hash;
+
         return {
           id: liveOp.id,
           type: liveOp.type,
@@ -200,7 +210,7 @@ export function createApi(config: HederaConfig, currencyId: string): Api<HederaM
             }),
           },
           tx: {
-            hash: liveOp.hash,
+            hash,
             fees: BigInt(liveOp.fee.toFixed(0)),
             ...(feesPayer && { feesPayer }),
             date: liveOp.date,

--- a/libs/coin-modules/coin-hedera/src/constants.ts
+++ b/libs/coin-modules/coin-hedera/src/constants.ts
@@ -154,3 +154,9 @@ export const OP_TYPES_EXCLUDING_FEES: OperationType[] = [
   "UPDATE_ACCOUNT",
   "CONTRACT_CALL",
 ];
+
+/**
+ * Suffix used for staking reward Ledger operations to distinguish them from operations that trigger the rewards claim.
+ * Since staking rewards on Hedera are not represented as separate transactions, we need to create synthetic operations for them.
+ */
+export const STAKING_REWARD_HASH_SUFFIX = "-staking-reward";

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.test.ts
@@ -21,6 +21,9 @@ describe("listOperations", () => {
     (utils.getMemoFromBase64 as jest.Mock).mockImplementation(memo =>
       memo ? `decoded-${memo}` : null,
     );
+    (utils.createStakingRewardOperationHash as jest.Mock).mockImplementation(
+      hash => `${hash}-reward`,
+    );
     (encodeOperationId as jest.Mock).mockImplementation(
       (accountId, hash, type) => `${accountId}-${hash}-${type}`,
     );
@@ -41,7 +44,6 @@ describe("listOperations", () => {
     const result = await listOperations({
       currency: mockCurrency,
       address,
-      minHeight: 0,
       limit: 10,
       order: "asc",
       mirrorTokens: [],
@@ -93,7 +95,6 @@ describe("listOperations", () => {
     const result = await listOperations({
       currency: mockCurrency,
       address,
-      minHeight: 0,
       limit: 10,
       order: "desc",
       mirrorTokens: [],
@@ -167,7 +168,6 @@ describe("listOperations", () => {
     const result = await listOperations({
       currency: mockCurrency,
       address,
-      minHeight: 0,
       limit: 10,
       order: "desc",
       mirrorTokens: [],
@@ -227,7 +227,6 @@ describe("listOperations", () => {
     const result = await listOperations({
       currency: mockCurrency,
       address,
-      minHeight: 0,
       limit: 10,
       order: "desc",
       mirrorTokens: [],
@@ -289,7 +288,6 @@ describe("listOperations", () => {
     const result = await listOperations({
       currency: mockCurrency,
       address,
-      minHeight: 0,
       limit: 10,
       order: "desc",
       mirrorTokens: [],
@@ -315,7 +313,6 @@ describe("listOperations", () => {
     await listOperations({
       currency: mockCurrency,
       address,
-      minHeight: 0,
       limit: 20,
       order: "asc",
       cursor: "1625097500.000000000",
@@ -366,7 +363,6 @@ describe("listOperations", () => {
     const result = await listOperations({
       currency: mockCurrency,
       address,
-      minHeight: 0,
       limit: 10,
       order: "desc",
       mirrorTokens: [],
@@ -408,7 +404,6 @@ describe("listOperations", () => {
     const result = await listOperations({
       currency: mockCurrency,
       address,
-      minHeight: 0,
       limit: 10,
       order: "desc",
       mirrorTokens: [],
@@ -426,7 +421,7 @@ describe("listOperations", () => {
     expect(result.coinOperations).toMatchObject([
       {
         type: "REWARD",
-        hash: `${mockTransaction.transaction_hash}-staking-reward`,
+        hash: utils.createStakingRewardOperationHash(mockTransaction.transaction_hash ?? ""),
         value: new BigNumber(1000000),
         fee: new BigNumber(0),
         senders: [getEnv("HEDERA_STAKING_REWARD_ACCOUNT_ID")],

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.ts
@@ -17,6 +17,7 @@ import type {
 import {
   analyzeStakingOperation,
   base64ToUrlSafeBase64,
+  createStakingRewardOperationHash,
   getMemoFromBase64,
   getSyntheticBlock,
 } from "./utils";
@@ -194,7 +195,7 @@ function processTransfers({
 
   // add REWARD operation representing staking reward transfers
   if (stakingReward.gt(0)) {
-    const stakingRewardHash = `${hash}-staking-reward`;
+    const stakingRewardHash = createStakingRewardOperationHash(hash);
     const stakingRewardType: OperationType = "REWARD";
     // offset timestamp by +1ms to ensure it appears just before the operation that triggered it
     const stakingRewardTimestamp = new Date(timestamp.getTime() + 1);

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -667,7 +667,7 @@ describe("listOperationsV2", () => {
     expect(result.coinOperations).toMatchObject([
       {
         type: "REWARD",
-        hash: `${mockTransaction.transaction_hash}-staking-reward`,
+        hash: utils.createStakingRewardOperationHash(mockTransaction.transaction_hash ?? ""),
         value: new BigNumber(1000000),
         fee: new BigNumber(0),
         senders: [getEnv("HEDERA_STAKING_REWARD_ACCOUNT_ID")],
@@ -754,7 +754,7 @@ describe("listOperationsV2", () => {
     expect(result.coinOperations).toEqual([
       expect.objectContaining({
         type: "REWARD",
-        hash: `${mockMirrorTransaction.transaction_hash}-staking-reward`,
+        hash: utils.createStakingRewardOperationHash(mockMirrorTransaction.transaction_hash ?? ""),
         value: new BigNumber(mockRewardAmount),
       }),
       expect.objectContaining({

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -21,6 +21,7 @@ import type {
 import {
   analyzeStakingOperation,
   base64ToUrlSafeBase64,
+  createStakingRewardOperationHash,
   getMemoFromBase64,
   getSyntheticBlock,
   mergeTransactionsFromDifferentSources,
@@ -87,7 +88,7 @@ function createStakingRewardOperation({
   }
 
   const { hash, date, blockHeight, blockHash } = commonData;
-  const stakingRewardHash = `${hash}-staking-reward`;
+  const stakingRewardHash = createStakingRewardOperationHash(hash);
   const stakingRewardType: OperationType = "REWARD";
   // offset timestamp by +1ms so that, when operations are sorted newest-first, this reward appears just before the operation that triggered it
   const stakingRewardTimestamp = new Date(date.getTime() + 1);

--- a/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
@@ -10,6 +10,7 @@ import {
   HEDERA_TRANSACTION_MODES,
   SYNTHETIC_BLOCK_WINDOW_SECONDS,
   OP_TYPES_EXCLUDING_FEES,
+  STAKING_REWARD_HASH_SUFFIX,
 } from "../constants";
 import { HederaRecipientInvalidChecksum } from "../errors";
 import { apiClient } from "../network/api";
@@ -85,6 +86,7 @@ import {
   millisToSeconds,
   nanosToSeconds,
   secondsToNanos,
+  createStakingRewardOperationHash,
 } from "./utils";
 
 jest.mock("../network/api");
@@ -1659,6 +1661,15 @@ describe("logic utils", () => {
 
     it("preserves nanosecond precision", () => {
       expect(nanosToSeconds(1_000_000_001)).toEqual(new BigNumber(1.000000001));
+    });
+  });
+
+  describe("createStakingRewardOperationHash", () => {
+    it("appends the staking reward suffix to the given hash", () => {
+      const hash = "0.0.12345-1234567890-123456789";
+      const result = createStakingRewardOperationHash(hash);
+
+      expect(result).toBe(`${hash}${STAKING_REWARD_HASH_SUFFIX}`);
     });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.ts
@@ -25,6 +25,7 @@ import {
   TINYBAR_SCALE,
   OP_TYPES_EXCLUDING_FEES,
   HEDERA_TRANSACTION_NAMES,
+  STAKING_REWARD_HASH_SUFFIX,
 } from "../constants";
 import { HederaRecipientInvalidChecksum } from "../errors";
 import { apiClient } from "../network/api";
@@ -781,4 +782,8 @@ export function secondsToNanos(seconds: number | BigNumber): BigNumber {
 
 export function nanosToSeconds(nanos: number | BigNumber): BigNumber {
   return new BigNumber(nanos).dividedBy(10 ** 9);
+}
+
+export function createStakingRewardOperationHash(hash: string): string {
+  return `${hash}${STAKING_REWARD_HASH_SUFFIX}`;
 }

--- a/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
@@ -167,7 +167,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
       "delegation": {
         "delegated": "333985159",
         "nodeId": 18,
-        "pendingReward": "1059459",
+        "pendingReward": "1158621",
       },
       "isAutoTokenAssociationEnabled": false,
       "maxAutomaticTokenAssociations": 0,
@@ -183,12 +183,12 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "used": true,
   },
   {
-    "balance": "40104",
+    "balance": "40110",
     "id": "js:2:hedera:0.0.8313485:hederaBip44+hedera%2Ferc20%2Fbonzo~!underscore!~atoken~!underscore!~usdc~!underscore!~0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
     "operationsCount": 4,
     "parentId": "js:2:hedera:0.0.8313485:hederaBip44",
     "pendingOperations": [],
-    "spendableBalance": "40104",
+    "spendableBalance": "40110",
     "swapHistory": [],
     "tokenId": "hedera/erc20/bonzo_atoken_usdc_0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
     "type": "TokenAccountRaw",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR removes `-staking-reward` suffix from tx.hash in Alpaca operations.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-27295


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
