### PR TITLE
[LWDM] feat(coin-celo): [LIVE-19721] Add support for paying fee with non-native tokens

### DIFF
--- a/.changeset/quiet-chairs-look.md
+++ b/.changeset/quiet-chairs-look.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-celo": minor
+---
+
+Added ability to pay fees with a currency other than the native token.

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/buildTransaction.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/buildTransaction.test.ts
@@ -4,6 +4,8 @@ import {
   accountFixture,
   accountWithTokenAccountFixture,
   transactionFixture,
+  transactionWithUsdcFeeFixture,
+  tokenTransactionWithUsdcFeeFixture,
 } from "../../bridge/fixtures";
 
 const chainIdMock = jest.fn();
@@ -540,5 +542,71 @@ describe("buildTransaction", () => {
       value: "0xa",
       gas: "12",
     });
+  });
+
+  it("should build a send transaction with USDC fee currency", async () => {
+    const transaction = await buildTransaction(
+      { ...accountFixture, spendableBalance: BigNumber(123) },
+      {
+        ...transactionWithUsdcFeeFixture,
+        recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+        amount: BigNumber(10),
+      },
+    );
+
+    expect(transaction).toMatchObject({
+      from: accountFixture.freshAddress,
+      to: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+      value: "0xa",
+      gas: "12",
+    });
+
+    // Verify feeCurrency is included in the transaction
+    expect(transaction.feeCurrency).toEqual(transactionWithUsdcFeeFixture.feeCurrency);
+  });
+
+  it("should build a token transaction with USDC fee currency", async () => {
+    const transaction = await buildTransaction(
+      {
+        ...accountWithTokenAccountFixture,
+        spendableBalance: BigNumber(123),
+      },
+      {
+        ...tokenTransactionWithUsdcFeeFixture,
+        recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+        mode: "send",
+      },
+    );
+
+    expect(transaction).toMatchObject({
+      from: accountFixture.freshAddress,
+      gas: "12",
+    });
+
+    // Verify feeCurrency is included in the transaction
+    expect(transaction.feeCurrency).toEqual(tokenTransactionWithUsdcFeeFixture.feeCurrency);
+  });
+
+  it("should build transaction with feeCurrency when using useAllAmount", async () => {
+    const transaction = await buildTransaction(
+      { ...accountFixture, spendableBalance: BigNumber(123) },
+      {
+        ...transactionWithUsdcFeeFixture,
+        recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+        amount: BigNumber(100),
+        useAllAmount: true,
+        fees: BigNumber(2),
+      },
+    );
+
+    expect(transaction).toMatchObject({
+      from: accountFixture.freshAddress,
+      to: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+      value: "0x7b", // 123 (full balance when paying fees in USDC)
+      gas: "12",
+    });
+
+    // Verify feeCurrency is included
+    expect(transaction.feeCurrency).toEqual(transactionWithUsdcFeeFixture.feeCurrency);
   });
 });

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/createTransaction.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/createTransaction.test.ts
@@ -12,6 +12,16 @@ describe("createTransaction", () => {
       fees: null,
       mode: "send",
       index: null,
+      feeCurrency: null,
+      feeCurrencyUnwrapped: null,
+      feeCurrencyAccountId: null,
     });
+  });
+
+  it("initializes fee currency fields as null", () => {
+    const transaction = createTransaction(accountFixture);
+    expect(transaction.feeCurrency).toBeNull();
+    expect(transaction.feeCurrencyUnwrapped).toBeNull();
+    expect(transaction.feeCurrencyAccountId).toBeNull();
   });
 });

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/estimateMaxSpendable.test.ts
@@ -5,9 +5,16 @@ import {
   accountWithTokenAccountFixture,
   tokenTransactionFixture,
   transactionFixture,
+  transactionWithUsdcFeeFixture,
+  tokenTransactionWithUsdcFeeFixture,
+  usdcTransactionWithSameTokenFeeFixture,
+  usdcTokenAccount,
 } from "../../bridge/fixtures";
 
-jest.mock("../../bridge/getFeesForTransaction", async () => 12);
+jest.mock("../../bridge/getFeesForTransaction", () => ({
+  __esModule: true,
+  default: jest.fn().mockResolvedValue(new BigNumber(12)),
+}));
 
 const voteMock = jest.fn(() => ({
   txo: {
@@ -79,6 +86,7 @@ jest.mock("../../network/sdk", () => {
             },
           })),
         })),
+        getGoldToken: jest.fn(async () => ({ address: "gold_token_address" })),
       },
       connection: {
         chainId: jest.fn(),
@@ -98,7 +106,7 @@ describe("estimateMaxSpendable", () => {
     expect(maximumAmount).toEqual(BigNumber(100));
   });
 
-  it("returns the maximum spendable for a celo account", async () => {
+  it("returns the maximum spendable for a token account", async () => {
     const maximumAmount = await estimateMaxSpendable({
       account: {
         ...accountWithTokenAccountFixture,
@@ -108,5 +116,67 @@ describe("estimateMaxSpendable", () => {
       transaction: tokenTransactionFixture,
     });
     expect(maximumAmount).toEqual(BigNumber(212));
+  });
+
+  it("returns the full balance when paying fees in different currency (USDC)", async () => {
+    const maximumAmount = await estimateMaxSpendable({
+      account: { ...accountFixture, balance: BigNumber(100), spendableBalance: BigNumber(100) },
+      transaction: transactionWithUsdcFeeFixture,
+    });
+    // When paying fees in USDC, can spend full CELO balance
+    expect(maximumAmount).toEqual(BigNumber(100));
+  });
+
+  it("returns the full token balance when paying fees in different token", async () => {
+    const maximumAmount = await estimateMaxSpendable({
+      account: {
+        ...accountWithTokenAccountFixture,
+        balance: BigNumber(100),
+        spendableBalance: BigNumber(100),
+      },
+      transaction: tokenTransactionWithUsdcFeeFixture,
+    });
+    // When paying fees in USDC for token transfer, can spend full token balance
+    expect(maximumAmount).toEqual(BigNumber(212));
+  });
+
+  it("subtracts fees when paying in native CELO", async () => {
+    // A valid Celo address is required so prepareTransaction doesn't early-return
+    // before calling getFeesForTransaction (which is mocked to return BigNumber(12)).
+    const validRecipient = "0x0000000000000000000000000000000000000001";
+    const maximumAmount = await estimateMaxSpendable({
+      account: { ...accountFixture, balance: BigNumber(100), spendableBalance: BigNumber(100) },
+      transaction: { ...transactionFixture, recipient: validRecipient },
+    });
+    // Fees are mocked to BigNumber(12), so max spendable = 100 - 12 = 88
+    expect(maximumAmount).toEqual(BigNumber(88));
+  });
+
+  it("subtracts fees when sending token and paying fees in the same token", async () => {
+    const accountWithUsdcSubAccount = {
+      ...accountFixture,
+      balance: BigNumber(100),
+      spendableBalance: BigNumber(100),
+      subAccounts: [
+        {
+          ...usdcTokenAccount,
+          balance: BigNumber(1000000000), // 1000 USDC in raw units (6 decimals)
+          spendableBalance: BigNumber(1000000000),
+        },
+      ],
+    };
+
+    const maximumAmount = await estimateMaxSpendable({
+      account: accountWithUsdcSubAccount,
+      transaction: {
+        ...usdcTransactionWithSameTokenFeeFixture,
+        fees: BigNumber(50000000000000), // 0.00005 USDC: 50_000_000_000_000 in 18-decimal units = 50 in 6-decimal units
+      },
+    });
+
+    // Balance: 1_000_000_000 (1000 USDC, 6 decimals)
+    // Fee:    50_000_000_000_000 (18-decimal representation) → 50 base units (6-decimal)
+    // Result: 1_000_000_000 - 50 = 999_999_950
+    expect(maximumAmount).toEqual(BigNumber(999999950));
   });
 });

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/getFeesForTransaction.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/getFeesForTransaction.test.ts
@@ -1,5 +1,10 @@
 import BigNumber from "bignumber.js";
-import { accountFixture, transactionFixture } from "../../bridge/fixtures";
+import {
+  accountFixture,
+  transactionFixture,
+  transactionWithUsdcFeeFixture,
+  tokenTransactionWithUsdcFeeFixture,
+} from "../../bridge/fixtures";
 import getFeesForTransaction from "../../bridge/getFeesForTransaction";
 
 const chainIdMock = jest.fn();
@@ -12,6 +17,7 @@ const voteMock = jest.fn(() => ({
 }));
 const revokeMock = jest.fn();
 const voteSignerToAccountMock = jest.fn();
+const gasPriceMock = jest.fn(async () => BigNumber(2));
 
 jest.mock("../../network/sdk", () => {
   return {
@@ -89,7 +95,7 @@ jest.mock("../../network/sdk", () => {
         chainId: chainIdMock,
         nonce: nonceMock,
         estimateGasWithInflationFactor: jest.fn().mockReturnValue(3),
-        gasPrice: jest.fn(async () => BigNumber(2)),
+        gasPrice: gasPriceMock,
         getMaxPriorityFeePerGas: jest.fn().mockResolvedValue(1),
       },
     })),
@@ -261,5 +267,40 @@ describe("getFeesForTransaction", () => {
     expect(fees).toBeInstanceOf(BigNumber);
     expect(fees.gt(0)).toBe(true);
     expect(fees.lt(pointOneCelo)).toBe(true);
+  });
+
+  it("should return the correct fees for a send transaction with USDC fee currency", async () => {
+    const fees = await getFeesForTransaction({
+      account: { ...accountFixture, balance: BigNumber(123), spendableBalance: BigNumber(123) },
+      transaction: transactionWithUsdcFeeFixture,
+    });
+
+    // Fees should still be calculated correctly when feeCurrency is provided
+    expect(fees).toBeInstanceOf(BigNumber);
+    expect(fees.gt(0)).toBe(true);
+  });
+
+  it("should return the correct fees for a token transaction with USDC fee currency", async () => {
+    const fees = await getFeesForTransaction({
+      account: { ...accountFixture, balance: BigNumber(123), spendableBalance: BigNumber(123) },
+      transaction: tokenTransactionWithUsdcFeeFixture,
+    });
+
+    // Fees should still be calculated correctly when feeCurrency is provided
+    expect(fees).toBeInstanceOf(BigNumber);
+    expect(fees.gt(0)).toBe(true);
+  });
+
+  it("should pass feeCurrency parameter to gasPrice when provided", async () => {
+    // Clear any previous calls
+    gasPriceMock.mockClear();
+
+    await getFeesForTransaction({
+      account: { ...accountFixture, balance: BigNumber(123), spendableBalance: BigNumber(123) },
+      transaction: transactionWithUsdcFeeFixture,
+    });
+
+    // Verify gasPrice was called with feeCurrency parameter
+    expect(gasPriceMock).toHaveBeenCalledWith(transactionWithUsdcFeeFixture.feeCurrency);
   });
 });

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/getTransactionStatus.test.ts
@@ -1,5 +1,13 @@
 import BigNumber from "bignumber.js";
-import { accountFixture, transactionFixture } from "../../bridge/fixtures";
+import {
+  accountFixture,
+  accountWithTokenAccountFixture,
+  transactionFixture,
+  tokenTransactionFixture,
+  transactionWithUsdcFeeFixture,
+  tokenTransactionWithUsdcFeeFixture,
+  usdcTokenAccount,
+} from "../../bridge/fixtures";
 import getTransactionStatus from "../../bridge/getTransactionStatus";
 
 jest.mock("../../network/sdk", () => {
@@ -328,5 +336,147 @@ describe("getTransactionStatus", () => {
 
     expect(transactionStatus.errors).not.toHaveProperty("amount");
     expect(transactionStatus.estimatedFees).toEqual(gasFee);
+  });
+
+  it("should convert fees from 18 decimals to 6 decimals when using USDC fee currency", async () => {
+    const feeInWei = new BigNumber("1000000000000000000"); // 1 CELO in Wei (18 decimals)
+    const expectedFeeInUsdc = new BigNumber("1000000"); // 1 USDC in 6 decimals
+
+    const transactionStatus = await getTransactionStatus(
+      {
+        ...accountWithTokenAccountFixture,
+        balance: BigNumber(123),
+        spendableBalance: BigNumber(123),
+      },
+      {
+        ...transactionWithUsdcFeeFixture,
+        recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+        amount: BigNumber(10),
+        fees: feeInWei,
+      },
+    );
+
+    // Fees should be converted to 6 decimals for display
+    expect(transactionStatus.estimatedFees).toEqual(expectedFeeInUsdc);
+  });
+
+  it("should calculate totalSpent correctly when paying fees in same currency (native CELO)", async () => {
+    const amount = new BigNumber("1000000000000000000"); // 1 CELO
+    const fees = new BigNumber("100000000000000000"); // 0.1 CELO
+    const expectedTotalSpent = amount.plus(fees);
+
+    const transactionStatus = await getTransactionStatus(
+      {
+        ...accountFixture,
+        balance: BigNumber("10000000000000000000"),
+        spendableBalance: BigNumber("10000000000000000000"),
+      },
+      {
+        ...transactionFixture,
+        recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+        amount,
+        fees,
+      },
+    );
+
+    expect(transactionStatus.totalSpent).toEqual(expectedTotalSpent);
+  });
+
+  it("should calculate totalSpent as just amount when paying fees in different currency", async () => {
+    const amount = new BigNumber("1000000000000000000"); // 1 CELO
+    const fees = new BigNumber("100000000000000000"); // 0.1 CELO in Wei
+
+    const transactionStatus = await getTransactionStatus(
+      {
+        ...accountFixture,
+        balance: BigNumber("10000000000000000000"),
+        spendableBalance: BigNumber("10000000000000000000"),
+      },
+      {
+        ...transactionWithUsdcFeeFixture,
+        recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+        amount,
+        fees,
+      },
+    );
+
+    // When paying fees in USDC, totalSpent should be just the amount (can't add different currencies)
+    expect(transactionStatus.totalSpent).toEqual(amount);
+  });
+
+  it("should calculate totalSpent correctly for token transfer with fees paid in same token", async () => {
+    const amount = new BigNumber("1000000"); // 1 USDC in 6 decimals
+    const feeInWei = new BigNumber("100000000000000000"); // 0.1 USDC in Wei
+    const feeInUsdc = new BigNumber("100000"); // 0.1 USDC in 6 decimals
+    const expectedTotalSpent = amount.plus(feeInUsdc);
+
+    const transactionStatus = await getTransactionStatus(accountWithTokenAccountFixture, {
+      ...tokenTransactionWithUsdcFeeFixture,
+      subAccountId: usdcTokenAccount.id, // Use USDC token account so fees are in same token
+      recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+      amount,
+      fees: feeInWei,
+    });
+
+    // Fees should be converted to 6 decimals and added to amount
+    expect(transactionStatus.totalSpent).toEqual(expectedTotalSpent);
+    expect(transactionStatus.estimatedFees).toEqual(feeInUsdc);
+  });
+
+  it("should keep fees in Wei (18 decimals) when no fee currency is specified", async () => {
+    const feeInWei = new BigNumber("100000000000000000"); // 0.1 CELO in Wei
+
+    const transactionStatus = await getTransactionStatus(
+      { ...accountFixture, balance: BigNumber(123), spendableBalance: BigNumber(123) },
+      {
+        ...transactionFixture,
+        recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+        amount: BigNumber(10),
+        fees: feeInWei,
+      },
+    );
+
+    // Fees should remain in Wei when no fee currency is specified
+    expect(transactionStatus.estimatedFees).toEqual(feeInWei);
+  });
+
+  it("should handle token transfer with fees paid in different token (USDC)", async () => {
+    const amount = new BigNumber("500000"); // 0.5 USDT in 6 decimals
+    const feeInWei = new BigNumber("100000000000000000"); // 0.1 USDC in Wei
+    const feeInUsdc = new BigNumber("100000"); // 0.1 USDC in 6 decimals
+
+    const transactionStatus = await getTransactionStatus(accountWithTokenAccountFixture, {
+      ...tokenTransactionFixture,
+      feeCurrency: "0xceba9300f2b948710d2653dd7b07f33a8b32118c" as `0x${string}`,
+      feeCurrencyUnwrapped: "0xceba9300f2b948710d2653dd7b07f33a8b32118c" as `0x${string}`,
+      feeCurrencyAccountId: usdcTokenAccount.id,
+      recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+      amount,
+      fees: feeInWei,
+    });
+
+    // When sending USDT and paying with USDC, totalSpent should be just the USDT amount
+    expect(transactionStatus.totalSpent).toEqual(amount);
+    expect(transactionStatus.estimatedFees).toEqual(feeInUsdc);
+  });
+
+  it("should return NotEnoughBalance error when fee token balance is insufficient", async () => {
+    const amount = new BigNumber("100000"); // 0.1 USDT in 6 decimals
+    const feeInWei = new BigNumber("2000000000000000000000"); // 2000 USDC in Wei (18 decimals)
+
+    const transactionStatus = await getTransactionStatus(accountWithTokenAccountFixture, {
+      ...tokenTransactionFixture,
+      subAccountId: "usdtTokenAccountId", // Use USDT account which has sufficient balance
+      feeCurrency: "0xceba9300f2b948710d2653dd7b07f33a8b32118c" as `0x${string}`,
+      feeCurrencyUnwrapped: "0xceba9300f2b948710d2653dd7b07f33a8b32118c" as `0x${string}`,
+      feeCurrencyAccountId: usdcTokenAccount.id,
+      recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+      amount,
+      fees: feeInWei,
+    });
+
+    // Should return NotEnoughBalance error for fees since USDC balance is 1000 USDC but fee requires 2000 USDC
+    expect(transactionStatus.errors["fees"].name).toEqual("NotEnoughBalance");
+    expect(transactionStatus.errors).not.toHaveProperty("amount");
   });
 });

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/prepareTransaction.test.ts
@@ -4,6 +4,8 @@ import {
   accountWithTokenAccountFixture,
   tokenTransactionFixture,
   transactionFixture,
+  tokenTransactionWithUsdcFeeFixture,
+  usdcTokenAccount,
 } from "../../bridge/fixtures";
 import prepareTransaction from "../../bridge/prepareTransaction";
 
@@ -251,5 +253,74 @@ describe("prepareTransaction", () => {
       subAccountId: "subAccountId",
       data: Buffer.from("0x73656E645F65726332305F746F6B656E5F64617461"),
     });
+  });
+
+  it("should return token transaction with fee currency preserved", async () => {
+    const transaction = await prepareTransaction(
+      {
+        ...accountWithTokenAccountFixture,
+        balance: BigNumber(222222),
+        spendableBalance: BigNumber(222222),
+      },
+      {
+        ...tokenTransactionWithUsdcFeeFixture,
+        recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+        amount: BigNumber(22),
+      },
+    );
+
+    expect(transaction.feeCurrency).toEqual(tokenTransactionWithUsdcFeeFixture.feeCurrency);
+    expect(transaction.feeCurrencyUnwrapped).toEqual(
+      tokenTransactionWithUsdcFeeFixture.feeCurrencyUnwrapped,
+    );
+    expect(transaction.feeCurrencyAccountId).toEqual(usdcTokenAccount.id);
+  });
+
+  it("should handle useAllAmount with fee currency in same token", async () => {
+    const transaction = await prepareTransaction(
+      {
+        ...accountWithTokenAccountFixture,
+        balance: BigNumber(222222),
+        spendableBalance: BigNumber(222222),
+      },
+      {
+        ...tokenTransactionWithUsdcFeeFixture,
+        recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+        amount: BigNumber(1000000), // 1 USDC
+        useAllAmount: true,
+      },
+    );
+
+    // With useAllAmount and paying fees in USDC, the amount should be full balance minus normalized fees
+    expect(transaction.useAllAmount).toBe(true);
+    expect(transaction.feeCurrency).toEqual(tokenTransactionWithUsdcFeeFixture.feeCurrency);
+    // Amount should be calculated considering fee conversion from Wei to token decimals
+    expect(transaction.amount.gt(0)).toBe(true);
+  });
+
+  it("should handle useAllAmount with fee currency in different token", async () => {
+    const transaction = await prepareTransaction(
+      {
+        ...accountWithTokenAccountFixture,
+        balance: BigNumber(222222),
+        spendableBalance: BigNumber(222222),
+      },
+      {
+        ...tokenTransactionFixture,
+        feeCurrency: "0x617f3112bf5397d0467d315cc709ef968d9ba546" as `0x${string}`, // USDT
+        feeCurrencyUnwrapped: "0x617f3112bf5397d0467d315cc709ef968d9ba546" as `0x${string}`,
+        feeCurrencyAccountId:
+          accountWithTokenAccountFixture.subAccounts[
+            accountWithTokenAccountFixture.subAccounts.length - 1
+          ].id,
+        recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+        amount: BigNumber(22),
+        useAllAmount: true,
+      },
+    );
+
+    // When paying fees in different token, should use full balance (212)
+    expect(transaction.amount).toEqual(BigNumber(212));
+    expect(transaction.useAllAmount).toBe(true);
   });
 });

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/utils.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/utils.test.ts
@@ -1,0 +1,154 @@
+import BigNumber from "bignumber.js";
+import { convertNumberDecimals, isSameTokenAsFee, normalizeAndSubtract } from "../../bridge/utils";
+
+describe("utils", () => {
+  describe("convertNumberDecimals", () => {
+    it("should return the same value when target decimals is 18", () => {
+      const feeInWei = new BigNumber("1000000000000000000"); // 1 CELO in Wei
+      const result = convertNumberDecimals(feeInWei, 18);
+      expect(result).toEqual(feeInWei);
+    });
+
+    it("should convert from 18 decimals to 6 decimals (USDC)", () => {
+      const feeInWei = new BigNumber("1000000000000000000"); // 1 CELO in Wei
+      const result = convertNumberDecimals(feeInWei, 6);
+      expect(result).toEqual(new BigNumber("1000000")); // 1 USDC in 6 decimals
+    });
+
+    it("should handle small fee amounts correctly", () => {
+      const feeInWei = new BigNumber("100000000000000"); // 0.0001 CELO in Wei
+      const result = convertNumberDecimals(feeInWei, 6);
+      expect(result).toEqual(new BigNumber("100")); // 0.0001 USDC in 6 decimals
+    });
+
+    it("should handle large fee amounts correctly", () => {
+      const feeInWei = new BigNumber("10000000000000000000"); // 10 CELO in Wei
+      const result = convertNumberDecimals(feeInWei, 6);
+      expect(result).toEqual(new BigNumber("10000000")); // 10 USDC in 6 decimals
+    });
+
+    it("should handle zero fee", () => {
+      const feeInWei = new BigNumber("0");
+      const result = convertNumberDecimals(feeInWei, 6);
+      expect(result).toEqual(new BigNumber("0"));
+    });
+
+    it("should convert from 18 decimals to 8 decimals", () => {
+      const feeInWei = new BigNumber("1000000000000000000"); // 1 CELO in Wei
+      const result = convertNumberDecimals(feeInWei, 8);
+      expect(result).toEqual(new BigNumber("100000000")); // 1 token in 8 decimals
+    });
+
+    it("should handle fractional results", () => {
+      const feeInWei = new BigNumber("1500000000000000000"); // 1.5 CELO in Wei
+      const result = convertNumberDecimals(feeInWei, 6);
+      expect(result).toEqual(new BigNumber("1500000")); // 1.5 USDC in 6 decimals
+    });
+  });
+
+  describe("isSameTokenAsFee", () => {
+    it("should return true when token contract address matches fee currency", () => {
+      const result = isSameTokenAsFee(
+        true,
+        "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+        "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should return false when token contract address does not match fee currency", () => {
+      const result = isSameTokenAsFee(
+        true,
+        "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+        "0x617f3112bf5397d0467d315cc709ef968d9ba546",
+      );
+      expect(result).toBe(false);
+    });
+
+    it("should return false when feeCurrency is null", () => {
+      const result = isSameTokenAsFee(true, "0xceba9300f2b948710d2653dd7b07f33a8b32118c", null);
+      expect(result).toBe(false);
+    });
+
+    it("should return false when feeCurrency is undefined", () => {
+      const result = isSameTokenAsFee(
+        true,
+        "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+        undefined,
+      );
+      expect(result).toBe(false);
+    });
+
+    it("should handle case-insensitive comparison", () => {
+      const result = isSameTokenAsFee(
+        true,
+        "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+        "0xCEBA9300F2B948710D2653DD7B07F33A8B32118C",
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should handle addresses without 0x prefix", () => {
+      const result = isSameTokenAsFee(
+        true,
+        "ceba9300f2b948710d2653dd7b07f33a8b32118c",
+        "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("normalizeAndSubtract", () => {
+    it("should convert 6-decimal balance to 18-decimal Wei and subtract", () => {
+      const balance = new BigNumber("1000000"); // 1 USDC in 6 decimals
+      const amount = new BigNumber("500000000000000000"); // 0.5 USDC in Wei (18 decimals)
+      const result = normalizeAndSubtract(balance, amount, 6);
+      // 1 USDC = 1000000000000000000 Wei
+      // 1000000000000000000 - 500000000000000000 = 500000000000000000
+      expect(result).toEqual(new BigNumber("500000000000000000"));
+    });
+
+    it("should handle zero balance", () => {
+      const balance = new BigNumber("0");
+      const amount = new BigNumber("100000000000000000");
+      const result = normalizeAndSubtract(balance, amount, 6);
+      expect(result).toEqual(new BigNumber("-100000000000000000"));
+    });
+
+    it("should handle zero amount", () => {
+      const balance = new BigNumber("1000000"); // 1 USDC in 6 decimals
+      const amount = new BigNumber("0");
+      const result = normalizeAndSubtract(balance, amount, 6);
+      expect(result).toEqual(new BigNumber("1000000000000000000")); // 1 USDC in Wei
+    });
+
+    it("should handle large balances", () => {
+      const balance = new BigNumber("1000000000000"); // 1,000,000 USDC in 6 decimals
+      const amount = new BigNumber("1000000000000000000"); // 1 USDC in Wei
+      const result = normalizeAndSubtract(balance, amount, 6);
+      // 1000000000000 * 10^12 - 1000000000000000000 = 999999000000000000000000
+      expect(result).toEqual(new BigNumber("999999000000000000000000"));
+    });
+
+    it("should handle result where balance equals amount after normalization", () => {
+      const balance = new BigNumber("1000000"); // 1 USDC in 6 decimals
+      const amount = new BigNumber("1000000000000000000"); // 1 USDC in Wei
+      const result = normalizeAndSubtract(balance, amount, 6);
+      expect(result).toEqual(new BigNumber("0"));
+    });
+
+    it("should handle fractional amounts", () => {
+      const balance = new BigNumber("1000000"); // 1 USDC in 6 decimals
+      const amount = new BigNumber("250000000000000000"); // 0.25 USDC in Wei
+      const result = normalizeAndSubtract(balance, amount, 6);
+      expect(result).toEqual(new BigNumber("750000000000000000")); // 0.75 USDC in Wei
+    });
+
+    it("should handle small balances", () => {
+      const balance = new BigNumber("1"); // 0.000001 USDC in 6 decimals
+      const amount = new BigNumber("500000000000"); // 0.0000005 USDC in Wei
+      const result = normalizeAndSubtract(balance, amount, 6);
+      expect(result).toEqual(new BigNumber("500000000000")); // 0.0000005 USDC in Wei
+    });
+  });
+});

--- a/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
@@ -9,7 +9,34 @@ import {
 import { getPendingStakingOperationAmounts, getVote } from "../logic";
 import { celoKit } from "../network/sdk";
 import type { CeloAccount, RevokeTxo, Transaction } from "../types";
-import { valueToHex } from "./utils";
+import { valueToHex, isSameTokenAsFee, normalizeAndSubtract, convertNumberDecimals } from "./utils";
+
+const calcTokenTransferValue = (
+  tokenAccount: NonNullable<ReturnType<typeof findSubAccountById>> & { type: "TokenAccount" },
+  transaction: Transaction,
+): BigNumber => {
+  if (!transaction.useAllAmount) return transaction.amount;
+
+  const shouldSubtractFee = isSameTokenAsFee(
+    true,
+    tokenAccount.token.contractAddress,
+    transaction.feeCurrencyUnwrapped,
+  );
+
+  if (shouldSubtractFee) {
+    const balanceAfterFee = normalizeAndSubtract(
+      tokenAccount.spendableBalance,
+      transaction.fees,
+      tokenAccount.token.units[0].magnitude,
+    );
+    return BigNumber.max(
+      0,
+      convertNumberDecimals(balanceAfterFee, tokenAccount.token.units[0].magnitude),
+    );
+  }
+
+  return tokenAccount.spendableBalance;
+};
 
 const buildTransaction = async (account: CeloAccount, transaction: Transaction) => {
   const kit = celoKit();
@@ -116,7 +143,7 @@ const buildTransaction = async (account: CeloAccount, transaction: Transaction) 
       gas: await accounts.createAccount().txo.estimateGas({ from: account.freshAddress }),
     };
   } else if (isTokenTransaction) {
-    value = transaction.useAllAmount ? tokenAccount.balance : transaction.amount;
+    value = calcTokenTransferValue(tokenAccount, transaction);
 
     let token;
     if (CELO_STABLE_TOKENS.includes(tokenAccount.token.id)) {
@@ -130,6 +157,11 @@ const buildTransaction = async (account: CeloAccount, transaction: Transaction) 
       to: transaction.recipient,
       data: token.transfer(transaction.recipient, value.toFixed()).txo.encodeABI(),
       value: valueToHex(value),
+      ...(transaction.feeCurrency
+        ? {
+            feeCurrency: transaction.feeCurrency,
+          }
+        : {}),
     };
   } else {
     // Send
@@ -137,6 +169,11 @@ const buildTransaction = async (account: CeloAccount, transaction: Transaction) 
       from: account.freshAddress,
       to: transaction.recipient,
       value: valueToHex(value),
+      ...(transaction.feeCurrency
+        ? {
+            feeCurrency: transaction.feeCurrency,
+          }
+        : {}),
     };
   }
 
@@ -155,26 +192,39 @@ const buildTransaction = async (account: CeloAccount, transaction: Transaction) 
   return tx;
 };
 
-const transactionValue = (account: CeloAccount, transaction: Transaction): BigNumber => {
-  let value = transaction.amount;
+const calcUseAllSendValue = (account: CeloAccount, transaction: Transaction): BigNumber => {
+  // For native CELO send operations, check if fee is paid in CELO.
+  const shouldSubtractFee = isSameTokenAsFee(false, undefined, transaction.feeCurrencyUnwrapped);
 
-  if (transaction.useAllAmount) {
-    if ((transaction.mode === "unlock" || transaction.mode === "vote") && account.celoResources) {
-      // Deduct the amount of pending vote transactions from
-      // the total non-voting locked balance to get the true non-voting locked balance.
-      const pendingOperationAmounts = getPendingStakingOperationAmounts(account);
-      const pendingOperationAmount =
-        transaction.mode === "vote" ? pendingOperationAmounts.vote : new BigNumber(0);
-      value = account.celoResources.nonvotingLockedBalance.minus(pendingOperationAmount);
-    } else if (transaction.mode === "revoke" && account.celoResources) {
-      const revoke = getVote(account, transaction.recipient, transaction.index);
-      if (revoke?.amount) value = revoke.amount;
-    } else {
-      value = BigNumber.max(0, account.spendableBalance.minus(transaction.fees || 0));
-    }
+  if (shouldSubtractFee) {
+    // Fee is paid in CELO - subtract from balance.
+    return BigNumber.max(0, account.spendableBalance.minus(transaction.fees || 0));
   }
 
-  return value;
+  // Fee is paid in different token - can send full balance.
+  return account.spendableBalance;
+};
+
+const calcUseAllTransactionValue = (account: CeloAccount, transaction: Transaction): BigNumber => {
+  if ((transaction.mode === "unlock" || transaction.mode === "vote") && account.celoResources) {
+    // Deduct pending vote operations to derive the true non-voting locked balance.
+    const pendingOperationAmounts = getPendingStakingOperationAmounts(account);
+    const pendingOperationAmount =
+      transaction.mode === "vote" ? pendingOperationAmounts.vote : new BigNumber(0);
+    return account.celoResources.nonvotingLockedBalance.minus(pendingOperationAmount);
+  }
+
+  if (transaction.mode === "revoke" && account.celoResources) {
+    const revoke = getVote(account, transaction.recipient, transaction.index);
+    return revoke?.amount ?? transaction.amount;
+  }
+
+  return calcUseAllSendValue(account, transaction);
+};
+
+const transactionValue = (account: CeloAccount, transaction: Transaction): BigNumber => {
+  if (!transaction.useAllAmount) return transaction.amount;
+  return calcUseAllTransactionValue(account, transaction);
 };
 
 export default buildTransaction;

--- a/libs/coin-modules/coin-celo/src/bridge/createTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/createTransaction.ts
@@ -8,6 +8,9 @@ export const createTransaction: AccountBridge<Transaction>["createTransaction"] 
   recipient: "",
   useAllAmount: false,
   fees: null,
+  feeCurrency: null,
+  feeCurrencyUnwrapped: null,
+  feeCurrencyAccountId: null,
   mode: "send",
   index: null,
 });

--- a/libs/coin-modules/coin-celo/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/estimateMaxSpendable.ts
@@ -1,8 +1,4 @@
-import {
-  findSubAccountById,
-  getMainAccount,
-  isTokenAccount,
-} from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { CeloAccount, Transaction } from "../types";
@@ -16,9 +12,6 @@ export const estimateMaxSpendable: AccountBridge<
 >["estimateMaxSpendable"] = async ({ account, parentAccount, transaction }) => {
   const mainAccount = getMainAccount(account, parentAccount);
 
-  const tokenAccount = findSubAccountById(mainAccount, transaction?.subAccountId ?? "");
-  const fromTokenAccount = tokenAccount && isTokenAccount(tokenAccount);
-
   const t = await prepareTransaction(mainAccount, {
     ...createTransaction(account),
     ...transaction,
@@ -26,13 +19,10 @@ export const estimateMaxSpendable: AccountBridge<
   });
 
   const { amount } = await getTransactionStatus(mainAccount, t);
-  const fees = t.fees ?? BigNumber(0);
 
-  return fromTokenAccount
-    ? tokenAccount.spendableBalance
-    : account.spendableBalance.gt(fees)
-      ? amount.minus(fees)
-      : new BigNumber(0);
+  // getTransactionStatus already handles fee subtraction when useAllAmount is true
+  // and returns the correct amount for both token and native CELO transfers
+  return BigNumber.max(0, amount);
 };
 
 export default estimateMaxSpendable;

--- a/libs/coin-modules/coin-celo/src/bridge/fixtures.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/fixtures.ts
@@ -40,6 +40,94 @@ const accountFixture: CeloAccount = {
   },
 };
 
+const usdcToken: TokenCurrency = {
+  type: "TokenCurrency",
+  id: "celo/erc20/usdc",
+  contractAddress: "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+  parentCurrency: currency,
+  name: "USD Coin",
+  ticker: "USDC",
+  units: [
+    {
+      name: "USDC",
+      code: "USDC",
+      magnitude: 6,
+    },
+  ],
+} as TokenCurrency;
+
+const usdtToken: TokenCurrency = {
+  type: "TokenCurrency",
+  id: "celo/erc20/usdt",
+  contractAddress: "0x617f3112bf5397d0467d315cc709ef968d9ba546",
+  parentCurrency: currency,
+  name: "Tether USD",
+  ticker: "USDT",
+  units: [
+    {
+      name: "USDT",
+      code: "USDT",
+      magnitude: 6,
+    },
+  ],
+} as TokenCurrency;
+
+const usdcTokenAccount: TokenAccount = {
+  id: "usdcTokenAccountId",
+  type: "TokenAccount",
+  parentId: accountFixture.id,
+  token: usdcToken,
+  balance: BigNumber(1000000000), // 1000 USDC in 6 decimals
+  spendableBalance: BigNumber(1000000000),
+  creationDate: faker.date.past(),
+  operationsCount: 0,
+  operations: [],
+  pendingOperations: [],
+  balanceHistoryCache: {
+    HOUR: {
+      latestDate: null,
+      balances: [],
+    },
+    DAY: {
+      latestDate: null,
+      balances: [],
+    },
+    WEEK: {
+      latestDate: null,
+      balances: [],
+    },
+  },
+  swapHistory: [],
+};
+
+const usdtTokenAccount: TokenAccount = {
+  id: "usdtTokenAccountId",
+  type: "TokenAccount",
+  parentId: accountFixture.id,
+  token: usdtToken,
+  balance: BigNumber(500000000), // 500 USDT in 6 decimals
+  spendableBalance: BigNumber(500000000),
+  creationDate: faker.date.past(),
+  operationsCount: 0,
+  operations: [],
+  pendingOperations: [],
+  balanceHistoryCache: {
+    HOUR: {
+      latestDate: null,
+      balances: [],
+    },
+    DAY: {
+      latestDate: null,
+      balances: [],
+    },
+    WEEK: {
+      latestDate: null,
+      balances: [],
+    },
+  },
+  swapHistory: [],
+};
+
 const subAccounts = [
   {
     id: "subAccountId",
@@ -73,6 +161,8 @@ const subAccounts = [
     },
     swapHistory: [],
   },
+  usdcTokenAccount,
+  usdtTokenAccount,
 ] as TokenAccount[];
 
 const accountWithTokenAccountFixture = {
@@ -88,6 +178,9 @@ const transactionFixture: Transaction = {
   mode: "send",
   index: 0,
   fees: null,
+  feeCurrency: null,
+  feeCurrencyUnwrapped: null,
+  feeCurrencyAccountId: null,
 };
 
 const tokenTransactionFixture: Transaction = {
@@ -95,9 +188,47 @@ const tokenTransactionFixture: Transaction = {
   subAccountId: "subAccountId",
 };
 
+const transactionWithUsdcFeeFixture: Transaction = {
+  ...transactionFixture,
+  feeCurrency: "0xceba9300f2b948710d2653dd7b07f33a8b32118c" as `0x${string}`,
+  feeCurrencyUnwrapped: "0xceba9300f2b948710d2653dd7b07f33a8b32118c" as `0x${string}`,
+  feeCurrencyAccountId: usdcTokenAccount.id,
+};
+
+const tokenTransactionWithUsdcFeeFixture: Transaction = {
+  ...tokenTransactionFixture,
+  feeCurrency: "0xceba9300f2b948710d2653dd7b07f33a8b32118c" as `0x${string}`,
+  feeCurrencyUnwrapped: "0xceba9300f2b948710d2653dd7b07f33a8b32118c" as `0x${string}`,
+  feeCurrencyAccountId: usdcTokenAccount.id,
+};
+
+const tokenTransactionWithUsdtFeeFixture: Transaction = {
+  ...tokenTransactionFixture,
+  feeCurrency: "0x617f3112bf5397d0467d315cc709ef968d9ba546" as `0x${string}`,
+  feeCurrencyUnwrapped: "0x617f3112bf5397d0467d315cc709ef968d9ba546" as `0x${string}`,
+  feeCurrencyAccountId: usdtTokenAccount.id,
+};
+
+// Transaction where fees are paid in the same token as the send (USDC)
+const usdcTransactionWithSameTokenFeeFixture: Transaction = {
+  ...transactionFixture,
+  subAccountId: usdcTokenAccount.id,
+  feeCurrency: "0xceba9300f2b948710d2653dd7b07f33a8b32118c" as `0x${string}`,
+  feeCurrencyUnwrapped: "0xceba9300f2b948710d2653dd7b07f33a8b32118c" as `0x${string}`,
+  feeCurrencyAccountId: usdcTokenAccount.id,
+};
+
 export {
   accountFixture,
   accountWithTokenAccountFixture,
   transactionFixture,
   tokenTransactionFixture,
+  transactionWithUsdcFeeFixture,
+  tokenTransactionWithUsdcFeeFixture,
+  tokenTransactionWithUsdtFeeFixture,
+  usdcTransactionWithSameTokenFeeFixture,
+  usdcToken,
+  usdtToken,
+  usdcTokenAccount,
+  usdtTokenAccount,
 };

--- a/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getFeesForTransaction.ts
@@ -42,7 +42,7 @@ const getFeesForTransaction = async ({
   const maxPriorityFeePerGas = await kit.connection.getMaxPriorityFeePerGas();
 
   // Align with @celo/connect setFeeMarketGas: used for final fee for all modes.
-  const gasPrice = await kit.connection.gasPrice();
+  const gasPrice = await kit.connection.gasPrice(transaction.feeCurrency ?? undefined);
   const maxFeePerGas =
     ((BigInt(gasPrice) - BigInt(maxPriorityFeePerGas)) * BigInt(120)) / BigInt(100) +
     BigInt(maxPriorityFeePerGas);
@@ -137,6 +137,11 @@ const getFeesForTransaction = async ({
       maxFeePerGas: maxFeePerGas.toString(),
       maxPriorityFeePerGas,
       value: valueToHex(value),
+      ...(transaction.feeCurrency
+        ? {
+            feeCurrency: transaction.feeCurrency,
+          }
+        : {}),
     };
 
     gas = Number(

--- a/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
@@ -14,6 +14,7 @@ import { CeloAllFundsWarning } from "../errors";
 import { getPendingStakingOperationAmounts, getVote } from "../logic";
 import { celoKit } from "../network/sdk";
 import { CeloAccount, Transaction, TransactionStatus } from "../types";
+import { isSameTokenAsFee, convertNumberDecimals, normalizeAndSubtract } from "./utils";
 
 const kit = celoKit();
 
@@ -54,6 +55,13 @@ export const getTransactionStatus: AccountBridge<
   const tokenAccount = findSubAccountById(account, transaction.subAccountId || "");
   const isTokenTransaction = tokenAccount?.type === "TokenAccount";
 
+  // Determine if we're paying fees in the same currency we're sending
+  const sameTokenAsFee = isSameTokenAsFee(
+    isTokenTransaction,
+    tokenAccount?.token?.contractAddress,
+    transaction.feeCurrencyUnwrapped,
+  );
+
   let amount: BigNumber = new BigNumber(0);
   if (useAllAmount && (transaction.mode === "unlock" || transaction.mode === "vote")) {
     amount = totalNonVotingLockedBalance ?? new BigNumber(0);
@@ -61,9 +69,20 @@ export const getTransactionStatus: AccountBridge<
     const revoke = getVote(account, transaction.recipient, transaction.index);
     if (revoke?.amount) amount = revoke.amount;
   } else if (useAllAmount) {
-    amount = isTokenTransaction
-      ? tokenAccount.spendableBalance
-      : totalSpendableBalance.minus(estimatedFees);
+    if (isTokenTransaction) {
+      amount = sameTokenAsFee
+        ? convertNumberDecimals(
+            normalizeAndSubtract(
+              tokenAccount.spendableBalance,
+              estimatedFees,
+              tokenAccount?.token.units[0].magnitude,
+            ),
+            tokenAccount?.token.units[0].magnitude,
+          )
+        : tokenAccount.spendableBalance;
+    } else {
+      amount = sameTokenAsFee ? totalSpendableBalance.minus(estimatedFees) : totalSpendableBalance;
+    }
   } else {
     amount = new BigNumber(transaction.amount);
   }
@@ -85,7 +104,13 @@ export const getTransactionStatus: AccountBridge<
     }
   }
 
-  const totalSpent = amount.plus(estimatedFees);
+  const feeTokenAccount = findSubAccountById(account, transaction.feeCurrencyAccountId ?? "");
+  const feesForTotalSpent = feeTokenAccount
+    ? convertNumberDecimals(estimatedFees, feeTokenAccount.token.units[0].magnitude)
+    : estimatedFees;
+
+  // Calculate totalSpent - only add fees if paying in the same currency
+  const totalSpent = sameTokenAsFee ? amount.plus(feesForTotalSpent) : amount;
 
   if (transaction.mode === "unlock" || transaction.mode === "vote") {
     if (!errors.amount && totalNonVotingLockedBalance && amount.gt(totalNonVotingLockedBalance)) {
@@ -96,13 +121,35 @@ export const getTransactionStatus: AccountBridge<
     if (!errors.amount && revoke?.amount && amount.gt(revoke.amount))
       errors.amount = new NotEnoughBalance();
   } else {
-    if (!errors.amount && totalSpent.gt(totalSpendableBalance)) {
+    const balanceToCheck =
+      isTokenTransaction && tokenAccount ? tokenAccount.spendableBalance : totalSpendableBalance;
+
+    const amountToCheck = sameTokenAsFee ? totalSpent : amount;
+    if (!errors.amount && amountToCheck.gt(balanceToCheck)) {
       errors.amount = new NotEnoughBalance();
     }
-  }
 
-  if (!errors.amount && totalSpendableBalance.lt(estimatedFees)) {
-    errors.amount = new NotEnoughBalance();
+    // When fees are paid in a different currency, verify fee token balance is sufficient
+    if (!errors.fees && !sameTokenAsFee) {
+      if (feeTokenAccount) {
+        const feeTokenBalance = feeTokenAccount.spendableBalance;
+        if (feesForTotalSpent.gt(feeTokenBalance)) {
+          errors.fees = new NotEnoughBalance();
+        }
+      } else if (isTokenTransaction) {
+        // Fees paid in native CELO — check main account spendable balance
+        if (estimatedFees.gt(totalSpendableBalance)) {
+          errors.fees = new NotEnoughBalance();
+        }
+      }
+    }
+
+    // When fees are paid in native CELO for a token transaction, verify the main account has enough CELO for gas
+    if (!errors.fees && isTokenTransaction && !sameTokenAsFee && !feeTokenAccount) {
+      if (totalSpendableBalance.lt(estimatedFees)) {
+        errors.fees = new NotEnoughBalance();
+      }
+    }
   }
 
   if (transaction.mode === "send") {
@@ -114,19 +161,16 @@ export const getTransactionStatus: AccountBridge<
       });
     }
 
-    const insufficientBalance =
-      totalSpent.gt(totalSpendableBalance) || totalSpendableBalance.lt(estimatedFees);
-    if (!errors.amount && insufficientBalance) {
-      errors.amount = new NotEnoughBalance();
-    }
-
     if (isTokenTransaction) {
+      // For token transactions, totalSpent depends on whether fees are in the same token
+      // If fees are in a different token, we can only show the amount (can't add different currencies)
+      // If fees are in the same token, show amount + fees (both already in token's decimals)
       return {
         errors,
         warnings,
-        estimatedFees,
+        estimatedFees: feesForTotalSpent,
         amount,
-        totalSpent: amount,
+        totalSpent,
       };
     }
   }
@@ -134,7 +178,7 @@ export const getTransactionStatus: AccountBridge<
   return {
     errors,
     warnings,
-    estimatedFees,
+    estimatedFees: feesForTotalSpent,
     amount,
     totalSpent,
   };

--- a/libs/coin-modules/coin-celo/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/prepareTransaction.ts
@@ -6,6 +6,7 @@ import { CELO_STABLE_TOKENS } from "../constants";
 import { celoKit } from "../network/sdk";
 import { CeloAccount, Transaction } from "../types";
 import getFeesForTransaction from "./getFeesForTransaction";
+import { isSameTokenAsFee } from "./utils";
 
 export const prepareTransaction: AccountBridge<
   Transaction,
@@ -29,8 +30,16 @@ export const prepareTransaction: AccountBridge<
   const tokenAccount = findSubAccountById(account, transaction.subAccountId || "");
   const isTokenTransaction = tokenAccount?.type === "TokenAccount";
 
+  const shouldSubtractFee = isSameTokenAsFee(
+    isTokenTransaction,
+    tokenAccount?.token?.contractAddress,
+    transaction.feeCurrencyUnwrapped,
+  );
+
   const amount =
-    transaction.useAllAmount && isTokenTransaction ? tokenAccount.balance : transaction.amount;
+    transaction.useAllAmount && isTokenTransaction && !shouldSubtractFee
+      ? tokenAccount?.spendableBalance
+      : transaction.amount;
 
   let token;
   if (isTokenTransaction) {

--- a/libs/coin-modules/coin-celo/src/bridge/transaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/transaction.ts
@@ -27,6 +27,9 @@ const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
     ...common,
     family: tr.family,
     fees: tr.fees ? new BigNumber(tr.fees) : null,
+    feeCurrency: tr.feeCurrency,
+    feeCurrencyUnwrapped: tr.feeCurrencyUnwrapped,
+    feeCurrencyAccountId: tr.feeCurrencyAccountId,
     mode: tr.mode,
     index: tr.index,
   };
@@ -38,6 +41,9 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
     ...common,
     family: t.family,
     fees: t.fees?.toString() || null,
+    feeCurrency: t.feeCurrency,
+    feeCurrencyUnwrapped: t.feeCurrencyUnwrapped,
+    feeCurrencyAccountId: t.feeCurrencyAccountId,
     mode: t.mode,
     index: t.index,
   };

--- a/libs/coin-modules/coin-celo/src/bridge/utils.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/utils.ts
@@ -5,3 +5,78 @@ export const valueToHex = (value: BigNumber): string => {
   if (value.isNaN() || value.isNegative() || value.isZero()) return "0x0";
   return "0x" + value.toString(16);
 };
+
+/**
+ * Determines if the fee currency matches the token being sent.
+ * Returns true when fees should be deducted from the sendable amount.
+ *
+ * @param isTokenTransaction - Whether this is a token transfer (not native CELO)
+ * @param tokenContractAddress - Contract address of the token being sent (if token transaction)
+ * @param feeCurrency - Contract address of the token used to pay fees (null/undefined = native CELO)
+ * @returns true if fee token matches send token, false otherwise
+ */
+export const isSameTokenAsFee = (
+  isTokenTransaction: boolean,
+  tokenContractAddress: string | undefined,
+  feeCurrency: `0x${string}` | null | undefined,
+): boolean => {
+  // Native CELO transfer with native CELO fee
+  if (!isTokenTransaction && !feeCurrency) {
+    return true;
+  }
+
+  // Token transfer with native CELO fee - different tokens
+  if (isTokenTransaction && !feeCurrency) {
+    return false;
+  }
+
+  // Native CELO transfer with token fee - different tokens
+  if (!isTokenTransaction && feeCurrency) {
+    return false;
+  }
+
+  // Token transfer with token fee - compare addresses (case-insensitive)
+  if (isTokenTransaction && feeCurrency && tokenContractAddress) {
+    // Normalize addresses by removing 0x prefix and converting to lowercase
+    const normalizeAddress = (addr: string) => addr.toLowerCase().replace(/^0x/, "");
+    return normalizeAddress(tokenContractAddress) === normalizeAddress(feeCurrency);
+  }
+
+  return false;
+};
+
+type EighteenDecimalBigNumber = BigNumber;
+
+export const normalizeAndSubtract = (
+  balance: BigNumber,
+  fee: EighteenDecimalBigNumber | null | undefined,
+  decimals: number,
+): BigNumber => {
+  const feeValue = fee || BigNumber(0);
+  const balanceInWei = balance.multipliedBy(new BigNumber(10).pow(18 - decimals));
+
+  return balanceInWei.minus(feeValue);
+};
+
+/**
+ * Adjusts the decimals of a given number from 18 decimals to a specified number of target decimals.
+ *
+ * Native CELO uses 18 decimals by default. This function is designed to scale the value
+ * to the corresponding number in the target decimal system. If the `targetDecimals` is
+ * already 18, the input number remains unchanged.
+ *
+ * @param {BigNumber} number - The numerical value to convert, represented as a BigNumber.
+ * @param {number} targetDecimals - The desired number of decimals to convert the value to.
+ * @returns {BigNumber} A new BigNumber instance adjusted to the specified target decimals.
+ */
+export const convertNumberDecimals = (number: BigNumber, targetDecimals: number): BigNumber => {
+  // Native CELO has 18 decimals, so no conversion needed
+  if (targetDecimals === 18) {
+    return number;
+  }
+
+  // Convert from 18 decimals to target decimals
+  // e.g., for 6 decimals: divide by 10^(18-6) = 10^12
+  const decimalDifference = 18 - targetDecimals;
+  return number.dividedToIntegerBy(new BigNumber(10).pow(decimalDifference));
+};

--- a/libs/coin-modules/coin-celo/src/types/types.ts
+++ b/libs/coin-modules/coin-celo/src/types/types.ts
@@ -61,6 +61,11 @@ export type CeloResourcesRaw = {
 export type Transaction = TransactionCommon & {
   family: "celo";
   fees: BigNumber | null | undefined;
+  // adapter address or contract address for fee currency
+  feeCurrency?: `0x${string}` | null | undefined;
+  // always contract address for fee currency
+  feeCurrencyUnwrapped?: `0x${string}` | null | undefined;
+  feeCurrencyAccountId?: string | null | undefined;
   mode: CeloOperationMode;
   index: number | null | undefined;
   data?: Buffer | null | undefined;
@@ -68,6 +73,9 @@ export type Transaction = TransactionCommon & {
 export type TransactionRaw = TransactionCommonRaw & {
   family: "celo";
   fees: string | null | undefined;
+  feeCurrency?: `0x${string}` | null | undefined;
+  feeCurrencyUnwrapped?: `0x${string}` | null | undefined;
+  feeCurrencyAccountId?: string | null | undefined;
   mode: CeloOperationMode;
   index: number | null | undefined;
 };


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - underlying work for paying fee with non native tokens
  - no breaking change for existing functionality 

### 📝 Description

# 🎯 Fee Abstraction Support for Celo Token Transactions

## Summary

This PR implements comprehensive support for **fee abstraction** in Celo, allowing users to pay transaction fees using ERC20 tokens (like USDC, USDT) instead of only the native CELO token. This feature leverages Celo's unique `feeCurrency` field and handles the complexity of adapter addresses for tokens with non-18 decimal precision.

## Key Features

### 🔧 Core Implementation

- **Fee Currency Selection**: Added `feeCurrency`, `feeCurrencyUnwrapped`, and `feeCurrencyAccount` fields to transaction types
  - `feeCurrency`: Adapter or token address used for paying fees (sent to blockchain)
  - `feeCurrencyUnwrapped`: Always the underlying token contract address (for internal logic)
  - `feeCurrencyAccount`: TokenAccount reference for fee currency metadata

### 📊 Smart Fee Calculation

- **Same-Token Detection**: Determines when fee currency matches the transfer token to correctly calculate available balance
- **Max Spendable Logic**: 
  - When sending USDC and paying fees in USDC → deduct fees from spendable amount
  - When sending USDC and paying fees in CELO → can send full USDC balance (fees paid separately)

### 🔢 Decimal Normalization (Critical Feature)

The Celo blockchain natively works with **18 decimals** for all gas calculations, but tokens like USDC and USDT use **6 decimals**. This creates a decimal mismatch that requires careful handling:

#### Why We Need `feeCurrencyUnwrapped` and Adapters:

1. **Adapter Purpose**: Celo uses adapter contracts to normalize non-18 decimal tokens to 18 decimals for fee calculations
   - USDC token address: `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` (6 decimals)
   - USDC adapter address: `0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B` (18 decimal interface)

2. **Storage Strategy**:
   - `feeCurrency`: Stores adapter address (for blockchain transactions)
   - `feeCurrencyUnwrapped`: Stores actual token address (for balance checks and UI logic)
   - This separation is essential because:
     - Blockchain needs adapter address for proper fee processing
     - UI needs token address to check user balance and display correct amounts
     - Internal logic needs token address to determine if fee token matches transfer token

3. **Decimal Conversion Functions**:
   - `convertFeeDecimals()`: Converts fees from 18 decimals (Wei) to token's native decimals for display
   - `normalizeAndSubtract()`: Normalizes token balance to 18 decimals for fee comparison
   - Example: 1 USDC fee = `1000000000000000000` Wei (18 decimals) → `1000000` (6 decimals for display)

## Technical Changes

### New Utility Functions (`src/bridge/utils.ts`)

- `isSameTokenAsFee()`: Determines if fee currency matches transfer token
- `normalizeAndSubtract()`: Normalizes balance and subtracts fees (handles decimal conversion)
- `convertFeeDecimals()`: Converts fee from Wei (18 decimals) to target token decimals

### Modified Bridge Functions

- **`buildTransaction.ts`**: Adds `feeCurrency` field to transaction payload, handles max amount calculation with fee consideration
- **`prepareTransaction.ts`**: Calculates correct `useAllAmount` based on fee currency matching
- **`getTransactionStatus.ts`**: 
  - Validates sufficient balance considering fee currency
  - Converts fees to correct decimals for UI display
  - Calculates `totalSpent` only when fee and transfer tokens match
- **`estimateMaxSpendable.ts`**: Accounts for fees when estimating max spendable amount
- **`getFeesForTransaction.ts`**: Passes `feeCurrency` to RPC for accurate gas price estimation
- **`createTransaction.ts`**: Includes `feeCurrency` in operation extra data

### Type Additions

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-19721
- https://ledgerhq.atlassian.net/browse/LIVE-19720


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
