### PR TITLE
[LWDM] fix(LIVE-27282): adjust senders and recipients in hedera operations

### DIFF
--- a/.changeset/long-tools-impress.md
+++ b/.changeset/long-tools-impress.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix: adjust senders and recipients in hedera operations

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@hashgraph/sdk";
 import type { FeeEstimation } from "@ledgerhq/coin-framework/api/types";
 import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { getEnv } from "@ledgerhq/live-env";
 import invariant from "invariant";
 import { createApi } from "../api";
 import { HEDERA_TRANSACTION_MODES, STAKING_REWARD_HASH_SUFFIX, TINYBAR_SCALE } from "../constants";
@@ -763,6 +764,8 @@ describe("createApi", () => {
   });
 
   describe("listOperations", () => {
+    const rewardPayerAddress = getEnv("HEDERA_STAKING_REWARD_ACCOUNT_ID");
+
     it("returns empty array for pristine account", async () => {
       const { items: operations } = await api.listOperations(
         MAINNET_TEST_ACCOUNTS.pristine.accountId,
@@ -876,6 +879,32 @@ describe("createApi", () => {
       expect(rewardOp?.tx.hash).not.toContain(STAKING_REWARD_HASH_SUFFIX);
       // every staking operation should have a fees payer
       expect(ops.every(op => /^0\.0\.\d+$/.test(op.tx.feesPayer ?? ""))).toBe(true);
+    });
+
+    it("returns valid senders and recipients for staking operations", async () => {
+      const cursor = "1772617523.000000000";
+      const { items: ops } = await api.listOperations(
+        MAINNET_TEST_ACCOUNTS.withStakingHistory.accountId,
+        { minHeight: 0, cursor, limit: 30, order: "desc" },
+      );
+
+      const delegateHash = "+07jwNyyEDuwngDgoW3sVgfTfDE5qn+HgPsbltlrUIW/n/LYpFSEwSQNOTu/8GLQ";
+      const undelegateHash = "v0jXJwjKaypunqz91EuQDU2mz/ejSb3AvEJ5fgYkftl+DDT2mBlwB5bSRqXWyoth";
+      const redelegateHash = "pm8vFWlcBEEPbB+pkZTUUxs0FfO2KyDtg0KNfOYnnba+rpHT63OIMhFKKNpfDokk";
+
+      const delegateOp = ops.find(o => o.type !== "REWARD" && o.tx.hash === delegateHash);
+      const undelegateOp = ops.find(o => o.type !== "REWARD" && o.tx.hash === undelegateHash);
+      const redelegateOp = ops.find(o => o.type !== "REWARD" && o.tx.hash === redelegateHash);
+      const rewardOp = ops.find(o => o.type === "REWARD");
+
+      expect(delegateOp?.senders).toEqual([MAINNET_TEST_ACCOUNTS.withStakingHistory.accountId]);
+      expect(delegateOp?.recipients).toEqual(["0.0.14"]);
+      expect(undelegateOp?.senders).toEqual([MAINNET_TEST_ACCOUNTS.withStakingHistory.accountId]);
+      expect(undelegateOp?.recipients).toEqual(["0.0.31"]);
+      expect(redelegateOp?.senders).toEqual([MAINNET_TEST_ACCOUNTS.withStakingHistory.accountId]);
+      expect(redelegateOp?.recipients).toEqual(["0.0.23"]);
+      expect(rewardOp?.senders).toEqual([rewardPayerAddress]);
+      expect(rewardOp?.recipients).toEqual([MAINNET_TEST_ACCOUNTS.withStakingHistory.accountId]);
     });
 
     it("returns valid stakedAmount, respecting uncommitted balance changes", async () => {

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -1328,4 +1328,37 @@ describe("listOperationsV2", () => {
       expect.objectContaining({ hash: mockERC20MirrorTransaction.transaction_hash, type: "FEES" }),
     ]);
   });
+
+  it("should use rawTx.node as recipient when recipients array is empty", async () => {
+    const nodeAccountId = "0.0.5";
+    const mockTransaction = getMockedMirrorTransaction({
+      node: nodeAccountId,
+      token_transfers: [],
+      staking_reward_transfers: [],
+      transfers: [{ account: mockMirrorAccount.account, amount: -500000 }],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (utils.analyzeStakingOperation as jest.Mock).mockResolvedValue(null);
+
+    const result = await listOperations({
+      limit: mockLimit,
+      order: mockOrder,
+      currency: mockCurrency,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      erc20Tokens: [],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+    });
+
+    expect(result.coinOperations).toHaveLength(1);
+    expect(result.coinOperations[0].recipients).toEqual([nodeAccountId]);
+  });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -299,6 +299,11 @@ function processCoinTransfers({
     extra.stakedAmount = new BigNumber(stakingAnalysis.stakedAmount.toString());
   }
 
+  // if recipients array is empty, add the node where the transaction was submitted as recipient
+  if (recipients.length === 0 && rawTx.node) {
+    recipients.push(rawTx.node);
+  }
+
   // try to enrich ASSOCIATE_TOKEN operation with extra.associatedTokenId
   // this value is used by custom OperationDetails components in Hedera family
   // accounts or contracts must first associate with an HTS token before they can receive or send that token; without association, token transfers fail

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -1,4 +1,5 @@
 import { setupMockCryptoAssetsStore } from "@ledgerhq/cryptoassets/cal-client/test-helpers";
+import { getEnv } from "@ledgerhq/live-env";
 import BigNumber from "bignumber.js";
 import { SUPPORTED_ERC20_TOKENS } from "../constants";
 import { getMockedAccount } from "../test/fixtures/account.fixture";
@@ -35,8 +36,10 @@ describe("network utils", () => {
   });
 
   describe("parseTransfers", () => {
+    const userAddress = "0.0.1234";
+    const rewardPayer = getEnv("HEDERA_STAKING_REWARD_ACCOUNT_ID");
+
     it("should correctly identify an incoming transfer", () => {
-      const userAddress = "0.0.1234";
       const transfers = [
         createMirrorCoinTransfer("0.0.5678", -100),
         createMirrorCoinTransfer(userAddress, 100),
@@ -51,7 +54,6 @@ describe("network utils", () => {
     });
 
     it("should correctly identify an outgoing transfer", () => {
-      const userAddress = "0.0.1234";
       const transfers = [
         createMirrorCoinTransfer(userAddress, -100),
         createMirrorCoinTransfer("0.0.5678", 100),
@@ -66,7 +68,6 @@ describe("network utils", () => {
     });
 
     it("should handle multiple senders and recipients", () => {
-      const userAddress = "0.0.1234";
       const transfers = [
         createMirrorCoinTransfer("0.0.5678", -50),
         createMirrorCoinTransfer(userAddress, -50),
@@ -82,7 +83,6 @@ describe("network utils", () => {
     });
 
     it("should correctly process token transfers", () => {
-      const userAddress = "0.0.1234";
       const tokenId = "0.0.7777";
       const transfers = [
         createMirrorTokenTransfer(userAddress, -10, tokenId),
@@ -98,7 +98,6 @@ describe("network utils", () => {
     });
 
     it("should exclude system accounts that are not nodes from recipients", () => {
-      const userAddress = "0.0.1234";
       const systemAccount = "0.0.500";
       const transfers = [
         createMirrorCoinTransfer(userAddress, -100),
@@ -114,7 +113,6 @@ describe("network utils", () => {
     });
 
     it("should include node accounts as recipients only if no other recipients", () => {
-      const userAddress = "0.0.1234";
       const nodeAccount = "0.0.3";
       const transfers = [
         createMirrorCoinTransfer(userAddress, -100),
@@ -130,7 +128,6 @@ describe("network utils", () => {
     });
 
     it("should exclude node accounts if there are other recipients", () => {
-      const userAddress = "0.0.1234";
       const normalAccount = "0.0.5678";
       const nodeAccount = "0.0.3";
       const transfers = [
@@ -148,7 +145,6 @@ describe("network utils", () => {
     });
 
     it("should handle transactions where user is not involved", () => {
-      const userAddress = "0.0.1234";
       const transfers = [
         createMirrorCoinTransfer("0.0.5678", -100),
         createMirrorCoinTransfer("0.0.9999", 100),
@@ -163,7 +159,6 @@ describe("network utils", () => {
     });
 
     it("should handle empty transfers array", () => {
-      const userAddress = "0.0.1234";
       const transfers: HederaMirrorCoinTransfer[] = [];
 
       const result = parseTransfers(transfers, userAddress);
@@ -175,7 +170,6 @@ describe("network utils", () => {
     });
 
     it("should reverse the order of senders and recipients", () => {
-      const userAddress = "0.0.1234";
       const transfers = [
         createMirrorCoinTransfer("0.0.900", -5),
         createMirrorCoinTransfer("0.0.5678", -95),
@@ -191,7 +185,6 @@ describe("network utils", () => {
     });
 
     it("should subtract staking reward from amount", () => {
-      const userAddress = "0.0.1234";
       const amount = new BigNumber(30);
       const stakingReward = new BigNumber(20);
       const transfers = [createMirrorCoinTransfer(userAddress, amount.toNumber())];
@@ -203,6 +196,30 @@ describe("network utils", () => {
         type: "IN",
         value: expectedAmountWithoutReward,
       });
+    });
+
+    it("excludes reward payer from senders when staking reward is present", () => {
+      const stakingReward = new BigNumber(30000000);
+      const transfers = [
+        createMirrorCoinTransfer(rewardPayer, -30000000),
+        createMirrorCoinTransfer("0.0.801", 1000),
+        createMirrorCoinTransfer(userAddress, 30000000),
+      ];
+
+      const result = parseTransfers(transfers, userAddress, stakingReward);
+
+      expect(result.senders).not.toContain(rewardPayer);
+    });
+
+    it("includes reward payer in senders when no staking reward", () => {
+      const transfers = [
+        createMirrorCoinTransfer(rewardPayer, -1000000),
+        createMirrorCoinTransfer(userAddress, 1000000),
+      ];
+
+      const result = parseTransfers(transfers, userAddress);
+
+      expect(result.senders).toContain(rewardPayer);
     });
   });
 

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -1,5 +1,6 @@
 import { AccountId } from "@hashgraph/sdk";
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
+import { getEnv } from "@ledgerhq/live-env";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
@@ -44,19 +45,28 @@ export function parseTransfers(
 
   const senders: string[] = [];
   const recipients: string[] = [];
+  const rewardPayerAddress = getEnv("HEDERA_STAKING_REWARD_ACCOUNT_ID");
 
   for (const transfer of mirrorTransfers) {
     const amount = new BigNumber(transfer.amount);
     const accountId = AccountId.fromString(transfer.account);
 
     // staking reward is included in transfer, so it can be positive even if user sent less HBARs than the reward is
+    const amountWithoutReward = transfer.account === address ? amount.minus(stakingReward) : amount;
+
     if (transfer.account === address) {
-      const amountWithoutReward = amount.minus(stakingReward);
       value = amountWithoutReward.abs();
       type = amountWithoutReward.isNegative() ? "OUT" : "IN";
     }
 
-    if (amount.isNegative()) {
+    if (amountWithoutReward.isNegative()) {
+      // exclude reward payer from senders list, because rewards are shown as separate operations
+      const shouldIgnoreAddress = transfer.account === rewardPayerAddress && stakingReward.gt(0);
+
+      if (shouldIgnoreAddress) {
+        continue;
+      }
+
       senders.push(transfer.account);
     } else if (isValidRecipient(accountId, recipients)) {
       recipients.push(transfer.account);

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/account.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/account.fixture.ts
@@ -152,4 +152,7 @@ export const MAINNET_TEST_ACCOUNTS = {
     accountId: "0.0.9806001",
     publicKey: "0283ef0997da7161c9a3aec45c57f4e074cb67916c97c1e5339d9f988e702e0450",
   },
+  withStakingHistory: {
+    accountId: "0.0.10083165",
+  },
 };

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/mirror.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/mirror.fixture.ts
@@ -73,6 +73,7 @@ export const getMockedMirrorTransaction = (
     transfers: [],
     token_transfers: [],
     memo_base64: "",
+    node: "0.0.3",
     ...overrides,
   };
 };

--- a/libs/coin-modules/coin-hedera/src/types/mirror.ts
+++ b/libs/coin-modules/coin-hedera/src/types/mirror.ts
@@ -27,6 +27,7 @@ export interface HederaMirrorTransaction {
   consensus_timestamp: string;
   entity_id: string | null;
   result: string;
+  node: string | null;
   name: string;
   memo_base64?: string;
 }

--- a/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
@@ -346,11 +346,10 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "1xhiUumIUOljak_LHryZWzRtp9qWA5MOv9xI_Yxudq0owHR0r1Mp-M2_zn5fNo0i",
       "id": "js:2:hedera:0.0.1040977:hederaBip44-1xhiUumIUOljak_LHryZWzRtp9qWA5MOv9xI_Yxudq0owHR0r1Mp-M2_zn5fNo0i-REDELEGATE",
       "recipients": [
-        "0.0.1040977",
         "0.0.3",
       ],
       "senders": [
-        "0.0.800",
+        "0.0.1040977",
       ],
       "type": "REDELEGATE",
       "value": "157370",
@@ -502,7 +501,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       ],
       "senders": [
         "0.0.8217344",
-        "0.0.800",
       ],
       "type": "IN",
       "value": "10000",
@@ -977,7 +975,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       ],
       "senders": [
         "0.0.1040977",
-        "0.0.800",
       ],
       "type": "OUT",
       "value": "100073908",
@@ -1378,7 +1375,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       ],
       "senders": [
         "0.0.1040977",
-        "0.0.800",
       ],
       "type": "OUT",
       "value": "31025298236",
@@ -1458,11 +1454,10 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "lDXnoFtP4uY-qU75njaAGqY8Ygm-LVA5uINnRP7ZytcKnLIwCq1EmBWBMFweVg88",
       "id": "js:2:hedera:0.0.1040977:hederaBip44-lDXnoFtP4uY-qU75njaAGqY8Ygm-LVA5uINnRP7ZytcKnLIwCq1EmBWBMFweVg88-UNDELEGATE",
       "recipients": [
-        "0.0.1040977",
         "0.0.3",
       ],
       "senders": [
-        "0.0.800",
+        "0.0.1040977",
       ],
       "type": "UNDELEGATE",
       "value": "167909",
@@ -1486,7 +1481,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       ],
       "senders": [
         "0.0.1040977",
-        "0.0.800",
       ],
       "type": "OUT",
       "value": "100070763",
@@ -2519,7 +2513,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       ],
       "senders": [
         "0.0.7305122",
-        "0.0.800",
       ],
       "type": "OUT",
       "value": "107731",
@@ -3689,11 +3682,10 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "D0THYkg2fTR1QjRmVbGV-N8TcD6nUmBpS0v8M17sJVvJLrrF-MOdF5W5u_Lde7qG",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-D0THYkg2fTR1QjRmVbGV-N8TcD6nUmBpS0v8M17sJVvJLrrF-MOdF5W5u_Lde7qG-REDELEGATE",
       "recipients": [
-        "0.0.8313485",
         "0.0.37",
       ],
       "senders": [
-        "0.0.800",
+        "0.0.8313485",
       ],
       "type": "REDELEGATE",
       "value": "184381",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Hedera operations list

### 📝 Description

This PR adjusts `senders` and `recipients` details in Hedera operations:
- reward payer address is excluded from `senders` of reward-triggering operation (we have dedicated REWARD operation to represent this)
- added fallback to `tx.node` when `recipients` array is empty after parsing transfers array (the node the transaction was submitted to)

<img width="1540" height="339" alt="list-operations-changes" src="https://github.com/user-attachments/assets/a7f06a79-373d-4722-a576-6cfa70a93712" />
<img width="1466" height="244" alt="image" src="https://github.com/user-attachments/assets/494c32be-0da3-44cb-9a3f-6f766d0875cc" />


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-27282


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
