### PR TITLE
[LWDM] feat(LIVE-27354): add aleo config isFeeSponsored field

### DIFF
--- a/.changeset/short-aleo-fee-auth-flag.md
+++ b/.changeset/short-aleo-fee-auth-flag.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aleo": minor
+"@ledgerhq/live-common": minor
+---
+
+Add Aleo currency config flag `isFeeSponsored` to control sponsored-fee behavior for private send flows.

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/config.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/config.fixture.ts
@@ -15,6 +15,7 @@ export const getMockedConfig = (networkType: "mainnet" | "testnet"): AleoCoinCon
       [TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC]: 18494,
     },
     feeSafetyMultiplier: 1,
+    isFeeSponsored: true,
     status: { type: "active" },
   };
 };

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -23,6 +23,7 @@ describe("createApi", () => {
         [TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC]: 18494,
       },
       feeSafetyMultiplier: 1,
+      isFeeSponsored: true,
     },
     "aleo",
   );

--- a/libs/coin-modules/coin-aleo/src/config.ts
+++ b/libs/coin-modules/coin-aleo/src/config.ts
@@ -9,6 +9,7 @@ export type AleoConfig = {
   };
   feeByTransactionType: Record<TransactionType, number>;
   feeSafetyMultiplier: number;
+  isFeeSponsored: boolean;
 };
 
 export type AleoCoinConfig = CurrencyConfig & AleoConfig;

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
@@ -27,6 +27,7 @@ describe("getPrivateBalance", () => {
         [TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC]: 18494,
       },
       feeSafetyMultiplier: 1,
+      isFeeSponsored: true,
     }));
   });
 

--- a/libs/ledger-live-common/src/families/aleo/config.ts
+++ b/libs/ledger-live-common/src/families/aleo/config.ts
@@ -14,6 +14,13 @@ const DEFAULT_FEE_BY_TRANSACTION_TYPE: Record<TransactionType, number> = {
 
 const DEFAULT_FEE_SAFETY_MULTIPLIER = 1;
 
+/**
+ * Controls whether fee sponsorship for single-record private transactions
+ * is enabled (fees paid by a 3rd party on behalf of the user).
+ * @see https://ledgerhq.atlassian.net/browse/LIVE-27354
+ */
+const IS_FEE_SPONSORED = true;
+
 export const aleoConfig: Record<string, ConfigInfo> = {
   config_currency_aleo: {
     type: "object",
@@ -29,6 +36,7 @@ export const aleoConfig: Record<string, ConfigInfo> = {
       },
       feeByTransactionType: DEFAULT_FEE_BY_TRANSACTION_TYPE,
       feeSafetyMultiplier: DEFAULT_FEE_SAFETY_MULTIPLIER,
+      isFeeSponsored: IS_FEE_SPONSORED,
     },
   },
   config_currency_aleo_testnet: {
@@ -45,6 +53,7 @@ export const aleoConfig: Record<string, ConfigInfo> = {
       },
       feeByTransactionType: DEFAULT_FEE_BY_TRANSACTION_TYPE,
       feeSafetyMultiplier: DEFAULT_FEE_SAFETY_MULTIPLIER,
+      isFeeSponsored: IS_FEE_SPONSORED,
     },
   },
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Aleo currency config flag `isSponsoringFees` added to control sponsored-fee behavior for private send flows.

### 📝 Description

This PR adds Aleo currency config flag `isSponsoringFees` to control sponsored-fee behavior for private send flows.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-27354

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
