### PR TITLE
[LWM] fix(mobile): prevent hooks order crash on ModularDrawer spam

### DIFF
--- a/.changeset/fix-modular-drawer-hooks-crash.md
+++ b/.changeset/fix-modular-drawer-hooks-crash.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix hooks order crash when spamming ModularDrawer open/close with lwmWallet40

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlowManager/ModularDrawerFlowView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlowManager/ModularDrawerFlowView.tsx
@@ -21,13 +21,29 @@ export function ModularDrawerFlowView({
 
   const { activeSteps, getStepAnimations } = useScreenTransition(currentStep);
 
+  const { assetsConfiguration } = assetsViewModel;
+  const assetSelectionKey = `${assetsConfiguration?.rightElement ?? "default"}-${assetsConfiguration?.leftElement ?? "default"}`;
+
+  const { networksConfiguration } = networksViewModel;
+  const networkSelectionKey = `${networksConfiguration?.rightElement ?? "default"}-${networksConfiguration?.leftElement ?? "default"}`;
+
   const renderStepContent = (step: ModularDrawerStep) => {
     switch (step) {
       case ModularDrawerStep.Asset:
-        return <AssetSelection {...assetsViewModel} useLumenBottomSheet={useLumenBottomSheet} />;
+        return (
+          <AssetSelection
+            key={assetSelectionKey}
+            {...assetsViewModel}
+            useLumenBottomSheet={useLumenBottomSheet}
+          />
+        );
       case ModularDrawerStep.Network:
         return (
-          <NetworkSelection {...networksViewModel} useLumenBottomSheet={useLumenBottomSheet} />
+          <NetworkSelection
+            key={networkSelectionKey}
+            {...networksViewModel}
+            useLumenBottomSheet={useLumenBottomSheet}
+          />
         );
       case ModularDrawerStep.Account:
         return (

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -97,7 +97,7 @@ const AssetSelection = ({
   const transformAssets = makeAssetConfigurationHook({
     assetsConfiguration,
   });
-  const formattedAssets = transformAssets(availableAssets);
+  const formattedAssets = transformAssets(availableAssets ?? []);
 
   const handleAssetClick = useCallback(
     (asset: AssetType) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/index.tsx
@@ -95,7 +95,7 @@ const NetworkSelection = ({
     networksConfig: networksConfiguration,
   });
 
-  const formattedNetworks = transformNetworks(availableNetworks);
+  const formattedNetworks = transformNetworks(availableNetworks ?? []);
 
   const keyExtractor = useCallback((item: AssetType, index: number) => `${item.id}-${index}`, []);
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - ModularDrawer asset selection flow (swap, earn, buy)
      - ModularDrawer network selection flow
      - Specifically with `lwmWallet40` feature flag enabled

### 📝 Description

**Problem**: When spamming the "Choose asset" button in the swap screen with the `lwmWallet40` feature flag enabled, the app crashes with:
1. `React has detected a change in the order of Hooks called by AssetSelection`
2. `Cannot read property 'length' of undefined`

**Root cause**: With `lwmWallet40`, the Lumen `BottomSheet` keeps children mounted on dismiss (unlike Gorhom's `BottomSheetModal` which unmounts them). When the drawer closes, `closeModularDrawer` resets `assetsConfiguration`/`networksConfiguration` to `INITIAL_STATE` while `AssetSelection`/`NetworkSelection` stay alive. Reopening with a different config changes the dynamic hooks called inside `createAssetConfigurationHook`/`createNetworkConfigurationHook` (via `composeHooks` with `.filter(Boolean)`), violating React's Rules of Hooks and corrupting state.

**Fix**:
- Add stable keys derived from the hook-relevant config properties (`rightElement`/`leftElement`) on `AssetSelection` and `NetworkSelection` so React remounts them cleanly when the configuration changes.
- Guard against undefined `availableAssets`/`availableNetworks` arrays as a defensive measure.

`AccountSelection` was verified safe — it doesn't use dynamic hook factories.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27193](https://ledgerhq.atlassian.net/browse/LIVE-27193)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27193]: https://ledgerhq.atlassian.net/browse/LIVE-27193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ