### PR TITLE
[LWDM] chore(live-common): update snapshot for bridge integration test

### DIFF
--- a/libs/ledger-live-common/src/families/cardano/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cardano/__snapshots__/bridge.integration.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`cardano_testnet currency bridge scanAccounts cardano_testnet seed 1 1`] = `
 [
   {
-    "balance": "11797404086",
+    "balance": "11805369934",
     "cardanoResources": {
       "delegation": {
         "dRepHex": undefined,
         "deposit": "2000000",
         "name": "Apex Cardano Pool",
         "poolId": "7facad662e180ce45e5c504957cd1341940c72a708728f7ecfc6e349",
-        "rewards": "1698574711",
+        "rewards": "1706540559",
         "status": true,
         "ticker": "APEX",
       },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - live-common `bridge.integration.test.ts.snap` updated, as it was failing on CI

### 📝 Description

**Required to push release through**

CI was failing for [Release 2026-03-04](https://github.com/LedgerHQ/ledger-live/pull/15009#top) and turns out snapshot was not updated correctly. Installed live-common, updated snapshot, confirmed with `git diff`

<img width="1732" height="1174" alt="image" src="https://github.com/user-attachments/assets/d0dbe4fb-84a4-40f9-8098-9fed6f15e488" />


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
Release 2026-03-04

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
