### PR TITLE
[LWM] feat(concordium): add custom receive confirmation screen for ccd

### DIFF
--- a/.changeset/healthy-melons-push.md
+++ b/.changeset/healthy-melons-push.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add custom receive confirmation screen for Concordium accounts

--- a/apps/ledger-live-mobile/src/families/concordium/Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/Confirmation.tsx
@@ -1,0 +1,165 @@
+import React, { useMemo } from "react";
+import { View } from "react-native";
+import QRCode from "react-native-qrcode-svg";
+import { Trans, useTranslation } from "~/context/Locale";
+import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { getDefaultExplorerView, getAddressExplorer } from "@ledgerhq/live-common/explorers";
+import { CompositeScreenProps } from "@react-navigation/native";
+import styled, { useTheme } from "styled-components/native";
+import { Box, Flex, Text } from "@ledgerhq/native-ui";
+import getWindowDimensions from "~/logic/getWindowDimensions";
+import { TrackScreen } from "~/analytics";
+import CurrencyIcon from "~/components/CurrencyIcon";
+import NavigationScrollView from "~/components/NavigationScrollView";
+import Alert from "~/components/Alert";
+import { ReceiveFundsStackParamList } from "~/components/RootNavigator/types/ReceiveFundsNavigator";
+import { ScreenName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { useMaybeAccountName } from "~/reducers/wallet";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+import { BaseStyledProps } from "@ledgerhq/native-ui/lib/components/styled";
+import { getFreshAccountAddress } from "~/utils/address";
+import CopyButton from "LLM/components/CopyButton";
+import ShareButton from "LLM/components/ShareButton";
+
+type ScreenProps = CompositeScreenProps<
+  StackNavigatorProps<ReceiveFundsStackParamList, ScreenName.ReceiveConfirmation>,
+  StackNavigatorProps<BaseNavigatorStackParamList>
+>;
+
+type Props = ScreenProps;
+
+export default function Confirmation({ route }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const { account, parentAccount } = useAccountScreen(route);
+
+  const mainAccount = account && getMainAccount(account, parentAccount);
+  const currency = account && getAccountCurrency(account);
+  const mainAccountName = useMaybeAccountName(mainAccount);
+
+  const freshAccountAddress = useMemo(() => {
+    return mainAccount && getFreshAccountAddress(mainAccount);
+  }, [mainAccount]);
+
+  const explorerUrl = useMemo(() => {
+    if (!mainAccount) return undefined;
+    const explorerView = getDefaultExplorerView(mainAccount.currency);
+    return freshAccountAddress ? getAddressExplorer(explorerView, freshAccountAddress) : undefined;
+  }, [mainAccount, freshAccountAddress]);
+
+  if (!mainAccount || !account || !currency || !freshAccountAddress) return null;
+
+  const { width } = getWindowDimensions();
+  const QRSize = Math.round(width / 1.8 - 16);
+  const QRContainerSize = QRSize + 16 * 4;
+
+  return (
+    <Flex flex={1}>
+      <NavigationScrollView
+        testID="receive-screen-scrollView"
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingBottom: 80 }}
+      >
+        <TrackScreen category="ReceiveFunds" name="Confirmation" currencyName={currency.name} />
+        <Flex flexDirection="column" justifyContent="space-around" flex={1}>
+          <Box alignItems="center" justifyContent="center" p={0}>
+            <Flex
+              alignItems="center"
+              justifyContent="center"
+              width={QRContainerSize}
+              p={6}
+              mt={10}
+              bg={colors.opacityDefault.c05}
+              borderRadius={2}
+            >
+              <View>
+                <Box mb={6}>
+                  <Text
+                    variant={"body"}
+                    fontWeight={"semiBold"}
+                    textAlign={"center"}
+                    numberOfLines={1}
+                    testID={"receive-account-name-" + mainAccountName}
+                  >
+                    {mainAccountName}
+                  </Text>
+                </Box>
+                <Flex
+                  p={6}
+                  borderRadius={24}
+                  position="relative"
+                  bg="constant.white"
+                  borderWidth={1}
+                  borderColor="neutral.c40"
+                  alignItems="center"
+                  justifyContent="center"
+                  testID={"receive-qr-code-container-" + mainAccountName}
+                >
+                  <QRCode size={QRSize} value={freshAccountAddress} ecl="H" />
+                  <Flex
+                    alignItems="center"
+                    justifyContent="center"
+                    width={QRSize * 0.3}
+                    height={QRSize * 0.3}
+                    bg="constant.white"
+                    position="absolute"
+                  >
+                    <CurrencyIcon currency={currency} size={48} />
+                  </Flex>
+                </Flex>
+                <Text
+                  testID="receive-fresh-address"
+                  variant={"body"}
+                  fontWeight={"medium"}
+                  textAlign={"center"}
+                  mt={6}
+                >
+                  {freshAccountAddress}
+                </Text>
+              </View>
+            </Flex>
+            <Flex width={QRContainerSize} flexDirection="row" mt={6}>
+              <StyledPressable
+                borderRadius={2}
+                style={({ pressed }: { pressed: boolean }) => [{ opacity: pressed ? 0.6 : 1 }]}
+              >
+                <ShareButton value={freshAccountAddress} />
+              </StyledPressable>
+              <StyledPressable
+                borderRadius={2}
+                isFlex
+                style={({ pressed }: { pressed: boolean }) => [{ opacity: pressed ? 0.6 : 1 }]}
+              >
+                <CopyButton text={freshAccountAddress}>
+                  <Trans i18nKey="transfer.receive.copyAddress" />
+                </CopyButton>
+              </StyledPressable>
+            </Flex>
+          </Box>
+          <Flex px={6} flexDirection="column" rowGap={8} mt={6} mb={4}>
+            <Alert
+              type="security"
+              learnMoreUrl={explorerUrl}
+              learnMoreText={t("concordium.receive.verifyLink")}
+            >
+              <Trans i18nKey="concordium.receive.messageIfSkipped" />
+            </Alert>
+          </Flex>
+        </Flex>
+      </NavigationScrollView>
+    </Flex>
+  );
+}
+
+const StyledPressable = styled.Pressable<BaseStyledProps & { isFlex?: boolean }>`
+  padding: 4px;
+  background-color: ${({ theme }) => theme.colors.opacityDefault.c05};
+  margin-right: 4px;
+  ${({ isFlex }) =>
+    isFlex &&
+    `
+      flex: 1;
+    `}
+`;

--- a/apps/ledger-live-mobile/src/families/concordium/ConnectDevice.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/ConnectDevice.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { ScreenName } from "~/const";
+import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { ReceiveFundsStackParamList } from "~/components/RootNavigator/types/ReceiveFundsNavigator";
+import { useAccountScreen } from "LLM/hooks/useAccountScreen";
+
+type Props = StackNavigatorProps<ReceiveFundsStackParamList, ScreenName.ReceiveConnectDevice>;
+
+export default function ConnectDevice({ navigation, route }: Props) {
+  const { account } = useAccountScreen(route);
+
+  useEffect(() => {
+    if (!account) return;
+    navigation.replace(ScreenName.ReceiveConfirmation, { ...route.params });
+  }, [account, navigation, route.params]);
+
+  return null;
+}

--- a/apps/ledger-live-mobile/src/families/concordium/__tests__/Confirmation.test.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/__tests__/Confirmation.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import Confirmation from "../Confirmation";
+
+jest.mock("LLM/hooks/useAccountScreen", () => ({
+  useAccountScreen: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/explorers", () => ({
+  getDefaultExplorerView: () => ({
+    tx: "https://testnet.ccdscan.io/transactions?dentity=transaction&dhash=$hash",
+    address: "https://testnet.ccdscan.io/accounts?dentity=account&daddress=$address",
+  }),
+  getAddressExplorer: (_view: unknown, address: string) =>
+    `https://testnet.ccdscan.io/accounts?dentity=account&daddress=${address}`,
+}));
+
+jest.mock("~/utils/address", () => ({
+  getFreshAccountAddress: (account: { freshAddress: string }) => account.freshAddress,
+}));
+
+// NavigationScrollView uses useRoute() which requires a navigator screen context
+jest.mock("~/components/NavigationScrollView", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ScrollView } = require("react-native");
+  return (props: { children: React.ReactNode }) => <ScrollView>{props.children}</ScrollView>;
+});
+
+const { useAccountScreen } = jest.requireMock("LLM/hooks/useAccountScreen");
+
+const mockAccount = {
+  id: "concordium-account-1",
+  type: "Account" as const,
+  freshAddress: "3YkS2vmBHAbo7RGKQ78MjJ3QhEDAqQTJgX2tnrGZbE9oLpuRqE",
+  freshAddressPath: "44'/919'/0'/0/0",
+  currency: {
+    type: "CryptoCurrency" as const,
+    id: "concordium",
+    name: "Concordium",
+    family: "concordium",
+  },
+  derivationMode: "",
+  seedIdentifier: "test-seed",
+  subAccounts: [],
+};
+
+const baseRoute = {
+  key: "test-key",
+  name: ScreenName.ReceiveConfirmation as const,
+  params: {
+    accountId: "concordium-account-1",
+    parentId: undefined,
+  },
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const baseNavigation = {
+  navigate: jest.fn(),
+  setOptions: jest.fn(),
+} as unknown as Parameters<typeof Confirmation>[0]["navigation"];
+
+describe("Confirmation (Concordium)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAccountScreen.mockReturnValue({
+      account: mockAccount,
+      parentAccount: null,
+    });
+  });
+
+  it("should render the fresh address", () => {
+    render(<Confirmation navigation={baseNavigation} route={baseRoute} />);
+    expect(screen.getByText(mockAccount.freshAddress)).toBeDefined();
+  });
+
+  it("should render the security alert about verification not being possible", () => {
+    render(<Confirmation navigation={baseNavigation} route={baseRoute} />);
+    expect(screen.getByText(/not possible to verify your Concordium Address/)).toBeDefined();
+  });
+
+  it("should render the verify link to the explorer", () => {
+    render(<Confirmation navigation={baseNavigation} route={baseRoute} />);
+    expect(screen.getByText("Verify")).toBeDefined();
+  });
+
+  it("should render nothing when account is missing", () => {
+    useAccountScreen.mockReturnValue({
+      account: undefined,
+      parentAccount: null,
+    });
+
+    const { toJSON } = render(<Confirmation navigation={baseNavigation} route={baseRoute} />);
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/concordium/__tests__/ConnectDevice.test.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/__tests__/ConnectDevice.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import ConnectDevice from "../ConnectDevice";
+
+const mockReplace = jest.fn();
+
+jest.mock("LLM/hooks/useAccountScreen", () => ({
+  useAccountScreen: jest.fn(),
+}));
+
+const { useAccountScreen } = jest.requireMock("LLM/hooks/useAccountScreen");
+
+const baseRoute = {
+  key: "test-key",
+  name: ScreenName.ReceiveConnectDevice as const,
+  params: {
+    accountId: "concordium-account-1",
+    parentId: undefined,
+  },
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const baseNavigation = {
+  replace: mockReplace,
+} as unknown as Parameters<typeof ConnectDevice>[0]["navigation"];
+
+describe("ConnectDevice (Concordium)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should replace with ReceiveConfirmation, skipping device verification", () => {
+    useAccountScreen.mockReturnValue({
+      account: { id: "concordium-account-1", type: "Account" },
+      parentAccount: null,
+    });
+
+    render(<ConnectDevice navigation={baseNavigation} route={baseRoute} />);
+
+    expect(mockReplace).toHaveBeenCalledWith(ScreenName.ReceiveConfirmation, {
+      accountId: "concordium-account-1",
+      parentId: undefined,
+    });
+  });
+
+  it("should not navigate when account is missing", () => {
+    useAccountScreen.mockReturnValue({
+      account: undefined,
+      parentAccount: null,
+    });
+
+    render(<ConnectDevice navigation={baseNavigation} route={baseRoute} />);
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8571,6 +8571,10 @@
     }
   },
   "concordium": {
+    "receive": {
+      "messageIfSkipped": "It is not possible to verify your Concordium Address at the moment. Please make sure to double-check by pasting your address in the Concordium explorer.",
+      "verifyLink": "Verify"
+    },
     "onboard": {
       "title": "Concordium Onboarding"
     }


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** Add custom Confirmation screen for Receive flow on Concordium accounts. Concordium integration on mobile is still behind feature flag and still under heavy development

### 📝 Description

There is no way (as of time of writing) to verify Concordium address on device. It is a product  decision to implement "simplified" receive flow, that displays account address and a sort of warning for the user. 

This PR implements custom "Recieve flow" on mobile mimicking the same for desktop

Reference:

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-03-11 at 19 00 34" src="https://github.com/user-attachments/assets/51fcb98d-815d-45b4-82c2-fd8bb9c9e420" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27255](https://ledgerhq.atlassian.net/browse/LIVE-27255)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27255]: https://ledgerhq.atlassian.net/browse/LIVE-27255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ