### PR TITLE
[LWM] feat(concordium): add concordium memo tag input for send flow

### DIFF
--- a/.changeset/nice-sheep-prove.md
+++ b/.changeset/nice-sheep-prove.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Concordium memo tag input for send flow

--- a/apps/ledger-live-mobile/src/families/concordium/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/MemoTagInput.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import type { Transaction as ConcordiumTransaction } from "@ledgerhq/live-common/families/concordium/types";
+import { MAX_MEMO_LENGTH } from "@ledgerhq/coin-concordium/constants";
+import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
+import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
+import { truncateUtf8 } from "LLM/utils/truncateUtf8";
+
+const MemoTagInput = (props: MemoTagInputProps<ConcordiumTransaction>) => (
+  <GenericMemoTagInput
+    {...props}
+    maxLength={MAX_MEMO_LENGTH}
+    textToValue={text => truncateUtf8(text, MAX_MEMO_LENGTH)}
+    valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
+  />
+);
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/families/concordium/__tests__/MemoTagInput.test.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/__tests__/MemoTagInput.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import MemoTagInput from "../MemoTagInput";
+
+describe("MemoTagInput (Concordium)", () => {
+  const onChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render the memo input", () => {
+    render(<MemoTagInput onChange={onChange} />);
+    expect(screen.getByTestId("memo-tag-input")).toBeDefined();
+  });
+
+  it("should call onChange with a transaction patch that sets memo", async () => {
+    const { user } = render(<MemoTagInput onChange={onChange} />);
+
+    await user.type(screen.getByTestId("memo-tag-input"), "hello");
+
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall.value).toBe("hello");
+
+    const tx = { memo: undefined, amount: 100 };
+    const patched = lastCall.patch(tx);
+    expect(patched.memo).toBe("hello");
+    expect(patched.amount).toBe(100);
+  });
+
+  it("should set memo to undefined when value is empty", async () => {
+    const { user } = render(<MemoTagInput onChange={onChange} />);
+
+    await user.type(screen.getByTestId("memo-tag-input"), "a");
+    await user.clear(screen.getByTestId("memo-tag-input"));
+
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    const tx = { memo: "old", amount: 100 };
+    const patched = lastCall.patch(tx);
+    expect(patched.memo).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** No actual impact, Concordium integration is under the feature flag on mobile and still under heavy development

### 📝 Description

Adds custom memo input tag for Concordium


### ❓ Context

- **JIRA or GitHub link**: [LIVE-27254](https://ledgerhq.atlassian.net/browse/LIVE-27254)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27254]: https://ledgerhq.atlassian.net/browse/LIVE-27254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ