### PR TITLE
chore(e2e): alternate wallet40/legacy on scheduled runs

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -4,7 +4,8 @@ run-name: >
 
 on:
   schedule:
-    - cron: "0 3 * * 1-5"
+    - cron: "0 3 * * 1,3,5" # Mon, Wed, Fri → Wallet 4.0
+    - cron: "0 3 * * 2,4"   # Tue, Thu → Legacy
   workflow_dispatch:
     inputs:
       ref:
@@ -123,6 +124,7 @@ env:
   SPECULOS_IMAGE_TAG: ghcr.io/ledgerhq/speculos:${{ inputs.speculos_device == 'nanoS' && '1be65b91a8e0691866f880fd437ac05fce78af9d' || 'latest' }}
   COINAPPS: ${{ github.workspace }}/coin-apps
   SPECULOS_DEVICE: ${{ inputs.speculos_device || 'nanoX' }}
+  E2E_ENABLE_WALLET40: ${{ ((github.event_name == 'schedule' && github.event.schedule == '0 3 * * 1,3,5') || inputs.enable_wallet40 == true) && '1' || '0' }}
   # Android AVD configuration
   AVD_API: 35
   AVD_ARCH: x86_64
@@ -203,7 +205,7 @@ jobs:
           echo "- **Test Execution ticket ID (iOS):** $TEST_EXECUTION_IOS"
           echo "- **Firebase env to target:** $BUILD_TYPE"
           echo "- **Broadcast enabled:** $BROADCAST_ENABLED"
-          echo "- **Wallet 4.0:** ${{ inputs.enable_wallet40 }}"
+          echo "- **Wallet 4.0:** ${{ env.E2E_ENABLE_WALLET40 == '1' && 'enabled' || 'disabled' }}"
           } >> $GITHUB_STEP_SUMMARY
 
       - name: Configure AWS credentials
@@ -563,7 +565,6 @@ jobs:
           REMOTE_SPECULOS: "true"
           PRODUCTION: ${{ inputs.production_firebase }}
           INPUTS_TEST_FILTER: ${{ needs.determine-builds.outputs.test_filter }}
-          E2E_ENABLE_WALLET40: ${{ inputs.enable_wallet40 == true && '1' || '0' }}
           SWAP_API_BASE: ${{ env.SWAP_API_BASE }}
           SHARD_INDEX: ${{ matrix.shard }}
 
@@ -812,7 +813,6 @@ jobs:
           INPUT_E2E: "true"
           PRODUCTION: ${{ inputs.production_firebase }}
           INPUTS_TEST_FILTER: ${{ needs.determine-builds.outputs.test_filter }}
-          E2E_ENABLE_WALLET40: ${{ inputs.enable_wallet40 == true && '1' || '0' }}
           SWAP_API_BASE: ${{ env.SWAP_API_BASE }}
           SHARD_INDEX: ${{ matrix.shard }}
           ADB: /usr/local/lib/android/sdk/platform-tools/adb # Needed for scrcpy


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Split nightly cron into two: Mon/Wed/Fri (Wallet 4.0) and Tue/Thu (Legacy)
- Move E2E_ENABLE_WALLET40 to top-level env block (DRY)
- Auto-enable wallet40 when triggered by the Mon/Wed/Fri schedule

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  QAA-1065

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
