### PR TITLE
[LWD] fix: image sizing in buy device dialog

### DIFF
--- a/.changeset/serious-beans-leave.md
+++ b/.changeset/serious-beans-leave.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Update image sizing in buy device dialog

--- a/apps/ledger-live-desktop/src/mvvm/features/BuyDevice/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/BuyDevice/index.tsx
@@ -51,10 +51,14 @@ const View = ({ isOpen, onClose, handleConnect, handleBuy }: BuyDeviceViewProps)
       <DialogContent className="max-h-[90vh] rounded-xl">
         <DialogHeader onClose={onClose} />
         <DialogBody className="min-h-0 flex-1 gap-24 overflow-y-auto">
-          <Image resource={BuyDeviceHeader} alt="Ledger devices" className="rounded-xl h-[200px]" />
-          <div className="flex relative flex-col right-auto gap-[unset]">
+          <Image
+            resource={BuyDeviceHeader}
+            alt="Ledger devices"
+            className="h-[200px] rounded-xl object-cover"
+          />
+          <div className="relative right-auto flex flex-col gap-[unset]">
             <span className="heading-2-semi-bold text-base">{t("buyDeviceModal.title")}</span>
-            <span className="body-2 text-muted mb-12">{t("buyDeviceModal.subtitle")}</span>
+            <span className="mb-12 body-2 text-muted">{t("buyDeviceModal.subtitle")}</span>
 
             {items.map(item => (
               <ListItem key={item.id} className="pointer-events-none">
@@ -70,7 +74,7 @@ const View = ({ isOpen, onClose, handleConnect, handleBuy }: BuyDeviceViewProps)
             ))}
           </div>
         </DialogBody>
-        <DialogFooter className="justify-center w-full">
+        <DialogFooter className="w-full justify-center">
           <Flex alignItems="center" flexDirection="column" flexGrow={1} rowGap={2}>
             <Button appearance="base" size="lg" onClick={handleConnect} className="w-full">
               {t("buyDeviceModal.connectCTA")}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/RecentHistory/RecentHistoryScreen.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/RecentHistory/RecentHistoryScreen.tsx
@@ -19,14 +19,14 @@ export function RecentHistoryScreen() {
           <h1 className="-mt-24 mb-6 heading-2-semi-bold text-base">
             {t("newSendFlow.recentHistory.dialog.title")}
           </h1>
-          <p className="m-0 body-1 text-base whitespace-normal break-words">
+          <p className="m-0 body-1 wrap-break-word whitespace-normal text-base">
             {t("newSendFlow.recentHistory.dialog.description")}
           </p>
         </div>
       </DialogBody>
       <DialogFooter className="justify-center px-24">
         <Button
-          className="w-full mt-12"
+          className="mt-12 w-full"
           appearance="base"
           size="lg"
           onClick={goBackToRecipient}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8334,7 +8334,7 @@
       },
       "navigation": {
         "title": "Access key actions faster",
-        "description": "Access Swap, Transfer, and Buy instantly. Find Earn and your Card in the bottom navigation."
+        "description": "Access Receive, Buy, Sell, and Send actions instantly."
       },
       "actions": {
         "title": "View market trends instantly",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Update sizing of image in buy device dialog as was looking squished. Also update wording in wallet tour.
Before:
<img width="756" height="442" alt="Screenshot 2026-03-12 at 09 50 45" src="https://github.com/user-attachments/assets/42ca545e-c95c-4018-bc0b-fd59851420aa" />

After:
<img width="774" height="462" alt="Screenshot 2026-03-12 at 09 50 16" src="https://github.com/user-attachments/assets/c2c843b0-cc46-47fc-8b65-c78ea17b4c35" />


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27528


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
