### PR TITLE
[LWD] fix: desktop send key value pairs contentcard trackings

### DIFF
--- a/.changeset/fuzzy-dryers-judge.md
+++ b/.changeset/fuzzy-dryers-judge.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix desktop content card tracking to include Braze canvas metadata

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
@@ -4,21 +4,43 @@ import { act, render, screen } from "tests/testSetup";
 import PortfolioContentCards from "../components/PortfolioContentCards";
 
 // Mocked functions
-import { logCardDismissal, logContentCardClick } from "@braze/web-sdk";
+import { ClassicCard, logCardDismissal, logContentCardClick } from "@braze/web-sdk";
 import { track } from "~/renderer/analytics/segment";
 
-jest.mock("@braze/web-sdk", () => ({
-  getCachedContentCards: jest.fn(() => ({
-    cards: Cards.map(({ id, ...extras }) => ({ id, extras })),
-  })),
-  logCardDismissal: jest.fn(),
-  logContentCardClick: jest.fn(),
-}));
+jest.mock("@braze/web-sdk", () => {
+  class ClassicCard {
+    id: string;
+    extras: Record<string, string>;
+    url?: string;
+
+    constructor(id: string, extras: Record<string, string>) {
+      this.id = id;
+      this.extras = extras;
+    }
+  }
+
+  return {
+    ClassicCard,
+    logCardDismissal: jest.fn(),
+    logContentCardClick: jest.fn(),
+  };
+});
 
 jest.mock("~/renderer/analytics/segment", () => ({
   ...jest.requireActual("~/renderer/analytics/segment"),
   track: jest.fn(),
 }));
+
+const brazeExtrasById: Record<string, { canvas_name: string; canvas_step_name: string }> = {
+  "0": {
+    canvas_name: "Portfolio Canvas",
+    canvas_step_name: "Portfolio Step",
+  },
+  "1": {
+    canvas_name: "Portfolio Canvas 2",
+    canvas_step_name: "Portfolio Step 2",
+  },
+};
 
 const Cards = [
   {
@@ -39,11 +61,13 @@ const Cards = [
   },
 ];
 
+const desktopCards = Cards.map(asBrazeCard);
+
 describe("PortfolioContentCards", () => {
   test("render slides", async () => {
     render(<PortfolioContentCards />, {
       initialState: {
-        dynamicContent: { portfolioCards: Cards },
+        dynamicContent: { desktopCards, portfolioCards: Cards },
         settings: { shareAnalytics: true, sharePersonalizedRecommandations: true },
       },
     });
@@ -95,8 +119,10 @@ describe("PortfolioContentCards", () => {
     expect(logCardDismissal).not.toHaveBeenCalled();
     expect(track).not.toHaveBeenCalledWith("contentcard_dismissed", expect.any(Object));
     act(() => screen.getAllByTestId("portfolio-card-close-button")[1].click());
-    expect(logCardDismissal).toHaveBeenCalledWith(asBrazeCard(Cards[1]));
+    expect(logCardDismissal).toHaveBeenCalledWith(desktopCards[1]);
     expect(track).toHaveBeenCalledWith("contentcard_dismissed", {
+      canvas_name: "Portfolio Canvas 2",
+      canvas_step_name: "Portfolio Step 2",
       card: "1",
       page: "Portfolio",
       type: "portfolio_carousel",
@@ -110,11 +136,16 @@ describe("PortfolioContentCards", () => {
     expect(track).not.toHaveBeenCalledWith("contentcard_clicked", expect.any(Object));
     act(() => cta0.click());
     expect(logContentCardClick).toHaveBeenCalledTimes(1);
-    expect(logContentCardClick).toHaveBeenCalledWith({
-      ...asBrazeCard(Cards[0]),
-      url: Cards[0].id,
-    });
+    expect(logContentCardClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: Cards[0].id,
+        extras: brazeExtrasById[Cards[0].id],
+        url: Cards[0].id,
+      }),
+    );
     expect(track).toHaveBeenCalledWith("contentcard_clicked", {
+      canvas_name: "Portfolio Canvas",
+      canvas_step_name: "Portfolio Step",
       contentcard: "Foo",
       link: "ledger-live://deep-link",
       campaign: "0",
@@ -125,6 +156,9 @@ describe("PortfolioContentCards", () => {
   });
 });
 
-function asBrazeCard({ id, ...extras }: (typeof Cards)[number]) {
-  return { id, extras };
+function asBrazeCard({ id }: (typeof Cards)[number]) {
+  return Object.assign(Object.create(ClassicCard.prototype), {
+    id,
+    extras: brazeExtrasById[id],
+  });
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/LogContentCardWrapper.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/LogContentCardWrapper.tsx
@@ -5,6 +5,7 @@ import {
   anonymousUserNotificationsSelector,
   trackingEnabledSelector,
 } from "~/renderer/reducers/settings";
+import { desktopContentCardSelector } from "~/renderer/reducers/dynamicContent";
 import { track } from "~/renderer/analytics/segment";
 import { Box } from "@ledgerhq/react-ui";
 import { updateAnonymousUserNotifications } from "~/renderer/actions/settings";
@@ -30,6 +31,7 @@ const LogContentCardWrapper: React.FC<LogContentCardWrapperProps> = ({
   location,
 }) => {
   const ref = useRef<HTMLDivElement>(null);
+  const desktopCards = useSelector(desktopContentCardSelector);
   const isTrackedUser = useSelector(trackingEnabledSelector);
   const anonymousUserNotifications = useSelector(anonymousUserNotificationsSelector);
   const dispatch = useDispatch();
@@ -38,15 +40,16 @@ const LogContentCardWrapper: React.FC<LogContentCardWrapperProps> = ({
   const notificationTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const currentCard = useMemo(() => {
-    const cards = braze.getCachedContentCards()?.cards ?? [];
-    return cards.find(card => card.id === id);
-  }, [id]);
+    return desktopCards.find(card => card.id === id);
+  }, [desktopCards, id]);
 
   useEffect(() => {
     if (!currentCard) return;
 
     const intersectionObserver = new IntersectionObserver(
       ([entry]) => {
+        if (!currentCard) return;
+
         const isContentCardNowVisible = entry.intersectionRatio > PERCENTAGE_OF_CARD_VISIBLE;
         if (isContentCardNowVisible && !isContentCardVisibleRef.current) {
           if (isTrackedUser) {
@@ -57,19 +60,20 @@ const LogContentCardWrapper: React.FC<LogContentCardWrapperProps> = ({
               ...additionalProps,
               displayedPosition,
             });
-          } else if (
-            anonymousUserNotifications[currentCard.id as string] !==
-            currentCard?.expiresAt?.getTime()
-          ) {
-            notificationTimerRef.current = setTimeout(() => {
-              dispatch(
-                updateAnonymousUserNotifications({
-                  notifications: {
-                    [currentCard.id as string]: currentCard?.expiresAt?.getTime() as number,
-                  },
-                }),
-              );
-            }, OFFLINE_SEEN_DELAY);
+          } else {
+            const cardId = currentCard.id;
+            if (!cardId) return;
+
+            const expiresAt = currentCard.expiresAt?.getTime();
+            if (expiresAt !== undefined && anonymousUserNotifications[cardId] !== expiresAt) {
+              notificationTimerRef.current = setTimeout(() => {
+                dispatch(
+                  updateAnonymousUserNotifications({
+                    notifications: { [cardId]: expiresAt },
+                  }),
+                );
+              }, OFFLINE_SEEN_DELAY);
+            }
           }
         }
         isContentCardVisibleRef.current = isContentCardNowVisible;

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/usePortfolioCards.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/usePortfolioCards.ts
@@ -1,11 +1,15 @@
 import * as braze from "@braze/web-sdk";
-import { useCallback, useEffect, useState } from "react";
+import { ClassicCard } from "@braze/web-sdk";
+import { useCallback } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 
 import { track } from "~/renderer/analytics/segment";
 import { setPortfolioCards } from "~/renderer/actions/dynamicContent";
 import { setDismissedContentCards } from "~/renderer/actions/settings";
-import { portfolioContentCardSelector } from "~/renderer/reducers/dynamicContent";
+import {
+  desktopContentCardSelector,
+  portfolioContentCardSelector,
+} from "~/renderer/reducers/dynamicContent";
 import { trackingEnabledSelector } from "~/renderer/reducers/settings";
 import type { PortfolioContentCard } from "~/types/dynamicContent";
 import type { CarouselActions } from "../types";
@@ -13,42 +17,39 @@ import type { CarouselActions } from "../types";
 type UsePortfolioCards = { portfolioCards: PortfolioContentCard[] } & CarouselActions;
 
 export function usePortfolioCards(): UsePortfolioCards {
-  const [cachedContentCards, setCachedContentCards] = useState<braze.Card[]>([]);
+  const desktopCards = useSelector(desktopContentCardSelector);
   const portfolioCards = useSelector(portfolioContentCardSelector);
   const isTrackedUser = useSelector(trackingEnabledSelector);
   const dispatch = useDispatch();
 
-  useEffect(() => {
-    const cards = braze.getCachedContentCards()?.cards ?? [];
-    setCachedContentCards(cards);
-  }, []);
+  const getBrazeCard = useCallback(
+    (cardId: string) => desktopCards.find(card => card.id === cardId),
+    [desktopCards],
+  );
 
   const dismissCard = useCallback<CarouselActions["dismissCard"]>(
     index => {
       const slide = portfolioCards[index];
       if (!slide?.id) return;
+      const currentCard = getBrazeCard(slide.id);
 
-      if (isTrackedUser) {
-        track("contentcard_dismissed", {
-          card: slide.id,
-          page: "Portfolio",
-          type: "portfolio_carousel",
-          location: slide.location,
-        });
-      }
-
-      const currentCard = cachedContentCards.find(card => card.id === slide.id);
       if (currentCard) {
         if (isTrackedUser) {
           braze.logCardDismissal(currentCard);
+          track("contentcard_dismissed", {
+            ...currentCard.extras,
+            card: slide.id,
+            page: "Portfolio",
+            type: "portfolio_carousel",
+            location: slide.location,
+          });
         } else if (currentCard.id) {
           dispatch(setDismissedContentCards({ id: currentCard.id, timestamp: Date.now() }));
         }
-        setCachedContentCards(cachedContentCards.filter(n => n.id !== currentCard.id));
       }
       dispatch(setPortfolioCards(portfolioCards.filter(n => n.id !== slide.id)));
     },
-    [portfolioCards, cachedContentCards, isTrackedUser, dispatch],
+    [portfolioCards, getBrazeCard, isTrackedUser, dispatch],
   );
 
   const logSlideClick = useCallback<CarouselActions["logSlideClick"]>(
@@ -57,8 +58,15 @@ export function usePortfolioCards(): UsePortfolioCards {
 
       const slide = portfolioCards.find(card => card.id === cardId);
       if (!slide) return;
+      const currentCard = getBrazeCard(cardId);
 
+      if (!currentCard || !(currentCard instanceof ClassicCard)) return;
+      // For some reason braze won't log the click event if the card url is empty
+      // Setting it as the card id just to have a dummy non empty value
+      currentCard.url = currentCard.id;
+      braze.logContentCardClick(currentCard);
       track("contentcard_clicked", {
+        ...currentCard.extras,
         contentcard: slide.title,
         link: slide.path || slide.url,
         campaign: cardId,
@@ -66,17 +74,8 @@ export function usePortfolioCards(): UsePortfolioCards {
         type: "portfolio_carousel",
         location: slide.location,
       });
-
-      const currentCard = cachedContentCards.find(card => card.id === cardId);
-      if (!currentCard) return;
-      // For some reason braze won't log the click event if the card url is empty
-      // Setting it as the card id just to have a dummy non empty value
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
-      currentCard.url = currentCard.id;
-      braze.logContentCardClick(currentCard as braze.ClassicCard);
     },
-    [portfolioCards, cachedContentCards, isTrackedUser],
+    [portfolioCards, getBrazeCard, isTrackedUser],
   );
 
   return { portfolioCards, logSlideClick, dismissCard };

--- a/apps/ledger-live-desktop/src/renderer/hooks/useActionCards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useActionCards.tsx
@@ -1,10 +1,14 @@
-import { useEffect, useState } from "react";
+import { ClassicCard } from "@braze/web-sdk";
+import { useCallback } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 
-import { actionContentCardSelector } from "~/renderer/reducers/dynamicContent";
 import * as braze from "@braze/web-sdk";
 import { setActionCards } from "~/renderer/actions/dynamicContent";
 import { openURL } from "~/renderer/linking";
+import {
+  actionContentCardSelector,
+  desktopContentCardSelector,
+} from "~/renderer/reducers/dynamicContent";
 import { track } from "../analytics/segment";
 import { trackingEnabledSelector } from "../reducers/settings";
 import { setDismissedContentCards } from "../actions/settings";
@@ -12,18 +16,18 @@ import { ActionContentCard } from "~/types/dynamicContent";
 
 const useActionCards = () => {
   const dispatch = useDispatch();
-  const [cachedContentCards, setCachedContentCards] = useState(
-    braze.getCachedContentCards()?.cards ?? [],
-  );
+  const desktopCards = useSelector(desktopContentCardSelector);
   const actionCards = useSelector(actionContentCardSelector);
   const isTrackedUser = useSelector(trackingEnabledSelector);
 
-  useEffect(() => {
-    setCachedContentCards(braze.getCachedContentCards()?.cards ?? []);
-  }, [actionCards]);
-
-  const findCard = (cardId: string) => cachedContentCards.find(card => card.id === cardId);
-  const findActionCard = (cardId: string) => actionCards.find(card => card.id === cardId);
+  const findCard = useCallback(
+    (cardId: string) => desktopCards.find(card => card.id === cardId),
+    [desktopCards],
+  );
+  const findActionCard = useCallback(
+    (cardId: string) => actionCards.find(card => card.id === cardId),
+    [actionCards],
+  );
 
   const onDismiss = (cardId: string, displayedPosition?: number) => {
     const currentCard = findCard(cardId);
@@ -35,12 +39,12 @@ const useActionCards = () => {
       } else if (currentCard.id) {
         dispatch(setDismissedContentCards({ id: currentCard.id, timestamp: Date.now() }));
       }
-      setCachedContentCards(cachedContentCards.filter(n => n.id !== currentCard.id));
     }
     dispatch(setActionCards(actionCards.filter((n: ActionContentCard) => n.id !== actionCard?.id)));
 
     if (actionCard && !actionCard.isMock) {
       track("contentcard_dismissed", {
+        ...currentCard?.extras,
         contentcard: actionCard.title,
         campaign: actionCard.id,
         page: "Portfolio",
@@ -57,17 +61,16 @@ const useActionCards = () => {
 
     if (actionCard?.isMock && link) openURL(link);
 
-    if (currentCard) {
+    if (currentCard && currentCard instanceof ClassicCard) {
       // For some reason braze won't log the click event if the card url is empty
       // Setting it as the card id just to have a dummy non empty value
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
       currentCard.url = currentCard.id;
-      if (isTrackedUser) braze.logContentCardClick(currentCard as braze.ClassicCard);
+      if (isTrackedUser) braze.logContentCardClick(currentCard);
       if (link) openURL(link);
     }
     if (actionCard) {
       track("contentcard_clicked", {
+        ...currentCard?.extras,
         contentcard: actionCard.title,
         link: actionCard.link,
         campaign: actionCard.id,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts
@@ -1,26 +1,25 @@
+import { ClassicCard } from "@braze/web-sdk";
 import * as braze from "@braze/web-sdk";
-import { useCallback, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { useCallback } from "react";
+import { useSelector } from "LLD/hooks/redux";
 
-import { LocationContentCard, NotificationContentCard, Platform } from "~/types/dynamicContent";
-import { notificationsContentCardSelector } from "~/renderer/reducers/dynamicContent";
+import { NotificationContentCard } from "~/types/dynamicContent";
+import {
+  desktopContentCardSelector,
+  notificationsContentCardSelector,
+} from "~/renderer/reducers/dynamicContent";
 import { track } from "../analytics/segment";
 import { trackingEnabledSelector } from "../reducers/settings";
 
 export function useNotifications() {
-  const [cachedNotifications, setCachedNotifications] = useState<braze.Card[]>([]);
-  const dispatch = useDispatch();
+  const desktopCards = useSelector(desktopContentCardSelector);
   const notificationsCards = useSelector(notificationsContentCardSelector);
   const isTrackedUser = useSelector(trackingEnabledSelector);
 
-  useEffect(() => {
-    const cards = (braze.getCachedContentCards()?.cards ?? []).filter(
-      card =>
-        card.extras?.platform === Platform.Desktop &&
-        card.extras?.location === LocationContentCard.NotificationCenter,
-    );
-    setCachedNotifications(cards);
-  }, [dispatch, notificationsCards]);
+  const getBrazeCard = useCallback(
+    (cardId: string) => desktopCards.find(card => card.id === cardId),
+    [desktopCards],
+  );
 
   // TODO use date library
   function startOfDayTime(date: Date): number {
@@ -62,33 +61,32 @@ export function useNotifications() {
 
   const onClickNotif = useCallback(
     (card: NotificationContentCard) => {
-      const currentCard = cachedNotifications.find(c => c.id === card.id);
+      const currentCard = getBrazeCard(card.id);
 
-      if (currentCard) {
+      if (currentCard instanceof ClassicCard) {
         // For some reason braze won't log the click event if the card url is empty
         // Setting it as the card id just to have a dummy non empty value
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
         currentCard.url = currentCard.id;
-        if (isTrackedUser) braze.logContentCardClick(currentCard);
+        if (isTrackedUser) {
+          braze.logContentCardClick(currentCard);
+          track("contentcard_clicked", {
+            ...currentCard.extras,
+            contentcard: card.title,
+            link: card.path || card.url,
+            campaign: card.id,
+            page: "notification_center",
+            location: card.location,
+          });
+        }
       }
-
-      track("contentcard_clicked", {
-        contentcard: card.title,
-        link: card.path || card.url,
-        campaign: card.id,
-        page: "notification_center",
-        location: card.location,
-      });
     },
-    [cachedNotifications, isTrackedUser],
+    [getBrazeCard, isTrackedUser],
   );
 
   return {
     groupNotifications,
     startOfDayTime,
     braze,
-    cachedNotifications,
     notificationsCards,
     onClickNotif,
   };

--- a/apps/ledger-live-desktop/src/types/dynamicContent.ts
+++ b/apps/ledger-live-desktop/src/types/dynamicContent.ts
@@ -16,6 +16,7 @@ export type ContentCard = {
   order?: number;
   created: Date | null;
   isMock?: boolean;
+  extras?: Record<string, string>;
 };
 
 export type ActionContentCard = ContentCard & {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio action card click and dismiss tracking
      - Portfolio carousel click and dismiss tracking
      - Notification center click tracking
      - Content card impression logging on desktop

### 📝 Description

This fixes a discrepancy where desktop content card analytics could be sent without `canvas_name` and `canvas_step_name`, even though Braze already had those values in the card key-value pairs.

The main change is that desktop content card tracking no longer relies on local `useEffect` state synchronized from `braze.getCachedContentCards()`. Instead, the tracking hooks and `LogContentCardWrapper` now read directly from the global desktop cards state, which is already populated from Braze and kept in sync centrally. This avoids duplicate local cache logic while preserving access to Braze extras for analytics payloads.

**Before:** some `contentcard_*` events were missing Braze canvas metadata in Mixpanel, and several desktop tracking paths depended on local mirrored Braze cache state.

**After:** tracked content card clicks, dismissals, and impressions reuse the global desktop cards state and include Braze canvas metadata whenever the matching desktop card is available.




<table>
<tr>
 <td>opt in users
 <td>opt out users
<tr>
 <td><video src="https://github.com/user-attachments/assets/24a09584-5b54-4650-91d5-476c137b0590"/>
 <td><video src="https://github.com/user-attachments/assets/118551c7-5889-4909-ac2b-f320505f2bbc"/>
</table>

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25117](https://ledgerhq.atlassian.net/browse/LIVE-25117)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25117]: https://ledgerhq.atlassian.net/browse/LIVE-25117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ