### PR TITLE
[LWM] chore(mobile): reduce repack build log verbosity

### DIFF
--- a/apps/ledger-live-mobile/rspack.config.mjs
+++ b/apps/ledger-live-mobile/rspack.config.mjs
@@ -213,12 +213,16 @@ export default withRozeniteUrlFix(
           ],
         },
         plugins: [
-          new Repack.RepackPlugin(),
+          new Repack.RepackPlugin({
+            logger: false,
+          }),
           new ReanimatedPlugin({
             unstable_disableTransform: true,
           }),
           new ExpoModulesPlugin(),
         ],
+        stats: "errors-warnings",
+        infrastructureLogging: { level: "warn" },
         devServer: {
           host: "local-ip",
           hot: true,


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not needed — config-only change with no package version impact._
- [ ] **Covered by automatic tests.** _Config change validated manually by running iOS bundle build locally._
- [x] **Impact of the changes:**
      - CI workflow log output for mobile bundle builds (iOS & Android)
      - No runtime behavior change — only build-time logging is affected

### 📝 Description

**Problem**: Repack's `LoggerPlugin` outputs full Rspack stats with `preset: 'normal'` during CI bundle builds. This dumps every module and asset — including binary assets (images, fonts) rendered as arrays of integers via `util.inspect` — producing hundreds of lines of useless noise that makes CI logs nearly impossible to debug.

**Solution**: Disable Repack's built-in `LoggerPlugin` and configure Rspack's native logging to only show errors and warnings:
- `logger: false` on `RepackPlugin` — removes the verbose stats output and log interception
- `stats: "errors-warnings"` — limits Rspack output to errors and warnings only (consistent with desktop configs in `rspack.renderer.ts` and `rspack.main.ts`)
- `infrastructureLogging: { level: "warn" }` — suppresses info-level infrastructure messages from Rspack internals

The dev server (`react-native start`) is unaffected as it has its own independent logging via the `Compiler` class.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27557](https://ledgerhq.atlassian.net/browse/LIVE-27557)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-27557]: https://ledgerhq.atlassian.net/browse/LIVE-27557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ