### PR TITLE
[LWM] feat: add safe padding to larger mover overlay

### DIFF
--- a/.changeset/rare-doors-fix.md
+++ b/.changeset/rare-doors-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add safe padding to larger mover overlay

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/components/OverlayTutorial.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/components/OverlayTutorial.tsx
@@ -1,15 +1,17 @@
 import React from "react";
+import { StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Flex, Text, Icons } from "@ledgerhq/native-ui";
-import { useTranslation } from "~/context/Locale";
 import { PromisableButton } from "@ledgerhq/native-ui/lib/components/cta/Button/index";
 import { BlurView } from "@sbaiahmed1/react-native-blur";
-import { StyleSheet } from "react-native";
-import { useDispatch } from "~/context/hooks";
-import { track, TrackScreen } from "~/analytics";
-import { PAGE_NAME } from "../const";
 import { setTutorial } from "~/actions/largeMoverLandingPage";
+import { track, TrackScreen } from "~/analytics";
+import { useDispatch } from "~/context/hooks";
+import { useTranslation } from "~/context/Locale";
+import { PAGE_NAME } from "../const";
 
 export const OverlayTutorial = () => {
+  const insets = useSafeAreaInsets();
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const handleCloseOverlay = () => {
@@ -33,7 +35,13 @@ export const OverlayTutorial = () => {
       <TrackScreen name="Large_Mover_Tutorial" />
       <BlurView style={StyleSheet.absoluteFill} blurAmount={20} blurType="dark" />
 
-      <Flex flex={1} justifyContent="space-between" alignItems="center" padding={6}>
+      <Flex
+        flex={1}
+        justifyContent="space-between"
+        alignItems="center"
+        padding={6}
+        paddingBottom={insets.bottom}
+      >
         <Flex flex={1} justifyContent="center" alignItems="center">
           <Flex paddingBottom={4}>
             <Icons.Swipe size="XXL" color="constant.white" />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When the three navbar is active the button in the large mover overlay was covered and couldn't be accessed. Added safe area padding to avoid this bug.

<img width="1080" height="2400" alt="Screenshot_1773396022" src="https://github.com/user-attachments/assets/925297e4-9bec-43b0-a50f-dc8fddd0d044" />
<img width="1080" height="2400" alt="Screenshot_1773395956" src="https://github.com/user-attachments/assets/4b4d159b-05ec-4f58-b79a-46cf5d045896" />


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
