### PR TITLE
[LWDM] test: fix JSON import in context of Node 24

### DIFF
--- a/e2e/mobile/jest.config.ts
+++ b/e2e/mobile/jest.config.ts
@@ -1,7 +1,16 @@
 import type { Config } from "jest";
 import type { ReporterOptions } from "jest-allure2-reporter";
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { compilerOptions } = require("./tsconfig.json");
+import { createRequire } from "node:module";
+
+// This file is loaded as ESM by Jest; typecheck uses CJS settings so import.meta is reported (TS1470).
+// @ts-expect-error - valid at runtime when Node loads this config as ESM
+const requireFromHere = createRequire(import.meta.url);
+const { compilerOptions } = requireFromHere("./tsconfig.json");
+
+// Load live-common e2e helper via CJS so Node 24 does not require JSON import attribute
+const { getDeviceFirmwareVersion, getSpeculosModel } = requireFromHere(
+  "@ledgerhq/live-common/e2e/speculosAppVersion",
+);
 
 function pathsToModuleNameMapper(
   paths: Record<string, string[]>,
@@ -22,10 +31,6 @@ function pathsToModuleNameMapper(
 
   return jestPaths;
 }
-import {
-  getDeviceFirmwareVersion,
-  getSpeculosModel,
-} from "@ledgerhq/live-common/e2e/speculosAppVersion";
 
 const jestAllure2ReporterOptions: ReporterOptions = {
   extends: "detox-allure2-adapter/preset-detox",
@@ -107,7 +112,8 @@ const config: Config = {
   testTimeout: 300_000,
   reporters: [
     "detox/runners/jest/reporter",
-    ["jest-allure2-reporter", jestAllure2ReporterOptions as Record<string, unknown>],
+    // ReporterOptions is compatible but Jest's Config type expects a looser reporter options type
+    ["jest-allure2-reporter", jestAllure2ReporterOptions as Record<string, unknown>], // eslint-disable-line @typescript-eslint/consistent-type-assertions
   ],
   globalSetup: "<rootDir>/jest.globalSetup.ts",
   globalTeardown: "<rootDir>/jest.globalTeardown.ts",

--- a/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
+++ b/libs/ledger-live-common/src/e2e/speculosAppVersion.ts
@@ -1,11 +1,15 @@
 import { HttpManagerApiRepository, ApplicationV2Entity } from "@ledgerhq/device-core";
-import { version } from "../../package.json";
+import { createRequire } from "node:module";
 import { getEnv } from "@ledgerhq/live-env";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { Device as CryptoWallet } from "./enum/Device";
 import { sanitizeError } from "./index";
 import * as fs from "fs";
 import * as path from "path";
+
+// CJS build: __filename is defined. E2E loads this via createRequire(import.meta.url) in jest.config so CJS is used.
+const req = createRequire(__filename);
+const version = req("../../package.json").version;
 
 export function getSpeculosModel(): DeviceModelId {
   const speculosDevice = process.env.SPECULOS_DEVICE;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**  https://github.com/LedgerHQ/ledger-live/actions/runs/23049424148/job/66947496390
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- **live-common:** Load `package.json` in `speculosAppVersion.ts` with `createRequire(__filename)` instead of a JSON import so the CJS build works and Node 24 doesn’t require a JSON import attribute.
- **e2e/mobile:** In `jest.config.ts` use `createRequire(import.meta.url)` for `tsconfig.json` and the live-common e2e helper so the config runs in ESM without `require` or JSON imports.

Fixes the mobile E2E failure after the Node 24 bump (PR #15304): `ERR_IMPORT_ATTRIBUTE_MISSING` and `require is not defined in ES module scope`.


### ❓ Context

- **JIRA or GitHub link**: https://ledger.slack.com/archives/C081T58FFHA/p1773400389579739?thread_ts=1773337771.682739&cid=C081T58FFHA


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
