### PR TITLE
[LWM] test(mobile): fix flaky queued drawer successive drawers test

### DIFF
--- a/.changeset/afraid-poets-relax.md
+++ b/.changeset/afraid-poets-relax.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+stabilize QueuedDrawer tests

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/__integrations__/openSuccessiveDrawers.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/__integrations__/openSuccessiveDrawers.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, LONG_TIMEOUT, waitForElementToBeRemoved } from "@tests/test-renderer";
+import { render, LONG_TIMEOUT, waitForElementToBeRemoved, waitFor } from "@tests/test-renderer";
 import { TestPages } from "./shared";
 import { TestIdPrefix, testIds } from "../TestScreens";
 
@@ -258,7 +258,9 @@ describe("QueuedDrawer", () => {
     await helpers.waitForMainScreenDisappear();
     expect(await findByText(drawerOnScreen1Text)).toBeVisible();
     await user.press(elements.closeButton());
-    helpers.expectDrawersClosed(drawerOnScreen1Text, drawer1Text, drawer2Text, drawer4Text);
+    await waitFor(() => {
+      helpers.expectDrawersClosed(drawerOnScreen1Text, drawer1Text, drawer2Text, drawer4Text);
+    });
     await user.press(elements.navigateBackButton());
     await helpers.expectBackOnMainScreen();
     await helpers.openDrawer1();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - QueuedDrawer integration test stability
  - No production code change

### 📝 Description

The test "opens two drawers, forces open another one, navigates to other screen" was flaky due to a `requestAnimationFrame` macrotask in the close animation chain (`closeAnim → scheduleOnRN → requestAnimationFrame → handleDismiss`). The synchronous `expectDrawersClosed` assertion could run before the drawer's `isVisible` state was set to `false`.

Wrapped the assertion in `waitFor` so RNTL retries until the close animation completes, making the test deterministic.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27580](https://ledgerhq.atlassian.net/browse/LIVE-27580)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27580]: https://ledgerhq.atlassian.net/browse/LIVE-27580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ