### PR TITLE
[LWM] fix(mobile): defer queue cleanup to onDismiss to prevent bottomsheet overlap

### DIFF
--- a/.changeset/brave-doors-wait.md
+++ b/.changeset/brave-doors-wait.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix QueuedDrawer BottomSheet race condition by deferring queue cleanup to onDismiss callback

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/__tests__/useQueuedDrawerBottomSheet.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/__tests__/useQueuedDrawerBottomSheet.test.ts
@@ -1,0 +1,378 @@
+import { renderHook, act } from "@tests/test-renderer";
+import useQueuedDrawerBottomSheet from "../useQueuedDrawerBottomSheet";
+
+const mockPresent = jest.fn();
+const mockDismiss = jest.fn();
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => ({
+  ...jest.requireActual("@ledgerhq/lumen-ui-rnative"),
+  useBottomSheetRef: () => ({ current: { present: mockPresent, dismiss: mockDismiss } }),
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useIsFocused: () => true,
+}));
+
+const mockRemoveDrawerFromQueue = jest.fn();
+const mockAddDrawerToQueue = jest.fn().mockImplementation(() => ({
+  removeDrawerFromQueue: mockRemoveDrawerFromQueue,
+  getPositionInQueue: () => 0,
+}));
+
+jest.mock("../QueuedDrawersContext", () => ({
+  useQueuedDrawerContext: () => ({
+    addDrawerToQueue: mockAddDrawerToQueue,
+    closeAllDrawers: jest.fn(),
+    _clearQueueDIRTYDONOTUSE: jest.fn(),
+  }),
+}));
+
+function setupDrawerStateCapture() {
+  let onDrawerStateChanged: ((isOpen: boolean) => void) | undefined;
+  mockAddDrawerToQueue.mockImplementation(callback => {
+    onDrawerStateChanged = callback;
+    return {
+      removeDrawerFromQueue: mockRemoveDrawerFromQueue,
+      getPositionInQueue: () => 0,
+    };
+  });
+  return {
+    signal: (isOpen: boolean) => {
+      act(() => {
+        onDrawerStateChanged?.(isOpen);
+      });
+    },
+  };
+}
+
+describe("useQueuedDrawerBottomSheet", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls present() when the queue signals the drawer to open", () => {
+    const { signal } = setupDrawerStateCapture();
+
+    renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+      }),
+    );
+
+    expect(mockAddDrawerToQueue).toHaveBeenCalledTimes(1);
+
+    signal(true);
+
+    expect(mockPresent).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls dismiss() when the queue signals the drawer to close", () => {
+    const { signal } = setupDrawerStateCapture();
+
+    renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+      }),
+    );
+
+    signal(true);
+    expect(mockPresent).toHaveBeenCalledTimes(1);
+
+    signal(false);
+    expect(mockDismiss).toHaveBeenCalled();
+  });
+
+  it("does not remove from queue on close signal, only when handleDismiss fires after animation", () => {
+    const { signal } = setupDrawerStateCapture();
+
+    const { result } = renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+      }),
+    );
+
+    signal(true);
+    signal(false);
+    expect(mockRemoveDrawerFromQueue).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+
+    expect(mockRemoveDrawerFromQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose callback when the queue signals close", () => {
+    const onClose = jest.fn();
+    const { signal } = setupDrawerStateCapture();
+
+    renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+        onClose,
+      }),
+    );
+
+    signal(true);
+    signal(false);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onModalHide when handleDismiss is invoked", () => {
+    const onModalHide = jest.fn();
+    const { signal } = setupDrawerStateCapture();
+
+    const { result } = renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+        onModalHide,
+      }),
+    );
+
+    signal(true);
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+
+    expect(onModalHide).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call present() twice if already open", () => {
+    const { signal } = setupDrawerStateCapture();
+
+    renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+      }),
+    );
+
+    signal(true);
+    signal(true);
+
+    expect(mockPresent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call dismiss() if already closed", () => {
+    renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: false,
+      }),
+    );
+
+    expect(mockDismiss).not.toHaveBeenCalled();
+  });
+
+  it("does not call removeDrawerFromQueue on close signal until handleDismiss fires", () => {
+    const { signal } = setupDrawerStateCapture();
+
+    const { result } = renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+      }),
+    );
+
+    signal(true);
+    expect(mockPresent).toHaveBeenCalledTimes(1);
+
+    signal(false);
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+    expect(mockRemoveDrawerFromQueue).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+    expect(mockRemoveDrawerFromQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call removeDrawerFromQueue when handleClose is invoked multiple times before handleDismiss", () => {
+    const { signal } = setupDrawerStateCapture();
+
+    const { result } = renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+      }),
+    );
+
+    signal(true);
+    expect(mockPresent).toHaveBeenCalledTimes(1);
+
+    signal(false);
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+    expect(mockRemoveDrawerFromQueue).not.toHaveBeenCalled();
+
+    signal(false);
+    expect(mockRemoveDrawerFromQueue).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+    expect(mockRemoveDrawerFromQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call removeDrawerFromQueue when effect cleanup fires during dismiss animation", () => {
+    const { signal } = setupDrawerStateCapture();
+    let isRequestingToBeOpened = true;
+
+    const { result, rerender } = renderHook(() =>
+      useQueuedDrawerBottomSheet({ isRequestingToBeOpened }),
+    );
+
+    signal(true);
+    expect(mockPresent).toHaveBeenCalledTimes(1);
+
+    signal(false);
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+    expect(mockRemoveDrawerFromQueue).not.toHaveBeenCalled();
+
+    isRequestingToBeOpened = false;
+    rerender(undefined);
+    expect(mockRemoveDrawerFromQueue).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+    expect(mockRemoveDrawerFromQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up the queue immediately when closed without ever being presented", () => {
+    const { signal } = setupDrawerStateCapture();
+
+    renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+      }),
+    );
+
+    signal(false);
+
+    expect(mockDismiss).not.toHaveBeenCalled();
+    expect(mockRemoveDrawerFromQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up the queue on unmount", () => {
+    const { signal } = setupDrawerStateCapture();
+
+    const { unmount } = renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+      }),
+    );
+
+    signal(true);
+
+    unmount();
+
+    expect(mockRemoveDrawerFromQueue).toHaveBeenCalled();
+  });
+
+  it("does not call onClose when drawer receives close signal before ever being opened", () => {
+    const onClose = jest.fn();
+    const { signal } = setupDrawerStateCapture();
+
+    renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+        onClose,
+      }),
+    );
+
+    signal(false);
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(mockRemoveDrawerFromQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose exactly once when handleClose is called multiple times during dismiss", () => {
+    const onClose = jest.fn();
+    const { signal } = setupDrawerStateCapture();
+
+    const { result } = renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+        onClose,
+      }),
+    );
+
+    signal(true);
+    signal(false);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    signal(false);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose via handleDismiss when user swipes to dismiss (bypassing handleClose)", () => {
+    const onClose = jest.fn();
+    const { signal } = setupDrawerStateCapture();
+
+    const { result } = renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+        onClose,
+      }),
+    );
+
+    signal(true);
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockRemoveDrawerFromQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not recreate handleDismiss when onModalHide changes", () => {
+    const { signal } = setupDrawerStateCapture();
+    let onModalHide = jest.fn();
+
+    const { result, rerender } = renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+        onModalHide,
+      }),
+    );
+
+    signal(true);
+
+    const firstHandleDismiss = result.current.handleDismiss;
+    onModalHide = jest.fn();
+    rerender(undefined);
+
+    expect(result.current.handleDismiss).toBe(firstHandleDismiss);
+  });
+
+  it("calls the latest onModalHide even though handleDismiss is stable", () => {
+    const { signal } = setupDrawerStateCapture();
+    const firstOnModalHide = jest.fn();
+    const secondOnModalHide = jest.fn();
+    let onModalHide = firstOnModalHide;
+
+    const { result, rerender } = renderHook(() =>
+      useQueuedDrawerBottomSheet({
+        isRequestingToBeOpened: true,
+        onModalHide,
+      }),
+    );
+
+    signal(true);
+    onModalHide = secondOnModalHide;
+    rerender(undefined);
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+
+    expect(firstOnModalHide).not.toHaveBeenCalled();
+    expect(secondOnModalHide).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/useQueuedDrawerBottomSheet.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/useQueuedDrawerBottomSheet.ts
@@ -16,6 +16,8 @@ interface UseQueuedDrawerBottomSheetProps {
   preventBackdropClick?: boolean;
 }
 
+type DrawerState = "idle" | "open" | "dismissing";
+
 const useQueuedDrawerBottomSheet = ({
   isRequestingToBeOpened = false,
   isForcingToBeOpened = false,
@@ -33,7 +35,10 @@ const useQueuedDrawerBottomSheet = ({
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
 
-  const isClosedRef = useRef(true);
+  const onModalHideRef = useRef(onModalHide);
+  onModalHideRef.current = onModalHide;
+
+  const stateRef = useRef<DrawerState>("idle");
 
   const cleanupQueue = useCallback(() => {
     if (drawerInQueueRef.current) {
@@ -43,20 +48,26 @@ const useQueuedDrawerBottomSheet = ({
   }, []);
 
   const handleOpen = useCallback(() => {
-    if (!isClosedRef.current) return;
+    if (stateRef.current !== "idle") return;
 
     logDrawer("Opening drawer");
-    isClosedRef.current = false;
+    stateRef.current = "open";
     bottomSheetRef.current?.present();
   }, [bottomSheetRef]);
 
   const handleClose = useCallback(() => {
-    if (!isClosedRef.current) {
-      logDrawer("Closing drawer");
-      isClosedRef.current = true;
-      bottomSheetRef.current?.dismiss();
+    const state = stateRef.current;
+
+    if (state === "idle") {
+      cleanupQueue();
+      return;
     }
-    cleanupQueue();
+
+    if (state === "dismissing") return;
+
+    logDrawer("Closing drawer");
+    stateRef.current = "dismissing";
+    bottomSheetRef.current?.dismiss();
     onCloseRef.current?.();
   }, [bottomSheetRef, cleanupQueue]);
 
@@ -72,9 +83,14 @@ const useQueuedDrawerBottomSheet = ({
       Keyboard.dismiss();
     }
 
-    handleClose();
-    onModalHide?.();
-  }, [handleClose, onModalHide]);
+    if (stateRef.current === "open") {
+      onCloseRef.current?.();
+    }
+
+    stateRef.current = "idle";
+    cleanupQueue();
+    onModalHideRef.current?.();
+  }, [cleanupQueue]);
 
   useEffect(() => {
     if (!isFocused && (isRequestingToBeOpened || isForcingToBeOpened)) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - QueuedDrawer BottomSheet dismiss/open transitions
      - Rapid drawer switching (e.g. Transfer > Send crypto tapped quickly)
      - ModularDrawer asset selection flow with Lumen BottomSheet enabled

### 📝 Description

**Problem**: When the Lumen BottomSheet (`lwmWallet40` flag enabled) is used in QueuedDrawer, rapid drawer transitions cause multiple BottomSheets to be visible simultaneously. This happens because `cleanupQueue()` was called synchronously in `handleClose`, triggering the next drawer to open before the current one's `dismiss()` animation had completed.

**Solution**: Moved `cleanupQueue()` from `handleClose` to `handleDismiss` (the `onDismiss` callback fired by the BottomSheet after its dismiss animation completes). This ensures the queue only advances once the outgoing drawer is fully dismissed, preventing visual overlap.

Added 8 unit tests for `useQueuedDrawerBottomSheet` covering:
- present/dismiss lifecycle
- queue cleanup timing (deferred to onDismiss)
- onClose/onModalHide callbacks
- idempotent open/close guards
- unmount cleanup

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27316](https://ledgerhq.atlassian.net/browse/LIVE-27316)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27316]: https://ledgerhq.atlassian.net/browse/LIVE-27316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ