### PR TITLE
[LWM] fix(mobile): allow feature flags settings to scroll with keyboard open

### DIFF
--- a/.changeset/gentle-panthers-scroll.md
+++ b/.changeset/gentle-panthers-scroll.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix feature flags settings scrolling when the keyboard is visible

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useMemo, useEffect } from "react";
+import React, { useCallback, useState, useMemo } from "react";
 import { useTranslation } from "~/context/Locale";
 import {
   DEFAULT_FEATURES,
@@ -23,9 +23,10 @@ import includes from "lodash/includes";
 import lowerCase from "lodash/lowerCase";
 import trim from "lodash/trim";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { Keyboard } from "react-native";
+import { Platform } from "react-native";
 import { useSelector, useDispatch } from "~/context/hooks";
 import NavigationScrollView from "~/components/NavigationScrollView";
+import KeyboardView from "~/components/KeyboardView";
 import FeatureFlagDetails, { TagDisabled, TagEnabled } from "./FeatureFlagDetails";
 import Alert from "~/components/Alert";
 import GroupedFeatures from "./GroupedFeatures";
@@ -120,17 +121,8 @@ export default function DebugFeatureFlags() {
   const project =
     params !== null && typeof params === "object" && "project" in params ? params.project : "";
 
-  const [keyboardVisible, setKeyboardVisible] = useState(false);
-  useEffect(() => {
-    const listenerShow = Keyboard.addListener("keyboardDidShow", () => setKeyboardVisible(true));
-    const listenerHide = Keyboard.addListener("keyboardDidHide", () => setKeyboardVisible(false));
-    return () => {
-      listenerShow.remove();
-      listenerHide.remove();
-    };
-  }, []);
-
   const additionalInfo = <Alert title={addFlagHint} type="hint" noIcon />;
+  const keyboardBehavior = Platform.OS === "ios" ? "padding" : "height";
 
   const hasLocallyOverriddenFlags = useHasLocallyOverriddenFeatureFlags();
   const featureFlagsBannerVisible = useSelector(featureFlagsBannerVisibleSelector);
@@ -144,73 +136,70 @@ export default function DebugFeatureFlags() {
 
   return (
     <SafeAreaView edges={["bottom"]} style={{ flex: 1 }}>
-      <NavigationScrollView keyboardShouldPersistTaps="handled">
-        <Flex px={16}>
-          <Alert type="primary" noIcon>
-            {t("settings.debug.featureFlagsTitle")}
-          </Alert>
-          <Flex flexDirection="row" mt={4}>
-            <Text>Legend: </Text>
-            <TagEnabled mx={2}>enabled flag</TagEnabled>
-            <TagDisabled mx={2}>disabled flag</TagDisabled>
+      <KeyboardView behavior={keyboardBehavior}>
+        <NavigationScrollView keyboardShouldPersistTaps="handled">
+          <Flex px={16}>
+            <Alert type="primary" noIcon>
+              {t("settings.debug.featureFlagsTitle")}
+            </Alert>
+            <Flex flexDirection="row" mt={4}>
+              <Text>Legend: </Text>
+              <TagEnabled mx={2}>enabled flag</TagEnabled>
+              <TagDisabled mx={2}>disabled flag</TagDisabled>
+            </Flex>
+            <Text my={3}>{t("settings.debug.firebaseProject")}</Text>
+            <Tag uppercase={false} type="color" alignSelf={"flex-start"}>
+              {project}
+            </Tag>
+            <Flex flexDirection="row" justifyContent="space-between">
+              <Text flexShrink={1} mt={3}>
+                {t("settings.debug.showBannerDesc")}
+              </Text>
+              <Switch checked={featureFlagsBannerVisible} onChange={setFeatureFlagBannerVisible} />
+            </Flex>
+            <Divider />
+            <ChipTabs
+              labels={[
+                t("settings.debug.featureFlagsTabAll"),
+                t("settings.debug.featureFlagsTabGroups"),
+              ]}
+              activeIndex={activeTab}
+              onChange={setActiveTab}
+            />
+            <Flex mt={3} />
+            <SearchInput
+              value={searchInput}
+              placeholder="Search flag"
+              onChange={handleSearch}
+              autoCapitalize="none"
+            />
+            <Button
+              mt={3}
+              size="small"
+              type="main"
+              outline
+              onPress={resetFeatures}
+              disabled={!hasLocallyOverriddenFlags}
+            >
+              {t("settings.debug.featureFlagsRestoreAll")}
+            </Button>
+            <Divider />
+            {activeTab === 0 ? (
+              <>
+                {filteredFlags.length === 0 ? (
+                  <>
+                    <Text>{`No flag matching "${searchInput}"`}</Text>
+                    {additionalInfo}
+                  </>
+                ) : null}
+                {flagsList}
+              </>
+            ) : (
+              <>{groupsList}</>
+            )}
           </Flex>
-          <Text my={3}>{t("settings.debug.firebaseProject")}</Text>
-          <Tag uppercase={false} type="color" alignSelf={"flex-start"}>
-            {project}
-          </Tag>
-          <Flex flexDirection="row" justifyContent="space-between">
-            <Text flexShrink={1} mt={3}>
-              {t("settings.debug.showBannerDesc")}
-            </Text>
-            <Switch checked={featureFlagsBannerVisible} onChange={setFeatureFlagBannerVisible} />
-          </Flex>
-          <Divider />
-          <ChipTabs
-            labels={[
-              t("settings.debug.featureFlagsTabAll"),
-              t("settings.debug.featureFlagsTabGroups"),
-            ]}
-            activeIndex={activeTab}
-            onChange={setActiveTab}
-          />
-          <Flex mt={3} />
-          <SearchInput
-            value={searchInput}
-            placeholder="Search flag"
-            onChange={handleSearch}
-            autoCapitalize="none"
-          />
-          <Button
-            mt={3}
-            size="small"
-            type="main"
-            outline
-            onPress={resetFeatures}
-            disabled={!hasLocallyOverriddenFlags}
-          >
-            {t("settings.debug.featureFlagsRestoreAll")}
-          </Button>
-          <Divider />
-          {activeTab === 0 ? (
-            <>
-              {filteredFlags.length === 0 ? (
-                <>
-                  <Text>{`No flag matching "${searchInput}"`}</Text>
-                  {keyboardVisible ? additionalInfo : null}
-                </>
-              ) : null}
-              {flagsList}
-            </>
-          ) : (
-            <>{groupsList}</>
-          )}
-        </Flex>
-      </NavigationScrollView>
-      {keyboardVisible ? null : (
-        <Flex px={16} mt={3}>
-          {additionalInfo}
-        </Flex>
-      )}
+        </NavigationScrollView>
+      </KeyboardView>
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Validated with `pnpm mobile typecheck`. No related Jest tests were found for this screen._
- [x] **Impact of the changes:**
      - Feature Flags settings screen scroll behavior when the keyboard is visible
      - Search field usability when only one flag or a short list is shown
      - iOS keyboard avoidance via `KeyboardView`

### 📝 Description

https://github.com/user-attachments/assets/dc2901c6-8064-4ee3-966d-f61e89c7455f


This PR fixes the mobile Feature Flags settings screen so the content remains scrollable while the keyboard is visible, including cases where the filtered results are short.

The previous implementation manually toggled the bottom hint based on keyboard visibility, which could leave the screen without enough scrollable space when searching. This change wraps the screen with the shared `KeyboardView` and keeps the hint inside the scrollable content so users can still reach all controls with the keyboard open.

### ❓ Context

- **JIRA or GitHub link**: None

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)