### PR TITLE
[LWD] ci: NX equivalent for "affected"

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -39,7 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   determine-affected:
-    name: "Turbo Affected"
+    name: "Affected"
     needs: pre_job
     if: ${{!github.event.pull_request.head.repo.fork && needs.pre_job.outputs.should_skip != 'true'}}
     uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@develop

--- a/.github/workflows/nx-affected-reusable.yml
+++ b/.github/workflows/nx-affected-reusable.yml
@@ -1,0 +1,96 @@
+name: "[All Platforms] - Determine Affected (Nx) - Called"
+
+on:
+  workflow_call:
+    inputs:
+      base_branch:
+        description: "Base branch"
+        type: string
+        required: true
+      head_branch:
+        description: "Head branch"
+        type: string
+        required: true
+      affected_debug:
+        description: "Enable verbose debug output for nx affected merge-base diagnostics"
+        type: boolean
+        required: false
+        default: false
+    outputs:
+      packages:
+        description: "Newline-separated list of affected packages"
+        value: ${{ jobs.nx-affected.outputs.packages }}
+      paths:
+        description: "Newline-separated list of affected paths"
+        value: ${{ jobs.nx-affected.outputs.paths }}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  nx-affected:
+    name: "Determine Affected (Nx)"
+    runs-on: ubuntu-22.04
+    outputs:
+      packages: ${{ steps.nx-affected.outputs.packages }}
+      paths: ${{ steps.nx-affected.outputs.paths }}
+    steps:
+      - name: Checkout head branch
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Fetch base branch
+        run: |
+          git fetch origin ${{ inputs.base_branch }} --depth=1
+
+      # Debug: refs and merge-base (remove after diagnosing CI vs local mismatch)
+      - name: Debug refs and merge-base for nx affected
+        if: ${{ inputs.affected_debug }}
+        run: |
+          echo "=== Refs after checkout + fetch ==="
+          git branch -a
+          echo "=== HEAD commit ==="
+          git rev-parse HEAD
+          echo "=== Local base branch ref (${{ inputs.base_branch }}) ==="
+          git rev-parse ${{ inputs.base_branch }} 2>/dev/null || echo "(ref not found)"
+          echo "=== origin/${{ inputs.base_branch }} (remote-tracking) ==="
+          git rev-parse origin/${{ inputs.base_branch }} 2>/dev/null || echo "(ref not found)"
+          echo "=== Merge base: HEAD vs local ${{ inputs.base_branch }} ==="
+          git merge-base HEAD ${{ inputs.base_branch }} 2>/dev/null || echo "(merge-base failed)"
+          echo "=== Merge base: HEAD vs origin/${{ inputs.base_branch }} ==="
+          git merge-base HEAD origin/${{ inputs.base_branch }} 2>/dev/null || echo "(merge-base failed)"
+          echo "=== Base ref passed to composite: origin/${{ inputs.base_branch }} ==="
+
+      - uses: actions/github-script@v7
+        id: clean-refs
+        with:
+          script: |
+            const head_branch = "${{ inputs.head_branch }}";
+            const base_branch = "${{ inputs.base_branch }}";
+
+            const newHeadBranch = head_branch.replace("refs/heads/", "");
+            const newBaseBranch = base_branch.replace("refs/heads/", "");
+
+            core.exportVariable("head_branch", newHeadBranch);
+            core.exportVariable("base_branch", newBaseBranch);
+            core.setOutput("base_ref", "origin/" + newBaseBranch);
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.24.0
+
+      - name: Install dev dependencies for root workspace
+        run: pnpm i -D -F "ledger-live" --ignore-scripts
+
+      - name: Get affected packages and paths
+        id: nx-affected
+        uses: ./tools/actions/composites/nx-affected-packages
+        with:
+          base: ${{ steps.clean-refs.outputs.base_ref }}
+          head: HEAD

--- a/apps/ledger-live-desktop/project.json
+++ b/apps/ledger-live-desktop/project.json
@@ -1,4 +1,5 @@
 {
+  "name": "ledger-live-desktop",
   "targets": {
     "build": {
       "cache": false,

--- a/apps/web-tools/project.json
+++ b/apps/web-tools/project.json
@@ -1,4 +1,5 @@
 {
+  "name": "@ledgerhq/web-tools",
   "targets": {
     "build": {
       "outputs": ["{projectRoot}/dist/**"],

--- a/tools/actions/composites/nx-affected-packages/README.md
+++ b/tools/actions/composites/nx-affected-packages/README.md
@@ -1,0 +1,60 @@
+# Nx affected packages and paths
+
+GitHub Action composite that runs `pnpm nx show projects --affected`, resolves each project's filesystem path via Nx, and sets outputs `packages` and `paths` for use in workflow conditions (e.g. `contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop')`). The composite uses **actions/github-script** (no repo package.json required).
+
+**This composite does not checkout or setup the workspace.** The caller job must run `actions/checkout` and ensure `pnpm`/`nx` are available. Pass trusted refs only for `base`/`head` (e.g. from `github.event`); do not use user-controlled input.
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `base` | No | Base ref for affected calculation (e.g. `origin/main`). When omitted, Nx uses its default (e.g. from Git). |
+| `head` | No | Head ref for affected calculation (e.g. `HEAD`). When omitted, Nx uses its default. |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `packages` | Newline-separated list of affected Nx project names. |
+| `paths` | Newline-separated list of affected project root paths (deduplicated). |
+
+## Usage
+
+```yaml
+steps:
+  - uses: actions/checkout@...
+  - uses: LedgerHQ/ledger-live/tools/actions/composites/nx-affected-packages@main
+    id: nx-affected
+    with:
+      base: origin/main
+      head: HEAD
+# In a later job:
+# if: contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop')
+```
+
+## Script (local use)
+
+The composite runs the Node.js script `get-affected-packages-and-paths.js`. You can run the same script locally from the repo root. It prints JSON to stdout:
+
+```json
+{"packages":["live-mobile",...],"paths":["apps/ledger-live-mobile",...]}
+```
+
+- **Base/head**: set env vars `BASE` and `HEAD` (e.g. `BASE=origin/main HEAD=HEAD`).
+- **Requires**: Node.js, `pnpm`, and `nx` (no `jq` required).
+
+### Local testing with Node.js
+
+From the repo root (with no refs, Nx uses Git defaults):
+
+```bash
+node tools/actions/composites/nx-affected-packages/get-affected-packages-and-paths.js
+```
+
+With base/head:
+
+```bash
+BASE=origin/main HEAD=HEAD node tools/actions/composites/nx-affected-packages/get-affected-packages-and-paths.js
+```
+
+Expected: exit code 0 and valid JSON. When nothing is affected, output is `{"packages":[],"paths":[]}`.

--- a/tools/actions/composites/nx-affected-packages/action.yml
+++ b/tools/actions/composites/nx-affected-packages/action.yml
@@ -1,0 +1,44 @@
+name: "Nx affected packages and paths"
+description: "Outputs affected Nx project names and their filesystem paths (for use with contains() in workflow conditions). Does not checkout or setup the workspace. When base/head are omitted, Nx uses its own defaults (e.g. from Git)."
+
+inputs:
+  base:
+    description: "Base ref for affected calculation (e.g. origin/main). Omit to use Nx default."
+    required: false
+  head:
+    description: "Head ref for affected calculation (e.g. HEAD). Omit to use Nx default."
+    required: false
+
+outputs:
+  packages:
+    description: "Newline-separated list of affected project names"
+    value: ${{ steps.nx-affected.outputs.packages }}
+  paths:
+    description: "Newline-separated list of affected project root paths (deduplicated)"
+    value: ${{ steps.nx-affected.outputs.paths }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get affected packages and paths
+      id: nx-affected
+      env:
+        BASE: ${{ inputs.base }}
+        HEAD: ${{ inputs.head }}
+        ACTION_PATH: ${{ github.action_path }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const path = require('path');
+          const scriptPath = path.join(process.env.ACTION_PATH, 'get-affected-packages-and-paths.js');
+          const { getAffectedPackagesAndPaths } = require(scriptPath);
+          const { packages: packageNames, paths: pathsDeduped } = await getAffectedPackagesAndPaths({
+            base: process.env.BASE || '',
+            head: process.env.HEAD || '',
+            exec,
+          });
+          const fs = require('fs');
+          const out = process.env.GITHUB_OUTPUT;
+          const eol = '\nEOF\n';
+          fs.appendFileSync(out, 'packages<<EOF\n' + packageNames.join('\n') + eol);
+          fs.appendFileSync(out, 'paths<<EOF\n' + pathsDeduped.join('\n') + eol);

--- a/tools/actions/composites/nx-affected-packages/get-affected-packages-and-paths.js
+++ b/tools/actions/composites/nx-affected-packages/get-affected-packages-and-paths.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * Get affected Nx project names and their filesystem paths.
+ * Run locally: node get-affected-packages-and-paths.js
+ *   Env: BASE, HEAD (optional refs for affected calculation)
+ *   Prints JSON to stdout: {"packages":["..."],"paths":["..."]}
+ * When required from actions/github-script, pass { base, head, exec } and use the returned result.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- CommonJS for standalone script and github-script require()
+const { spawnSync } = require("child_process");
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- CommonJS for path.relative()
+const path = require("path");
+
+async function runPnpm(args, exec) {
+  if (exec && exec.getExecOutput) {
+    // @actions/exec#getExecOutput returns { stdout, stderr, exitCode }
+    return await exec.getExecOutput("pnpm", args, {
+      ignoreReturnCode: true,
+      silent: true,
+    });
+  }
+  const r = spawnSync("pnpm", args, {
+    encoding: "utf-8",
+  });
+  return {
+    stdout: (r.stdout || "").trim(),
+    stderr: (r.stderr || "").trim(),
+    exitCode: r.status ?? 1,
+  };
+}
+
+async function getAffectedPackagesAndPaths(options = {}) {
+  const base = options.base ?? process.env.BASE ?? "";
+  const head = options.head ?? process.env.HEAD ?? "";
+  const exec = options.exec;
+
+  // Build name → relative path map from pnpm workspace (one call instead of Nx per project)
+  const nameToPath = new Map();
+  const { stdout: lsStdout, exitCode: lsCode } = await runPnpm(
+    ["ls", "-r", "--depth=-1", "--json"],
+    exec,
+  );
+  if (lsCode === 0 && lsStdout && lsStdout.trim()) {
+    try {
+      const list = JSON.parse(lsStdout.trim());
+      if (Array.isArray(list)) {
+        const cwd = process.cwd();
+        for (const item of list) {
+          if (item && item.name != null && item.path) {
+            const relativeRoot = path.relative(cwd, item.path);
+            nameToPath.set(item.name, relativeRoot);
+          }
+        }
+      }
+    } catch {
+      // Ignore; we fall back to nx show project for each name
+    }
+  }
+
+  const args = ["nx", "show", "projects", "--affected", "--json"];
+  if (base) args.push("--base", base);
+  if (head) args.push("--head", head);
+
+  let packageNames = [];
+  const {
+    stdout: affectedStdout,
+    stderr: affectedStderr,
+    exitCode,
+  } = await runPnpm(args, exec);
+
+  // If Nx cannot compute affected projects, fail instead of silently
+  // returning an empty list, which could cause CI to skip tests/jobs.
+  if (exitCode !== 0) {
+    const debugEnabled =
+      process.env.RUNNER_DEBUG === "1" || process.env.DEBUG_NX_AFFECTED;
+    if (debugEnabled) {
+      console.error(
+        "[nx-affected] `pnpm nx show projects --affected --json` failed.",
+        "exitCode:",
+        exitCode,
+        "stderr:",
+        affectedStderr || "<none>",
+        "stdout:",
+        affectedStdout || "<none>",
+      );
+    }
+    throw new Error(
+      `pnpm nx show projects --affected --json failed with exit code ${exitCode}`,
+    );
+  }
+
+  if (!affectedStdout || !affectedStdout.trim()) {
+    const debugEnabled =
+      process.env.RUNNER_DEBUG === "1" || process.env.DEBUG_NX_AFFECTED;
+    if (debugEnabled) {
+      console.error(
+        "[nx-affected] `pnpm nx show projects --affected --json` produced no output.",
+        "stderr:",
+        affectedStderr || "<none>",
+      );
+    }
+    throw new Error(
+      "pnpm nx show projects --affected --json returned empty output",
+    );
+  }
+
+  try {
+    const parsed = JSON.parse(affectedStdout.trim());
+    if (Array.isArray(parsed)) packageNames = parsed.filter(Boolean);
+  } catch (e) {
+    const debugEnabled =
+      process.env.RUNNER_DEBUG === "1" || process.env.DEBUG_NX_AFFECTED;
+    if (debugEnabled) {
+      console.error(
+        "[nx-affected] Failed to parse affected projects JSON.",
+        "error:",
+        e,
+        "stderr:",
+        affectedStderr || "<none>",
+        "stdout:",
+        affectedStdout || "<none>",
+      );
+    }
+    throw new Error("Failed to parse output from pnpm nx show projects");
+  }
+
+  const paths = [];
+  for (const name of packageNames) {
+    const mapped = nameToPath.get(name);
+    if (mapped != null) {
+      paths.push(mapped);
+      continue;
+    }
+    // Fallback: Nx project not in pnpm workspace
+    try {
+      const { stdout: projectStdout, exitCode: projectCode } = await runPnpm(
+        ["nx", "show", "project", name, "--json"],
+        exec,
+      );
+      if (projectCode === 0 && projectStdout && projectStdout.trim()) {
+        const project = JSON.parse(projectStdout.trim());
+        if (project && project.root) paths.push(project.root);
+      }
+    } catch {
+      // Ignore per-project lookup errors; skip this project
+    }
+  }
+  const pathsDeduped = [...new Set(paths)];
+
+  return { packages: packageNames, paths: pathsDeduped };
+}
+
+module.exports = { getAffectedPackagesAndPaths };
+
+if (require.main === module) {
+  getAffectedPackagesAndPaths()
+    .then(result => console.log(JSON.stringify(result)))
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
### 📝 Description

Create an nx-affected alternative to turbo affected in advance of migration.

Note, this is intentionally not used by any flows

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-26819
Green Run: https://github.com/LedgerHQ/ledger-live/actions/runs/23144212977