### PR TITLE
test(e2e-desktop): use backward compatible navigation for receive spec

### DIFF
--- a/e2e/desktop/tests/specs/receive.address.spec.ts
+++ b/e2e/desktop/tests/specs/receive.address.spec.ts
@@ -60,7 +60,7 @@ for (const account of accounts) {
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-        await app.layout.goToAccounts();
+        await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(account.account.accountName);
         await app.account.expectAccountVisibility(account.account.accountName);
         await app.account.clickReceive();
@@ -130,7 +130,7 @@ test.describe("Receive", () => {
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-      await app.layout.goToAccounts();
+      await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.accountName);
       await app.account.expectAccountVisibility(account.accountName);
       await app.account.clickReceive();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Use the backward compatible navigation function for legacy and wallet 4.0.

Receive spec 4.0 **ENABLED**:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23061841652
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/4052ce51-76ba-45a7-b3f8-f2a208053748/

Receive spec 4.0 **DISABLED**:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23061852813
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/da270b00-6536-4a59-a553-8372e6b168c5/

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/QAA-1051


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
