### PR TITLE
chore: bootstrap team-split convention with CODEOWNERS and rules

### DIFF
--- a/.cursor/agents/code-reviewer.md
+++ b/.cursor/agents/code-reviewer.md
@@ -14,6 +14,7 @@ Follow all project rules in `.cursor/rules/`. Pay special attention to:
 - `ldls-native.mdc` — Lumen UI for mobile (`src/mvvm/`)
 - `coin-families-contract.mdc` — No coin-specific branches (`if (family === "evm")` etc.) in generic UI; extend the families contract and implement in `families/<family>/` instead
 - `jest-mocks.mdc` — Jest mock patterns for test files (avoids flaky tests and mock conflicts)
+- `team-split-convention.mdc` — Multi-team files should be split into `[foo]/index.ts` and `[foo]/team-[team]/*.ts`; suggest this when a touched file clearly involves many teams
 
 ## Review Scope
 
@@ -34,6 +35,7 @@ By default, review unstaged changes from `git diff`. The user may specify differ
 - Missing integration tests for new features under `src/mvvm/` (required by `react-mvvm.mdc`)
 - Lumen UI compliance: verify new UI in `src/mvvm/` uses design-system components
 - **Coin-families contract:** In generic code (outside `families/<family>/`), flag new `if (family === "…")` or coin-specific hooks; suggest extending the families contract and implementing in the family folder instead (see `coin-families-contract.mdc`)
+- **Cross-team files:** When a PR touches a file or directory that is owned by or relevant to multiple teams, suggest refactoring to the **team-split convention** (splitting reduces friction between teams in CODEOWNERS by giving each team clear ownership of its files): split into `[foo]/index.ts` and `[foo]/team-[team]/*.ts`; one file or small set per team; index re-exports all. For the full convention and examples, see `.cursor/rules/team-split-convention.mdc` (CODEOWNERS defines the allowed `team-*` slugs).
 
 ## Confidence Scoring
 

--- a/.cursor/rules/team-split-convention.mdc
+++ b/.cursor/rules/team-split-convention.mdc
@@ -1,0 +1,43 @@
+---
+description: Team-split convention for multi-team files — split into team-* folders to reduce CODEOWNERS friction
+globs: ["**/team-*/**"]
+alwaysApply: false
+---
+
+# Team-split convention
+
+Monolithic files or folders that many teams touch must be split into pieces to reduce the friction between teams in CODEOWNERS (clear ownership per team, fewer cross-team review bottlenecks).
+
+## When to apply
+
+- A file or folder is contributed to by many teams (single large file or flat directory with many owners).
+- Rule activates when editing or adding such areas or when the agent infers a multi-team file.
+
+## Target layout
+
+Transform `[foo].ts` or `[foo]/` into:
+
+```
+[foo]/
+  index.ts              # re-exports only
+  team-[team]/          # one or more files per team
+    <feature>.ts
+```
+
+**Example**: `[foo]/` → `[foo]/index.ts` and `[foo]/team-coin-integration/coin_bitcoin.ts`.
+
+## Structure
+
+- **`[foo]/index.ts`** — Only re-exports (e.g. `export * from "./team-coin-integration/coin_bitcoin"`). Not generated; maintain by hand or with AI. Must export from every team file that is part of the public API.
+- **`[foo]/team-[team]/`** — One or more files per team. Team slug = CODEOWNERS team name **without** the `@ledgerhq/` prefix (e.g. `coin-integration`, `ledger-partner-hoodies`).
+
+## Naming
+
+- Folder: `team-<slug>` (slug from CODEOWNERS).
+- Files inside: named by feature (e.g. `coin_bitcoin.ts`, `swap.handler.ts`).
+
+## CODEOWNERS
+
+Each `**/team-<team>/` path is owned by `@ledgerhq/<team>`. See CODEOWNERS for the canonical list of team slugs. When a new team is added to CODEOWNERS elsewhere, add a matching `**/team-<new-team>/` line in that block.
+
+Apply this convention when refactoring multi-team areas so ownership stays clear per team.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 <!-- Source: .cursor/agents/code-reviewer.md -->
-<!-- Last synced: 2026-02-13 -->
+<!-- Last synced: 2026-03-13 -->
 
 # Ledger Live Monorepo
 
@@ -55,6 +55,13 @@ If in doubt, the lockfile diff should be explainable by the set of `package.json
 - **Mobile:** Same idea: optional slots or generated maps (e.g. `NoAssociatedAccounts`), implemented per family; generic code looks up by contract, not by `family === "…"`.
 
 When a flow needs new coin-specific behaviour, the fix is to **extend the contract** (new optional slot) and implement it in the family folder, not to add branching in generic code. This keeps the codebase ready for modularisation and lazy loading. See `.cursor/rules/coin-families-contract.mdc` for the full rule and the Scan Device “no associated accounts” example.
+
+## Cross-team files (team-split convention)
+
+When a PR touches a file or directory that is **owned by or relevant to multiple teams**, suggest refactoring to the **team-split convention**: splitting reduces friction between teams in CODEOWNERS by giving each team clear ownership of its files.
+
+- Split into `[foo]/index.ts` and `[foo]/team-[team]/*.ts` (one file or small set per team; index re-exports all).
+- For the full convention and examples, see **`.cursor/rules/team-split-convention.mdc`**. CODEOWNERS defines the allowed `team-*` slugs.
 
 ## Translations
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -318,6 +318,21 @@ libs/ledger-live-common/src/e2e/                                            @led
 apps/ledger-live-mobile/e2e/                                                @ledgerhq/wallet-xp
 tools/actions/composites/merge-e2e-detox-timings/                           @ledgerhq/qaa
 
+# Team-split convention: ownership of team-* folders (order: last match wins)
+**/team-wallet-ci/                @ledgerhq/wallet-ci
+**/team-qaa/                      @ledgerhq/qaa
+**/team-wallet-xp/                @ledgerhq/wallet-xp
+**/team-platform/                 @ledgerhq/platform
+**/team-coin-integration/         @ledgerhq/coin-integration
+**/team-blockchain-support/       @ledgerhq/blockchain-support
+**/team-ledger-partner-hoodies/   @ledgerhq/ledger-partner-hoodies
+**/team-ledger-partner-blockydevs/ @ledgerhq/ledger-partner-blockydevs
+**/team-ptx/                      @ledgerhq/ptx
+**/team-cloud-wallet/             @ledgerhq/cloud-wallet
+**/team-live-devices/             @ledgerhq/live-devices
+**/team-recover-software/         @ledgerhq/recover-software
+**/team-engagement/               @ledgerhq/engagement
+
 # Cross-team generic files can be opted out (no strict ownership when it concerns everyone)
 .github/copilot-instructions.md
 libs/ledger-live-common/src/featureFlags/defaultFeatures.ts


### PR DESCRIPTION
This introduce new rules and convention for a team split organisation for features that require it. Typically usecases: envs, feature flags, deeplinks,... they today tend to be one monolithic files that all team push to. This PR introduce rules to have a generic convention to follow with automatic team ownerships.

read the rules for more information (in files changed)