### PR TITLE
test(e2e-desktop): use backward compatible navigation for send tx spec

### DIFF
--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -295,7 +295,7 @@ test.describe("Send flows", () => {
             await addBugLink([transaction.bugTicket]);
           }
 
-          await app.layout.goToAccounts();
+          await app.mainNavigation.openTargetFromMainNavigation("accounts");
           await app.accounts.navigateToAccountByName(
             transaction.transaction.accountToDebit.accountName,
           );
@@ -347,7 +347,7 @@ test.describe("Send flows", () => {
         async ({ app }) => {
           await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-          await app.layout.goToAccounts();
+          await app.mainNavigation.openTargetFromMainNavigation("accounts");
           await app.accounts.navigateToAccountByName(
             transaction.transaction.accountToDebit.accountName,
           );
@@ -398,7 +398,7 @@ test.describe("Send flows", () => {
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-        await app.layout.goToAccounts();
+        await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(
           transactionInputValid.accountToDebit.accountName,
         );
@@ -448,7 +448,7 @@ test.describe("Send flows", () => {
         async ({ app }) => {
           await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-          await app.layout.goToAccounts();
+          await app.mainNavigation.openTargetFromMainNavigation("accounts");
           await app.accounts.navigateToAccountByName(
             transaction.transaction.accountToDebit.accountName,
           );
@@ -523,7 +523,7 @@ test.describe("Send flows", () => {
         async ({ app }) => {
           await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-          await app.layout.goToAccounts();
+          await app.mainNavigation.openTargetFromMainNavigation("accounts");
           await app.accounts.navigateToAccountByName(
             transaction.transaction.accountToDebit.accountName,
           );
@@ -580,7 +580,7 @@ test.describe("Send flows", () => {
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-        await app.layout.goToAccounts();
+        await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(
           transactionEnsAddress.accountToDebit.accountName,
         );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Use the backward compatible navigation route for legacy and 4.0.

Send TX wallet 4.0 **ENABLED**:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23062739283
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/0e23f791-d07b-4d88-9454-643828d3a6d3/

Send TX wallet 4.0 **DISABLED**:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23062751254
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/13e2afb7-8211-429c-870b-0a4d1321be60/

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/QAA-1051

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
