### PR TITLE
test(e2e-desktop): delete account changes for 4.0

### DIFF
--- a/e2e/desktop/tests/specs/delete.account.spec.ts
+++ b/e2e/desktop/tests/specs/delete.account.spec.ts
@@ -61,7 +61,7 @@ for (const account of accounts) {
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-        await app.layout.goToAccounts();
+        await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(account.account.accountName);
         await app.account.expectAccountVisibility(account.account.accountName);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Changes for Wallet 4.0.

Delete Account 4.0 ENABLED:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23138150519
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/0db4d8a7-7a6c-4799-9411-c457998b53e6/

Delete Account 4.0 DISABLED:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23138160513
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/05d06371-9e60-4a3e-81ef-6296cfa99ded/

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/QAA-1051


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
