### PR TITLE
[LWDM] feat(mobile): add asset section for empty states (no accounts / read-only)

### DIFF
--- a/.changeset/bright-rivers-glow.md
+++ b/.changeset/bright-rivers-glow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add asset section for empty states using DADA API with stablecoin filtering and placeholder price display

--- a/apps/ledger-live-mobile/src/mocks/dada/handler.ts
+++ b/apps/ledger-live-mobile/src/mocks/dada/handler.ts
@@ -4,9 +4,9 @@ import { mockStablecoinsResponse } from "@ledgerhq/live-common/dada-client/mocks
 
 const handler = ({ request }: { request: Request }) => {
   const searchParams = new URL(request.url).searchParams;
-  const category = searchParams.get("category");
+  const categories = searchParams.get("categories");
 
-  if (category === "stablecoin") return HttpResponse.json(mockStablecoinsResponse);
+  if (categories === "stablecoins") return HttpResponse.json(mockStablecoinsResponse);
 
   const search = searchParams.get("search")?.toLowerCase().trim();
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/portfolio.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/portfolio.integration.test.tsx
@@ -8,6 +8,7 @@ import {
   overrideInitialStateWithGraphReworkAndReadOnly,
   overrideInitialStateWithPerpsEntryPoint,
   overrideInitialStateWithAssetSection,
+  overrideInitialStateWithNoAccountsAndAssetSection,
 } from "./shared";
 
 describe("Portfolio Screen", () => {
@@ -106,9 +107,31 @@ describe("Portfolio Screen", () => {
       expect(screen.queryByTestId("PortfolioCryptosList")).toBeNull();
     });
 
-    it("should not display the cryptos list when user has no accounts", async () => {
+    it("should not display the cryptos list when user has no accounts and assetSection is disabled", async () => {
       renderWithReactQuery(<PortfolioTest />, {
         overrideInitialState: overrideInitialStateWithFeatureFlag,
+      });
+
+      await screen.findByTestId("PortfolioEmptyList");
+
+      expect(screen.queryByTestId("PortfolioCryptosList")).toBeNull();
+    });
+
+    it("should display the cryptos list with DADA API assets when no accounts and assetSection is enabled", async () => {
+      renderWithReactQuery(<PortfolioTest />, {
+        overrideInitialState: overrideInitialStateWithNoAccountsAndAssetSection(true),
+      });
+
+      await screen.findByTestId("PortfolioEmptyList");
+
+      expect(await screen.findByTestId("PortfolioCryptosList")).toBeVisible();
+      expect(await screen.findByTestId("assetItem-Bitcoin")).toBeVisible();
+      expect(await screen.findByTestId("assetItem-Ethereum")).toBeVisible();
+    });
+
+    it("should not display the cryptos list when no accounts and assetSection is disabled", async () => {
+      renderWithReactQuery(<PortfolioTest />, {
+        overrideInitialState: overrideInitialStateWithNoAccountsAndAssetSection(false),
       });
 
       await screen.findByTestId("PortfolioEmptyList");

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/shared.tsx
@@ -7,6 +7,7 @@ import { PortfolioScreen as Portfolio } from "../screens/Portfolio";
 import ReadOnlyPortfolio from "../screens/ReadOnly";
 import { WalletTabNavigatorStackParamList } from "~/components/RootNavigator/types/WalletTabNavigator";
 import { State } from "~/reducers/types";
+import { Account } from "@ledgerhq/types-live";
 
 type TestStackParamList = WalletTabNavigatorStackParamList;
 
@@ -81,11 +82,11 @@ export const overrideInitialStateWithPerpsEntryPoint =
   });
 
 export const overrideInitialStateWithAssetSection =
-  (assetSection: boolean) =>
+  (assetSection: boolean, accounts: Account[] = [mockAccount]) =>
   (state: State): State => ({
     ...state,
     accounts: {
-      active: [mockAccount],
+      active: accounts,
     },
     settings: {
       ...state.settings,
@@ -95,3 +96,8 @@ export const overrideInitialStateWithAssetSection =
       },
     },
   });
+
+export const overrideInitialStateWithNoAccountsAndAssetSection =
+  (assetSection: boolean) =>
+  (state: State): State =>
+    overrideInitialStateWithAssetSection(assetSection, [])(state);

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/usePortfolioCryptosSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/usePortfolioCryptosSectionViewModel.test.ts
@@ -19,6 +19,10 @@ jest.mock("~/actions/general", () => ({
   useDistribution: jest.fn(),
 }));
 
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData", () => ({
+  useAssetsData: () => ({ data: undefined, isLoading: false }),
+}));
+
 const mockDistribution = (list: Asset[] = [], isAvailable = true) => {
   (useDistribution as jest.Mock).mockReturnValue({ isAvailable, list });
 };
@@ -118,6 +122,33 @@ describe("usePortfolioCryptosSectionViewModel", () => {
         screen: ScreenName.Asset,
         params: { currency: ethereum },
       });
+    });
+
+    it("should navigate to MarketDetail for placeholder assets", () => {
+      const placeholderAsset: Asset = {
+        ...createCryptoAsset(bitcoin, 0),
+        isPlaceholder: true,
+        marketId: "bitcoin",
+      };
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel());
+
+      act(() => {
+        result.current.onItemPress(placeholderAsset);
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MarketDetail, {
+        currencyId: "bitcoin",
+      });
+    });
+  });
+
+  describe("isEmptyState", () => {
+    it("should always return hasMore false", () => {
+      const { result } = renderHook(() =>
+        usePortfolioCryptosSectionViewModel({ isEmptyState: true }),
+      );
+
+      expect(result.current.hasMore).toBe(false);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/index.tsx
@@ -13,10 +13,16 @@ import { useTranslation } from "~/context/Locale";
 import AssetListItem from "./AssetListItem";
 import usePortfolioCryptosSectionViewModel from "./usePortfolioCryptosSectionViewModel";
 
-const PortfolioCryptosSectionComponent: React.FC = () => {
+interface PortfolioCryptosSectionProps {
+  isEmptyState?: boolean;
+}
+
+const PortfolioCryptosSectionComponent: React.FC<PortfolioCryptosSectionProps> = ({
+  isEmptyState,
+}) => {
   const { t } = useTranslation();
   const { assetsCount, hasMore, assetsToDisplay, onPressShowAll, onItemPress } =
-    usePortfolioCryptosSectionViewModel();
+    usePortfolioCryptosSectionViewModel({ isEmptyState });
 
   if (assetsCount === 0) return null;
 
@@ -48,7 +54,7 @@ const PortfolioCryptosSectionComponent: React.FC = () => {
           size="lg"
           isFull
           onPress={onPressShowAll}
-          lx={{ marginTop: "s24", marginBottom: "s48" }}
+          lx={{ marginTop: "s24", marginBottom: "s24" }}
         >
           {t("portfolio.seeAllAssets")}
         </Button>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/useAssetListItemViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/useAssetListItemViewModel.ts
@@ -40,32 +40,45 @@ export const useAssetListItemViewModel = (asset: Asset): AssetListItemViewModelR
     disableRounding: true,
   });
 
-  const formattedCounterValue = useMemo(
-    () =>
-      typeof countervalueRaw === "number"
-        ? formatCurrencyUnit(counterValueCurrency.units[0], new BigNumber(countervalueRaw), {
-            locale,
-            showCode: true,
-            discreet,
-          })
-        : null,
-    [countervalueRaw, counterValueCurrency, locale, discreet],
-  );
+  const formattedCounterValue = useMemo(() => {
+    if (asset.isPlaceholder && asset.placeholderPrice != null) {
+      const unit = counterValueCurrency.units[0];
+      const value = new BigNumber(asset.placeholderPrice).times(
+        new BigNumber(10).pow(unit.magnitude),
+      );
+      return formatCurrencyUnit(unit, value, { locale, showCode: true, discreet });
+    }
+    return typeof countervalueRaw === "number"
+      ? formatCurrencyUnit(counterValueCurrency.units[0], new BigNumber(countervalueRaw), {
+          locale,
+          showCode: true,
+          discreet,
+        })
+      : null;
+  }, [
+    asset.isPlaceholder,
+    asset.placeholderPrice,
+    countervalueRaw,
+    counterValueCurrency,
+    locale,
+    discreet,
+  ]);
 
-  const percentage = portfolio.countervalueChange.percentage;
-  // default to – when percentage is null
   let deltaText = "–";
   let deltaColor: AssetListItemViewModelResult["deltaColor"] = "muted";
 
-  if (percentage != null) {
-    const sign = percentage > 0 ? "+" : "";
-    deltaText = `${sign}${(percentage * 100).toFixed(2)}%`;
-    if (percentage > 0) {
-      deltaColor = "success";
-    } else if (percentage < 0) {
-      deltaColor = "error";
-    } else {
-      deltaColor = "muted";
+  if (!asset.isPlaceholder) {
+    const percentage = portfolio.countervalueChange.percentage;
+    if (percentage != null) {
+      const sign = percentage > 0 ? "+" : "";
+      deltaText = `${sign}${(percentage * 100).toFixed(2)}%`;
+      if (percentage > 0) {
+        deltaColor = "success";
+      } else if (percentage < 0) {
+        deltaColor = "error";
+      } else {
+        deltaColor = "muted";
+      }
     }
   }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/useDefaultAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/useDefaultAssets.ts
@@ -1,0 +1,53 @@
+import { useMemo } from "react";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
+import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
+import { selectCurrencyForMetaId } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
+import VersionNumber from "react-native-version-number";
+import { Asset } from "~/types/asset";
+import { EMPTY_STATE_MAX_ASSETS } from "./usePortfolioCryptosSectionViewModel";
+
+export function useDefaultAssets(isEmptyState: boolean): Asset[] {
+  const skip = !isEmptyState;
+
+  const { data: assetsData } = useAssetsData({
+    product: "llm",
+    version: VersionNumber.appVersion,
+    skip,
+  });
+  const { tickers: stablecoinTickers } = useStablecoinTickers(
+    "llm",
+    VersionNumber.appVersion,
+    skip,
+  );
+
+  const assets = useMemo(() => {
+    if (!assetsData) return [];
+
+    const items: Asset[] = [];
+    for (const id of assetsData.currenciesOrder.metaCurrencyIds) {
+      if (items.length >= EMPTY_STATE_MAX_ASSETS) break;
+      const currency = selectCurrencyForMetaId(id, assetsData);
+      if (!currency) continue;
+
+      const ticker = assetsData.cryptoAssets[id]?.ticker?.toUpperCase() ?? "";
+      if (stablecoinTickers.has(ticker)) continue;
+
+      const { price, id: marketId } = assetsData.markets?.[currency.id] ?? {};
+      items.push({
+        currency,
+        accounts: [],
+        amount: 0,
+        countervalue: 0,
+        isPlaceholder: true,
+        placeholderPrice: price,
+        marketId: marketId ?? currency.id,
+      });
+    }
+    return items;
+  }, [assetsData, stablecoinTickers]);
+
+  // Early return after all hooks — no API data needed outside empty state
+  if (!isEmptyState) return [];
+
+  return assets;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/usePortfolioCryptosSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/usePortfolioCryptosSectionViewModel.ts
@@ -9,8 +9,10 @@ import { NavigatorName, ScreenName } from "~/const";
 import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 import { Asset } from "~/types/asset";
 import { track } from "~/analytics";
+import { useDefaultAssets } from "./useDefaultAssets";
 
 export const MAX_ASSETS_TO_DISPLAY = 6;
+export const EMPTY_STATE_MAX_ASSETS = 4;
 
 export interface PortfolioCryptosSectionViewModelResult {
   assetsCount: number;
@@ -20,7 +22,13 @@ export interface PortfolioCryptosSectionViewModelResult {
   onItemPress: (asset: Asset) => void;
 }
 
-const usePortfolioCryptosSectionViewModel = (): PortfolioCryptosSectionViewModelResult => {
+interface UsePortfolioCryptosSectionViewModelOptions {
+  isEmptyState?: boolean;
+}
+
+const usePortfolioCryptosSectionViewModel = ({
+  isEmptyState = false,
+}: UsePortfolioCryptosSectionViewModelOptions = {}): PortfolioCryptosSectionViewModelResult => {
   const hideEmptyTokenAccount = useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
 
@@ -32,25 +40,28 @@ const usePortfolioCryptosSectionViewModel = (): PortfolioCryptosSectionViewModel
     hideEmptyTokenAccount,
   });
 
-  const allAssets = useMemo(
+  const distributionAssets = useMemo(
     () => (distribution.isAvailable && distribution.list.length > 0 ? distribution.list : []),
     [distribution],
   );
 
   const filteredAssets = useMemo(
     () =>
-      allAssets.filter(
+      distributionAssets.filter(
         ({ currency }) =>
           currency.type !== "TokenCurrency" || !blacklistedTokenIdsSet.has(currency.id),
       ),
-    [allAssets, blacklistedTokenIdsSet],
+    [distributionAssets, blacklistedTokenIdsSet],
   );
 
-  const assetsCount = filteredAssets.length;
+  const defaultAssets = useDefaultAssets(isEmptyState);
+
+  const assets = isEmptyState ? defaultAssets : filteredAssets;
+  const assetsCount = assets.length;
 
   const assetsToDisplay = useMemo(
-    () => filteredAssets.slice(0, MAX_ASSETS_TO_DISPLAY),
-    [filteredAssets],
+    () => assets.slice(0, isEmptyState ? EMPTY_STATE_MAX_ASSETS : MAX_ASSETS_TO_DISPLAY),
+    [assets, isEmptyState],
   );
 
   const onPressShowAll = useCallback(() => {
@@ -75,19 +86,25 @@ const usePortfolioCryptosSectionViewModel = (): PortfolioCryptosSectionViewModel
         asset: asset.currency.name,
         page: "Wallet",
       });
-      navigation.navigate(NavigatorName.Accounts, {
-        screen: ScreenName.Asset,
-        params: {
-          currency: asset.currency,
-        },
-      });
+      if (asset.isPlaceholder) {
+        navigation.navigate(ScreenName.MarketDetail, {
+          currencyId: asset.marketId ?? asset.currency.id,
+        });
+      } else {
+        navigation.navigate(NavigatorName.Accounts, {
+          screen: ScreenName.Asset,
+          params: {
+            currency: asset.currency,
+          },
+        });
+      }
     },
     [navigation],
   );
 
   return {
     assetsCount,
-    hasMore: assetsCount > MAX_ASSETS_TO_DISPLAY,
+    hasMore: isEmptyState ? false : assetsCount > MAX_ASSETS_TO_DISPLAY,
     assetsToDisplay,
     onPressShowAll,
     onItemPress,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoAccountsContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoAccountsContent.tsx
@@ -4,12 +4,14 @@ import { QuickActionsCtas, TransferDrawer } from "LLM/features/QuickActions";
 import MarketBanner from "LLM/features/MarketBanner";
 import { ScreenName } from "~/const";
 import { PortfolioBannersSection } from "../PortfolioBannersSection";
+import { PortfolioCryptosSection } from "../PortfolioCryptosSection";
 import AddAccountDrawer from "LLM/features/Accounts/screens/AddAccount";
 import { useTranslation } from "~/context/Locale";
 import TrackScreen from "~/analytics/TrackScreen";
 
 type PortfolioNoAccountsContentProps = {
   readonly isLNSUpsellBannerShown: boolean;
+  readonly shouldDisplayAssetSection?: boolean;
   readonly openAddModal: () => void;
   readonly closeAddModal: () => void;
   readonly isAddModalOpened: boolean;
@@ -17,6 +19,7 @@ type PortfolioNoAccountsContentProps = {
 
 const PortfolioNoAccountsContent = ({
   isLNSUpsellBannerShown,
+  shouldDisplayAssetSection = false,
   openAddModal,
   closeAddModal,
   isAddModalOpened,
@@ -30,10 +33,15 @@ const PortfolioNoAccountsContent = ({
       <TransferDrawer />
       <PortfolioBannersSection isFirst={true} isLNSUpsellBannerShown={isLNSUpsellBannerShown} />
       <MarketBanner />
+      {shouldDisplayAssetSection && <PortfolioCryptosSection isEmptyState />}
       <Button
         appearance="gray"
         size="lg"
-        lx={{ width: "full" }}
+        lx={{
+          width: "full",
+          marginTop: "s24",
+          marginBottom: "s48",
+        }}
         onPress={openAddModal}
         testID="add-account-cta"
       >

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoSignerContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoSignerContent.tsx
@@ -11,11 +11,13 @@ import { TRACKING_LABEL_MAP } from "LLM/components/MainTabBar/constants";
 interface PortfolioNoSignerContentProps {
   readonly isLNSUpsellBannerShown: boolean;
   readonly shouldDisplayAssetSection?: boolean;
+  readonly isEmptyState?: boolean;
 }
 
 export const PortfolioNoSignerContent = ({
   isLNSUpsellBannerShown,
   shouldDisplayAssetSection = false,
+  isEmptyState,
 }: PortfolioNoSignerContentProps) => (
   <Box lx={{ paddingHorizontal: "s16" }}>
     <TrackScreen name={TRACKING_LABEL_MAP[NavigatorName.Portfolio]} />
@@ -23,6 +25,6 @@ export const PortfolioNoSignerContent = ({
     <TransferDrawer />
     <PortfolioBannersSection isFirst={true} isLNSUpsellBannerShown={isLNSUpsellBannerShown} />
     <MarketBanner />
-    {shouldDisplayAssetSection && <PortfolioCryptosSection />}
+    {shouldDisplayAssetSection && <PortfolioCryptosSection isEmptyState={isEmptyState} />}
   </Box>
 );

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/__integrations__/portfolioEmptySection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/__integrations__/portfolioEmptySection.integration.test.tsx
@@ -3,7 +3,11 @@ import { render, renderWithReactQuery, screen } from "@tests/test-renderer";
 import { PortfolioEmptySection } from "../index";
 import { State } from "~/reducers/types";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
-import { btcCurrency, ethCurrency } from "../../../__integrations__/shared";
+import {
+  btcCurrency,
+  ethCurrency,
+  overrideInitialStateWithAssetSection,
+} from "../../../__integrations__/shared";
 import { QUICK_ACTIONS_TEST_IDS } from "LLM/features/QuickActions/testIds";
 
 const mockNavigate = jest.fn();
@@ -106,6 +110,14 @@ describe("PortfolioEmptySection", () => {
       });
 
       expect(await screen.findByTestId("PortfolioCryptosList")).toBeVisible();
+    });
+
+    it("should not render the cryptos section when assetSection flag is off", () => {
+      renderWithReactQuery(<PortfolioEmptySection isLNSUpsellBannerShown={false} />, {
+        overrideInitialState: overrideInitialStateWithAssetSection(false),
+      });
+
+      expect(screen.queryByTestId("PortfolioCryptosList")).toBeNull();
     });
 
     it("should render quick actions CTAs", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/index.tsx
@@ -15,6 +15,7 @@ export const PortfolioEmptySection = ({ isLNSUpsellBannerShown }: PortfolioEmpty
     return (
       <PortfolioNoAccountsContent
         isLNSUpsellBannerShown={isLNSUpsellBannerShown}
+        shouldDisplayAssetSection={shouldDisplayAssetSection}
         openAddModal={openAddModal}
         closeAddModal={closeAddModal}
         isAddModalOpened={isAddModalOpened}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/index.tsx
@@ -57,6 +57,7 @@ function ReadOnlyPortfolioScreen({ navigation }: NavigationProps) {
         key="noSigner"
         isLNSUpsellBannerShown={isLNSUpsellBannerShown}
         shouldDisplayAssetSection={shouldDisplayAssetSection}
+        isEmptyState
       />,
     ],
     [

--- a/apps/ledger-live-mobile/src/types/asset.ts
+++ b/apps/ledger-live-mobile/src/types/asset.ts
@@ -7,4 +7,7 @@ export type Asset = {
   distribution?: number;
   amount: number;
   countervalue?: number;
+  isPlaceholder?: boolean;
+  placeholderPrice?: number;
+  marketId?: string;
 };

--- a/libs/ledger-live-common/src/dada-client/hooks/__tests__/useStablecoinTickers.test.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/__tests__/useStablecoinTickers.test.ts
@@ -88,10 +88,31 @@ describe("useStablecoinTickers", () => {
 
     renderHook(() => useStablecoinTickers(hookParams.product, hookParams.version));
 
-    expect(mockUseGetAssetsByCategoryQuery).toHaveBeenCalledWith({
-      category: AssetCategory.Stablecoins,
-      product: hookParams.product,
-      version: hookParams.version,
+    expect(mockUseGetAssetsByCategoryQuery).toHaveBeenCalledWith(
+      {
+        category: AssetCategory.Stablecoins,
+        product: hookParams.product,
+        version: hookParams.version,
+      },
+      { skip: undefined },
+    );
+  });
+
+  it("should skip the query when skip is true", () => {
+    mockUseGetAssetsByCategoryQuery.mockReturnValue({
+      ...defaultMockValues,
+      isUninitialized: true,
     });
+
+    renderHook(() => useStablecoinTickers(hookParams.product, hookParams.version, true));
+
+    expect(mockUseGetAssetsByCategoryQuery).toHaveBeenCalledWith(
+      {
+        category: AssetCategory.Stablecoins,
+        product: hookParams.product,
+        version: hookParams.version,
+      },
+      { skip: true },
+    );
   });
 });

--- a/libs/ledger-live-common/src/dada-client/hooks/useStablecoinTickers.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/useStablecoinTickers.ts
@@ -4,12 +4,15 @@ import { AssetCategory } from "../state-manager/types";
 
 const emptySet = new Set<string>();
 
-export function useStablecoinTickers(product: "llm" | "lld", version: string) {
-  const { data, isLoading } = useGetAssetsByCategoryQuery({
-    category: AssetCategory.Stablecoins,
-    product,
-    version,
-  });
+export function useStablecoinTickers(product: "llm" | "lld", version: string, skip?: boolean) {
+  const { data, isLoading } = useGetAssetsByCategoryQuery(
+    {
+      category: AssetCategory.Stablecoins,
+      product,
+      version,
+    },
+    { skip },
+  );
   const tickers = useMemo(
     () => (data ? new Set(data.map(t => t.toUpperCase())) : emptySet),
     [data],


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio empty states (no accounts, no signer, read-only) now display top crypto assets from DADA API
  - Asset section visibility is gated by `lwmWallet40.params.assetSection` feature flag
  - Placeholder prices are correctly formatted using counter-value currency magnitude
  - Stablecoins are filtered from top crypto list

### 📝 Description

**Problem**: When users have no accounts or are in read-only mode, the portfolio displays no asset section, missing an opportunity to show relevant market data and guide users toward their first purchase.

**Solution**: Extended `PortfolioCryptosSection` with an `isEmptyState` mode that fetches top cryptocurrencies from the DADA API instead of relying on account distribution data. Key changes:

- **DADA API integration**: Added `useDefaultAssets` hook using `useAssetsData` and `selectCurrencyForMetaId` (mutualized from `@ledgerhq/live-common`) to fetch top 4 assets by market cap
- **Stablecoin filtering**: Integrated `useStablecoinTickers` to exclude stablecoins (USDT, USDC, etc.) from the top crypto list, matching desktop behavior
- **Placeholder price formatting**: Fixed price display by applying `10 ** unit.magnitude` conversion, aligning with desktop's `usePriceCellViewModel`
- **Feature flag gating**: All empty-state asset rendering is controlled by `lwmWallet40.params.assetSection` — when off, no asset section is shown
- **Empty state UI**: Placeholder assets show no allocation bar, no account count in subheader, and no navigation arrow; clicking navigates to the asset detail page

Files changed:
- `usePortfolioCryptosSectionViewModel.ts` — core logic for empty state data fetching + stablecoin filtering
- `useAssetListItemViewModel.ts` — placeholder price formatting fix
- `PortfolioCryptosSection/index.tsx` — `isEmptyState` prop support
- `PortfolioNoAccountsContent.tsx` / `PortfolioNoSignerContent.tsx` / `ReadOnly/index.tsx` — conditional rendering with feature flag
- `types/asset.ts` — added `isPlaceholder`, `placeholderPrice`, `marketId` fields
- Integration tests updated for new behavior

read only
<img width="300" height="750" alt="simulator_screenshot_0B686FC7-C572-4C8D-836A-5FA4B0E0AE4B" src="https://github.com/user-attachments/assets/fdad3645-f8d7-43b5-97c6-761438117c46" />

no accounts
<img width="300" height="750" alt="simulator_screenshot_0BDFB32A-8E3C-403F-AE3C-4B85C3053A3C" src="https://github.com/user-attachments/assets/e5f0dd55-563a-419c-9562-543f2ce1917c" />

accounts
<img width="300" height="750" alt="simulator_screenshot_9B9F380B-14B5-4795-9174-7AA0B8C952A0" src="https://github.com/user-attachments/assets/009a8d19-91cc-4f4d-953b-cfd6bc52106b" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26973](https://ledgerhq.atlassian.net/browse/LIVE-26973)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26973]: https://ledgerhq.atlassian.net/browse/LIVE-26973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ