### PR TITLE
[LWM] feat(mobile): add earn info bottom sheet for PTX flow

### DIFF
--- a/.changeset/earn-info-bottom-sheet-live-27276.md
+++ b/.changeset/earn-info-bottom-sheet-live-27276.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add EarnInfoBottomSheet for Earn PTX flow and custom.bottomSheet.info handler

--- a/apps/ledger-live-mobile/src/actions/earn.ts
+++ b/apps/ledger-live-mobile/src/actions/earn.ts
@@ -2,12 +2,17 @@ import { createAction } from "redux-actions";
 import { EarnActionTypes } from "./types";
 import type {
   EarnSetInfoModalPayload,
+  EarnSetInfoBottomSheetPayload,
   EarnSetMenuModalPayload,
   EarnSetProtocolInfoModalPayload,
 } from "./types";
 
 export const makeSetEarnInfoModalAction = createAction<EarnSetInfoModalPayload>(
   EarnActionTypes.EARN_INFO_MODAL,
+);
+
+export const makeSetEarnInfoBottomSheetAction = createAction<EarnSetInfoBottomSheetPayload>(
+  EarnActionTypes.EARN_INFO_BOTTOM_SHEET,
 );
 
 export const makeSetEarnMenuModalAction = createAction<EarnSetMenuModalPayload>(

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -482,11 +482,14 @@ export enum SwapActionTypes {
 // === EARN ACTIONS ==
 export enum EarnActionTypes {
   EARN_INFO_MODAL = "EARN_INFO_MODAL",
+  EARN_INFO_BOTTOM_SHEET = "EARN_INFO_BOTTOM_SHEET",
   EARN_MENU_MODAL = "EARN_MENU_MODAL",
   EARN_PROTOCOL_INFO_MODAL = "EARN_PROTOCOL_INFO_MODAL",
 }
 
 export type EarnSetInfoModalPayload = EarnState["infoModal"] | undefined;
+
+export type EarnSetInfoBottomSheetPayload = EarnState["infoBottomSheet"];
 
 export type EarnSetMenuModalPayload = EarnState["menuModal"] | undefined;
 
@@ -494,6 +497,7 @@ export type EarnSetProtocolInfoModalPayload = EarnState["protocolInfoModal"] | u
 
 export type EarnPayload =
   | EarnSetInfoModalPayload
+  | EarnSetInfoBottomSheetPayload
   | EarnSetMenuModalPayload
   | EarnSetProtocolInfoModalPayload;
 

--- a/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
@@ -15,6 +15,7 @@ import { EarnScreen } from "~/screens/PTX/Earn";
 import { EarnInfoDrawer } from "~/screens/PTX/Earn/EarnInfoDrawer";
 import { EarnMenuDrawer } from "~/screens/PTX/Earn/EarnMenuDrawer";
 import { EarnProtocolInfoDrawer } from "~/screens/PTX/Earn/EarnProtocolInfoDrawer";
+import { EarnInfoBottomSheet } from "~/screens/PTX/Earn/EarnInfoBottomSheet";
 import { useStakingDrawer } from "../Stake/useStakingDrawer";
 import { useOpenStakeDrawer } from "LLM/features/Stake";
 import type { EarnLiveAppNavigatorParamList } from "./types/EarnLiveAppNavigator";
@@ -175,6 +176,7 @@ const Earn = (props: NavigationProps) => {
       />
       <EarnProtocolInfoDrawer />
       <EarnInfoDrawer />
+      <EarnInfoBottomSheet />
       <EarnMenuDrawer navigation={navigation} />
     </>
   );

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
@@ -39,6 +39,15 @@ import { useRemoteLiveAppContext } from "@ledgerhq/live-common/platform/provider
 import { useLocalLiveAppContext } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import { usesEncodedAccountIdFormat } from "@ledgerhq/live-common/wallet-api/utils/deriveAccountIdForManifest";
 import { updateAccountWithUpdater } from "~/actions/accounts";
+import { makeSetEarnInfoBottomSheetAction } from "~/actions/earn";
+import {
+  MAX_LABEL_LENGTH,
+  MAX_MESSAGE_LENGTH,
+  MAX_TITLE_LENGTH,
+  sanitizeString,
+  validateUrl,
+} from "~/navigation/deeplinks/validation";
+import type { Dispatch } from "redux";
 import { useDispatch } from "~/context/hooks";
 import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
@@ -287,6 +296,7 @@ export function useCustomExchangeHandlers({
 
         return results;
       },
+      "custom.bottomSheet.info": createOpenInfoBottomSheetHandler(dispatch),
     };
 
     return {
@@ -500,4 +510,70 @@ export function useCustomExchangeHandlers({
 
 export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], accounts: AccountLike[]) {
   return useCustomExchangeHandlers({ manifest, accounts, sendAppReady: sendEarnLiveAppReady });
+}
+
+export function createOpenInfoBottomSheetHandler(dispatch: Dispatch) {
+  return async (request: {
+    params?: {
+      title: unknown;
+      message: unknown;
+      linkText?: unknown;
+      linkHref?: unknown;
+    };
+  }) => {
+    const { params } = request;
+    if (!params) {
+      throw new Error("Missing params for custom.bottomSheet.info");
+    }
+
+    const { title, message, linkText, linkHref } = params;
+
+    if (typeof title !== "string" || typeof message !== "string") {
+      throw new TypeError(
+        "Invalid params for custom.bottomSheet.info: expected non-empty string 'title' and 'message'.",
+      );
+    }
+
+    const sanitizedTitle = sanitizeString(title, MAX_TITLE_LENGTH);
+    const sanitizedMessage = sanitizeString(message, MAX_MESSAGE_LENGTH);
+    if (!sanitizedTitle || !sanitizedMessage) {
+      throw new Error(
+        "Invalid params for custom.bottomSheet.info: expected non-empty string 'title' and 'message'.",
+      );
+    }
+
+    if (linkText != null && typeof linkText !== "string") {
+      throw new Error(
+        "Invalid params for custom.bottomSheet.info: 'linkText' must be a string when provided.",
+      );
+    }
+    if (linkHref != null && typeof linkHref !== "string") {
+      throw new Error(
+        "Invalid params for custom.bottomSheet.info: 'linkHref' must be a string when provided.",
+      );
+    }
+
+    const sanitizedLinkText = linkText
+      ? sanitizeString(linkText, MAX_LABEL_LENGTH) || undefined
+      : undefined;
+
+    let validatedLinkHref: string | undefined;
+    if (linkHref != null) {
+      validatedLinkHref = validateUrl(linkHref);
+      if (validatedLinkHref === "") {
+        throw new Error(
+          "Invalid params for custom.bottomSheet.info: 'linkHref' is not an allowed URL.",
+        );
+      }
+    }
+
+    dispatch(
+      makeSetEarnInfoBottomSheetAction({
+        title: sanitizedTitle,
+        message: sanitizedMessage,
+        linkText: sanitizedLinkText,
+        linkHref: validatedLinkHref,
+      }),
+    );
+  };
 }

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/__tests__/CustomHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/__tests__/CustomHandlers.test.ts
@@ -1,0 +1,190 @@
+import { createOpenInfoBottomSheetHandler } from "../CustomHandlers";
+import { makeSetEarnInfoBottomSheetAction } from "~/actions/earn";
+
+describe("createOpenInfoBottomSheetHandler", () => {
+  it("should dispatch makeSetEarnInfoBottomSheetAction with title and message when params are provided", async () => {
+    const dispatch = jest.fn();
+    const handler = createOpenInfoBottomSheetHandler(dispatch);
+
+    await handler({
+      params: { title: "Earn info title", message: "Earn info message body" },
+    });
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      makeSetEarnInfoBottomSheetAction({
+        title: "Earn info title",
+        message: "Earn info message body",
+        linkText: undefined,
+        linkHref: undefined,
+      }),
+    );
+  });
+
+  it("should sanitize title and message (strip tags, cap length) before dispatch", async () => {
+    const dispatch = jest.fn();
+    const handler = createOpenInfoBottomSheetHandler(dispatch);
+    const longTitle = `${"a".repeat(120)}<b>x</b>`;
+    const longMessage = `${"m".repeat(800)}<script>x</script>`;
+
+    await handler({
+      params: {
+        title: longTitle,
+        message: longMessage,
+      },
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      makeSetEarnInfoBottomSheetAction({
+        title: `${"a".repeat(100)}`,
+        message: `${"m".repeat(700)}`,
+        linkText: undefined,
+        linkHref: undefined,
+      }),
+    );
+  });
+
+  it("should throw when title or message is empty after sanitization", async () => {
+    const dispatch = jest.fn();
+    const handler = createOpenInfoBottomSheetHandler(dispatch);
+
+    await expect(handler({ params: { title: "   ", message: "ok" } })).rejects.toThrow(
+      "Invalid params for custom.bottomSheet.info: expected non-empty string 'title' and 'message'.",
+    );
+    await expect(handler({ params: { title: "<p></p>", message: "ok" } })).rejects.toThrow(
+      "Invalid params for custom.bottomSheet.info: expected non-empty string 'title' and 'message'.",
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("should sanitize linkText length and omit when only markup remains", async () => {
+    const dispatch = jest.fn();
+    const handler = createOpenInfoBottomSheetHandler(dispatch);
+    const linkHref = "https://www.ledger.com";
+
+    await handler({
+      params: {
+        title: "T",
+        message: "M",
+        linkText: `${"L".repeat(60)}`,
+        linkHref,
+      },
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      makeSetEarnInfoBottomSheetAction({
+        title: "T",
+        message: "M",
+        linkText: "L".repeat(50),
+        linkHref,
+      }),
+    );
+
+    dispatch.mockClear();
+    await handler({
+      params: {
+        title: "T",
+        message: "M",
+        linkText: "<i></i>",
+        linkHref,
+      },
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      makeSetEarnInfoBottomSheetAction({
+        title: "T",
+        message: "M",
+        linkText: undefined,
+        linkHref,
+      }),
+    );
+  });
+
+  it("should dispatch with linkText and validated linkHref when optional link fields are valid", async () => {
+    const dispatch = jest.fn();
+    const handler = createOpenInfoBottomSheetHandler(dispatch);
+    const linkHref = "https://www.ledger.com";
+
+    await handler({
+      params: {
+        title: "Title",
+        message: "Message",
+        linkText: "Learn more",
+        linkHref,
+      },
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      makeSetEarnInfoBottomSheetAction({
+        title: "Title",
+        message: "Message",
+        linkText: "Learn more",
+        linkHref,
+      }),
+    );
+  });
+
+  it("should throw and not dispatch when linkHref fails validateUrl (non-allowlisted domain)", async () => {
+    const dispatch = jest.fn();
+    const handler = createOpenInfoBottomSheetHandler(dispatch);
+
+    await expect(
+      handler({
+        params: {
+          title: "Title",
+          message: "Message",
+          linkText: "Learn more",
+          linkHref: "https://example.com",
+        },
+      }),
+    ).rejects.toThrow(
+      "Invalid params for custom.bottomSheet.info: 'linkHref' is not an allowed URL.",
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("should throw and not dispatch when no params are provided", async () => {
+    const dispatch = jest.fn();
+    const handler = createOpenInfoBottomSheetHandler(dispatch);
+
+    await expect(handler({})).rejects.toThrow("Missing params for custom.bottomSheet.info");
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      params: { title: 123, message: "Earn info message" },
+      description: "title is not a string",
+      expectedError:
+        "Invalid params for custom.bottomSheet.info: expected non-empty string 'title' and 'message'.",
+    },
+    {
+      params: { title: "Earn info title", message: true },
+      description: "message is not a string",
+      expectedError:
+        "Invalid params for custom.bottomSheet.info: expected non-empty string 'title' and 'message'.",
+    },
+    {
+      params: { title: "Title", message: "Message", linkText: 42 },
+      description: "linkText is provided but not a string",
+      expectedError:
+        "Invalid params for custom.bottomSheet.info: 'linkText' must be a string when provided.",
+    },
+    {
+      params: { title: "Title", message: "Message", linkHref: {} },
+      description: "linkHref is provided but not a string",
+      expectedError:
+        "Invalid params for custom.bottomSheet.info: 'linkHref' must be a string when provided.",
+    },
+  ])("should throw and not dispatch when $description", async ({ params, expectedError }) => {
+    const dispatch = jest.fn();
+    const handler = createOpenInfoBottomSheetHandler(dispatch);
+
+    await expect(handler({ params })).rejects.toThrow(expectedError);
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/validation.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/validation.ts
@@ -11,9 +11,9 @@ import { isDatadogEnabled } from "../../datadog";
 import type { OptionMetadata } from "../../reducers/types";
 
 // Maximum allowed lengths for string parameters
-const MAX_MESSAGE_LENGTH = 700;
-const MAX_TITLE_LENGTH = 100;
-const MAX_LABEL_LENGTH = 50;
+export const MAX_MESSAGE_LENGTH = 700;
+export const MAX_TITLE_LENGTH = 100;
+export const MAX_LABEL_LENGTH = 50;
 
 // Allowed domains for external links
 const ALLOWED_DOMAINS = [
@@ -59,7 +59,7 @@ export interface ValidatedEarnMenuModal {
 /**
  * Sanitizes a string by removing potentially dangerous characters
  */
-function sanitizeString(input: string, maxLength: number): string {
+export function sanitizeString(input: string, maxLength: number): string {
   if (!input || typeof input !== "string") {
     return "";
   }
@@ -79,7 +79,7 @@ function sanitizeString(input: string, maxLength: number): string {
 /**
  * Validates and sanitizes a URL to ensure it points to a trusted domain
  */
-function validateUrl(urlString: string): string {
+export function validateUrl(urlString: string): string {
   if (!urlString || typeof urlString !== "string") {
     return "";
   }

--- a/apps/ledger-live-mobile/src/reducers/__tests__/earn.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/earn.test.ts
@@ -1,0 +1,59 @@
+import reducer, { INITIAL_STATE, earnInfoBottomSheetSelector } from "../earn";
+import { makeSetEarnInfoBottomSheetAction } from "../../actions/earn";
+import type { State } from "../types";
+
+describe("earn reducer", () => {
+  describe("EARN_INFO_BOTTOM_SHEET", () => {
+    it("should set infoBottomSheet from payload", () => {
+      const payload = { message: "Earn info", title: "Info" };
+      const action = makeSetEarnInfoBottomSheetAction(payload);
+      const state = reducer(INITIAL_STATE, action);
+
+      expect(state.infoBottomSheet).toEqual(payload);
+    });
+
+    it("should set infoBottomSheet to undefined when payload is undefined", () => {
+      const action = makeSetEarnInfoBottomSheetAction(undefined);
+      const state = reducer(INITIAL_STATE, action);
+
+      expect(state.infoBottomSheet).toBeUndefined();
+    });
+
+    it("should preserve other earn state when updating infoBottomSheet", () => {
+      const baseState = {
+        ...INITIAL_STATE,
+        infoModal: { messageTitle: "Modal" },
+      };
+      const payload = { title: "Sheet", message: "Sheet message" };
+      const action = makeSetEarnInfoBottomSheetAction(payload);
+      const state = reducer(baseState, action);
+
+      expect(state.infoBottomSheet).toEqual(payload);
+      expect(state.infoModal).toEqual({ messageTitle: "Modal" });
+    });
+  });
+});
+
+describe("earnInfoBottomSheetSelector", () => {
+  it("should return infoBottomSheet from earn state", () => {
+    const infoBottomSheet = { message: "Test", title: "Test Title" };
+    const state: State = {
+      ...({} as State),
+      earn: {
+        ...INITIAL_STATE,
+        infoBottomSheet,
+      },
+    };
+
+    expect(earnInfoBottomSheetSelector(state)).toEqual(infoBottomSheet);
+  });
+
+  it("should return undefined when infoBottomSheet is initial", () => {
+    const state: State = {
+      ...({} as State),
+      earn: INITIAL_STATE,
+    };
+
+    expect(earnInfoBottomSheetSelector(state)).toBeUndefined();
+  });
+});

--- a/apps/ledger-live-mobile/src/reducers/earn.ts
+++ b/apps/ledger-live-mobile/src/reducers/earn.ts
@@ -5,6 +5,7 @@ import {
   EarnActionTypes,
   EarnPayload,
   EarnSetInfoModalPayload,
+  EarnSetInfoBottomSheetPayload,
   EarnSetMenuModalPayload,
   EarnSetProtocolInfoModalPayload,
 } from "../actions/types";
@@ -12,6 +13,7 @@ import type { EarnState, State } from "./types";
 
 export const INITIAL_STATE: EarnState = {
   infoModal: {},
+  infoBottomSheet: undefined,
   menuModal: undefined,
   protocolInfoModal: undefined,
 };
@@ -20,6 +22,10 @@ const handlers: ReducerMap<EarnState, EarnPayload> = {
   [EarnActionTypes.EARN_INFO_MODAL]: (state, action): EarnState => ({
     ...state,
     infoModal: (action as Action<EarnSetInfoModalPayload>).payload ?? {},
+  }),
+  [EarnActionTypes.EARN_INFO_BOTTOM_SHEET]: (state, action): EarnState => ({
+    ...state,
+    infoBottomSheet: (action as Action<EarnSetInfoBottomSheetPayload>).payload,
   }),
   [EarnActionTypes.EARN_MENU_MODAL]: (state, action): EarnState => ({
     ...state,
@@ -38,6 +44,11 @@ export const exportSelector = storeSelector;
 export const earnInfoModalSelector = createSelector(
   storeSelector,
   (state: EarnState) => state.infoModal,
+);
+
+export const earnInfoBottomSheetSelector = createSelector(
+  storeSelector,
+  (state: EarnState) => state.infoBottomSheet,
 );
 
 export const earnMenuModalSelector = createSelector(

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -318,6 +318,12 @@ export type EarnState = {
     messageTitle?: string;
     learnMoreLink?: string;
   };
+  infoBottomSheet?: {
+    message: string;
+    title: string;
+    linkText?: string;
+    linkHref?: string;
+  };
   menuModal?: {
     title?: string;
     options: { label: string; metadata: OptionMetadata }[];

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoBottomSheet.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoBottomSheet.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { BottomSheetView, BottomSheetHeader, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Linking } from "react-native";
+import { useSelector, useDispatch } from "~/context/hooks";
+import { makeSetEarnInfoBottomSheetAction } from "~/actions/earn";
+import { earnInfoBottomSheetSelector } from "~/reducers/earn";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+
+export function EarnInfoBottomSheet() {
+  const dispatch = useDispatch();
+  const infoBottomSheet = useSelector(earnInfoBottomSheetSelector);
+  const message = infoBottomSheet?.message;
+  const title = infoBottomSheet?.title;
+  const linkText = infoBottomSheet?.linkText;
+  const linkHref = infoBottomSheet?.linkHref;
+
+  const isRequestingToBeOpened = !!infoBottomSheet;
+
+  const closeBottomSheet = () => dispatch(makeSetEarnInfoBottomSheetAction(undefined));
+
+  const onLinkPress = () => {
+    if (linkHref) {
+      Linking.openURL(linkHref);
+    }
+  };
+
+  const showInlineLink = Boolean(linkText && linkHref);
+
+  return (
+    <QueuedDrawerBottomSheet
+      isRequestingToBeOpened={isRequestingToBeOpened}
+      onClose={closeBottomSheet}
+      enableDynamicSizing
+    >
+      <BottomSheetView>
+        <BottomSheetHeader />
+        <Text typography="heading3SemiBold" lx={{ color: "base", marginBottom: "s12" }}>
+          {title}
+        </Text>
+        <Text typography="body1" lx={{ color: "base", marginBottom: "s24" }}>
+          {message}
+          {showInlineLink ? " " : null}
+          {showInlineLink ? (
+            <Text typography="body1" lx={{ color: "interactive" }} onPress={onLinkPress}>
+              {linkText}
+            </Text>
+          ) : null}
+        </Text>
+      </BottomSheetView>
+    </QueuedDrawerBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/__tests__/EarnInfoBottomSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/__tests__/EarnInfoBottomSheet.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { Linking } from "react-native";
+import { render, screen } from "@tests/test-renderer";
+import { EarnInfoBottomSheet } from "../EarnInfoBottomSheet";
+import { State } from "~/reducers/types";
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const React = require("react");
+  const RN = require("react-native");
+  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
+  return {
+    ...actual,
+    BottomSheetView: ({ children }: { children: React.ReactNode }) => <RN.View>{children}</RN.View>,
+    BottomSheetHeader: () => <RN.View testID="bottom-sheet-header" />,
+  };
+});
+
+jest.mock("LLM/components/QueuedDrawer/QueuedDrawerBottomSheet", () => {
+  const React = require("react");
+  const { View, Text, Pressable } = require("react-native");
+  return function MockQueuedDrawerBottomSheet({
+    children,
+    onClose,
+    isRequestingToBeOpened,
+  }: {
+    children: React.ReactNode;
+    onClose: () => void;
+    isRequestingToBeOpened: boolean;
+  }) {
+    return (
+      <View testID="queued-drawer-bottom-sheet">
+        <Text testID="is-requesting-to-be-opened">{isRequestingToBeOpened ? "true" : "false"}</Text>
+        {children}
+        <Pressable testID="close-bottom-sheet" onPress={onClose}>
+          <Text>Close</Text>
+        </Pressable>
+      </View>
+    );
+  };
+});
+
+const renderEarnInfoBottomSheet = (infoBottomSheet: State["earn"]["infoBottomSheet"]) =>
+  render(<EarnInfoBottomSheet />, {
+    overrideInitialState: (state: State) => ({
+      ...state,
+      earn: {
+        ...state.earn,
+        infoBottomSheet,
+      },
+    }),
+  });
+
+describe("EarnInfoBottomSheet", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders without crashing when info bottom sheet state is empty", () => {
+    const { getByTestId } = renderEarnInfoBottomSheet(undefined);
+
+    expect(getByTestId("queued-drawer-bottom-sheet")).toBeTruthy();
+  });
+
+  it("passes isRequestingToBeOpened false when info bottom sheet state is undefined", () => {
+    renderEarnInfoBottomSheet(undefined);
+
+    expect(screen.getByTestId("is-requesting-to-be-opened")).toHaveTextContent("false");
+  });
+
+  it("displays title and message when provided in state", () => {
+    renderEarnInfoBottomSheet({
+      title: "Earn info title",
+      message: "Earn info message body",
+    });
+
+    expect(screen.getByText("Earn info title")).toBeTruthy();
+    expect(screen.getByText("Earn info message body")).toBeTruthy();
+  });
+
+  it("passes isRequestingToBeOpened true when title and message are set", () => {
+    renderEarnInfoBottomSheet({
+      title: "Some title",
+      message: "Some message",
+    });
+
+    expect(screen.getByTestId("is-requesting-to-be-opened")).toHaveTextContent("true");
+  });
+
+  it("clears earn info bottom sheet state when close is pressed", async () => {
+    const { store, user } = renderEarnInfoBottomSheet({
+      title: "Title",
+      message: "Message",
+    });
+
+    await user.press(screen.getByTestId("close-bottom-sheet"));
+
+    expect(store.getState().earn.infoBottomSheet).toBeUndefined();
+  });
+
+  it("renders inline link and opens URL when linkText and linkHref are set", async () => {
+    const { user } = renderEarnInfoBottomSheet({
+      title: "Title",
+      message: "For more information,",
+      linkText: "Learn more",
+      linkHref: "https://example.com",
+    });
+
+    expect(screen.getByText("Learn more")).toBeTruthy();
+
+    await user.press(screen.getByText("Learn more"));
+
+    expect(Linking.openURL).toHaveBeenCalledTimes(1);
+    expect(Linking.openURL).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("does not render inline link when only linkText is set", () => {
+    renderEarnInfoBottomSheet({
+      title: "Title",
+      message: "Message",
+      linkText: "No href",
+    });
+
+    expect(screen.queryByText("No href")).toBeNull();
+  });
+
+  it("does not render inline link when only linkHref is set", () => {
+    renderEarnInfoBottomSheet({
+      title: "Title",
+      message: "Message",
+      linkHref: "https://example.com",
+    });
+
+    expect(Linking.openURL).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] Covered by automatic tests.
- [x] **Impact of the changes:**
  - Earn PTX flow: opening and closing the new Earn Info bottom sheet
  - WebPTXPlayer custom handler `custom.bottomSheet.info` (Earn Live App integration)
  - Earn navigator: bottom sheet is mounted and driven by Redux state

### 📝 Description

**Problem:** The Earn Live App (web PTX) needs a way to show informational content in a native bottom sheet on mobile (e.g. tooltips, explanations) instead of only in-web UI.

**Solution:** This PR adds:

- **EarnInfoBottomSheet** – A native bottom sheet component that displays a configurable `title` and `message`, using `QueuedDrawerBottomSheet`, Lumen header and text.
- **Redux state** – New action `makeSetEarnInfoBottomSheetAction` and reducer/selector for `earnInfoBottomSheet` (`{ title, message }`). Setting payload opens the sheet; setting `undefined` closes it.
- **Custom handler** – In `CustomHandlers.ts`, the handler `custom.bottomSheet.info` accepts `{ title, message }` and dispatches the action so the Earn web app can open the bottom sheet from the wallet API.
- **Integration** – `EarnInfoBottomSheet` is rendered inside `EarnLiveAppNavigator` so it is available in the Earn PTX flow.

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-16 at 10 52 19" src="https://github.com/user-attachments/assets/28c890a2-e15c-42ae-9828-8917d9cbbad6" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27276](https://ledgerhq.atlassian.net/browse/LIVE-27276)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27276]: https://ledgerhq.atlassian.net/browse/LIVE-27276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ