### PR TITLE
[LWD] fix: show tooltip when activity indicator is refreshing

### DIFF
--- a/.changeset/little-buses-explain.md
+++ b/.changeset/little-buses-explain.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(lwd): show tooltip when activity indicator is refreshing

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicator.test.ts
@@ -60,7 +60,7 @@ describe("useActivityIndicator", () => {
 
     expect(result.current.isRotating).toBe(true);
     expect(result.current.icon).toBe(Spinner);
-    expect(result.current.tooltip).toBeUndefined();
+    expect(result.current.tooltip).toBe("Refreshing...");
   });
 
   it("should return Warning icon and isError true when failed", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicatorTooltip.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useActivityIndicatorTooltip.test.ts
@@ -4,7 +4,7 @@ import { useActivityIndicatorTooltip } from "../useActivityIndicatorTooltip";
 const enUsState = { settings: { locale: "en-US" } };
 
 describe("useActivityIndicatorTooltip", () => {
-  it("returns undefined when isRotating is true", () => {
+  it("returns Refreshing... when isRotating is true", () => {
     const { result } = renderHook(() =>
       useActivityIndicatorTooltip({
         isRotating: true,
@@ -13,7 +13,7 @@ describe("useActivityIndicatorTooltip", () => {
         lastSyncMs: 0,
       }),
     );
-    expect(result.current).toBeUndefined();
+    expect(result.current).toBe("Refreshing...");
   });
 
   it("returns emptyErrorToolTip when isError is true and no account names", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicatorTooltip.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useActivityIndicatorTooltip.ts
@@ -18,12 +18,12 @@ export function useActivityIndicatorTooltip({
   isError,
   listOfErrorAccountNames,
   lastSyncMs,
-}: ActivityIndicatorTooltipParams): string | undefined {
+}: ActivityIndicatorTooltipParams): string {
   const { t } = useTranslation();
   const locale = useSelector(localeSelector);
 
   if (isRotating) {
-    return undefined;
+    return t("topBar.activityIndicator.refreshing");
   }
 
   if (isError) {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8161,7 +8161,8 @@
       "errorToolTip": "There was a temporary network issue. Your assets are safe.\n List of accounts impacted: {{accounts}}. Tap to retry",
       "emptyErrorToolTip": "There was a temporary network issue. Your assets are safe.\n Tap to retry",
       "upToDate": "You're up to date",
-      "lastSync": "Last sync: {{timeAgo}}. Tap to refresh"
+      "lastSync": "Last sync: {{timeAgo}}. Tap to refresh",
+      "refreshing": "Refreshing..."
     },
     "notificationIndicator": {
       "tooltip": "Notifications"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a minor update to the activity indicator in Ledger Live Desktop, ensuring that a tooltip is displayed while the indicator is in the refreshing state. This improves user feedback during refresh operations. The update includes changes to the tooltip logic, test cases, and localization strings.

<img width="387" height="161" alt="Screenshot 2026-03-16 at 11 37 13" src="https://github.com/user-attachments/assets/39f1324b-6a79-4e08-afba-9c6399fcbc09" />


### ❓ Context

[LIVE-27639](https://ledgerhq.atlassian.net/browse/LIVE-27639)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27639]: https://ledgerhq.atlassian.net/browse/LIVE-27639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ