### PR TITLE
feat(mobile): track notification drawer trigger attempts

### DIFF
--- a/.changeset/fair-taxis-rest.md
+++ b/.changeset/fair-taxis-rest.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add tracking attempt_to_trigger_push_notification_drawer_after_action

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
@@ -131,6 +131,15 @@ export const useNotificationsDrawer = ({
       }
 
       const shouldPrompt = shouldPromptOptInDrawerAfterAction();
+
+      track("attempt_to_trigger_push_notification_drawer_after_action", {
+        action: actionSource,
+        shouldPrompt,
+        variant: featureNewWordingNotificationsDrawer?.params?.variant,
+        repromptDelay: nextRepromptDelay,
+        dismissedCount: pushNotificationsDataOfUser?.dismissedOptInDrawerAtList?.length ?? 0,
+      });
+
       if (!shouldPrompt) {
         return;
       }
@@ -211,6 +220,8 @@ export const useNotificationsDrawer = ({
       featureNewWordingNotificationsDrawer?.enabled,
       featureNewWordingNotificationsDrawer?.params?.variant,
       openDrawer,
+      nextRepromptDelay,
+      pushNotificationsDataOfUser?.dismissedOptInDrawerAtList?.length,
     ],
   );
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No automated tests were added because this change only adds analytics instrumentation to an existing mobile flow._
- [x] **Impact of the changes:**
      - Analytics coverage for notification drawer trigger attempts after an action
      - Visibility into whether `shouldPromptOptInDrawerAfterAction()` allowed or blocked the drawer
      - Tracking payloads for action source and notification drawer variant on mobile

### 📝 Description

This PR is now scoped only to analytics instrumentation for the mobile notifications prompt flow. The goal is to make notification drawer trigger attempts observable after an action, so we can distinguish trigger-path execution from prompt-eligibility guard conditions.

The change adds a new `attempt_to_trigger_push_notification_drawer_after_action` track event in `useNotificationsDrawer`, emitted before the early return on `shouldPrompt`. The event includes the action source, computed `shouldPrompt` result, and active drawer variant.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27326](https://ledgerhq.atlassian.net/browse/LIVE-27326)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27326]: https://ledgerhq.atlassian.net/browse/LIVE-27326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ