### PR TITLE
[LWDM] test(coin-sui): add diagnostic tests for overlapping operations in de…

### DIFF
--- a/libs/coin-modules/coin-sui/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.integ.test.ts
@@ -66,9 +66,29 @@ describe("Sui Api", () => {
       expect(operations2[0].tx.hash).not.toBe(operations1[0].tx.hash);
 
       // check that none of the operations in operations2 are in operations1
-      expect(operations2.every(op2 => !operations1.some(op1 => op1.tx.hash === op2.tx.hash))).toBe(
-        true,
-      );
+      const hashes1 = new Set(operations1.map(op => op.tx.hash));
+      const overlapping = operations2.filter(op => hashes1.has(op.tx.hash));
+      if (overlapping.length > 0) {
+        const cursorTs = token1!.split(":")[0];
+        console.error(
+          `[DIAG] order=${order} cursor=${token1} p1=${operations1.length}ops p2=${operations2.length}ops overlap=${overlapping.length}`,
+        );
+        console.error(
+          `[DIAG] p1: first=${operations1[0].tx.hash}(${operations1[0].tx.date.toISOString()}) last=${operations1.at(-1)!.tx.hash}(${operations1.at(-1)!.tx.date.toISOString()})`,
+        );
+        console.error(
+          `[DIAG] p2: first=${operations2[0].tx.hash}(${operations2[0].tx.date.toISOString()}) last=${operations2.at(-1)!.tx.hash}(${operations2.at(-1)!.tx.date.toISOString()})`,
+        );
+        for (const op of overlapping) {
+          const p1 = operations1.find(o => o.tx.hash === op.tx.hash)!;
+          console.error(
+            `[DIAG] overlap: hash=${op.tx.hash} p1_date=${p1.tx.date.toISOString()} p2_date=${op.tx.date.toISOString()} p1_block=${p1.tx.block.height} p2_block=${op.tx.block.height}`,
+          );
+        }
+        const sameTs = operations1.filter(op => op.tx.date.getTime().toString() === cursorTs);
+        console.error(`[DIAG] same-ts cluster at cursor: ${sameTs.length} ops on page1`);
+      }
+      expect(overlapping).toEqual([]);
     }
 
     it("should fetch operations successfully in desc order", async () => {


### PR DESCRIPTION
…scending order

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
