### PR TITLE
[LWD] fix(desktop): update navigation for Device Setup when lazy onboarding is active

### DIFF
--- a/.changeset/chilled-moons-train.md
+++ b/.changeset/chilled-moons-train.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix: update navigation for the device setup button

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/LaunchOnboardingBtn.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/LaunchOnboardingBtn.tsx
@@ -3,14 +3,20 @@ import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import Track from "~/renderer/analytics/Track";
 import Button from "~/renderer/components/Button";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 const LaunchOnboardingBtn = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("desktop");
 
   const handleLaunchOnboarding = useCallback(() => {
-    navigate("/onboarding");
-  }, [navigate]);
+    if (shouldUseLazyOnboarding) {
+      navigate("/onboarding/select-device");
+    } else {
+      navigate("/onboarding");
+    }
+  }, [navigate, shouldUseLazyOnboarding]);
 
   return (
     <>


### PR DESCRIPTION
### ✅ Checklist
- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [ ] **Impact of the changes:**

### 📝 Description

When in the lazy onboarding scenario and the Device Setup button is clicked, we don't want to go through the `Welcome -> Select Device` navigation logic, instead we want to go straight to `Select Device`, preventing a redirect bug.

| Before        | After         |
| ------------- | ------------- |
|       <video src="https://github.com/user-attachments/assets/10808467-89d9-4b3b-9370-52b0eca34f59" />        |     <video src="https://github.com/user-attachments/assets/e2fdd7ed-bc76-4325-9dbd-e1224cdcd435" />      |

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27645


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
