### PR TITLE
[LWDM] fix(coin-bitcoin): align send max estimate with build

### DIFF
--- a/.changeset/large-lizards-build.md
+++ b/.changeset/large-lizards-build.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-bitcoin": minor
+---
+
+fix(btc): align send max estimate with build (exclude non‑rentable UTXOs, round feePerByte)

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.estimateMaxSpendable.integ.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.estimateMaxSpendable.integ.test.ts
@@ -27,26 +27,38 @@ describe("testing estimateMaxSpendable", () => {
 
   it("should estimate max spendable correctly", async () => {
     await wallet.syncAccount(account);
-    let maxSpendable = await wallet.estimateAccountMaxSpendable(account, 0, []);
+    const maxSpendableAtMinFee = await wallet.estimateAccountMaxSpendable(account, 0, []);
     const balance = 109088;
-    expect(maxSpendable.toNumber()).toEqual(balance);
+    expect(maxSpendableAtMinFee.toNumber()).toEqual(
+      balance - utils.maxTxSizeCeil(2, [], true, account.xpub.crypto, account.xpub.derivationMode),
+    );
     const maxSpendableExcludeUtxo = await wallet.estimateAccountMaxSpendable(account, 0, [
       {
         hash: "f80246be50064bb254d2cad82fb0d4ce7768582b99c113694e72411f8032fd7a",
         outputIndex: 0,
       },
     ]);
-    expect(maxSpendableExcludeUtxo.toNumber()).toEqual(balance - 1000);
-    let feesPerByte = 100;
-    maxSpendable = await wallet.estimateAccountMaxSpendable(account, feesPerByte, []);
-    expect(maxSpendable.toNumber()).toEqual(
+    expect(maxSpendableExcludeUtxo.toNumber()).toEqual(
       balance -
-        feesPerByte *
-          utils.maxTxSizeCeil(2, [], true, account.xpub.crypto, account.xpub.derivationMode),
+        1000 -
+        utils.maxTxSizeCeil(1, [], true, account.xpub.crypto, account.xpub.derivationMode),
     );
+    let feesPerByte = 100;
+    const maxSpendableAtMediumFee = await wallet.estimateAccountMaxSpendable(
+      account,
+      feesPerByte,
+      [],
+    );
+    expect(maxSpendableAtMediumFee.gt(0)).toBe(true);
+    expect(maxSpendableAtMediumFee.lt(maxSpendableAtMinFee)).toBe(true);
     feesPerByte = 10000;
-    maxSpendable = await wallet.estimateAccountMaxSpendable(account, feesPerByte, []);
-    expect(maxSpendable.toNumber()).toEqual(0);
+    const maxSpendableAtHighFee = await wallet.estimateAccountMaxSpendable(
+      account,
+      feesPerByte,
+      [],
+    );
+    expect(maxSpendableAtHighFee.gte(0)).toBe(true);
+    expect(maxSpendableAtHighFee.lte(maxSpendableAtMediumFee)).toBe(true);
   }, 120000);
 
   it("should generate a new account", async () => {
@@ -70,26 +82,37 @@ describe("testing estimateMaxSpendable", () => {
   it("should estimate max spendable correctly with utxo rbf set to true", async () => {
     // TODO: fix a more stable account, as this one had some activity recently
     await wallet.syncAccount(account);
-    let maxSpendable = await wallet.estimateAccountMaxSpendable(account, 0, []);
+    const maxSpendableAtMinFee = await wallet.estimateAccountMaxSpendable(account, 0, []);
     const balance = 12835640;
-    expect(maxSpendable.toNumber()).toEqual(balance);
+    expect(maxSpendableAtMinFee.toNumber()).toEqual(
+      balance - utils.maxTxSizeCeil(24, [], true, account.xpub.crypto, account.xpub.derivationMode),
+    );
     const maxSpendableExcludeUtxo = await wallet.estimateAccountMaxSpendable(account, 0, [
       {
         hash: "a24445474a9a7c0698e8db221ad2cae06792a899e9bc7f5a590687c3c810c480",
         outputIndex: 0,
       },
     ]);
-    expect(maxSpendableExcludeUtxo.toNumber()).toEqual(balance - 1000);
-    let feesPerByte = 100;
-    maxSpendable = await wallet.estimateAccountMaxSpendable(account, feesPerByte, []);
-    // NOTE: inputCount should be computed from account, not hardcoded in test here
-    expect(maxSpendable.toNumber()).toEqual(
+    expect(maxSpendableExcludeUtxo.toNumber()).toEqual(
       balance -
-        feesPerByte *
-          utils.maxTxSizeCeil(24, [], true, account.xpub.crypto, account.xpub.derivationMode),
+        1000 -
+        utils.maxTxSizeCeil(23, [], true, account.xpub.crypto, account.xpub.derivationMode),
     );
+    let feesPerByte = 100;
+    const maxSpendableAtMediumFee = await wallet.estimateAccountMaxSpendable(
+      account,
+      feesPerByte,
+      [],
+    );
+    expect(maxSpendableAtMediumFee.gt(0)).toBe(true);
+    expect(maxSpendableAtMediumFee.lt(maxSpendableAtMinFee)).toBe(true);
     feesPerByte = 10000;
-    maxSpendable = await wallet.estimateAccountMaxSpendable(account, feesPerByte, []);
-    expect(maxSpendable.toNumber()).toEqual(0);
+    const maxSpendableAtHighFee = await wallet.estimateAccountMaxSpendable(
+      account,
+      feesPerByte,
+      [],
+    );
+    expect(maxSpendableAtHighFee.gte(0)).toBe(true);
+    expect(maxSpendableAtHighFee.lte(maxSpendableAtMediumFee)).toBe(true);
   }, 120000);
 });

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.unit.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.unit.test.ts
@@ -8,6 +8,7 @@ import Xpub from "../xpub";
 import { PickingStrategy } from "../pickingstrategies/types";
 import { TX, Address, Output } from "../storage/types";
 import { DerivationModes, TransactionInfo } from "../types";
+import * as utils from "../utils";
 
 import { getMockAccount } from "./fixtures/common.fixtures";
 import { mockSigner } from "../../fixtures/common.fixtures";
@@ -789,12 +790,15 @@ describe("BitcoinLikeWallet", () => {
     });
 
     it("estimate fees for one utxo", async () => {
-      // NOTE: setting the feePerByte to 0 to avoid the fee calculation
-      const maxSpendable = await wallet.estimateAccountMaxSpendable(mockAccount, 0, []);
+      const feePerByte = 1;
+      const maxSpendable = await wallet.estimateAccountMaxSpendable(mockAccount, feePerByte, []);
+      const expectedFees =
+        feePerByte *
+        utils.maxTxSizeCeil(1, [], true, mockAccount.xpub.crypto, mockAccount.xpub.derivationMode);
 
       expect(mockAccount.xpub.getXpubAddresses).toHaveBeenCalled();
       expect(mockAccount.xpub.getAccountAddresses).toHaveBeenCalledWith(1);
-      expect(maxSpendable.toNumber()).toEqual(UTXO_VALUES.utxo1);
+      expect(maxSpendable.toNumber()).toEqual(UTXO_VALUES.utxo1 - expectedFees);
     });
 
     it("estimate fees when one of the utxos is a change address", async () => {
@@ -813,13 +817,17 @@ describe("BitcoinLikeWallet", () => {
       mockAccount.xpub.storage.getAddressUnspentUtxos = jest
         .fn()
         .mockResolvedValue(utxosWithChangeAddress);
+      const feePerByte = 1;
       const maxSpendableWithChangeAddressUtxo = await wallet.estimateAccountMaxSpendable(
         mockAccount,
-        0,
+        feePerByte,
         [],
       );
+      const expectedFees =
+        feePerByte *
+        utils.maxTxSizeCeil(2, [], true, mockAccount.xpub.crypto, mockAccount.xpub.derivationMode);
       expect(maxSpendableWithChangeAddressUtxo.toNumber()).toEqual(
-        UTXO_VALUES.utxo1 + UTXO_VALUES.utxo2,
+        UTXO_VALUES.utxo1 + UTXO_VALUES.utxo2 - expectedFees,
       );
     });
 
@@ -837,12 +845,69 @@ describe("BitcoinLikeWallet", () => {
       mockAccount.xpub.storage.getAddressUnspentUtxos = jest
         .fn()
         .mockResolvedValue(utxosWithUnconfirmedTx);
+      const feePerByte = 1;
       const maxSpendableWithUnconfirmedTx = await wallet.estimateAccountMaxSpendable(
         mockAccount,
-        0,
+        feePerByte,
         [],
       );
-      expect(maxSpendableWithUnconfirmedTx.toNumber()).toEqual(UTXO_VALUES.utxo1);
+      const expectedFees =
+        feePerByte *
+        utils.maxTxSizeCeil(1, [], true, mockAccount.xpub.crypto, mockAccount.xpub.derivationMode);
+      expect(maxSpendableWithUnconfirmedTx.toNumber()).toEqual(UTXO_VALUES.utxo1 - expectedFees);
+    });
+
+    it("excludes utxos whose effective value is zero or negative", async () => {
+      const fixedVBytes = utils.maxTxVBytesCeil(
+        0,
+        [],
+        false,
+        mockAccount.xpub.crypto,
+        mockAccount.xpub.derivationMode,
+      );
+      const oneInputVBytes =
+        utils.maxTxVBytesCeil(
+          1,
+          [],
+          false,
+          mockAccount.xpub.crypto,
+          mockAccount.xpub.derivationMode,
+        ) - fixedVBytes;
+      const ineffectiveUtxoValue = oneInputVBytes;
+      const utxosWithIneffectiveValue = [
+        ...utxos,
+        {
+          value: `${ineffectiveUtxoValue}`,
+          address: "address1",
+          output_hash: "hash-ineffective",
+          output_index: 1,
+          block_height: 1000,
+        },
+      ] as Output[];
+
+      mockAccount.xpub.storage.getAddressUnspentUtxos = jest
+        .fn()
+        .mockResolvedValue(utxosWithIneffectiveValue);
+
+      const maxSpendable = await wallet.estimateAccountMaxSpendable(mockAccount, 1, []);
+      const expectedFees = utils.maxTxSizeCeil(
+        1,
+        [],
+        true,
+        mockAccount.xpub.crypto,
+        mockAccount.xpub.derivationMode,
+      );
+
+      expect(maxSpendable.toNumber()).toEqual(UTXO_VALUES.utxo1 - expectedFees);
+    });
+
+    it("rounds feePerByte up like the real build", async () => {
+      const maxSpendable = await wallet.estimateAccountMaxSpendable(mockAccount, 1.2, []);
+      const expectedFees =
+        2 *
+        utils.maxTxSizeCeil(1, [], true, mockAccount.xpub.crypto, mockAccount.xpub.derivationMode);
+
+      expect(maxSpendable.toNumber()).toEqual(UTXO_VALUES.utxo1 - expectedFees);
     });
   });
 });

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/wallet.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/wallet.ts
@@ -161,6 +161,17 @@ class BitcoinLikeWallet {
 
     let balance = new BigNumber(0);
     log("btcwallet", "estimateAccountMaxSpendable utxos", utxos);
+    const safeFeePerByte = Math.max(1, Math.ceil(feePerByte));
+    const fixedVBytes = utils.maxTxVBytesCeil(
+      0,
+      [],
+      false,
+      account.xpub.crypto,
+      account.xpub.derivationMode,
+    );
+    const oneInputVBytes =
+      utils.maxTxVBytesCeil(1, [], false, account.xpub.crypto, account.xpub.derivationMode) -
+      fixedVBytes;
     let usableUtxoCount = 0;
     successfulUtxos.forEach(utxo => {
       if (
@@ -172,6 +183,10 @@ class BitcoinLikeWallet {
         // we can use non-pending utxos or change utxo (whether pending or not)
         // NOTE: check ledger-live-common/src/families/bitcoin/docs/RBF.md for more details
         if (changeAddresses.includes(utxo.address) || utxo.block_height !== null) {
+          const effectiveValue = Number(utxo.value) - safeFeePerByte * oneInputVBytes;
+          if (effectiveValue <= 0) {
+            return;
+          }
           usableUtxoCount++;
           balance = balance.plus(utxo.value);
         }
@@ -186,7 +201,7 @@ class BitcoinLikeWallet {
 
     // fees if we use all utxo
     const fees =
-      feePerByte *
+      safeFeePerByte *
       utils.maxTxSizeCeil(
         usableUtxoCount,
         outputScripts,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

on small balances, using "send max" could show an amount and then fail with "insufficient balance" when building the transaction. The estimate was too optimistic compared to what the real build could spend.
The build (CoinSelect/Merge/DeepFirst) excludes non‑rentable UTXOs and uses that rounded fee, so the estimate could promise more than the build could deliver.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-27588)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
