### PR TITLE
[LWM] feat(mobile): add skeleton placeholder for portfolio balance loading

### DIFF
--- a/.changeset/cuddly-rockets-lie.md
+++ b/.changeset/cuddly-rockets-lie.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+add skeleton when switching countervalues

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { AmountDisplay, Box, Pressable, Text } from "@ledgerhq/lumen-ui-rnative";
+import { AmountDisplay, Box, Pressable, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
 import { DiscreetModeIcon } from "./DiscreetModeIcon";
 import type { FormattedValue } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
@@ -64,28 +64,34 @@ export const PortfolioBalanceSectionView = ({
       <>
         <Pressable onPress={onToggleDiscreetMode} testID="portfolio-balance-toggle">
           <Box lx={{ flexDirection: "row", alignItems: "baseline", gap: "s14" }}>
-            <AmountDisplay
-              key={unit.code}
-              value={balance}
-              formatter={formatter}
-              hidden={discreet || (!shouldDisplayBalanceRefreshRework && !isBalanceAvailable)}
-              loading={shouldDisplayBalanceRefreshRework && isLoading}
-              testID="portfolio-balance-amount"
-            />
+            {isBalanceAvailable ? (
+              <AmountDisplay
+                key={unit.code}
+                value={balance}
+                formatter={formatter}
+                hidden={discreet}
+                loading={shouldDisplayBalanceRefreshRework && isLoading}
+                testID="portfolio-balance-amount"
+              />
+            ) : (
+              <Skeleton
+                testID="portfolio-placeholder-balance"
+                lx={{ height: "s48", width: "s256" }}
+              />
+            )}
             {discreet && <DiscreetModeIcon />}
           </Box>
         </Pressable>
-        {isBalanceAvailable && (
-          <Box
-            lx={{
-              flexDirection: "row",
-              alignItems: "center",
-              marginTop: "s12",
-            }}
-          >
-            <AnalyticPill valueChange={countervalueChange} />
-          </Box>
-        )}
+
+        <Box
+          lx={{
+            flexDirection: "row",
+            alignItems: "center",
+            marginTop: "s12",
+          }}
+        >
+          <AnalyticPill valueChange={countervalueChange} />
+        </Box>
       </>
     );
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/PortfolioBalanceSectionView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/PortfolioBalanceSectionView.test.tsx
@@ -46,15 +46,17 @@ describe("PortfolioBalanceSectionView", () => {
   });
 
   describe("loading states", () => {
-    it("should use loading testID and hide analytics pill when balance is not available", () => {
+    it("should show skeleton placeholder when balance is not available and still show analytics pill", () => {
       renderView({ isBalanceAvailable: false });
 
       expect(screen.getByTestId("portfolio-balance-loading")).toBeVisible();
+      expect(screen.getByTestId("portfolio-placeholder-balance")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-balance-amount")).toBeNull();
       expect(screen.queryByTestId("portfolio-balance-normal")).toBeNull();
-      expect(screen.queryByTestId("portfolio-balance-analytics-pill")).toBeNull();
+      expect(screen.getByTestId("portfolio-balance-analytics-pill")).toBeVisible();
     });
 
-    it("should show shimmer when balance refresh rework is enabled and loading", () => {
+    it("should show skeleton when balance refresh rework is enabled and balance is not available", () => {
       renderView({
         isBalanceAvailable: false,
         isLoading: true,
@@ -62,8 +64,21 @@ describe("PortfolioBalanceSectionView", () => {
       });
 
       expect(screen.getByTestId("portfolio-balance-loading")).toBeVisible();
+      expect(screen.getByTestId("portfolio-placeholder-balance")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-balance-amount")).toBeNull();
+      expect(screen.getByTestId("portfolio-balance-analytics-pill")).toBeVisible();
+    });
+
+    it("should show shimmer on amount when balance is available and loading with rework enabled", () => {
+      renderView({
+        isBalanceAvailable: true,
+        isLoading: true,
+        shouldDisplayBalanceRefreshRework: true,
+      });
+
+      expect(screen.getByTestId("portfolio-balance-normal")).toBeVisible();
       expect(screen.getByTestId("portfolio-balance-amount")).toBeVisible();
-      expect(screen.queryByTestId("portfolio-balance-analytics-pill")).toBeNull();
+      expect(screen.queryByTestId("portfolio-placeholder-balance")).toBeNull();
     });
   });
 });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio balance section rendering when balance is not yet available
      - Skeleton placeholder visibility during countervalue switches

### 📝 Description

When switching countervalues, the portfolio balance would render with a hidden `AmountDisplay`, providing no visual feedback to the user during the loading state.

This PR replaces the hidden `AmountDisplay` with a `Skeleton` placeholder when the balance is not yet available, giving users clear visual feedback and preventing layout shift. The skeleton height matches the combined height of the `AmountDisplay` and `AnalyticPill` components.



https://github.com/user-attachments/assets/02047e65-c930-40b6-a9f5-aaa658345896



### ❓ Context

- **JIRA or GitHub link**: [LIVE-27637](https://ledgerhq.atlassian.net/browse/LIVE-27637)
- https://ledgerhq.atlassian.net/browse/LIVE-27638

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27637]: https://ledgerhq.atlassian.net/browse/LIVE-27637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ