### PR TITLE
[LWM] fix(mobile): improve portfolio balance UX on cold start & pull-to-refresh

### DIFF
--- a/.changeset/silver-wolf-fix.md
+++ b/.changeset/silver-wolf-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix portfolio balance UX on cold start and pull-to-refresh

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
@@ -22,6 +22,7 @@ export const PortfolioBalanceSectionView = ({
   countervalueChange,
   unit,
   isBalanceAvailable,
+  isAnalyticPillVisible,
   isLoading,
   shouldDisplayBalanceRefreshRework,
   onToggleDiscreetMode,
@@ -44,6 +45,15 @@ export const PortfolioBalanceSectionView = ({
       return `portfolio-balance-${state}`;
     }
     return isBalanceAvailable ? "portfolio-balance-normal" : "portfolio-balance-loading";
+  };
+
+  const renderAnalyticPill = () => {
+    if (!isAnalyticPillVisible) return null;
+    return (
+      <Box lx={{ flexDirection: "row", alignItems: "center", marginTop: "s12" }}>
+        <AnalyticPill valueChange={countervalueChange} />
+      </Box>
+    );
   };
 
   const renderContent = () => {
@@ -82,16 +92,7 @@ export const PortfolioBalanceSectionView = ({
             {discreet && <DiscreetModeIcon />}
           </Box>
         </Pressable>
-
-        <Box
-          lx={{
-            flexDirection: "row",
-            alignItems: "center",
-            marginTop: "s12",
-          }}
-        >
-          <AnalyticPill valueChange={countervalueChange} />
-        </Box>
+        {renderAnalyticPill()}
       </>
     );
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/PortfolioBalanceSectionView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/PortfolioBalanceSectionView.test.tsx
@@ -12,6 +12,7 @@ const baseProps: PortfolioBalanceSectionViewProps = {
   countervalueChange: { percentage: 1.5, value: 150 },
   unit: usd.units[0],
   isBalanceAvailable: true,
+  isAnalyticPillVisible: true,
   isLoading: false,
   shouldDisplayBalanceRefreshRework: false,
   onToggleDiscreetMode: jest.fn(),
@@ -46,19 +47,20 @@ describe("PortfolioBalanceSectionView", () => {
   });
 
   describe("loading states", () => {
-    it("should show skeleton placeholder when balance is not available and still show analytics pill", () => {
-      renderView({ isBalanceAvailable: false });
+    it("should use loading testID and hide analytics pill when balance is not available", () => {
+      renderView({ isBalanceAvailable: false, isAnalyticPillVisible: false });
 
       expect(screen.getByTestId("portfolio-balance-loading")).toBeVisible();
       expect(screen.getByTestId("portfolio-placeholder-balance")).toBeVisible();
       expect(screen.queryByTestId("portfolio-balance-amount")).toBeNull();
       expect(screen.queryByTestId("portfolio-balance-normal")).toBeNull();
-      expect(screen.getByTestId("portfolio-balance-analytics-pill")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-balance-analytics-pill")).toBeNull();
     });
 
-    it("should show skeleton when balance refresh rework is enabled and balance is not available", () => {
+    it("should show skeleton when balance refresh rework is enabled and loading", () => {
       renderView({
         isBalanceAvailable: false,
+        isAnalyticPillVisible: true,
         isLoading: true,
         shouldDisplayBalanceRefreshRework: true,
       });
@@ -79,6 +81,7 @@ describe("PortfolioBalanceSectionView", () => {
       expect(screen.getByTestId("portfolio-balance-normal")).toBeVisible();
       expect(screen.getByTestId("portfolio-balance-amount")).toBeVisible();
       expect(screen.queryByTestId("portfolio-placeholder-balance")).toBeNull();
+      expect(screen.getByTestId("portfolio-balance-analytics-pill")).toBeVisible();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePersistedPortfolioBalance.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePersistedPortfolioBalance.test.ts
@@ -1,0 +1,95 @@
+import { renderHook, act } from "@testing-library/react-native";
+import { MMKV } from "react-native-mmkv";
+import { usePersistedPortfolioBalance } from "../usePersistedPortfolioBalance";
+import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/index";
+
+const CURRENCY = "USD";
+const KEY = `portfolioLastKnownBalance_${CURRENCY}`;
+let store: Record<string, unknown> = {};
+
+let getNumberSpy: jest.SpyInstance;
+let setSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  store = {};
+  getNumberSpy = jest.spyOn(MMKV.prototype, "getNumber").mockImplementation((k: string) => {
+    const v = store[k];
+    return typeof v === "number" ? v : undefined;
+  });
+  setSpy = jest.spyOn(MMKV.prototype, "set").mockImplementation((k: string, v: unknown) => {
+    store[k] = v;
+  });
+});
+
+afterEach(() => {
+  getNumberSpy.mockRestore();
+  setSpy.mockRestore();
+});
+
+describe("usePersistedPortfolioBalance", () => {
+  it("returns latestBalance when non-zero", () => {
+    const { result } = renderHook(() => usePersistedPortfolioBalance(1500, "synced", CURRENCY));
+    expect(result.current).toBe(1500);
+  });
+
+  it("falls back to MMKV cache when latestBalance is 0 during syncing", () => {
+    store[KEY] = 3000;
+    const { result } = renderHook(() => usePersistedPortfolioBalance(0, "syncing", CURRENCY));
+    expect(result.current).toBe(3000);
+  });
+
+  it("returns 0 when latestBalance is 0 and no cache exists", () => {
+    const { result } = renderHook(() => usePersistedPortfolioBalance(0, "syncing", CURRENCY));
+    expect(result.current).toBe(0);
+  });
+
+  it("returns 0 after sync completes even if cache has a stale non-zero value", () => {
+    store[KEY] = 3000;
+    const { result } = renderHook(() => usePersistedPortfolioBalance(0, "synced", CURRENCY));
+    expect(result.current).toBe(0);
+  });
+
+  it("persists balance on synced, including zero (authoritative empty portfolio)", () => {
+    const { rerender } = renderHook(
+      ({ balance, phase }: { balance: number; phase: SyncPhase }) =>
+        usePersistedPortfolioBalance(balance, phase, CURRENCY),
+      { initialProps: { balance: 2500, phase: "syncing" as SyncPhase } },
+    );
+
+    expect(store[KEY]).toBeUndefined();
+
+    act(() => rerender({ balance: 2500, phase: "synced" }));
+    expect(store[KEY]).toBe(2500);
+
+    // A real $0 portfolio must overwrite the stale cached value.
+    act(() => rerender({ balance: 0, phase: "synced" }));
+    expect(store[KEY]).toBe(0);
+  });
+
+  it("does not persist when syncPhase is failed", () => {
+    store[KEY] = 3000;
+    const { rerender } = renderHook(
+      ({ balance, phase }: { balance: number; phase: SyncPhase }) =>
+        usePersistedPortfolioBalance(balance, phase, CURRENCY),
+      { initialProps: { balance: 3000, phase: "syncing" as SyncPhase } },
+    );
+
+    act(() => rerender({ balance: 1234, phase: "failed" }));
+    expect(store[KEY]).toBe(3000); // stale cache untouched
+  });
+
+  it("reloads cached value from MMKV when currency switches", () => {
+    store[`portfolioLastKnownBalance_USD`] = 1000;
+    store[`portfolioLastKnownBalance_EUR`] = 900;
+
+    const { result, rerender } = renderHook(
+      ({ currency }: { currency: string }) => usePersistedPortfolioBalance(0, "syncing", currency),
+      { initialProps: { currency: "USD" } },
+    );
+
+    expect(result.current).toBe(1000);
+
+    act(() => rerender({ currency: "EUR" }));
+    expect(result.current).toBe(900);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
@@ -5,6 +5,9 @@ import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/index";
 import type { State } from "~/reducers/types";
 
 jest.mock("LLM/hooks/usePortfolioBalance");
+jest.mock("../usePersistedPortfolioBalance", () => ({
+  usePersistedPortfolioBalance: (b: number) => b,
+}));
 
 const mockUsePortfolioBalance = jest.mocked(usePortfolioBalanceModule.usePortfolioBalance);
 
@@ -21,12 +24,11 @@ const defaultPortfolio = {
   countervalueSendSum: 0,
 };
 
-function makePortfolioBalanceReturn(
+function makeReturn(
   overrides: Partial<{
-    portfolio: typeof defaultPortfolio;
     balanceAvailable: boolean;
     syncPhase: SyncPhase;
-    isBalanceLoading: boolean;
+    portfolio: typeof defaultPortfolio;
   }> = {},
 ) {
   return {
@@ -35,6 +37,7 @@ function makePortfolioBalanceReturn(
     syncPhase: "synced" as SyncPhase,
     isBalanceLoading: false,
     isColdStart: false,
+    isManualRefreshLoading: false,
     allAccounts: [],
     accountsWithError: [],
     listOfErrorAccountNames: "",
@@ -47,102 +50,61 @@ function makePortfolioBalanceReturn(
 
 const defaultProps = { showAssets: true, isReadOnlyMode: false };
 
+const withFreezeFlag = {
+  overrideInitialState: (state: State): State => ({
+    ...state,
+    settings: {
+      ...state.settings,
+      overriddenFeatureFlags: {
+        lwmWallet40: { enabled: true, params: { balanceRefreshRework: true } },
+      },
+    },
+  }),
+};
+
 describe("usePortfolioBalanceSectionViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUsePortfolioBalance.mockReturnValue(makePortfolioBalanceReturn());
+    mockUsePortfolioBalance.mockReturnValue(makeReturn());
   });
 
-  describe("state determination", () => {
-    it("should return 'noSigner' state when isReadOnlyMode is true", () => {
+  describe("state", () => {
+    it("returns noSigner when readOnly, regardless of showAssets", () => {
       const { result } = renderHook(() =>
-        usePortfolioBalanceSectionViewModel({
-          showAssets: false,
-          isReadOnlyMode: true,
-        }),
+        usePortfolioBalanceSectionViewModel({ showAssets: false, isReadOnlyMode: true }),
       );
-
       expect(result.current.state).toBe("noSigner");
     });
 
-    it("should return 'noAccounts' state when isReadOnlyMode is false and showAssets is false", () => {
+    it("returns noAccounts when showAssets is false", () => {
       const { result } = renderHook(() =>
-        usePortfolioBalanceSectionViewModel({
-          showAssets: false,
-          isReadOnlyMode: false,
-        }),
+        usePortfolioBalanceSectionViewModel({ showAssets: false, isReadOnlyMode: false }),
       );
-
       expect(result.current.state).toBe("noAccounts");
-    });
-
-    it("should return 'normal' state when isReadOnlyMode is false and showAssets is true", () => {
-      const { result } = renderHook(() =>
-        usePortfolioBalanceSectionViewModel({
-          showAssets: true,
-          isReadOnlyMode: false,
-        }),
-      );
-
-      expect(result.current.state).toBe("normal");
-    });
-
-    it("should prioritize noSigner over noAccounts when both conditions are met", () => {
-      const { result } = renderHook(() =>
-        usePortfolioBalanceSectionViewModel({
-          showAssets: false,
-          isReadOnlyMode: true,
-        }),
-      );
-
-      expect(result.current.state).toBe("noSigner");
     });
   });
 
   describe("isLoading", () => {
-    it("should be false when syncPhase is synced", () => {
-      const { result } = renderHook(() => usePortfolioBalanceSectionViewModel(defaultProps));
-
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    it("should be true when syncPhase is syncing", () => {
-      mockUsePortfolioBalance.mockReturnValue(
-        makePortfolioBalanceReturn({ syncPhase: "syncing", isBalanceLoading: true }),
+    it("is true while syncPhase is syncing, false otherwise", () => {
+      const { result, rerender } = renderHook(() =>
+        usePortfolioBalanceSectionViewModel(defaultProps),
       );
+      expect(result.current.isLoading).toBe(false);
 
-      const { result } = renderHook(() => usePortfolioBalanceSectionViewModel(defaultProps));
-
+      mockUsePortfolioBalance.mockReturnValue(makeReturn({ syncPhase: "syncing" }));
+      rerender({});
       expect(result.current.isLoading).toBe(true);
-    });
 
-    it("should be false when syncPhase is failed", () => {
-      mockUsePortfolioBalance.mockReturnValue(makePortfolioBalanceReturn({ syncPhase: "failed" }));
-
-      const { result } = renderHook(() => usePortfolioBalanceSectionViewModel(defaultProps));
-
+      mockUsePortfolioBalance.mockReturnValue(makeReturn({ syncPhase: "failed" }));
+      rerender({});
       expect(result.current.isLoading).toBe(false);
     });
   });
 
-  describe("balance freeze during sync", () => {
-    // Balance freeze requires shouldDisplayBalanceRefreshRework to be enabled.
-    const withFreezeFlag = {
-      overrideInitialState: (state: State): State => ({
-        ...state,
-        settings: {
-          ...state.settings,
-          overriddenFeatureFlags: {
-            lwmWallet40: { enabled: true, params: { balanceRefreshRework: true } },
-          },
-        },
-      }),
-    };
-
-    it("should freeze balance during syncing and release when synced", () => {
+  describe("balance freeze", () => {
+    it("freezes at pre-sync value and releases on settle", () => {
       mockUsePortfolioBalance.mockReturnValue(
-        makePortfolioBalanceReturn({
-          syncPhase: "synced",
+        makeReturn({
           portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 1500 }] },
         }),
       );
@@ -154,9 +116,8 @@ describe("usePortfolioBalanceSectionViewModel", () => {
       expect(result.current.balance).toBe(1500);
 
       mockUsePortfolioBalance.mockReturnValue(
-        makePortfolioBalanceReturn({
+        makeReturn({
           syncPhase: "syncing",
-          isBalanceLoading: true,
           portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 2000 }] },
         }),
       );
@@ -164,8 +125,7 @@ describe("usePortfolioBalanceSectionViewModel", () => {
       expect(result.current.balance).toBe(1500);
 
       mockUsePortfolioBalance.mockReturnValue(
-        makePortfolioBalanceReturn({
-          syncPhase: "synced",
+        makeReturn({
           portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 2000 }] },
         }),
       );
@@ -174,14 +134,15 @@ describe("usePortfolioBalanceSectionViewModel", () => {
     });
   });
 
-  describe("balanceAvailable stickiness", () => {
-    it("should keep balanceAvailable false until sync settles (no shimmer gap after skeleton)", () => {
+  describe("isBalanceAvailable", () => {
+    it("stays false until syncPhase settles when there is no cached balance", () => {
+      const emptyPortfolio = {
+        ...defaultPortfolio,
+        balanceHistory: [{ date: new Date(), value: 0 }],
+      };
+
       mockUsePortfolioBalance.mockReturnValue(
-        makePortfolioBalanceReturn({
-          balanceAvailable: false,
-          syncPhase: "syncing",
-          isBalanceLoading: true,
-        }),
+        makeReturn({ balanceAvailable: false, syncPhase: "syncing", portfolio: emptyPortfolio }),
       );
 
       const { result, rerender } = renderHook(() =>
@@ -190,26 +151,28 @@ describe("usePortfolioBalanceSectionViewModel", () => {
       expect(result.current.isBalanceAvailable).toBe(false);
 
       mockUsePortfolioBalance.mockReturnValue(
-        makePortfolioBalanceReturn({
-          balanceAvailable: true,
-          syncPhase: "syncing",
-          isBalanceLoading: false,
-          portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 1200 }] },
-        }),
+        makeReturn({ balanceAvailable: true, syncPhase: "syncing", portfolio: emptyPortfolio }),
       );
       rerender({});
       expect(result.current.isBalanceAvailable).toBe(false);
 
       mockUsePortfolioBalance.mockReturnValue(
-        makePortfolioBalanceReturn({
-          balanceAvailable: true,
-          syncPhase: "synced",
-          portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 1200 }] },
-        }),
+        makeReturn({ balanceAvailable: true, syncPhase: "synced", portfolio: emptyPortfolio }),
       );
       rerender({});
       expect(result.current.isBalanceAvailable).toBe(true);
-      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("is true immediately at cold start when a cached balance exists", () => {
+      mockUsePortfolioBalance.mockReturnValue(
+        makeReturn({ balanceAvailable: false, syncPhase: "syncing" }),
+      );
+
+      const { result } = renderHook(() => usePortfolioBalanceSectionViewModel(defaultProps));
+
+      // effectiveLatestBalance = 1000 (from defaultPortfolio via pass-through mock),
+      // so effectiveRawBalanceAvailable = true and balanceAvailable starts as true.
+      expect(result.current.isBalanceAvailable).toBe(true);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/index.tsx
@@ -7,30 +7,7 @@ export const PortfolioBalanceSection = ({
   showAssets,
   isReadOnlyMode = false,
 }: PortfolioBalanceSectionProps) => {
-  const {
-    state,
-    balance,
-    countervalueChange,
-    unit,
-    isBalanceAvailable,
-    isLoading,
-    shouldDisplayBalanceRefreshRework,
-    onToggleDiscreetMode,
-  } = usePortfolioBalanceSectionViewModel({
-    showAssets,
-    isReadOnlyMode,
-  });
+  const vm = usePortfolioBalanceSectionViewModel({ showAssets, isReadOnlyMode });
 
-  return (
-    <PortfolioBalanceSectionView
-      state={state}
-      balance={balance}
-      countervalueChange={countervalueChange}
-      unit={unit}
-      isBalanceAvailable={isBalanceAvailable}
-      isLoading={isLoading}
-      shouldDisplayBalanceRefreshRework={shouldDisplayBalanceRefreshRework}
-      onToggleDiscreetMode={onToggleDiscreetMode}
-    />
-  );
+  return <PortfolioBalanceSectionView {...vm} />;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/types.ts
@@ -14,6 +14,7 @@ export interface PortfolioBalanceSectionViewProps {
   readonly countervalueChange: ValueChange;
   readonly unit: Unit;
   readonly isBalanceAvailable: boolean;
+  readonly isAnalyticPillVisible: boolean;
   readonly isLoading: boolean;
   readonly shouldDisplayBalanceRefreshRework: boolean;
   readonly onToggleDiscreetMode: () => void;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePersistedPortfolioBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePersistedPortfolioBalance.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from "react";
+import { mmkv } from "LLM/storage/mmkvStorageWrapper";
+import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/index";
+
+const PORTFOLIO_BALANCE_KEY = "portfolioLastKnownBalance";
+
+/**
+ * Persists the last-known portfolio balance to MMKV and provides it as a
+ * fallback when the portfolio hasn't been computed yet (e.g. first frame of
+ * a cold start before countervalues are loaded from cache).
+ *
+ * - On mount: reads the previously persisted balance synchronously.
+ * - When sync completes: writes the new stable balance for the next session.
+ * - Returns: the computed balance when available, otherwise the persisted one.
+ *
+ * This mirrors the desktop experience where the portfolio is computed from
+ * fully-cached countervalues at mount, so the balance is never $0 at start.
+ */
+export function usePersistedPortfolioBalance(
+  latestBalance: number,
+  syncPhase: SyncPhase,
+  currencyCode: string,
+): number {
+  const key = `${PORTFOLIO_BALANCE_KEY}_${currencyCode}`;
+  const persistedRef = useRef<number>(mmkv.getNumber(key) ?? 0);
+
+  // When the countervalue currency changes at runtime, reload the cached value for the new currency.
+  const prevKeyRef = useRef(key);
+  if (prevKeyRef.current !== key) {
+    prevKeyRef.current = key;
+    persistedRef.current = mmkv.getNumber(key) ?? 0;
+  }
+
+  useEffect(() => {
+    if (syncPhase === "synced") {
+      mmkv.set(key, latestBalance);
+      persistedRef.current = latestBalance;
+    }
+  }, [key, syncPhase, latestBalance]);
+
+  // Only substitute during syncing — once sync settles the real balance (even $0) is authoritative.
+  return syncPhase === "syncing" ? latestBalance || persistedRef.current : latestBalance;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
@@ -5,6 +5,7 @@ import { useSelector } from "~/context/hooks";
 import { useToggleDiscreetMode } from "~/hooks/useToggleDiscreetMode";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { usePortfolioBalance } from "LLM/hooks/usePortfolioBalance";
+import { usePersistedPortfolioBalance } from "./usePersistedPortfolioBalance";
 import {
   PortfolioBalanceState,
   PortfolioBalanceSectionProps,
@@ -26,12 +27,24 @@ export const usePortfolioBalanceSectionViewModel = ({
   const latestBalance = lastItem?.value ?? 0;
   const unit = counterValueCurrency.units[0];
 
-  const { balanceAvailable, displayedBalance, isLoading } = useBalanceSyncState({
-    rawBalanceAvailable,
-    syncPhase,
+  const effectiveLatestBalance = usePersistedPortfolioBalance(
     latestBalance,
+    syncPhase,
+    counterValueCurrency.ticker,
+  );
+
+  // If MMKV has a cached balance from a previous session, treat it as available
+  // immediately so the cached value is shown at cold start instead of a skeleton.
+  const effectiveRawBalanceAvailable = rawBalanceAvailable || effectiveLatestBalance > 0;
+
+  const { balanceAvailable, displayedBalance } = useBalanceSyncState({
+    rawBalanceAvailable: effectiveRawBalanceAvailable,
+    syncPhase,
+    latestBalance: effectiveLatestBalance,
     shouldFreezeOnSync: shouldDisplayBalanceRefreshRework,
   });
+
+  const effectiveIsLoading = syncPhase === "syncing";
 
   const state: PortfolioBalanceState = useMemo(() => {
     if (isReadOnlyMode) {
@@ -43,13 +56,18 @@ export const usePortfolioBalanceSectionViewModel = ({
     return "normal";
   }, [isReadOnlyMode, showAssets]);
 
+  const isAnalyticPillVisible =
+    state === "normal" &&
+    (balanceAvailable || (shouldDisplayBalanceRefreshRework && effectiveIsLoading));
+
   return {
     state,
     balance: displayedBalance,
     countervalueChange,
     unit,
     isBalanceAvailable: balanceAvailable,
-    isLoading,
+    isAnalyticPillVisible,
+    isLoading: effectiveIsLoading,
     shouldDisplayBalanceRefreshRework,
     onToggleDiscreetMode: toggleDiscreetMode,
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__tests__/usePortfolioRefreshStatusViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__tests__/usePortfolioRefreshStatusViewModel.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from "@tests/test-renderer";
+import * as usePortfolioBalanceModule from "LLM/hooks/usePortfolioBalance";
+import * as useWalletFeaturesConfigModule from "@ledgerhq/live-common/featureFlags/index";
+import type { WalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/types";
+import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/index";
+import { usePortfolioRefreshStatusViewModel } from "../usePortfolioRefreshStatusViewModel";
+
+jest.mock("LLM/hooks/usePortfolioBalance");
+jest.mock("@ledgerhq/live-common/featureFlags/index");
+
+const mockUsePortfolioBalance = jest.mocked(usePortfolioBalanceModule.usePortfolioBalance);
+const mockUseWalletFeaturesConfig = jest.mocked(
+  useWalletFeaturesConfigModule.useWalletFeaturesConfig,
+);
+
+function mockSync(syncPhase: SyncPhase, isManualRefreshLoading = false) {
+  mockUsePortfolioBalance.mockReturnValue({ syncPhase, isManualRefreshLoading } as ReturnType<
+    typeof mockUsePortfolioBalance
+  >);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseWalletFeaturesConfig.mockReturnValue({
+    shouldDisplayBalanceRefreshRework: true,
+  } as WalletFeaturesConfig);
+});
+
+it("banner stays visible through the settle-guard window then clears on synced", () => {
+  mockSync("syncing", true);
+  const { result, rerender } = renderHook(() => usePortfolioRefreshStatusViewModel());
+  expect(result.current.isRefreshing).toBe(true);
+
+  // accounts done but syncPhase still "syncing" (settle-guard) → banner must stay
+  mockSync("syncing", false);
+  rerender({});
+  expect(result.current.isRefreshing).toBe(true);
+
+  mockSync("synced");
+  rerender({});
+  expect(result.current.isRefreshing).toBe(false);
+});
+
+it("never shows banner during cold start (syncPhase syncing but no user trigger)", () => {
+  mockSync("syncing", false);
+  const { result, rerender } = renderHook(() => usePortfolioRefreshStatusViewModel());
+  expect(result.current.isRefreshing).toBe(false);
+  expect(result.current.isVisible).toBe(false);
+
+  mockSync("synced");
+  rerender({});
+  expect(result.current.isRefreshing).toBe(false);
+  expect(result.current.isVisible).toBe(false);
+});
+
+it("outcome becomes error when syncPhase is failed after user refresh", () => {
+  mockSync("syncing", true);
+  const { result, rerender } = renderHook(() => usePortfolioRefreshStatusViewModel());
+  expect(result.current.isRefreshing).toBe(true);
+
+  mockSync("failed", false);
+  rerender({});
+  expect(result.current.isRefreshing).toBe(false);
+  expect(result.current.outcome).toBe("error");
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/usePortfolioRefreshStatusViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/usePortfolioRefreshStatusViewModel.ts
@@ -22,10 +22,19 @@ export const usePortfolioRefreshStatusViewModel = (): UsePortfolioRefreshStatusV
   const { t } = useTranslation();
   const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
   const legacyIsRefreshing = useSelector(selectIsRefreshing);
-  const { syncPhase } = usePortfolioBalance();
+  const { syncPhase, isManualRefreshLoading } = usePortfolioBalance();
+
+  // Stays true for the entire sync cycle once the user triggers a refresh;
+  // reset when sync leaves "syncing" (either "synced" or "failed"). Never set at cold start.
+  const wasUserTriggeredRef = useRef(false);
+  if (isManualRefreshLoading) {
+    wasUserTriggeredRef.current = true;
+  } else if (syncPhase !== "syncing") {
+    wasUserTriggeredRef.current = false;
+  }
 
   const isSyncing = shouldDisplayBalanceRefreshRework
-    ? syncPhase === "syncing"
+    ? syncPhase === "syncing" && wasUserTriggeredRef.current
     : legacyIsRefreshing;
 
   const [outcome, setOutcome] = useState<RefreshOutcome>(null);

--- a/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalance.ts
@@ -117,6 +117,7 @@ export function usePortfolioBalance() {
     syncPhase,
     isBalanceLoading,
     isColdStart,
+    isManualRefreshLoading,
     allAccounts,
     accountsWithError,
     listOfErrorAccountNames,


### PR DESCRIPTION
### ✅ Checklist

- [ ] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio balance shimmer: no more \`$0\` flash or flickering during cold start
  - Pull-to-refresh: shimmer and \"Refreshing...\" banner now stop simultaneously
  - Analytic pill visible during loading (cold start & pull-to-refresh)

### 📝 Description

Several UX issues were affecting the portfolio balance section during cold start and pull-to-refresh:

- **\$0 flash**: balance showed \`$0\` before countervalues were loaded from cache
- **Balance flickering**: intermediate portfolio recalculations were visible
- **Shimmer/banner desync**: the \"Refreshing...\" banner disappeared before the shimmer (3s settle-guard gap)
- **Analytic pill hidden**: the pill only appeared after the full sync cycle

**Solution:**

- `usePersistedPortfolioBalance`: persists the last-known balance to MMKV so the frozen ref always starts from a meaningful cached value, never \`$0\`
- `shouldFreezeOnSync: shouldDisplayBalanceRefreshRework` (always when flag is on, like desktop): balance is frozen at mount-time value for the entire `syncPhase === "syncing"` window — shimmer hides all intermediate recalculations
- `wasUserTriggeredRef` latch in `usePortfolioRefreshStatusViewModel`: the \"Refreshing...\" banner stays visible throughout the settle-guard window and only disappears when `syncPhase` transitions to `"synced"` — in sync with the shimmer
- `isAnalyticPillVisible` exposed from the ViewModel: pill is shown during loading (rework path) and the display condition moved out of the View

https://github.com/user-attachments/assets/4f73d9b7-e023-4f63-8b49-7edd53425fbb


### ❓ Context

- **JIRA or GitHub link**: [LIVE-27636](https://ledgerhq.atlassian.net/browse/LIVE-27636) · [LIVE-27635](https://ledgerhq.atlassian.net/browse/LIVE-27635)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-27636]: https://ledgerhq.atlassian.net/browse/LIVE-27636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ