### PR TITLE
[LWDM] feat(coin-solana): [LIVE-18682] alpaca api listOperations

### DIFF
--- a/.changeset/little-jars-grab.md
+++ b/.changeset/little-jars-grab.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": minor
+---
+
+coin-solana alpaca api listOperations

--- a/libs/coin-framework/.unimportedrc.json
+++ b/libs/coin-framework/.unimportedrc.json
@@ -16,6 +16,7 @@
     "src/errors.ts",
     "src/features/types.ts",
     "src/setup.ts",
+    "src/test/utils.ts",
     "src/utils.ts"
   ],
   "ignoreUnresolved": [

--- a/libs/coin-framework/src/test/utils.ts
+++ b/libs/coin-framework/src/test/utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Recursively makes all properties optional.
+ * Arrays keep their element type (but each element is deeply partial).
+ * Primitives and built-in value types (Date, RegExp) are preserved as-is.
+ */
+export type DeepPartial<T> = T extends (infer U)[]
+  ? DeepPartial<U>[]
+  : T extends Date | RegExp
+    ? T
+    : T extends object
+      ? { [K in keyof T]?: DeepPartial<T[K]> }
+      : T;
+
+/**
+ * Re-types a function so its return value is wrapped in `Promise<DeepPartial<…>>`,
+ * while keeping the original parameter types intact.
+ *
+ * Useful for typing Jest mock functions that return partial RPC/API data:
+ * ```ts
+ * const mock = jest.fn() as jest.MockedFunction<DeepPartialReturn<SomeApi["method"]>>;
+ * mock.mockResolvedValue({ onlyTheFieldsWeNeed: true });
+ * ```
+ */
+export type DeepPartialReturn<F extends (...args: never[]) => unknown> = (
+  ...args: Parameters<F>
+) => Promise<DeepPartial<Awaited<ReturnType<F>>>>;

--- a/libs/coin-modules/coin-solana/src/api/index.ts
+++ b/libs/coin-modules/coin-solana/src/api/index.ts
@@ -14,6 +14,7 @@ import { craftTransaction } from "../logic/craftTransaction";
 import { estimateFees } from "../logic/estimateFees";
 import { getBalance } from "../logic/getBalance";
 import { lastBlock } from "../logic/lastBlock";
+import { listOperations } from "../logic/listOperations";
 import { getChainAPI } from "../network";
 import { endpointByCurrencyId } from "../utils";
 
@@ -52,6 +53,9 @@ export function createApi(config: SolanaCoinConfig, currencyId: string): AlpacaA
     lastBlock: () => {
       return lastBlock(api);
     },
+    listOperations: (_address: string, _options: ListOperationsOptions) => {
+      return listOperations(api, _address, _options);
+    },
     getBlock: () => {
       throw new Error("getBlock is not supported");
     },
@@ -63,9 +67,6 @@ export function createApi(config: SolanaCoinConfig, currencyId: string): AlpacaA
     },
     getValidators: () => {
       throw new Error("getValidators is not supported");
-    },
-    listOperations: (_address: string, _options: ListOperationsOptions) => {
-      throw new Error("listOperations is not supported");
     },
     getStakes: (_address: string, _cursor?: Cursor) => {
       throw new Error("getStakes is not supported");

--- a/libs/coin-modules/coin-solana/src/api/index.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/api/index.unit.test.ts
@@ -3,6 +3,8 @@ import type {
   AlpacaApi,
   Balance,
   CraftedTransaction,
+  Operation,
+  Page,
   TransactionIntent,
 } from "@ledgerhq/coin-framework/api/types";
 import coinConfig from "../config";
@@ -14,6 +16,7 @@ import { craftTransaction } from "../logic/craftTransaction";
 import { estimateFees } from "../logic/estimateFees";
 import { getBalance } from "../logic/getBalance";
 import { lastBlock } from "../logic/lastBlock";
+import { listOperations } from "../logic/listOperations";
 import { ChainAPI } from "../network";
 import { createApi } from ".";
 
@@ -49,6 +52,10 @@ jest.mock("../logic/estimateFees", () => ({
 
 jest.mock("../logic/getBalance", () => ({
   getBalance: jest.fn(),
+}));
+
+jest.mock("../logic/listOperations", () => ({
+  listOperations: jest.fn(),
 }));
 
 describe("createApi", () => {
@@ -205,6 +212,20 @@ describe("createApi", () => {
     expect(result).toEqual(mockResult);
   });
 
+  it("should pass parameters correctly to listOperations", async () => {
+    const mockResult: Page<Operation> = { items: [], next: "next" };
+    jest.mocked(listOperations).mockResolvedValueOnce(mockResult);
+
+    const api: AlpacaApi = createApi(mockConfig, "solana");
+    const result = await api.listOperations("address", { minHeight: 14, order: "asc" });
+
+    expect(listOperations).toHaveBeenCalledWith(mockChainAPI, "address", {
+      minHeight: 14,
+      order: "asc",
+    });
+    expect(result).toEqual(mockResult);
+  });
+
   it("should throw for unsupported methods", () => {
     const api = createApi(mockConfig, "solana");
 
@@ -222,9 +243,6 @@ describe("createApi", () => {
     expect(() => api.getRewards("addr")).toThrow("getRewards is not supported");
     expect(() => api.getStakes("address")).toThrow("getStakes is not supported");
     expect(() => api.getValidators()).toThrow("getValidators is not supported");
-    expect(() => api.listOperations("address", { minHeight: 14, order: "asc" })).toThrow(
-      "listOperations is not supported",
-    );
     expect(() => api.validateIntent(intent, [])).toThrow("validateIntent is not supported");
     expect(() => api.getNextSequence("address")).toThrow("getNextSequence is not supported");
     expect(() => api.validateAddress("address", {})).toThrow("validateAddress is not supported");

--- a/libs/coin-modules/coin-solana/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/logic/craftTransaction.ts
@@ -12,8 +12,15 @@ import {
   TransactionMessage,
   BlockhashWithExpiryBlockHeight,
 } from "@solana/web3.js";
+import BigNumber from "bignumber.js";
+import { bpsToPercent, calculateToken2022TransferFees } from "../helpers/token";
 import { isValidBase58Address } from "../logic";
 import type { ChainAPI } from "../network";
+import type {
+  TransferFeeConfigExt,
+  TransferFeeConfigState,
+} from "../network/chain/account/tokenExtensions";
+import { PARSED_PROGRAMS } from "../network/chain/program/constants";
 import {
   buildTransferInstructions,
   buildTokenTransferInstructions,
@@ -35,6 +42,7 @@ import type {
   Command,
   TokenTransferCommand,
   TransferCommand,
+  TransferFeeCalculated,
   Transaction,
   SolanaTokenProgram,
 } from "../types";
@@ -269,7 +277,7 @@ async function resolveTokenTransferCommand(
   const shouldCreateAta =
     recipientTokenAccount === undefined || recipientTokenAccount instanceof Error;
 
-  return {
+  const command: TokenTransferCommand = {
     kind: "token.transfer",
     ownerAddress: intent.sender,
     ownerAssociatedTokenAccountAddress: senderAta.toBase58(),
@@ -285,5 +293,85 @@ async function resolveTokenTransferCommand(
     tokenId: mintAddress,
     memo,
     tokenProgram: resolvedProgram,
+  };
+
+  // Token-2022 tokens may have a transfer-fee extension that requires the
+  // instruction to include the calculated fee. Two code paths:
+  //
+  //  • Normal send: `calculateToken2022TransferFees` takes the NET amount the
+  //    recipient should receive and computes `transferAmountIncludingFee` (> net).
+  //
+  //  • Send all: `computeTransferFeeFromTotal` takes the TOTAL balance
+  //    (= amount deducted from ATA) and derives the fee from that total, so
+  //    `transferAmountIncludingFee == balance` and the instruction won't exceed
+  //    the sender's holdings.
+  if (resolvedProgram === PARSED_PROGRAMS.SPL_TOKEN_2022) {
+    const transferFeeConfigExt = mintAccount.extensions?.find(
+      (ext): ext is TransferFeeConfigExt => ext.extension === "transferFeeConfig",
+    );
+    if (transferFeeConfigExt) {
+      const { epoch } = await api.getEpochInfo();
+      if (intent.useAllAmount) {
+        command.extensions = {
+          transferFee: computeTransferFeeFromTotal(
+            intent.amount.toString(),
+            transferFeeConfigExt.state,
+            epoch,
+          ),
+        };
+      } else {
+        command.extensions = {
+          transferFee: calculateToken2022TransferFees({
+            transferAmount: Number(intent.amount),
+            transferFeeConfigState: transferFeeConfigExt.state,
+            currentEpoch: epoch,
+          }),
+        };
+      }
+    }
+  }
+
+  return command;
+}
+
+/**
+ * Computes Token-2022 transfer fees for the "send all" case.
+ *
+ * Unlike `calculateToken2022TransferFees` which works from net → gross, this
+ * function works from gross → net: the total deducted from the sender's ATA
+ * equals the full token balance, and the fee is derived from that total.
+ *
+ * Formula: `fee = min( ceil(total × bps / 10 000), maximumFee )`
+ *
+ * Selects the active fee schedule based on `currentEpoch` vs the
+ * `newerTransferFee.epoch` threshold.
+ */
+function computeTransferFeeFromTotal(
+  totalAmount: BigNumber.Value,
+  config: Pick<TransferFeeConfigState, "newerTransferFee" | "olderTransferFee">,
+  currentEpoch: number,
+): TransferFeeCalculated {
+  const { newerTransferFee, olderTransferFee } = config;
+  const feeConfig = currentEpoch >= newerTransferFee.epoch ? newerTransferFee : olderTransferFee;
+  const { maximumFee, transferFeeBasisPoints } = feeConfig;
+  const feePercent = bpsToPercent(transferFeeBasisPoints);
+
+  const totalBn = BigNumber(totalAmount);
+  const maxFeeBn = BigNumber(maximumFee);
+  let transferFeeBn = totalBn
+    .times(transferFeeBasisPoints)
+    .div(10000)
+    .decimalPlaces(0, BigNumber.ROUND_CEIL);
+  if (transferFeeBn.gt(maxFeeBn)) {
+    transferFeeBn = maxFeeBn;
+  }
+
+  return {
+    feePercent,
+    maxTransferFee: maximumFee,
+    transferFee: transferFeeBn.toNumber(),
+    feeBps: transferFeeBasisPoints,
+    transferAmountIncludingFee: totalBn.toNumber(),
+    transferAmountExcludingFee: totalBn.minus(transferFeeBn).toNumber(),
   };
 }

--- a/libs/coin-modules/coin-solana/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-solana/src/logic/estimateFees.ts
@@ -6,6 +6,7 @@ import { ChainAPI } from "../network";
 import { PARSED_PROGRAMS } from "../network/chain/program/constants";
 import { getStakeAccountAddressWithSeed } from "../network/chain/web3";
 import { UserInputType } from "../signer";
+import type { SolanaTokenProgram, TokenTransferCommand } from "../types";
 import { Transaction, TransactionModel } from "../types";
 import { LEDGER_VALIDATOR_DEFAULT, assertUnreachable } from "../utils";
 import { buildVersionedTransaction } from "./craftTransaction";
@@ -33,7 +34,8 @@ export async function estimateFees(
   _customFeesParameters?: FeeEstimation["parameters"],
 ): Promise<FeeEstimation> {
   const kind = mapIntentToTxKind(intent);
-  const fee = await estimateTxFee(api, intent.sender, kind);
+  const tokenProgram = resolveTokenProgramFromAsset(intent.asset);
+  const fee = await estimateTxFee(api, intent.sender, kind, tokenProgram);
   return { value: BigInt(fee) };
 }
 
@@ -41,8 +43,9 @@ export async function estimateTxFee(
   api: ChainAPI,
   address: string,
   kind: TransactionModel["kind"],
+  tokenProgram?: SolanaTokenProgram,
 ) {
-  const tx = await createDummyTx(address, kind);
+  const tx = await createDummyTx(address, kind, tokenProgram);
   const [onChainTx] = await buildVersionedTransaction(address, tx, api);
 
   let fee = await api.getFeeForMessage(onChainTx.message);
@@ -62,7 +65,11 @@ export async function estimateTxFee(
   return fee;
 }
 
-const createDummyTx = (address: string, kind: TransactionModel["kind"]) => {
+const createDummyTx = (
+  address: string,
+  kind: TransactionModel["kind"],
+  tokenProgram?: SolanaTokenProgram,
+) => {
   switch (kind) {
     case "transfer":
       return createDummyTransferTx(address);
@@ -75,7 +82,7 @@ const createDummyTx = (address: string, kind: TransactionModel["kind"]) => {
     case "stake.withdraw":
       return createDummyStakeWithdrawTx(address);
     case "token.transfer":
-      return createDummyTokenTransferTx(address);
+      return createDummyTokenTransferTx(address, tokenProgram);
     case "token.approve":
       return createDummyTokenApproveTx(address);
     case "token.revoke":
@@ -189,29 +196,51 @@ const createDummyStakeWithdrawTx = (address: string): Transaction => {
   };
 };
 
-const createDummyTokenTransferTx = (address: string): Transaction => {
+const createDummyTokenTransferTx = (
+  address: string,
+  tokenProgram: SolanaTokenProgram = PARSED_PROGRAMS.SPL_TOKEN,
+): Transaction => {
+  const command: TokenTransferCommand = {
+    kind: "token.transfer",
+    amount: 0,
+    mintAddress: randomAddresses[0],
+    mintDecimals: 0,
+    tokenId: "",
+    ownerAddress: address,
+    ownerAssociatedTokenAccountAddress: randomAddresses[1],
+    recipientDescriptor: {
+      walletAddress: randomAddresses[1],
+      tokenAccAddress: randomAddresses[2],
+      shouldCreateAsAssociatedTokenAccount: true,
+      userInputType: UserInputType.SOL,
+    },
+    tokenProgram,
+  };
+
+  // Token-2022 tokens with a transfer-fee extension use a different
+  // instruction (transferCheckedWithFee) that consumes more compute units.
+  // Include a dummy transferFee so buildTokenTransferInstructions picks the
+  // right instruction variant for fee estimation.
+  if (tokenProgram === PARSED_PROGRAMS.SPL_TOKEN_2022) {
+    command.extensions = {
+      transferFee: {
+        feePercent: 0,
+        maxTransferFee: 0,
+        transferFee: 0,
+        feeBps: 0,
+        transferAmountIncludingFee: 0,
+        transferAmountExcludingFee: 0,
+      },
+    };
+  }
+
   return {
     ...BASE_TRANSACTION,
     model: {
       kind: "token.transfer",
       uiState: {} as any,
       commandDescriptor: {
-        command: {
-          kind: "token.transfer",
-          amount: 0,
-          mintAddress: randomAddresses[0],
-          mintDecimals: 0,
-          tokenId: "",
-          ownerAddress: address,
-          ownerAssociatedTokenAccountAddress: randomAddresses[1],
-          recipientDescriptor: {
-            walletAddress: randomAddresses[1],
-            tokenAccAddress: randomAddresses[2],
-            shouldCreateAsAssociatedTokenAccount: true,
-            userInputType: UserInputType.SOL,
-          },
-          tokenProgram: PARSED_PROGRAMS.SPL_TOKEN,
-        },
+        command,
         ...commandDescriptorCommons,
       },
     },
@@ -320,4 +349,17 @@ function mapIntentToTxKind(intent: TransactionIntent): TransactionModel["kind"] 
     return "transfer";
   }
   throw new Error(`Unsupported intent type: ${intent.intentType}`);
+}
+
+/**
+ * Maps the intent asset type to the Solana token program identifier.
+ * Token-2022 assets produce a different instruction variant
+ * (transferCheckedWithFee) that affects compute-unit consumption.
+ */
+function resolveTokenProgramFromAsset(
+  asset: TransactionIntent["asset"],
+): SolanaTokenProgram | undefined {
+  if (asset.type === "native") return undefined;
+  if (asset.type === PARSED_PROGRAMS.SPL_TOKEN_2022) return PARSED_PROGRAMS.SPL_TOKEN_2022;
+  return PARSED_PROGRAMS.SPL_TOKEN;
 }

--- a/libs/coin-modules/coin-solana/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-solana/src/logic/getBalance.ts
@@ -31,10 +31,15 @@ export async function getBalance(
     locked: lockedLamports,
   };
 
-  const splBalances = mapTokenAccountsToBalances(splTokenAccounts, PARSED_PROGRAMS.SPL_TOKEN);
+  const splBalances = mapTokenAccountsToBalances(
+    splTokenAccounts,
+    PARSED_PROGRAMS.SPL_TOKEN,
+    address,
+  );
   const token2022Balances = mapTokenAccountsToBalances(
     token2022Accounts,
     PARSED_PROGRAMS.SPL_TOKEN_2022,
+    address,
   );
 
   return [nativeBalance, ...splBalances, ...token2022Balances];
@@ -43,6 +48,7 @@ export async function getBalance(
 function mapTokenAccountsToBalances(
   accounts: ReadonlyArray<ParsedOnChainTokenAccount>,
   tokenProgram: SolanaTokenProgram,
+  ownerAddress: string,
 ): Balance[] {
   const balancesByMint = new Map<string, bigint>();
 
@@ -57,6 +63,7 @@ function mapTokenAccountsToBalances(
     asset: {
       type: tokenProgram,
       assetReference: mint,
+      assetOwner: ownerAddress,
     },
   }));
 }

--- a/libs/coin-modules/coin-solana/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-solana/src/logic/listOperations.ts
@@ -1,0 +1,341 @@
+import type {
+  AssetInfo,
+  ListOperationsOptions,
+  Operation,
+  Page,
+} from "@ledgerhq/coin-framework/api/index";
+import { TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import type {
+  ConfirmedSignatureInfo,
+  ParsedTransactionWithMeta,
+  SignaturesForAddressOptions,
+  TokenBalance,
+} from "@solana/web3.js";
+import type { ChainAPI } from "../network";
+import { PARSED_PROGRAMS } from "../network/chain/program/constants";
+import type { SolanaTokenProgram } from "../types";
+
+const PROGRAM_ID_TO_NAME: Record<string, SolanaTokenProgram> = {
+  [TOKEN_PROGRAM_ID.toBase58()]: PARSED_PROGRAMS.SPL_TOKEN,
+  [TOKEN_2022_PROGRAM_ID.toBase58()]: PARSED_PROGRAMS.SPL_TOKEN_2022,
+};
+
+export async function listOperations(
+  api: ChainAPI,
+  address: string,
+  { minHeight, cursor, order, limit }: ListOperationsOptions,
+): Promise<Page<Operation>> {
+  if (order === "asc") {
+    throw new Error("ascending order is not supported");
+  }
+
+  const rpcLimit = limit ?? 100;
+  const opts: SignaturesForAddressOptions = { limit: rpcLimit };
+
+  if (cursor) {
+    opts.before = cursor;
+  }
+
+  const signatures = await api.getSignaturesForAddress(address, opts);
+
+  if (signatures.length === 0) {
+    return { items: [], next: undefined };
+  }
+
+  const sigStrings = signatures.map(s => s.signature);
+  const parsed = await api.getParsedTransactions(sigStrings);
+
+  const items: Operation[] = [];
+  for (let i = 0; i < signatures.length; i++) {
+    const sig = signatures[i];
+    const tx = parsed[i];
+    if (!tx || !tx.meta || sig.blockTime === null || sig.blockTime === undefined) continue;
+
+    if (minHeight > 0 && sig.slot < minHeight) continue;
+
+    const txMeta = buildTxMeta(sig, tx);
+
+    const nativeOps = parseNativeOperations(address, tx, txMeta);
+    const tokenOps = parseTokenOperations(address, tx, txMeta);
+
+    items.push(...nativeOps, ...tokenOps);
+  }
+
+  const lastSig = signatures[signatures.length - 1];
+  const hasMore = signatures.length === rpcLimit;
+  const reachedMinHeightBoundary = minHeight > 0 && lastSig.slot < minHeight;
+  const next =
+    items.length > 0 && hasMore && !reachedMinHeightBoundary ? lastSig.signature : undefined;
+
+  return { items, next };
+}
+
+type TxMeta = {
+  hash: string;
+  slot: number;
+  blockTime: number;
+  fee: bigint;
+  feesPayer: string;
+  failed: boolean;
+};
+
+/**
+ * Extracts a flat metadata object from the RPC signature info and parsed transaction,
+ * normalising types (e.g. fee → bigint) so downstream helpers don't depend on RPC shapes.
+ * Callers guarantee that `sig.blockTime` and `tx.meta` are non-null before calling.
+ */
+function buildTxMeta(sig: ConfirmedSignatureInfo, tx: ParsedTransactionWithMeta): TxMeta {
+  return {
+    hash: sig.signature,
+    slot: sig.slot,
+    blockTime: sig.blockTime!,
+    fee: BigInt(tx.meta!.fee),
+    feesPayer: tx.transaction.message.accountKeys[0]?.pubkey.toBase58(),
+    failed: !!sig.err,
+  };
+}
+
+function makeOperation(
+  address: string,
+  opType: string,
+  value: bigint,
+  senders: string[],
+  recipients: string[],
+  asset: AssetInfo,
+  meta: TxMeta,
+  operationIndex: number,
+  details?: Record<string, unknown>,
+): Operation {
+  return {
+    id: `${address}-${meta.hash}-${opType}-${operationIndex}`,
+    type: opType,
+    senders,
+    recipients,
+    value,
+    asset,
+    ...(details ? { details } : {}),
+    tx: {
+      hash: meta.hash,
+      block: {
+        height: meta.slot,
+        hash: "", // Solana block hashes are not available in parsed tx data; no reorg risk so empty string per spec
+        time: new Date(meta.blockTime * 1000),
+      },
+      fees: meta.fee,
+      feesPayer: meta.feesPayer,
+      date: new Date(meta.blockTime * 1000),
+      failed: meta.failed,
+    },
+  };
+}
+
+/**
+ * Derives a single native-SOL operation from a transaction's pre/post lamport balances.
+ *
+ * Operation type depends on the address role:
+ *   - Fee payer (accountIndex 0): fee is subtracted from balanceDelta before classification.
+ *     delta < 0 → OUT, delta > 0 → IN, delta == 0 → FEES (only fees were paid).
+ *   - Other accounts: raw delta determines the type (IN / OUT / NONE).
+ *
+ * Counterparty is the first account whose lamport balance changed (heuristic — may be
+ * inaccurate for complex multi-account transactions).
+ */
+function parseNativeOperations(
+  address: string,
+  tx: ParsedTransactionWithMeta,
+  meta: TxMeta,
+): Operation[] {
+  const { message } = tx.transaction;
+  const accountIndex = message.accountKeys.findIndex(k => k.pubkey.toBase58() === address);
+  if (accountIndex < 0) return [];
+
+  const { preBalances, postBalances } = tx.meta!;
+  const balanceDelta = BigInt(postBalances[accountIndex]) - BigInt(preBalances[accountIndex]);
+  const isFeePayer = accountIndex === 0;
+  const txFee = meta.fee;
+
+  let opType: string;
+  let value: bigint;
+
+  if (isFeePayer) {
+    const deltaWithoutFee = balanceDelta + txFee;
+    if (deltaWithoutFee < 0n) {
+      opType = "OUT";
+      value = -deltaWithoutFee;
+    } else if (deltaWithoutFee > 0n) {
+      opType = "IN";
+      value = deltaWithoutFee;
+    } else {
+      opType = "FEES";
+      value = txFee;
+    }
+  } else {
+    if (balanceDelta > 0n) {
+      opType = "IN";
+      value = balanceDelta;
+    } else if (balanceDelta < 0n) {
+      opType = "OUT";
+      value = -balanceDelta;
+    } else {
+      opType = "NONE";
+      value = 0n;
+    }
+  }
+
+  const counterpartyIndex = message.accountKeys.findIndex(
+    (_k, idx) =>
+      idx !== accountIndex && BigInt(postBalances[idx]) - BigInt(preBalances[idx]) !== 0n,
+  );
+  const counterparty =
+    counterpartyIndex >= 0 ? message.accountKeys[counterpartyIndex].pubkey.toBase58() : undefined;
+
+  const senders =
+    opType === "OUT" || opType === "FEES" ? [address] : counterparty ? [counterparty] : [];
+  const recipients = opType === "IN" ? [address] : counterparty ? [counterparty] : [];
+
+  return [makeOperation(address, opType, value, senders, recipients, { type: "native" }, meta, 0)];
+}
+
+/**
+ * Derives SPL / Token-2022 operations from pre/post token balance arrays.
+ *
+ * For each mint where the owner's balance changed, emits an IN or OUT operation.
+ * Zero-delta tokens are silently skipped.
+ * operationIndex starts at 1 (0 is reserved for the native operation).
+ *
+ * Token operations are marked `internal: true` in their details so that the
+ * generic-alpaca bridge (`getAccountShape`) excludes them from the parent
+ * account's operations list — they only surface as sub-account operations.
+ * Without this flag, a single token transfer would produce duplicate parent
+ * operations (one native + one token) with potentially different IDs when
+ * the native op type differs from the token op type (e.g. send-all with
+ * ATA close yields native IN + token OUT).
+ */
+function parseTokenOperations(
+  address: string,
+  tx: ParsedTransactionWithMeta,
+  meta: TxMeta,
+): Operation[] {
+  const preTokenBalances = tx.meta?.preTokenBalances ?? [];
+  const postTokenBalances = tx.meta?.postTokenBalances ?? [];
+  if (preTokenBalances.length === 0 && postTokenBalances.length === 0) return [];
+
+  const tokenChanges = computeTokenBalanceDeltas(address, preTokenBalances, postTokenBalances);
+  const ops: Operation[] = [];
+  let operationIndex = 1;
+
+  for (const [, change] of tokenChanges) {
+    const { mint, delta, tokenType } = change;
+    if (delta === 0n) continue;
+
+    const asset: AssetInfo = {
+      type: tokenType,
+      assetReference: mint,
+      assetOwner: address,
+    };
+
+    const opType = delta > 0n ? "IN" : "OUT";
+    const value = delta > 0n ? delta : -delta;
+
+    const counterparty = findTokenCounterparty(
+      address,
+      mint,
+      preTokenBalances,
+      postTokenBalances,
+      tx.transaction.message.accountKeys.map(k => k.pubkey.toBase58()),
+    );
+
+    const senders = opType === "OUT" ? [address] : counterparty ? [counterparty] : [];
+    const recipients = opType === "IN" ? [address] : counterparty ? [counterparty] : [];
+
+    ops.push(
+      makeOperation(address, opType, value, senders, recipients, asset, meta, operationIndex, {
+        ledgerOpType: opType,
+        assetAmount: value.toString(),
+        assetSenders: senders,
+        assetRecipients: recipients,
+        internal: true,
+      }),
+    );
+    operationIndex++;
+  }
+
+  return ops;
+}
+
+type TokenChange = { mint: string; delta: bigint; tokenType: SolanaTokenProgram };
+
+/** Maps a program ID to the internal token type name, defaulting to SPL_TOKEN for unknown IDs. */
+function resolveTokenType(programId: string | undefined): SolanaTokenProgram {
+  if (programId && PROGRAM_ID_TO_NAME[programId]) return PROGRAM_ID_TO_NAME[programId];
+  return PARSED_PROGRAMS.SPL_TOKEN;
+}
+
+/**
+ * Computes per-mint balance deltas for the given owner across a transaction.
+ *
+ * Two passes:
+ *  1. Iterate postTokenBalances for the owner → delta = post − (matched pre or 0).
+ *     Covers tokens that still exist after the tx (increase, decrease, or unchanged).
+ *  2. Iterate preTokenBalances for entries not yet seen → delta = −pre.
+ *     Covers tokens fully consumed by the tx (e.g. account closed / all tokens sent away).
+ */
+function computeTokenBalanceDeltas(
+  ownerAddress: string,
+  preTokenBalances: TokenBalance[],
+  postTokenBalances: TokenBalance[],
+): Map<string, TokenChange> {
+  const changes = new Map<string, TokenChange>();
+
+  const preBalancesByMint = new Map<string, bigint>();
+  for (const pre of preTokenBalances) {
+    if (pre.owner !== ownerAddress) continue;
+    if (!preBalancesByMint.has(pre.mint)) {
+      preBalancesByMint.set(pre.mint, BigInt(pre.uiTokenAmount.amount));
+    }
+  }
+
+  for (const post of postTokenBalances) {
+    if (post.owner !== ownerAddress) continue;
+    const tokenType = resolveTokenType(post.programId);
+    const key = `${post.mint}-${tokenType}`;
+    const postAmount = BigInt(post.uiTokenAmount.amount);
+    const preAmount = preBalancesByMint.get(post.mint) ?? 0n;
+    changes.set(key, { mint: post.mint, delta: postAmount - preAmount, tokenType });
+  }
+
+  for (const pre of preTokenBalances) {
+    if (pre.owner !== ownerAddress) continue;
+    const tokenType = resolveTokenType(pre.programId);
+    const key = `${pre.mint}-${tokenType}`;
+    if (!changes.has(key)) {
+      changes.set(key, { mint: pre.mint, delta: -BigInt(pre.uiTokenAmount.amount), tokenType });
+    }
+  }
+
+  return changes;
+}
+
+/**
+ * Best-effort counterparty detection for token transfers.
+ *
+ * Searches both post and pre token balance arrays for another wallet owner
+ * of the same mint. Post is checked first because the recipient may not exist
+ * in pre when their ATA is created in the same transaction.
+ *
+ * Falls back to the first different account key when neither array has an
+ * owner-populated entry for a counterparty.
+ */
+function findTokenCounterparty(
+  ownerAddress: string,
+  mint: string,
+  preTokenBalances: TokenBalance[],
+  postTokenBalances: TokenBalance[],
+  accountKeys: string[],
+): string | undefined {
+  for (const balances of [postTokenBalances, preTokenBalances]) {
+    const entry = balances.find(b => b.owner && b.owner !== ownerAddress && b.mint === mint);
+    if (entry?.owner) return entry.owner;
+  }
+  return accountKeys.find(k => k !== ownerAddress);
+}

--- a/libs/coin-modules/coin-solana/src/logic/tests/craftTransaction.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/craftTransaction.unit.test.ts
@@ -15,6 +15,11 @@ import { buildVersionedTransaction, craftTransaction } from "../craftTransaction
 jest.mock("../../network/chain/web3", () => ({
   ...jest.requireActual("../../network/chain/web3"),
   buildTransferInstructions: jest.fn().mockResolvedValue([]),
+  buildTokenTransferInstructions: jest.fn().mockResolvedValue([]),
+  getMaybeMintAccount: jest.fn(),
+  getMaybeTokenMintProgram: jest.fn(),
+  getMaybeTokenAccount: jest.fn(),
+  findAssociatedTokenAccountPubkey: jest.fn(),
 }));
 
 const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
@@ -180,6 +185,259 @@ describe("craftTransaction", () => {
       api,
       expect.objectContaining({ memo: "test memo" }),
     );
+  });
+
+  describe("Token-2022 transfer fee", () => {
+    const {
+      getMaybeMintAccount,
+      getMaybeTokenMintProgram,
+      getMaybeTokenAccount,
+      findAssociatedTokenAccountPubkey,
+      buildTokenTransferInstructions,
+    } = jest.requireMock("../../network/chain/web3");
+
+    const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const CWIF_MINT = "7atgF8KQo4wJrD5ATGX7t1V2zVvykPJbFfNeVf1icFv1";
+    const SENDER_ATA = new PublicKey("AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ");
+
+    function setupTokenMocks(opts: {
+      mintDecimals?: number;
+      tokenProgram?: string;
+      transferFeeConfig?:
+        | {
+            newerTransferFee: { epoch: number; maximumFee: number; transferFeeBasisPoints: number };
+            olderTransferFee: { epoch: number; maximumFee: number; transferFeeBasisPoints: number };
+          }
+        | undefined;
+      recipientAtaExists?: boolean;
+      currentEpoch?: number;
+    }) {
+      const {
+        mintDecimals = 6,
+        tokenProgram = "spl-token-2022",
+        transferFeeConfig,
+        recipientAtaExists = true,
+        currentEpoch = 100,
+      } = opts;
+
+      const extensions = transferFeeConfig
+        ? [
+            {
+              extension: "transferFeeConfig",
+              state: {
+                ...transferFeeConfig,
+                transferFeeConfigAuthority: null,
+                withdrawWithheldAuthority: null,
+                withheldAmount: 0,
+              },
+            },
+          ]
+        : undefined;
+
+      getMaybeMintAccount.mockResolvedValue({
+        decimals: mintDecimals,
+        supply: "1000000000",
+        isInitialized: true,
+        mintAuthority: null,
+        freezeAuthority: null,
+        extensions,
+      });
+      getMaybeTokenMintProgram.mockResolvedValue(tokenProgram);
+      getMaybeTokenAccount.mockResolvedValue(recipientAtaExists ? { mint: CWIF_MINT } : undefined);
+      findAssociatedTokenAccountPubkey.mockResolvedValue(SENDER_ATA);
+      buildTokenTransferInstructions.mockResolvedValue([]);
+
+      const mockApi = {
+        getLatestBlockhash: mockGetLatestBlockhash,
+        getFeeForMessage: mockGetFeeForMessage,
+        getEpochInfo: jest.fn().mockResolvedValue({ epoch: currentEpoch }),
+        connection: {},
+      } as unknown as ChainAPI;
+
+      mockGetLatestBlockhash.mockResolvedValue({
+        blockhash: TEST_BLOCKHASH,
+        lastValidBlockHeight: 280064048,
+      });
+      mockGetFeeForMessage.mockResolvedValue(5000);
+
+      return mockApi;
+    }
+
+    it("should calculate transfer fee for Token-2022 token with transferFeeConfig", async () => {
+      const mockApi = setupTokenMocks({
+        transferFeeConfig: {
+          newerTransferFee: { epoch: 50, maximumFee: 1000000, transferFeeBasisPoints: 100 },
+          olderTransferFee: { epoch: 0, maximumFee: 500000, transferFeeBasisPoints: 50 },
+        },
+        currentEpoch: 100,
+      });
+
+      await craftTransaction(mockApi, {
+        intentType: "transaction",
+        type: "send",
+        sender: TEST_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        amount: 1000n,
+        asset: { type: "spl-token-2022", assetReference: CWIF_MINT, assetOwner: TEST_ADDRESS },
+      });
+
+      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+        mockApi,
+        expect.objectContaining({
+          extensions: expect.objectContaining({
+            transferFee: expect.objectContaining({
+              transferFee: expect.any(Number),
+              transferAmountIncludingFee: expect.any(Number),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should not set extensions for SPL token without transfer fee config", async () => {
+      const mockApi = setupTokenMocks({
+        tokenProgram: "spl-token",
+        transferFeeConfig: undefined,
+      });
+
+      await craftTransaction(mockApi, {
+        intentType: "transaction",
+        type: "send",
+        sender: TEST_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        amount: 1000n,
+        asset: { type: "spl-token", assetReference: USDC_MINT, assetOwner: TEST_ADDRESS },
+      });
+
+      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+        mockApi,
+        expect.not.objectContaining({
+          extensions: expect.anything(),
+        }),
+      );
+    });
+
+    it("should use computeTransferFeeFromTotal for useAllAmount", async () => {
+      const mockApi = setupTokenMocks({
+        transferFeeConfig: {
+          newerTransferFee: { epoch: 50, maximumFee: 1000000, transferFeeBasisPoints: 100 },
+          olderTransferFee: { epoch: 0, maximumFee: 500000, transferFeeBasisPoints: 50 },
+        },
+        currentEpoch: 100,
+      });
+
+      await craftTransaction(mockApi, {
+        intentType: "transaction",
+        type: "send",
+        sender: TEST_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        amount: 500n,
+        useAllAmount: true,
+        asset: { type: "spl-token-2022", assetReference: CWIF_MINT, assetOwner: TEST_ADDRESS },
+      });
+
+      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+        mockApi,
+        expect.objectContaining({
+          extensions: expect.objectContaining({
+            transferFee: expect.objectContaining({
+              transferAmountIncludingFee: 500,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should cap transfer fee at maximumFee for send-all", async () => {
+      const mockApi = setupTokenMocks({
+        transferFeeConfig: {
+          newerTransferFee: { epoch: 50, maximumFee: 2, transferFeeBasisPoints: 5000 },
+          olderTransferFee: { epoch: 0, maximumFee: 1, transferFeeBasisPoints: 5000 },
+        },
+        currentEpoch: 100,
+      });
+
+      await craftTransaction(mockApi, {
+        intentType: "transaction",
+        type: "send",
+        sender: TEST_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        amount: 1000n,
+        useAllAmount: true,
+        asset: { type: "spl-token-2022", assetReference: CWIF_MINT, assetOwner: TEST_ADDRESS },
+      });
+
+      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+        mockApi,
+        expect.objectContaining({
+          extensions: expect.objectContaining({
+            transferFee: expect.objectContaining({
+              transferFee: 2,
+              transferAmountIncludingFee: 1000,
+              transferAmountExcludingFee: 998,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should use olderTransferFee when currentEpoch < newerTransferFee.epoch", async () => {
+      const mockApi = setupTokenMocks({
+        transferFeeConfig: {
+          newerTransferFee: { epoch: 200, maximumFee: 1000000, transferFeeBasisPoints: 500 },
+          olderTransferFee: { epoch: 0, maximumFee: 1000000, transferFeeBasisPoints: 100 },
+        },
+        currentEpoch: 100,
+      });
+
+      await craftTransaction(mockApi, {
+        intentType: "transaction",
+        type: "send",
+        sender: TEST_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        amount: 10000n,
+        useAllAmount: true,
+        asset: { type: "spl-token-2022", assetReference: CWIF_MINT, assetOwner: TEST_ADDRESS },
+      });
+
+      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+        mockApi,
+        expect.objectContaining({
+          extensions: expect.objectContaining({
+            transferFee: expect.objectContaining({
+              feeBps: 100,
+              transferAmountIncludingFee: 10000,
+              transferFee: 100,
+              transferAmountExcludingFee: 9900,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should create ATA when recipient does not have one", async () => {
+      const mockApi = setupTokenMocks({
+        recipientAtaExists: false,
+      });
+
+      await craftTransaction(mockApi, {
+        intentType: "transaction",
+        type: "send",
+        sender: TEST_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        amount: 1000n,
+        asset: { type: "spl-token-2022", assetReference: CWIF_MINT, assetOwner: TEST_ADDRESS },
+      });
+
+      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+        mockApi,
+        expect.objectContaining({
+          recipientDescriptor: expect.objectContaining({
+            shouldCreateAsAssociatedTokenAccount: true,
+          }),
+        }),
+      );
+    });
   });
 });
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.test.ts
@@ -26,6 +26,20 @@ function stubFeeEstimation(fee = 5000) {
     }),
     getRecentPrioritizationFees: () => [],
     getMinimumBalanceForRentExemption: () => 2039280,
+    getAccountInfo: () => ({
+      context: { slot: 100 },
+      value: {
+        data: [
+          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+          "base64",
+        ],
+        executable: false,
+        lamports: 1_000_000,
+        owner: "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+        rentEpoch: 0,
+        space: 82,
+      },
+    }),
   });
 }
 
@@ -54,7 +68,7 @@ describe("estimateFees (MSW integration)", () => {
         recipient: TEST_RECIPIENT,
         amount: 1_000_000n,
         asset: { type: "native" },
-      } as any),
+      }),
     ).rejects.toThrow("Unsupported intent type: staking");
   });
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.unit.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type { TransactionIntent } from "@ledgerhq/coin-framework/api/index";
 import type { ChainAPI } from "../../network";
 import { estimateFees, estimateTxFee } from "../estimateFees";
@@ -80,6 +81,52 @@ describe("estimateFees", () => {
     expect(tx.model.kind).toBe("token.transfer");
   });
 
+  it("should use spl-token program for standard SPL token intents", async () => {
+    const api = createMockApi([5000]);
+    setupBuildMock();
+
+    await estimateFees(api, {
+      intentType: "transaction",
+      type: "send",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      amount: 1000000n,
+      asset: { type: "spl-token", assetReference: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+    } as TransactionIntent);
+
+    const tx = buildVersionedTransaction.mock.calls[0][1];
+    const command = tx.model.commandDescriptor.command;
+    expect(command.tokenProgram).toBe("spl-token");
+    expect(command.extensions).toBeUndefined();
+  });
+
+  it("should use spl-token-2022 program and include dummy extensions for Token-2022 intents", async () => {
+    const api = createMockApi([5000]);
+    setupBuildMock();
+
+    await estimateFees(api, {
+      intentType: "transaction",
+      type: "send",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      amount: 1000000n,
+      asset: { type: "spl-token-2022", assetReference: "SomeMintAddress" },
+    } as TransactionIntent);
+
+    const tx = buildVersionedTransaction.mock.calls[0][1];
+    const command = tx.model.commandDescriptor.command;
+    expect(command.tokenProgram).toBe("spl-token-2022");
+    expect(command.extensions).not.toBeUndefined();
+    expect(command.extensions.transferFee).toEqual({
+      feePercent: 0,
+      maxTransferFee: 0,
+      transferFee: 0,
+      feeBps: 0,
+      transferAmountIncludingFee: 0,
+      transferAmountExcludingFee: 0,
+    });
+  });
+
   it("should propagate errors from estimateTxFee", async () => {
     buildVersionedTransaction.mockRejectedValueOnce(new Error("RPC error"));
 
@@ -106,7 +153,7 @@ describe("estimateFees", () => {
         recipient: TEST_RECIPIENT,
         amount: 1000000n,
         asset: { type: "native" },
-      } as any),
+      } as unknown as TransactionIntent),
     ).rejects.toThrow("Unsupported intent type: staking");
   });
 });

--- a/libs/coin-modules/coin-solana/src/logic/tests/getBalance.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getBalance.integ.test.ts
@@ -26,6 +26,7 @@ describe("getBalance (integration)", () => {
         "assetReference",
         expect.stringMatching(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/),
       );
+      expect(b.asset).toHaveProperty("assetOwner", FUNDED_ADDRESS);
       expect(b.value).toBeGreaterThanOrEqual(0n);
     }
   });

--- a/libs/coin-modules/coin-solana/src/logic/tests/getBalance.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getBalance.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { PublicKey } from "@solana/web3.js";
 import { getBalance } from "../getBalance";
 import { server, rpcHandler, createTestChainApi } from "../tests/helpers/msw-rpc.mock";
 
@@ -74,7 +75,7 @@ describe("getBalance (MSW integration)", () => {
 
     function splTokenAccount(mint: string, amount: string) {
       return {
-        pubkey: "AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ",
+        pubkey: new PublicKey("AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ"),
         account: {
           data: {
             parsed: {
@@ -90,7 +91,7 @@ describe("getBalance (MSW integration)", () => {
           },
           executable: false,
           lamports: 2039280,
-          owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          owner: new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
           rentEpoch: 0,
         },
       };
@@ -124,7 +125,7 @@ describe("getBalance (MSW integration)", () => {
       });
       expect(result[1]).toEqual({
         value: 5_000_000n,
-        asset: { type: "spl-token", assetReference: USDC_MINT },
+        asset: { type: "spl-token", assetReference: USDC_MINT, assetOwner: TEST_ADDRESS },
       });
     });
   });
@@ -134,7 +135,7 @@ describe("getBalance (MSW integration)", () => {
 
     function token2022Account(mint: string, amount: string) {
       return {
-        pubkey: "FvbvvXMY4Rf1AtGG7UHJUesjt8FFgPnPy6o83Dna9mXK",
+        pubkey: new PublicKey("FvbvvXMY4Rf1AtGG7UHJUesjt8FFgPnPy6o83Dna9mXK"),
         account: {
           data: {
             parsed: {
@@ -150,7 +151,7 @@ describe("getBalance (MSW integration)", () => {
           },
           executable: false,
           lamports: 2039280,
-          owner: "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+          owner: new PublicKey("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"),
           rentEpoch: 0,
         },
       };
@@ -184,7 +185,7 @@ describe("getBalance (MSW integration)", () => {
       });
       expect(result[1]).toEqual({
         value: 10_000_000n,
-        asset: { type: "spl-token-2022", assetReference: PYUSD_MINT },
+        asset: { type: "spl-token-2022", assetReference: PYUSD_MINT, assetOwner: TEST_ADDRESS },
       });
     });
   });

--- a/libs/coin-modules/coin-solana/src/logic/tests/getBalance.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getBalance.unit.test.ts
@@ -66,7 +66,7 @@ describe("getBalance", () => {
     expect(result).toHaveLength(2);
     expect(result[1]).toEqual({
       value: 5_000_000n,
-      asset: { type: "spl-token", assetReference: USDC_MINT },
+      asset: { type: "spl-token", assetReference: USDC_MINT, assetOwner: TEST_ADDRESS },
     });
     expect(mockGetParsedToken2022AccountsByOwner).not.toHaveBeenCalled();
   });
@@ -98,7 +98,7 @@ describe("getBalance", () => {
     expect(result).toHaveLength(2);
     expect(result[1]).toEqual({
       value: 10_000_000n,
-      asset: { type: "spl-token-2022", assetReference: PYUSD_MINT },
+      asset: { type: "spl-token-2022", assetReference: PYUSD_MINT, assetOwner: TEST_ADDRESS },
     });
     expect(mockGetParsedToken2022AccountsByOwner).toHaveBeenCalledWith(TEST_ADDRESS);
   });
@@ -127,7 +127,7 @@ describe("getBalance", () => {
     expect(result).toHaveLength(2);
     expect(result[1]).toEqual({
       value: 10_000_000n,
-      asset: { type: "spl-token", assetReference: USDC_MINT },
+      asset: { type: "spl-token", assetReference: USDC_MINT, assetOwner: TEST_ADDRESS },
     });
   });
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/helpers/msw-rpc.mock.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/helpers/msw-rpc.mock.ts
@@ -1,17 +1,62 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import type { BlockhashWithExpiryBlockHeight, TransactionSignature } from "@solana/web3.js";
+import type {
+  BlockhashWithExpiryBlockHeight,
+  Connection,
+  TransactionSignature,
+} from "@solana/web3.js";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { getChainAPI, type ChainAPI } from "../../../network";
 
 export const TEST_ENDPOINT = "https://test-solana-rpc.example.com";
 
-type RpcMethodHandler = (params: unknown[]) => unknown;
+/**
+ * Maps Solana JSON-RPC method names to the {@link Connection} method whose return
+ * type matches the raw RPC `result` shape.
+ *
+ * When `Connection` unwraps the `{ context, value }` envelope (e.g. `getBalance`),
+ * the `*AndContext` variant is used instead (e.g. `getBalanceAndContext`).
+ * When the RPC name differs from the Connection name (e.g. `getTransaction` vs
+ * `getParsedTransaction`), the mapping makes the correspondence explicit.
+ *
+ * All handlers must return fully-typed data matching the Connection return type
+ * (the SDK validates responses at runtime via Superstruct).
+ */
+type RpcToConnection = {
+  getSignaturesForAddress: "getSignaturesForAddress";
+  getTransaction: "getParsedTransaction";
+  getBalance: "getBalanceAndContext";
+  getLatestBlockhash: "getLatestBlockhashAndContext";
+  getFeeForMessage: "getFeeForMessage";
+  getTokenAccountsByOwner: "getParsedTokenAccountsByOwner";
+  simulateTransaction: "simulateTransaction";
+  getBlockTime: "getBlockTime";
+  getBlockHeight: "getBlockHeight";
+  sendTransaction: "sendTransaction";
+  getMinimumBalanceForRentExemption: "getMinimumBalanceForRentExemption";
+  getRecentPrioritizationFees: "getRecentPrioritizationFees";
+  getSlot: "getSlot";
+};
+
+type ConnectionResult<M extends keyof Connection> = Connection[M] extends (
+  ...args: never[]
+) => Promise<infer R>
+  ? R
+  : never;
+
+type RpcMethodHandlers = Partial<
+  {
+    [K in keyof RpcToConnection]: (params: unknown[]) => ConnectionResult<RpcToConnection[K]>;
+  } & {
+    // Raw RPC encoding (string[] for base64 / parsed object) doesn't map to Connection's Buffer | ParsedAccountData
+    getAccountInfo: (params: unknown[]) => { context: { slot: number }; value: unknown };
+  }
+>;
 
 type RpcRequest = { method: string; params: unknown[]; id: string | number | null };
 
 function invokeHandler(
-  handler: RpcMethodHandler | undefined,
+  handler: ((params: unknown[]) => unknown) | undefined,
   method: string,
   params: unknown[],
   id: string | number | null,
@@ -35,18 +80,19 @@ function invokeHandler(
   }
 }
 
-export function rpcHandler(methodHandlers: Record<string, RpcMethodHandler>) {
+export function rpcHandler(methodHandlers: RpcMethodHandlers) {
+  const handlers = methodHandlers as Record<string, (params: unknown[]) => unknown>;
   return http.post(TEST_ENDPOINT, async ({ request }) => {
     const body = (await request.json()) as RpcRequest | RpcRequest[];
 
     if (Array.isArray(body)) {
       return HttpResponse.json(
-        body.map(req => invokeHandler(methodHandlers[req.method], req.method, req.params, req.id)),
+        body.map(req => invokeHandler(handlers[req.method], req.method, req.params, req.id)),
       );
     }
 
     return HttpResponse.json(
-      invokeHandler(methodHandlers[body.method], body.method, body.params, body.id),
+      invokeHandler(handlers[body.method], body.method, body.params, body.id),
     );
   });
 }

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.integ.test.ts
@@ -1,0 +1,72 @@
+import { Keypair } from "@solana/web3.js";
+import { getChainAPI } from "../../network";
+import { listOperations } from "../listOperations";
+
+const api = getChainAPI({ endpoint: "https://solana.coin.ledger.com" });
+
+const ACTIVE_ADDRESS = "7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE";
+const UNUSED_ADDRESS = Keypair.generate().publicKey.toBase58();
+
+describe("listOperations (integration)", () => {
+  it("fetches operations for an active account", async () => {
+    const result = await listOperations(api, ACTIVE_ADDRESS, {
+      minHeight: 0,
+      order: "desc",
+      limit: 5,
+    });
+
+    expect(result.items.length).toBeGreaterThan(0);
+
+    for (const op of result.items) {
+      expect(op.tx.hash.length).toBeGreaterThan(0);
+      expect(op.tx.block.height).toBeGreaterThan(0);
+      expect(op.tx.block.time).toBeInstanceOf(Date);
+      expect(typeof op.value).toBe("bigint");
+      expect(["IN", "OUT", "FEES", "NONE"]).toContain(op.type);
+    }
+  });
+
+  it("returns pagination cursor when more results are available", async () => {
+    const result = await listOperations(api, ACTIVE_ADDRESS, {
+      minHeight: 0,
+      order: "desc",
+      limit: 2,
+    });
+
+    expect(result.items.length).toBeGreaterThan(0);
+    expect(typeof result.next).toBe("string");
+  });
+
+  it("returns empty list for an unused address", async () => {
+    const result = await listOperations(api, UNUSED_ADDRESS, {
+      minHeight: 0,
+      order: "desc",
+    });
+
+    expect(result.items).toEqual([]);
+    expect(result.next).toBeUndefined();
+  });
+
+  it("supports cursor-based pagination", async () => {
+    const page1 = await listOperations(api, ACTIVE_ADDRESS, {
+      minHeight: 0,
+      order: "desc",
+      limit: 2,
+    });
+
+    expect(typeof page1.next).toBe("string");
+
+    const page2 = await listOperations(api, ACTIVE_ADDRESS, {
+      minHeight: 0,
+      order: "desc",
+      limit: 2,
+      cursor: page1.next ?? "",
+    });
+
+    expect(page2.items.length).toBeGreaterThan(0);
+    const page1Hashes = new Set(page1.items.map(op => op.tx.hash));
+    for (const op of page2.items) {
+      expect(page1Hashes.has(op.tx.hash)).toBe(false);
+    }
+  });
+});

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
@@ -1,0 +1,460 @@
+import { PublicKey } from "@solana/web3.js";
+import { listOperations } from "../listOperations";
+import { server, rpcHandler, createTestChainApi } from "./helpers/msw-rpc.mock";
+
+const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
+const TEST_RECIPIENT = "AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ";
+const TEST_BLOCKHASH = "EEbZs6DmDyDjucyYbo3LwVJU7pQYuVopYcYTSEZXskW3";
+
+const api = createTestChainApi();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function makeParsedTx({
+  accountKeys,
+  fee = 5000,
+  preBalances,
+  postBalances,
+  slot = 100,
+  blockTime = 1700000000,
+  err = null,
+}: {
+  accountKeys: { pubkey: string; signer: boolean; writable: boolean }[];
+  fee?: number;
+  preBalances: number[];
+  postBalances: number[];
+  slot?: number;
+  blockTime?: number;
+  err?: null | { InstructionError: [number, string] } | string;
+}) {
+  return {
+    transaction: {
+      signatures: ["sig-placeholder"],
+      message: {
+        accountKeys: accountKeys.map(k => ({ ...k, pubkey: new PublicKey(k.pubkey) })),
+        recentBlockhash: TEST_BLOCKHASH,
+        instructions: [],
+      },
+    },
+    meta: {
+      fee,
+      preBalances,
+      postBalances,
+      preTokenBalances: [],
+      postTokenBalances: [],
+      err,
+    },
+    slot,
+    blockTime,
+    version: "legacy" as const,
+  };
+}
+
+describe("listOperations (MSW integration)", () => {
+  it("should return empty page when no signatures found", async () => {
+    server.use(
+      rpcHandler({
+        getSignaturesForAddress: () => [],
+      }),
+    );
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toEqual([]);
+    expect(result.next).toBeUndefined();
+  });
+
+  it("should parse an OUT operation from RPC data", async () => {
+    const blockTime = 1700000000;
+    server.use(
+      rpcHandler({
+        getSignaturesForAddress: () => [
+          {
+            signature: "sig1",
+            slot: 100,
+            blockTime,
+            err: null,
+            memo: null,
+            confirmationStatus: "finalized",
+          },
+        ],
+        getTransaction: () =>
+          makeParsedTx({
+            accountKeys: [
+              { pubkey: TEST_ADDRESS, signer: true, writable: true },
+              { pubkey: TEST_RECIPIENT, signer: false, writable: true },
+            ],
+            preBalances: [1_000_000_000, 0],
+            postBalances: [899_995_000, 100_000_000],
+            slot: 100,
+            blockTime,
+          }),
+      }),
+    );
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    const op = result.items[0];
+    expect(op.type).toBe("OUT");
+    expect(op.value).toBe(100_000_000n);
+    expect(op.senders).toEqual([TEST_ADDRESS]);
+    expect(op.recipients).toEqual([TEST_RECIPIENT]);
+    expect(op.tx.hash).toBe("sig1");
+    expect(op.tx.fees).toBe(5000n);
+    expect(op.tx.block.height).toBe(100);
+    expect(op.tx.failed).toBe(false);
+  });
+
+  it("should filter by minHeight", async () => {
+    const blockTime = 1700000000;
+    server.use(
+      rpcHandler({
+        getSignaturesForAddress: () => [
+          {
+            signature: "sig-low",
+            slot: 50,
+            blockTime,
+            err: null,
+            memo: null,
+            confirmationStatus: "finalized",
+          },
+          {
+            signature: "sig-high",
+            slot: 200,
+            blockTime,
+            err: null,
+            memo: null,
+            confirmationStatus: "finalized",
+          },
+        ],
+        getTransaction: () =>
+          makeParsedTx({
+            accountKeys: [{ pubkey: TEST_ADDRESS, signer: true, writable: true }],
+            preBalances: [1_000_000],
+            postBalances: [995_000],
+            blockTime,
+          }),
+      }),
+    );
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 100, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].tx.block.height).toBe(200);
+  });
+
+  it("should throw when order is asc", async () => {
+    await expect(listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "asc" })).rejects.toThrow(
+      "ascending order is not supported",
+    );
+  });
+
+  describe("SPL Token operations", () => {
+    const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+
+    it("should return an OUT token operation when sender's token balance decreases", async () => {
+      const blockTime = 1700000000;
+      server.use(
+        rpcHandler({
+          getSignaturesForAddress: () => [
+            {
+              signature: "sig-token-out",
+              slot: 200,
+              blockTime,
+              err: null,
+              memo: null,
+              confirmationStatus: "finalized",
+            },
+          ],
+          getTransaction: () => ({
+            ...makeParsedTx({
+              accountKeys: [
+                { pubkey: TEST_ADDRESS, signer: true, writable: true },
+                { pubkey: TEST_RECIPIENT, signer: false, writable: true },
+              ],
+              preBalances: [1_000_000_000, 2039280],
+              postBalances: [999_995_000, 2039280],
+              blockTime,
+            }),
+            meta: {
+              fee: 5000,
+              preBalances: [1_000_000_000, 2039280],
+              postBalances: [999_995_000, 2039280],
+              err: null,
+              preTokenBalances: [
+                {
+                  accountIndex: 0,
+                  mint: USDC_MINT,
+                  owner: TEST_ADDRESS,
+                  programId: TOKEN_PROGRAM_ID,
+                  uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
+                },
+              ],
+              postTokenBalances: [
+                {
+                  accountIndex: 0,
+                  mint: USDC_MINT,
+                  owner: TEST_ADDRESS,
+                  programId: TOKEN_PROGRAM_ID,
+                  uiTokenAmount: { amount: "3000000", decimals: 6, uiAmount: 3.0 },
+                },
+                {
+                  accountIndex: 1,
+                  mint: USDC_MINT,
+                  owner: TEST_RECIPIENT,
+                  programId: TOKEN_PROGRAM_ID,
+                  uiTokenAmount: { amount: "2000000", decimals: 6, uiAmount: 2.0 },
+                },
+              ],
+            },
+          }),
+        }),
+      );
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(1);
+
+      const op = tokenOps[0];
+      expect(op.type).toBe("OUT");
+      expect(op.value).toBe(2_000_000n);
+      expect(op.senders).toEqual([TEST_ADDRESS]);
+      expect(op.recipients).toEqual([TEST_RECIPIENT]);
+      expect(op.asset).toEqual({
+        type: "spl-token",
+        assetReference: USDC_MINT,
+        assetOwner: TEST_ADDRESS,
+      });
+      expect(op.tx.hash).toBe("sig-token-out");
+      expect(op.details).toEqual({
+        ledgerOpType: "OUT",
+        assetAmount: "2000000",
+        assetSenders: [TEST_ADDRESS],
+        assetRecipients: [TEST_RECIPIENT],
+        internal: true,
+      });
+    });
+
+    it("should return an IN token operation when recipient's token balance increases", async () => {
+      const blockTime = 1700000000;
+      server.use(
+        rpcHandler({
+          getSignaturesForAddress: () => [
+            {
+              signature: "sig-token-in",
+              slot: 200,
+              blockTime,
+              err: null,
+              memo: null,
+              confirmationStatus: "finalized",
+            },
+          ],
+          getTransaction: () => ({
+            ...makeParsedTx({
+              accountKeys: [
+                { pubkey: TEST_RECIPIENT, signer: true, writable: true },
+                { pubkey: TEST_ADDRESS, signer: false, writable: true },
+              ],
+              preBalances: [1_000_000_000, 500_000_000],
+              postBalances: [999_995_000, 500_000_000],
+              blockTime,
+            }),
+            meta: {
+              fee: 5000,
+              preBalances: [1_000_000_000, 500_000_000],
+              postBalances: [999_995_000, 500_000_000],
+              err: null,
+              preTokenBalances: [
+                {
+                  accountIndex: 1,
+                  mint: USDC_MINT,
+                  owner: TEST_ADDRESS,
+                  programId: TOKEN_PROGRAM_ID,
+                  uiTokenAmount: { amount: "1000000", decimals: 6, uiAmount: 1.0 },
+                },
+              ],
+              postTokenBalances: [
+                {
+                  accountIndex: 1,
+                  mint: USDC_MINT,
+                  owner: TEST_ADDRESS,
+                  programId: TOKEN_PROGRAM_ID,
+                  uiTokenAmount: { amount: "4000000", decimals: 6, uiAmount: 4.0 },
+                },
+                {
+                  accountIndex: 0,
+                  mint: USDC_MINT,
+                  owner: TEST_RECIPIENT,
+                  programId: TOKEN_PROGRAM_ID,
+                  uiTokenAmount: { amount: "6000000", decimals: 6, uiAmount: 6.0 },
+                },
+              ],
+            },
+          }),
+        }),
+      );
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(1);
+
+      const op = tokenOps[0];
+      expect(op.type).toBe("IN");
+      expect(op.value).toBe(3_000_000n);
+      expect(op.recipients).toEqual([TEST_ADDRESS]);
+      expect(op.senders).toEqual([TEST_RECIPIENT]);
+      expect(op.asset).toEqual({
+        type: "spl-token",
+        assetReference: USDC_MINT,
+        assetOwner: TEST_ADDRESS,
+      });
+      expect(op.details).toEqual({
+        ledgerOpType: "IN",
+        assetAmount: "3000000",
+        assetSenders: [TEST_RECIPIENT],
+        assetRecipients: [TEST_ADDRESS],
+        internal: true,
+      });
+    });
+  });
+
+  describe("Token-2022 operations", () => {
+    const PYUSD_MINT = "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo";
+    const TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+
+    it("should return an OUT Token-2022 operation", async () => {
+      const blockTime = 1700000000;
+      server.use(
+        rpcHandler({
+          getSignaturesForAddress: () => [
+            {
+              signature: "sig-t22-out",
+              slot: 300,
+              blockTime,
+              err: null,
+              memo: null,
+              confirmationStatus: "finalized",
+            },
+          ],
+          getTransaction: () => ({
+            ...makeParsedTx({
+              accountKeys: [
+                { pubkey: TEST_ADDRESS, signer: true, writable: true },
+                { pubkey: TEST_RECIPIENT, signer: false, writable: true },
+              ],
+              preBalances: [1_000_000_000, 2039280],
+              postBalances: [999_995_000, 2039280],
+              blockTime,
+            }),
+            meta: {
+              fee: 5000,
+              preBalances: [1_000_000_000, 2039280],
+              postBalances: [999_995_000, 2039280],
+              err: null,
+              preTokenBalances: [
+                {
+                  accountIndex: 0,
+                  mint: PYUSD_MINT,
+                  owner: TEST_ADDRESS,
+                  programId: TOKEN_2022_PROGRAM_ID,
+                  uiTokenAmount: { amount: "10000000", decimals: 6, uiAmount: 10.0 },
+                },
+              ],
+              postTokenBalances: [
+                {
+                  accountIndex: 0,
+                  mint: PYUSD_MINT,
+                  owner: TEST_ADDRESS,
+                  programId: TOKEN_2022_PROGRAM_ID,
+                  uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
+                },
+                {
+                  accountIndex: 1,
+                  mint: PYUSD_MINT,
+                  owner: TEST_RECIPIENT,
+                  programId: TOKEN_2022_PROGRAM_ID,
+                  uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
+                },
+              ],
+            },
+          }),
+        }),
+      );
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(1);
+
+      const op = tokenOps[0];
+      expect(op.type).toBe("OUT");
+      expect(op.value).toBe(5_000_000n);
+      expect(op.asset).toEqual({
+        type: "spl-token-2022",
+        assetReference: PYUSD_MINT,
+        assetOwner: TEST_ADDRESS,
+      });
+    });
+
+    it("should return an IN Token-2022 operation", async () => {
+      const blockTime = 1700000000;
+      server.use(
+        rpcHandler({
+          getSignaturesForAddress: () => [
+            {
+              signature: "sig-t22-in",
+              slot: 300,
+              blockTime,
+              err: null,
+              memo: null,
+              confirmationStatus: "finalized",
+            },
+          ],
+          getTransaction: () => ({
+            ...makeParsedTx({
+              accountKeys: [
+                { pubkey: TEST_RECIPIENT, signer: true, writable: true },
+                { pubkey: TEST_ADDRESS, signer: false, writable: true },
+              ],
+              preBalances: [1_000_000_000, 500_000_000],
+              postBalances: [999_995_000, 500_000_000],
+              blockTime,
+            }),
+            meta: {
+              fee: 5000,
+              preBalances: [1_000_000_000, 500_000_000],
+              postBalances: [999_995_000, 500_000_000],
+              err: null,
+              preTokenBalances: [],
+              postTokenBalances: [
+                {
+                  accountIndex: 1,
+                  mint: PYUSD_MINT,
+                  owner: TEST_ADDRESS,
+                  programId: TOKEN_2022_PROGRAM_ID,
+                  uiTokenAmount: { amount: "8000000", decimals: 6, uiAmount: 8.0 },
+                },
+              ],
+            },
+          }),
+        }),
+      );
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(1);
+
+      const op = tokenOps[0];
+      expect(op.type).toBe("IN");
+      expect(op.value).toBe(8_000_000n);
+      expect(op.recipients).toEqual([TEST_ADDRESS]);
+    });
+  });
+});

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
@@ -1,0 +1,836 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import type { DeepPartialReturn } from "@ledgerhq/coin-framework/test/utils";
+import { PublicKey } from "@solana/web3.js";
+import type { ChainAPI } from "../../network";
+import { listOperations } from "../listOperations";
+
+const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
+const TEST_RECIPIENT = "AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ";
+const TEST_BLOCKHASH = "EEbZs6DmDyDjucyYbo3LwVJU7pQYuVopYcYTSEZXskW3";
+
+describe("listOperations", () => {
+  const mockGetSignaturesForAddress = jest.fn() as jest.MockedFunction<
+    DeepPartialReturn<ChainAPI["getSignaturesForAddress"]>
+  >;
+  const mockGetParsedTransactions = jest.fn() as jest.MockedFunction<
+    DeepPartialReturn<ChainAPI["getParsedTransactions"]>
+  >;
+
+  const api = {
+    getSignaturesForAddress: mockGetSignaturesForAddress,
+    getParsedTransactions: mockGetParsedTransactions,
+  } as unknown as ChainAPI;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return empty list when no signatures found", async () => {
+    mockGetSignaturesForAddress.mockResolvedValue([]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toEqual([]);
+    expect(result.next).toBeUndefined();
+  });
+
+  it("should return OUT operations from parsed transactions", async () => {
+    const blockTime = 1700000000;
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [
+              { pubkey: new PublicKey(TEST_ADDRESS) },
+              { pubkey: new PublicKey(TEST_RECIPIENT) },
+            ],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: {
+          fee: 5000,
+          preBalances: [1_000_000_000, 0],
+          postBalances: [899_995_000, 100_000_000],
+        },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toEqual({
+      id: `${TEST_ADDRESS}-sig1-OUT-0`,
+      type: "OUT",
+      value: 100_000_000n,
+      asset: { type: "native" },
+      senders: [TEST_ADDRESS],
+      recipients: [TEST_RECIPIENT],
+      tx: {
+        hash: "sig1",
+        block: {
+          height: 100,
+          hash: "",
+          time: new Date(blockTime * 1000),
+        },
+        fees: 5000n,
+        feesPayer: TEST_ADDRESS,
+        date: new Date(blockTime * 1000),
+        failed: false,
+      },
+    });
+  });
+
+  it("should detect IN operations", async () => {
+    const blockTime = 1700000000;
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [
+              { pubkey: new PublicKey(TEST_RECIPIENT) },
+              { pubkey: new PublicKey(TEST_ADDRESS) },
+            ],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: {
+          fee: 5000,
+          preBalances: [1_000_000_000, 0],
+          postBalances: [899_995_000, 100_000_000],
+        },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].type).toBe("IN");
+    expect(result.items[0].value).toBe(BigInt(100_000_000));
+    expect(result.items[0].senders).toEqual([TEST_RECIPIENT]);
+    expect(result.items[0].recipients).toEqual([TEST_ADDRESS]);
+  });
+
+  it("should detect FEES operations when fee payer has zero net change", async () => {
+    const blockTime = 1700000000;
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: {
+          fee: 5000,
+          preBalances: [1_000_000_000],
+          postBalances: [999_995_000],
+        },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].type).toBe("FEES");
+    expect(result.items[0].value).toBe(5000n);
+  });
+
+  it("should pass cursor as before parameter", async () => {
+    mockGetSignaturesForAddress.mockResolvedValue([]);
+
+    await listOperations(api, TEST_ADDRESS, {
+      minHeight: 0,
+      cursor: "prev-sig-hash",
+      order: "desc",
+    });
+
+    expect(mockGetSignaturesForAddress).toHaveBeenCalledWith(TEST_ADDRESS, {
+      limit: 100,
+      before: "prev-sig-hash",
+    });
+  });
+
+  it("should set next cursor when result count equals limit", async () => {
+    const blockTime = 1700000000;
+    const sigs = Array.from({ length: 100 }, (_, i) => ({
+      signature: `sig-${i}`,
+      slot: 200 - i,
+      blockTime,
+      err: null,
+    }));
+    mockGetSignaturesForAddress.mockResolvedValue(sigs);
+
+    const txs = sigs.map(() => ({
+      transaction: {
+        message: {
+          accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+          recentBlockhash: TEST_BLOCKHASH,
+        },
+      },
+      meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
+    }));
+    mockGetParsedTransactions.mockResolvedValue(txs);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.next).toBe("sig-99");
+  });
+
+  it("should not set next cursor when result count is less than limit", async () => {
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime: 1700000000, err: null },
+    ]);
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.next).toBeUndefined();
+  });
+
+  it("should filter by minHeight", async () => {
+    const blockTime = 1700000000;
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig-low", slot: 50, blockTime, err: null },
+      { signature: "sig-high", slot: 200, blockTime, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
+      },
+      {
+        transaction: {
+          message: {
+            accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 100, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].tx.block.height).toBe(200);
+  });
+
+  it("should not set next cursor when all items are filtered by minHeight", async () => {
+    const blockTime = 1700000000;
+    const sigs = Array.from({ length: 100 }, (_, i) => ({
+      signature: `sig-${i}`,
+      slot: 10 + i,
+      blockTime,
+      err: null,
+    }));
+    mockGetSignaturesForAddress.mockResolvedValue(sigs);
+
+    const txs = sigs.map(() => ({
+      transaction: {
+        message: {
+          accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+          recentBlockhash: TEST_BLOCKHASH,
+        },
+      },
+      meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
+    }));
+    mockGetParsedTransactions.mockResolvedValue(txs);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 99999, order: "desc" });
+
+    expect(result.items).toHaveLength(0);
+    expect(result.next).toBeUndefined();
+  });
+
+  it("should mark failed transactions", async () => {
+    const blockTime = 1700000000;
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime, err: { InstructionError: [0, "Custom"] } },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].tx.failed).toBe(true);
+  });
+
+  it("should skip transactions with null meta", async () => {
+    const blockTime = 1700000000;
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime, err: null },
+      { signature: "sig2", slot: 101, blockTime, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      null,
+      {
+        transaction: {
+          message: {
+            accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].tx.hash).toBe("sig2");
+  });
+
+  it("should skip transactions where address is not in accountKeys", async () => {
+    const blockTime = 1700000000;
+    const OTHER_ADDRESS = "9ZNTfG4NyQgxy2SWjSiQoUyBPEvXT2xo7fKc5hPYYJ7b";
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [{ pubkey: new PublicKey(OTHER_ADDRESS) }],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(0);
+  });
+
+  it("should detect NONE type for non-fee-payer with zero balance delta", async () => {
+    const blockTime = 1700000000;
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [
+              { pubkey: new PublicKey(TEST_RECIPIENT) },
+              { pubkey: new PublicKey(TEST_ADDRESS) },
+            ],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: {
+          fee: 5000,
+          preBalances: [1_000_000_000, 500_000],
+          postBalances: [999_995_000, 500_000],
+        },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].type).toBe("NONE");
+    expect(result.items[0].value).toBe(0n);
+  });
+
+  it("should detect IN operation when fee payer receives funds (deltaWithoutFee > 0)", async () => {
+    const blockTime = 1700000000;
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [
+              { pubkey: new PublicKey(TEST_ADDRESS) },
+              { pubkey: new PublicKey(TEST_RECIPIENT) },
+            ],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: {
+          fee: 5000,
+          preBalances: [500_000_000, 600_000_000],
+          postBalances: [699_995_000, 400_000_000],
+        },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].type).toBe("IN");
+    expect(result.items[0].value).toBe(200_000_000n);
+    expect(result.items[0].recipients).toEqual([TEST_ADDRESS]);
+  });
+
+  it("should detect OUT operation for non-fee-payer with negative balance delta", async () => {
+    const blockTime = 1700000000;
+    const THIRD_ADDRESS = "9ZNTfG4NyQgxy2SWjSiQoUyBPEvXT2xo7fKc5hPYYJ7b";
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [
+              { pubkey: new PublicKey(THIRD_ADDRESS) },
+              { pubkey: new PublicKey(TEST_ADDRESS) },
+            ],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: {
+          fee: 5000,
+          preBalances: [500_000_000, 300_000_000],
+          postBalances: [699_995_000, 100_000_000],
+        },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].type).toBe("OUT");
+    expect(result.items[0].value).toBe(200_000_000n);
+    expect(result.items[0].senders).toEqual([TEST_ADDRESS]);
+  });
+
+  it("should handle no counterparty when all other accounts have zero balance delta", async () => {
+    const blockTime = 1700000000;
+    const OTHER = "9ZNTfG4NyQgxy2SWjSiQoUyBPEvXT2xo7fKc5hPYYJ7b";
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [
+              { pubkey: new PublicKey(TEST_ADDRESS) },
+              { pubkey: new PublicKey(OTHER) },
+            ],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: {
+          fee: 5000,
+          preBalances: [1_000_000_000, 500_000],
+          postBalances: [899_995_000, 500_000],
+        },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].type).toBe("OUT");
+    expect(result.items[0].senders).toEqual([TEST_ADDRESS]);
+    expect(result.items[0].recipients).toEqual([]);
+  });
+
+  it("should skip transactions with null blockTime", async () => {
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 100, blockTime: null, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          message: {
+            accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(0);
+  });
+
+  it("should propagate errors from getSignaturesForAddress", async () => {
+    mockGetSignaturesForAddress.mockRejectedValue(new Error("RPC error"));
+
+    await expect(
+      listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" }),
+    ).rejects.toThrow("RPC error");
+  });
+
+  it("should throw when order is asc", async () => {
+    await expect(listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "asc" })).rejects.toThrow(
+      "ascending order is not supported",
+    );
+  });
+
+  describe("token operations", () => {
+    const TOKEN_PROGRAM_ID_STR = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+    const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const BONK_MINT = "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263";
+
+    function makeTxWithTokenBalances(
+      preTokenBalances: object[],
+      postTokenBalances: object[],
+      accountKeys: string[] = [TEST_ADDRESS],
+    ) {
+      return {
+        transaction: {
+          message: {
+            accountKeys: accountKeys.map(k => ({ pubkey: new PublicKey(k) })),
+            recentBlockhash: TEST_BLOCKHASH,
+          },
+        },
+        meta: {
+          fee: 5000,
+          preBalances: accountKeys.map(() => 1_000_000),
+          postBalances: accountKeys.map(() => 1_000_000),
+          preTokenBalances,
+          postTokenBalances,
+        },
+      };
+    }
+
+    it("should detect a fully spent token (present in pre, absent from post)", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeTxWithTokenBalances(
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
+            },
+          ],
+          [],
+          [TEST_ADDRESS, TEST_RECIPIENT],
+        ),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(1);
+      expect(tokenOps[0].type).toBe("OUT");
+      expect(tokenOps[0].value).toBe(5_000_000n);
+    });
+
+    it("should skip tokens with zero delta", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeTxWithTokenBalances(
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
+            },
+          ],
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
+            },
+          ],
+        ),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(0);
+    });
+
+    it("should fall back to spl-token for unknown programId", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeTxWithTokenBalances(
+          [],
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: "UnknownProgramId111111111111111111111111111",
+              uiTokenAmount: { amount: "1000000", decimals: 6, uiAmount: 1.0 },
+            },
+          ],
+        ),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(1);
+      expect(tokenOps[0].asset).toEqual({
+        type: "spl-token",
+        assetReference: USDC_MINT,
+        assetOwner: TEST_ADDRESS,
+      });
+      expect(tokenOps[0].details).toEqual({
+        ledgerOpType: "IN",
+        assetAmount: "1000000",
+        assetSenders: [],
+        assetRecipients: [TEST_ADDRESS],
+        internal: true,
+      });
+    });
+
+    it("should fall back to accountKeys for counterparty when not in token balances", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeTxWithTokenBalances(
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
+            },
+          ],
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "3000000", decimals: 6, uiAmount: 3.0 },
+            },
+          ],
+          [TEST_ADDRESS, TEST_RECIPIENT],
+        ),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(1);
+      expect(tokenOps[0].type).toBe("OUT");
+      expect(tokenOps[0].recipients).toEqual([TEST_RECIPIENT]);
+    });
+
+    it("should handle token operation with no counterparty (single account)", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeTxWithTokenBalances(
+          [],
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "1000000", decimals: 6, uiAmount: 1.0 },
+            },
+          ],
+          [TEST_ADDRESS],
+        ),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(1);
+      expect(tokenOps[0].type).toBe("IN");
+      expect(tokenOps[0].senders).toEqual([]);
+      expect(tokenOps[0].recipients).toEqual([TEST_ADDRESS]);
+    });
+
+    it("should handle multiple token changes in a single transaction", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeTxWithTokenBalances(
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
+            },
+          ],
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "3000000", decimals: 6, uiAmount: 3.0 },
+            },
+            {
+              accountIndex: 0,
+              mint: BONK_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "9000000", decimals: 5, uiAmount: 90.0 },
+            },
+          ],
+        ),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(2);
+
+      const usdcOp = tokenOps.find(
+        op => (op.asset as { assetReference?: string }).assetReference === USDC_MINT,
+      )!;
+      expect(usdcOp.type).toBe("OUT");
+      expect(usdcOp.value).toBe(2_000_000n);
+
+      const bonkOp = tokenOps.find(
+        op => (op.asset as { assetReference?: string }).assetReference === BONK_MINT,
+      )!;
+      expect(bonkOp.type).toBe("IN");
+      expect(bonkOp.value).toBe(9_000_000n);
+    });
+
+    it("should find counterparty in postTokenBalances when absent from preTokenBalances (new ATA)", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeTxWithTokenBalances(
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
+            },
+          ],
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "3000000", decimals: 6, uiAmount: 3.0 },
+            },
+            {
+              accountIndex: 1,
+              mint: USDC_MINT,
+              owner: TEST_RECIPIENT,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "2000000", decimals: 6, uiAmount: 2.0 },
+            },
+          ],
+          [TEST_ADDRESS, TEST_RECIPIENT],
+        ),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(1);
+      expect(tokenOps[0].type).toBe("OUT");
+      expect(tokenOps[0].recipients).toEqual([TEST_RECIPIENT]);
+    });
+
+    it("should include internal: true in token operation details", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeTxWithTokenBalances(
+          [],
+          [
+            {
+              accountIndex: 0,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "1000000", decimals: 6, uiAmount: 1.0 },
+            },
+          ],
+          [TEST_ADDRESS],
+        ),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(1);
+      expect(tokenOps[0].details).toEqual(expect.objectContaining({ internal: true }));
+    });
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.**
- [X] **Impact of the changes:** : None
- [x] Comprehensive unit + MSW integration tests for all new/changed logic (~1700 lines of new tests)
- [x] Integration tests against live Solana RPC
- [x] Typecheck passes

### 📝 Description

Implement `listOperations` for the coin-solana Alpaca API, and add Token-2022 transfer fee support to `craftTransaction` / `estimateFees`.
- **`listOperations`**: Parses on-chain history from RPC (native SOL + SPL/Token-2022) with cursor-based pagination, minHeight filtering, and counterparty detection. Token ops are flagged `internal: true` to avoid duplicate parent-account entries.
- **`craftTransaction`**: Handles Token-2022 `transferFeeConfig` extension (normal send and send-all with epoch-based fee schedule).
- **`estimateFees`**: Resolves token program from intent asset to pick the right instruction variant for Token-2022.
- **`getBalance`**: Adds `assetOwner` to token balances for sub-account matching in listOperations.
- **Test infra**: Strongly-typed MSW RPC mock handlers + new `DeepPartialReturn` utility type in coin-framework.


### ❓ Context

- **JIRA or GitHub link**: LIVE-18682

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
