### PR TITLE
[LWDM] fix: firmware now returns 6e01 as invalid CLA when in bootloader mode

### DIFF
--- a/libs/ledger-live-common/src/hw/getDeviceInfo.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceInfo.ts
@@ -25,7 +25,7 @@ export default async function (transport: Transport): Promise<DeviceInfo> {
     .catch(e => {
       tracer.trace(`Error from getAppAndVersion: ${e}`, { error: e });
       if (e instanceof TransportStatusError) {
-        if (e.statusCode === 0x6e00) {
+        if (e.statusCode === 0x6e00 || e.statusCode === 0x6e01) {
           return true;
         }
 


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

During firmware updates, LW sometimes polls the device to get its status.
When in bootloader mode, we need to get device informations.
New firmware now returns a new error code (6e01) as invalid CLA which causes the polling to never end.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
