### PR TITLE
chore(cursor): upgrade /pre-review command and add run-tests-pr skill

### DIFF
--- a/.cursor/commands/pre-review.md
+++ b/.cursor/commands/pre-review.md
@@ -1,30 +1,26 @@
 # Pre-Review
 
-Run automated checks before submitting for code review.
+Deep code review
 
 ## Process
 
-1. **Identify changes**: `git diff --name-only develop..HEAD`
-2. **Launch agents in parallel**:
-   - `test-runner` — Run tests, fix failures
-   - `code-reviewer` — Check rules compliance (see `.cursor/rules/`)
-3. **Fix issues** found by agents
-4. **Report summary**
+1. Run `git diff develop..HEAD` to get the full diff.
 
-## Summary Template
+2. Launch 4 `code-reviewer` agents **in parallel**, each with a different focus:
+   - **A** — Architecture & MVVM compliance
+   - **B** — Correctness & security (edge cases, null handling, error states)
+   - **C** — Code quality & conventions (Lumen UI, TypeScript, naming, new deps)
+   - **D** — General review — DRY, KISS, missing tests, anything that would slow down a reviewer or cause future regressions
 
-```markdown
-## Pre-Review Summary
+   Each agent prompt: _"Review the diff vs develop. Focus on [FOCUS]. Return findings with file:line, severity (🔴 Critical / 🟡 Suggestion / 🟢 Nice to have), and suggested fix."_
 
-### Tests
-✅ / ❌ — X passed, Y failed
+3. Merge + deduplicate findings. Present grouped by severity:
 
-### Code Review
-✅ / ⚠️ — Issues found (if any)
+   ```
+   🔴 Critical — path/to/file.ts:42 — issue → fix
+   🟡 Suggestion — ...
+   🟢 Nice to have — ...
+   Summary: X critical, Y suggestions, Z nice-to-haves
+   ```
 
-### Ready for Review
-- [ ] Tests passing
-- [ ] Critical issues addressed
-```
-
-**Next**: `/cleanup` if needed, then `/create-pr`
+4. Ask the user which items to fix: **"all criticals"**, **"all"**, **"#1,#2, #3"**, or **"skip"** → `/create-pr`

--- a/.cursor/skills/run-tests/SKILL.md
+++ b/.cursor/skills/run-tests/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: run-tests
+description: Run unit tests scoped to files changed in the current branch. Use when the user asks to run tests, validate changes, or before a PR.
+---
+
+# Run Tests
+
+Run tests only on files touched in this branch:
+
+```bash
+git diff --name-only develop..HEAD
+```
+
+Map to scope:
+- `apps/ledger-live-desktop/` → `pnpm desktop test:jest "path/to/file"`
+- `apps/ledger-live-mobile/` → `pnpm mobile test:jest "path/to/file"`
+- `libs/<name>/` → `pnpm --filter <package-name> test "path/to/file"`
+
+Fix failures one at a time — never skip or comment out a test.
+
+Report: `✅ X suites pass` or `❌ failure in ... → Fixed: [description]`


### PR DESCRIPTION
### ✅ Checklist

- [ ] **Covered by automatic tests.** _Cursor tooling only — no app code changed._
- [x] **Impact of the changes:**
  - `/pre-review` command: now a focused code review orchestrator (3 parallel agents, synthesized report, interactive follow-up)
  - New `run-tests-pr` skill: standalone skill for running typecheck + unit tests scoped to changed packages

### 📝 Description

The `/pre-review` command was doing too much: it mixed test-running and code review in a thin, undifferentiated prompt.

**Changes:**
- `/pre-review` now exclusively handles code review: launches 3 `code-reviewer` subagents in parallel (architecture/MVVM, correctness/security, code quality/conventions), synthesizes their findings into a structured report grouped by severity, and proposes actionable next steps to the user.
- New `run-tests-pr` skill extracted for explicit test validation: identifies changed packages from `git diff`, runs typecheck + unit tests scoped to affected packages only, and guides fixing failures iteratively.