### PR TITLE
[LWDM] feat(sui): add stacking event details to API operation

### DIFF
--- a/.changeset/grumpy-meals-promise.md
+++ b/.changeset/grumpy-meals-promise.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": minor
+---
+
+Add staking details to delegate/undelegate operations

--- a/libs/coin-modules/coin-sui/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.test.ts
@@ -263,6 +263,7 @@ const mockTransaction = {
 // amount must be a negative number
 function mockStakingTx(address: string, amount: string) {
   assert(new BigNumber(amount).lte(0), "amount must be a negative number");
+  const validatorAddress = "0x3d9fb148e35ef4d74fcfc36995da14fc504b885d5f2bfeca37d6ea2cc044a32d";
   return {
     digest: "delegate_tx_digest_123",
     transaction: {
@@ -297,6 +298,15 @@ function mockStakingTx(address: string, amount: string) {
         amount: amount.startsWith("-") ? amount : `-${amount}`,
       },
     ],
+    events: [
+      {
+        type: "0x3::staking_pool::StakingRequestEvent",
+        parsedJson: {
+          validator_address: validatorAddress,
+          staked_sui_id: "0xstaked_object_id_123",
+        },
+      },
+    ],
     timestampMs: "1742294454878",
     checkpoint: "313024",
   } as unknown as SuiTransactionBlockResponse;
@@ -304,6 +314,7 @@ function mockStakingTx(address: string, amount: string) {
 
 // amount must be a positive number
 function mockUnstakingTx(address: string, amount: string) {
+  const validatorAddress = "0x3d9fb148e35ef4d74fcfc36995da14fc504b885d5f2bfeca37d6ea2cc044a32d";
   return {
     digest: "undelegate_tx_digest_456",
     transaction: {
@@ -336,6 +347,16 @@ function mockUnstakingTx(address: string, amount: string) {
         owner: { AddressOwner: address },
         coinType: "0x2::sui::SUI",
         amount: amount,
+      },
+    ],
+    events: [
+      {
+        type: "0x3::validator::UnstakingRequestEvent",
+        parsedJson: {
+          validator_address: validatorAddress,
+          principal_amount: "1200000000",
+          reward_amount: "50000000",
+        },
       },
     ],
     timestampMs: "1742294454878",
@@ -939,6 +960,8 @@ describe("Staking Operations", () => {
         tx: { block: expect.any(Object), feesPayer: address },
         details: {
           stakedAmount: 1000000000n,
+          validatorAddress: "0x3d9fb148e35ef4d74fcfc36995da14fc504b885d5f2bfeca37d6ea2cc044a32d",
+          stakedObjectId: "0xstaked_object_id_123",
         },
       });
     });
@@ -961,7 +984,66 @@ describe("Staking Operations", () => {
         tx: { block: expect.any(Object), feesPayer: address },
         details: {
           stakedAmount: 1000000000n,
+          validatorAddress: "0x3d9fb148e35ef4d74fcfc36995da14fc504b885d5f2bfeca37d6ea2cc044a32d",
+          rewardAmount: 50000000n,
+          withdrawnAmount: 1200000000n,
         },
+      });
+    });
+
+    test("transactionToOp should return staking details without events", () => {
+      const address = "0x65449f57946938c84c512732f1d69405d1fce417d9c9894696ddf4522f479e24";
+      const tx = mockStakingTx(address, "-1001050000");
+      delete (tx as any).events;
+
+      const operation = sdk.alpacaTransactionToOp(address, tx, "mockCheckpointHash");
+
+      expect(operation.details).toEqual({ stakedAmount: 1000000000n });
+    });
+
+    test("transactionToOp should return unstaking details without events", () => {
+      const address = "0x65449f57946938c84c512732f1d69405d1fce417d9c9894696ddf4522f479e24";
+      const tx = mockUnstakingTx(address, "998950000");
+      delete (tx as any).events;
+
+      const operation = sdk.alpacaTransactionToOp(address, tx, "mockCheckpointHash");
+
+      expect(operation.details).toEqual({ stakedAmount: 1000000000n });
+    });
+
+    test("transactionToOp should handle partial staking event fields", () => {
+      const address = "0x65449f57946938c84c512732f1d69405d1fce417d9c9894696ddf4522f479e24";
+      const tx = mockStakingTx(address, "-1001050000");
+      (tx as any).events = [
+        {
+          type: "0x3::staking_pool::StakingRequestEvent",
+          parsedJson: { validator_address: "0xabc" },
+        },
+      ];
+
+      const operation = sdk.alpacaTransactionToOp(address, tx, "mockCheckpointHash");
+
+      expect(operation.details).toEqual({
+        stakedAmount: 1000000000n,
+        validatorAddress: "0xabc",
+      });
+    });
+
+    test("transactionToOp should handle partial unstaking event fields", () => {
+      const address = "0x65449f57946938c84c512732f1d69405d1fce417d9c9894696ddf4522f479e24";
+      const tx = mockUnstakingTx(address, "998950000");
+      (tx as any).events = [
+        {
+          type: "0x3::validator::UnstakingRequestEvent",
+          parsedJson: { validator_address: "0xdef" },
+        },
+      ];
+
+      const operation = sdk.alpacaTransactionToOp(address, tx, "mockCheckpointHash");
+
+      expect(operation.details).toEqual({
+        stakedAmount: 1000000000n,
+        validatorAddress: "0xdef",
       });
     });
 
@@ -990,6 +1072,69 @@ describe("Staking Operations", () => {
       );
       expect(operation.tx.feesPayer).toBe(sponsorAddress);
     });
+  });
+});
+
+describe("getStakingEventDetails", () => {
+  const makeTx = (events?: unknown[]) => ({ events }) as unknown as SuiTransactionBlockResponse;
+
+  it("should extract all fields from StakingRequestEvent", () => {
+    const tx = makeTx([
+      {
+        type: "0x3::staking_pool::StakingRequestEvent",
+        parsedJson: {
+          validator_address: "0xabc",
+          staked_sui_id: "0xobj123",
+        },
+      },
+    ]);
+    expect(sdk.getStakingEventDetails(tx)).toEqual({
+      validatorAddress: "0xabc",
+      stakedObjectId: "0xobj123",
+    });
+  });
+
+  it("should extract all fields from UnstakingRequestEvent", () => {
+    const tx = makeTx([
+      {
+        type: "0x3::validator::UnstakingRequestEvent",
+        parsedJson: {
+          validator_address: "0xdef",
+          reward_amount: "50000000",
+          principal_amount: "1200000000",
+        },
+      },
+    ]);
+    expect(sdk.getStakingEventDetails(tx)).toEqual({
+      validatorAddress: "0xdef",
+      rewardAmount: 50000000n,
+      withdrawnAmount: 1200000000n,
+    });
+  });
+
+  it("should handle partial StakingRequestEvent fields", () => {
+    const tx = makeTx([
+      {
+        type: "0x3::staking_pool::StakingRequestEvent",
+        parsedJson: { validator_address: "0xabc" },
+      },
+    ]);
+    expect(sdk.getStakingEventDetails(tx)).toEqual({ validatorAddress: "0xabc" });
+  });
+
+  it("should handle partial UnstakingRequestEvent fields", () => {
+    const tx = makeTx([
+      {
+        type: "0x3::validator::UnstakingRequestEvent",
+        parsedJson: { validator_address: "0xdef" },
+      },
+    ]);
+    expect(sdk.getStakingEventDetails(tx)).toEqual({ validatorAddress: "0xdef" });
+  });
+
+  it("should return empty object when no staking events", () => {
+    expect(sdk.getStakingEventDetails(makeTx([]))).toEqual({});
+    expect(sdk.getStakingEventDetails(makeTx(undefined))).toEqual({});
   });
 });
 

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -60,6 +60,9 @@ const BLOCK_HEIGHT = 5; // sui has no block height metainfo, we use it simulate 
 
 export const DEFAULT_COIN_TYPE = "0x2::sui::SUI";
 
+const STAKING_REQUEST_EVENT = "0x3::staking_pool::StakingRequestEvent";
+const UNSTAKING_REQUEST_EVENT = "0x3::validator::UnstakingRequestEvent";
+
 /** Default options for querying transactions. */
 const TRANSACTIONS_QUERY_OPTIONS: SuiTransactionBlockResponseOptions = {
   showInput: true,
@@ -325,7 +328,7 @@ export const getOperationExtra = (digest: string): Promise<Record<string, string
 
     if (isUnstaking(response.transaction?.data?.transaction)) {
       const { principal_amount: amount, validator_address: address } = response.events?.find(
-        e => e.type === "0x3::validator::UnstakingRequestEvent",
+        e => e.type === UNSTAKING_REQUEST_EVENT,
       )?.parsedJson as Record<string, string>;
       const name = getCurrentSuiPreloadData().validators.find(x => x.suiAddress === address)?.name;
 
@@ -439,6 +442,46 @@ export const alpacaGetOperationAmount = (
 };
 
 /**
+ * Extract staking/unstaking event details from transaction events.
+ * For DELEGATE: extracts validatorAddress, stakedObjectId from StakingRequestEvent
+ * For UNDELEGATE: extracts validatorAddress, rewardAmount, withdrawnAmount (from principal_amount) from UnstakingRequestEvent
+ */
+export function getStakingEventDetails(
+  transaction: SuiTransactionBlockResponse,
+): Record<string, unknown> {
+  const stakingDetails = transaction.events?.find(e => e.type === STAKING_REQUEST_EVENT)
+    ?.parsedJson as Record<string, string> | undefined;
+
+  if (stakingDetails) {
+    return Object.fromEntries(
+      Object.entries({
+        stakedObjectId: stakingDetails.staked_sui_id,
+        validatorAddress: stakingDetails.validator_address,
+      }).filter(([, v]) => v !== undefined),
+    );
+  }
+
+  const unstakingDetails = transaction.events?.find(e => e.type === UNSTAKING_REQUEST_EVENT)
+    ?.parsedJson as Record<string, string> | undefined;
+
+  if (unstakingDetails) {
+    return Object.fromEntries(
+      Object.entries({
+        rewardAmount: unstakingDetails.reward_amount
+          ? BigInt(unstakingDetails.reward_amount)
+          : undefined,
+        validatorAddress: unstakingDetails.validator_address,
+        withdrawnAmount: unstakingDetails.principal_amount
+          ? BigInt(unstakingDetails.principal_amount)
+          : undefined,
+      }).filter(([, v]) => v !== undefined),
+    );
+  }
+
+  return {};
+}
+
+/**
  * This function is only used by alpaca code path
  *
  * @returns the operation converted. Note that if param `transaction` was retrieved as an "IN" operations, the type may be converted to "OUT".
@@ -481,10 +524,11 @@ export function alpacaTransactionToOp(
   };
 
   if (type === "DELEGATE" || type === "UNDELEGATE") {
-    // for staking, the amount is stored in the details
     op.details = {
       stakedAmount: op.value,
+      ...getStakingEventDetails(transaction),
     };
+    // for staking, the amount is stored in the details
     op.value = 0n;
   }
 
@@ -863,6 +907,7 @@ export const getListOperations = async (
         type: "OUT",
         cursor: rpcCursor,
         order: rpcOrder,
+        options: { showEvents: true },
       }),
       queryTransactions({
         api,
@@ -870,6 +915,7 @@ export const getListOperations = async (
         type: "IN",
         cursor: rpcCursor,
         order: rpcOrder,
+        options: { showEvents: true },
       }),
     ]);
 
@@ -1230,8 +1276,9 @@ export const queryTransactions = async (params: {
   type: OperationType;
   order: "ascending" | "descending";
   cursor?: QueryTransactionBlocksParams["cursor"];
+  options?: Pick<SuiTransactionBlockResponseOptions, "showEvents">;
 }): Promise<PaginatedTransactionResponse> => {
-  const { api, addr, type, cursor, order } = params;
+  const { api, addr, type, cursor, order, options = {} } = params;
   // what we really want is a FromOrToAddress filter, but it's not supported yet
   // it would relieve a lot of complexity in the merged/sorted pagination and cursor boundary filtering logic above
   const filter: QueryTransactionBlocksParams["filter"] =
@@ -1241,7 +1288,7 @@ export const queryTransactions = async (params: {
     filter,
     cursor,
     order,
-    options: TRANSACTIONS_QUERY_OPTIONS,
+    options: { ...TRANSACTIONS_QUERY_OPTIONS, ...options },
     limit: TRANSACTIONS_LIMIT_PER_QUERY,
   });
 };
@@ -1255,15 +1302,16 @@ export const queryTransactions = async (params: {
 export const queryTransactionsByDigest = async (params: {
   api: SuiClient;
   digests: string[];
+  options?: Pick<SuiTransactionBlockResponseOptions, "showEvents">;
 }): Promise<SuiTransactionBlockResponse[]> => {
-  const { api, digests } = params;
+  const { api, digests, options = {} } = params;
   const chunkSize = TRANSACTIONS_LIMIT_PER_QUERY;
   const responses: SuiTransactionBlockResponse[] = [];
 
   for (let i = 0; i < digests.length; i += chunkSize) {
     const chunk = await api.multiGetTransactionBlocks({
       digests: digests.slice(i, i + chunkSize),
-      options: TRANSACTIONS_QUERY_OPTIONS,
+      options: { ...TRANSACTIONS_QUERY_OPTIONS, ...options },
     });
     responses.push(...chunk);
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** Added stacking event details to operation's details

### 📝 Description

- Enriched SUI staking operation details by extracting event data from StakingRequestEvent (DELEGATE) and UnstakingRequestEvent (UNDELEGATE) transaction events
- DELEGATE operations now include validatorAddress and stakedObjectId in op.details
- UNDELEGATE operations now include validatorAddress, rewardAmount (bigint), and withdrawnAmount (bigint) in op.details
- Events are fetched only in the getListOperations code path via a new optional options param on queryTransactions/queryTransactionsByDigest, avoiding unnecessary payload overhead for history sync and block queries

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27178](https://ledgerhq.atlassian.net/browse/LIVE-27178)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27178]: https://ledgerhq.atlassian.net/browse/LIVE-27178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ