### PR TITLE
[LWDM] chore(desktop,mobile): remove postOnboardingAssetsTransfer feature flag

### DIFF
--- a/.changeset/unlucky-bats-lay.md
+++ b/.changeset/unlucky-bats-lay.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/types-live": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+"@shared/feature-flags": minor
+---
+
+chore: remove postOnboardingAssetsTransfer feature flag (default to true)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -287,6 +287,7 @@ apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/             
 apps/ledger-live-mobile/src/mvvm/features/WelcomePage/                                         @ledgerhq/engagement
 apps/ledger-live-mobile/src/screens/Onboarding/                                                @ledgerhq/engagement
 apps/ledger-live-mobile/src/screens/PostOnboarding/                                            @ledgerhq/engagement
+apps/ledger-live-mobile/src/logic/postOnboarding/                                              @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/postOnboarding.handler.ts  @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/hooks/useBuyDeviceIntercept.ts                           @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/hooks/useBuyDeviceIntercept.test.ts                      @ledgerhq/engagement

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/index.tsx
@@ -11,7 +11,6 @@ import CustomImage from "~/renderer/screens/customImage";
 
 const assetsTransfer: PostOnboardingAction = {
   id: PostOnboardingActionId.assetsTransfer,
-  featureFlagId: "postOnboardingAssetsTransfer",
   Icon: Icons.Lock,
   title: "postOnboarding.actions.assetsTransfer.title",
   titleCompleted: "postOnboarding.actions.assetsTransfer.titleCompleted",
@@ -120,7 +119,6 @@ const customImageMock: PostOnboardingAction = {
 
 const assetsTransferMock: PostOnboardingAction = {
   id: PostOnboardingActionId.assetsTransferMock,
-  featureFlagId: "postOnboardingAssetsTransfer",
   Icon: Icons.Lock,
   title: "postOnboarding.actions.assetsTransfer.title",
   titleCompleted: "postOnboarding.actions.assetsTransfer.titleCompleted",

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/actions.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/actions.ts
@@ -9,7 +9,6 @@ import { NavigatorName, ScreenName } from "~/const";
 export const assetsTransferAction: PostOnboardingAction = {
   id: PostOnboardingActionId.assetsTransfer,
   disabled: false,
-  featureFlagId: "postOnboardingAssetsTransfer",
   Icon: Icons.Lock,
   title: "postOnboarding.actions.assetsTransfer.title",
   titleCompleted: "postOnboarding.actions.assetsTransfer.titleCompleted",

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/mockActions.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/mockActions.ts
@@ -9,7 +9,6 @@ import { NavigatorName, ScreenName } from "~/const";
 export const assetsTransferMock: PostOnboardingAction = {
   id: PostOnboardingActionId.assetsTransferMock,
   disabled: false,
-  featureFlagId: "postOnboardingAssetsTransfer",
   Icon: Icons.Lock,
   title: "postOnboarding.actions.assetsTransfer.title",
   titleCompleted: "postOnboarding.actions.assetsTransfer.titleCompleted",

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -130,7 +130,6 @@ export const DEFAULT_FEATURES: Features = {
   ...CURRENCY_DEFAULT_FEATURES,
   nanoOnboardingFundWallet: DEFAULT_FEATURE,
   portfolioExchangeBanner: DEFAULT_FEATURE,
-  postOnboardingAssetsTransfer: DEFAULT_FEATURE,
   counterValue: DEFAULT_FEATURE,
   mockFeature: DEFAULT_FEATURE,
   ptxServiceCtaExchangeDrawer: DEFAULT_FEATURE,

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -191,7 +191,6 @@ export type Features = CurrencyFeatures & {
   ethStakingModalWithFilters: DefaultFeature;
   ethStakingProviders: Feature_EthStakingProviders;
   storyly: Feature_Storyly;
-  postOnboardingAssetsTransfer: Feature_PostOnboardingAssetsTransfer;
   firebaseEnvironmentReadOnly: Feature_FirebaseEnvironmentReadOnly;
   protectServicesMobile: Feature_ProtectServicesMobile;
   protectServicesDesktop: Feature_ProtectServicesDesktop;
@@ -751,7 +750,6 @@ export type Feature_MockFeature = DefaultFeature;
 export type Feature_DisableNftSend = DefaultFeature;
 export type Feature_DisableNftLedgerMarket = DefaultFeature;
 export type Feature_DisableNftRaribleOpensea = DefaultFeature;
-export type Feature_PostOnboardingAssetsTransfer = DefaultFeature;
 export type Feature_PtxServiceCtaExchangeDrawer = DefaultFeature;
 export type Feature_PtxServiceCtaScreens = DefaultFeature;
 export type Feature_PortfolioExchangeBanner = DefaultFeature;

--- a/shared/feature-flags/src/flags/team-engagement/index.ts
+++ b/shared/feature-flags/src/flags/team-engagement/index.ts
@@ -20,7 +20,6 @@ export * from "./lwmNewWordingOptInNotificationsDrawer";
 export * from "./nanoOnboardingFundWallet";
 export * from "./newsfeedPage";
 export * from "./npsRatingsPrompt";
-export * from "./postOnboardingAssetsTransfer";
 export * from "./ratingsPrompt";
 export * from "./referralProgramDesktopSidebar";
 export * from "./storyly";

--- a/shared/feature-flags/src/flags/team-engagement/postOnboardingAssetsTransfer.ts
+++ b/shared/feature-flags/src/flags/team-engagement/postOnboardingAssetsTransfer.ts
@@ -1,2 +1,0 @@
-import { flag } from "../../define";
-export const postOnboardingAssetsTransfer = flag();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**

### 📝 Description

* Feature flag has been set to true since 26 October 2023.
* Feature flag removed on both Desktop and Mobile.
* Update `CODEOWNERS` file to give ownership of `postOnboarding` logic to Engagement team.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27795

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
