### PR TITLE
[LWDM] perf(desktop): load bridge and families only when the app shell is used

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/BridgeAndFamiliesLayer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/BridgeAndFamiliesLayer.tsx
@@ -1,0 +1,21 @@
+/**
+ * Lazy-loaded layer that pulls in the bridge (all coin implementations) and the
+ * renderer families barrel. By loading this chunk only when the main app shell
+ * mounts, we avoid loading coins/families at init (see jest-perf.md § Costly import tree).
+ * SyncNewAccounts must live here (not in Default) so it doesn't statically import the bridge.
+ */
+import React from "react";
+import "~/renderer/families";
+import { BridgeSyncProvider } from "~/renderer/bridge/BridgeSyncContext";
+import { SyncNewAccounts } from "~/renderer/bridge/SyncNewAccounts";
+
+type Props = { children: React.ReactNode };
+
+export default function BridgeAndFamiliesLayer({ children }: Props) {
+  return (
+    <BridgeSyncProvider>
+      <SyncNewAccounts priority={2} />
+      {children}
+    </BridgeSyncProvider>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -5,9 +5,7 @@ import { Navigate, Route, Routes, useNavigate, useLocation } from "react-router"
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import TrackAppStart from "~/renderer/components/TrackAppStart";
 import { LiveApp } from "~/renderer/screens/platform";
-import { BridgeSyncProvider } from "~/renderer/bridge/BridgeSyncContext";
 import { WalletSyncProvider } from "LLD/features/WalletSync/components/WalletSyncContext";
-import { SyncNewAccounts } from "~/renderer/bridge/SyncNewAccounts";
 import Box from "~/renderer/components/Box/Box";
 import { useListenToHidDevices } from "./hooks/useListenToHidDevices";
 import ExportLogsButton from "~/renderer/components/ExportLogsButton";
@@ -96,6 +94,7 @@ const WelcomeScreenSettings = lazy(
 const SyncOnboarding = lazy(() => import("./components/SyncOnboarding"));
 const RecoverPlayer = lazy(() => import("~/renderer/screens/recover/Player"));
 
+const BridgeAndFamiliesLayer = lazy(() => import("~/renderer/BridgeAndFamiliesLayer"));
 const RecoverRestore = lazy(() => import("~/renderer/components/RecoverRestore"));
 const Onboarding = lazy(() => import("~/renderer/components/Onboarding"));
 const PostOnboardingScreen = lazy(() => import("~/renderer/components/PostOnboardingScreen"));
@@ -308,7 +307,6 @@ export const MainAppLayout = () => {
           <IsTermOfUseUpdated />
         </>
       )}
-      <SyncNewAccounts priority={2} />
 
       {useWallet40Layout ? (
         <div
@@ -457,77 +455,79 @@ export default function Default() {
       <AppGeoBlocker>
         <AppVersionBlocker>
           <IsUnlocked>
-            <BridgeSyncProvider>
-              <WalletSyncProvider>
-                <ContextMenuWrapper>
-                  <ModalsLayer />
-                  <DebugWrapper>
-                    {process.env.MOCK ? <DebugMock /> : null}
-                    {process.env.DEBUG_UPDATE ? <DebugUpdater /> : null}
-                    {process.env.DEBUG_SKELETONS ? <DebugSkeletons /> : null}
-                    {process.env.DEBUG_FIRMWARE_UPDATE ? <DebugFirmwareUpdater /> : null}
-                  </DebugWrapper>
-                  {process.env.DISABLE_TRANSACTION_BROADCAST ? (
-                    <DisableTransactionBroadcastWarning
-                      value={process.env.DISABLE_TRANSACTION_BROADCAST}
-                    />
-                  ) : null}
+            <Suspense fallback={<Fallback />}>
+              <BridgeAndFamiliesLayer>
+                <WalletSyncProvider>
+                  <ContextMenuWrapper>
+                    <ModalsLayer />
+                    <DebugWrapper>
+                      {process.env.MOCK ? <DebugMock /> : null}
+                      {process.env.DEBUG_UPDATE ? <DebugUpdater /> : null}
+                      {process.env.DEBUG_SKELETONS ? <DebugSkeletons /> : null}
+                      {process.env.DEBUG_FIRMWARE_UPDATE ? <DebugFirmwareUpdater /> : null}
+                    </DebugWrapper>
+                    {process.env.DISABLE_TRANSACTION_BROADCAST ? (
+                      <DisableTransactionBroadcastWarning
+                        value={process.env.DISABLE_TRANSACTION_BROADCAST}
+                      />
+                    ) : null}
 
-                  <GlobalDialogs />
+                    <GlobalDialogs />
 
-                  <Routes>
-                    <Route
-                      path="/onboarding/*"
-                      element={
-                        <>
+                    <Routes>
+                      <Route
+                        path="/onboarding/*"
+                        element={
+                          <>
+                            <Suspense fallback={<Fallback />}>
+                              <Onboarding />
+                            </Suspense>
+                            <Drawer />
+                          </>
+                        }
+                      />
+                      <Route path="/sync-onboarding/*" element={withSuspense(SyncOnboarding)({})} />
+                      <Route
+                        path="/post-onboarding"
+                        element={
+                          <>
+                            <Suspense fallback={<Fallback />}>
+                              <PostOnboardingScreen />
+                            </Suspense>
+                            <Drawer />
+                          </>
+                        }
+                      />
+                      <Route path="/recover-restore" element={withSuspense(RecoverRestore)({})} />
+
+                      <Route
+                        path="/USBTroubleshooting"
+                        element={
                           <Suspense fallback={<Fallback />}>
-                            <Onboarding />
+                            <USBTroubleshooting onboarding={!hasCompletedOnboarding} />
                           </Suspense>
-                          <Drawer />
-                        </>
-                      }
-                    />
-                    <Route path="/sync-onboarding/*" element={withSuspense(SyncOnboarding)({})} />
-                    <Route
-                      path="/post-onboarding"
-                      element={
+                        }
+                      />
+
+                      {hasCompletedOnboarding ? (
+                        <Route path="/*" element={<MainAppLayout />} />
+                      ) : (
                         <>
-                          <Suspense fallback={<Fallback />}>
-                            <PostOnboardingScreen />
-                          </Suspense>
-                          <Drawer />
+                          <Route
+                            path="/settings/*"
+                            element={withSuspense(WelcomeScreenSettings)({})}
+                          />
+                          <Route
+                            path="/recover/:appId"
+                            element={<RecoverPlayerWithFeatureToggle />}
+                          />
                         </>
-                      }
-                    />
-                    <Route path="/recover-restore" element={withSuspense(RecoverRestore)({})} />
-
-                    <Route
-                      path="/USBTroubleshooting"
-                      element={
-                        <Suspense fallback={<Fallback />}>
-                          <USBTroubleshooting onboarding={!hasCompletedOnboarding} />
-                        </Suspense>
-                      }
-                    />
-
-                    {hasCompletedOnboarding ? (
-                      <Route path="/*" element={<MainAppLayout />} />
-                    ) : (
-                      <>
-                        <Route
-                          path="/settings/*"
-                          element={withSuspense(WelcomeScreenSettings)({})}
-                        />
-                        <Route
-                          path="/recover/:appId"
-                          element={<RecoverPlayerWithFeatureToggle />}
-                        />
-                      </>
-                    )}
-                  </Routes>
-                </ContextMenuWrapper>
-              </WalletSyncProvider>
-            </BridgeSyncProvider>
+                      )}
+                    </Routes>
+                  </ContextMenuWrapper>
+                </WalletSyncProvider>
+              </BridgeAndFamiliesLayer>
+            </Suspense>
           </IsUnlocked>
         </AppVersionBlocker>
       </AppGeoBlocker>

--- a/apps/ledger-live-desktop/src/renderer/__tests__/heavyLoadGuards.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/__tests__/heavyLoadGuards.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Ensures the boot path does NOT load the families barrel or the bridge (all coin impls).
+ * The only allowed entry point for heavy load is BridgeAndFamiliesLayer (lazy chunk).
+ *
+ * Run in isolation to verify: pnpm desktop test:jest heavyLoadGuards
+ * In full suite this may run after another test that already loaded families/bridge in the
+ * same worker, so the guards can be set; run the command above for a reliable check.
+ */
+import { registerTransportModules } from "~/renderer/live-common-setup";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __LEDGER_FAMILIES_BARREL_LOADED__: true | undefined;
+  // eslint-disable-next-line no-var
+  var __LEDGER_BRIDGE_IMPL_LOADED__: true | undefined;
+}
+
+describe("Heavy load guards (boot path)", () => {
+  it("loading live-common-setup alone does not load families barrel", () => {
+    expect(registerTransportModules).toBeDefined();
+    expect(globalThis.__LEDGER_FAMILIES_BARREL_LOADED__).toBeUndefined();
+  });
+
+  it("loading live-common-setup alone does not load bridge impl (generated/bridge/js → all coins)", () => {
+    expect(registerTransportModules).toBeDefined();
+    expect(globalThis.__LEDGER_BRIDGE_IMPL_LOADED__).toBeUndefined();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Guard: mark that the families barrel (and thus all family UIs + generated) has loaded.
+ * Used by tests to assert heavy load is deferred (see heavyLoadGuards.test.ts).
+ */
+if (typeof globalThis !== "undefined") {
+  Object.defineProperty(globalThis, "__LEDGER_FAMILIES_BARREL_LOADED__", { value: true });
+}
+
 import {
   Account,
   TransactionCommon,

--- a/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
+++ b/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
@@ -1,6 +1,6 @@
 import "~/live-common-setup-base";
 import "~/live-common-set-supported-currencies";
-import "./families";
+// Families barrel is loaded lazily via BridgeAndFamiliesLayer (see jest-perf.md § Costly import tree)
 
 import { Store } from "redux";
 import VaultTransport from "@ledgerhq/hw-transport-vault";

--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -7,6 +7,14 @@ import { decodeAccountId, getMainAccount, checkAccountSupported } from "../accou
 import { getEnv } from "@ledgerhq/live-env";
 import jsBridges from "../generated/bridge/js";
 import mockBridges from "../generated/bridge/mock";
+
+/**
+ * Guard: this module loads generated/bridge/js (all family setups → all @ledgerhq/coin-*).
+ * Used by apps (e.g. desktop) to assert heavy load is deferred (see heavyLoadGuards.test.ts).
+ */
+if (typeof globalThis !== "undefined") {
+  Object.defineProperty(globalThis, "__LEDGER_BRIDGE_IMPL_LOADED__", { value: true });
+}
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import {
   Account,


### PR DESCRIPTION

We avoid loading the heavy “bridge + all coins” code until a test (or the app) actually needs the main app shell.

- **Before:** As soon as any test touched code that imported the main app, we loaded the bridge and all coin libs for that worker, even when the test didn’t need them.
- **After:** That heavy code lives in a lazy chunk and loads only when we render the main app shell. Tests that don’t render it never load it → faster runs for most tests.

We also add a small test that checks the boot path doesn’t load the bridge or families by mistake.