### PR TITLE
[LWD] PERF STUDY: perf(desktop): run jest with NODE_ENV=production for test speed

### DIFF
--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -39,7 +39,7 @@
     "release": "node ./tools/dist --release -v",
     "storybook": "storybook dev -p 6006",
     "test": "pnpm test:jest:coverage && pnpm test:playwright",
-    "test:jest": "NODE_OPTIONS=--max-old-space-size=8192 jest --maxWorkers=50%",
+    "test:jest": "NODE_OPTIONS=--max-old-space-size=8192 cross-env NODE_ENV=production jest --maxWorkers=50%",
     "test:jest:watch": "pnpm test:jest --watch",
     "test:jest:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand",
     "test:jest:coverage": "pnpm test:jest --ci --coverage",


### PR DESCRIPTION
Disable React and reselect dev-mode checks in unit tests to reduce overhead (e.g. reselect input-stability warnings, React dev warnings).
