### PR TITLE
[LWM] fix(mobile): prevent double render of MarketBanner in portfolio screen

### DIFF
--- a/.changeset/brave-banners-fix.md
+++ b/.changeset/brave-banners-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix double render of MarketBanner in Portfolio screen when lwmWallet40 is enabled with assetSection param disabled

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioAssetsSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioAssetsSection/index.tsx
@@ -16,22 +16,15 @@ export const PortfolioAssetsSection = ({
   openAddModal,
   onHeightChange,
 }: PortfolioAssetsSectionProps) => {
-  if (isAccountListUIEnabled) {
-    return (
-      <AnimatedContainer onHeightChange={onHeightChange}>
-        <Box px={6} key="PortfolioAssets">
-          <PortfolioAssets
-            hideEmptyTokenAccount={hideEmptyTokenAccount}
-            openAddModal={openAddModal}
-          />
-        </Box>
-      </AnimatedContainer>
-    );
-  }
-
-  return (
+  const content = (
     <Box px={6} key="PortfolioAssets">
       <PortfolioAssets hideEmptyTokenAccount={hideEmptyTokenAccount} openAddModal={openAddModal} />
     </Box>
   );
+
+  if (isAccountListUIEnabled) {
+    return <AnimatedContainer onHeightChange={onHeightChange}>{content}</AnimatedContainer>;
+  }
+
+  return content;
 };

--- a/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioAssets.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioAssets.tsx
@@ -16,7 +16,6 @@ import {
 import { setSelectedTabPortfolioAssets } from "~/actions/settings";
 import Assets from "./Assets";
 import PortfolioQuickActionsBar from "./PortfolioQuickActionsBar";
-import MarketBanner from "LLM/features/MarketBanner";
 import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import TabSection, { TAB_OPTIONS, type TabListType } from "./TabSection";
 import { flattenAccountsSelector } from "~/reducers/accounts";
@@ -145,8 +144,6 @@ const PortfolioAssets = ({ hideEmptyTokenAccount, openAddModal }: Props) => {
       )}
 
       {!isWallet40Enabled && <PortfolioPerpsEntryPoint />}
-
-      <MarketBanner />
 
       {isWallet40Enabled && <PortfolioPerpsEntryPoint />}
 


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _The fix is a simple component removal — the rendering logic is straightforward and existing tests cover the feature flag behavior._
- [x] **Impact of the changes:**
  - Portfolio screen with `lwmWallet40` enabled and `assetSection` param disabled
  - `MarketBanner` visibility on the Portfolio screen

### 📝 Description

When the `lwmWallet40` feature flag is enabled with the `marketBanner` param active but the `assetSection` param disabled, the `MarketBanner` component was rendered twice simultaneously on the Portfolio screen.

The root cause was that `PortfolioAssets` (used via `PortfolioAssetsSection` when `assetSection` is off) was rendering its own `<MarketBanner />`, while `PortfolioScreen` (MVVM) was already rendering another one at the screen level when `shouldDisplayMarketBanner` is true. Additionally, the `MarketBanner` component self-regulates its visibility via its own ViewModel (`isEnabled: shouldDisplayMarketBanner`), making its presence inside `PortfolioAssets` entirely redundant.

The fix removes `MarketBanner` from `PortfolioAssets` entirely — banner management is now exclusively the responsibility of the screen-level component (`PortfolioScreen`).

https://github.com/user-attachments/assets/32bf79fa-a644-47b4-ae47-04a9075292f1
### ❓ Context

- **JIRA or GitHub link**: [LIVE-27785](https://ledgerhq.atlassian.net/browse/LIVE-27785)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27785]: https://ledgerhq.atlassian.net/browse/LIVE-27785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ