### PR TITLE
[LWD] test(e2e): update ledger sync test selectors for wallet sync button change

### DIFF
--- a/.changeset/quiet-lions-smile.md
+++ b/.changeset/quiet-lions-smile.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"ledger-live-desktop-e2e-tests": patch
+---
+
+Update ledger sync E2E test selectors for wallet sync button FF change

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/WalletSync.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/WalletSync.tsx
@@ -39,7 +39,13 @@ const WalletSyncRow = ({ variant = "manage" }: WalletSyncRowProps) => {
 
   if (variant === "sync") {
     return (
-      <Button small event="Sync WalletSync" primary onClick={handleSyncClick}>
+      <Button
+        data-testid="button-sync-walletSync"
+        small
+        event="Sync WalletSync"
+        primary
+        onClick={handleSyncClick}
+      >
         {t("walletSync.banner.cta")}
       </Button>
     );
@@ -47,7 +53,13 @@ const WalletSyncRow = ({ variant = "manage" }: WalletSyncRowProps) => {
 
   if (variant === "manage") {
     return (
-      <Button small event="Manage WalletSync" primary onClick={handleManageClick}>
+      <Button
+        data-testid="button-manage-walletSync"
+        small
+        event="Manage WalletSync"
+        primary
+        onClick={handleManageClick}
+      >
         {t("walletSync.manage.cta")}
       </Button>
     );

--- a/e2e/desktop/tests/page/settings.page.ts
+++ b/e2e/desktop/tests/page/settings.page.ts
@@ -7,7 +7,8 @@ import { FileUtils } from "../utils/fileUtils";
 import { mkdir, rename } from "fs/promises";
 
 export class SettingsPage extends AppPage {
-  private manageLedgerSyncButton = this.page.getByRole("button", { name: "Manage" });
+  private syncWalletSyncButton = this.page.getByTestId("button-sync-walletSync");
+  private manageWalletSyncButton = this.page.getByTestId("button-manage-walletSync");
   private clearCacheButton = this.page.getByRole("button", { name: "Clear" });
   private confirmButton = this.page.getByRole("button", { name: "Confirm" });
   private accountsTab = this.page.getByTestId("settings-accounts-tab");
@@ -59,7 +60,21 @@ export class SettingsPage extends AppPage {
 
   @step("Open Ledger Sync Manager")
   async openManageLedgerSync() {
-    await this.manageLedgerSyncButton.click();
+    await this.manageWalletSyncButton.click();
+  }
+
+  @step("Open Wallet Sync Manager")
+  async openWalletSyncManager() {
+    await this.syncWalletSyncButton.click();
+  }
+
+  @step("Enable Wallet Sync")
+  async enableWalletSync() {
+    if (await this.syncWalletSyncButton.isVisible()) {
+      await this.syncWalletSyncButton.click();
+    } else {
+      await this.manageWalletSyncButton.click();
+    }
   }
 
   @step("Clear cache")

--- a/e2e/desktop/tests/specs/ledgerSync.spec.ts
+++ b/e2e/desktop/tests/specs/ledgerSync.spec.ts
@@ -71,7 +71,7 @@ test.describe(`[${app.name}] Sync Accounts`, () => {
       }
 
       await app.mainNavigation.openSettings();
-      await app.settings.openManageLedgerSync();
+      await app.settings.enableWalletSync();
       await app.ledgerSync.expectSyncAccountsButtonExist();
 
       await app.ledgerSync.syncAccounts();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This PR fixes E2E tests themselves._
- [x] **Impact of the changes:**
  - Ledger Sync E2E test reliability after FF change
  - WalletSync settings button selectors

### 📝 Description

A feature flag change altered which button variant (`sync` vs `manage`) is shown in the WalletSync settings row. The E2E test was using `getByRole("button", { name: "Manage" })` which no longer matches.

**Fix:**
- Add `data-testid` attributes to both WalletSync button variants (`button-sync-walletSync`, `button-manage-walletSync`)
- Update the settings page object to use `getByTestId` selectors
- Add `enableWalletSync()` method that handles both variants
- Use `enableWalletSync()` in the ledger sync spec

### ❓ Context

- **JIRA or GitHub link**: N/A — E2E test fix after FF change

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.