### PR TITLE
[LWM] fix: remove buy device modal from sync

### DIFF
--- a/.changeset/fix-wallet-sync-readonly-buy-drawer.md
+++ b/.changeset/fix-wallet-sync-readonly-buy-drawer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix Wallet Sync blocked by buy device drawer in read-only mode

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/components/Activation/ActivationFlow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/components/Activation/ActivationFlow.tsx
@@ -95,10 +95,7 @@ const ActivationFlow = ({
         return (
           <>
             <TrackScreen category={AnalyticsPage.ChooseSyncMethod} />
-            <ChooseSyncMethod
-              onScanMethodPress={navigateToQrCodeMethod}
-              onConnectDevicePress={onCreateKey}
-            />
+            <ChooseSyncMethod onScanMethodPress={navigateToQrCodeMethod} />
           </>
         );
       case Steps.QrCodeMethod:

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Synchronize/ChooseMethod.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Synchronize/ChooseMethod.tsx
@@ -18,23 +18,18 @@ type NavigationProps = BaseComposite<
 
 type Props = {
   onScanMethodPress: () => void;
-  onConnectDevicePress?: () => void;
 };
 
-const ChooseSyncMethod = ({ onScanMethodPress, onConnectDevicePress }: Props) => {
+const ChooseSyncMethod = ({ onScanMethodPress }: Props) => {
   const { t } = useTranslation();
   const navigation = useNavigation<NavigationProps["navigation"]>();
   const { onClickTrack } = useLedgerSyncAnalytics();
 
   const onConnectDeviceMethodPress = () => {
     onClickTrack({ button: AnalyticsButton.UseYourLedger, page: AnalyticsPage.ChooseSyncMethod });
-    if (onConnectDevicePress) {
-      onConnectDevicePress();
-    } else {
-      navigation.navigate(NavigatorName.WalletSync, {
-        screen: ScreenName.WalletSyncActivationProcess,
-      });
-    }
+    navigation.navigate(NavigatorName.WalletSync, {
+      screen: ScreenName.WalletSyncActivationProcess,
+    });
   };
 
   return (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Remove buy device modal from sync.
"When the user tries to do ledger sync via the settings, ij the read only mode, he is blocked by the buydevice drawer which shouldn't be the case"

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-25796


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
