### PR TITLE
[LWDM] chore(desktop,mobile): bump lumen-ui and adapt to breaking changes

### DIFF
--- a/.changeset/eleven-wolves-serve.md
+++ b/.changeset/eleven-wolves-serve.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Bump lumen-ui packages and adapt to breaking API changes (TileSpot → Spot, extended → expanded)

--- a/apps/ledger-live-desktop/src/mvvm/features/FearAndGreed/components/FearAndGreedDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FearAndGreed/components/FearAndGreedDialog.tsx
@@ -20,7 +20,7 @@ export const FearAndGreedDialog = ({ children }: { children: React.ReactNode }) 
 
       <DialogContent data-testid="fear-and-greed-dialog-content">
         <DialogHeader
-          appearance="extended"
+          appearance="expanded"
           title={t("fearAndGreed.dialog.title")}
           onClose={() => setOpen(false)}
         />

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Tile, TileSpot, TileTitle, TileContent } from "@ledgerhq/lumen-ui-react";
+import { Tile, Spot, TileTitle, TileContent } from "@ledgerhq/lumen-ui-react";
 import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
 import { PerformanceIndicator } from "./PerformanceIndicator";
 import { useNavigate } from "react-router";
@@ -51,7 +51,7 @@ export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
               onClick={onAssetClick(item.id)}
               data-testid={`market-banner-asset-${item.id}`}
             >
-              <TileSpot
+              <Spot
                 size={40}
                 appearance="icon"
                 icon={() => <AssetIcon item={item} getCapitalizedTicker={getCapitalizedTicker} />}

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/ViewAllTile.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/ViewAllTile.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronRight } from "@ledgerhq/lumen-ui-react/symbols";
-import { Tile, TileSpot, TileTitle, TileContent } from "@ledgerhq/lumen-ui-react";
+import { Tile, Spot, TileTitle, TileContent } from "@ledgerhq/lumen-ui-react";
 import { useNavigate } from "react-router";
 
 export const ViewAllTile = () => {
@@ -19,7 +19,7 @@ export const ViewAllTile = () => {
       onClick={goToMarket}
       data-testid="market-banner-view-all"
     >
-      <TileSpot appearance="icon" icon={ChevronRight} size={40} />
+      <Spot appearance="icon" icon={ChevronRight} size={40} />
       <TileContent>
         <TileTitle>{t("marketBanner.cta")}</TileTitle>
       </TileContent>

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/ModularDialogContent.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/ModularDialogContent.tsx
@@ -32,7 +32,7 @@ export const ModularDialogContent = ({
   return (
     <>
       <DialogHeader
-        appearance="extended"
+        appearance="expanded"
         title={t(TranslationKeyMap[currentStep])}
         description={description}
         onClose={handleClose}

--- a/apps/ledger-live-desktop/src/mvvm/features/Receive/screens/ReceiveOptions/ReceiveOptionsDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Receive/screens/ReceiveOptions/ReceiveOptionsDialog.tsx
@@ -17,7 +17,7 @@ export function ReceiveOptionsDialog({ onClose, onGoToAccount }: ReceiveOptionsD
     <Dialog open onOpenChange={open => !open && onClose()}>
       <DialogContent>
         <TrackPage category="receive_drawer" type="drawer" />
-        <DialogHeader appearance="extended" title={t("receive.title")} />
+        <DialogHeader appearance="expanded" title={t("receive.title")} />
         <DialogBody className="px-16! pt-12">
           <ReceiveOptionsView onGoToBank={handleGoToBank} onGoToCrypto={handleGoToCrypto} />
         </DialogBody>

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/StrategySelect.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/StrategySelect.tsx
@@ -6,7 +6,6 @@ import {
   SelectItemText,
   SelectTrigger,
   Subheader,
-  SubheaderAction,
   SubheaderRow,
   SubheaderTitle,
 } from "@ledgerhq/lumen-ui-react";
@@ -34,14 +33,14 @@ export const StrategySelect = ({
   return (
     <div className="flex flex-col gap-12">
       <Subheader>
-        <SubheaderRow className="px-8">
-          <SubheaderTitle>{strategyLabel}</SubheaderTitle>
-          <SubheaderAction onClick={onLearnMoreClick}>
-            <Link appearance="accent" underline={false} size="md">
-              {learnMoreLabel}
-            </Link>
-          </SubheaderAction>
-        </SubheaderRow>
+        <div className="flex items-center gap-24">
+          <SubheaderRow className="min-w-0 flex-1">
+            <SubheaderTitle>{strategyLabel}</SubheaderTitle>
+          </SubheaderRow>
+          <Link appearance="accent" underline={false} size="md" onClick={onLearnMoreClick}>
+            {learnMoreLabel}
+          </Link>
+        </div>
       </Subheader>
       <Select value={value} onValueChange={onValueChange}>
         <SelectTrigger />

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -90,6 +90,24 @@ jest.mock("react-native-haptic-feedback", () => ({
   },
 }));
 
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  selectionAsync: jest.fn(),
+  ImpactFeedbackStyle: {
+    Light: "light",
+    Medium: "medium",
+    Heavy: "heavy",
+    Soft: "soft",
+    Rigid: "rigid",
+  },
+  NotificationFeedbackType: {
+    Success: "success",
+    Warning: "warning",
+    Error: "error",
+  },
+}));
+
 jest.mock("react-native-launch-arguments", () => ({}));
 
 NativeModules.BluetoothHelperModule = {

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -147,6 +147,8 @@ PODS:
     - ExpoModulesCore
   - ExpoFont (13.3.2):
     - ExpoModulesCore
+  - ExpoHaptics (14.1.4):
+    - ExpoModulesCore
   - ExpoImageManipulator (13.1.7):
     - EXImageLoader
     - ExpoModulesCore
@@ -2808,6 +2810,7 @@ DEPENDENCIES:
   - "ExpoCrypto (from `../../../node_modules/.pnpm/expo-crypto@14.1.5_expo-modules-core@2.5.0_react-native@0.79.7_patch_hash=461d44d8d4f5e_437882c4c7615832de65b9d2f3d25360/node_modules/expo-crypto/ios`)"
   - "ExpoFileSystem (from `../../../node_modules/.pnpm/expo-file-system@18.1.11_expo-modules-core@2.5.0_react-native@0.79.7_patch_hash=461d44d_8038309ebf44ea46aed5989233848551/node_modules/expo-file-system/ios`)"
   - "ExpoFont (from `../../../node_modules/.pnpm/expo-font@13.3.2_363258475871bbd677d6166de800f3d7/node_modules/expo-font/ios`)"
+  - "ExpoHaptics (from `../../../node_modules/.pnpm/expo-haptics@14.1.4_expo-modules-core@2.5.0_react-native@0.79.7_patch_hash=461d44d8d4f5_b9263c434cfd32854af40c4cc1e4ca29/node_modules/expo-haptics/ios`)"
   - "ExpoImageManipulator (from `../../../node_modules/.pnpm/expo-image-manipulator@13.1.7_expo-modules-core@2.5.0_react-native@0.79.7_patch_hash=46_c4a66dfa736c68bc96dc46085868e4f3/node_modules/expo-image-manipulator/ios`)"
   - "ExpoKeepAwake (from `../../../node_modules/.pnpm/expo-keep-awake@14.1.4_expo-modules-core@2.5.0_react-native@0.79.7_patch_hash=461d44d8d_60b653d6cb99678413261feb029a3d07/node_modules/expo-keep-awake/ios`)"
   - "ExpoModulesCore (from `../../../node_modules/.pnpm/expo-modules-core@2.5.0_react-native@0.79.7_patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cf_09451534d09b9a7d7d177d4de70db930/node_modules/expo-modules-core`)"
@@ -2995,6 +2998,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/.pnpm/expo-file-system@18.1.11_expo-modules-core@2.5.0_react-native@0.79.7_patch_hash=461d44d_8038309ebf44ea46aed5989233848551/node_modules/expo-file-system/ios"
   ExpoFont:
     :path: "../../../node_modules/.pnpm/expo-font@13.3.2_363258475871bbd677d6166de800f3d7/node_modules/expo-font/ios"
+  ExpoHaptics:
+    :path: "../../../node_modules/.pnpm/expo-haptics@14.1.4_expo-modules-core@2.5.0_react-native@0.79.7_patch_hash=461d44d8d4f5_b9263c434cfd32854af40c4cc1e4ca29/node_modules/expo-haptics/ios"
   ExpoImageManipulator:
     :path: "../../../node_modules/.pnpm/expo-image-manipulator@13.1.7_expo-modules-core@2.5.0_react-native@0.79.7_patch_hash=46_c4a66dfa736c68bc96dc46085868e4f3/node_modules/expo-image-manipulator/ios"
   ExpoKeepAwake:
@@ -3258,6 +3263,7 @@ SPEC CHECKSUMS:
   ExpoCrypto: a9f1d75baeea6ef8b03c1660621585196c382e85
   ExpoFileSystem: 7f92f7be2f5c5ed40a7c9efc8fa30821181d9d63
   ExpoFont: cf508bc2e6b70871e05386d71cab927c8524cc8e
+  ExpoHaptics: 0ff6e0d83cd891178a306e548da1450249d54500
   ExpoImageManipulator: 1e06e7a1e56f454e75d01b7032c1e44963bfc865
   ExpoKeepAwake: bf0811570c8da182bfb879169437d4de298376e7
   ExpoModulesCore: 471ae18809dc8a5c9a623193a317eef6048a4f8a

--- a/apps/ledger-live-mobile/jest.config.js
+++ b/apps/ledger-live-mobile/jest.config.js
@@ -96,7 +96,9 @@ module.exports = {
   moduleNameMapper: {
     ...pathsToModuleNameMapper(compilerOptions.paths),
     "^@features/(.*)$": "<rootDir>/../../features/$1/src",
-    "^@ledgerhq/(lumen-ui-rnative|lumen-design-core)$": "<rootDir>/node_modules/@ledgerhq/$1",
+    "^@ledgerhq/lumen-ui-rnative$":
+      "<rootDir>/node_modules/@ledgerhq/lumen-ui-rnative/src/index.ts",
+    "^@ledgerhq/lumen-design-core$": "<rootDir>/node_modules/@ledgerhq/lumen-design-core",
     "^react$": "<rootDir>/node_modules/react",
     "^react/(.*)$": "<rootDir>/node_modules/react/$1",
     "^react-native/(.*)$": "<rootDir>/node_modules/react-native/$1",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -160,6 +160,7 @@
     "expo": "catalog:",
     "expo-crypto": "catalog:",
     "expo-file-system": "catalog:",
+    "expo-haptics": "catalog:",
     "expo-image-loader": "catalog:",
     "expo-image-manipulator": "catalog:",
     "expo-keep-awake": "catalog:",

--- a/apps/ledger-live-mobile/scripts/resolver.js
+++ b/apps/ledger-live-mobile/scripts/resolver.js
@@ -17,7 +17,6 @@ module.exports = (path, options) => {
       ]);
 
       if (pkgNamesToTarget.has(pkg.name)) {
-        // console.log('>>>', pkg.name)
         delete pkg["exports"];
         delete pkg["module"];
       }

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketTile/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketTile/index.tsx
@@ -5,7 +5,7 @@ import {
   TileTitle,
   TileDescription,
   Text,
-  TileSpot,
+  Spot,
 } from "@ledgerhq/lumen-ui-rnative";
 import { useTranslation } from "~/context/Locale";
 import { getChangePercentage } from "@ledgerhq/live-common/market/utils/index";
@@ -46,7 +46,7 @@ const MarketTile = ({ item, index, range, onPress }: MarketTileProps) => {
       accessibilityHint={t("marketBanner.tile.accessibilityHint")}
       accessibilityRole="button"
     >
-      <TileSpot size={40} appearance="icon" icon={renderIcon} />
+      <Spot size={40} appearance="icon" icon={renderIcon} />
       <TileContent>
         <TileTitle>{capitalizedTicker}</TileTitle>
         <TileDescription>

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/ViewAllTile/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/ViewAllTile/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Tile, TileSpot, TileContent, TileTitle } from "@ledgerhq/lumen-ui-rnative";
+import { Tile, Spot, TileContent, TileTitle } from "@ledgerhq/lumen-ui-rnative";
 import { ChevronRight } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useTranslation } from "~/context/Locale";
 import { ViewAllTileProps } from "../../types";
@@ -17,7 +17,7 @@ const ViewAllTile = ({ onPress }: ViewAllTileProps) => {
       accessibilityLabel={t("marketBanner.viewAll")}
       accessibilityHint={t("marketBanner.viewAllAccessibilityHint")}
     >
-      <TileSpot size={40} appearance="icon" icon={ChevronRight} />
+      <Spot size={40} appearance="icon" icon={ChevronRight} />
       <TileContent>
         <TileTitle>{t("marketBanner.viewAll")}</TileTitle>
       </TileContent>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
@@ -14,8 +14,11 @@ jest.mock("react-native-reanimated", () => {
     useAnimatedStyle: () => ({}),
     useAnimatedReaction: () => {},
     withTiming: (toValue: unknown) => toValue,
+    withRepeat: (animation: unknown) => animation,
     withDelay: (_delay: number, animation: unknown) => animation,
     withSpring: (toValue: unknown) => toValue,
+    cancelAnimation: () => {},
+    useReducedMotion: () => false,
     default: {
       View: RN.View,
       Text: RN.Text,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecentAddress.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecentAddress.tsx
@@ -1,11 +1,5 @@
 import type { RecentAddress as RecentAddressType } from "@ledgerhq/live-common/flows/send/recipient/types";
-import {
-  Tile,
-  TileContent,
-  TileDescription,
-  TileSpot,
-  TileTitle,
-} from "@ledgerhq/lumen-ui-rnative";
+import { Tile, TileContent, TileDescription, Spot, TileTitle } from "@ledgerhq/lumen-ui-rnative";
 import React from "react";
 import { useRecentAddressDisplay } from "../hooks/useRecentAddressDisplay";
 
@@ -29,7 +23,7 @@ export function RecentAddress({
       onLongPress={() => onLongPress(recentAddress)}
       lx={{ width: "s112" }}
     >
-      <TileSpot size={48} appearance="icon" icon={icon} />
+      <Spot size={48} appearance="icon" icon={icon} />
       <TileContent>
         <TileTitle ellipsizeMode="middle" typography="body2SemiBold">
           {displayName}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,14 +40,14 @@ catalogs:
       specifier: 1.2.3
       version: 1.2.3
     '@ledgerhq/lumen-design-core':
-      specifier: 0.1.3
-      version: 0.1.3
+      specifier: 0.1.5
+      version: 0.1.5
     '@ledgerhq/lumen-ui-react':
-      specifier: 0.1.9
-      version: 0.1.9
+      specifier: 0.1.12
+      version: 0.1.12
     '@ledgerhq/lumen-ui-rnative':
-      specifier: 0.1.8
-      version: 0.1.8
+      specifier: 0.1.11
+      version: 0.1.11
     '@ledgerhq/speculos-device-controller':
       specifier: 0.2.3
       version: 0.2.3
@@ -276,6 +276,9 @@ catalogs:
     expo-font:
       specifier: 13.3.2
       version: 13.3.2
+    expo-haptics:
+      specifier: 14.1.4
+      version: 14.1.4
     expo-image-loader:
       specifier: 5.0.0
       version: 5.0.0
@@ -506,7 +509,7 @@ importers:
         version: link:tools/create-release-hash
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.3
+        version: 0.1.5
       '@ledgerhq/pnpm-utils':
         specifier: workspace:*
         version: link:tools/pnpm-utils
@@ -892,10 +895,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.3
+        version: 0.1.5
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.9(e3565a5b1275aee5d93efe21059eb47c)
+        version: 0.1.12(e3565a5b1275aee5d93efe21059eb47c)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -1542,10 +1545,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.3
+        version: 0.1.5
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.8(627272c88a11b23a05018dc6be287ca4)
+        version: 0.1.11(63a7b567f0c1f07a3d57d2905cc6546b)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -1660,6 +1663,9 @@ importers:
       expo-file-system:
         specifier: 'catalog:'
         version: 18.1.11(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(8b8ff0c82326e851a5df6b820b50a185))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      expo-haptics:
+        specifier: 'catalog:'
+        version: 14.1.4(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(8b8ff0c82326e851a5df6b820b50a185))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       expo-image-loader:
         specifier: 'catalog:'
         version: 5.0.0(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(8b8ff0c82326e851a5df6b820b50a185))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -2603,13 +2609,13 @@ importers:
         version: 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.3
+        version: 0.1.5
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.9(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.12(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.8(65a148326fef7725fbbb3ece085cdedf)
+        version: 0.1.11(fd7f3efdbf514d106ae2ca6d94c175a8)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -15520,11 +15526,11 @@ packages:
   '@ledgerhq/logs@6.14.0':
     resolution: {integrity: sha512-kJFu1+asWQmU9XlfR1RM3lYR76wuEoPyZvkI/CNjpft78BQr3+MMf3Nu77ABzcKFnhIcmAkOLlDQ6B8L6hDXHA==}
 
-  '@ledgerhq/lumen-design-core@0.1.3':
-    resolution: {integrity: sha512-8/QgqcKfKpukwkplQEqTK+clkC5VPTWuQ7dOw8hfiRBxmqxEmP9hHYfYaC4XyesvToUjeSnD5IIRyTESnMWr6A==}
+  '@ledgerhq/lumen-design-core@0.1.5':
+    resolution: {integrity: sha512-9WN3KUUytMf30WrvXp1PhGDy39XYawo1DWfJEC48KfYda27aaQtz127qHX740V8WvBIeFIo6v6aX9Af8VofoEQ==}
 
-  '@ledgerhq/lumen-ui-react@0.1.9':
-    resolution: {integrity: sha512-HYSU/B1jmJ1fWHz4kD8Xpgr184WLL0dqBeTOuYCGVYnbi0ST8j3ok5N7v4JBHtk3W/XZSYDMoDRwK2RCsWSojA==}
+  '@ledgerhq/lumen-ui-react@0.1.12':
+    resolution: {integrity: sha512-PIPjjoCRqcz43XHRwYxaOr2JXH0r117grTLEp5ar+nLtYynBlWXRTj0j6YblERtiEyYf2FPkRWgGMe1dUGY/xA==}
     peerDependencies:
       '@radix-ui/react-checkbox': ^1.3.2
       '@radix-ui/react-dialog': ^1.1.15
@@ -15540,21 +15546,23 @@ packages:
       react-dom: 19.0.0
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-rnative@0.1.8':
-    resolution: {integrity: sha512-OjANUhWU2c3SVhpE4h5gLSymOQCa9ODV+N6uiX0lAF/XJNiUg/6ij1DLE/D+wf0ZryWV3YTbTeMUsKLY/ibgmg==}
+  '@ledgerhq/lumen-ui-rnative@0.1.11':
+    resolution: {integrity: sha512-/AGBIBx8LLsCbOAU6cFME8Qrz/H5LS9ocMI/56gw2Y6i22QneraEXoq/I/Bjya1iFVp7kXZ3nSqH3XvGh6PIgQ==}
     peerDependencies:
       '@gorhom/bottom-sheet': ^5.0.0
-      '@ledgerhq/lumen-design-core': 0.1.3
+      '@ledgerhq/lumen-design-core': 0.1.5
       '@sbaiahmed1/react-native-blur': ^4.5.5
       '@types/react': ^19.0.0
+      expo: '>=53.0.0'
+      expo-haptics: ~14.1.4
       react: 19.0.0
       react-native: ~0.79.7
       react-native-reanimated: ^3.0.0
       react-native-safe-area-context: ^4.0.0 || ^5.0.0
       react-native-svg: ^15.0.0
 
-  '@ledgerhq/lumen-utils-shared@0.1.1':
-    resolution: {integrity: sha512-iBf0QO4Ki/72pygmavVTexdSug4TuBXUOtfgcl2Ro8eg/jphmLwxGAcxIDej3dKi/aFUtcE+RRrAGQyQ4eRZ5w==}
+  '@ledgerhq/lumen-utils-shared@0.1.2':
+    resolution: {integrity: sha512-ct6OSX5ExBn69pJ3cSBygBJ3SE4DJXV+TCLerqyI+iyO/0L1Mgf0LRmNeSXlFrHXQmmuPw18BISvQA+5J2Cp0w==}
     peerDependencies:
       react: 19.0.0
 
@@ -25147,6 +25155,24 @@ packages:
       expo-constants:
         optional: true
       expo-modules-core:
+        optional: true
+      react-native:
+        optional: true
+
+  expo-haptics@14.1.4:
+    resolution: {integrity: sha512-QZdE3NMX74rTuIl82I+n12XGwpDWKb8zfs5EpwsnGi/D/n7O2Jd4tO5ivH+muEG/OCJOMq5aeaVDqqaQOhTkcA==}
+    peerDependencies:
+      expo: '*'
+      expo-constants: '*'
+      expo-modules-core: '*'
+      react: 19.0.0
+      react-native: '*'
+    peerDependenciesMeta:
+      expo-constants:
+        optional: true
+      expo-modules-core:
+        optional: true
+      react:
         optional: true
       react-native:
         optional: true
@@ -42608,14 +42634,14 @@ snapshots:
 
   '@ledgerhq/logs@6.14.0': {}
 
-  '@ledgerhq/lumen-design-core@0.1.3':
+  '@ledgerhq/lumen-design-core@0.1.5':
     dependencies:
       tailwindcss: 4.1.18
       tslib: 2.6.2
 
-  '@ledgerhq/lumen-ui-react@0.1.9(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.12(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
-      '@ledgerhq/lumen-utils-shared': 0.1.1(react@19.0.0)
+      '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
       clsx: 2.1.1
       i18next: 23.10.1
       react: 19.0.0
@@ -42625,9 +42651,9 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.9(e3565a5b1275aee5d93efe21059eb47c)':
+  '@ledgerhq/lumen-ui-react@0.1.12(e3565a5b1275aee5d93efe21059eb47c)':
     dependencies:
-      '@ledgerhq/lumen-utils-shared': 0.1.1(react@19.0.0)
+      '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -42646,13 +42672,15 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-rnative@0.1.8(627272c88a11b23a05018dc6be287ca4)':
+  '@ledgerhq/lumen-ui-rnative@0.1.11(63a7b567f0c1f07a3d57d2905cc6546b)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(9b9b36296d827f645c841ba7168b6543)
-      '@ledgerhq/lumen-design-core': 0.1.3
-      '@ledgerhq/lumen-utils-shared': 0.1.1(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.5
+      '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
       '@sbaiahmed1/react-native-blur': 4.5.5(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@types/react': 19.0.14
+      expo: 53.0.25(8b8ff0c82326e851a5df6b820b50a185)
+      expo-haptics: 14.1.4(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(8b8ff0c82326e851a5df6b820b50a185))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       i18next: 23.10.1
       react: 19.0.0
       react-i18next: 14.1.3(i18next@23.10.1)(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -42663,11 +42691,11 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.8(65a148326fef7725fbbb3ece085cdedf)':
+  '@ledgerhq/lumen-ui-rnative@0.1.11(fd7f3efdbf514d106ae2ca6d94c175a8)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      '@ledgerhq/lumen-design-core': 0.1.3
-      '@ledgerhq/lumen-utils-shared': 0.1.1(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.5
+      '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
       '@types/react': 19.0.14
       i18next: 23.10.1
       react: 19.0.0
@@ -42679,7 +42707,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-utils-shared@0.1.1(react@19.0.0)':
+  '@ledgerhq/lumen-utils-shared@0.1.2(react@19.0.0)':
     dependencies:
       clsx: 2.1.1
       react: 19.0.0
@@ -55922,6 +55950,14 @@ snapshots:
       expo-constants: 17.1.8(expo-modules-core@2.5.0)(expo@53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       expo-modules-core: 2.5.0(expo-constants@17.1.8)(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       react-native: 0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@5.9.3))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
+
+  expo-haptics@14.1.4(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(8b8ff0c82326e851a5df6b820b50a185))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+    dependencies:
+      expo: 53.0.25(8b8ff0c82326e851a5df6b820b50a185)
+    optionalDependencies:
+      expo-modules-core: 2.5.0(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-native: 0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0)
 
   expo-image-loader@5.0.0(expo-modules-core@2.5.0(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(expo@53.0.25(8b8ff0c82326e851a5df6b820b50a185))(react-native@0.79.7(patch_hash=461d44d8d4f5eecdc7a3b2b8cc6a48cfbe0c4a73d6d130be09381aba6618e877)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.9.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,9 +28,9 @@ catalog:
   "@ledgerhq/device-transport-kit-speculos": 1.2.0
   "@ledgerhq/device-transport-kit-web-hid": 1.2.3
   "@ledgerhq/speculos-device-controller": 0.2.3
-  "@ledgerhq/lumen-design-core": 0.1.3
-  "@ledgerhq/lumen-ui-react": 0.1.9
-  "@ledgerhq/lumen-ui-rnative": 0.1.8
+  "@ledgerhq/lumen-design-core": 0.1.5
+  "@ledgerhq/lumen-ui-react": 0.1.12
+  "@ledgerhq/lumen-ui-rnative": 0.1.11
   # React Native
   react-native: 0.79.7
   "@react-native/assets-registry": 0.79.7
@@ -53,6 +53,7 @@ catalog:
   expo-file-system: 18.1.11
   expo-image-loader: 5.0.0
   expo-image-manipulator: 13.1.7
+  expo-haptics: 14.1.4
   expo-keep-awake: 14.1.4
   expo-modules-autolinking: 2.1.14
   expo-modules-core: 2.5.0


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new logic introduced — dependency bump with mechanical renames only._
- [x] **Impact of the changes:**
      - Desktop: FearAndGreedDialog, ModularDialogContent, ReceiveOptionsDialog (`extended` → `expanded`)
      - Desktop: TrendingAssetsList, ViewAllTile (`TileSpot` → `Spot`)
      - Desktop: StrategySelect (`SubheaderAction` removed, replaced with inline layout)
      - Mobile: MarketTile, ViewAllTile, RecentAddress (`TileSpot` → `Spot`)

### 📝 Description

Bumps Lumen UI packages to their latest versions:
- `@ledgerhq/lumen-design-core`: 0.1.3 → 0.1.5
- `@ledgerhq/lumen-ui-react`: 0.1.9 → 0.1.12
- `@ledgerhq/lumen-ui-rnative`: 0.1.8 → 0.1.11

Adapts consuming code to the following breaking API changes:
- **`TileSpot` → `Spot`**: Component renamed across both desktop and mobile.
- **`DialogHeader` appearance `"extended"` → `"expanded"`**: Prop value renamed on desktop.
- **`SubheaderAction` removed**: Replaced with a custom flex layout + `Link` in `StrategySelect`.

### ❓ Context

- Routine dependency bump to stay on latest Lumen design system. https://ledgerhq.atlassian.net/browse/LIVE-27850

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)