### PR TITLE
[LWM] perf(mobile): fix redux selector warnings and unnecessary re-renders

### DIFF
--- a/.changeset/bright-selectors-clean.md
+++ b/.changeset/bright-selectors-clean.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Redux selector warnings by replacing identity selectors with store subscriptions, suppressing intentional identity function checks, and adding shallowEqual to currency settings selector

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -1,11 +1,10 @@
 import { trustchainStoreSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { postOnboardingSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { exportWalletState, walletStateExportShouldDiffer } from "@ledgerhq/live-wallet/store";
-import identity from "lodash/identity";
 import isEqual from "lodash/isEqual";
 import throttleFn from "lodash/throttle";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useSelector } from "~/context/hooks";
+import { useStore } from "~/context/hooks";
 import { useTrackingPairs, useUserSettings } from "~/actions/general";
 import {
   saveAccounts,
@@ -28,7 +27,6 @@ import { exportMarketSelector } from "~/reducers/market";
 import { settingsStoreSelector } from "~/reducers/settings";
 import type { State } from "~/reducers/types";
 import { walletSelector } from "~/reducers/wallet";
-import { Maybe } from "../types/helpers";
 import {
   extractPersistedCALFromState,
   persistedCALContentEqual,
@@ -39,8 +37,6 @@ import {
   exportCountervalues,
   hasNewCountervaluesToExport,
 } from "@ledgerhq/live-countervalues/logic";
-
-type MaybeState = Maybe<State>;
 
 type Props<Data, Stats> = {
   throttle: number;
@@ -57,50 +53,47 @@ function useDBSaveEffect<D, S>({
   getChangesStats,
   saveAtStart = false,
 }: Props<D, S>) {
-  const state: MaybeState = useSelector(identity);
+  const store = useStore();
   const forceSave = useRef(saveAtStart);
-  const lastSavedState = useRef(state);
+  const lastSavedState = useRef<State>(store.getState());
   const isSaving = useRef(false);
-  // we keep an updated version of current props in "latestProps" ref
   const latestProps = useRef({
     lense,
     save,
-    state,
     getChangesStats,
   });
   const checkForSave = useMemo(
     () =>
-      // throttle allow to not spam lense and save too much because they are costly
-      // nb it does not prevent race condition here. save must be idempotent and atomic
       throttleFn(async (): Promise<void> => {
-        if (isSaving.current) return checkForSave(); // if we are already saving, we re-schedule
-        const { lense, save, state, getChangesStats } = latestProps.current;
-        if (lastSavedState?.current && state) {
-          const changedStats = getChangesStats(lastSavedState.current, state); // we compare last saved with latest state
-          if (!changedStats && !forceSave.current) return; // if it's falsy, it means there is no changes
+        if (isSaving.current) return checkForSave();
+        const { lense, save, getChangesStats } = latestProps.current;
+        const state = store.getState();
+        if (lastSavedState.current && state) {
+          const changedStats = getChangesStats(lastSavedState.current, state);
+          if (!changedStats && !forceSave.current) return;
           isSaving.current = true;
           try {
-            await save(lense(state), changedStats); // we save it for real
+            await save(lense(state), changedStats);
           } finally {
             isSaving.current = false;
           }
-          lastSavedState.current = state; // for the next round, we will be able to compare with latest successful state
+          lastSavedState.current = state;
           forceSave.current = false;
         }
       }, throttle),
-    [throttle],
+    [throttle, store],
   );
   useFlushMechanism(checkForSave);
-  // each time a prop changes, we will checkForSave
+
   useEffect(() => {
-    latestProps.current = {
-      lense,
-      save,
-      state,
-      getChangesStats,
-    };
+    const unsubscribe = store.subscribe(() => checkForSave());
+    return unsubscribe;
+  }, [store, checkForSave]);
+
+  useEffect(() => {
+    latestProps.current = { lense, save, getChangesStats };
     checkForSave();
-  }, [lense, save, state, checkForSave, getChangesStats]);
+  }, [lense, save, checkForSave, getChangesStats]);
 }
 const flushes: Array<() => void> = [];
 export const flushAll = () => Promise.all(flushes.map(flush => flush()));

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useCurrencySettingsForAccount.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useCurrencySettingsForAccount.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { shallowEqual } from "react-redux";
 import { useSelector } from "~/context/hooks";
 import type { AccountLike } from "@ledgerhq/types-live";
 import { currencySettingsForAccountSelector } from "~/reducers/settings";
@@ -18,5 +19,5 @@ export function useCurrencySettingsForAccount(account: AccountLike) {
     (state: State) => currencySettingsForAccountSelector(state.settings, { account }),
     [account],
   );
-  return useSelector(selector);
+  return useSelector(selector, shallowEqual);
 }

--- a/apps/ledger-live-mobile/src/reducers/accounts.ts
+++ b/apps/ledger-live-mobile/src/reducers/accounts.ts
@@ -166,7 +166,9 @@ const shallowAccountsSelectorCreator = createSelectorCreator(lruMemoize, (a, b):
     flattenAccounts(b as AccountLikeArray).map(accountHash),
   ),
 );
-export const shallowAccountsSelector = shallowAccountsSelectorCreator(accountsSelector, a => a);
+export const shallowAccountsSelector = shallowAccountsSelectorCreator(accountsSelector, a => a, {
+  devModeChecks: { identityFunctionCheck: "never" },
+});
 
 export const flattenAccountsSelector = createSelector(accountsSelector, flattenAccounts);
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Store.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Store.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable no-console */
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import styled from "styled-components/native";
 import get from "lodash/get";
 import set from "lodash/set";
 import cloneDeep from "lodash/cloneDeep";
 import { BigNumber } from "bignumber.js";
 import { StyleSheet, ScrollView } from "react-native";
-import { useDispatch, useSelector } from "~/context/hooks";
+import { useDispatch, useStore } from "~/context/hooks";
 import { Alert, Flex } from "@ledgerhq/native-ui";
 import { useTheme } from "@react-navigation/native";
 import Share from "react-native-share";
@@ -28,7 +28,9 @@ const Separator = styled(Flex).attrs({
 })``;
 
 export default function Store() {
-  const state = useSelector(s => s);
+  const store = useStore();
+  const [state, setState] = useState<State>(() => store.getState());
+  useEffect(() => store.subscribe(() => setState(store.getState())), [store]);
   const { colors } = useTheme();
 
   const [hasMadeChanges, setHasMadeChanges] = useState(false);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing tests pass. No new tests added as changes are internal refactors of hook internals._
- [x] **Impact of the changes:**
      - App startup log noise (11x "Selector identity returned root state" warnings eliminated)
      - `ConfigureDBSaveEffects` performance (11 fewer re-renders per Redux dispatch)
      - `OperationRow` re-render frequency (shallowEqual prevents spurious re-renders)
      - Debug Store screen (warning suppressed)

### 📝 Description

**Problem**: The mobile app in dev mode floods the console with Redux selector warnings at startup and on every state change. Three distinct issues: `useDBSaveEffect` uses `useSelector(identity)` selecting the entire root state 11 times, `shallowAccountsSelector` triggers a false-positive identity function warning from Reselect 5, and `currencySettingsSelector` creates new object references on every call causing unnecessary `OperationRow` re-renders.

**Solution**:
- Replaced `useSelector(identity)` in `DBSave.ts` with `useStore()` + `store.subscribe()`, moving save logic entirely outside the React render cycle
- Added `devModeChecks: { identityFunctionCheck: "never" }` to `shallowAccountsSelector` (intentional identity pattern for custom memoization)
- Added `shallowEqual` comparator to `useCurrencySettingsForAccount` hook

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27816

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
EOF
)"