### PR TITLE
[LWM] fix(mobile): restore read-only fake coins list when asset section flag is disabled

### DIFF
--- a/.changeset/silent-coins-restore.md
+++ b/.changeset/silent-coins-restore.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix read-only portfolio to restore fake coins list when asset section flag is disabled

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/usePortfolioCryptosSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/__tests__/usePortfolioCryptosSectionViewModel.test.ts
@@ -3,6 +3,7 @@ import { renderHook } from "@tests/test-renderer";
 import { NavigatorName, ScreenName } from "~/const";
 import { useDistribution } from "~/actions/general";
 import { Asset } from "~/types/asset";
+import { State } from "~/reducers/types";
 import usePortfolioCryptosSectionViewModel from "../usePortfolioCryptosSectionViewModel";
 import { bitcoin, ethereum, createCryptoAsset } from "./shared";
 
@@ -23,6 +24,12 @@ jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData", () => ({
   useAssetsData: () => ({ data: undefined, isLoading: false }),
 }));
 
+const mockReadOnlyCoins = jest.fn();
+
+jest.mock("~/hooks/useReadOnlyCoins", () => ({
+  useReadOnlyCoins: (opts: { maxDisplayed: number }) => mockReadOnlyCoins(opts),
+}));
+
 const mockDistribution = (list: Asset[] = [], isAvailable = true) => {
   (useDistribution as jest.Mock).mockReturnValue({ isAvailable, list });
 };
@@ -31,6 +38,7 @@ describe("usePortfolioCryptosSectionViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDistribution();
+    mockReadOnlyCoins.mockReturnValue({ sortedCryptoCurrencies: [] });
   });
 
   describe("asset filtering and display", () => {
@@ -91,8 +99,16 @@ describe("usePortfolioCryptosSectionViewModel", () => {
   });
 
   describe("onPressShowAll", () => {
-    it("should navigate to AssetsList screen", () => {
-      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel());
+    it("should navigate to AssetsList when llmAccountListUI is enabled", () => {
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            overriddenFeatureFlags: { llmAccountListUI: { enabled: true } },
+          },
+        }),
+      });
 
       act(() => {
         result.current.onPressShowAll();
@@ -105,6 +121,26 @@ describe("usePortfolioCryptosSectionViewModel", () => {
           showHeader: true,
           isSyncEnabled: true,
         },
+      });
+    });
+
+    it("should navigate to legacy Assets screen when llmAccountListUI is disabled", () => {
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            overriddenFeatureFlags: { llmAccountListUI: { enabled: false } },
+          },
+        }),
+      });
+
+      act(() => {
+        result.current.onPressShowAll();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+        screen: ScreenName.Assets,
       });
     });
   });
@@ -149,6 +185,88 @@ describe("usePortfolioCryptosSectionViewModel", () => {
       );
 
       expect(result.current.hasMore).toBe(false);
+    });
+  });
+
+  describe("isReadOnly", () => {
+    it("should return assets from useReadOnlyCoins", () => {
+      mockReadOnlyCoins.mockReturnValue({
+        sortedCryptoCurrencies: [bitcoin, ethereum],
+      });
+
+      const { result } = renderHook(() =>
+        usePortfolioCryptosSectionViewModel({ isReadOnly: true }),
+      );
+
+      expect(result.current.assetsCount).toBe(2);
+      expect(result.current.assetsToDisplay).toHaveLength(2);
+      expect(result.current.assetsToDisplay[0].currency).toBe(bitcoin);
+      expect(result.current.assetsToDisplay[1].currency).toBe(ethereum);
+    });
+
+    it("should always return hasMore true", () => {
+      mockReadOnlyCoins.mockReturnValue({
+        sortedCryptoCurrencies: [bitcoin, ethereum],
+      });
+
+      const { result } = renderHook(() =>
+        usePortfolioCryptosSectionViewModel({ isReadOnly: true }),
+      );
+
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    it("should navigate to legacy Assets screen on show all press", () => {
+      mockReadOnlyCoins.mockReturnValue({
+        sortedCryptoCurrencies: [bitcoin, ethereum],
+      });
+
+      const { result } = renderHook(() =>
+        usePortfolioCryptosSectionViewModel({ isReadOnly: true }),
+      );
+
+      act(() => {
+        result.current.onPressShowAll();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+        screen: ScreenName.Assets,
+      });
+    });
+
+    it("should build assets with zero amount and empty accounts", () => {
+      mockReadOnlyCoins.mockReturnValue({
+        sortedCryptoCurrencies: [bitcoin],
+      });
+
+      const { result } = renderHook(() =>
+        usePortfolioCryptosSectionViewModel({ isReadOnly: true }),
+      );
+
+      expect(result.current.assetsToDisplay[0]).toMatchObject({
+        currency: bitcoin,
+        amount: 0,
+        accounts: [],
+      });
+    });
+
+    it("should navigate to Asset detail on item press", () => {
+      mockReadOnlyCoins.mockReturnValue({
+        sortedCryptoCurrencies: [ethereum],
+      });
+
+      const { result } = renderHook(() =>
+        usePortfolioCryptosSectionViewModel({ isReadOnly: true }),
+      );
+
+      act(() => {
+        result.current.onItemPress(result.current.assetsToDisplay[0]);
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+        screen: ScreenName.Asset,
+        params: { currency: ethereum },
+      });
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/index.tsx
@@ -15,14 +15,16 @@ import usePortfolioCryptosSectionViewModel from "./usePortfolioCryptosSectionVie
 
 interface PortfolioCryptosSectionProps {
   isEmptyState?: boolean;
+  isReadOnly?: boolean;
 }
 
 const PortfolioCryptosSectionComponent: React.FC<PortfolioCryptosSectionProps> = ({
   isEmptyState,
+  isReadOnly,
 }) => {
   const { t } = useTranslation();
   const { assetsCount, hasMore, assetsToDisplay, onPressShowAll, onItemPress } =
-    usePortfolioCryptosSectionViewModel({ isEmptyState });
+    usePortfolioCryptosSectionViewModel({ isEmptyState, isReadOnly });
 
   if (assetsCount === 0) return null;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/usePortfolioCryptosSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCryptosSection/usePortfolioCryptosSectionViewModel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
@@ -10,9 +11,11 @@ import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 import { Asset } from "~/types/asset";
 import { track } from "~/analytics";
 import { useDefaultAssets } from "./useDefaultAssets";
+import { useReadOnlyCoins } from "~/hooks/useReadOnlyCoins";
 
 export const MAX_ASSETS_TO_DISPLAY = 6;
 export const EMPTY_STATE_MAX_ASSETS = 4;
+export const READ_ONLY_MAX_ASSETS = 5;
 
 export interface PortfolioCryptosSectionViewModelResult {
   assetsCount: number;
@@ -24,12 +27,15 @@ export interface PortfolioCryptosSectionViewModelResult {
 
 interface UsePortfolioCryptosSectionViewModelOptions {
   isEmptyState?: boolean;
+  isReadOnly?: boolean;
 }
 
 const usePortfolioCryptosSectionViewModel = ({
   isEmptyState = false,
+  isReadOnly = false,
 }: UsePortfolioCryptosSectionViewModelOptions = {}): PortfolioCryptosSectionViewModelResult => {
   const hideEmptyTokenAccount = useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
+  const isAccountListUIEnabled = useFeature("llmAccountListUI")?.enabled;
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
 
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
@@ -56,7 +62,18 @@ const usePortfolioCryptosSectionViewModel = ({
 
   const defaultAssets = useDefaultAssets(isEmptyState);
 
-  const assets = isEmptyState ? defaultAssets : filteredAssets;
+  const { sortedCryptoCurrencies } = useReadOnlyCoins({ maxDisplayed: READ_ONLY_MAX_ASSETS });
+  const readOnlyAssets = useMemo<Asset[]>(
+    () => sortedCryptoCurrencies.map(currency => ({ amount: 0, accounts: [], currency })),
+    [sortedCryptoCurrencies],
+  );
+
+  const assets = useMemo<Asset[]>(() => {
+    if (isEmptyState) return defaultAssets;
+    if (isReadOnly) return readOnlyAssets;
+    return filteredAssets;
+  }, [isEmptyState, isReadOnly, defaultAssets, readOnlyAssets, filteredAssets]);
+
   const assetsCount = assets.length;
 
   const assetsToDisplay = useMemo(
@@ -70,15 +87,21 @@ const usePortfolioCryptosSectionViewModel = ({
       type: "view",
       page: "Wallet",
     });
-    navigation.navigate(NavigatorName.Assets, {
-      screen: ScreenName.AssetsList,
-      params: {
-        sourceScreenName: ScreenName.Portfolio,
-        showHeader: true,
-        isSyncEnabled: true,
-      },
-    });
-  }, [navigation]);
+    if (!isReadOnly && isAccountListUIEnabled) {
+      navigation.navigate(NavigatorName.Assets, {
+        screen: ScreenName.AssetsList,
+        params: {
+          sourceScreenName: ScreenName.Portfolio,
+          showHeader: true,
+          isSyncEnabled: true,
+        },
+      });
+    } else {
+      navigation.navigate(NavigatorName.Accounts, {
+        screen: ScreenName.Assets,
+      });
+    }
+  }, [navigation, isAccountListUIEnabled, isReadOnly]);
 
   const onItemPress = useCallback(
     (asset: Asset) => {
@@ -102,9 +125,15 @@ const usePortfolioCryptosSectionViewModel = ({
     [navigation],
   );
 
+  const hasMore = useMemo(() => {
+    if (isEmptyState) return false;
+    if (isReadOnly) return true;
+    return assetsCount > MAX_ASSETS_TO_DISPLAY;
+  }, [isEmptyState, isReadOnly, assetsCount]);
+
   return {
     assetsCount,
-    hasMore: isEmptyState ? false : assetsCount > MAX_ASSETS_TO_DISPLAY,
+    hasMore,
     assetsToDisplay,
     onPressShowAll,
     onItemPress,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoSignerContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoSignerContent.tsx
@@ -25,6 +25,10 @@ export const PortfolioNoSignerContent = ({
     <TransferDrawer />
     <PortfolioBannersSection isFirst={true} isLNSUpsellBannerShown={isLNSUpsellBannerShown} />
     <MarketBanner />
-    {shouldDisplayAssetSection && <PortfolioCryptosSection isEmptyState={isEmptyState} />}
+    {shouldDisplayAssetSection ? (
+      <PortfolioCryptosSection isEmptyState={isEmptyState} />
+    ) : (
+      <PortfolioCryptosSection isReadOnly />
+    )}
   </Box>
 );

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/__integrations__/portfolioEmptySection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/__integrations__/portfolioEmptySection.integration.test.tsx
@@ -112,12 +112,12 @@ describe("PortfolioEmptySection", () => {
       expect(await screen.findByTestId("PortfolioCryptosList")).toBeVisible();
     });
 
-    it("should not render the cryptos section when assetSection flag is off", () => {
+    it("should render the read-only coins fallback when assetSection flag is off", async () => {
       renderWithReactQuery(<PortfolioEmptySection isLNSUpsellBannerShown={false} />, {
         overrideInitialState: overrideInitialStateWithAssetSection(false),
       });
 
-      expect(screen.queryByTestId("PortfolioCryptosList")).toBeNull();
+      expect(await screen.findByTestId("PortfolioCryptosList")).toBeVisible();
     });
 
     it("should render quick actions CTAs", () => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio screen in read-only / no-signer mode
  - `PortfolioCryptosSection` rendering when `assetSection` feature flag is off
  - `usePortfolioCryptosSectionViewModel` behaviour with `isReadOnly` prop

### 📝 Description

When the `assetSection` feature flag was disabled, `PortfolioNoSignerContent` was completely hiding the `PortfolioCryptosSection`, leaving the portfolio empty and providing no visual context for users without a signer.

This fix restores the expected behaviour by rendering `PortfolioCryptosSection` with an `isReadOnly` prop when the flag is off. In that mode, the component uses `useReadOnlyCoins` to display a curated list of coins with zero amounts — preserving the meaningful "fake list" UX while keeping the section gated correctly.

<img width="601" height="1311" alt="Simulator Screenshot - Test Ios - 2026-03-18 at 10 54 26" src="https://github.com/user-attachments/assets/b649c894-3c91-4bfe-a787-09161988195b" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-27825](https://ledgerhq.atlassian.net/browse/LIVE-27825)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27825]: https://ledgerhq.atlassian.net/browse/LIVE-27825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ