### PR TITLE
[LWM] Revert "[LWM] fix(mobile): keep portfolio title on one line"

### DIFF
--- a/.changeset/restore-two-line-limit.md
+++ b/.changeset/restore-two-line-limit.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Restore line limit to two for portfolio header

--- a/apps/ledger-live-mobile/src/screens/Portfolio/Header.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/Header.tsx
@@ -107,7 +107,7 @@ function PortfolioHeader({ hidePortfolio }: { hidePortfolio: boolean }) {
           flexShrink={1}
           textAlign="center"
           mr={3}
-          numberOfLines={1}
+          numberOfLines={2}
         >
           {t("tabs.portfolio")}
         </Text>


### PR DESCRIPTION
Reverts LedgerHQ/ledger-live#13959

**Why revert?**

We now truncate “Wallet” even if we have enough space.

https://ledgerhq.atlassian.net/browse/LIVE-24858?focusedCommentId=663161&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-663161