### PR TITLE
[LWM] fix(mobile): display yield instead of earn for gb users in main tab bar

### DIFF
--- a/.changeset/orange-books-complain.md
+++ b/.changeset/orange-books-complain.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix yield label for uk

--- a/apps/ledger-live-mobile/src/helpers/__tests__/getStakeLabelLocaleBased.test.ts
+++ b/apps/ledger-live-mobile/src/helpers/__tests__/getStakeLabelLocaleBased.test.ts
@@ -1,0 +1,49 @@
+import RNLocalize from "react-native-localize";
+import {
+  getCountryLocale,
+  getEarnOrYieldSuffix,
+  getStakeLabelLocaleBased,
+} from "../getStakeLabelLocaleBased";
+
+jest.mock("react-native-localize", () => ({
+  getCountry: jest.fn(() => "US"),
+}));
+
+const mockGetCountry = jest.mocked(RNLocalize.getCountry);
+
+describe("getStakeLabelLocaleBased", () => {
+  beforeEach(() => {
+    mockGetCountry.mockReturnValue("US");
+  });
+
+  describe("getCountryLocale", () => {
+    it("should delegate to RNLocalize.getCountry", () => {
+      mockGetCountry.mockReturnValue("FR");
+      expect(getCountryLocale()).toBe("FR");
+    });
+  });
+
+  describe("getEarnOrYieldSuffix", () => {
+    it('should return "yield" when locale is GB', () => {
+      mockGetCountry.mockReturnValue("GB");
+      expect(getEarnOrYieldSuffix()).toBe("yield");
+    });
+
+    it.each(["US", "FR", "DE", "JP"])('should return "earn" when locale is %s', locale => {
+      mockGetCountry.mockReturnValue(locale);
+      expect(getEarnOrYieldSuffix()).toBe("earn");
+    });
+  });
+
+  describe("getStakeLabelLocaleBased", () => {
+    it('should return "account.yield" for GB users', () => {
+      mockGetCountry.mockReturnValue("GB");
+      expect(getStakeLabelLocaleBased()).toBe("account.yield");
+    });
+
+    it('should return "account.earn" for non-GB users', () => {
+      mockGetCountry.mockReturnValue("US");
+      expect(getStakeLabelLocaleBased()).toBe("account.earn");
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/helpers/getStakeLabelLocaleBased.ts
+++ b/apps/ledger-live-mobile/src/helpers/getStakeLabelLocaleBased.ts
@@ -1,6 +1,8 @@
 import RNLocalize from "react-native-localize";
 
-export const getStakeLabelLocaleBased = () =>
-  RNLocalize.getCountry() === "GB" ? "account.yield" : "account.earn";
-
 export const getCountryLocale = () => RNLocalize.getCountry();
+
+export const getEarnOrYieldSuffix = (): "yield" | "earn" =>
+  getCountryLocale() === "GB" ? "yield" : "earn";
+
+export const getStakeLabelLocaleBased = () => `account.${getEarnOrYieldSuffix()}` as const;

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8688,6 +8688,7 @@
     "home": "Home",
     "swap": "Swap",
     "earn": "Earn",
+    "yield": "Yield",
     "card": "Card"
   },
   "syncIndicator": {

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/__integrations__/MainTabBar.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/__integrations__/MainTabBar.integration.test.tsx
@@ -3,8 +3,16 @@ import { View, Text } from "react-native";
 import { render, screen } from "@tests/test-renderer";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { NavigatorName } from "~/const";
+import * as stakeLabelHelpers from "~/helpers/getStakeLabelLocaleBased";
 import { MainTabBar } from "../index";
 import type { MainTabBarProps } from "../types";
+
+jest.mock("~/helpers/getStakeLabelLocaleBased", () => ({
+  ...jest.requireActual("~/helpers/getStakeLabelLocaleBased"),
+  getEarnOrYieldSuffix: jest.fn(() => "earn" as const),
+}));
+
+const mockGetEarnOrYieldSuffix = jest.mocked(stakeLabelHelpers.getEarnOrYieldSuffix);
 
 const Tab = createBottomTabNavigator();
 
@@ -70,5 +78,14 @@ describe("MainTabBar Integration", () => {
 
     const homeTab = screen.getByRole("tab", { name: "Home" });
     expect(homeTab).toHaveProp("accessibilityState", { selected: true });
+  });
+
+  it("should render 'Yield' instead of 'Earn' for GB users", () => {
+    mockGetEarnOrYieldSuffix.mockReturnValueOnce("yield");
+
+    render(<TestNavigator />);
+
+    expect(screen.getByRole("tab", { name: "Yield" })).toBeVisible();
+    expect(screen.queryByRole("tab", { name: "Earn" })).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/__tests__/useMainTabBarViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/__tests__/useMainTabBarViewModel.test.ts
@@ -1,8 +1,16 @@
 import { renderHook, act } from "@tests/test-renderer";
 import { NavigatorName } from "~/const";
+import * as stakeLabelHelpers from "~/helpers/getStakeLabelLocaleBased";
 import { scrollToTopEvent } from "../scrollToTopEvent";
 import { useMainTabBarViewModel } from "../useMainTabBarViewModel";
 import { track } from "~/analytics";
+
+jest.mock("~/helpers/getStakeLabelLocaleBased", () => ({
+  ...jest.requireActual("~/helpers/getStakeLabelLocaleBased"),
+  getEarnOrYieldSuffix: jest.fn(() => "earn" as const),
+}));
+
+const mockGetEarnOrYieldSuffix = jest.mocked(stakeLabelHelpers.getEarnOrYieldSuffix);
 
 const TAB_ROUTE_NAMES = [
   NavigatorName.Portfolio,
@@ -24,6 +32,31 @@ function createNavigation() {
 }
 
 describe("useMainTabBarViewModel", () => {
+  afterEach(() => {
+    mockGetEarnOrYieldSuffix.mockReset().mockReturnValue("earn");
+  });
+
+  describe("earn/yield tab label", () => {
+    it.each([
+      { suffix: "earn" as const, expectedLabel: "Earn" },
+      { suffix: "yield" as const, expectedLabel: "Yield" },
+    ])(
+      "should use '$expectedLabel' label when getEarnOrYieldSuffix returns '$suffix'",
+      ({ suffix, expectedLabel }) => {
+        mockGetEarnOrYieldSuffix.mockReturnValue(suffix);
+
+        const state = createState(0);
+        const navigation = createNavigation();
+        const { result } = renderHook(() =>
+          useMainTabBarViewModel({ state: state as never, navigation: navigation as never }),
+        );
+
+        const earnTab = result.current.tabItems.find(item => item.value === NavigatorName.Earn);
+        expect(earnTab?.label).toBe(expectedLabel);
+      },
+    );
+  });
+
   describe("scroll to top", () => {
     it("should emit scroll-to-top when re-pressing Home tab while already on Home", () => {
       const onScrollToTop = jest.fn();

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/constants.ts
@@ -1,11 +1,16 @@
 import { NavigatorName } from "~/const";
+import { getEarnOrYieldSuffix } from "~/helpers/getStakeLabelLocaleBased";
 
-export const LABELKEY_MAP: Partial<Record<string, string>> = {
+const LABELKEY_MAP: Partial<Record<string, string>> = {
   [NavigatorName.Portfolio]: "mainNavigation.home",
   [NavigatorName.Swap]: "mainNavigation.swap",
-  [NavigatorName.Earn]: "mainNavigation.earn",
   [NavigatorName.CardTab]: "mainNavigation.card",
 };
+
+export const getLabelKey = (routeName: string): string =>
+  routeName === NavigatorName.Earn
+    ? `mainNavigation.${getEarnOrYieldSuffix()}`
+    : LABELKEY_MAP[routeName] ?? routeName;
 
 export const TRACKING_MENUENTRY_EVENT = "menuentry_clicked";
 

--- a/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/MainTabBar/useMainTabBarViewModel.ts
@@ -14,7 +14,7 @@ import { NavigatorName } from "~/const";
 import type { TabItemConfig, MainTabBarViewProps } from "./types";
 import { useTranslation } from "~/context/Locale";
 import { track } from "~/analytics";
-import { LABELKEY_MAP, TRACKING_LABEL_MAP, TRACKING_MENUENTRY_EVENT } from "./constants";
+import { getLabelKey, TRACKING_LABEL_MAP, TRACKING_MENUENTRY_EVENT } from "./constants";
 import { scrollToTopEvent } from "./scrollToTopEvent";
 
 type UseMainTabBarViewModelParams = Pick<BottomTabBarProps, "state" | "navigation">;
@@ -63,7 +63,7 @@ export const useMainTabBarViewModel = ({
     () =>
       state.routes.map(route => ({
         value: route.name,
-        label: t(LABELKEY_MAP[route.name] ?? route.name),
+        label: t(getLabelKey(route.name)),
         testID: TAB_TEST_IDS[route.name],
         ...TAB_ICONS[route.name],
       })),


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Main tab bar label rendering for GB-locale users
      - Earn/Yield label resolution logic in `getStakeLabelLocaleBased`

### 📝 Description

**Problem**: UK-based users see "Earn" in the bottom navigation tab, but the correct label for GB locale should be "Yield".

**Solution**: Refactored `getStakeLabelLocaleBased` to expose a reusable `getEarnOrYieldSuffix()` helper that returns `"yield"` or `"earn"` based on the device locale. Updated `MainTabBar/constants.ts` to dynamically resolve the tab label key using this helper instead of a hardcoded `"mainNavigation.earn"` entry. Added the `"yield"` translation key to `common.json` and covered the behavior with unit and integration tests.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27821](https://ledgerhq.atlassian.net/browse/LIVE-27821)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27821]: https://ledgerhq.atlassian.net/browse/LIVE-27821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ