### PR TITLE
[LWDM] chore(concordium) share onboarding error types between desktop and mobile

### DIFF
--- a/.changeset/slow-bikes-cheat.md
+++ b/.changeset/slow-bikes-cheat.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-concordium": minor
+"@ledgerhq/errors": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+share onboarding error types between desktop and mobile

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
@@ -5,6 +5,7 @@ import {
   setSupportedCurrencies,
 } from "@ledgerhq/live-common/currencies/index";
 import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
+import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
 import { Account } from "@ledgerhq/types-live";
 import OnboardModal from "../index";
 import {
@@ -266,7 +267,7 @@ describe("OnboardModal", () => {
 
   it("should auto-retry when pairing session expires", async () => {
     mockPairWalletConnect
-      .mockReturnValueOnce(createMockPairErrorObservable(new Error("Session expired")))
+      .mockReturnValueOnce(createMockPairErrorObservable(new ConcordiumPairingExpiredError()))
       .mockReturnValueOnce(createMockPairObservable());
 
     const { user } = render(<OnboardModal {...defaultProps} />, { initialState });

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/__tests__/pairing.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/__tests__/pairing.test.ts
@@ -1,4 +1,5 @@
 import { AccountOnboardStatus, ConcordiumPairingStatus } from "@ledgerhq/coin-concordium/types";
+import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
 import {
   getConfirmationCode,
   shouldRetryPairing,
@@ -34,8 +35,8 @@ describe("pairing utils", () => {
   });
 
   describe("shouldRetryPairing", () => {
-    it("returns true for expired error under retry limit", () => {
-      const error = new Error("Session expired");
+    it("returns true for ConcordiumPairingExpiredError under retry limit", () => {
+      const error = new ConcordiumPairingExpiredError();
 
       expect(shouldRetryPairing(error, 0)).toBe(true);
       expect(shouldRetryPairing(error, 1)).toBe(true);
@@ -43,23 +44,18 @@ describe("pairing utils", () => {
     });
 
     it("returns false when retry limit reached", () => {
-      const error = new Error("Session expired");
+      const error = new ConcordiumPairingExpiredError();
 
       expect(shouldRetryPairing(error, MAX_EXPIRED_RETRIES)).toBe(false);
     });
 
-    it("returns false for non-expired errors", () => {
+    it("returns false for non-pairing-expired errors", () => {
       const error = new Error("Connection failed");
 
       expect(shouldRetryPairing(error, 0)).toBe(false);
     });
 
-    it("handles string errors", () => {
-      expect(shouldRetryPairing("expired", 0)).toBe(true);
-      expect(shouldRetryPairing("other error", 0)).toBe(false);
-    });
-
-    it("handles null/undefined errors", () => {
+    it("returns false for null/undefined errors", () => {
       expect(shouldRetryPairing(null, 0)).toBe(false);
       expect(shouldRetryPairing(undefined, 0)).toBe(false);
     });

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/pairing.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/pairing.ts
@@ -3,6 +3,7 @@ import {
   ConcordiumPairingProgress,
   ConcordiumPairingStatus,
 } from "@ledgerhq/coin-concordium/types";
+import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
 
 export const MAX_EXPIRED_RETRIES = 3;
 export const CONFIRMATION_CODE_LENGTH = 4;
@@ -21,9 +22,7 @@ export function shouldRetryPairing(error: unknown, retryCount: number): boolean 
     return false;
   }
 
-  const errorMessage = error instanceof Error ? error.message : String(error);
-
-  return errorMessage.toLowerCase().includes("expired");
+  return error instanceof ConcordiumPairingExpiredError;
 }
 
 export type PairingStateUpdate = {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7044,6 +7044,14 @@
     "ConcordiumInsufficientFunds": {
       "title": "Sorry, insufficient funds"
     },
+    "ConcordiumPairingExpiredError": {
+      "title": "Pairing expired",
+      "description": "The connection to Concordium ID App has timed out. Please try again."
+    },
+    "ConcordiumSessionExpiredError": {
+      "title": "Session expired",
+      "description": "The Concordium ID App session is no longer active. Please pair again."
+    },
     "StacksMemoTooLong": {
       "title": "Memo length is too long"
     },

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/__tests__/useOnboarding.test.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/__tests__/useOnboarding.test.ts
@@ -1,15 +1,10 @@
 import { renderHook, waitFor, act } from "@tests/test-renderer";
 import { Subject } from "rxjs";
 import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
-import { LockedDeviceError } from "@ledgerhq/errors";
+import { ConcordiumSessionExpiredError, LockedDeviceError } from "@ledgerhq/errors";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import {
-  CreateStatus,
-  getConfirmationCode,
-  isSessionExpiredError,
-  useOnboarding,
-} from "../hooks/useOnboarding";
+import { CreateStatus, getConfirmationCode, useOnboarding } from "../hooks/useOnboarding";
 
 let onboardSubject: Subject<unknown>;
 
@@ -31,28 +26,6 @@ describe("getConfirmationCode", () => {
 
   it("should handle already uppercase input", () => {
     expect(getConfirmationCode("WXYZ9999")).toBe("WXYZ");
-  });
-});
-
-describe("isSessionExpiredError", () => {
-  it("should return true for no active session error", () => {
-    expect(
-      isSessionExpiredError(new Error("No active WalletConnect session for concordium_testnet")),
-    ).toBe(true);
-  });
-
-  it("should return true for pairing approval expired", () => {
-    expect(isSessionExpiredError(new Error("Pairing approval is expired. Please try again."))).toBe(
-      true,
-    );
-  });
-
-  it("should return false for other errors", () => {
-    expect(isSessionExpiredError(new Error("network failure"))).toBe(false);
-  });
-
-  it("should return false for unrelated expired errors", () => {
-    expect(isSessionExpiredError(new Error("certificate expired"))).toBe(false);
   });
 });
 
@@ -125,7 +98,7 @@ describe("useOnboarding", () => {
     );
 
     act(() => {
-      onboardSubject.error(new Error("No active WalletConnect session for concordium_testnet"));
+      onboardSubject.error(new ConcordiumSessionExpiredError());
     });
 
     await waitFor(() => {

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/index.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/index.ts
@@ -1,8 +1,3 @@
 export { usePairing, PairStatus } from "./usePairing";
 export { useIdAppDetection } from "./useIdAppDetection";
-export {
-  useOnboarding,
-  CreateStatus,
-  getConfirmationCode,
-  isSessionExpiredError,
-} from "./useOnboarding";
+export { useOnboarding, CreateStatus, getConfirmationCode } from "./useOnboarding";

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
-import { LockedDeviceError } from "@ledgerhq/errors";
+import {
+  ConcordiumPairingExpiredError,
+  ConcordiumSessionExpiredError,
+  LockedDeviceError,
+} from "@ledgerhq/errors";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
 import { log } from "@ledgerhq/logs";
@@ -19,14 +23,6 @@ export enum CreateStatus {
 
 export function getConfirmationCode(sessionTopic: string): string {
   return sessionTopic.substring(0, CONFIRMATION_CODE_LENGTH).toUpperCase();
-}
-
-export function isSessionExpiredError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return (
-    message.includes("No active WalletConnect session") ||
-    message.includes("Pairing approval is expired")
-  );
 }
 
 export function useOnboarding(
@@ -89,7 +85,10 @@ export function useOnboarding(
           unsubscribe();
           if (error instanceof LockedDeviceError) {
             setCreateStatus(CreateStatus.DEVICE_LOCKED);
-          } else if (isSessionExpiredError(error)) {
+          } else if (
+            error instanceof ConcordiumSessionExpiredError ||
+            error instanceof ConcordiumPairingExpiredError
+          ) {
             onSessionExpired();
           } else {
             setCreateStatus(CreateStatus.ERROR);

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ConcordiumPairingProgress } from "@ledgerhq/coin-concordium/types";
 import { ConcordiumPairingStatus } from "@ledgerhq/coin-concordium/types";
+import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { log } from "@ledgerhq/logs";
 import { Subscription } from "rxjs";
@@ -13,11 +14,6 @@ export enum PairStatus {
   QR_READY = "QR_READY",
   SUCCESS = "SUCCESS",
   ERROR = "ERROR",
-}
-
-function isPairingExpiredError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("Pairing approval is expired");
 }
 
 export function usePairing(currency: CryptoCurrency, onPaired: (sessionTopic: string) => void) {
@@ -66,7 +62,10 @@ export function usePairing(currency: CryptoCurrency, onPaired: (sessionTopic: st
           }
         },
         error: (error: unknown) => {
-          if (isPairingExpiredError(error) && retryCountRef.current < MAX_EXPIRED_RETRIES) {
+          if (
+            error instanceof ConcordiumPairingExpiredError &&
+            retryCountRef.current < MAX_EXPIRED_RETRIES
+          ) {
             retryCountRef.current++;
             log("concordium-onboarding", "pairing expired, retrying", {
               attempt: retryCountRef.current,

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -176,6 +176,21 @@
       "title": "The rewards are smaller than the estimated fees to claim them.",
       "description": ""
     },
+    "ConcordiumInsufficientFunds": {
+      "title": "Sorry, insufficient funds"
+    },
+    "ConcordiumMemoTooLong": {
+      "title": "Memo exceeds maximum length",
+      "description": "Your memo is {{memoLength}} bytes, but the maximum allowed is {{maxLength}} bytes. Please reduce the memo size."
+    },
+    "ConcordiumPairingExpiredError": {
+      "title": "Pairing expired",
+      "description": "The connection to Concordium ID App has timed out. Please try again."
+    },
+    "ConcordiumSessionExpiredError": {
+      "title": "Session expired",
+      "description": "The Concordium ID App session is no longer active. Please pair again."
+    },
     "CosmosBroadcastCodeInternal": {
       "title": "Something went wrong (Error #1)",
       "description": "Please save your logs using the button below and provide them to Ledger Support."

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.integ.test.ts
@@ -1,3 +1,4 @@
+import { ConcordiumSessionExpiredError } from "@ledgerhq/errors";
 import { firstValueFrom, toArray } from "rxjs";
 import coinConfig from "../config";
 import { submitCredential } from "../network/proxyClient";
@@ -121,7 +122,7 @@ describe("onboard (testnet integration)", () => {
       const observable = onboardAccount(currency.id, "test-device", account);
 
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
-        "No active WalletConnect session",
+        ConcordiumSessionExpiredError,
       );
     }, 15000);
 

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.test.ts
@@ -1,4 +1,9 @@
-import { LockedDeviceError, TransportStatusError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import {
+  ConcordiumSessionExpiredError,
+  LockedDeviceError,
+  TransportStatusError,
+  UserRefusedOnDevice,
+} from "@ledgerhq/errors";
 import { firstValueFrom, toArray } from "rxjs";
 import { AccountOnboardStatus, ConcordiumPairingStatus } from "../types";
 import {
@@ -151,7 +156,7 @@ describe("onboard", () => {
 
       // THEN
       await expect(firstValueFrom(observable.pipe(toArray()))).rejects.toThrow(
-        "No active WalletConnect session",
+        ConcordiumSessionExpiredError,
       );
     });
 

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
@@ -1,5 +1,11 @@
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
-import { LockedDeviceError, TransportStatusError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import {
+  ConcordiumPairingExpiredError,
+  ConcordiumSessionExpiredError,
+  LockedDeviceError,
+  TransportStatusError,
+  UserRefusedOnDevice,
+} from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import type { Account } from "@ledgerhq/types-live";
 import { Observable } from "rxjs";
@@ -25,13 +31,13 @@ import { submitCredential } from "../network/proxyClient";
  * Wraps a promise with a 5-minute timeout that automatically cleans up when settled.
  * Prevents timer leaks and unhandled rejections when used in Promise.race().
  */
-const withTimeout = <T>(promise: Promise<T>, errorMessage: string): Promise<T> => {
+const withTimeout = <T>(promise: Promise<T>, error: Error): Promise<T> => {
   const REQUEST_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
   let timeoutId: NodeJS.Timeout;
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
-      reject(new Error(errorMessage));
+      reject(error);
     }, REQUEST_TIMEOUT_MS);
   });
 
@@ -68,7 +74,7 @@ export const buildOnboardAccount =
 
           const session = await walletConnect.getSession(network);
           if (!session) {
-            throw new Error(
+            throw new ConcordiumSessionExpiredError(
               `No active WalletConnect session for ${network}. Please pair with Concordium IDApp first.`,
             );
           }
@@ -197,10 +203,7 @@ export const buildPairWalletConnect =
           const walletConnectUri = `${CONCORDIUM_ID_APP_MOBILE_HOST}wallet-connect?encodedUri=${encodedUri}`;
           o.next({ status: ConcordiumPairingStatus.PREPARE, walletConnectUri });
 
-          const session = await withTimeout(
-            approval(),
-            "Pairing approval is expired. Please try again.",
-          );
+          const session = await withTimeout(approval(), new ConcordiumPairingExpiredError());
 
           o.next({ status: ConcordiumPairingStatus.SUCCESS, sessionTopic: session.topic });
         } catch (error: unknown) {

--- a/libs/coin-modules/coin-concordium/src/types/errors.ts
+++ b/libs/coin-modules/coin-concordium/src/types/errors.ts
@@ -1,7 +1,5 @@
 import { createCustomErrorClass } from "@ledgerhq/errors";
 
+export { ConcordiumMemoTooLong, ConcordiumInsufficientFunds } from "@ledgerhq/errors";
+
 export const SimulationError = createCustomErrorClass("SimulationError");
-
-export const ConcordiumMemoTooLong = createCustomErrorClass("ConcordiumMemoTooLong");
-
-export const ConcordiumInsufficientFunds = createCustomErrorClass("ConcordiumInsufficientFunds");

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -207,6 +207,16 @@ export const ReplacementTransactionUnderpriced = createCustomErrorClass(
 export const OpReturnDataSizeLimit = createCustomErrorClass("OpReturnSizeLimit");
 export const DustLimit = createCustomErrorClass("DustLimit");
 
+// Concordium family
+export const ConcordiumInsufficientFunds = createCustomErrorClass("ConcordiumInsufficientFunds");
+export const ConcordiumMemoTooLong = createCustomErrorClass("ConcordiumMemoTooLong");
+export const ConcordiumPairingExpiredError = createCustomErrorClass(
+  "ConcordiumPairingExpiredError",
+);
+export const ConcordiumSessionExpiredError = createCustomErrorClass(
+  "ConcordiumSessionExpiredError",
+);
+
 // Language
 export const LanguageNotFound = createCustomErrorClass("LanguageNotFound");
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** no functional changes; custom Concordium-specific errors now shared between mobile and desktop

### 📝 Description

* Move ConcordiumMemoTooLong and ConcordiumInsufficientFunds from coin-concordium to @ledgerhq/errors. 
* Add ConcordiumPairingExpiredError and ConcordiumSessionExpiredError as shared typed errors replacing duplicated string-matching logic in both desktop and mobile onboarding flows.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26420](https://ledgerhq.atlassian.net/browse/LIVE-26420)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26420]: https://ledgerhq.atlassian.net/browse/LIVE-26420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ