### PR TITLE
test(e2e-desktop): force toggle until variant is picked

### DIFF
--- a/e2e/desktop/tests/specs/earn.spec.ts
+++ b/e2e/desktop/tests/specs/earn.spec.ts
@@ -47,6 +47,26 @@ for (const { account, provider, xrayTicket } of ethEarn) {
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: account.currency.speculosApp,
       cliCommands: [liveDataWithAddressCommand(account)],
+      featureFlags: {
+        // TODO: sync Firebase environments and remove this override when final variant is chosen
+        stakePrograms: {
+          enabled: true,
+          params: {
+            list: ["ethereum"],
+            redirects: {
+              "ethereum/erc20/usd__coin": {
+                platform: "earn",
+                name: "Earn - Deposit",
+                queryParams: {
+                  cryptoAssetId: "ethereum/erc20/usd__coin",
+                  intent: "deposit",
+                  deposit: "stablecoin",
+                },
+              },
+            },
+          },
+        },
+      },
     });
 
     const family = getFamilyByCurrencyId(account.currency.id);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

FF are different on test vs prod.

Force the value until the final variant is picked and synced across envs.

EARN in test env: https://github.com/LedgerHQ/ledger-live/actions/runs/23242452567
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/00f3ba39-d7c4-4426-81c6-d6f0af5d1abe/

EARN in prod env: https://github.com/LedgerHQ/ledger-live/actions/runs/23242496550
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/b90e2143-c665-468d-98d6-e934d32316e2/

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://github.com/LedgerHQ/qaa-flaky-tests/issues/35


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
