### PR TITLE
[LWDM] fix(coin-evm): deduplicate native transfers in getBlock

### DIFF
--- a/.changeset/hungry-tips-push.md
+++ b/.changeset/hungry-tips-push.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+coin-evm: deduplicate native operations in getBlock

--- a/libs/coin-modules/coin-evm/src/adapters/blockOperations.test.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/blockOperations.test.ts
@@ -165,7 +165,7 @@ describe("EVM Family", () => {
             blockHash: "0xabc",
             blockNumber: 1,
             transactionPosition: 0,
-            traceAddress: [],
+            traceAddress: [0],
             subtraces: 0,
             type: "call",
             ...overrides,
@@ -311,6 +311,16 @@ describe("EVM Family", () => {
 
           expect(byHash.size).toBe(1);
           expect(byHash.get("0xhash1")).toHaveLength(2);
+        });
+
+        it("should skip top-level traces (traceAddress=[]) since their value is already in the RPC tx", () => {
+          const items: TraceBlockItem[] = [
+            makeTraceItem({ transactionHash: "0xhash1", traceAddress: [] }),
+          ];
+
+          const byHash = traceBlockItemsToOperationsByHash(items);
+
+          expect(byHash.size).toBe(0);
         });
 
         it("should return empty map for empty input", () => {

--- a/libs/coin-modules/coin-evm/src/adapters/blockOperations.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/blockOperations.ts
@@ -81,6 +81,13 @@ function extractActionFields(
   if (!item.transactionHash) return null;
   if (!isTraceBlockCallAction(action)) return null;
 
+  // The trace_block RPC returns ALL execution traces, including the top-level call (traceAddress: []).
+  // This top-level call's native value transfer is identical to the RPC transaction's value field,
+  // which rpcTransactionToBlockOperations already converts to BlockOperations.
+  // When traceBlockItemsToOperationsByHash processed the top-level trace without filtering it out,
+  // the same native transfer appeared twice after merging.
+  if (item.traceAddress.length === 0) return null;
+
   const value = BigInt(action.value);
   if (value === 0n) return null;
 

--- a/libs/coin-modules/coin-evm/src/api/index.linea.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.linea.integ.test.ts
@@ -10,6 +10,9 @@ import { createApi } from "./index";
  * Linea block 19500620, tx 0x85a126db75d00c52b7ee410b6ddedef9108c9727f5e588d747d76ca9da22c55f
  * contains an internal native transfer of 240000481795678944 from
  * 0x224D8Fd7aB6AD4c6eb4611Ce56EF35Dec2277F03 to 0x9F41fE989C556d8b312Ce398b7f7B5Ac90919a73.
+ *
+ * Linea block 5234650, tx 0x86130492fc3195c7163f5b1a3b42d79c737d20834365bff434cd6ab94832d610
+ * is a plain native transfer of 2 ETH (single negative transfer op from sender, no duplicate internals).
  */
 
 describe("Linea (etherscan explorer)", () => {
@@ -62,6 +65,34 @@ describe("Linea (etherscan explorer)", () => {
         asset: { type: "native" },
         amount: EXPECTED_AMOUNT,
       });
+    });
+
+    it("block 5234650: exactly one sender native transfer (2 ETH) on simple value tx", async () => {
+      const blockHeight = 5234650;
+      const txHash = "0x86130492fc3195c7163f5b1a3b42d79c737d20834365bff434cd6ab94832d610";
+      const sender = "0x9F41fE989C556d8b312Ce398b7f7B5Ac90919a73";
+      const recipient = "0x5d50bE703836C330Fc2d147a631CDd7bb8D7171c";
+      const block = await module.getBlock(blockHeight);
+      const tx = block.transactions.find(t => t.hash === txHash);
+      if (!tx) {
+        fail(`Transaction ${txHash} not found in block ${blockHeight}`);
+      }
+      const expectedOp = {
+        type: "transfer",
+        address: sender,
+        peer: recipient,
+        asset: { type: "native" },
+        amount: -2000000000000000000n,
+      };
+      const senderOutNative = tx.operations.filter(
+        op =>
+          op.type === "transfer" &&
+          op.asset.type === "native" &&
+          op.amount === expectedOp.amount &&
+          op.address === expectedOp.address &&
+          op.peer === expectedOp.peer,
+      );
+      expect(senderOutNative).toEqual([expectedOp]);
     });
   });
 });

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
@@ -114,7 +114,7 @@ describe("getBlock", () => {
       blockNumber: 12345,
       transactionHash: "0xtx1",
       transactionPosition: 0,
-      traceAddress: [],
+      traceAddress: [0],
       subtraces: 0,
       type: "call",
       ...overrides,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - bug fix on getBlock

### 📝 Description

The trace_block RPC returns ALL execution traces, including the top-level call (traceAddress: []) so there was duplicated operations


### ❓ Context

https://ledgerhq.atlassian.net/browse/BACK-10905

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
