### PR TITLE
[LWD] fix(desktop): memoize market banner tiles to prevent icon blinking

### DIFF
--- a/.changeset/chilly-pears-care.md
+++ b/.changeset/chilly-pears-care.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Explore market icons blinking on Home dashboard by memoizing tile components

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetTile.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetTile.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { TrendingAssetTile } from "../components/TrendingAssetTile";
+import { createMockMarketPerformer } from "@ledgerhq/live-common/market/utils/fixtures";
+
+describe("TrendingAssetTile", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should render capitalized ticker with performance and navigate on click", async () => {
+    const clickHandler = jest.fn();
+    const onNavigate = jest.fn(() => clickHandler);
+    const item = createMockMarketPerformer({
+      id: "bitcoin",
+      ticker: "btc",
+      priceChangePercentage24h: 5.5,
+    });
+
+    const { user } = render(<TrendingAssetTile item={item} onNavigate={onNavigate} />);
+
+    expect(screen.getByText("BTC")).toBeVisible();
+    expect(screen.getByText("+5.50%")).toBeVisible();
+
+    await user.click(screen.getByTestId("market-banner-asset-bitcoin"));
+    expect(onNavigate).toHaveBeenCalledWith("bitcoin");
+    expect(clickHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/AssetIcon.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/AssetIcon.tsx
@@ -1,16 +1,16 @@
 import React from "react";
-import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 
-export const AssetIcon = ({
-  item,
-  getCapitalizedTicker,
-}: {
-  item: MarketItemPerformer;
-  getCapitalizedTicker: (item: MarketItemPerformer) => string;
-}) => {
-  if (item.ledgerIds && item.ledgerIds.length > 0 && item.ticker) {
-    return <CryptoIcon ledgerId={item.ledgerIds[0]} ticker={item.ticker} size="40px" />;
+type AssetIconProps = {
+  readonly ledgerId?: string;
+  readonly ticker?: string;
+  readonly image?: string;
+  readonly capitalizedTicker: string;
+};
+
+export const AssetIcon = ({ ledgerId, ticker, image, capitalizedTicker }: AssetIconProps) => {
+  if (ledgerId && ticker) {
+    return <CryptoIcon ledgerId={ledgerId} ticker={ticker} size="40px" />;
   }
 
   return (
@@ -18,8 +18,8 @@ export const AssetIcon = ({
       width={40}
       height={40}
       className="overflow-hidden rounded-full"
-      src={item.image}
-      alt={`${getCapitalizedTicker(item)} logo`}
+      src={image}
+      alt={`${capitalizedTicker} logo`}
     />
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetTile.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetTile.tsx
@@ -1,0 +1,46 @@
+import React, { useCallback } from "react";
+import { Tile, Spot, TileTitle, TileContent } from "@ledgerhq/lumen-ui-react";
+import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
+import { PerformanceIndicator } from "./PerformanceIndicator";
+import { AssetIcon } from "./AssetIcon";
+
+type TrendingAssetTileProps = {
+  readonly item: MarketItemPerformer;
+  readonly onNavigate: (id: string) => () => void;
+};
+
+const TrendingAssetTileComponent = ({ item, onNavigate }: TrendingAssetTileProps) => {
+  const capitalizedTicker = item.ticker.toUpperCase();
+  const ledgerId = item.ledgerIds?.[0];
+  const ticker = item.ticker;
+  const image = item.image;
+
+  const renderIcon = useCallback(
+    () => (
+      <AssetIcon
+        ledgerId={ledgerId}
+        ticker={ticker}
+        image={image}
+        capitalizedTicker={capitalizedTicker}
+      />
+    ),
+    [ledgerId, ticker, image, capitalizedTicker],
+  );
+
+  return (
+    <Tile
+      className="w-[98px]"
+      appearance="card"
+      onClick={onNavigate(item.id)}
+      data-testid={`market-banner-asset-${item.id}`}
+    >
+      <Spot size={40} appearance="icon" icon={renderIcon} />
+      <TileContent>
+        <TileTitle>{capitalizedTicker}</TileTitle>
+        <PerformanceIndicator value={item} />
+      </TileContent>
+    </Tile>
+  );
+};
+
+export const TrendingAssetTile = React.memo(TrendingAssetTileComponent);

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
@@ -1,10 +1,8 @@
 import React, { useCallback } from "react";
-import { Tile, Spot, TileTitle, TileContent } from "@ledgerhq/lumen-ui-react";
-import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
-import { PerformanceIndicator } from "./PerformanceIndicator";
 import { useNavigate } from "react-router";
+import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
 import { ViewAllTile } from "./ViewAllTile";
-import { AssetIcon } from "./AssetIcon";
+import { TrendingAssetTile } from "./TrendingAssetTile";
 import { track } from "~/renderer/analytics/segment";
 import FearAndGreed from "LLD/features/FearAndGreed";
 import { useHorizontalScroll } from "../hooks/useHorizontalScroll";
@@ -31,8 +29,6 @@ export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
     [navigate],
   );
 
-  const getCapitalizedTicker = (item: MarketItemPerformer) => item.ticker.toUpperCase();
-
   return (
     <div className="group relative" data-testid="trending-assets-list">
       {!isAtStart && <ScrollArrowButton direction="left" onClick={scrollLeft} />}
@@ -44,23 +40,7 @@ export const TrendingAssetsList = ({ items }: TrendingAssetsListProps) => {
         <div className="flex items-stretch gap-8">
           <FearAndGreed />
           {items.map(item => (
-            <Tile
-              className="w-[98px]"
-              key={item.id}
-              appearance="card"
-              onClick={onAssetClick(item.id)}
-              data-testid={`market-banner-asset-${item.id}`}
-            >
-              <Spot
-                size={40}
-                appearance="icon"
-                icon={() => <AssetIcon item={item} getCapitalizedTicker={getCapitalizedTicker} />}
-              />
-              <TileContent>
-                <TileTitle>{getCapitalizedTicker(item)}</TileTitle>
-                <PerformanceIndicator value={item} />
-              </TileContent>
-            </Tile>
+            <TrendingAssetTile key={item.id} item={item} onNavigate={onAssetClick} />
           ))}
           <ViewAllTile />
         </div>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Explore market section on the Home dashboard
      - Icon rendering stability in trending asset tiles

### 📝 Description

Icons in the **Explore market** section on the Home dashboard blink on re-renders (scroll, market data refetch).

**Root cause**: Each tile passed an inline `icon={() => ...}` function to `TileSpot`, creating a new reference on every render and causing icon remounts.

**Fix**: Extract a `TrendingAssetTile` component wrapped in `React.memo` with a stable `useCallback` icon reference, so icons no longer re-render unnecessarily.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27840](https://ledgerhq.atlassian.net/browse/LIVE-27840)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27840]: https://ledgerhq.atlassian.net/browse/LIVE-27840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ