### PR TITLE
[LWDM] fix(live-signer-evm): DmkSignerEth getAddress chainId value on parsing error

### DIFF
--- a/.changeset/small-hairs-explain.md
+++ b/.changeset/small-hairs-explain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-signer-evm": patch
+---
+
+Fix DmkSignerEth getAddress chainId value on parsing error

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -31,8 +31,6 @@ export type DAError =
   | SignTransactionDAError
   | SignPersonalMessageDAError;
 
-const DEFAULT_CHAIN_ID = 1;
-
 export class DmkSignerEth implements EvmSigner {
   private readonly signer: SignerEth;
   constructor(
@@ -127,7 +125,7 @@ export class DmkSignerEth implements EvmSigner {
       const numericChainId = Number(chainId);
       parsedChainId =
         !Number.isFinite(numericChainId) || !Number.isInteger(numericChainId) || numericChainId <= 0
-          ? DEFAULT_CHAIN_ID
+          ? undefined
           : numericChainId;
     }
 

--- a/libs/live-signer-evm/tests/DmkSignerEth.test.ts
+++ b/libs/live-signer-evm/tests/DmkSignerEth.test.ts
@@ -180,7 +180,7 @@ describe("DmkSignerEth", () => {
       ["float", "1.5"],
       ["empty string", ""],
       ["NaN", "NaN"],
-    ])("should set chainId default to 1 for invalid chainId input: %s", async (_label, invalidChainId) => {
+    ])("should omit chaindId when input is invalid: %s", async (_label, invalidChainId) => {
       // GIVEN
       const signerEth = (signer as unknown as { signer: { getAddress: jest.Mock } }).signer;
       const getAddressSpy = jest.spyOn(signerEth, "getAddress");
@@ -192,7 +192,7 @@ describe("DmkSignerEth", () => {
       expect(getAddressSpy).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          chainId: 1,
+          chainId: undefined,
         }),
       );
     });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 

### 📝 Description

 Fix DmkSignerEth getAddress chainId value on parsing error

### ❓ Context

- **JIRA link**: [LIVE-27848](https://ledgerhq.atlassian.net/jira/software/c/projects/DSDK/boards/817?quickFilter=2705&selectedIssue=LIVE-27848)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27848]: https://ledgerhq.atlassian.net/browse/LIVE-27848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ