### PR TITLE
[LWDM] feat(coin-solana): [LIVE-21670] alpaca api getStakes

### DIFF
--- a/.changeset/breezy-vans-return.md
+++ b/.changeset/breezy-vans-return.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-solana": minor
+"@ledgerhq/coin-framework": minor
+---
+
+coin-solana: Implement getStakes into alpaca api
+coin-framework: Add helper method isStakingTransactionIntent

--- a/libs/coin-framework/src/utils.ts
+++ b/libs/coin-framework/src/utils.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { SendTransactionIntent, TransactionIntent } from "./api";
+import { SendTransactionIntent, StakingTransactionIntent, TransactionIntent } from "./api";
 
 export function fromBigNumberToBigInt<T>(
   bigNumber: BigNumber | undefined,
@@ -13,4 +13,8 @@ export function fromBigNumberToBigInt<T>(
 
 export function isSendTransactionIntent(tx: TransactionIntent): tx is SendTransactionIntent {
   return tx.intentType === "transaction";
+}
+
+export function isStakingTransactionIntent(tx: TransactionIntent): tx is StakingTransactionIntent {
+  return tx.intentType === "staking";
 }

--- a/libs/coin-modules/coin-solana/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/logic/craftTransaction.ts
@@ -1,9 +1,13 @@
 import type {
   CraftedTransaction,
   FeeEstimation,
+  StakingTransactionIntent,
   TransactionIntent,
 } from "@ledgerhq/coin-framework/api/index";
-import { isSendTransactionIntent } from "@ledgerhq/coin-framework/utils";
+import {
+  isSendTransactionIntent,
+  isStakingTransactionIntent,
+} from "@ledgerhq/coin-framework/utils";
 import { trace } from "@ledgerhq/logs";
 import {
   PublicKey,
@@ -36,10 +40,17 @@ import {
   getMaybeMintAccount,
   getMaybeTokenAccount,
   getMaybeTokenMintProgram,
+  getStakeAccountAddressWithSeed,
+  getStakeAccountMinimumBalanceForRentExemption,
 } from "../network/chain/web3";
 import { UserInputType } from "../signer";
+import { createStakeAccountSeed } from "../stakeAccountSeed";
 import type {
   Command,
+  StakeCreateAccountCommand,
+  StakeDelegateCommand,
+  StakeUndelegateCommand,
+  StakeWithdrawCommand,
   TokenTransferCommand,
   TransferCommand,
   TransferFeeCalculated,
@@ -57,13 +68,22 @@ export async function craftTransaction(
   intent: TransactionIntent,
   customFees?: FeeEstimation,
 ): Promise<CraftedTransaction> {
-  if (!isSendTransactionIntent(intent)) {
-    throw new Error("Only send transaction intents are supported");
-  }
-
   if (!isValidBase58Address(intent.sender)) {
     throw new Error("Invalid sender address");
   }
+
+  if (intent.type === "stake.withdraw") {
+    return craftWithdrawTransaction(api, intent, customFees);
+  }
+
+  if (isStakingTransactionIntent(intent)) {
+    return craftStakingTransaction(api, intent, customFees);
+  }
+
+  if (!isSendTransactionIntent(intent)) {
+    throw new Error(`Unsupported intent type: ${intent.intentType}`);
+  }
+
   if (!isValidBase58Address(intent.recipient)) {
     throw new Error("Invalid recipient address");
   }
@@ -103,6 +123,142 @@ export async function craftTransaction(
       estimatedFee: fee.toString(),
     },
   };
+}
+
+async function craftWithdrawTransaction(
+  api: ChainAPI,
+  intent: TransactionIntent,
+  customFees?: FeeEstimation,
+): Promise<CraftedTransaction> {
+  const command: StakeWithdrawCommand = {
+    kind: "stake.withdraw",
+    authorizedAccAddr: intent.sender,
+    stakeAccAddr: intent.recipient,
+    toAccAddr: intent.sender,
+    amount: Number(intent.amount),
+  };
+  const instructions = await buildInstructionsForCommand(api, command);
+  const recentBlockhash = await api.getLatestBlockhash();
+
+  const message = new TransactionMessage({
+    payerKey: new PublicKey(intent.sender),
+    recentBlockhash: recentBlockhash.blockhash,
+    instructions,
+  });
+
+  const transaction = new VersionedTransaction(message.compileToLegacyMessage());
+
+  let fee: bigint;
+  if (customFees) {
+    fee = customFees.value;
+  } else {
+    const feeForMsg = await api.getFeeForMessage(transaction.message);
+    fee = BigInt(feeForMsg ?? 5000);
+  }
+
+  return {
+    transaction: Buffer.from(transaction.serialize()).toString("base64"),
+    details: {
+      recentBlockhash: recentBlockhash.blockhash,
+      lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+      estimatedFee: fee.toString(),
+    },
+  };
+}
+
+async function craftStakingTransaction(
+  api: ChainAPI,
+  intent: StakingTransactionIntent,
+  customFees?: FeeEstimation,
+): Promise<CraftedTransaction> {
+  const command = await resolveStakingCommand(api, intent);
+  const instructions = await buildInstructionsForCommand(api, command);
+  const recentBlockhash = await api.getLatestBlockhash();
+
+  const message = new TransactionMessage({
+    payerKey: new PublicKey(intent.sender),
+    recentBlockhash: recentBlockhash.blockhash,
+    instructions,
+  });
+
+  const transaction = new VersionedTransaction(message.compileToLegacyMessage());
+
+  let fee: bigint;
+  if (customFees) {
+    fee = customFees.value;
+  } else {
+    const feeForMsg = await api.getFeeForMessage(transaction.message);
+    fee = BigInt(feeForMsg ?? 5000);
+  }
+
+  return {
+    transaction: Buffer.from(transaction.serialize()).toString("base64"),
+    details: {
+      recentBlockhash: recentBlockhash.blockhash,
+      lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+      estimatedFee: fee.toString(),
+    },
+  };
+}
+
+async function resolveStakingCommand(
+  api: ChainAPI,
+  intent: StakingTransactionIntent,
+): Promise<Command> {
+  switch (intent.mode) {
+    case "delegate": {
+      if (intent.type === "stake.delegate") {
+        if (!intent.recipient) {
+          throw new Error("stake.delegate requires a stake account address (via recipient)");
+        }
+        const command: StakeDelegateCommand = {
+          kind: "stake.delegate",
+          authorizedAccAddr: intent.sender,
+          stakeAccAddr: intent.recipient,
+          voteAccAddr: intent.valAddress,
+        };
+        return command;
+      }
+
+      const voteAccAddress = intent.valAddress;
+      const seed = createStakeAccountSeed();
+      const stakeAccAddress = await getStakeAccountAddressWithSeed({
+        fromAddress: intent.sender,
+        seed,
+      });
+      const stakeAccRentExemptAmount = await getStakeAccountMinimumBalanceForRentExemption(api);
+
+      const delegationAmount = intent.useAllAmount
+        ? Math.max(0, Number(intent.amount) - stakeAccRentExemptAmount)
+        : Number(intent.amount);
+
+      const command: StakeCreateAccountCommand = {
+        kind: "stake.createAccount",
+        fromAccAddress: intent.sender,
+        stakeAccAddress,
+        seed,
+        amount: delegationAmount,
+        stakeAccRentExemptAmount,
+        delegate: { voteAccAddress },
+      };
+      return command;
+    }
+
+    case "undelegate": {
+      const command: StakeUndelegateCommand = {
+        kind: "stake.undelegate",
+        authorizedAccAddr: intent.sender,
+        stakeAccAddr: intent.recipient,
+      };
+      return command;
+    }
+
+    case "redelegate":
+      throw new Error("Solana does not support redelegate");
+
+    default:
+      throw new Error(`Unsupported staking mode: ${intent.mode}`);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/libs/coin-modules/coin-solana/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-solana/src/logic/estimateFees.ts
@@ -1,4 +1,5 @@
 import type { FeeEstimation, TransactionIntent } from "@ledgerhq/coin-framework/api/index";
+import { isStakingTransactionIntent } from "@ledgerhq/coin-framework/utils";
 import { log } from "@ledgerhq/logs";
 import { VersionedTransaction as OnChainTransaction } from "@solana/web3.js";
 import BigNumber from "bignumber.js";
@@ -342,13 +343,13 @@ async function waitNextBlockhash(api: ChainAPI, currentBlockhash: string) {
 }
 
 function mapIntentToTxKind(intent: TransactionIntent): TransactionModel["kind"] {
-  if (intent.intentType === "transaction") {
-    if (intent.asset.type !== "native") {
-      return "token.transfer";
-    }
-    return "transfer";
+  if (isStakingTransactionIntent(intent) || intent.type === "stake.withdraw") {
+    return intent.type as TransactionModel["kind"];
   }
-  throw new Error(`Unsupported intent type: ${intent.intentType}`);
+  if (intent.asset.type !== "native") {
+    return "token.transfer";
+  }
+  return "transfer";
 }
 
 /**

--- a/libs/coin-modules/coin-solana/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-solana/src/logic/getBalance.ts
@@ -3,6 +3,7 @@ import type { ChainAPI } from "../network";
 import { PARSED_PROGRAMS } from "../network/chain/program/constants";
 import type { ParsedOnChainTokenAccount } from "../network/chain/web3";
 import type { SolanaTokenProgram } from "../types";
+import { computeUnstakeReserve, getStakeAccounts } from "./getStakes";
 
 export async function getBalance(
   api: ChainAPI,
@@ -11,24 +12,35 @@ export async function getBalance(
 ): Promise<Balance[]> {
   const token2022Enabled = options?.token2022Enabled ?? false;
 
-  const [balanceLamports, rentExemptMin, splTokenAccounts, token2022Accounts] = await Promise.all([
-    api.getBalance(address),
-    api.getMinimumBalanceForRentExemption(0),
-    api.getParsedTokenAccountsByOwner(address).then(r => r.value),
-    token2022Enabled
-      ? api.getParsedToken2022AccountsByOwner(address).then(r => r.value)
-      : Promise.resolve([]),
-  ]);
+  const [balanceLamports, rentExemptMin, splTokenAccounts, token2022Accounts, stakeAccounts] =
+    await Promise.all([
+      api.getBalance(address),
+      api.getMinimumBalanceForRentExemption(0),
+      api.getParsedTokenAccountsByOwner(address).then(r => r.value),
+      token2022Enabled
+        ? api.getParsedToken2022AccountsByOwner(address).then(r => r.value)
+        : Promise.resolve([]),
+      getStakeAccounts(api, address),
+    ]);
+
+  const stakedLamports = stakeAccounts.reduce(
+    (sum, sa) => sum + BigInt(sa.account.onChainAcc.account.lamports),
+    0n,
+  );
+
+  const unstakeReserve = await computeUnstakeReserve(api, address, stakeAccounts);
 
   const balanceLamportBigInt = BigInt(balanceLamports);
+  const totalBalance = balanceLamportBigInt + stakedLamports;
   const rentExemptMinBigInt = BigInt(rentExemptMin);
   const lockedLamports =
     balanceLamportBigInt < rentExemptMinBigInt ? balanceLamportBigInt : rentExemptMinBigInt;
 
+  const rawLocked = lockedLamports + stakedLamports + BigInt(unstakeReserve);
   const nativeBalance: Balance = {
-    value: balanceLamportBigInt,
+    value: totalBalance,
     asset: { type: "native" },
-    locked: lockedLamports,
+    locked: rawLocked > totalBalance ? totalBalance : rawLocked,
   };
 
   const splBalances = mapTokenAccountsToBalances(

--- a/libs/coin-modules/coin-solana/src/logic/getStakes.ts
+++ b/libs/coin-modules/coin-solana/src/logic/getStakes.ts
@@ -1,0 +1,121 @@
+import type { Cursor, Page, Stake, StakeState } from "@ledgerhq/coin-framework/api/types";
+import { isStakeLockUpInForce, withdrawableFromStake } from "../logic";
+import type { ChainAPI } from "../network";
+import { getStakeAccounts, type StakeAccount } from "../network/chain/stake-activation/rpc";
+import type { SolanaStake } from "../types";
+import { estimateTxFee } from "./estimateFees";
+
+export { getStakeAccounts, type StakeAccount } from "../network/chain/stake-activation/rpc";
+
+export async function getStakes(
+  api: ChainAPI,
+  address: string,
+  _cursor?: Cursor,
+): Promise<Page<Stake>> {
+  const stakeAccounts = await getStakeAccounts(api, address);
+
+  const items: Stake[] = stakeAccounts.map(({ account, activation }) => {
+    const delegation = account.info.stake?.delegation;
+    const delegateAddress = delegation?.voter.toBase58();
+
+    const stake: Stake = {
+      uid: account.onChainAcc.pubkey.toBase58(),
+      address: account.onChainAcc.pubkey.toBase58(),
+      state: activation.state as StakeState,
+      asset: { type: "native" },
+      amount: BigInt(account.onChainAcc.account.lamports),
+      details: {
+        activationEpoch: delegation?.activationEpoch.toString(),
+        deactivationEpoch: delegation?.deactivationEpoch.toString(),
+        rentExemptReserve: account.info.meta.rentExemptReserve.toString(),
+        activeStake: activation.active,
+        inactiveStake: activation.inactive,
+      },
+    };
+
+    if (delegateAddress) {
+      stake.delegate = delegateAddress;
+    }
+    if (delegation) {
+      stake.amountDeposited = BigInt(delegation.stake.toString());
+    }
+
+    return stake;
+  });
+
+  return { items };
+}
+
+/**
+ * Compute the SOL reserve that must be kept in the main account to cover
+ * future unstaking transaction fees (undelegate + withdraw per stake).
+ *
+ * "active" and "activating" stakes require both deactivating + withdrawing steps.
+ * "inactive" and "deactivating" stakes require withdrawing only.
+ */
+export async function computeUnstakeReserve(
+  api: ChainAPI,
+  address: string,
+  stakeAccounts: StakeAccount[],
+): Promise<number> {
+  if (stakeAccounts.length === 0) return 0;
+
+  const [undelegateFee, withdrawFee] = await Promise.all([
+    estimateTxFee(api, address, "stake.undelegate"),
+    estimateTxFee(api, address, "stake.withdraw"),
+  ]);
+
+  const activeStakes = stakeAccounts.filter(
+    s => s.activation.state === "active" || s.activation.state === "activating",
+  );
+  return stakeAccounts.length * withdrawFee + activeStakes.length * undelegateFee;
+}
+
+/**
+ * Convert raw on-chain stake accounts into the legacy {@link SolanaStake} type
+ * used throughout the UI (LLD, LLM) and the legacy bridge.
+ */
+export function mapStakeAccountsToSolanaStakes(
+  stakeAccounts: StakeAccount[],
+  mainAccAddress: string,
+  epoch: number,
+): SolanaStake[] {
+  return stakeAccounts.map(({ account, activation }) => {
+    const {
+      info: { meta, stake },
+    } = account;
+    const rentExemptReserve = meta.rentExemptReserve.toNumber();
+    const stakeAccBalance = account.onChainAcc.account.lamports;
+    const hasWithdrawAuth =
+      meta.authorized.withdrawer.toBase58() === mainAccAddress &&
+      !isStakeLockUpInForce({
+        lockup: meta.lockup,
+        custodianAddress: mainAccAddress,
+        epoch,
+      });
+
+    return {
+      stakeAccAddr: account.onChainAcc.pubkey.toBase58(),
+      stakeAccBalance,
+      rentExemptReserve,
+      hasStakeAuth: meta.authorized.staker.toBase58() === mainAccAddress,
+      hasWithdrawAuth,
+      delegation:
+        stake === null
+          ? undefined
+          : {
+              stake: activation.state === "inactive" ? 0 : stake.delegation.stake.toNumber(),
+              voteAccAddr: stake.delegation.voter.toBase58(),
+            },
+      activation,
+      withdrawable: hasWithdrawAuth
+        ? withdrawableFromStake({
+            stakeAccBalance,
+            activation,
+            rentExemptReserve,
+          })
+        : 0,
+      reward: undefined,
+    };
+  });
+}

--- a/libs/coin-modules/coin-solana/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-solana/src/logic/listOperations.ts
@@ -49,7 +49,7 @@ export async function listOperations(
   for (let i = 0; i < signatures.length; i++) {
     const sig = signatures[i];
     const tx = parsed[i];
-    if (!tx || !tx.meta || sig.blockTime === null || sig.blockTime === undefined) continue;
+    if (!tx?.meta || sig.blockTime === null || sig.blockTime === undefined) continue;
 
     if (minHeight > 0 && sig.slot < minHeight) continue;
 
@@ -95,17 +95,21 @@ function buildTxMeta(sig: ConfirmedSignatureInfo, tx: ParsedTransactionWithMeta)
   };
 }
 
-function makeOperation(
-  address: string,
-  opType: string,
-  value: bigint,
-  senders: string[],
-  recipients: string[],
-  asset: AssetInfo,
-  meta: TxMeta,
-  operationIndex: number,
-  details?: Record<string, unknown>,
-): Operation {
+type MakeOperationParams = {
+  address: string;
+  opType: string;
+  value: bigint;
+  senders: string[];
+  recipients: string[];
+  asset: AssetInfo;
+  meta: TxMeta;
+  operationIndex: number;
+  details?: Record<string, unknown>;
+};
+
+function makeOperation(params: MakeOperationParams): Operation {
+  const { address, opType, value, senders, recipients, asset, meta, operationIndex, details } =
+    params;
   return {
     id: `${address}-${meta.hash}-${opType}-${operationIndex}`,
     type: opType,
@@ -132,13 +136,8 @@ function makeOperation(
 /**
  * Derives a single native-SOL operation from a transaction's pre/post lamport balances.
  *
- * Operation type depends on the address role:
- *   - Fee payer (accountIndex 0): fee is subtracted from balanceDelta before classification.
- *     delta < 0 → OUT, delta > 0 → IN, delta == 0 → FEES (only fees were paid).
- *   - Other accounts: raw delta determines the type (IN / OUT / NONE).
- *
- * Counterparty is the first account whose lamport balance changed (heuristic — may be
- * inaccurate for complex multi-account transactions).
+ * Staking transactions (create+delegate, delegate, deactivate, withdraw) are detected
+ * from parsed instructions and mapped to DELEGATE / UNDELEGATE / WITHDRAW_UNBONDED types.
  */
 function parseNativeOperations(
   address: string,
@@ -149,51 +148,198 @@ function parseNativeOperations(
   const accountIndex = message.accountKeys.findIndex(k => k.pubkey.toBase58() === address);
   if (accountIndex < 0) return [];
 
-  const { preBalances, postBalances } = tx.meta!;
+  const txMeta = tx.meta!;
+  const { preBalances, postBalances } = txMeta;
   const balanceDelta = BigInt(postBalances[accountIndex]) - BigInt(preBalances[accountIndex]);
+
+  const stakingOp = detectStakingOperation(tx, balanceDelta);
+  if (stakingOp) {
+    return [
+      makeOperation({
+        address,
+        opType: stakingOp.opType,
+        value: stakingOp.value,
+        senders: [],
+        recipients: [],
+        asset: { type: "native" },
+        meta,
+        operationIndex: 0,
+        ...(stakingOp.details ? { details: stakingOp.details } : {}),
+      }),
+    ];
+  }
+
   const isFeePayer = accountIndex === 0;
-  const txFee = meta.fee;
+  const { opType, value } = classifyNativeTransfer(balanceDelta, isFeePayer, meta.fee);
 
-  let opType: string;
-  let value: bigint;
+  const counterparty = findNativeCounterparty(message.accountKeys, accountIndex, txMeta);
+  const { senders, recipients } = buildParties(opType, address, counterparty);
 
+  return [
+    makeOperation({
+      address,
+      opType,
+      value,
+      senders,
+      recipients,
+      asset: { type: "native" },
+      meta,
+      operationIndex: 0,
+    }),
+  ];
+}
+
+/**
+ * Classifies the native transfer direction from a lamport balance delta.
+ *
+ *   - Fee payer: fee is added back before classification.
+ *     delta < 0 → OUT, delta > 0 → IN, delta == 0 → FEES (only fees were paid).
+ *   - Other accounts: raw delta determines the type (IN / OUT / NONE).
+ */
+function classifyNativeTransfer(
+  balanceDelta: bigint,
+  isFeePayer: boolean,
+  txFee: bigint,
+): { opType: string; value: bigint } {
   if (isFeePayer) {
     const deltaWithoutFee = balanceDelta + txFee;
-    if (deltaWithoutFee < 0n) {
-      opType = "OUT";
-      value = -deltaWithoutFee;
-    } else if (deltaWithoutFee > 0n) {
-      opType = "IN";
-      value = deltaWithoutFee;
-    } else {
-      opType = "FEES";
-      value = txFee;
-    }
-  } else {
-    if (balanceDelta > 0n) {
-      opType = "IN";
-      value = balanceDelta;
-    } else if (balanceDelta < 0n) {
-      opType = "OUT";
-      value = -balanceDelta;
-    } else {
-      opType = "NONE";
-      value = 0n;
+    if (deltaWithoutFee < 0n) return { opType: "OUT", value: -deltaWithoutFee };
+    if (deltaWithoutFee > 0n) return { opType: "IN", value: deltaWithoutFee };
+    return { opType: "FEES", value: txFee };
+  }
+
+  if (balanceDelta > 0n) return { opType: "IN", value: balanceDelta };
+  if (balanceDelta < 0n) return { opType: "OUT", value: -balanceDelta };
+  return { opType: "NONE", value: 0n };
+}
+
+/**
+ * Heuristic counterparty: first account whose lamport balance changed.
+ * May be inaccurate for complex multi-account transactions.
+ */
+function findNativeCounterparty(
+  accountKeys: ParsedTransactionWithMeta["transaction"]["message"]["accountKeys"],
+  accountIndex: number,
+  txMeta: NonNullable<ParsedTransactionWithMeta["meta"]>,
+): string | undefined {
+  const { preBalances, postBalances } = txMeta;
+  const idx = accountKeys.findIndex(
+    (_k, i) => i !== accountIndex && BigInt(postBalances[i]) - BigInt(preBalances[i]) !== 0n,
+  );
+  return idx >= 0 ? accountKeys[idx].pubkey.toBase58() : undefined;
+}
+
+function buildParties(
+  opType: string,
+  address: string,
+  counterparty: string | undefined,
+): { senders: string[]; recipients: string[] } {
+  const otherParty = counterparty ? [counterparty] : [];
+
+  const isSender = opType === "OUT" || opType === "FEES";
+  const senders = isSender ? [address] : otherParty;
+
+  const recipients = opType === "IN" ? [address] : otherParty;
+
+  return { senders, recipients };
+}
+
+type ParsedIx = { program: string; type: string; info: Record<string, unknown> | undefined };
+
+function getParsedInstructions(tx: ParsedTransactionWithMeta): ParsedIx[] {
+  const results: ParsedIx[] = [];
+  for (const ix of tx.transaction.message.instructions) {
+    if (!("parsed" in ix)) continue;
+    const raw = ix as { program?: string; parsed?: unknown };
+    if (typeof raw.parsed !== "object" || raw.parsed === null) continue;
+    const parsed = raw.parsed as { type?: string; info?: Record<string, unknown> };
+    if (typeof parsed.type !== "string") continue;
+    results.push({
+      program: raw.program ?? "",
+      type: parsed.type,
+      info: parsed.info ?? undefined,
+    });
+  }
+  return results;
+}
+
+/**
+ * Detects staking program instructions and returns a typed operation.
+ *
+ * Value semantics (accounting for the generic-alpaca adapter which adds fee
+ * for DELEGATE and UNDELEGATE but not WITHDRAW_UNBONDED):
+ * - DELEGATE / UNDELEGATE: value = 0  (adapter adds fee → final = fee)
+ * - WITHDRAW_UNBONDED:    value = fee (adapter keeps as-is → final = fee)
+ */
+type StakingResult = {
+  opType: string;
+  value: bigint;
+  details: Record<string, unknown> | undefined;
+};
+
+function detectStakingOperation(
+  tx: ParsedTransactionWithMeta,
+  balanceDelta: bigint,
+): StakingResult | null {
+  const ixs = getParsedInstructions(tx);
+
+  if (ixs.length === 3) {
+    const [first, second, third] = ixs;
+    if (
+      first.program === "system" &&
+      (first.type === "createAccountWithSeed" || first.type === "createAccount") &&
+      second.program === "stake" &&
+      second.type === "initialize" &&
+      third.program === "stake" &&
+      third.type === "delegate"
+    ) {
+      return makeDelegateResult(third.info, balanceDelta);
     }
   }
 
-  const counterpartyIndex = message.accountKeys.findIndex(
-    (_k, idx) =>
-      idx !== accountIndex && BigInt(postBalances[idx]) - BigInt(preBalances[idx]) !== 0n,
-  );
-  const counterparty =
-    counterpartyIndex >= 0 ? message.accountKeys[counterpartyIndex].pubkey.toBase58() : undefined;
+  if (ixs.length !== 1) {
+    return null;
+  }
 
-  const senders =
-    opType === "OUT" || opType === "FEES" ? [address] : counterparty ? [counterparty] : [];
-  const recipients = opType === "IN" ? [address] : counterparty ? [counterparty] : [];
+  const ix = ixs[0];
+  if (ix.program !== "stake") {
+    return null;
+  }
 
-  return [makeOperation(address, opType, value, senders, recipients, { type: "native" }, meta, 0)];
+  switch (ix.type) {
+    case "delegate":
+      return makeDelegateResult(ix.info, balanceDelta);
+    case "deactivate":
+      return { opType: "UNDELEGATE", value: 0n, details: undefined };
+    case "withdraw": {
+      const stakeAccount = ix.info?.stakeAccount as string | undefined;
+      const lamports = ix.info?.lamports as number | undefined;
+      const txFee = BigInt(tx.meta!.fee);
+      return {
+        opType: "WITHDRAW_UNBONDED",
+        value: txFee,
+        details:
+          stakeAccount && lamports
+            ? { stake: { address: stakeAccount, amount: BigInt(lamports) } }
+            : undefined,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function makeDelegateResult(
+  info: Record<string, unknown> | undefined,
+  balanceDelta: bigint,
+): StakingResult {
+  const voteAccount = info?.voteAccount as string | undefined;
+  const absDelta = balanceDelta < 0n ? -balanceDelta : balanceDelta;
+  return {
+    opType: "DELEGATE",
+    value: 0n,
+    details: voteAccount ? { stake: { address: voteAccount, amount: absDelta } } : undefined,
+  };
 }
 
 /**
@@ -206,10 +352,6 @@ function parseNativeOperations(
  * Token operations are marked `internal: true` in their details so that the
  * generic-alpaca bridge (`getAccountShape`) excludes them from the parent
  * account's operations list — they only surface as sub-account operations.
- * Without this flag, a single token transfer would produce duplicate parent
- * operations (one native + one token) with potentially different IDs when
- * the native op type differs from the token op type (e.g. send-all with
- * ATA close yields native IN + token OUT).
  */
 function parseTokenOperations(
   address: string,
@@ -221,46 +363,70 @@ function parseTokenOperations(
   if (preTokenBalances.length === 0 && postTokenBalances.length === 0) return [];
 
   const tokenChanges = computeTokenBalanceDeltas(address, preTokenBalances, postTokenBalances);
+  const accountKeys = tx.transaction.message.accountKeys.map(k => k.pubkey.toBase58());
   const ops: Operation[] = [];
   let operationIndex = 1;
 
   for (const [, change] of tokenChanges) {
-    const { mint, delta, tokenType } = change;
-    if (delta === 0n) continue;
+    if (change.delta === 0n) continue;
 
-    const asset: AssetInfo = {
-      type: tokenType,
-      assetReference: mint,
-      assetOwner: address,
-    };
-
-    const opType = delta > 0n ? "IN" : "OUT";
-    const value = delta > 0n ? delta : -delta;
-
-    const counterparty = findTokenCounterparty(
+    const op = buildTokenOperation(
       address,
-      mint,
+      change,
       preTokenBalances,
       postTokenBalances,
-      tx.transaction.message.accountKeys.map(k => k.pubkey.toBase58()),
+      accountKeys,
+      meta,
+      operationIndex,
     );
-
-    const senders = opType === "OUT" ? [address] : counterparty ? [counterparty] : [];
-    const recipients = opType === "IN" ? [address] : counterparty ? [counterparty] : [];
-
-    ops.push(
-      makeOperation(address, opType, value, senders, recipients, asset, meta, operationIndex, {
-        ledgerOpType: opType,
-        assetAmount: value.toString(),
-        assetSenders: senders,
-        assetRecipients: recipients,
-        internal: true,
-      }),
-    );
+    ops.push(op);
     operationIndex++;
   }
 
   return ops;
+}
+
+function buildTokenOperation(
+  address: string,
+  change: TokenChange,
+  preTokenBalances: TokenBalance[],
+  postTokenBalances: TokenBalance[],
+  accountKeys: string[],
+  meta: TxMeta,
+  operationIndex: number,
+): Operation {
+  const { mint, delta, tokenType } = change;
+  const asset: AssetInfo = { type: tokenType, assetReference: mint, assetOwner: address };
+
+  const opType = delta > 0n ? "IN" : "OUT";
+  const value = delta > 0n ? delta : -delta;
+
+  const counterparty = findTokenCounterparty(
+    address,
+    mint,
+    preTokenBalances,
+    postTokenBalances,
+    accountKeys,
+  );
+  const { senders, recipients } = buildParties(opType, address, counterparty);
+
+  return makeOperation({
+    address,
+    opType,
+    value,
+    senders,
+    recipients,
+    asset,
+    meta,
+    operationIndex,
+    details: {
+      ledgerOpType: opType,
+      assetAmount: value.toString(),
+      assetSenders: senders,
+      assetRecipients: recipients,
+      internal: true,
+    },
+  });
 }
 
 type TokenChange = { mint: string; delta: bigint; tokenType: SolanaTokenProgram };

--- a/libs/coin-modules/coin-solana/src/logic/tests/craftTransaction.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/craftTransaction.unit.test.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import { TransactionIntent } from "@ledgerhq/coin-framework/api/types";
+import type {
+  StakingTransactionIntent,
+  TransactionIntent,
+} from "@ledgerhq/coin-framework/api/types";
+import type { DeepPartialReturn } from "@ledgerhq/coin-framework/test/utils";
 import {
   BlockhashWithExpiryBlockHeight,
   PublicKey,
@@ -8,7 +12,19 @@ import {
 } from "@solana/web3.js";
 import { transaction } from "../../__tests__/fixtures/helpers.fixture";
 import type { ChainAPI } from "../../network";
-import type { Transaction } from "../../types";
+import {
+  buildTransferInstructions,
+  buildTokenTransferInstructions,
+  buildStakeCreateAccountInstructions,
+  buildStakeDelegateInstructions,
+  buildStakeUndelegateInstructions,
+  buildStakeWithdrawInstructions,
+  getMaybeMintAccount,
+  getMaybeTokenMintProgram,
+  getMaybeTokenAccount,
+  findAssociatedTokenAccountPubkey,
+} from "../../network/chain/web3";
+import type { SolanaTokenProgram, Transaction } from "../../types";
 import { DUMMY_SIGNATURE } from "../../utils";
 import { buildVersionedTransaction, craftTransaction } from "../craftTransaction";
 
@@ -16,11 +32,38 @@ jest.mock("../../network/chain/web3", () => ({
   ...jest.requireActual("../../network/chain/web3"),
   buildTransferInstructions: jest.fn().mockResolvedValue([]),
   buildTokenTransferInstructions: jest.fn().mockResolvedValue([]),
+  buildStakeCreateAccountInstructions: jest.fn().mockResolvedValue([]),
+  buildStakeDelegateInstructions: jest.fn().mockResolvedValue([]),
+  buildStakeUndelegateInstructions: jest.fn().mockResolvedValue([]),
+  buildStakeWithdrawInstructions: jest.fn().mockResolvedValue([]),
+  getStakeAccountAddressWithSeed: jest
+    .fn()
+    .mockResolvedValue("StakeAccAddr1111111111111111111111111111111"),
+  getStakeAccountMinimumBalanceForRentExemption: jest.fn().mockResolvedValue(2_282_880),
   getMaybeMintAccount: jest.fn(),
   getMaybeTokenMintProgram: jest.fn(),
   getMaybeTokenAccount: jest.fn(),
   findAssociatedTokenAccountPubkey: jest.fn(),
 }));
+
+jest.mock("../../stakeAccountSeed", () => ({
+  createStakeAccountSeed: jest.fn().mockReturnValue("test-seed-123"),
+}));
+
+const mockedBuildTransferInstructions = jest.mocked(buildTransferInstructions);
+const mockedBuildTokenTransferInstructions = jest.mocked(buildTokenTransferInstructions);
+const mockedBuildStakeCreateAccountInstructions = jest.mocked(buildStakeCreateAccountInstructions);
+const mockedBuildStakeDelegateInstructions = jest.mocked(buildStakeDelegateInstructions);
+const mockedBuildStakeUndelegateInstructions = jest.mocked(buildStakeUndelegateInstructions);
+const mockedBuildStakeWithdrawInstructions = jest.mocked(buildStakeWithdrawInstructions);
+const mockedGetMaybeMintAccount = getMaybeMintAccount as jest.MockedFunction<
+  DeepPartialReturn<typeof getMaybeMintAccount>
+>;
+const mockedGetMaybeTokenMintProgram = jest.mocked(getMaybeTokenMintProgram);
+const mockedGetMaybeTokenAccount = getMaybeTokenAccount as jest.MockedFunction<
+  DeepPartialReturn<typeof getMaybeTokenAccount>
+>;
+const mockedFindAssociatedTokenAccountPubkey = jest.mocked(findAssociatedTokenAccountPubkey);
 
 const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
 const TEST_RECIPIENT = "AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ";
@@ -31,8 +74,8 @@ const TEST_BLOCKHASH = "EEbZs6DmDyDjucyYbo3LwVJU7pQYuVopYcYTSEZXskW3";
 // ---------------------------------------------------------------------------
 
 describe("craftTransaction", () => {
-  const mockGetLatestBlockhash = jest.fn();
-  const mockGetFeeForMessage = jest.fn();
+  const mockGetLatestBlockhash = jest.fn() as jest.MockedFunction<ChainAPI["getLatestBlockhash"]>;
+  const mockGetFeeForMessage = jest.fn() as jest.MockedFunction<ChainAPI["getFeeForMessage"]>;
 
   const api = {
     getLatestBlockhash: mockGetLatestBlockhash,
@@ -131,17 +174,17 @@ describe("craftTransaction", () => {
     ).rejects.toThrow("Amount exceeds safe integer range");
   });
 
-  it("should throw for non-send intents", async () => {
+  it("should throw for unsupported intent types", async () => {
     await expect(
       craftTransaction(api, {
-        intentType: "staking",
-        type: "delegate",
+        intentType: "unknown",
+        type: "unknown",
         sender: TEST_ADDRESS,
         recipient: TEST_RECIPIENT,
         amount: 1000000n,
         asset: { type: "native" },
-      } as unknown as TransactionIntent),
-    ).rejects.toThrow("Only send transaction intents are supported");
+      } as TransactionIntent),
+    ).rejects.toThrow("Unsupported intent type: unknown");
   });
 
   it("should fallback to default fee (5000) when getFeeForMessage returns null", async () => {
@@ -164,7 +207,6 @@ describe("craftTransaction", () => {
   });
 
   it("should pass memo through to transfer command", async () => {
-    const { buildTransferInstructions } = jest.requireMock("../../network/chain/web3");
     mockGetLatestBlockhash.mockResolvedValue({
       blockhash: TEST_BLOCKHASH,
       lastValidBlockHeight: 280064048,
@@ -179,30 +221,22 @@ describe("craftTransaction", () => {
       amount: 1000000n,
       asset: { type: "native" },
       memo: "test memo",
-    } as unknown as TransactionIntent);
+    } as TransactionIntent);
 
-    expect(buildTransferInstructions).toHaveBeenCalledWith(
+    expect(mockedBuildTransferInstructions).toHaveBeenCalledWith(
       api,
       expect.objectContaining({ memo: "test memo" }),
     );
   });
 
   describe("Token-2022 transfer fee", () => {
-    const {
-      getMaybeMintAccount,
-      getMaybeTokenMintProgram,
-      getMaybeTokenAccount,
-      findAssociatedTokenAccountPubkey,
-      buildTokenTransferInstructions,
-    } = jest.requireMock("../../network/chain/web3");
-
     const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
     const CWIF_MINT = "7atgF8KQo4wJrD5ATGX7t1V2zVvykPJbFfNeVf1icFv1";
     const SENDER_ATA = new PublicKey("AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ");
 
     function setupTokenMocks(opts: {
       mintDecimals?: number;
-      tokenProgram?: string;
+      tokenProgram?: SolanaTokenProgram;
       transferFeeConfig?:
         | {
             newerTransferFee: { epoch: number; maximumFee: number; transferFeeBasisPoints: number };
@@ -234,7 +268,7 @@ describe("craftTransaction", () => {
           ]
         : undefined;
 
-      getMaybeMintAccount.mockResolvedValue({
+      mockedGetMaybeMintAccount.mockResolvedValue({
         decimals: mintDecimals,
         supply: "1000000000",
         isInitialized: true,
@@ -242,10 +276,12 @@ describe("craftTransaction", () => {
         freezeAuthority: null,
         extensions,
       });
-      getMaybeTokenMintProgram.mockResolvedValue(tokenProgram);
-      getMaybeTokenAccount.mockResolvedValue(recipientAtaExists ? { mint: CWIF_MINT } : undefined);
-      findAssociatedTokenAccountPubkey.mockResolvedValue(SENDER_ATA);
-      buildTokenTransferInstructions.mockResolvedValue([]);
+      mockedGetMaybeTokenMintProgram.mockResolvedValue(tokenProgram);
+      mockedGetMaybeTokenAccount.mockResolvedValue(
+        recipientAtaExists ? { mint: CWIF_MINT } : undefined,
+      );
+      mockedFindAssociatedTokenAccountPubkey.mockResolvedValue(SENDER_ATA);
+      mockedBuildTokenTransferInstructions.mockResolvedValue([]);
 
       const mockApi = {
         getLatestBlockhash: mockGetLatestBlockhash,
@@ -281,7 +317,7 @@ describe("craftTransaction", () => {
         asset: { type: "spl-token-2022", assetReference: CWIF_MINT, assetOwner: TEST_ADDRESS },
       });
 
-      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+      expect(mockedBuildTokenTransferInstructions).toHaveBeenCalledWith(
         mockApi,
         expect.objectContaining({
           extensions: expect.objectContaining({
@@ -309,7 +345,7 @@ describe("craftTransaction", () => {
         asset: { type: "spl-token", assetReference: USDC_MINT, assetOwner: TEST_ADDRESS },
       });
 
-      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+      expect(mockedBuildTokenTransferInstructions).toHaveBeenCalledWith(
         mockApi,
         expect.not.objectContaining({
           extensions: expect.anything(),
@@ -336,7 +372,7 @@ describe("craftTransaction", () => {
         asset: { type: "spl-token-2022", assetReference: CWIF_MINT, assetOwner: TEST_ADDRESS },
       });
 
-      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+      expect(mockedBuildTokenTransferInstructions).toHaveBeenCalledWith(
         mockApi,
         expect.objectContaining({
           extensions: expect.objectContaining({
@@ -367,7 +403,7 @@ describe("craftTransaction", () => {
         asset: { type: "spl-token-2022", assetReference: CWIF_MINT, assetOwner: TEST_ADDRESS },
       });
 
-      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+      expect(mockedBuildTokenTransferInstructions).toHaveBeenCalledWith(
         mockApi,
         expect.objectContaining({
           extensions: expect.objectContaining({
@@ -400,7 +436,7 @@ describe("craftTransaction", () => {
         asset: { type: "spl-token-2022", assetReference: CWIF_MINT, assetOwner: TEST_ADDRESS },
       });
 
-      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+      expect(mockedBuildTokenTransferInstructions).toHaveBeenCalledWith(
         mockApi,
         expect.objectContaining({
           extensions: expect.objectContaining({
@@ -429,7 +465,7 @@ describe("craftTransaction", () => {
         asset: { type: "spl-token-2022", assetReference: CWIF_MINT, assetOwner: TEST_ADDRESS },
       });
 
-      expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+      expect(mockedBuildTokenTransferInstructions).toHaveBeenCalledWith(
         mockApi,
         expect.objectContaining({
           recipientDescriptor: expect.objectContaining({
@@ -445,8 +481,10 @@ describe("craftTransaction", () => {
 // buildVersionedTransaction
 // ---------------------------------------------------------------------------
 
-const mockAddSignature = jest.fn();
-const mockSerialize = jest.fn().mockReturnValue(new Uint8Array([1, 2, 3]));
+const mockAddSignature = jest.fn() as jest.MockedFunction<VersionedTransaction["addSignature"]>;
+const mockSerialize = jest.fn().mockReturnValue(new Uint8Array([1, 2, 3])) as jest.MockedFunction<
+  VersionedTransaction["serialize"]
+>;
 let spiedDeserialize: jest.Spied<typeof VersionedTransaction.deserialize> | undefined = undefined;
 
 function setDeserialize(
@@ -758,5 +796,261 @@ describe("buildInstructions edge cases", () => {
 
     expect(solTx).toEqual(expectedSolanaTransaction);
     expect(solTx.message.recentBlockhash).toBe(BLOCKHASH);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// craftTransaction – staking intents
+// ---------------------------------------------------------------------------
+
+describe("craftTransaction – staking", () => {
+  const mockGetLatestBlockhash = jest.fn().mockResolvedValue({
+    blockhash: TEST_BLOCKHASH,
+    lastValidBlockHeight: 280064048,
+  }) as jest.MockedFunction<ChainAPI["getLatestBlockhash"]>;
+  const mockGetFeeForMessage = jest.fn().mockResolvedValue(5000) as jest.MockedFunction<
+    ChainAPI["getFeeForMessage"]
+  >;
+
+  const api = {
+    getLatestBlockhash: mockGetLatestBlockhash,
+    getFeeForMessage: mockGetFeeForMessage,
+  } as unknown as ChainAPI;
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe("stake.createAccount", () => {
+    it("should craft a valid transaction and pass the delegation command", async () => {
+      const result = await craftTransaction(api, {
+        intentType: "staking",
+        type: "stake.createAccount",
+        mode: "delegate",
+        sender: TEST_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        valAddress: TEST_RECIPIENT,
+        amount: 5_000_000_000n,
+        asset: { type: "native" },
+      } as StakingTransactionIntent);
+
+      expect(result.transaction).not.toBeUndefined();
+      expect(result.details?.estimatedFee).toBe("5000");
+      expect(mockedBuildStakeCreateAccountInstructions).toHaveBeenCalledWith(
+        api,
+        expect.objectContaining({
+          kind: "stake.createAccount",
+          fromAccAddress: TEST_ADDRESS,
+          amount: 5_000_000_000,
+          delegate: expect.objectContaining({ voteAccAddress: TEST_RECIPIENT }),
+        }),
+      );
+    });
+
+    it("should subtract rent exemption from amount when useAllAmount is true", async () => {
+      await craftTransaction(api, {
+        intentType: "staking",
+        type: "stake.createAccount",
+        mode: "delegate",
+        sender: TEST_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        valAddress: TEST_RECIPIENT,
+        amount: 10_000_000_000n,
+        useAllAmount: true,
+        asset: { type: "native" },
+      } as StakingTransactionIntent);
+
+      expect(mockedBuildStakeCreateAccountInstructions).toHaveBeenCalledWith(
+        api,
+        expect.objectContaining({
+          amount: 10_000_000_000 - 2_282_880,
+        }),
+      );
+    });
+
+    it("should use custom fees when provided", async () => {
+      const result = await craftTransaction(
+        api,
+        {
+          intentType: "staking",
+          type: "stake.createAccount",
+          mode: "delegate",
+          sender: TEST_ADDRESS,
+          recipient: TEST_RECIPIENT,
+          valAddress: TEST_RECIPIENT,
+          amount: 1_000_000_000n,
+          asset: { type: "native" },
+        } as StakingTransactionIntent,
+        { value: 42000n },
+      );
+
+      expect(result.details?.estimatedFee).toBe("42000");
+      expect(mockGetFeeForMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("stake.delegate", () => {
+    it("should craft a delegate command using valAddress and recipient", async () => {
+      await craftTransaction(api, {
+        intentType: "staking",
+        type: "stake.delegate",
+        mode: "delegate",
+        sender: TEST_ADDRESS,
+        recipient: "StakeAccXYZ111111111111111111111111111111111",
+        valAddress: TEST_RECIPIENT,
+        amount: 0n,
+        asset: { type: "native" },
+      } as StakingTransactionIntent);
+
+      expect(mockedBuildStakeDelegateInstructions).toHaveBeenCalledWith(
+        api,
+        expect.objectContaining({
+          kind: "stake.delegate",
+          authorizedAccAddr: TEST_ADDRESS,
+          stakeAccAddr: "StakeAccXYZ111111111111111111111111111111111",
+          voteAccAddr: TEST_RECIPIENT,
+        }),
+      );
+    });
+
+    it("should throw when no stake account address is provided via recipient", async () => {
+      await expect(
+        craftTransaction(api, {
+          intentType: "staking",
+          type: "stake.delegate",
+          mode: "delegate",
+          sender: TEST_ADDRESS,
+          recipient: "",
+          valAddress: TEST_RECIPIENT,
+          amount: 0n,
+          asset: { type: "native" },
+        } as StakingTransactionIntent),
+      ).rejects.toThrow("stake.delegate requires a stake account address (via recipient)");
+    });
+  });
+
+  describe("stake.undelegate", () => {
+    it("should craft an undelegate command", async () => {
+      await craftTransaction(api, {
+        intentType: "staking",
+        type: "stake.undelegate",
+        mode: "undelegate",
+        sender: TEST_ADDRESS,
+        recipient: "StakeAccAddr1111111111111111111111111111111",
+        valAddress: "",
+        amount: 0n,
+        asset: { type: "native" },
+      } as StakingTransactionIntent);
+
+      expect(mockedBuildStakeUndelegateInstructions).toHaveBeenCalledWith(
+        api,
+        expect.objectContaining({
+          kind: "stake.undelegate",
+          authorizedAccAddr: TEST_ADDRESS,
+          stakeAccAddr: "StakeAccAddr1111111111111111111111111111111",
+        }),
+      );
+    });
+  });
+
+  describe("stake.withdraw", () => {
+    it("should craft a withdraw command with correct amount and addresses", async () => {
+      await craftTransaction(api, {
+        intentType: "transaction",
+        type: "stake.withdraw",
+        sender: TEST_ADDRESS,
+        recipient: "StakeAccAddr1111111111111111111111111111111",
+        amount: 3_000_000_000n,
+        asset: { type: "native" },
+      } as TransactionIntent);
+
+      expect(mockedBuildStakeWithdrawInstructions).toHaveBeenCalledWith(
+        api,
+        expect.objectContaining({
+          kind: "stake.withdraw",
+          authorizedAccAddr: TEST_ADDRESS,
+          stakeAccAddr: "StakeAccAddr1111111111111111111111111111111",
+          toAccAddr: TEST_ADDRESS,
+          amount: 3_000_000_000,
+        }),
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// craftTransaction – token edge cases
+// ---------------------------------------------------------------------------
+
+describe("craftTransaction – token edge cases", () => {
+  const mockGetLatestBlockhash = jest.fn().mockResolvedValue({
+    blockhash: TEST_BLOCKHASH,
+    lastValidBlockHeight: 280064048,
+  }) as jest.MockedFunction<ChainAPI["getLatestBlockhash"]>;
+  const mockGetFeeForMessage = jest.fn().mockResolvedValue(5000) as jest.MockedFunction<
+    ChainAPI["getFeeForMessage"]
+  >;
+
+  const api = {
+    getLatestBlockhash: mockGetLatestBlockhash,
+    getFeeForMessage: mockGetFeeForMessage,
+  } as unknown as ChainAPI;
+
+  afterEach(() => jest.clearAllMocks());
+
+  it("should throw when getMaybeMintAccount returns an Error", async () => {
+    mockedGetMaybeMintAccount.mockResolvedValue(new Error("network failure"));
+    mockedGetMaybeTokenMintProgram.mockResolvedValue("spl-token");
+
+    await expect(
+      craftTransaction(api, {
+        intentType: "transaction",
+        type: "send",
+        sender: TEST_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        amount: 1000n,
+        asset: { type: "spl-token", assetReference: "SomeMint11111111111111111111111111111111111" },
+      }),
+    ).rejects.toThrow("Cannot resolve mint account");
+  });
+
+  it("should throw when getMaybeMintAccount returns undefined", async () => {
+    mockedGetMaybeMintAccount.mockResolvedValue(undefined);
+    mockedGetMaybeTokenMintProgram.mockResolvedValue("spl-token");
+
+    await expect(
+      craftTransaction(api, {
+        intentType: "transaction",
+        type: "send",
+        sender: TEST_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        amount: 1000n,
+        asset: { type: "spl-token", assetReference: "SomeMint11111111111111111111111111111111111" },
+      }),
+    ).rejects.toThrow("Cannot resolve mint account");
+  });
+
+  it("should fallback to spl-token when getMaybeTokenMintProgram returns an Error", async () => {
+    mockedGetMaybeMintAccount.mockResolvedValue({
+      decimals: 6,
+      supply: "1000",
+      isInitialized: true,
+    });
+    mockedGetMaybeTokenMintProgram.mockResolvedValue(new Error("not found"));
+    mockedGetMaybeTokenAccount.mockResolvedValue({ mint: "x" });
+    mockedFindAssociatedTokenAccountPubkey.mockResolvedValue(new PublicKey(TEST_RECIPIENT));
+    mockedBuildTokenTransferInstructions.mockResolvedValue([]);
+
+    await craftTransaction(api, {
+      intentType: "transaction",
+      type: "send",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      amount: 1000n,
+      asset: { type: "spl-token", assetReference: "SomeMint11111111111111111111111111111111111" },
+    });
+
+    expect(buildTokenTransferInstructions).toHaveBeenCalledWith(
+      api,
+      expect.objectContaining({ tokenProgram: "spl-token" }),
+    );
   });
 });

--- a/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.test.ts
@@ -59,17 +59,21 @@ describe("estimateFees (MSW integration)", () => {
     expect(result.value).toBe(5000n);
   });
 
-  it("should throw for unsupported intent types", async () => {
-    await expect(
-      estimateFees(api, {
-        intentType: "staking",
-        type: "delegate",
-        sender: TEST_ADDRESS,
-        recipient: TEST_RECIPIENT,
-        amount: 1_000_000n,
-        asset: { type: "native" },
-      }),
-    ).rejects.toThrow("Unsupported intent type: staking");
+  it("should estimate fees for staking intent types", async () => {
+    server.use(stubFeeEstimation(5000));
+
+    const result = await estimateFees(api, {
+      intentType: "staking",
+      type: "stake.createAccount",
+      mode: "delegate",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      valAddress: TEST_RECIPIENT,
+      amount: 1_000_000n,
+      asset: { type: "native" },
+    } as any);
+
+    expect(result.value).toBe(5000n);
   });
 
   describe("SPL Token fee estimation", () => {

--- a/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/estimateFees.unit.test.ts
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import type { TransactionIntent } from "@ledgerhq/coin-framework/api/index";
+import type {
+  StakingTransactionIntent,
+  TransactionIntent,
+} from "@ledgerhq/coin-framework/api/index";
 import type { ChainAPI } from "../../network";
 import { estimateFees, estimateTxFee } from "../estimateFees";
 
@@ -143,18 +146,19 @@ describe("estimateFees", () => {
     ).rejects.toThrow("RPC error");
   });
 
-  it("should throw for unsupported intent types", async () => {
+  it("should estimate fees for staking intent types", async () => {
     const api = createMockApi([5000]);
-    await expect(
-      estimateFees(api, {
-        intentType: "staking",
-        type: "delegate",
-        sender: TEST_ADDRESS,
-        recipient: TEST_RECIPIENT,
-        amount: 1000000n,
-        asset: { type: "native" },
-      } as unknown as TransactionIntent),
-    ).rejects.toThrow("Unsupported intent type: staking");
+    const result = await estimateFees(api, {
+      intentType: "staking",
+      type: "stake.createAccount",
+      mode: "delegate",
+      sender: TEST_ADDRESS,
+      recipient: TEST_RECIPIENT,
+      valAddress: TEST_RECIPIENT,
+      amount: 1000000n,
+      asset: { type: "native" },
+    } as StakingTransactionIntent);
+    expect(result.value).toBe(5000n);
   });
 });
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/getBalance.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getBalance.test.ts
@@ -22,6 +22,7 @@ describe("getBalance (MSW integration)", () => {
         getBalance: () => ({ context: { slot: 100 }, value: 2_000_000_000 }),
         getMinimumBalanceForRentExemption: () => 890880,
         getTokenAccountsByOwner: () => emptyTokenAccounts(),
+        getProgramAccounts: () => [],
       }),
     );
 
@@ -42,6 +43,7 @@ describe("getBalance (MSW integration)", () => {
         getBalance: () => ({ context: { slot: 100 }, value: 100_000 }),
         getMinimumBalanceForRentExemption: () => 890880,
         getTokenAccountsByOwner: () => emptyTokenAccounts(),
+        getProgramAccounts: () => [],
       }),
     );
 
@@ -64,6 +66,7 @@ describe("getBalance (MSW integration)", () => {
         },
         getMinimumBalanceForRentExemption: () => 890880,
         getTokenAccountsByOwner: () => emptyTokenAccounts(),
+        getProgramAccounts: () => [],
       }),
     );
 
@@ -112,6 +115,7 @@ describe("getBalance (MSW integration)", () => {
             }
             return emptyTokenAccounts();
           },
+          getProgramAccounts: () => [],
         }),
       );
 
@@ -127,6 +131,119 @@ describe("getBalance (MSW integration)", () => {
         value: 5_000_000n,
         asset: { type: "spl-token", assetReference: USDC_MINT, assetOwner: TEST_ADDRESS },
       });
+    });
+  });
+
+  describe("Stake account balances", () => {
+    const STAKE_PUBKEY = "AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ";
+    const VOTER_PUBKEY = "EvnRmnMrd69kFdbLMxWkTn1icZ7DCceRhvmb2SJXqDo4";
+
+    function stakeAccountRpcEntry(lamports: number) {
+      return {
+        pubkey: STAKE_PUBKEY,
+        account: {
+          lamports,
+          data: {
+            parsed: {
+              type: "delegated",
+              info: {
+                meta: {
+                  rentExemptReserve: "2282880",
+                  authorized: { staker: TEST_ADDRESS, withdrawer: TEST_ADDRESS },
+                  lockup: {
+                    unixTimestamp: 0,
+                    epoch: 0,
+                    custodian: "11111111111111111111111111111111",
+                  },
+                },
+                stake: {
+                  delegation: {
+                    voter: VOTER_PUBKEY,
+                    stake: String(lamports - 2282880),
+                    activationEpoch: "300",
+                    deactivationEpoch: "18446744073709551615",
+                    warmupCooldownRate: 0.25,
+                  },
+                  creditsObserved: 100000,
+                },
+              },
+            },
+            program: "stake",
+            space: 200,
+          },
+          owner: "Stake11111111111111111111111111111111111111",
+          executable: false,
+          rentEpoch: 0,
+        },
+      };
+    }
+
+    function stakeHistoryAccountInfo() {
+      return {
+        context: { slot: 100 },
+        value: {
+          lamports: 1000000,
+          data: {
+            parsed: {
+              type: "stakeHistory",
+              info: [
+                {
+                  epoch: 400,
+                  stakeHistory: { effective: 100000000000, activating: 0, deactivating: 0 },
+                },
+              ],
+            },
+            program: "stake",
+            space: 1000,
+          },
+          owner: "SysvarStakeHistory1111111111111111111111111",
+          executable: false,
+          rentEpoch: 0,
+        },
+      };
+    }
+
+    function stakeHandlers(stakeLamports: number) {
+      return {
+        getBalance: () => ({ context: { slot: 100 }, value: 1_000_000_000 }),
+        getMinimumBalanceForRentExemption: () => 890880,
+        getTokenAccountsByOwner: () => emptyTokenAccounts(),
+        getProgramAccounts: () => [stakeAccountRpcEntry(stakeLamports)],
+        getAccountInfo: () => stakeHistoryAccountInfo(),
+        getEpochInfo: () => ({
+          epoch: 400,
+          slotIndex: 100,
+          slotsInEpoch: 432000,
+          absoluteSlot: 172800100,
+          blockHeight: 160000000,
+          transactionCount: 0,
+        }),
+        getLatestBlockhash: () => ({
+          context: { slot: 100 },
+          value: {
+            blockhash: "EEbZs6DmDyDjucyYbo3LwVJU7pQYuVopYcYTSEZXskW3",
+            lastValidBlockHeight: 200000000,
+          },
+        }),
+        getFeeForMessage: () => ({ context: { slot: 100 }, value: 5000 }),
+        getRecentPrioritizationFees: () => [],
+        simulateTransaction: () => ({
+          context: { slot: 100 },
+          value: { err: null, logs: [], unitsConsumed: 200000 },
+        }),
+      };
+    }
+
+    it("should include staked balance in totalBalance and locked", async () => {
+      const stakeLamports = 2_000_000_000;
+      server.use(rpcHandler(stakeHandlers(stakeLamports)));
+
+      const result = await getBalance(api, TEST_ADDRESS);
+
+      const native = result[0];
+      expect(native.value).toBe(BigInt(1_000_000_000 + stakeLamports));
+      expect(native.asset).toEqual({ type: "native" });
+      expect(native.locked).toBeGreaterThan(BigInt(890880 + stakeLamports));
     });
   });
 
@@ -172,6 +289,7 @@ describe("getBalance (MSW integration)", () => {
             }
             return emptyTokenAccounts();
           },
+          getProgramAccounts: () => [],
         }),
       );
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/getBalance.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getBalance.unit.test.ts
@@ -1,14 +1,35 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
+import type { DeepPartialReturn } from "@ledgerhq/coin-framework/test/utils";
 import type { ChainAPI } from "../../network";
+import type { StakeAccount } from "../../network/chain/stake-activation/rpc";
 import { getBalance } from "../getBalance";
+import { getStakeAccounts, computeUnstakeReserve } from "../getStakes";
+
+jest.mock("../getStakes", () => ({
+  getStakeAccounts: jest.fn().mockResolvedValue([]),
+  computeUnstakeReserve: jest.fn().mockResolvedValue(0),
+}));
+
+const mockGetStakeAccounts = jest.mocked(getStakeAccounts);
+const mockComputeUnstakeReserve = jest.mocked(computeUnstakeReserve);
+
+function makeStakeAccountStub(lamports: number) {
+  return { account: { onChainAcc: { account: { lamports } } } };
+}
 
 const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
 
 describe("getBalance", () => {
-  const mockGetBalance = jest.fn();
-  const mockGetMinimumBalanceForRentExemption = jest.fn();
-  const mockGetParsedTokenAccountsByOwner = jest.fn();
-  const mockGetParsedToken2022AccountsByOwner = jest.fn();
+  const mockGetBalance = jest.fn() as jest.MockedFunction<ChainAPI["getBalance"]>;
+  const mockGetMinimumBalanceForRentExemption = jest.fn() as jest.MockedFunction<
+    ChainAPI["getMinimumBalanceForRentExemption"]
+  >;
+  const mockGetParsedTokenAccountsByOwner = jest.fn() as jest.MockedFunction<
+    DeepPartialReturn<ChainAPI["getParsedTokenAccountsByOwner"]>
+  >;
+  const mockGetParsedToken2022AccountsByOwner = jest.fn() as jest.MockedFunction<
+    DeepPartialReturn<ChainAPI["getParsedTokenAccountsByOwner"]>
+  >;
 
   const api = {
     getBalance: mockGetBalance,
@@ -137,5 +158,81 @@ describe("getBalance", () => {
     mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
 
     await expect(getBalance(api, TEST_ADDRESS)).rejects.toThrow("RPC error");
+  });
+
+  describe("stakeAccounts", () => {
+    it("should include staked lamports in totalBalance", async () => {
+      mockGetBalance.mockResolvedValue(1_000_000_000);
+      mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
+      mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
+      mockGetStakeAccounts.mockResolvedValue([
+        makeStakeAccountStub(2_000_000_000),
+      ] as StakeAccount[]);
+      mockComputeUnstakeReserve.mockResolvedValue(0);
+
+      const result = await getBalance(api, TEST_ADDRESS);
+
+      expect(result[0]).toEqual({
+        value: 3_000_000_000n,
+        asset: { type: "native" },
+        locked: 890880n + 2_000_000_000n,
+      });
+    });
+
+    it("should include unstakeReserve in locked", async () => {
+      mockGetBalance.mockResolvedValue(1_000_000_000);
+      mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
+      mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
+      mockGetStakeAccounts.mockResolvedValue([
+        makeStakeAccountStub(2_000_000_000),
+      ] as StakeAccount[]);
+      mockComputeUnstakeReserve.mockResolvedValue(11000);
+
+      const result = await getBalance(api, TEST_ADDRESS);
+
+      // locked = rentExemptMin + stakedLamports + unstakeReserve
+      expect(result[0]).toEqual({
+        value: 3_000_000_000n,
+        asset: { type: "native" },
+        locked: 890880n + 2_000_000_000n + 11000n,
+      });
+    });
+
+    it("should clamp locked to totalBalance when rawLocked exceeds it", async () => {
+      mockGetBalance.mockResolvedValue(100);
+      mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
+      mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
+      mockGetStakeAccounts.mockResolvedValue([makeStakeAccountStub(1000)] as StakeAccount[]);
+      mockComputeUnstakeReserve.mockResolvedValue(999_999);
+
+      const result = await getBalance(api, TEST_ADDRESS);
+
+      // totalBalance = 100 + 1000 = 1100
+      // rawLocked = 100 (balance < rentExemptMin) + 1000 + 999_999 = 1_001_099 > 1100
+      expect(result[0]).toEqual({
+        value: 1100n,
+        asset: { type: "native" },
+        locked: 1100n,
+      });
+    });
+
+    it("should sum lamports across multiple stake accounts", async () => {
+      mockGetBalance.mockResolvedValue(500_000_000);
+      mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
+      mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
+      mockGetStakeAccounts.mockResolvedValue([
+        makeStakeAccountStub(1_000_000_000),
+        makeStakeAccountStub(3_000_000_000),
+      ] as StakeAccount[]);
+      mockComputeUnstakeReserve.mockResolvedValue(0);
+
+      const result = await getBalance(api, TEST_ADDRESS);
+
+      expect(result[0]).toEqual({
+        value: 4_500_000_000n,
+        asset: { type: "native" },
+        locked: 890880n + 4_000_000_000n,
+      });
+    });
   });
 });

--- a/libs/coin-modules/coin-solana/src/logic/tests/getStakes.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getStakes.integ.test.ts
@@ -1,0 +1,42 @@
+import { Keypair } from "@solana/web3.js";
+import { getChainAPI } from "../../network";
+import { getStakes } from "../getStakes";
+
+const api = getChainAPI({ endpoint: "https://solana.coin.ledger.com" });
+
+const STAKER_ADDRESS = "7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE";
+const UNUSED_ADDRESS = Keypair.generate().publicKey.toBase58();
+
+describe("getStakes (integration)", () => {
+  it("returns well-formed stakes for a known address", async () => {
+    const result = await getStakes(api, STAKER_ADDRESS);
+
+    expect(Array.isArray(result.items)).toBe(true);
+
+    for (const stake of result.items) {
+      expect(typeof stake.uid).toBe("string");
+      expect(stake.uid.length).toBeGreaterThan(0);
+      expect(typeof stake.address).toBe("string");
+      expect(["active", "inactive", "activating", "deactivating"]).toContain(stake.state);
+      expect(stake.asset).toEqual({ type: "native" });
+      expect(typeof stake.amount).toBe("bigint");
+      expect(stake.amount).toBeGreaterThanOrEqual(0n);
+
+      if (stake.delegate) {
+        expect(typeof stake.delegate).toBe("string");
+        expect(stake.delegate.length).toBeGreaterThan(0);
+      }
+      if (stake.amountDeposited !== undefined) {
+        expect(typeof stake.amountDeposited).toBe("bigint");
+      }
+      expect(stake.details).not.toBeUndefined();
+      expect(typeof stake.details?.rentExemptReserve).toBe("string");
+    }
+  });
+
+  it("returns empty page for an unused address", async () => {
+    const result = await getStakes(api, UNUSED_ADDRESS);
+
+    expect(result).toEqual({ items: [] });
+  });
+});

--- a/libs/coin-modules/coin-solana/src/logic/tests/getStakes.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getStakes.test.ts
@@ -1,0 +1,196 @@
+import { SYSVAR_STAKE_HISTORY_PUBKEY } from "@solana/web3.js";
+import { getStakes } from "../getStakes";
+import { server, rpcHandler, createTestChainApi } from "./helpers/msw-rpc.mock";
+
+const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
+const VOTER_ADDRESS = "EvnRmnMrd69kFdbLMxWkTn1icZ7DCceRhvmb2SJXqDo4";
+const STAKE_PUBKEY = "AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ";
+
+const api = createTestChainApi();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function stakeAccountEntry(
+  pubkey: string,
+  lamports: number,
+  opts: {
+    voter: string;
+    stake: string;
+    activationEpoch: string;
+    deactivationEpoch: string;
+  },
+) {
+  return {
+    pubkey,
+    account: {
+      lamports,
+      data: {
+        parsed: {
+          type: "delegated",
+          info: {
+            meta: {
+              rentExemptReserve: "2282880",
+              authorized: { staker: TEST_ADDRESS, withdrawer: TEST_ADDRESS },
+              lockup: { unixTimestamp: 0, epoch: 0, custodian: "11111111111111111111111111111111" },
+            },
+            stake: {
+              delegation: {
+                voter: opts.voter,
+                stake: opts.stake,
+                activationEpoch: opts.activationEpoch,
+                deactivationEpoch: opts.deactivationEpoch,
+                warmupCooldownRate: 0.09,
+              },
+              creditsObserved: 100000,
+            },
+          },
+        },
+        program: "stake",
+        space: 200,
+      },
+      owner: "Stake11111111111111111111111111111111111111",
+      executable: false,
+      rentEpoch: 0,
+    },
+  };
+}
+
+function stakeHistorySysvar(epoch: number) {
+  return {
+    data: {
+      parsed: {
+        type: "stakeHistory",
+        info: [
+          {
+            epoch,
+            stakeHistory: {
+              effective: 400_000_000_000,
+              activating: 1_000_000,
+              deactivating: 500_000,
+            },
+          },
+          {
+            epoch: epoch - 1,
+            stakeHistory: {
+              effective: 399_000_000_000,
+              activating: 2_000_000,
+              deactivating: 1_000_000,
+            },
+          },
+        ],
+      },
+      program: "stake",
+      space: 16392,
+    },
+    executable: false,
+    lamports: 114979200,
+    owner: "Sysvar1111111111111111111111111111111111111",
+    rentEpoch: 0,
+  };
+}
+
+function epochInfo(epoch: number) {
+  return {
+    absoluteSlot: 200_000_000,
+    blockHeight: 180_000_000,
+    epoch,
+    slotIndex: 100_000,
+    slotsInEpoch: 432_000,
+    transactionCount: 1_000_000_000,
+  };
+}
+
+const STAKE_HISTORY_ADDRESS = SYSVAR_STAKE_HISTORY_PUBKEY.toBase58();
+
+describe("getStakes (MSW integration)", () => {
+  it("should return empty page when no stake accounts exist", async () => {
+    server.use(
+      rpcHandler({
+        getProgramAccounts: () => [],
+      }),
+    );
+
+    const result = await getStakes(api, TEST_ADDRESS);
+
+    expect(result).toEqual({ items: [] });
+  });
+
+  it("should return a fully active delegated stake", async () => {
+    const currentEpoch = 350;
+
+    server.use(
+      rpcHandler({
+        getProgramAccounts: () => [
+          stakeAccountEntry(STAKE_PUBKEY, 5_000_000_000, {
+            voter: VOTER_ADDRESS,
+            stake: "4997717120",
+            activationEpoch: "300",
+            deactivationEpoch: "18446744073709551615",
+          }),
+        ],
+        getAccountInfo: (params: unknown[]) => {
+          if ((params[0] as string) === STAKE_HISTORY_ADDRESS) {
+            return { context: { slot: 200_000_000 }, value: stakeHistorySysvar(currentEpoch) };
+          }
+          return { context: { slot: 200_000_000 }, value: null };
+        },
+        getEpochInfo: () => epochInfo(currentEpoch),
+      }),
+    );
+
+    const result = await getStakes(api, TEST_ADDRESS);
+
+    expect(result.items).toHaveLength(1);
+    const stake = result.items[0];
+    expect(stake.uid).toBe(STAKE_PUBKEY);
+    expect(stake.delegate).toBe(VOTER_ADDRESS);
+    expect(stake.state).toBe("active");
+    expect(stake.asset).toEqual({ type: "native" });
+    expect(stake.amount).toBe(BigInt(5_000_000_000));
+    expect(stake.amountDeposited).toBe(BigInt(4_997_717_120));
+    expect(stake.details?.rentExemptReserve).toBe("2282880");
+  });
+
+  it("should return an inactive stake when deactivation epoch has passed", async () => {
+    const currentEpoch = 360;
+
+    server.use(
+      rpcHandler({
+        getProgramAccounts: () => [
+          stakeAccountEntry(STAKE_PUBKEY, 5_000_000_000, {
+            voter: VOTER_ADDRESS,
+            stake: "4997717120",
+            activationEpoch: "300",
+            deactivationEpoch: "340",
+          }),
+        ],
+        getAccountInfo: (params: unknown[]) => {
+          if ((params[0] as string) === STAKE_HISTORY_ADDRESS) {
+            return { context: { slot: 200_000_000 }, value: stakeHistorySysvar(currentEpoch) };
+          }
+          return { context: { slot: 200_000_000 }, value: null };
+        },
+        getEpochInfo: () => epochInfo(currentEpoch),
+      }),
+    );
+
+    const result = await getStakes(api, TEST_ADDRESS);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].state).toBe("inactive");
+  });
+
+  it("should propagate RPC errors", async () => {
+    server.use(
+      rpcHandler({
+        getProgramAccounts: () => {
+          throw new Error("RPC unavailable");
+        },
+      }),
+    );
+
+    await expect(getStakes(api, TEST_ADDRESS)).rejects.toThrow();
+  });
+});

--- a/libs/coin-modules/coin-solana/src/logic/tests/getStakes.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getStakes.unit.test.ts
@@ -1,0 +1,271 @@
+import type { DeepPartial, DeepPartialReturn } from "@ledgerhq/coin-framework/test/utils";
+import { PublicKey, type StakeActivationData } from "@solana/web3.js";
+import BigNumber from "bignumber.js";
+import type { ChainAPI } from "../../network";
+import { getStakeAccounts } from "../../network/chain/stake-activation/rpc";
+import type { StakeAccount } from "../../network/chain/stake-activation/rpc";
+import { estimateTxFee } from "../estimateFees";
+import { computeUnstakeReserve, getStakes, mapStakeAccountsToSolanaStakes } from "../getStakes";
+
+jest.mock("../../network/chain/stake-activation/rpc", () => ({
+  getStakeAccounts: jest.fn(),
+}));
+
+jest.mock("../estimateFees", () => ({
+  estimateTxFee: jest.fn(),
+}));
+
+const mockGetStakeAccounts = getStakeAccounts as unknown as jest.MockedFunction<
+  DeepPartialReturn<typeof getStakeAccounts>
+>;
+const mockEstimateTxFee = estimateTxFee as jest.MockedFunction<typeof estimateTxFee>;
+
+const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
+const STAKE_PUBKEY = new PublicKey("AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ");
+const VOTER_PUBKEY = new PublicKey("EvnRmnMrd69kFdbLMxWkTn1icZ7DCceRhvmb2SJXqDo4");
+
+const api = {} as ChainAPI;
+
+function makeStakeAccount(overrides?: {
+  state?: StakeActivationData["state"];
+  lamports?: number;
+  active?: number;
+  inactive?: number;
+}): DeepPartial<StakeAccount> {
+  const {
+    state = "active",
+    lamports = 5_000_000_000,
+    active = 4_997_717_120,
+    inactive = 0,
+  } = overrides ?? {};
+
+  return {
+    account: {
+      onChainAcc: {
+        pubkey: STAKE_PUBKEY,
+        account: { lamports },
+      },
+      info: {
+        meta: {
+          rentExemptReserve: new BigNumber(2282880),
+          authorized: {
+            staker: new PublicKey(TEST_ADDRESS),
+            withdrawer: new PublicKey(TEST_ADDRESS),
+          },
+          lockup: { unixTimestamp: 0, epoch: 0, custodian: PublicKey.default },
+        },
+        stake: {
+          delegation: {
+            voter: VOTER_PUBKEY,
+            stake: new BigNumber(4_997_717_120),
+            activationEpoch: new BigNumber(300),
+            deactivationEpoch: new BigNumber("18446744073709551615"),
+            warmupCooldownRate: 0.09,
+          },
+          creditsObserved: 100000,
+        },
+      },
+    },
+    activation: { state, active, inactive },
+    reward: null,
+  };
+}
+
+describe("getStakes", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("should return empty page when no stake accounts", async () => {
+    mockGetStakeAccounts.mockResolvedValue([]);
+
+    const result = await getStakes(api, TEST_ADDRESS);
+
+    expect(result).toEqual({ items: [] });
+    expect(mockGetStakeAccounts).toHaveBeenCalledWith(api, TEST_ADDRESS);
+  });
+
+  it("should map an active delegated stake account", async () => {
+    mockGetStakeAccounts.mockResolvedValue([makeStakeAccount()]);
+
+    const result = await getStakes(api, TEST_ADDRESS);
+
+    expect(result.items).toHaveLength(1);
+    const stake = result.items[0];
+    expect(stake.uid).toBe(STAKE_PUBKEY.toBase58());
+    expect(stake.address).toBe(STAKE_PUBKEY.toBase58());
+    expect(stake.delegate).toBe(VOTER_PUBKEY.toBase58());
+    expect(stake.state).toBe("active");
+    expect(stake.asset).toEqual({ type: "native" });
+    expect(stake.amount).toBe(BigInt(5_000_000_000));
+    expect(stake.amountDeposited).toBe(BigInt(4_997_717_120));
+    expect(stake.details?.rentExemptReserve).toBe("2282880");
+    expect(stake.details?.activeStake).toBe(4_997_717_120);
+  });
+
+  it("should map a deactivating stake account", async () => {
+    mockGetStakeAccounts.mockResolvedValue([
+      makeStakeAccount({ state: "deactivating", active: 2_000_000_000, inactive: 2_997_717_120 }),
+    ]);
+
+    const result = await getStakes(api, TEST_ADDRESS);
+
+    expect(result.items[0].state).toBe("deactivating");
+    expect(result.items[0].details?.inactiveStake).toBe(2_997_717_120);
+  });
+
+  it("should propagate errors from getStakeAccounts", async () => {
+    mockGetStakeAccounts.mockRejectedValue(new Error("RPC error"));
+
+    await expect(getStakes(api, TEST_ADDRESS)).rejects.toThrow("RPC error");
+  });
+});
+
+describe("computeUnstakeReserve", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("should return 0 when there are no stake accounts", async () => {
+    const result = await computeUnstakeReserve(api, TEST_ADDRESS, []);
+    expect(result).toBe(0);
+    expect(mockEstimateTxFee).not.toHaveBeenCalled();
+  });
+
+  it("should compute reserve for a single active stake", async () => {
+    mockEstimateTxFee.mockImplementation(async (_api: ChainAPI, _addr: string, kind: string) =>
+      kind === "stake.undelegate" ? 5000 : 6000,
+    );
+
+    const stakeAccounts = [makeStakeAccount({ state: "active" })];
+    const result = await computeUnstakeReserve(api, TEST_ADDRESS, stakeAccounts as StakeAccount[]);
+
+    // 1 * withdrawFee + 1 * undelegateFee = 6000 + 5000
+    expect(result).toBe(11000);
+  });
+
+  it("should compute reserve for mixed activation states", async () => {
+    mockEstimateTxFee.mockResolvedValue(5000);
+
+    const stakeAccounts = [
+      makeStakeAccount({ state: "active" }),
+      makeStakeAccount({ state: "activating" }),
+      makeStakeAccount({ state: "deactivating" }),
+      makeStakeAccount({ state: "inactive" }),
+    ];
+    const result = await computeUnstakeReserve(api, TEST_ADDRESS, stakeAccounts as StakeAccount[]);
+
+    // 4 * withdrawFee + 2 * undelegateFee (active + activating)
+    // = 4 * 5000 + 2 * 5000 = 30000
+    expect(result).toBe(30000);
+  });
+
+  it("should compute reserve for only inactive/deactivating stakes", async () => {
+    mockEstimateTxFee.mockResolvedValue(5000);
+
+    const stakeAccounts = [
+      makeStakeAccount({ state: "inactive" }),
+      makeStakeAccount({ state: "deactivating" }),
+    ];
+    const result = await computeUnstakeReserve(api, TEST_ADDRESS, stakeAccounts as StakeAccount[]);
+
+    // 2 * withdrawFee + 0 * undelegateFee = 10000
+    expect(result).toBe(10000);
+  });
+});
+
+describe("mapStakeAccountsToSolanaStakes", () => {
+  const EPOCH = 400;
+
+  it("should map an active delegated stake account", () => {
+    const stakeAccounts = [makeStakeAccount()];
+    const result = mapStakeAccountsToSolanaStakes(
+      stakeAccounts as StakeAccount[],
+      TEST_ADDRESS,
+      EPOCH,
+    );
+
+    expect(result).toHaveLength(1);
+    const stake = result[0];
+    expect(stake.stakeAccAddr).toBe(STAKE_PUBKEY.toBase58());
+    expect(stake.stakeAccBalance).toBe(5_000_000_000);
+    expect(stake.rentExemptReserve).toBe(2282880);
+    expect(stake.hasStakeAuth).toBe(true);
+    expect(stake.hasWithdrawAuth).toBe(true);
+    expect(stake.delegation).toEqual({
+      stake: 4_997_717_120,
+      voteAccAddr: VOTER_PUBKEY.toBase58(),
+    });
+    expect(stake.activation).toEqual({ state: "active", active: 4_997_717_120, inactive: 0 });
+    expect(stake.withdrawable).toBe(0);
+    expect(stake.reward).toBeUndefined();
+  });
+
+  it("should compute withdrawable for an inactive stake", () => {
+    const stakeAccounts = [
+      makeStakeAccount({ state: "inactive", active: 0, inactive: 5_000_000_000 }),
+    ];
+    const result = mapStakeAccountsToSolanaStakes(
+      stakeAccounts as StakeAccount[],
+      TEST_ADDRESS,
+      EPOCH,
+    );
+
+    expect(result[0].withdrawable).toBe(5_000_000_000);
+  });
+
+  it("should set hasStakeAuth and hasWithdrawAuth to false for different authorities", () => {
+    const differentAuth = new PublicKey("EvnRmnMrd69kFdbLMxWkTn1icZ7DCceRhvmb2SJXqDo4");
+    const stakeAccount = makeStakeAccount();
+    stakeAccount.account!.info!.meta!.authorized!.staker = differentAuth;
+    stakeAccount.account!.info!.meta!.authorized!.withdrawer = differentAuth;
+
+    const result = mapStakeAccountsToSolanaStakes(
+      [stakeAccount] as StakeAccount[],
+      TEST_ADDRESS,
+      EPOCH,
+    );
+
+    expect(result[0].hasStakeAuth).toBe(false);
+    expect(result[0].hasWithdrawAuth).toBe(false);
+    expect(result[0].withdrawable).toBe(0);
+  });
+
+  it("should set hasWithdrawAuth to false when lockup is in force", () => {
+    const stakeAccount = makeStakeAccount();
+    stakeAccount.account!.info!.meta!.lockup = {
+      unixTimestamp: Math.floor(Date.now() / 1000) + 100000,
+      epoch: EPOCH + 100,
+      custodian: PublicKey.default,
+    };
+
+    const result = mapStakeAccountsToSolanaStakes(
+      [stakeAccount] as StakeAccount[],
+      TEST_ADDRESS,
+      EPOCH,
+    );
+
+    expect(result[0].hasWithdrawAuth).toBe(false);
+    expect(result[0].withdrawable).toBe(0);
+  });
+
+  it("should set delegation to undefined when stake is null", () => {
+    const stakeAccount = makeStakeAccount();
+    stakeAccount.account!.info!.stake = null as never;
+
+    const result = mapStakeAccountsToSolanaStakes(
+      [stakeAccount] as StakeAccount[],
+      TEST_ADDRESS,
+      EPOCH,
+    );
+
+    expect(result[0].delegation).toBeUndefined();
+  });
+
+  it("should set delegation.stake to 0 for inactive state", () => {
+    const stakeAccounts = [makeStakeAccount({ state: "inactive", active: 0, inactive: 0 })];
+    const result = mapStakeAccountsToSolanaStakes(
+      stakeAccounts as StakeAccount[],
+      TEST_ADDRESS,
+      EPOCH,
+    );
+
+    expect(result[0].delegation?.stake).toBe(0);
+  });
+});

--- a/libs/coin-modules/coin-solana/src/logic/tests/helpers/msw-rpc.mock.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/helpers/msw-rpc.mock.ts
@@ -5,7 +5,7 @@ import type {
   TransactionSignature,
 } from "@solana/web3.js";
 import { http, HttpResponse } from "msw";
-import { setupServer } from "msw/node";
+import { type SetupServer, setupServer } from "msw/node";
 import { getChainAPI, type ChainAPI } from "../../../network";
 
 export const TEST_ENDPOINT = "https://test-solana-rpc.example.com";
@@ -48,8 +48,11 @@ type RpcMethodHandlers = Partial<
   {
     [K in keyof RpcToConnection]: (params: unknown[]) => ConnectionResult<RpcToConnection[K]>;
   } & {
-    // Raw RPC encoding (string[] for base64 / parsed object) doesn't map to Connection's Buffer | ParsedAccountData
+    // Raw RPC encoding (string[] for base64 / parsed object) doesn't map
+    // cleanly to Connection's typed return values, so we use loose types.
     getAccountInfo: (params: unknown[]) => { context: { slot: number }; value: unknown };
+    getProgramAccounts: (params: unknown[]) => unknown[];
+    getEpochInfo: (params: unknown[]) => unknown;
   }
 >;
 
@@ -82,7 +85,7 @@ function invokeHandler(
 
 export function rpcHandler(methodHandlers: RpcMethodHandlers) {
   const handlers = methodHandlers as Record<string, (params: unknown[]) => unknown>;
-  return http.post(TEST_ENDPOINT, async ({ request }) => {
+  return http.post(TEST_ENDPOINT, async ({ request }: { request: Request }) => {
     const body = (await request.json()) as RpcRequest | RpcRequest[];
 
     if (Array.isArray(body)) {
@@ -97,7 +100,7 @@ export function rpcHandler(methodHandlers: RpcMethodHandlers) {
   });
 }
 
-export const server = setupServer();
+export const server = setupServer() as unknown as SetupServer;
 
 async function fetchRpc(method: string, params: unknown[]): Promise<unknown> {
   const response = await fetch(TEST_ENDPOINT, {

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.integ.test.ts
@@ -7,6 +7,10 @@ const api = getChainAPI({ endpoint: "https://solana.coin.ledger.com" });
 const ACTIVE_ADDRESS = "7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE";
 const UNUSED_ADDRESS = Keypair.generate().publicKey.toBase58();
 
+const KNOWN_TYPES = ["IN", "OUT", "FEES", "NONE", "DELEGATE", "UNDELEGATE", "WITHDRAW_UNBONDED"];
+
+// Per-type coverage (all 7 types) is in listOperations.test.ts (MSW) and
+// listOperations.unit.test.ts. This file focuses on real-RPC smoke tests.
 describe("listOperations (integration)", () => {
   it("fetches operations for an active account", async () => {
     const result = await listOperations(api, ACTIVE_ADDRESS, {
@@ -22,7 +26,7 @@ describe("listOperations (integration)", () => {
       expect(op.tx.block.height).toBeGreaterThan(0);
       expect(op.tx.block.time).toBeInstanceOf(Date);
       expect(typeof op.value).toBe("bigint");
-      expect(["IN", "OUT", "FEES", "NONE"]).toContain(op.type);
+      expect(KNOWN_TYPES).toContain(op.type);
     }
   });
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import type { ParsedInstruction, PartiallyDecodedInstruction } from "@solana/web3.js";
 import { PublicKey } from "@solana/web3.js";
 import { listOperations } from "../listOperations";
 import { server, rpcHandler, createTestChainApi } from "./helpers/msw-rpc.mock";
@@ -20,6 +22,7 @@ function makeParsedTx({
   slot = 100,
   blockTime = 1700000000,
   err = null,
+  instructions = [],
 }: {
   accountKeys: { pubkey: string; signer: boolean; writable: boolean }[];
   fee?: number;
@@ -28,6 +31,7 @@ function makeParsedTx({
   slot?: number;
   blockTime?: number;
   err?: null | { InstructionError: [number, string] } | string;
+  instructions?: object[];
 }) {
   return {
     transaction: {
@@ -35,7 +39,7 @@ function makeParsedTx({
       message: {
         accountKeys: accountKeys.map(k => ({ ...k, pubkey: new PublicKey(k.pubkey) })),
         recentBlockhash: TEST_BLOCKHASH,
-        instructions: [],
+        instructions: instructions as (ParsedInstruction | PartiallyDecodedInstruction)[],
       },
     },
     meta: {
@@ -321,6 +325,176 @@ describe("listOperations (MSW integration)", () => {
         assetRecipients: [TEST_ADDRESS],
         internal: true,
       });
+    });
+  });
+
+  describe("All operation types", () => {
+    const VOTE_ACCOUNT = "EvnRmnMrd69kFdbLMxWkTn1icZ7DCceRhvmb2SJXqDo4";
+    const STAKE_ACCOUNT = "9ZNTfG4NyQgxy2SWjSiQoUyBPEvXT2xo7fKc5hPYYJ7b";
+    const blockTime = 1700000000;
+
+    function makeSig(name: string) {
+      return {
+        signature: name,
+        slot: 100,
+        blockTime,
+        err: null,
+        memo: null,
+        confirmationStatus: "finalized" as const,
+      };
+    }
+
+    const PROGRAM_IDS: Record<string, string> = {
+      system: "11111111111111111111111111111111",
+      stake: "Stake11111111111111111111111111111111111111",
+    };
+
+    function ix(program: string, type: string, info?: Record<string, unknown>) {
+      return {
+        program,
+        programId: new PublicKey(PROGRAM_IDS[program] ?? PROGRAM_IDS.system),
+        parsed: { type, info: info ?? {} },
+      };
+    }
+
+    const txMap: Record<string, ReturnType<typeof makeParsedTx>> = {
+      "sig-out": makeParsedTx({
+        accountKeys: [
+          { pubkey: TEST_ADDRESS, signer: true, writable: true },
+          { pubkey: TEST_RECIPIENT, signer: false, writable: true },
+        ],
+        preBalances: [1_000_000_000, 0],
+        postBalances: [899_995_000, 100_000_000],
+      }),
+      "sig-in": makeParsedTx({
+        accountKeys: [
+          { pubkey: TEST_RECIPIENT, signer: true, writable: true },
+          { pubkey: TEST_ADDRESS, signer: false, writable: true },
+        ],
+        preBalances: [0, 0],
+        postBalances: [0, 100_000_000],
+      }),
+      "sig-fees": makeParsedTx({
+        accountKeys: [{ pubkey: TEST_ADDRESS, signer: true, writable: true }],
+        fee: 5000,
+        preBalances: [1_000_000_000],
+        postBalances: [999_995_000],
+      }),
+      "sig-none": makeParsedTx({
+        accountKeys: [
+          { pubkey: TEST_RECIPIENT, signer: true, writable: true },
+          { pubkey: TEST_ADDRESS, signer: false, writable: true },
+        ],
+        preBalances: [1_000_000_000, 500_000],
+        postBalances: [999_995_000, 500_000],
+      }),
+      "sig-delegate": makeParsedTx({
+        accountKeys: [{ pubkey: TEST_ADDRESS, signer: true, writable: true }],
+        preBalances: [10_000_000_000],
+        postBalances: [7_000_000_000],
+        instructions: [
+          ix("system", "createAccountWithSeed"),
+          ix("stake", "initialize"),
+          ix("stake", "delegate", { voteAccount: VOTE_ACCOUNT }),
+        ],
+      }),
+      "sig-undelegate": makeParsedTx({
+        accountKeys: [{ pubkey: TEST_ADDRESS, signer: true, writable: true }],
+        preBalances: [5_000_000_000],
+        postBalances: [4_999_995_000],
+        instructions: [ix("stake", "deactivate")],
+      }),
+      "sig-withdraw": makeParsedTx({
+        accountKeys: [{ pubkey: TEST_ADDRESS, signer: true, writable: true }],
+        preBalances: [5_000_000_000],
+        postBalances: [7_999_995_000],
+        instructions: [
+          ix("stake", "withdraw", { stakeAccount: STAKE_ACCOUNT, lamports: 3_000_000_000 }),
+        ],
+      }),
+    };
+
+    let items: Awaited<ReturnType<typeof listOperations>>["items"];
+
+    beforeAll(async () => {
+      server.use(
+        rpcHandler({
+          getSignaturesForAddress: () => Object.keys(txMap).map(s => makeSig(s)),
+          getTransaction: (params: unknown[]) => txMap[String(params[0])] ?? null,
+        }),
+      );
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+      items = result.items;
+    });
+
+    it("should produce all 7 expected native operation types", () => {
+      const nativeOps = items.filter(op => op.asset.type === "native");
+      const types = new Set(nativeOps.map(op => op.type));
+      expect(types).toEqual(
+        new Set(["OUT", "IN", "FEES", "NONE", "DELEGATE", "UNDELEGATE", "WITHDRAW_UNBONDED"]),
+      );
+    });
+
+    it("should have correct OUT operation", () => {
+      const op = items.find(op => op.tx.hash === "sig-out" && op.type === "OUT");
+      expect(op).not.toBeUndefined();
+      expect(op!.value).toBe(100_000_000n);
+      expect(op!.senders).toEqual([TEST_ADDRESS]);
+      expect(op!.recipients).toEqual([TEST_RECIPIENT]);
+    });
+
+    it("should have correct IN operation", () => {
+      const op = items.find(op => op.tx.hash === "sig-in" && op.type === "IN");
+      expect(op).not.toBeUndefined();
+      expect(op!.value).toBe(100_000_000n);
+      expect(op!.recipients).toContain(TEST_ADDRESS);
+    });
+
+    it("should have correct FEES operation", () => {
+      const op = items.find(op => op.tx.hash === "sig-fees" && op.type === "FEES");
+      expect(op).not.toBeUndefined();
+      expect(op!.value).toBe(5000n);
+    });
+
+    it("should have correct NONE operation", () => {
+      const op = items.find(op => op.tx.hash === "sig-none" && op.type === "NONE");
+      expect(op).not.toBeUndefined();
+      expect(op!.value).toBe(0n);
+    });
+
+    it("should have correct DELEGATE operation", () => {
+      const op = items.find(op => op.tx.hash === "sig-delegate" && op.type === "DELEGATE");
+      expect(op).not.toBeUndefined();
+      expect(op!.value).toBe(0n);
+      expect(op!.details).toEqual(
+        expect.objectContaining({
+          stake: expect.objectContaining({
+            address: VOTE_ACCOUNT,
+            amount: 3_000_000_000n,
+          }),
+        }),
+      );
+    });
+
+    it("should have correct UNDELEGATE operation", () => {
+      const op = items.find(op => op.tx.hash === "sig-undelegate" && op.type === "UNDELEGATE");
+      expect(op).not.toBeUndefined();
+      expect(op!.value).toBe(0n);
+    });
+
+    it("should have correct WITHDRAW_UNBONDED operation", () => {
+      const op = items.find(op => op.tx.hash === "sig-withdraw" && op.type === "WITHDRAW_UNBONDED");
+      expect(op).not.toBeUndefined();
+      expect(op!.value).toBe(5000n);
+      expect(op!.details).toEqual(
+        expect.objectContaining({
+          stake: expect.objectContaining({
+            address: STAKE_ACCOUNT,
+            amount: 3_000_000_000n,
+          }),
+        }),
+      );
     });
   });
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
@@ -49,6 +49,7 @@ describe("listOperations", () => {
               { pubkey: new PublicKey(TEST_RECIPIENT) },
             ],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: {
@@ -99,6 +100,7 @@ describe("listOperations", () => {
               { pubkey: new PublicKey(TEST_ADDRESS) },
             ],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: {
@@ -130,6 +132,7 @@ describe("listOperations", () => {
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: {
@@ -177,6 +180,7 @@ describe("listOperations", () => {
         message: {
           accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
           recentBlockhash: TEST_BLOCKHASH,
+          instructions: [],
         },
       },
       meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
@@ -198,6 +202,7 @@ describe("listOperations", () => {
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
@@ -222,6 +227,7 @@ describe("listOperations", () => {
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
@@ -231,6 +237,7 @@ describe("listOperations", () => {
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
@@ -258,6 +265,7 @@ describe("listOperations", () => {
         message: {
           accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
           recentBlockhash: TEST_BLOCKHASH,
+          instructions: [],
         },
       },
       meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
@@ -282,6 +290,7 @@ describe("listOperations", () => {
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
@@ -308,6 +317,7 @@ describe("listOperations", () => {
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
@@ -333,6 +343,7 @@ describe("listOperations", () => {
           message: {
             accountKeys: [{ pubkey: new PublicKey(OTHER_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
@@ -359,6 +370,7 @@ describe("listOperations", () => {
               { pubkey: new PublicKey(TEST_ADDRESS) },
             ],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: {
@@ -373,6 +385,7 @@ describe("listOperations", () => {
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0].type).toBe("NONE");
+
     expect(result.items[0].value).toBe(0n);
   });
 
@@ -391,6 +404,7 @@ describe("listOperations", () => {
               { pubkey: new PublicKey(TEST_RECIPIENT) },
             ],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: {
@@ -425,6 +439,7 @@ describe("listOperations", () => {
               { pubkey: new PublicKey(TEST_ADDRESS) },
             ],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: {
@@ -459,6 +474,7 @@ describe("listOperations", () => {
               { pubkey: new PublicKey(OTHER) },
             ],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: {
@@ -488,6 +504,7 @@ describe("listOperations", () => {
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: { fee: 5000, preBalances: [1000000], postBalances: [995000] },
@@ -513,6 +530,151 @@ describe("listOperations", () => {
     );
   });
 
+  describe("staking operations", () => {
+    const VOTE_ACCOUNT = "EvnRmnMrd69kFdbLMxWkTn1icZ7DCceRhvmb2SJXqDo4";
+    const STAKE_ACCOUNT = "9ZNTfG4NyQgxy2SWjSiQoUyBPEvXT2xo7fKc5hPYYJ7b";
+
+    function makeParsedIx(program: string, type: string, info?: Record<string, unknown>) {
+      return { program, parsed: { type, info } };
+    }
+
+    function makeStakingTx(
+      instructions: object[],
+      { preBalance = 10_000_000_000, postBalance = 7_000_000_000, fee = 5000 } = {},
+    ) {
+      return {
+        transaction: {
+          message: {
+            accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+            recentBlockhash: TEST_BLOCKHASH,
+            instructions,
+          },
+        },
+        meta: {
+          fee,
+          preBalances: [preBalance],
+          postBalances: [postBalance],
+        },
+      };
+    }
+
+    it("should detect DELEGATE via create+delegate (3 instructions)", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig-delegate-create", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeStakingTx([
+          makeParsedIx("system", "createAccountWithSeed"),
+          makeParsedIx("stake", "initialize"),
+          makeParsedIx("stake", "delegate", { voteAccount: VOTE_ACCOUNT }),
+        ]),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      expect(result.items).toHaveLength(1);
+      const op = result.items[0];
+      expect(op.type).toBe("DELEGATE");
+      expect(op.value).toBe(0n);
+      expect(op.details).toEqual({
+        stake: { address: VOTE_ACCOUNT, amount: 3_000_000_000n },
+      });
+    });
+
+    it("should detect DELEGATE via standalone delegate (1 instruction)", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig-delegate-solo", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeStakingTx([makeParsedIx("stake", "delegate", { voteAccount: VOTE_ACCOUNT })], {
+          preBalance: 5_000_000_000,
+          postBalance: 4_999_995_000,
+        }),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      expect(result.items).toHaveLength(1);
+      const op = result.items[0];
+      expect(op.type).toBe("DELEGATE");
+      expect(op.value).toBe(0n);
+      expect(op.details).toEqual({
+        stake: { address: VOTE_ACCOUNT, amount: 5000n },
+      });
+    });
+
+    it("should detect UNDELEGATE via deactivate", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig-undelegate", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeStakingTx([makeParsedIx("stake", "deactivate")], {
+          preBalance: 5_000_000_000,
+          postBalance: 4_999_995_000,
+        }),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      expect(result.items).toHaveLength(1);
+      const op = result.items[0];
+      expect(op.type).toBe("UNDELEGATE");
+      expect(op.value).toBe(0n);
+      expect(op.details).toBeUndefined();
+    });
+
+    it("should detect WITHDRAW_UNBONDED via withdraw", async () => {
+      const blockTime = 1700000000;
+      const withdrawLamports = 2_000_000_000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig-withdraw", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeStakingTx(
+          [
+            makeParsedIx("stake", "withdraw", {
+              stakeAccount: STAKE_ACCOUNT,
+              lamports: withdrawLamports,
+            }),
+          ],
+          { preBalance: 5_000_000_000, postBalance: 6_999_995_000, fee: 5000 },
+        ),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      expect(result.items).toHaveLength(1);
+      const op = result.items[0];
+      expect(op.type).toBe("WITHDRAW_UNBONDED");
+      expect(op.value).toBe(5000n);
+      expect(op.details).toEqual({
+        stake: { address: STAKE_ACCOUNT, amount: BigInt(withdrawLamports) },
+      });
+    });
+
+    it("should detect DELEGATE via createAccount (not createAccountWithSeed)", async () => {
+      const blockTime = 1700000000;
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig-delegate-create2", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeStakingTx([
+          makeParsedIx("system", "createAccount"),
+          makeParsedIx("stake", "initialize"),
+          makeParsedIx("stake", "delegate", { voteAccount: VOTE_ACCOUNT }),
+        ]),
+      ]);
+
+      const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].type).toBe("DELEGATE");
+    });
+  });
+
   describe("token operations", () => {
     const TOKEN_PROGRAM_ID_STR = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
     const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
@@ -528,6 +690,7 @@ describe("listOperations", () => {
           message: {
             accountKeys: accountKeys.map(k => ({ pubkey: new PublicKey(k) })),
             recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
           },
         },
         meta: {

--- a/libs/coin-modules/coin-solana/src/network/chain/stake-activation/rpc.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/stake-activation/rpc.ts
@@ -31,10 +31,10 @@ export interface StakeActivationData {
   inactive: number;
 }
 
-interface StakeAccount {
+export interface StakeAccount {
   account: ParsedOnChainStakeAccountWithInfo;
   activation: StakeActivationData;
-  reward: null;
+  reward: { amount: number } | null;
 }
 
 function toStakeAccount(

--- a/libs/coin-modules/coin-solana/src/synchronization.ts
+++ b/libs/coin-modules/coin-solana/src/synchronization.ts
@@ -8,12 +8,7 @@ import { encodeNftId } from "@ledgerhq/ledger-wallet-framework/nft/nftId";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { Operation, OperationType, ProtoNFT, TokenAccount } from "@ledgerhq/types-live";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
-import {
-  InflationReward,
-  ParsedTransaction,
-  PublicKey,
-  StakeActivationData,
-} from "@solana/web3.js";
+import { ParsedTransaction, PublicKey } from "@solana/web3.js";
 import BigNumber from "bignumber.js";
 
 import ky from "ky";
@@ -35,12 +30,11 @@ import { MintExtensions } from "./network/chain/account/tokenExtensions";
 import { DelegateInfo, WithdrawInfo } from "./network/chain/instruction/stake/types";
 import { parseQuiet } from "./network/chain/program";
 import { PARSED_PROGRAMS } from "./network/chain/program/constants";
-import { getStakeAccounts } from "./network/chain/stake-activation/rpc";
+import { getStakeAccounts, StakeAccount } from "./network/chain/stake-activation/rpc";
 import {
   getAccountMinimumBalanceForRentExemption,
   getTokenAccruedInterestDelta,
   getTransactions,
-  ParsedOnChainStakeAccountWithInfo,
   toTokenAccountWithInfo,
   TransactionDescriptor,
 } from "./network/chain/web3";
@@ -62,11 +56,7 @@ export async function getAccount(
   balance: BigNumber;
   blockHeight: number;
   tokenAccounts: ParsedOnChainTokenAccountWithInfo[];
-  stakes: {
-    account: ParsedOnChainStakeAccountWithInfo;
-    activation: StakeActivationData;
-    reward: InflationReward | null;
-  }[];
+  stakes: StakeAccount[];
 }> {
   const [
     {


### PR DESCRIPTION
### ✅ Checklist

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.**
- [X] **Impact of the changes:**
  - New Alpaca API methods for Solana: `getStakes`, `computeIntentType`
  - Refactored `craftTransaction`, `estimateFees`, `listOperations`, `getBalance` to work with the `TransactionIntent` pattern
  - No user-facing changes
 
### 📝 Description
Implements the `getStakes` Alpaca API method for Solana and adapts existing logic (`craftTransaction`, `estimateFees`, `listOperations`, `getBalance`) to work with the `TransactionIntent` based pattern required by the generic-alpaca bridge.

### ❓ Context
- **JIRA or GitHub link**: LIVE-21670

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
