### PR TITLE
[LWM] fix: flicker on homescreen

### DIFF
--- a/.changeset/funny-files-wink.md
+++ b/.changeset/funny-files-wink.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix(mobile): prevent homescreen flicker and grey background flash

--- a/apps/ledger-live-mobile/src/components/RootNavigator/WalletTabNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/WalletTabNavigator.tsx
@@ -6,6 +6,7 @@ import {
   MaterialTopTabBarProps,
 } from "@react-navigation/material-top-tabs";
 import { NavigationContainerEventMap } from "@react-navigation/native";
+import { useTheme } from "styled-components/native";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useWallet40Theme } from "LLM/hooks/useWallet40Theme";
 import MarketWalletTabNavigator from "LLM/features/Market/WalletTabNavigator";
@@ -39,11 +40,13 @@ const styles = {
   navigator: { backgroundColor: "transparent" } satisfies StyleProp<ViewStyle>,
 } as const;
 
-const screenOptions = {
+// Use theme background for scene container to prevent grey flicker when landing on homescreen (LIVE-25288).
+// Material Top Tabs can show a default grey background if sceneStyle is transparent.
+const getScreenOptions = (sceneBackgroundColor: string) => ({
   lazy: true,
   swipeEnabled: false, // For Contents Cards issue
-  sceneStyle: { backgroundColor: "transparent" },
-} as const;
+  sceneStyle: { backgroundColor: sceneBackgroundColor },
+});
 
 export default function WalletTabNavigator() {
   const dispatch = useDispatch();
@@ -59,6 +62,13 @@ export default function WalletTabNavigator() {
     shouldDisplayWallet40MainNav: shouldDisplayWallet40TopBar,
   } = useWalletFeaturesConfig("mobile");
   const { backgroundColor } = useWallet40Theme("mobile");
+  const { colors } = useTheme();
+  const sceneBackgroundColor = 
+    backgroundColor === "#000000" ? "#000000" : colors.background.main;
+  const screenOptions = useMemo(
+    () => getScreenOptions(sceneBackgroundColor),
+    [sceneBackgroundColor],
+  );
 
   const PortfolioComponent = useMemo(() => {
     if (readOnlyModeEnabled && hasNoAccounts) {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useSelector } from "~/context/hooks";
 import Config from "react-native-config";
+import { useTheme } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { NavigatorName } from "~/const";
 import { hasCompletedOnboardingSelector } from "~/reducers/settings";
@@ -13,15 +14,21 @@ import { StartupTimeMarker } from "../../StartupTimeMarker";
 export default function RootNavigator() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const goToOnboarding = !hasCompletedOnboarding && !Config.SKIP_ONBOARDING;
+  const { colors } = useTheme();
+  const rootScreenOptions = useMemo(
+    () => ({
+      headerShown: false,
+      contentStyle: {
+        backgroundColor: colors.background ?? "#131214",
+      },
+    }),
+    [colors.background],
+  );
 
   return (
     <StartupTimeMarker>
       <AnalyticsContextProvider>
-        <Stack.Navigator
-          screenOptions={{
-            headerShown: false,
-          }}
-        >
+        <Stack.Navigator screenOptions={rootScreenOptions}>
           {goToOnboarding ? (
             <Stack.Screen name={NavigatorName.BaseOnboarding} component={BaseOnboardingNavigator} />
           ) : null}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
  - No new automated tests; fix is visual/UX. Manual QA on iOS and Android recommended.
- [ ] **Impact of the changes:**
  - **WalletTabNavigator:** Tab scene background is now the theme background instead of transparent; no change to behaviour, only to the underlying container colour.
  - **RootNavigator:** Root stack screens use theme background via `contentStyle`; no change to navigation flow.
  - **QA focus:** Cold start and landing on homescreen (Portfolio), tab switches (Portfolio ↔ Market), and theme (light/dark) — confirm no grey flash or flicker and smooth transitions.

### 📝 Description

Fixes homescreen flicker and grey background flash ([LIVE-25288](https://ledgerhq.atlassian.net/browse/LIVE-25288)).

**Problem:** On iOS/Android, when opening the app or landing on the homescreen, users saw a grey flash and non-smooth transitions. This came from (1) the Material Top Tab scene container using a transparent background so the library’s default grey showed, and (2) the root stack having no `contentStyle`, so the system default background could appear on first paint.

**Solution:**
- **WalletTabNavigator:** Resolve the theme background (Wallet 4.0 dark `#000000` or `background.main`) and pass it into the tab navigator’s `sceneStyle.backgroundColor` so the scene container never shows the default grey.
- **RootNavigator:** Use `useTheme()` from React Navigation and set the root stack `screenOptions.contentStyle.backgroundColor` to the theme background (with fallback `#131214`) so the root stack never flashes the system default.

Result: no grey flash when opening the app or switching to the homescreen, and transitions stay visually consistent.

<!--
| Before        | After         |
| ------------- | ------------- |
| Grey flash when landing on homescreen; jumpy transitions. | Consistent theme background; no grey flash; smooth transitions. |
-->

### ❓ Context

- **JIRA or GitHub link:** [LIVE-25288](https://ledgerhq.atlassian.net/browse/LIVE-25288)
- **ADR link (if any):** N/A

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25288]: https://ledgerhq.atlassian.net/browse/LIVE-25288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ