### PR TITLE
[LWDM] chore(mobile): update wordings for Wallet 4.0

### DIFF
--- a/.changeset/warm-walls-wave.md
+++ b/.changeset/warm-walls-wave.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+Update wordings for Wallet 4.0 and rename Fear & Greed index levels

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8121,11 +8121,11 @@
   },
   "fearAndGreed": {
     "levels": {
-      "extremeFear": "Fear+",
       "fear": "Fear",
+      "cautious": "Cautious",
       "neutral": "Neutral",
-      "greed": "Greed",
-      "extremeGreed": "Greed+"
+      "optimistic": "Optimistic",
+      "greedy": "Greedy"
     },
     "dialog": {
       "title": "Mood index",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2743,8 +2743,8 @@
     },
     "walletBalance": "Wallet balance",
     "balance": {
-      "noSigner": "The most secure\nwallet",
-      "noAccounts": "Secure your\ncrypto"
+      "noSigner": "Your secure\ncrypto wallet",
+      "noAccounts": "Start by funding\nyour wallet"
     },
     "seeAllAssets": "See all assets",
     "seeAllAccounts": "See all accounts",
@@ -2775,10 +2775,10 @@
       "buyLedger": "Buy a Ledger",
       "transferDrawer": {
         "title": "Transfer",
-        "receiveCrypto": "Receive crypto",
+        "receiveCrypto": "Receive via crypto address",
         "sendCrypto": "Send crypto",
-        "bankTransfer": "Bank transfer",
-        "bankTransferDescription": "Receive stablecoin by sending cash"
+        "bankTransfer": "Receive via bank transfer",
+        "bankTransferDescription": "Receive stablecoins by simply sending cash."
       }
     },
     "recoverBanner": {
@@ -2794,8 +2794,8 @@
     },
     "refreshStatus": {
       "refreshing": "Refreshing...",
-      "upToDate": "You're up to date",
-      "syncError": "Some accounts failed to sync"
+      "upToDate": "Portfolio up to date",
+      "syncError": "Some account data couldn’t load"
     }
   },
   "addAccountsModal": {
@@ -8319,7 +8319,7 @@
     }
   },
   "marketBanner": {
-    "title": "Explore market",
+    "title": "Explore the market",
     "viewAll": "View all",
     "viewAllAccessibilityHint": "Double tap to view all market assets",
     "connectionFailed": "Connection failed",
@@ -8646,13 +8646,13 @@
   },
   "fearAndGreed": {
     "title": "Mood index",
-    "description": "The mood index indicates the emotional state of the market. It ranges from 0 to 100, where a lower value indicates extreme fear, and a higher value indicates extreme greed.",
+    "description": "Shows overall market sentiment from 0 to 100, based on trends and activity. Use it to understand how the market is behaving: lower values indicate fear, higher values indicate greed.",
     "levels": {
-      "extremeFear": "Fear+",
       "fear": "Fear",
+      "cautious": "Cautious",
       "neutral": "Neutral",
-      "greed": "Greed",
-      "extremeGreed": "Greed+"
+      "optimistic": "Optimistic",
+      "greedy": "Greedy"
     },
     "tileTitle": "Mood"
   },
@@ -8669,7 +8669,7 @@
   },
   "cardLanding": {
     "title": "Spend your\ncrypto",
-    "subtitle": "Pay online or in store with a crypto card",
+    "subtitle": "Pay online or in stores with a crypto card.",
     "ctas": {
       "exploreCards": "Explore cards",
       "iHaveACard": "I have a card"
@@ -8710,8 +8710,8 @@
       "default": "Synchronize"
     },
     "bottomSheet": {
-      "title": "Couldn't sync some accounts",
-      "description": "There was a temporary network issue. Your assets are safe. List of accounts impacted: {{accounts}}",
+      "title": "Some account data couldn’t load",
+      "description": "Your assets are safe. This is a temporary sync issue.\nAffected accounts: {{accounts}}",
       "close": "Close"
     }
   },

--- a/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/__integrations__/FearAndGreed.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FearAndGreed/__integrations__/FearAndGreed.test.tsx
@@ -38,11 +38,11 @@ describe("FearAndGreed Integration", () => {
 
   describe("Mood levels", () => {
     it.each([
-      { value: 15, label: "Fear+", classification: "Extreme Fear" },
-      { value: 40, label: "Fear", classification: "Fear" },
+      { value: 15, label: "Fear", classification: "Extreme Fear" },
+      { value: 40, label: "Cautious", classification: "Fear" },
       { value: 50, label: "Neutral", classification: "Neutral" },
-      { value: 70, label: "Greed", classification: "Greed" },
-      { value: 90, label: "Greed+", classification: "Extreme Greed" },
+      { value: 70, label: "Optimistic", classification: "Greed" },
+      { value: 90, label: "Greedy", classification: "Extreme Greed" },
     ])("should render $label when value is $value", async ({ value, label, classification }) => {
       server.use(
         http.get(API_ENDPOINT, () => HttpResponse.json(createMockResponse(value, classification))),
@@ -65,7 +65,9 @@ describe("FearAndGreed Integration", () => {
       await user.press(card);
 
       expect(
-        screen.getByText(/the mood index indicates the emotional state of the market/i),
+        screen.getByText(
+          /Shows overall market sentiment from 0 to 100, based on trends and activity. Use it to understand how the market is behaving: lower values indicate fear, higher values indicate greed./i,
+        ),
       ).toBeVisible();
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Card/screens/CardLandingScreen/CardLandingScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Card/screens/CardLandingScreen/CardLandingScreen.test.tsx
@@ -48,7 +48,7 @@ describe("CardLandingScreen", () => {
 
     expect(getByTestId(CARD_LANDING_TEST_IDS.title).props.children).toBe("Spend your\ncrypto");
     expect(getByTestId(CARD_LANDING_TEST_IDS.subtitle).props.children).toBe(
-      "Pay online or in store with a crypto card",
+      "Pay online or in stores with a crypto card.",
     );
     expect(getByText(/Explore cards/i)).toBeVisible();
     expect(getByText(/I have a card/i)).toBeVisible();

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/__integrations__/marketBanner.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/__integrations__/marketBanner.integration.test.tsx
@@ -252,7 +252,7 @@ describe("MarketBanner Integration Tests", () => {
         }),
       });
 
-      expect(await screen.findByText(/Explore market/i)).toBeVisible();
+      expect(await screen.findByText(/Explore the market/i)).toBeVisible();
     });
   });
 
@@ -332,7 +332,7 @@ describe("MarketBanner Integration Tests", () => {
         }),
       });
 
-      const sectionTitle = await screen.findByText(/Explore market/i);
+      const sectionTitle = await screen.findByText(/Explore the market/i);
       await user.press(sectionTitle);
 
       await waitFor(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
@@ -121,7 +121,7 @@ describe("PortfolioRefreshStatus", () => {
       completeRefresh(store);
 
       expect(screen.getByTestId("portfolio-refresh-status-up-to-date")).toBeVisible();
-      expect(screen.getByText("You're up to date")).toBeVisible();
+      expect(screen.getByText("Portfolio up to date")).toBeVisible();
       expect(screen.getByTestId("portfolio-refresh-status-checkmark")).toBeTruthy();
       expect(screen.queryByTestId("portfolio-refresh-status-spinner")).toBeNull();
     });

--- a/libs/ledger-live-common/src/cmc-client/state-manager/types.ts
+++ b/libs/ledger-live-common/src/cmc-client/state-manager/types.ts
@@ -34,4 +34,4 @@ export type FearAndGreedStatus = z.infer<typeof FearAndGreedStatusSchema>;
 export type FearAndGreedResponse = z.infer<typeof FearAndGreedResponseSchema>;
 export type FearAndGreedIndex = z.infer<typeof FearAndGreedIndexSchema>;
 
-export type FearAndGreedLevel = "extremeFear" | "fear" | "neutral" | "greed" | "extremeGreed";
+export type FearAndGreedLevel = "fear" | "cautious" | "neutral" | "optimistic" | "greedy";

--- a/libs/ledger-live-common/src/cmc-client/utils/__test__/fearAndGreed.test.ts
+++ b/libs/ledger-live-common/src/cmc-client/utils/__test__/fearAndGreed.test.ts
@@ -9,21 +9,21 @@ import {
 describe("Fear and Greed utils", () => {
   describe("getFearAndGreedLevel", () => {
     it.each([
-      { value: 0, expected: "extremeFear" },
-      { value: 10, expected: "extremeFear" },
-      { value: 19, expected: "extremeFear" },
-      { value: 26, expected: "fear" },
-      { value: 35, expected: "fear" },
-      { value: 40, expected: "fear" },
+      { value: 0, expected: "fear" },
+      { value: 10, expected: "fear" },
+      { value: 19, expected: "fear" },
+      { value: 26, expected: "cautious" },
+      { value: 35, expected: "cautious" },
+      { value: 40, expected: "cautious" },
       { value: 46, expected: "neutral" },
       { value: 50, expected: "neutral" },
       { value: 55, expected: "neutral" },
-      { value: 61, expected: "greed" },
-      { value: 70, expected: "greed" },
-      { value: 75, expected: "greed" },
-      { value: 81, expected: "extremeGreed" },
-      { value: 90, expected: "extremeGreed" },
-      { value: 100, expected: "extremeGreed" },
+      { value: 61, expected: "optimistic" },
+      { value: 70, expected: "optimistic" },
+      { value: 75, expected: "optimistic" },
+      { value: 81, expected: "greedy" },
+      { value: 90, expected: "greedy" },
+      { value: 100, expected: "greedy" },
     ])("should return $expected for value $value", ({ value, expected }) => {
       expect(getFearAndGreedLevel(value)).toBe(expected);
     });
@@ -31,11 +31,11 @@ describe("Fear and Greed utils", () => {
 
   describe("getFearAndGreedTranslationKey", () => {
     it.each([
-      { value: 10, expected: "fearAndGreed.levels.extremeFear" },
-      { value: 35, expected: "fearAndGreed.levels.fear" },
+      { value: 10, expected: "fearAndGreed.levels.fear" },
+      { value: 35, expected: "fearAndGreed.levels.cautious" },
       { value: 50, expected: "fearAndGreed.levels.neutral" },
-      { value: 70, expected: "fearAndGreed.levels.greed" },
-      { value: 90, expected: "fearAndGreed.levels.extremeGreed" },
+      { value: 70, expected: "fearAndGreed.levels.optimistic" },
+      { value: 90, expected: "fearAndGreed.levels.greedy" },
     ])("should return $expected for value $value", ({ value, expected }) => {
       expect(getFearAndGreedTranslationKey(value)).toBe(expected);
     });
@@ -43,11 +43,11 @@ describe("Fear and Greed utils", () => {
 
   describe("getFearAndGreedColor", () => {
     it.each([
-      { value: 10, level: "extremeFear", color: "error" },
-      { value: 35, level: "fear", color: "warning" },
+      { value: 10, level: "fear", color: "error" },
+      { value: 35, level: "cautious", color: "warning" },
       { value: 50, level: "neutral", color: "muted" },
-      { value: 70, level: "greed", color: "success" },
-      { value: 90, level: "extremeGreed", color: "success" },
+      { value: 70, level: "optimistic", color: "success" },
+      { value: 90, level: "greedy", color: "success" },
     ])("should return $color for value $value ($level)", ({ value, level, color }) => {
       expect(getFearAndGreedColorKey(value)).toBe(FEAR_AND_GREED_COLORS[level]);
       expect(getFearAndGreedColorKey(value)).toBe(color);
@@ -57,11 +57,11 @@ describe("Fear and Greed utils", () => {
   describe("Constants", () => {
     describe("FEAR_AND_GREED_COLORS", () => {
       it.each([
-        { level: "extremeFear", color: "error" },
-        { level: "fear", color: "warning" },
+        { level: "fear", color: "error" },
+        { level: "cautious", color: "warning" },
         { level: "neutral", color: "muted" },
-        { level: "greed", color: "success" },
-        { level: "extremeGreed", color: "success" },
+        { level: "optimistic", color: "success" },
+        { level: "greedy", color: "success" },
       ])("should have correct color for $level", ({ level, color }) => {
         expect(FEAR_AND_GREED_COLORS[level]).toBe(color);
       });
@@ -69,11 +69,11 @@ describe("Fear and Greed utils", () => {
 
     describe("FEAR_AND_GREED_TRANSLATION_KEYS", () => {
       it.each([
-        { level: "extremeFear", key: "fearAndGreed.levels.extremeFear" },
         { level: "fear", key: "fearAndGreed.levels.fear" },
+        { level: "cautious", key: "fearAndGreed.levels.cautious" },
         { level: "neutral", key: "fearAndGreed.levels.neutral" },
-        { level: "greed", key: "fearAndGreed.levels.greed" },
-        { level: "extremeGreed", key: "fearAndGreed.levels.extremeGreed" },
+        { level: "optimistic", key: "fearAndGreed.levels.optimistic" },
+        { level: "greedy", key: "fearAndGreed.levels.greedy" },
       ])("should have correct key for $level", ({ level, key }) => {
         expect(FEAR_AND_GREED_TRANSLATION_KEYS[level]).toBe(key);
       });
@@ -82,10 +82,10 @@ describe("Fear and Greed utils", () => {
 
   describe("Boundary values", () => {
     it.each([
-      { value: 20, level: "extremeFear", color: "error" },
-      { value: 40, level: "fear", color: "warning" },
+      { value: 20, level: "fear", color: "error" },
+      { value: 40, level: "cautious", color: "warning" },
       { value: 60, level: "neutral", color: "muted" },
-      { value: 80, level: "greed", color: "success" },
+      { value: 80, level: "optimistic", color: "success" },
     ])("should handle boundary at $value ($level)", ({ value, level, color }) => {
       expect(getFearAndGreedLevel(value)).toBe(level);
       expect(getFearAndGreedColorKey(value)).toBe(color);

--- a/libs/ledger-live-common/src/cmc-client/utils/fearAndGreed.ts
+++ b/libs/ledger-live-common/src/cmc-client/utils/fearAndGreed.ts
@@ -1,27 +1,27 @@
 import type { FearAndGreedLevel } from "../state-manager/types";
 
 export const FEAR_AND_GREED_TRANSLATION_KEYS: Record<FearAndGreedLevel, string> = {
-  extremeFear: "fearAndGreed.levels.extremeFear",
   fear: "fearAndGreed.levels.fear",
+  cautious: "fearAndGreed.levels.cautious",
   neutral: "fearAndGreed.levels.neutral",
-  greed: "fearAndGreed.levels.greed",
-  extremeGreed: "fearAndGreed.levels.extremeGreed",
+  optimistic: "fearAndGreed.levels.optimistic",
+  greedy: "fearAndGreed.levels.greedy",
 };
 
 export const FEAR_AND_GREED_COLORS: Record<FearAndGreedLevel, string> = {
-  extremeFear: "error",
-  fear: "warning",
+  fear: "error",
+  cautious: "warning",
   neutral: "muted",
-  greed: "success",
-  extremeGreed: "success",
+  optimistic: "success",
+  greedy: "success",
 };
 
 export function getFearAndGreedLevel(value: number): FearAndGreedLevel {
-  if (value <= 20) return "extremeFear";
-  if (value <= 40) return "fear";
+  if (value <= 20) return "fear";
+  if (value <= 40) return "cautious";
   if (value <= 60) return "neutral";
-  if (value <= 80) return "greed";
-  return "extremeGreed";
+  if (value <= 80) return "optimistic";
+  return "greedy";
 }
 
 export function getFearAndGreedTranslationKey(value: number): string {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio hero section wordings (lazy onboarding, no accounts state)
      - Market banner title
      - Fear & Greed index level labels and internal keys

### 📝 Description

Update mobile wordings to align with Wallet 4.0 Figma designs.

**Wording changes (en locale):**
- "Explore market" → "Explore the market"
- "The most secure wallet" → "The secure wallet" (lazy onboarding)
- "Secure your crypto" → "Start by funding your wallet" (no accounts state)
- Fear & Greed index levels: Fear+ → Fear, Fear → Cautious, Neutral (unchanged), Greed → Optimistic, Greed+ → Greedy

**Refactor:** Renamed `FearAndGreedLevel` type values and all associated keys (`extremeFear` → `fear`, `fear` → `cautious`, `greed` → `optimistic`, `extremeGreed` → `greedy`) across type definitions, constants, utility functions, tests, and locale keys for consistency.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27843](https://ledgerhq.atlassian.net/browse/LIVE-27843)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27843]: https://ledgerhq.atlassian.net/browse/LIVE-27843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ