### PR TITLE
[LWM] fix(mobile): export full countervalues history to avoid repull on boot

### DIFF
--- a/.changeset/full-countervalues-export-mobile.md
+++ b/.changeset/full-countervalues-export-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Export full countervalues history on mobile to avoid repull on boot

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -6,7 +6,7 @@ import isEqual from "lodash/isEqual";
 import throttleFn from "lodash/throttle";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useSelector } from "~/context/hooks";
-import { useTrackingPairs, useUserSettings } from "~/actions/general";
+import { useTrackingPairs } from "~/actions/general";
 import {
   saveAccounts,
   saveBle,
@@ -175,19 +175,13 @@ const countervaluesChangesStats = (oldState: State, newState: State) => {
 export const ConfigureDBSaveEffects = () => {
   // TODO: instead of using these hooks, we should select from the redux state and make a static lense function.
   const trackingPairs = useTrackingPairs();
-  const userSettings = useUserSettings();
 
   useDBSaveEffect({
     throttle: 2000,
     getChangesStats: countervaluesChangesStats,
     lense: useCallback(
-      (state: State) =>
-        exportCountervalues(
-          countervaluesStateSelector(state),
-          trackingPairs,
-          userSettings.selectedTimeRange,
-        ),
-      [trackingPairs, userSettings.selectedTimeRange],
+      (state: State) => exportCountervalues(countervaluesStateSelector(state), trackingPairs),
+      [trackingPairs],
     ),
     save: saveCountervalues,
   });


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLM only
  - graphs and operations **countervalues**

### 📝 Description

Recently, we did an optimisation to reduce the app.json and the stored cached countervalues.
This comes with a cost: less cache but more http calls.
In current live-countervalues implementaiton, we are in the paradigm to load them all at boot, and with this optimisation, it actually often means we need to repull the history again. 
This makes a lot of http calls at load and we suspect this contribute to more slowness than before on mobile app. 
This PR is here to confirm or not this hypothesis. 

**BEFORE**

<img width="1242" height="447" alt="Screenshot 2026-03-20 at 13 58 06" src="https://github.com/user-attachments/assets/7856acb7-160d-45c1-9aee-b43dbe50f7c3" />

<img width="657" height="181" alt="Screenshot 2026-03-20 at 14 02 40" src="https://github.com/user-attachments/assets/1940c3f9-a956-458f-a5bf-e27815c8175b" />

**AFTER**

<img width="1262" height="471" alt="Screenshot 2026-03-20 at 13 57 59" src="https://github.com/user-attachments/assets/8cf71385-bf6d-4a1e-a209-e6328bd475fb" />


<img width="683" height="246" alt="Screenshot 2026-03-20 at 14 02 49" src="https://github.com/user-attachments/assets/2d7b6555-ae2c-40cc-a67f-e8a2165065f5" />



### ❓ Context

- **JIRA or GitHub link**: NA
- **ADR link (if any)**: NA