### PR TITLE
[LWM] feat(mobile): increase iOS max HTTP connections per host for faster boot

### DIFF
--- a/.changeset/ios-http-connections-per-host.md
+++ b/.changeset/ios-http-connections-per-host.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Increase iOS max HTTP connections per host to improve boot-time request parallelism

--- a/apps/ledger-live-mobile/ios/AppDelegate.swift
+++ b/apps/ledger-live-mobile/ios/AppDelegate.swift
@@ -29,6 +29,20 @@ class AppDelegate: RCTAppDelegate, UNUserNotificationCenterDelegate {
     self.moduleName = "ledgerlivemobile"
     self.dependencyProvider = RCTAppDependencyProvider()
 
+    // Increase max concurrent HTTP connections per host (iOS default is 6) to reduce boot-time
+    // request queuing. See: https://developer.apple.com/documentation/foundation/urlsessionconfiguration/httpmaximumconnectionsperhost
+    RCTSetCustomNSURLSessionConfigurationProvider {
+      let config = URLSessionConfiguration.default
+      config.httpMaximumConnectionsPerHost = 16
+      if let useWifiOnly = Bundle.main.infoDictionary?["ReactNetworkForceWifiOnly"] as? Bool, useWifiOnly {
+        config.allowsCellularAccess = false
+      }
+      config.httpShouldSetCookies = true
+      config.httpCookieAcceptPolicy = .always
+      config.httpCookieStorage = HTTPCookieStorage.shared
+      return config
+    }
+
     FirebaseConfigurator.configure()
 
     var pushAutoEnabled = true

--- a/apps/ledger-live-mobile/ios/LedgerWallet-Bridging-Header.h
+++ b/apps/ledger-live-mobile/ios/LedgerWallet-Bridging-Header.h
@@ -11,6 +11,7 @@
 
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTHTTPRequestHandler.h>
 
 
 // Environment variables:


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Set httpMaximumConnectionsPerHost to 16 via RCTSetCustomNSURLSessionConfigurationProvider to reduce request queuing at app launch (iOS default is 6).


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
