### PR TITLE
[LWDM] fix(coin-hedera): group erc20 transfers by transaction hash to avoid duplicates

### DIFF
--- a/.changeset/poor-clouds-eat.md
+++ b/.changeset/poor-clouds-eat.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix: group erc20 transfers by transaction hash

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -773,6 +773,66 @@ describe("createApi", () => {
       expect(block.info.time).toBeInstanceOf(Date);
       expect(block.transactions).toBeInstanceOf(Array);
     });
+
+    it("returns single transaction for multiple erc20 transfers", async () => {
+      const data = await api.getBlock(177314999);
+
+      const erc20Asset = {
+        type: "erc20",
+        assetReference: "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
+      };
+      const erc20TxHash = "givnas3WAL3fiGeap+oSRIYOqUbqE0Ig2XIMTWgTDQzTMc8g7aOC1vxc8hQy7wZX";
+      const filteredTransactions = data.transactions.filter(tx => tx.hash === erc20TxHash);
+
+      expect(filteredTransactions).toEqual([
+        expect.objectContaining({
+          operations: [
+            {
+              type: "transfer",
+              address: "0.0.802",
+              asset: {
+                type: "native",
+              },
+              amount: 26596592n,
+            },
+            {
+              type: "transfer",
+              address: "0.0.10067136",
+              asset: {
+                type: "native",
+              },
+              amount: 0n,
+            },
+            {
+              type: "transfer",
+              address: "0.0.6145236",
+              asset: erc20Asset,
+              amount: 2863838n,
+            },
+            {
+              type: "transfer",
+              address: "0x0000000000000000000000000000000000000000",
+              asset: erc20Asset,
+              amount: -2863838n,
+            },
+            {
+              type: "transfer",
+              address: "0.0.10067136",
+              asset: erc20Asset,
+              amount: 148440n,
+            },
+            {
+              type: "transfer",
+              address: "0x0000000000000000000000000000000000000000",
+              asset: erc20Asset,
+              amount: -148440n,
+            },
+          ],
+          fees: 26596592n,
+          feesPayer: "0.0.10067136",
+        }),
+      ]);
+    });
   });
 
   describe("lastBlock", () => {

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
@@ -270,7 +270,7 @@ describe("getBlockV2", () => {
     const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
       mirrorTransaction: mockMirrorTransaction,
       contractCallResult: mockContractCallResult,
-      transfer: mockERC20Transfer,
+      transfers: [mockERC20Transfer],
     });
 
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([
@@ -348,7 +348,7 @@ describe("getBlockV2", () => {
     const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
       mirrorTransaction: mockMirrorContractCall,
       contractCallResult: mockContractCallResult,
-      transfer: mockERC20Transfer,
+      transfers: [mockERC20Transfer],
     });
 
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([
@@ -397,7 +397,7 @@ describe("getBlockV2", () => {
     const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
       mirrorTransaction: mockMirrorTransaction,
       contractCallResult: mockContractCallResult,
-      transfer: mockERC20Transfer,
+      transfers: [mockERC20Transfer],
     });
 
     (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
@@ -216,7 +216,7 @@ export async function getBlockV2(height: number): Promise<Block> {
       )[] = [
         ...mirrorTx.transfers,
         ...mirrorTx.token_transfers,
-        ...(item.type === "erc20" ? [item.data.transfer] : []),
+        ...(item.type === "erc20" ? item.data.transfers : []),
       ];
 
       operations = allTransfers.flatMap(transfer => {

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -281,7 +281,7 @@ describe("listOperationsV2", () => {
     const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
       mirrorTransaction: mockMirrorTransaction,
       contractCallResult: mockContractCallResult,
-      transfer: mockERC20Transfer,
+      transfers: [mockERC20Transfer],
     });
 
     jest.spyOn(networkUtils, "enrichERC20Transfers").mockResolvedValue([mockEnrichedERC20Transfer]);
@@ -371,7 +371,7 @@ describe("listOperationsV2", () => {
     const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
       mirrorTransaction: mockMirrorTransaction,
       contractCallResult: mockContractCallResult,
-      transfer: mockERC20Transfer,
+      transfers: [mockERC20Transfer],
     });
 
     jest.spyOn(networkUtils, "enrichERC20Transfers").mockResolvedValue([mockEnrichedERC20Transfer]);
@@ -754,7 +754,7 @@ describe("listOperationsV2", () => {
     const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
       mirrorTransaction: mockMirrorTransaction,
       contractCallResult: mockContractCallResult,
-      transfer: mockERC20Transfer,
+      transfers: [mockERC20Transfer],
     });
 
     jest.spyOn(networkUtils, "enrichERC20Transfers").mockResolvedValue([mockEnrichedERC20Transfer]);
@@ -993,7 +993,7 @@ describe("listOperationsV2", () => {
     const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
       mirrorTransaction: mockMirrorTransaction,
       contractCallResult: mockContractCallResult,
-      transfer: mockERC20Transfer,
+      transfers: [mockERC20Transfer],
     });
 
     jest.spyOn(networkUtils, "enrichERC20Transfers").mockResolvedValue([mockEnrichedERC20Transfer]);
@@ -1026,6 +1026,81 @@ describe("listOperationsV2", () => {
 
     expect(result.coinOperations).toEqual([]);
     expect(result.tokenOperations).toEqual([expect.objectContaining({ type: "IN" })]);
+  });
+
+  it("should produce two token operations for a swap with two different-token transfers", async () => {
+    const sharedHash = "erc20-in-transfer-hash";
+    const mockTokenA = getMockedERC20TokenCurrency({
+      id: "hedera/erc20/0xTokenA",
+      contractAddress: "0xTokenA",
+    });
+    const mockTokenB = getMockedERC20TokenCurrency({
+      id: "hedera/erc20/0xTokenB",
+      contractAddress: "0xTokenB",
+    });
+
+    const mockErc20TransferOut = getMockedERC20TokenTransfer({
+      token_evm_address: mockTokenA.contractAddress,
+      sender_evm_address: mockMirrorAccount.evm_address,
+      sender_account_id: 12345,
+      receiver_account_id: 99999,
+      transfer_type: "transfer",
+      amount: 1000,
+      transaction_hash: sharedHash,
+    });
+    const mockErc20TransferIn = getMockedERC20TokenTransfer({
+      token_evm_address: mockTokenB.contractAddress,
+      receiver_evm_address: mockMirrorAccount.evm_address,
+      sender_account_id: 99999,
+      receiver_account_id: 12345,
+      transfer_type: "transfer",
+      amount: 2000,
+      transaction_hash: sharedHash,
+    });
+
+    const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
+      transfers: [mockErc20TransferOut, mockErc20TransferIn],
+    });
+
+    jest.spyOn(networkUtils, "enrichERC20Transfers").mockResolvedValue([mockEnrichedERC20Transfer]);
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [],
+      nextCursor: null,
+    });
+    (hgraphClient.getERC20Transfers as jest.Mock).mockResolvedValue([]);
+    (hgraphClient.getLatestIndexedConsensusTimestamp as jest.Mock).mockResolvedValue(
+      new BigNumber("1625097600.000000000"),
+    );
+
+    setupMockCryptoAssetsStore({
+      findTokenByAddressInCurrency: jest
+        .fn()
+        .mockResolvedValueOnce(mockTokenA) // for transfer out
+        .mockResolvedValueOnce(mockTokenB), // for transfer in
+    });
+
+    const result = await listOperations({
+      limit: mockLimit,
+      order: mockOrder,
+      currency: mockCurrency,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      erc20Tokens: [
+        { token: mockTokenA, balance: new BigNumber(10000) },
+        { token: mockTokenB, balance: new BigNumber(20000) },
+      ],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+    });
+
+    expect(result.coinOperations).toEqual([expect.objectContaining({ type: "FEES" })]);
+    expect(result.tokenOperations).toEqual([
+      expect.objectContaining({ type: "OUT" }),
+      expect.objectContaining({ type: "IN" }),
+    ]);
   });
 
   it("should skip FEES operations when skipFeesForTokenOperations is true", async () => {
@@ -1189,7 +1264,7 @@ describe("listOperationsV2", () => {
     const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
       mirrorTransaction: mockMirrorTransaction,
       contractCallResult: mockContractCallResult,
-      transfer: mockERC20Transfer,
+      transfers: [mockERC20Transfer],
     });
 
     jest.spyOn(networkUtils, "enrichERC20Transfers").mockResolvedValue([mockEnrichedERC20Transfer]);
@@ -1257,7 +1332,7 @@ describe("listOperationsV2", () => {
     const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
       mirrorTransaction: mockMirrorTransaction,
       contractCallResult: mockContractCallResult,
-      transfer: mockERC20Transfer,
+      transfers: [mockERC20Transfer],
     });
 
     jest.spyOn(networkUtils, "enrichERC20Transfers").mockResolvedValue([mockEnrichedERC20Transfer]);
@@ -1391,7 +1466,7 @@ describe("listOperationsV2", () => {
     const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
       mirrorTransaction: mockERC20MirrorTransaction,
       contractCallResult: mockContractCallResult,
-      transfer: mockERC20Transfer,
+      transfers: [mockERC20Transfer],
     });
 
     jest.spyOn(networkUtils, "enrichERC20Transfers").mockResolvedValue([mockEnrichedERC20Transfer]);

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -142,74 +142,89 @@ async function processERC20TokenTransfer({
   commonData: ReturnType<typeof getCommonMirrorOperationData>;
 }): Promise<{
   coinOperation: Operation<HederaOperationExtra> | undefined;
-  tokenOperation: Operation<HederaOperationExtra>;
-} | null> {
-  const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(
-    enrichedERC20Transfer.transfer.token_evm_address,
-    "hedera",
-  );
-
-  if (!token) return null;
-
+  tokenOperations: Operation<HederaOperationExtra>[];
+}> {
   let coinOperation: Operation<HederaOperationExtra> | undefined;
+  const tokenOperations: Operation<HederaOperationExtra>[] = [];
 
-  const senderEvmAddress = enrichedERC20Transfer.transfer.sender_evm_address;
-  const senderAddress = enrichedERC20Transfer.transfer.sender_account_id
-    ? toEntityId({ num: enrichedERC20Transfer.transfer.sender_account_id })
-    : enrichedERC20Transfer.transfer.sender_evm_address;
-  const recipientAddress = enrichedERC20Transfer.transfer.receiver_account_id
-    ? toEntityId({ num: enrichedERC20Transfer.transfer.receiver_account_id })
-    : enrichedERC20Transfer.transfer.receiver_evm_address;
+  for (const transfer of enrichedERC20Transfer.transfers) {
+    const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(
+      transfer.token_evm_address,
+      "hedera",
+    );
 
-  const commonFields = {
-    ...commonData,
-    type: getOperationTypeFromERC20Details({
-      transferType: enrichedERC20Transfer.transfer.transfer_type,
-      senderEvmAddress,
-      evmAddress,
-    }),
-    contract: token.contractAddress,
-    standard: "erc20",
-    blockHeight: commonData.blockHeight,
-    blockHash: commonData.blockHash,
-    senders: [senderAddress],
-    recipients: [recipientAddress],
-    fee: new BigNumber(enrichedERC20Transfer.mirrorTransaction.charged_tx_fee),
-    value: new BigNumber(enrichedERC20Transfer.transfer.amount),
-    extra: {
-      ...commonData.extra,
-      gasConsumed: enrichedERC20Transfer.contractCallResult.gas_consumed,
-      gasLimit: enrichedERC20Transfer.contractCallResult.gas_limit,
-      gasUsed: enrichedERC20Transfer.contractCallResult.gas_used,
-    },
-  } satisfies Partial<Operation<HederaOperationExtra>>;
+    if (!token) continue;
 
-  const encodedTokenAccountId = encodeTokenAccountId(ledgerAccountId, token);
-  const encodedOperationId = encodeOperationId(
-    encodedTokenAccountId,
-    commonFields.hash,
-    commonFields.type,
-  );
+    const senderEvmAddress = transfer.sender_evm_address;
+    const senderAddress = transfer.sender_account_id
+      ? toEntityId({ num: transfer.sender_account_id })
+      : transfer.sender_evm_address;
+    const recipientAddress = transfer.receiver_account_id
+      ? toEntityId({ num: transfer.receiver_account_id })
+      : transfer.receiver_evm_address;
 
-  const tokenOperation = {
-    ...commonFields,
-    id: encodedOperationId,
-    accountId: encodedTokenAccountId,
-  } satisfies Operation<HederaOperationExtra>;
+    const commonFields = {
+      ...commonData,
+      type: getOperationTypeFromERC20Details({
+        transferType: transfer.transfer_type,
+        senderEvmAddress,
+        evmAddress,
+      }),
+      contract: token.contractAddress,
+      standard: "erc20",
+      blockHeight: commonData.blockHeight,
+      blockHash: commonData.blockHash,
+      senders: [senderAddress],
+      recipients: [recipientAddress],
+      fee: new BigNumber(enrichedERC20Transfer.mirrorTransaction.charged_tx_fee),
+      value: new BigNumber(transfer.amount),
+      extra: {
+        ...commonData.extra,
+        gasConsumed: enrichedERC20Transfer.contractCallResult.gas_consumed,
+        gasLimit: enrichedERC20Transfer.contractCallResult.gas_limit,
+        gasUsed: enrichedERC20Transfer.contractCallResult.gas_used,
+      },
+    } satisfies Partial<Operation<HederaOperationExtra>>;
 
-  if (commonFields.type === "OUT") {
-    coinOperation = {
+    const encodedTokenAccountId = encodeTokenAccountId(ledgerAccountId, token);
+    const encodedOperationId = encodeOperationId(
+      encodedTokenAccountId,
+      commonFields.hash,
+      commonFields.type,
+    );
+
+    const tokenOperation = {
       ...commonFields,
-      id: encodeOperationId(ledgerAccountId, commonFields.hash, "FEES"),
+      id: encodedOperationId,
+      accountId: encodedTokenAccountId,
+    } satisfies Operation<HederaOperationExtra>;
+
+    tokenOperations.push(tokenOperation);
+  }
+
+  // create FEES operation for outgoing ERC20 transfer
+  const outgoingTransfer = tokenOperations.find(transfer => transfer.type === "OUT");
+  if (outgoingTransfer) {
+    coinOperation = {
+      ...commonData,
+      id: encodeOperationId(ledgerAccountId, commonData.hash, "FEES"),
       accountId: ledgerAccountId,
       type: "FEES",
-      value: commonFields.fee,
+      ...(outgoingTransfer.contract && { contract: outgoingTransfer.contract }),
+      ...(outgoingTransfer.standard && { standard: outgoingTransfer.standard }),
+      blockHeight: outgoingTransfer.blockHeight,
+      blockHash: outgoingTransfer.blockHash,
+      senders: outgoingTransfer.senders,
+      recipients: outgoingTransfer.recipients,
+      fee: outgoingTransfer.fee,
+      value: outgoingTransfer.fee,
+      extra: outgoingTransfer.extra,
     } satisfies Operation<HederaOperationExtra>;
   }
 
   return {
     coinOperation,
-    tokenOperation,
+    tokenOperations,
   };
 }
 
@@ -435,8 +450,8 @@ async function processTransactionItem({
       commonData,
     });
 
-    if (erc20TokenResult?.tokenOperation) newTokenOperations.push(erc20TokenResult.tokenOperation);
-    if (erc20TokenResult?.coinOperation) newCoinOperations.push(erc20TokenResult.coinOperation);
+    if (erc20TokenResult.coinOperation) newCoinOperations.push(erc20TokenResult.coinOperation);
+    newTokenOperations.push(...erc20TokenResult.tokenOperations);
   }
 
   return { newCoinOperations, newTokenOperations };

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -480,7 +480,7 @@ describe("network utils", () => {
 
       expect(result).toEqual([
         {
-          transfer: mockERC20Transfer,
+          transfers: [mockERC20Transfer],
           contractCallResult: mockContractCallResult,
           mirrorTransaction: mockMirrorTransaction,
         },
@@ -492,6 +492,19 @@ describe("network utils", () => {
         timestamp: "1704067200.000000000",
         payerAddress: `0.0.${payerAccountId}`,
       });
+    });
+
+    it("should group multiple transfers with the same transaction hash into one enriched result", async () => {
+      const transfer1 = { ...mockERC20Transfer, amount: 1000 };
+      const transfer2 = { ...mockERC20Transfer, amount: 2000 }; // same transaction_hash
+
+      const result = await enrichERC20Transfers([transfer1, transfer2]);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          transfers: [transfer1, transfer2],
+        }),
+      ]);
     });
 
     it("should skip transfers where mirror transaction is not found", async () => {
@@ -510,7 +523,7 @@ describe("network utils", () => {
       );
 
       const result = await enrichERC20Transfers(transfers);
-      const txHashes = result.map(r => r.transfer.transaction_hash);
+      const txHashes = result.flatMap(r => r.transfers.map(t => t.transaction_hash));
 
       expect(txHashes).toEqual([mockERC20Transfer.transaction_hash, "hash456"]);
     });

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -203,14 +203,26 @@ export function parseThirdwebTransactionParams(
 export const enrichERC20Transfers = async (erc20Transfers: ERC20TokenTransfer[]) => {
   const enrichedTransfers: EnrichedERC20Transfer[] = [];
 
-  for (const rawTransfer of erc20Transfers) {
-    const payerAddress = toEntityId({ num: rawTransfer.payer_account_id });
-    const hash = rawTransfer.transaction_hash;
-    const inaccurateConsensusTimestampNs = new BigNumber(rawTransfer.consensus_timestamp);
+  // with hgraph we can get two different transfers with the same transaction hash
+  const groupedByTxHash = new Map<string, [ERC20TokenTransfer, ...ERC20TokenTransfer[]]>();
+  for (const transfer of erc20Transfers) {
+    const group = groupedByTxHash.get(transfer.transaction_hash);
+
+    if (!group) {
+      groupedByTxHash.set(transfer.transaction_hash, [transfer]);
+      continue;
+    }
+
+    group.push(transfer);
+  }
+
+  for (const [txHash, transfers] of groupedByTxHash.entries()) {
+    const payerAddress = toEntityId({ num: transfers[0].payer_account_id });
+    const inaccurateConsensusTimestampNs = new BigNumber(transfers[0].consensus_timestamp);
     const inaccurateConsensusTimestamp = nanosToSeconds(inaccurateConsensusTimestampNs).toFixed(9);
 
     const [contractCallResult, mirrorTransaction] = await Promise.all([
-      apiClient.getContractCallResult(hash),
+      apiClient.getContractCallResult(txHash),
       apiClient.findTransactionByContractCallV2({
         payerAddress,
         timestamp: inaccurateConsensusTimestamp,
@@ -222,7 +234,7 @@ export const enrichERC20Transfers = async (erc20Transfers: ERC20TokenTransfer[])
     }
 
     enrichedTransfers.push({
-      transfer: rawTransfer,
+      transfers,
       contractCallResult,
       mirrorTransaction,
     });

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/common.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/common.fixture.ts
@@ -84,19 +84,21 @@ export const getMockedEnrichedERC20Transfer = (
     overrides?.mirrorTransaction?.consensus_timestamp ?? "1625097600.000000000";
 
   return {
-    transfer: {
-      token_id: 12345,
-      token_evm_address: "0x1234",
-      sender_account_id: 1234,
-      receiver_account_id: 5678,
-      sender_evm_address: "0x1234",
-      receiver_evm_address: "0x5678",
-      payer_account_id: 1234,
-      amount: 1000,
-      transaction_hash: `hash_erc20_${consensusTimestamp}`,
-      consensus_timestamp: Number(consensusTimestamp) * 10 ** 9,
-      transfer_type: "transfer",
-    },
+    transfers: [
+      {
+        token_id: 12345,
+        token_evm_address: "0x1234",
+        sender_account_id: 1234,
+        receiver_account_id: 5678,
+        sender_evm_address: "0x1234",
+        receiver_evm_address: "0x5678",
+        payer_account_id: 1234,
+        amount: 1000,
+        transaction_hash: `hash_erc20_${consensusTimestamp}`,
+        consensus_timestamp: Number(consensusTimestamp) * 10 ** 9,
+        transfer_type: "transfer",
+      },
+    ],
     contractCallResult: {
       block_hash: "0xblock",
       contract_id: "0.0.12345",

--- a/libs/coin-modules/coin-hedera/src/types/logic.ts
+++ b/libs/coin-modules/coin-hedera/src/types/logic.ts
@@ -59,7 +59,7 @@ export interface StakingAnalysis {
 }
 
 export interface EnrichedERC20Transfer {
-  transfer: ERC20TokenTransfer;
+  transfers: ERC20TokenTransfer[];
   contractCallResult: HederaMirrorContractCallResult;
   mirrorTransaction: HederaMirrorTransaction;
 }


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - getBlock endpoint should return unique transactions

### 📝 Description

This PR fixes duplicated ERC20 transactions in getBlock caused by Hgraph returning multiple transfers with the same transaction_hash.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-27851

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
