### PR TITLE
[LWM] feat(mobile): add sync error analytics tracking and offline account handling

### DIFF
--- a/.changeset/sync-error-refresh-button.md
+++ b/.changeset/sync-error-refresh-button.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add sync error analytics tracking (SyncError, SyncErrorList, SyncRefreshClick) and improve offline account error handling

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
@@ -26,6 +26,7 @@ const defaultSyncState = {
   isPending: false,
   listOfErrorAccountNames: "",
   syncAccessibilityLabel: "Synchronize",
+  errorCurrencyIds: [],
 };
 
 describe("TopBar navigation", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
@@ -1,8 +1,10 @@
-import { renderHook, act, withReadOnlyDisabled } from "@tests/test-renderer";
+import { renderHook, withReadOnlyDisabled, act } from "@tests/test-renderer";
 import { NavigatorName, ScreenName } from "~/const";
 import { State } from "~/reducers/types";
+import { track } from "~/analytics";
 import { expectedNavigationParams } from "../const";
 import { useTopBarViewModel } from "../useTopBarViewModel";
+import { useSyncIndicator } from "../hooks/useSyncIndicator";
 
 const mockNavigate = jest.fn();
 
@@ -11,15 +13,18 @@ jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
-jest.mock("../hooks/useSyncIndicator", () => ({
-  useSyncIndicator: () => ({
-    hasAccounts: false,
-    isError: false,
-    isPending: false,
-    listOfErrorAccountNames: "",
-    syncAccessibilityLabel: "Synchronize",
-  }),
-}));
+jest.mock("../hooks/useSyncIndicator");
+
+const mockedUseSyncIndicator = jest.mocked(useSyncIndicator);
+
+const defaultSyncState = {
+  hasAccounts: false,
+  isError: false,
+  isPending: false,
+  listOfErrorAccountNames: "",
+  syncAccessibilityLabel: "Synchronize",
+  errorCurrencyIds: [],
+};
 
 const mockNavigation = { navigate: mockNavigate };
 
@@ -36,6 +41,8 @@ const withWeb3Hub = (enabled: boolean) => (state: State) => ({
 describe("useTopBarViewModel", () => {
   beforeEach(() => {
     mockNavigate.mockClear();
+    (track as jest.Mock).mockClear();
+    mockedUseSyncIndicator.mockReturnValue(defaultSyncState);
   });
 
   it("should call navigate with expected params when onMyLedgerPress is invoked", () => {
@@ -108,5 +115,29 @@ describe("useTopBarViewModel", () => {
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(expectedNavigationParams.settings.name);
+  });
+
+  describe("sync drawer", () => {
+    it("should open the drawer and track SyncErrorList with error currency ids on openSyncDrawer", () => {
+      mockedUseSyncIndicator.mockReturnValue({
+        ...defaultSyncState,
+        isError: true,
+        errorCurrencyIds: ["bitcoin", "ethereum"],
+      });
+
+      const { result } = renderHook(() => useTopBarViewModel(mockNavigation as never));
+
+      expect(result.current.isSyncDrawerOpen).toBe(false);
+
+      act(() => {
+        result.current.openSyncDrawer();
+      });
+
+      expect(result.current.isSyncDrawerOpen).toBe(true);
+      expect(track).toHaveBeenCalledWith("SyncErrorList", {
+        currencies: ["bitcoin", "ethereum"],
+        page: ScreenName.Portfolio,
+      });
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/hooks/useSyncIndicator.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/hooks/useSyncIndicator.ts
@@ -1,12 +1,27 @@
+import { useEffect, useRef } from "react";
 import { useTranslation } from "~/context/Locale";
+import { track } from "~/analytics";
 import { usePortfolioBalance } from "LLM/hooks/usePortfolioBalance";
 
 export function useSyncIndicator() {
   const { t } = useTranslation();
-  const { hasAccounts, syncPhase, listOfErrorAccountNames } = usePortfolioBalance();
+  const { hasAccounts, syncPhase, listOfErrorAccountNames, errorCurrencyIds } =
+    usePortfolioBalance();
 
   const isError = syncPhase === "failed";
   const isPending = syncPhase === "syncing";
+
+  const prevIsErrorRef = useRef(false);
+  useEffect(() => {
+    const wasError = prevIsErrorRef.current;
+    prevIsErrorRef.current = isError;
+
+    if (!isError || wasError) return;
+
+    for (const currencyId of errorCurrencyIds) {
+      track("SyncError", { currency: currencyId });
+    }
+  }, [isError, errorCurrencyIds]);
 
   let syncAccessibilityLabel;
   if (isError) {
@@ -23,5 +38,6 @@ export function useSyncIndicator() {
     isPending,
     listOfErrorAccountNames,
     syncAccessibilityLabel,
+    errorCurrencyIds,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
@@ -20,10 +20,22 @@ export function useTopBarViewModel(
   const page = screenName ?? ScreenName.Portfolio;
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const { navigateToRebornFlow } = useRebornFlow();
-  const { hasAccounts, isError, isPending, listOfErrorAccountNames, syncAccessibilityLabel } =
-    useSyncIndicator();
+  const {
+    hasAccounts,
+    isError,
+    isPending,
+    listOfErrorAccountNames,
+    syncAccessibilityLabel,
+    errorCurrencyIds,
+  } = useSyncIndicator();
   const [isSyncDrawerOpen, setIsSyncDrawerOpen] = useState(false);
-  const openSyncDrawer = useCallback(() => setIsSyncDrawerOpen(true), []);
+  const openSyncDrawer = useCallback(() => {
+    setIsSyncDrawerOpen(true);
+    track("SyncErrorList", {
+      currencies: errorCurrencyIds,
+      page,
+    });
+  }, [errorCurrencyIds, page]);
   const closeSyncDrawer = useCallback(() => setIsSyncDrawerOpen(false), []);
 
   const hasUnreadNotifications = useMemo(

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
@@ -40,6 +40,8 @@ function makeReturn(
     isManualRefreshLoading: false,
     allAccounts: [],
     accountsWithError: [],
+    accountsImpactedByError: [],
+    errorCurrencyIds: [],
     listOfErrorAccountNames: "",
     areAllAccountsUpToDate: true,
     hasAccounts: true,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -57,6 +57,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     isAddModalOpened,
     shouldDisplayGraphRework,
     backgroundColor,
+    isSyncError,
     openAddModal,
     closeAddModal,
     handleHeightChange,
@@ -192,6 +193,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
           testID={showAssets ? "PortfolioAccountsList" : "PortfolioEmptyList"}
           useSafeArea={!shouldDisplayWallet40MainNav}
           overrideRefreshControlProps={{ progressViewOffset }}
+          isError={isSyncError}
         />
         <AddAccountDrawer
           isOpened={isAddModalOpened}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
@@ -10,6 +10,7 @@ import type { Feature_LlmMmkvMigration } from "@ledgerhq/types-live";
 
 import { useRefreshAccountsOrdering } from "~/actions/general";
 import { track } from "~/analytics";
+import { usePortfolioBalance } from "LLM/hooks/usePortfolioBalance";
 import {
   flattenAccountsSelector,
   hasNonTokenAccountsSelector,
@@ -40,6 +41,7 @@ interface UsePortfolioViewModelResult {
   isAddModalOpened: boolean;
   shouldDisplayGraphRework: boolean;
   backgroundColor: string;
+  isSyncError: boolean;
   openAddModal: () => void;
   closeAddModal: () => void;
   handleHeightChange: (newHeight: number) => void;
@@ -139,6 +141,9 @@ const usePortfolioViewModel = (navigation: {
     navigation.navigate(ScreenName.AnalyticsAllocation);
   }, [navigation]);
 
+  const { syncPhase } = usePortfolioBalance();
+  const isSyncError = syncPhase === "failed";
+
   return {
     hideEmptyTokenAccount,
     isAWalletCardDisplayed,
@@ -152,6 +157,7 @@ const usePortfolioViewModel = (navigation: {
     isAddModalOpened,
     shouldDisplayGraphRework,
     backgroundColor,
+    isSyncError,
     openAddModal,
     closeAddModal,
     handleHeightChange,

--- a/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalance.ts
@@ -4,6 +4,7 @@ import { useNetInfo } from "@react-native-community/netinfo";
 import { accountsWithUpToDateCheckSelector, hasNoAccountsSelector } from "~/reducers/accounts";
 import { useBatchMaybeAccountName } from "~/reducers/wallet";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import {
   useAccountsSyncStatus,
   useSyncLifecycle,
@@ -68,15 +69,6 @@ export function usePortfolioBalance() {
   const { allAccounts, accountsWithError, areAllAccountsUpToDate } =
     useAccountsSyncStatus(accountsWithUpToDateCheck);
 
-  const maybeAccountNames = useBatchMaybeAccountName(accountsWithError);
-  const listOfErrorAccountNames = useMemo(
-    () =>
-      maybeAccountNames
-        .map((name, i) => name ?? getDefaultAccountName(accountsWithError[i]))
-        .join("/"),
-    [maybeAccountNames, accountsWithError],
-  );
-
   const hasEverBeenUpToDateRef = useRef(areAllAccountsUpToDate);
   useEffect(() => {
     if (areAllAccountsUpToDate) {
@@ -91,6 +83,22 @@ export function usePortfolioBalance() {
     hasAccountDegradation ||
     syncSources.hasWalletSyncError ||
     isOffline;
+
+  // When offline with no specific bridge errors, every account is impacted
+  const accountsImpactedByError =
+    isOffline && accountsWithError.length === 0 ? allAccounts : accountsWithError;
+  const errorCurrencyIds = useMemo(
+    () => accountsImpactedByError.map(a => getAccountCurrency(a).id),
+    [accountsImpactedByError],
+  );
+  const maybeAccountNames = useBatchMaybeAccountName(accountsImpactedByError);
+  const listOfErrorAccountNames = useMemo(
+    () =>
+      maybeAccountNames
+        .map((name, i) => name ?? getDefaultAccountName(accountsImpactedByError[i]))
+        .join("/"),
+    [maybeAccountNames, accountsImpactedByError],
+  );
 
   const syncPhase: SyncPhase = useSyncLifecycle(
     isBalanceLoading,
@@ -120,6 +128,8 @@ export function usePortfolioBalance() {
     isManualRefreshLoading,
     allAccounts,
     accountsWithError,
+    accountsImpactedByError,
+    errorCurrencyIds,
     listOfErrorAccountNames,
     areAllAccountsUpToDate,
     hasAccounts,


### PR DESCRIPTION
## Summary

Cherry-pick of commit `65c9f8c6fc` from `develop` into `release`.

- Track `SyncError` event per currency when sync transitions to error state
- Track `SyncErrorList` event when user opens sync error drawer
- Track `SyncRefreshClick` with `triggeredAfterSyncError` flag on pull-to-refresh
- Expose `isSyncError` to portfolio screen for pull-to-refresh analytics
- Improve offline handling: all accounts shown as impacted when offline

LIVE-27563

## Test plan

- [ ] Verify sync error analytics events are correctly fired
- [ ] Verify offline handling shows all accounts as impacted
- [ ] Verify pull-to-refresh tracking includes `triggeredAfterSyncError` flag