### PR TITLE
[LWM] fix: safe area view on device connection screen

### DIFF
--- a/.changeset/four-planes-double.md
+++ b/.changeset/four-planes-double.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix safe area view on device connection screen

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/DeviceSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/DeviceSelection/index.tsx
@@ -106,7 +106,7 @@ const WalletSyncActivationDeviceSelection: React.FC<ChooseDeviceProps> = ({
   if (!isFocused) return null;
 
   return (
-    <SafeAreaView edges={["left", "right"]} style={{ flex: 1 }}>
+    <SafeAreaView edges={["left", "right", "top"]} style={{ flex: 1 }}>
       <TrackScreen category="Manager" name="ChooseDevice" />
       {!isHeaderOverridden ? (
         <Flex px={16} pb={8}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

There is currently a safe area bug that is sometimes triggered when going back to device selection screen causing the screen to be shifted up and clashing with the mobile status bar at the top of the screen. This PR adds safe area padding to the top of the screen to prevent this.

Before:

https://github.com/user-attachments/assets/b589b04e-fa1f-4b1b-a364-b4b6f46e80f6

After:

https://github.com/user-attachments/assets/5008d0fa-ddfd-4692-b25f-24efd829e818



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26066


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
