### PR TITLE
[LWDM] feat: add estimateMaxSpendable for private transaction in aleo module

### DIFF
--- a/.changeset/two-chefs-draw.md
+++ b/.changeset/two-chefs-draw.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Add estimateMaxSpendable for private in aleo module

--- a/libs/coin-modules/coin-aleo/src/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/estimateMaxSpendable.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { getMockedAccount } from "../__tests__/fixtures/account.fixture";
+import { getMockedAccount, mockUnspentRecord1 } from "../__tests__/fixtures/account.fixture";
 import type { Transaction } from "../types";
 import { TRANSACTION_TYPE } from "../constants";
 import { estimateMaxSpendable } from "./estimateMaxSpendable";
@@ -90,5 +90,92 @@ describe("estimateMaxSpendable", () => {
 
     expect(mockCreateTransaction).toHaveBeenCalledTimes(1);
     expect(mockCreateTransaction).toHaveBeenCalledWith(mockAccount);
+  });
+
+  it("should return zero for private tx when amountRecordCommitment is missing", async () => {
+    mockPrepareTransaction.mockResolvedValue({
+      ...mockPreparedTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitment: null,
+        feeRecordCommitment: null,
+      },
+    });
+
+    const result = await estimateMaxSpendable({
+      account: mockAccount,
+      parentAccount: undefined,
+      transaction: undefined,
+    });
+
+    expect(result).toEqual(new BigNumber(0));
+  });
+
+  it("should return microcredits value for private tx when amountRecordCommitment exists", async () => {
+    const commitment = "record-1-commitment";
+    const privateRecordAmount = "12345";
+    const aleoResources = mockAccount.aleoResources!;
+    const accountWithPrivateRecord = getMockedAccount({
+      aleoResources: {
+        ...aleoResources,
+        unspentPrivateRecords: [
+          {
+            ...mockUnspentRecord1,
+            commitment,
+            microcredits: privateRecordAmount,
+          },
+        ],
+      },
+    });
+
+    mockPrepareTransaction.mockResolvedValue({
+      ...mockPreparedTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitment: commitment,
+        feeRecordCommitment: null,
+      },
+    });
+
+    const result = await estimateMaxSpendable({
+      account: accountWithPrivateRecord,
+      parentAccount: undefined,
+      transaction: undefined,
+    });
+
+    expect(result).toEqual(new BigNumber(privateRecordAmount));
+  });
+
+  it("should return zero for private tx when amountRecordCommitment exists but no record matches", async () => {
+    const commitment = "record-1-commitment";
+    const aleoResources = mockAccount.aleoResources!;
+    const accountWithoutMatchingRecord = getMockedAccount({
+      aleoResources: {
+        ...aleoResources,
+        unspentPrivateRecords: [
+          {
+            ...mockUnspentRecord1,
+            commitment: "different-commitment",
+          },
+        ],
+      },
+    });
+
+    mockPrepareTransaction.mockResolvedValue({
+      ...mockPreparedTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitment: commitment,
+        feeRecordCommitment: null,
+      },
+    });
+
+    await expect(
+      estimateMaxSpendable({
+        account: accountWithoutMatchingRecord,
+        parentAccount: undefined,
+        transaction: undefined,
+      }),
+    ).resolves.toEqual(new BigNumber(0));
   });
 });

--- a/libs/coin-modules/coin-aleo/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/estimateMaxSpendable.ts
@@ -1,6 +1,8 @@
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import BigNumber from "bignumber.js";
 import type { AleoAccount, Transaction as AleoTransaction } from "../types";
+import { getRecordByCommitment, isPrivateTransaction } from "../logic/utils";
 import { createTransaction } from "./createTransaction";
 import { prepareTransaction } from "./prepareTransaction";
 
@@ -15,6 +17,15 @@ export const estimateMaxSpendable: AccountBridge<
     ...t,
     useAllAmount: true,
   });
+
+  if (isPrivateTransaction(preparedTransaction)) {
+    const commitment = preparedTransaction.properties.amountRecordCommitment;
+    const amountRecord = commitment
+      ? getRecordByCommitment({ account: mainAccount, commitment })
+      : null;
+
+    return new BigNumber(amountRecord?.microcredits ?? "0");
+  }
 
   return preparedTransaction.amount;
 };

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -1310,7 +1310,7 @@ describe("getRecordByCommitment", () => {
     expect(result).toBeNull();
   });
 
-  it("should throw when unspent private records are missing", () => {
+  it("should return null when unspentPrivateRecords is null", () => {
     const account = getMockedAccount({
       aleoResources: {
         ...mockAleoResources,
@@ -1318,11 +1318,23 @@ describe("getRecordByCommitment", () => {
       },
     });
 
-    expect(() =>
-      getRecordByCommitment({
-        account,
-        commitment: mockUnspentRecord1.commitment,
-      }),
-    ).toThrow("aleo: unspent private records are required");
+    const result = getRecordByCommitment({
+      account,
+      commitment: mockUnspentRecord1.commitment,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null when aleoResources is undefined", () => {
+    const account = getMockedAccount();
+    delete account.aleoResources;
+
+    const result = getRecordByCommitment({
+      account,
+      commitment: mockUnspentRecord1.commitment,
+    });
+
+    expect(result).toBeNull();
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -535,8 +535,7 @@ export function getRecordByCommitment({
   account: AleoAccount;
   commitment: string;
 }): AleoUnspentRecord | null {
-  const unspentPrivateRecords = account.aleoResources?.unspentPrivateRecords;
-  invariant(unspentPrivateRecords, "aleo: unspent private records are required");
+  const unspentPrivateRecords = account.aleoResources?.unspentPrivateRecords ?? [];
 
   return unspentPrivateRecords.find(record => record.commitment === commitment) ?? null;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  -  Add estimateMaxSpendable for private transaction in aleo module

### 📝 Description

This PR adds estimateMaxSpendable for private transactions in aleo package

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-26447

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)