### PR TITLE
[LWDM] fix(tron): :bug: typerror on cache transaction info

### DIFF
--- a/.changeset/selfish-needles-rush.md
+++ b/.changeset/selfish-needles-rush.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+Fix: Tron TypeError on cacheTransactionInfoById

--- a/libs/coin-modules/coin-tron/src/bridge/synchronization.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/synchronization.test.ts
@@ -273,6 +273,70 @@ describe("sync", () => {
 
     expect(account).toMatchObject(expectedAccount);
   });
+
+  it("clones initial cacheTransactionInfoById before sync writes", async () => {
+    const address = "TT2T17KZhoDu47i2E4FWxfG79zdkEWkU9N";
+    const existingCacheEntry = {
+      fee: 1,
+      blockNumber: 1,
+      withdraw_amount: 0,
+      unfreeze_amount: 0,
+    };
+    const frozenInitialCache = Object.freeze({
+      existingTx: existingCacheEntry,
+    });
+
+    mockFunctions.getLastBlock.mockResolvedValueOnce({ height: 0, hash: "", time: new Date() });
+    mockFunctions.fetchTronAccount.mockResolvedValueOnce([
+      {
+        address,
+        balance: 0,
+        trc20: [],
+        assetV2: [],
+      } as AccountTronAPI,
+    ]);
+    mockFunctions.fetchTronAccountTxs.mockImplementationOnce(async (_addr, _predicate, cache) => {
+      cache.newTx = {
+        fee: 2,
+        blockNumber: 2,
+        withdraw_amount: 0,
+        unfreeze_amount: 0,
+      };
+      return [];
+    });
+    mockFunctions.getTronAccountNetwork.mockResolvedValueOnce({
+      family: "tron",
+      freeNetUsed: BigNumber(0),
+      freeNetLimit: BigNumber(1),
+      netUsed: BigNumber(0),
+      netLimit: BigNumber(0),
+      energyUsed: BigNumber(0),
+      energyLimit: BigNumber(0),
+    } as NetworkInfo);
+    mockFunctions.getUnwithdrawnReward.mockResolvedValueOnce(BigNumber(0));
+
+    const account = await syncAccount<Transaction, TronAccount>(bridge.accountBridge, {
+      ...dummyAccount,
+      id: `js:2:tron:${address}:`,
+      freshAddress: address,
+      tronResources: {
+        ...dummyAccount.tronResources,
+        cacheTransactionInfoById: frozenInitialCache,
+      },
+    });
+
+    expect(account.tronResources.cacheTransactionInfoById).toEqual({
+      existingTx: existingCacheEntry,
+      newTx: {
+        fee: 2,
+        blockNumber: 2,
+        withdraw_amount: 0,
+        unfreeze_amount: 0,
+      },
+    });
+    expect(account.tronResources.cacheTransactionInfoById).not.toBe(frozenInitialCache);
+    expect(frozenInitialCache).toEqual({ existingTx: existingCacheEntry });
+  });
 });
 
 describe("scanAccounts", () => {

--- a/libs/coin-modules/coin-tron/src/bridge/synchronization.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/synchronization.ts
@@ -96,7 +96,9 @@ export const getAccountShape: GetAccountShape<TronAccount> = async (
   }
 
   const acc = tronAcc[0];
-  const cacheTransactionInfoById = initialAccount?.tronResources?.cacheTransactionInfoById || {};
+  const cacheTransactionInfoById = {
+    ...(initialAccount?.tronResources?.cacheTransactionInfoById ?? {}),
+  };
   const operationsPageSize = Math.min(
     MAX_OPERATIONS_PAGE_SIZE,
     getOperationsPageSize(initialAccount?.id, syncConfig),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR fixes a mobile-only Tron sync crash (`TypeError: cannot add a new property`) that happened after broadcasting and returning to the account page.
The root cause was that `initialAccount.tronResources.cacheTransactionInfoById` could be non-extensible (e.g. frozen/shared reference), while sync code later mutates it during transaction detail hydration.

By creating a fresh plain object for `cacheTransactionInfoById`, subsequent writes like `cacheTransactionInfoById[txID] = detail` always happen on a mutable object, preventing the runtime `TypeError`.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26491](https://ledgerhq.atlassian.net/browse/LIVE-26491)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26491]: https://ledgerhq.atlassian.net/browse/LIVE-26491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ