### PR TITLE
[LWDM] feat: lwd add icon image key value for braze action cards

### DIFF
--- a/.changeset/silent-rice-shop.md
+++ b/.changeset/silent-rice-shop.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+feat: lwd add icon image key value for braze action cards

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentBannerActionCard/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentBannerActionCard/index.tsx
@@ -7,6 +7,7 @@ import {
   InteractiveIcon,
   Spot,
 } from "@ledgerhq/lumen-ui-react";
+import * as Icons from "@ledgerhq/lumen-ui-react/symbols";
 import { Close, Settings } from "@ledgerhq/lumen-ui-react/symbols";
 
 export type ContentBannerActionCardProps = {
@@ -14,6 +15,8 @@ export type ContentBannerActionCardProps = {
   description?: string;
   onClose: () => void;
   onClick: () => void;
+  icon?: string;
+  image_background?: string;
 };
 
 export const ContentBannerActionCard = ({
@@ -21,6 +24,8 @@ export const ContentBannerActionCard = ({
   description,
   onClose,
   onClick,
+  icon: iconName,
+  image_background,
 }: ContentBannerActionCardProps) => {
   const handleClose = useCallback(
     (e?: React.MouseEvent) => {
@@ -31,6 +36,36 @@ export const ContentBannerActionCard = ({
     [onClose],
   );
 
+  const icon = iconName && iconName in Icons ? Icons[iconName as keyof typeof Icons] : Settings;
+
+  if (image_background && image_background.length > 0) {
+    return (
+      <div className="relative">
+        <button
+          type="button"
+          onClick={onClick}
+          className="w-full cursor-pointer border-none bg-transparent p-0 text-left"
+        >
+          <ContentBanner className="pr-48">
+            <ContentBannerContent>
+              {title && <ContentBannerTitle>{title}</ContentBannerTitle>}
+              {description && <ContentBannerDescription>{description}</ContentBannerDescription>}
+            </ContentBannerContent>
+          </ContentBanner>
+        </button>
+        <InteractiveIcon
+          type="button"
+          iconType="stroked"
+          aria-label="Close content banner"
+          onClick={handleClose}
+          className="absolute top-8 right-8"
+        >
+          <Close size={16} />
+        </InteractiveIcon>
+      </div>
+    );
+  }
+
   return (
     <div className="relative">
       <button
@@ -39,7 +74,7 @@ export const ContentBannerActionCard = ({
         className="w-full cursor-pointer border-none bg-transparent p-0 text-left"
       >
         <ContentBanner className="pr-48">
-          <Spot appearance="icon" icon={Settings} size={48} />
+          <Spot appearance="icon" icon={icon} size={48} />
           <ContentBannerContent>
             {title && <ContentBannerTitle>{title}</ContentBannerTitle>}
             {description && <ContentBannerDescription>{description}</ContentBannerDescription>}

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -57,6 +57,8 @@ export const mapAsActionContentCard = (card: ClassicCard): ActionContentCard => 
   description: card.extras?.description,
   id: String(card.id),
   image: card.extras?.image,
+  image_background: card.extras?.image_background,
+  icon: card.extras?.icon,
   link: card.extras?.link,
   location: LocationContentCard.Action,
   mainCta: card.extras?.mainCta,

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/ActionContentCards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/ActionContentCards.tsx
@@ -68,6 +68,8 @@ const ActionContentCards = ({ variant }: { variant: ABTestingVariants }) => {
         description={slide.description}
         onClose={() => onDismiss(slide.id, index)}
         onClick={() => onClick(slide.id, slide.link, index)}
+        icon={slide.icon}
+        image_background={slide.image_background}
       />
     </LogContentCardWrapper>
   ));

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Hooks/useGenerateLocalBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Hooks/useGenerateLocalBraze.ts
@@ -46,6 +46,8 @@ const generateNewActionCard = (
   link: string,
   secondaryCta: string,
   order?: number,
+  icon?: string,
+  image_background?: string,
 ): ActionContentCard => ({
   id: String(Date.now()),
   title,
@@ -58,6 +60,8 @@ const generateNewActionCard = (
   created: new Date(),
   order,
   isMock: true,
+  ...(icon !== undefined && { icon }),
+  ...(image_background !== undefined && image_background !== "" && { image_background }),
 });
 
 const generateNewNotificationCard = (
@@ -110,6 +114,8 @@ export const useGenerateLocalBraze = () => {
     link: string,
     secondaryCta: string,
     order?: number,
+    icon?: string,
+    image_background?: string,
   ) => {
     const newCard = generateNewActionCard(
       title,
@@ -119,6 +125,8 @@ export const useGenerateLocalBraze = () => {
       link,
       secondaryCta,
       order,
+      icon,
+      image_background,
     );
     dispatch(setActionCards([...actionCards, newCard]));
   };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Modal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Modal/Body.tsx
@@ -25,6 +25,8 @@ interface FormState {
   title: string;
   description: string;
   image: string;
+  image_background: string;
+  icon: string;
   mainCta: string;
   link: string;
   secondaryCta: string;
@@ -44,6 +46,8 @@ const initialState: FormState = {
   description: "Dummy Description",
   image:
     "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQec1piP0de4iTT4LlWAg_SSU8DRv12XEfqwQ&s",
+  image_background: "",
+  icon: "Settings",
   mainCta: "Dummy Main CTA",
   link: "https://www.ledger.com/",
   secondaryCta: "Dummy Dismiss CTA",
@@ -72,12 +76,35 @@ export const ModalBody: React.FC = () => {
     useGenerateLocalBraze();
 
   const handleAddCard = () => {
-    const { title, description, image, mainCta, link, secondaryCta, cta, tag, url, path, order } =
-      formData;
+    const {
+      title,
+      description,
+      image,
+      image_background,
+      icon,
+      mainCta,
+      link,
+      secondaryCta,
+      cta,
+      tag,
+      url,
+      path,
+      order,
+    } = formData;
     if (selectedTab === "PortfolioContentCard") {
       addLocalPortfolioCard(title, description, image, order, url, cta, tag);
     } else if (selectedTab === "ActionContentCard") {
-      addLocalActionCard(title, description, image, mainCta, link, secondaryCta, order);
+      addLocalActionCard(
+        title,
+        description,
+        image,
+        mainCta,
+        link,
+        secondaryCta,
+        order,
+        icon,
+        image_background,
+      );
     } else if (selectedTab === "NotificationContentCard") {
       addLocalNotificationCard(title, description, cta, false, url, path, order);
     }
@@ -149,6 +176,16 @@ export const ModalBody: React.FC = () => {
         field: "image",
         placeholder: "Image URL",
         label: t("settings.developer.brazeTools.modal.fields.image"),
+      },
+      {
+        field: "image_background",
+        placeholder: "Image background URL (braze placement)",
+        label: "Image background",
+      },
+      {
+        field: "icon",
+        placeholder: "Icon name (e.g. Settings, Wallet)",
+        label: "Icon",
       },
       {
         field: "mainCta",

--- a/apps/ledger-live-desktop/src/types/dynamicContent.ts
+++ b/apps/ledger-live-desktop/src/types/dynamicContent.ts
@@ -20,6 +20,8 @@ export type ContentCard = {
 
 export type ActionContentCard = ContentCard & {
   image?: string;
+  image_background?: string;
+  icon?: string;
   mainCta?: string;
   link?: string;
   secondaryCta?: string;

--- a/apps/ledger-live-mobile/src/contentCards/cards/contentBannerAction/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/contentBannerAction/index.tsx
@@ -16,7 +16,10 @@ const ContentBannerActionCard = ContentCardBuilder<ContentCardProps>(props => {
   const { title, metadata } = props;
   const description = "description" in props ? props.description : undefined;
 
-  const imageUrl = "image" in props ? props.image : undefined;
+  const imageBackground =
+    "image_background" in props && props.image_background?.length
+      ? props.image_background
+      : undefined;
   const iconProp =
     "icon" in props && props.icon !== undefined ? (props.icon as keyof typeof Icons) : "Settings";
   const icon = Icons[iconProp] || Icons.Settings;
@@ -34,7 +37,7 @@ const ContentBannerActionCard = ContentCardBuilder<ContentCardProps>(props => {
     [metadata.actions],
   );
 
-  if (imageUrl && imageUrl.length > 0) {
+  if (imageBackground && imageBackground.length > 0) {
     return (
       <Pressable onPress={metadata.actions?.onClick} key={metadata.id}>
         <ContentBanner onClose={handleDismiss}>

--- a/apps/ledger-live-mobile/src/dynamicContent/types.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/types.ts
@@ -133,6 +133,7 @@ type HorizontalContentCard = ContentCardCommonProperties & {
   link?: string;
   description?: string;
   image?: string;
+  image_background?: string;
   icon?: string;
   gridWidthFactor?: WidthFactor;
 };

--- a/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
@@ -140,6 +140,7 @@ export const mapAsHorizontalContentCard = (card: BrazeContentCard): HorizontalCo
   title: card.extras.title,
   description: card.extras.description,
   image: card.extras.image,
+  image_background: card.extras.image_background,
   icon: card.extras.icon,
   link: card.extras.link,
   createdAt: card.created,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- add icon and image_background braze key value
- display icon or image variant in consequence (image variant not ready so it's mocked)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26627]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->

<img width="1512" height="982" alt="Screenshot 2026-03-19 at 16 42 39" src="https://github.com/user-attachments/assets/8e644064-aaa0-4a39-96f8-ad067b51509e" />

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26627]: https://ledgerhq.atlassian.net/browse/LIVE-26627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ