### PR TITLE
chore(common): CODEOWNERS — toolchain / monorepo → Platform

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -339,8 +339,11 @@ tools/actions/composites/merge-e2e-detox-timings/                           @led
 **/.oxfmtrc.*                                         @ledgerhq/platform
 **/.eslintrc.*                                        @ledgerhq/platform
 **/tsconfig*                                          @ledgerhq/platform
-**/nx.json                                            @ledgerhq/platform
 **/knip.json                                          @ledgerhq/platform
+
+# CI — Turborepo & Nx
+/turbo.json                                           @ledgerhq/wallet-ci
+/nx.json                                              @ledgerhq/wallet-ci
 
 # Cross-team generic files can be opted out (no strict ownership when it concerns everyone)
 .github/copilot-instructions.md


### PR DESCRIPTION
## Context

When we send PRs today that modify tsconfig files, that triggers all teams to review:

<img width="1236" height="522" alt="Screenshot 2026-03-20 at 09 58 17" src="https://github.com/user-attachments/assets/6f1c690a-27ac-4c42-9c19-511b07b73598" />

but in fact, it's team-platform that is now responsible to maintain these.

## Changes

- **Platform** owns monorepo/toolchain files: `tsconfig*`, `.eslintrc*` variants, `.oxlintrc.json`, `.oxfmtrc.json`, knip, etc.
- **CI** is on Turbo & NX.
- Reduce noisy review requests on systemic PRs (TypeScript, oxlint, tsconfig mass updates) that previously matched many path-based owners.
  - e.g. allows other teams to mass edit all tsconfig with only one team that will need to review too.
- Have platform team always having to review these config edits