### PR TITLE
[LWM] feat(mobile): switch device mode from polling to event

### DIFF
--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -23,7 +23,7 @@ listen(log => {
 });
 
 setGlobalOnBridgeError(e => logger.critical(e));
-setDeviceMode("polling");
+setDeviceMode("event");
 setWalletAPIVersion(WALLET_API_VERSION);
 
 setSupportedCurrencies([


### PR DESCRIPTION
## Summary

- Switch `setDeviceMode` from `"polling"` to `"event"` in the mobile live-common setup
- The event-based transport is more stable and achieves parity with the desktop transport, ensuring consistent behavior across platforms

## Test plan

- [ ] Verify BLE and USB device connections work correctly on mobile
- [ ] Confirm firmware update flow (OTA) completes successfully
- [ ] Check app install/uninstall via Manager still works
- [ ] Test on both iOS and Android


Made with [Cursor](https://cursor.com)