### PR TITLE
[LWM] feat(mobile): switch device mode from polling to event

### DIFF
--- a/.changeset/swift-devices-stream.md
+++ b/.changeset/swift-devices-stream.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Switch device mode from polling to event-based transport

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -24,7 +24,7 @@ listen(log => {
 });
 
 setGlobalOnBridgeError(e => logger.critical(e));
-setDeviceMode("polling");
+setDeviceMode("event");
 setWalletAPIVersion(WALLET_API_VERSION);
 setResolutionConfig({
   platform: Platform.OS === "ios" ? "ios" : "android",


### PR DESCRIPTION
## Summary

- Switch `setDeviceMode` from `"polling"` to `"event"` in the mobile live-common setup
- The event-based transport is more stable and achieves parity with the desktop transport, ensuring consistent behavior across platforms

Jira: LIVE-25566

## Test plan

- [ ] Verify BLE and USB device connections work correctly on mobile
- [ ] Confirm firmware update flow (OTA) completes successfully
- [ ] Check app install/uninstall via Manager still works
- [ ] Test on both iOS and Android


Made with [Cursor](https://cursor.com)