### PR TITLE
[LWDM] feat(wallet40): add operationList param to w4.0 feature flags

### DIFF
--- a/.changeset/cyan-clouds-allow.md
+++ b/.changeset/cyan-clouds-allow.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/types-live": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+"@shared/feature-flags": minor
+---
+
+introduce operationList FF for W4

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
@@ -12,6 +12,7 @@ export const WALLET_FEATURES_PARAMS = [
   { key: "balanceRefreshRework", label: "Balance Refresh Rework" },
   { key: "assetSection", label: "Asset Section" },
   { key: "brazePlacement", label: "Braze Placement (Lumen content banner)" },
+  { key: "operationsList", label: "TX History" },
 ] as const;
 
 export type WalletFeatureParamKey = (typeof WALLET_FEATURES_PARAMS)[number]["key"];

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
@@ -14,6 +14,7 @@ export const WALLET_40_PARAMS = [
   { key: "assetSection", label: "Asset Section" },
   { key: "onboardingWidget", label: "Post-onboarding Widget" },
   { key: "brazePlacement", label: "Braze Placement (ContentBanner)" },
+  { key: "operationList", label: "TX History" },
 ] as const;
 
 type WalletFeatureParamKey = (typeof WALLET_40_PARAMS)[number]["key"];

--- a/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
+++ b/libs/ledger-live-common/src/analytics/featureFlagHelpers/wallet40.ts
@@ -27,5 +27,6 @@ export const getWallet40Attributes = (
     balanceRefreshRework: wallet40FeatureFlag?.params?.balanceRefreshRework ?? false,
     assetSection: wallet40FeatureFlag?.params?.assetSection ?? false,
     brazePlacement: wallet40FeatureFlag?.params?.brazePlacement ?? false,
+    operationsList: wallet40FeatureFlag?.params?.operationsList ?? false,
   };
 };

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -810,6 +810,7 @@ export const DEFAULT_FEATURES: Features = {
       assetSection: true,
       onboardingWidget: true,
       brazePlacement: true,
+      operationsList: true,
     },
   },
   lwdWallet40: {
@@ -824,6 +825,7 @@ export const DEFAULT_FEATURES: Features = {
       newReceiveDialog: true,
       balanceRefreshRework: true,
       assetSection: true,
+      operationsList: true,
     },
   },
   addressPoisoningOperationsFilter: {

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
@@ -12,6 +12,7 @@ export type Wallet40Params = {
   readonly assetSection?: boolean;
   readonly onboardingWidget?: boolean;
   readonly brazePlacement?: boolean;
+  readonly operationsList?: boolean;
 };
 
 export const FEATURE_FLAG_KEYS = {
@@ -45,4 +46,6 @@ export interface WalletFeaturesConfig {
   readonly shouldDisplayOnboardingWidget: boolean;
   /** Whether to show Braze content cards as ContentBanner (e.g. action cards on portfolio, mobile only) */
   readonly shouldDisplayBrazePlacement: boolean;
+  /** Whether to show the TX History section */
+  readonly shouldDisplayOperationsList: boolean;
 }

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
@@ -31,64 +31,45 @@ const expectConfig = (
   expect(result.current).toEqual(expected);
 };
 
-const DISABLED_CONFIG: WalletFeaturesConfig = {
-  isEnabled: false,
-  shouldDisplayMarketBanner: false,
-  shouldDisplayGraphRework: false,
-  shouldDisplayQuickActionCtas: false,
-  shouldDisplayNewReceiveDialog: false,
-  shouldDisplayWallet40MainNav: false,
-  shouldUseLazyOnboarding: false,
-  shouldDisplayBalanceRefreshRework: false,
-  shouldDisplayTour: false,
-  shouldDisplayAssetSection: false,
-  shouldDisplayOnboardingWidget: false,
-  shouldDisplayBrazePlacement: false,
-};
+const makeConfig = (
+  value: boolean,
+  overrides?: Partial<WalletFeaturesConfig>,
+): WalletFeaturesConfig => ({
+  isEnabled: value,
+  shouldDisplayMarketBanner: value,
+  shouldDisplayGraphRework: value,
+  shouldDisplayQuickActionCtas: value,
+  shouldDisplayNewReceiveDialog: value,
+  shouldDisplayWallet40MainNav: value,
+  shouldUseLazyOnboarding: value,
+  shouldDisplayBalanceRefreshRework: value,
+  shouldDisplayTour: value,
+  shouldDisplayAssetSection: value,
+  shouldDisplayOnboardingWidget: value,
+  shouldDisplayBrazePlacement: value,
+  shouldDisplayOperationsList: value,
+  ...overrides,
+});
 
-const ENABLED_NO_PARAMS_CONFIG: WalletFeaturesConfig = {
-  isEnabled: true,
-  shouldDisplayMarketBanner: false,
-  shouldDisplayGraphRework: false,
-  shouldDisplayQuickActionCtas: false,
-  shouldDisplayNewReceiveDialog: false,
-  shouldDisplayWallet40MainNav: false,
-  shouldUseLazyOnboarding: false,
-  shouldDisplayBalanceRefreshRework: false,
-  shouldDisplayTour: false,
-  shouldDisplayAssetSection: false,
-  shouldDisplayOnboardingWidget: false,
-  shouldDisplayBrazePlacement: false,
-};
+const makeParams = (value: boolean): Wallet40Params => ({
+  marketBanner: value,
+  graphRework: value,
+  quickActionCtas: value,
+  newReceiveDialog: value,
+  mainNavigation: value,
+  lazyOnboarding: value,
+  balanceRefreshRework: value,
+  tour: value,
+  assetSection: value,
+  onboardingWidget: value,
+  brazePlacement: value,
+  operationsList: value,
+});
 
-const ALL_ENABLED_CONFIG: WalletFeaturesConfig = {
-  isEnabled: true,
-  shouldDisplayMarketBanner: true,
-  shouldDisplayGraphRework: true,
-  shouldDisplayQuickActionCtas: true,
-  shouldDisplayNewReceiveDialog: true,
-  shouldDisplayWallet40MainNav: true,
-  shouldUseLazyOnboarding: true,
-  shouldDisplayBalanceRefreshRework: true,
-  shouldDisplayTour: true,
-  shouldDisplayAssetSection: true,
-  shouldDisplayOnboardingWidget: true,
-  shouldDisplayBrazePlacement: true,
-};
-
-const ALL_PARAMS_ENABLED: Wallet40Params = {
-  marketBanner: true,
-  graphRework: true,
-  quickActionCtas: true,
-  newReceiveDialog: true,
-  mainNavigation: true,
-  lazyOnboarding: true,
-  balanceRefreshRework: true,
-  tour: true,
-  assetSection: true,
-  onboardingWidget: true,
-  brazePlacement: true,
-};
+const DISABLED_CONFIG = makeConfig(false);
+const ENABLED_NO_PARAMS_CONFIG = makeConfig(false, { isEnabled: true });
+const ALL_ENABLED_CONFIG = makeConfig(true);
+const ALL_PARAMS_ENABLED = makeParams(true);
 
 describe("useWalletFeaturesConfig hook", () => {
   describe("when feature flag is disabled", () => {
@@ -142,6 +123,7 @@ describe("useWalletFeaturesConfig hook", () => {
         ["assetSection", { assetSection: true }, { shouldDisplayAssetSection: true }],
         ["onboardingWidget", { onboardingWidget: true }, { shouldDisplayOnboardingWidget: true }],
         ["brazePlacement", { brazePlacement: true }, { shouldDisplayBrazePlacement: true }],
+        ["operationsList", { operationsList: true }, { shouldDisplayOperationsList: true }],
       ])("should return correct config when only %s is enabled", (_, params, expectedOverrides) => {
         const { result } = renderWalletFeaturesConfig(platform, {
           [flagKey]: createFeatureFlag(true, params),

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
@@ -44,6 +44,7 @@ export const useWalletFeaturesConfig = (platform: WalletPlatform): WalletFeature
       shouldDisplayOnboardingWidget:
         isEnabled && Boolean(params && "onboardingWidget" in params && params.onboardingWidget),
       shouldDisplayBrazePlacement: isEnabled && Boolean(params?.brazePlacement),
+      shouldDisplayOperationsList: isEnabled && Boolean(params?.operationsList),
     };
   }, [walletFeatureFlag]);
 };

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -829,6 +829,7 @@ type Feature_Wallet40_Params = {
   lazyOnboarding: boolean;
   balanceRefreshRework: boolean;
   assetSection: boolean;
+  operationsList: boolean;
 
   // Specifics
   brazePlacement?: boolean;

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
@@ -12,6 +12,7 @@ export const lwdWallet40 = flagWith(
     balanceRefreshRework: z.boolean(),
     assetSection: z.boolean(),
     newReceiveDialog: z.boolean(),
+    operationsList: z.boolean(),
   },
   {
     enabled: false,
@@ -25,6 +26,7 @@ export const lwdWallet40 = flagWith(
       newReceiveDialog: true,
       balanceRefreshRework: true,
       assetSection: true,
+      operationsList: true,
     },
   },
 );

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
@@ -13,6 +13,7 @@ export const lwmWallet40 = flagWith(
     assetSection: z.boolean(),
     onboardingWidget: z.boolean(),
     newReceiveDialog: z.boolean().optional(),
+    operationsList: z.boolean(),
   },
   {
     enabled: false,
@@ -26,6 +27,7 @@ export const lwmWallet40 = flagWith(
       balanceRefreshRework: true,
       assetSection: true,
       onboardingWidget: true,
+      operationsList: true,
     },
   },
 );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new logic introduced — parameter addition only._
- [x] **Impact of the changes:**
      - W4.0 feature flag params on both LWD and LWM
      - Analytics attributes for wallet40
      - Dev tools / debug screens on both platforms

### 📝 Description

**Problem**: The W4.0 TX History feature needs to be togglable independently behind its own feature flag parameter, rather than being always enabled when W4.0 is active.

**Solution**: Added a new `operationList` boolean parameter to both `lwdWallet40` and `lwmWallet40` feature flags. Changes include:
- Zod schema updates in shared feature-flags package
- Type definition in `@ledgerhq/types-live`
- Default feature values in `@ledgerhq/live-common`
- Analytics helper in `wallet40.ts`
- Dev tool entries on both desktop and mobile

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26150](https://ledgerhq.atlassian.net/browse/LIVE-26150)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26150]: https://ledgerhq.atlassian.net/browse/LIVE-26150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ