### PR TITLE
chore: turbo / nx are co-owned by CI and platform

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -342,8 +342,8 @@ tools/actions/composites/merge-e2e-detox-timings/                           @led
 **/knip.json                                          @ledgerhq/platform
 
 # CI — Turborepo & Nx
-/turbo.json                                           @ledgerhq/wallet-ci
-/nx.json                                              @ledgerhq/wallet-ci
+/turbo.json                                           @ledgerhq/platform @ledgerhq/wallet-ci
+/nx.json                                              @ledgerhq/platform @ledgerhq/wallet-ci
 
 # Cross-team generic files can be opted out (no strict ownership when it concerns everyone)
 .github/copilot-instructions.md


### PR DESCRIPTION
Updated CODEOWNERS to assign ownership of turbo.json and nx.json to both platform and wallet-ci teams.
