### PR TITLE
[LWM] fix: recover banner storage flag

### DIFF
--- a/.changeset/spotty-impalas-wonder.md
+++ b/.changeset/spotty-impalas-wonder.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix recover banner not showing due to async storage

--- a/apps/ledger-live-mobile/src/store.ts
+++ b/apps/ledger-live-mobile/src/store.ts
@@ -1,8 +1,8 @@
 import storage from "LLM/storage";
 import isEmpty from "lodash/isEmpty";
 
-export function getStoreValue<T>(key: string, storeId: string): T | undefined {
-  const value = storage.get(`${storeId}-${key}`);
+export async function getStoreValue<T>(key: string, storeId: string): Promise<T | undefined> {
+  const value = await storage.get(`${storeId}-${key}`);
   return isEmpty(value) ? undefined : (value as T);
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Recover banner not showing due to storage flag retrieval.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27983


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
