### PR TITLE
fix(feature-flags): bridge settings hydration into featureFlags slice

### DIFF
--- a/shared/feature-flags/src/data/slice.test.ts
+++ b/shared/feature-flags/src/data/slice.test.ts
@@ -403,4 +403,116 @@ describe("featureFlagsSlice extraReducers (legacy bridge)", () => {
       expect(store.getState().featureFlags.bannerVisible).toBe(true);
     });
   });
+
+  describe.each(["SETTINGS_IMPORT", "FETCH_SETTINGS"] as const)(
+    "%s (settings hydration bridge)",
+    actionType => {
+      it("hydrates overrides and resolved from overriddenFeatureFlags", () => {
+        const store = createStore();
+        store.dispatch({
+          type: actionType,
+          payload: { overriddenFeatureFlags: { mockFeature: { enabled: true, params: { v: 1 } } } },
+        });
+        expect(store.getState().featureFlags.overrides).toEqual({
+          mockFeature: { enabled: true, params: { v: 1 } },
+        });
+        expect(store.getState().featureFlags.resolved.mockFeature).toEqual({
+          enabled: true,
+          params: { v: 1 },
+        });
+      });
+
+      it("filters out undefined values from overriddenFeatureFlags", () => {
+        const store = createStore();
+        store.dispatch({
+          type: actionType,
+          payload: {
+            overriddenFeatureFlags: { mockFeature: { enabled: true }, ptxCard: undefined },
+          },
+        });
+        expect(store.getState().featureFlags.overrides).toEqual({
+          mockFeature: { enabled: true },
+        });
+        expect(store.getState().featureFlags.overrides.ptxCard).toBeUndefined();
+      });
+
+      it("clears stale overrides when overriddenFeatureFlags is empty", () => {
+        const store = createStore({
+          overrides: { mockFeature: { enabled: true } },
+          remote: {},
+          resolved: { ...defaults, mockFeature: { enabled: true } },
+          bannerVisible: false,
+        });
+        store.dispatch({
+          type: actionType,
+          payload: { overriddenFeatureFlags: {} },
+        });
+        expect(store.getState().featureFlags.overrides).toEqual({});
+        expect(store.getState().featureFlags.resolved.mockFeature).toEqual(defaults.mockFeature);
+      });
+
+      it("hydrates bannerVisible from featureFlagsBannerVisible", () => {
+        const store = createStore();
+        store.dispatch({
+          type: actionType,
+          payload: { featureFlagsBannerVisible: true },
+        });
+        expect(store.getState().featureFlags.bannerVisible).toBe(true);
+      });
+
+      it("hydrates bannerVisible from featureFlagsButtonVisible", () => {
+        const store = createStore();
+        store.dispatch({
+          type: actionType,
+          payload: { featureFlagsButtonVisible: true },
+        });
+        expect(store.getState().featureFlags.bannerVisible).toBe(true);
+      });
+
+      it("prefers featureFlagsBannerVisible over featureFlagsButtonVisible", () => {
+        const store = createStore();
+        store.dispatch({
+          type: actionType,
+          payload: { featureFlagsBannerVisible: false, featureFlagsButtonVisible: true },
+        });
+        expect(store.getState().featureFlags.bannerVisible).toBe(false);
+      });
+
+      it("does not change bannerVisible when neither field is present", () => {
+        const store = createStore({
+          overrides: {},
+          remote: {},
+          resolved: defaults,
+          bannerVisible: true,
+        });
+        store.dispatch({
+          type: actionType,
+          payload: { overriddenFeatureFlags: {} },
+        });
+        expect(store.getState().featureFlags.bannerVisible).toBe(true);
+      });
+
+      it("handles both overrides and banner in a single payload", () => {
+        const store = createStore();
+        store.dispatch({
+          type: actionType,
+          payload: {
+            overriddenFeatureFlags: { mockFeature: { enabled: true } },
+            featureFlagsBannerVisible: true,
+          },
+        });
+        expect(store.getState().featureFlags.overrides).toEqual({
+          mockFeature: { enabled: true },
+        });
+        expect(store.getState().featureFlags.bannerVisible).toBe(true);
+      });
+
+      it("no-ops when payload is falsy", () => {
+        const store = createStore();
+        const before = store.getState().featureFlags;
+        store.dispatch({ type: actionType, payload: null });
+        expect(store.getState().featureFlags).toEqual(before);
+      });
+    },
+  );
 });

--- a/shared/feature-flags/src/data/slice.ts
+++ b/shared/feature-flags/src/data/slice.ts
@@ -129,11 +129,9 @@ const featureFlagsSlice = createSlice({
           const filtered = Object.fromEntries(
             Object.entries(payload.overriddenFeatureFlags).filter(([, v]) => v !== undefined),
           );
-          if (Object.keys(filtered).length > 0) {
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            state.overrides = filtered as FeatureFlagsState["overrides"];
-            state.resolved = resolveAll(state.overrides, state.remote, getResolutionConfig());
-          }
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          state.overrides = filtered as FeatureFlagsState["overrides"];
+          state.resolved = resolveAll(state.overrides, state.remote, getResolutionConfig());
         }
 
         const bannerValue =


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Shared package only — no changeset needed._
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Feature flags overrides and banner visibility on app boot (both LLM and LLD)
  - Ensures featureFlags slice is populated from legacy settings hydration actions

### 📝 Description

**Problem**: On app boot, LLM dispatches `SETTINGS_IMPORT` and LLD dispatches `FETCH_SETTINGS` to hydrate settings from persistence. These payloads contain `overriddenFeatureFlags` and `featureFlagsBannerVisible` / `featureFlagsButtonVisible`, but the `featureFlags` slice has no `extraReducers` to pick them up. As a result, `state.featureFlags.overrides` and `state.featureFlags.bannerVisible` remain at their initial (empty) values until Firebase remote config fires.

**Solution**: Add `extraReducers` entries in the `featureFlags` slice for both `SETTINGS_IMPORT` and `FETCH_SETTINGS`. When either action is dispatched, the slice extracts the feature flag data from the settings payload and populates `overrides`, `resolved`, and `bannerVisible` accordingly. This ensures the slice is correctly hydrated from the very first render.

This is a preparatory fix ahead of upcoming consumer rewiring PRs that will redirect feature flag selectors to read from `state.featureFlags` instead of `state.settings`.

### ❓ Required to do

- **JIRA or GitHub link**: 
[LIVE-27406](https://ledgerhq.atlassian.net/browse/LIVE-27406)
[LIVE-27405](https://ledgerhq.atlassian.net/browse/LIVE-27405)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27406]: https://ledgerhq.atlassian.net/browse/LIVE-27406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ