### PR TITLE
test(e2e-desktop): fix swap webview race condition

### DIFF
--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -41,9 +41,6 @@ export class SwapPage extends WebViewAppPage {
   private insufficientFundsWarning = "insufficient-funds-warning";
   private executeButtonDisabled = "execute-button-disabled";
 
-  // Exchange Drawer Components
-  readonly swapId = this.page.getByTestId("swap-id");
-
   // History Components
   readonly historyButton = this.page.getByTestId("History-tab-button");
   private operationRows = this.page.locator("[data-testid^='operation-row-']");
@@ -333,17 +330,16 @@ export class SwapPage extends WebViewAppPage {
     return await webview.getByTestId(this.fromAccountAmountInput).inputValue();
   }
 
-  @step("Check currency to swap from is $0")
-  async switchYouSendAndYouReceive(electronApp: ElectronApplication) {
-    const [, webview] = electronApp.windows();
+  @step("Click switch button")
+  async switchYouSendAndYouReceive() {
+    const webview = await this.getWebView();
     await webview.getByTestId(this.switchButton).click();
   }
 
-  @step("Check currency to swap from is $1")
-  async checkAssetFrom(electronApp: ElectronApplication, currency: string) {
-    const [, webview] = electronApp.windows();
-    const fromAccount = webview.getByTestId(this.fromAccountCoinSelector);
-    await expect(fromAccount).toContainText(currency);
+  @step("Check currency to swap from contains $0")
+  async checkAssetFromContains(expected: string) {
+    const webview = await this.getWebView();
+    await expect(webview.getByTestId(this.fromAccountCoinSelector)).toContainText(expected);
   }
 
   @step("Expect asset or account selected $0 to be displayed")
@@ -424,15 +420,10 @@ export class SwapPage extends WebViewAppPage {
     await webview.getByTestId(this.fromAccountCoinSelector).click();
   }
 
-  @step("Check currency to swap to is $1")
-  async checkAssetTo(electronApp: ElectronApplication, currency: string) {
-    const [, webview] = electronApp.windows();
-    const assetTo = webview.getByTestId(this.toAccountCoinSelector);
-    if (currency === "") {
-      await expect(assetTo).toContainText("Choose asset");
-    } else {
-      await expect(assetTo).toContainText(currency);
-    }
+  @step("Check currency to swap to contains $0")
+  async checkAssetToContains(expected: string) {
+    const webview = await this.getWebView();
+    await expect(webview.getByTestId(this.toAccountCoinSelector)).toContainText(expected);
   }
 
   @step("Verify swap amount error message match: $1")

--- a/e2e/desktop/tests/specs/accounts.swap.spec.ts
+++ b/e2e/desktop/tests/specs/accounts.swap.spec.ts
@@ -67,14 +67,14 @@ test.describe("Swap - Default currency when landing on swap", () => {
       ],
       annotation: { type: "TMS", description: "B2CQA-3079" },
     },
-    async ({ app, electronApp }) => {
+    async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.mainNavigation.openTargetFromMainNavigation("swap"),
       );
-      await app.swap.checkAssetFrom(electronApp, "BTC");
-      await app.swap.checkAssetTo(electronApp, "");
+      await app.swap.checkAssetFromContains("BTC");
+      await app.swap.checkAssetToContains("Choose asset");
     },
   );
 
@@ -107,8 +107,8 @@ test.describe("Swap - Default currency when landing on swap", () => {
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.mainNavigation.openTargetFromMainNavigation("swap"),
       );
-      await app.swap.checkAssetFrom(electronApp, swap.accountToDebit.currency.ticker);
-      await app.swap.checkAssetTo(electronApp, swap.accountToCredit.currency.ticker);
+      await app.swap.checkAssetFromContains(swap.accountToDebit.currency.ticker);
+      await app.swap.checkAssetToContains(swap.accountToCredit.currency.ticker);
     },
   );
 });
@@ -359,8 +359,8 @@ test.describe("Swap a coin for which you have no account yet - from present to n
         await app.addAccount.done();
         await app.swapDrawer.selectAccountByName(account2);
       }
-      await app.swap.checkAssetFrom(electronApp, account1.currency.name);
-      await app.swap.checkAssetTo(electronApp, account2.currency.name);
+      await app.swap.checkAssetFromContains(account1.currency.name);
+      await app.swap.checkAssetToContains(account2.currency.name);
     },
   );
 });
@@ -431,8 +431,8 @@ test.describe("Swap a coin for which you have no account yet - from not present 
         await app.swap.selectAssetTo(electronApp, account2.currency.name);
         await app.swapDrawer.selectAccountByName(account2);
       }
-      await app.swap.checkAssetFrom(electronApp, account1.currency.name);
-      await app.swap.checkAssetTo(electronApp, account2.currency.name);
+      await app.swap.checkAssetFromContains(account1.currency.name);
+      await app.swap.checkAssetToContains(account2.currency.name);
     },
   );
 });
@@ -489,8 +489,8 @@ test.describe("Swap a coin for which you have no account yet - both not present"
 
         await app.scanAccountsDrawer.selectFirstAccount();
         await app.scanAccountsDrawer.clickContinueButton();
-        await app.swap.checkAssetFrom(electronApp, account1.currency.name);
-        await app.swap.checkAssetTo(electronApp, account2.currency.name);
+        await app.swap.checkAssetFromContains(account1.currency.name);
+        await app.swap.checkAssetToContains(account2.currency.name);
       }
     },
   );
@@ -541,9 +541,9 @@ test.describe("Swap - Switch You send and You receive currency", () => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
       await performSwapUntilQuoteSelectionStep(app, electronApp, swap, swap.amount ?? "0");
-      await app.swap.switchYouSendAndYouReceive(electronApp);
-      await app.swap.checkAssetFrom(electronApp, swap.accountToCredit.currency.ticker);
-      await app.swap.checkAssetTo(electronApp, swap.accountToDebit.currency.ticker);
+      await app.swap.switchYouSendAndYouReceive();
+      await app.swap.checkAssetFromContains(swap.accountToCredit.currency.ticker);
+      await app.swap.checkAssetToContains(swap.accountToDebit.currency.ticker);
     },
   );
 });

--- a/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
+++ b/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
@@ -98,13 +98,13 @@ test.describe("Swap flow from different entry point", () => {
         description: "B2CQA-2986",
       },
     },
-    async ({ app, electronApp }) => {
+    async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.clickOnSelectedAssetRow(swapEntryPoint.swap.accountToDebit.currency.name);
 
       await app.swap.goAndWaitForSwapToBeReady(() => app.assetPage.startSwapFlow());
-      await app.swap.checkAssetTo(electronApp, swapEntryPoint.swap.accountToDebit.currency.name);
+      await app.swap.checkAssetToContains(swapEntryPoint.swap.accountToDebit.currency.name);
     },
   );
 
@@ -128,7 +128,7 @@ test.describe("Swap flow from different entry point", () => {
         description: "B2CQA-2987",
       },
     },
-    async ({ app, electronApp }) => {
+    async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
       if (await isWallet40Enabled(app.getPage())) {
@@ -140,8 +140,8 @@ test.describe("Swap flow from different entry point", () => {
       await app.swap.goAndWaitForSwapToBeReady(() =>
         app.market.startSwapForSelectedTicker(swapEntryPoint.swap.accountToDebit.currency.ticker),
       );
-      await app.swap.checkAssetTo(electronApp, swapEntryPoint.swap.accountToDebit.currency.name);
-      await app.swap.checkAssetTo(electronApp, swapEntryPoint.swap.accountToDebit.accountName);
+      await app.swap.checkAssetToContains(swapEntryPoint.swap.accountToDebit.currency.name);
+      await app.swap.checkAssetToContains(swapEntryPoint.swap.accountToDebit.accountName);
     },
   );
 
@@ -165,7 +165,7 @@ test.describe("Swap flow from different entry point", () => {
         description: "B2CQA-2988",
       },
     },
-    async ({ app, electronApp }) => {
+    async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
       if (await isWallet40Enabled(app.getPage())) {
@@ -176,7 +176,7 @@ test.describe("Swap flow from different entry point", () => {
 
       await app.market.openCoinPage(swapEntryPoint.swap.accountToDebit.currency.ticker);
       await app.swap.goAndWaitForSwapToBeReady(() => app.market.clickOnSwapButtonOnAsset());
-      await app.swap.checkAssetTo(electronApp, swapEntryPoint.swap.accountToDebit.currency.name);
+      await app.swap.checkAssetToContains(swapEntryPoint.swap.accountToDebit.currency.name);
     },
   );
 
@@ -200,15 +200,15 @@ test.describe("Swap flow from different entry point", () => {
         description: "B2CQA-2989",
       },
     },
-    async ({ app, electronApp }) => {
+    async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(
         getParentAccountName(swapEntryPoint.swap.accountToDebit),
       );
       await app.swap.goAndWaitForSwapToBeReady(() => app.account.navigateToSwap());
-      await app.swap.checkAssetTo(electronApp, swapEntryPoint.swap.accountToDebit.currency.name);
-      await app.swap.checkAssetTo(electronApp, swapEntryPoint.swap.accountToDebit.accountName);
+      await app.swap.checkAssetToContains(swapEntryPoint.swap.accountToDebit.currency.name);
+      await app.swap.checkAssetToContains(swapEntryPoint.swap.accountToDebit.accountName);
     },
   );
 

--- a/e2e/desktop/tests/utils/swapUtils.ts
+++ b/e2e/desktop/tests/utils/swapUtils.ts
@@ -64,7 +64,7 @@ async function selectAccountFrom(app: Application, electronApp: ElectronApplicat
   const selector = await getModularSelector(app, "ASSET");
   if (selector) {
     await selectAccountMAD(selector, swap.accountToDebit);
-    await app.swap.checkAssetFrom(electronApp, swap.accountToDebit.currency.ticker);
+    await app.swap.checkAssetFromContains(swap.accountToDebit.currency.ticker);
   }
 }
 
@@ -73,7 +73,7 @@ async function selectAccountTo(app: Application, electronApp: ElectronApplicatio
   const selector = await getModularSelector(app, "ASSET");
   if (selector) {
     await selectAccountMAD(selector, swap.accountToCredit);
-    await app.swap.checkAssetTo(electronApp, swap.accountToCredit.currency.ticker);
+    await app.swap.checkAssetToContains(swap.accountToCredit.currency.ticker);
   }
 }
 


### PR DESCRIPTION
test(e2e-desktop): get the specific webview

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Avoid calling function on undefined webview and improve readability.

Should address https://github.com/LedgerHQ/qaa-flaky-tests/issues/36

Regression 4.0 **ENABLED**:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23352766676
Report: 

Regression 4.0 **DISABLED**:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23352794637
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/18c510c8-7872-49b9-a732-f99669bc0acd/

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://github.com/LedgerHQ/qaa-flaky-tests/issues/36


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
