### PR TITLE
chore(deps): bump playwright for fixes and improvements

### DIFF
--- a/e2e/desktop/playwright.config.ts
+++ b/e2e/desktop/playwright.config.ts
@@ -13,7 +13,9 @@ const config: PlaywrightTestConfig = {
   globalTeardown: require.resolve("./tests/utils/global.teardown"),
   use: {
     ignoreHTTPSErrors: true,
-    screenshot: process.env.CI ? "only-on-failure" : "off",
+    // Playwright will capture screenshots for the main view and any open webviews
+    // Handle screenshots ourselves to avoid multiple results
+    screenshot: "off",
   },
   forbidOnly: !!process.env.CI,
   preserveOutput: process.env.CI ? "failures-only" : "always",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: 0.2.3
       version: 0.2.3
     '@playwright/test':
-      specifier: 1.51.1
-      version: 1.51.1
+      specifier: 1.53.0
+      version: 1.53.0
     '@polkadot/api':
       specifier: 16.5.4
       version: 16.5.4
@@ -334,8 +334,8 @@ catalogs:
       specifier: 1.51.0
       version: 1.51.0
     playwright:
-      specifier: 1.51.1
-      version: 1.51.1
+      specifier: 1.53.0
+      version: 1.53.0
     react-i18next:
       specifier: 16.5.0
       version: 16.5.0
@@ -1187,7 +1187,7 @@ importers:
         version: link:../../libs/test-utils
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.51.1
+        version: 1.53.0
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 1.7.2
@@ -1307,7 +1307,7 @@ importers:
         version: 4.0.17(msw@2.7.3(@types/node@24.12.0)(typescript@5.9.3))
       allure-playwright:
         specifier: 'catalog:'
-        version: 3.2.1(@playwright/test@1.51.1)
+        version: 3.2.1(@playwright/test@1.53.0)
       autoprefixer:
         specifier: 10.4.22
         version: 10.4.22(postcss@8.5.6)
@@ -2399,16 +2399,16 @@ importers:
         version: link:../../libs/ledgerjs/packages/types-live
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.51.1
+        version: 1.53.0
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
       allure-js-commons:
         specifier: 'catalog:'
-        version: 3.2.1(allure-playwright@3.2.1(@playwright/test@1.51.1))
+        version: 3.2.1(allure-playwright@3.2.1(@playwright/test@1.53.0))
       allure-playwright:
         specifier: 'catalog:'
-        version: 3.2.1(@playwright/test@1.51.1)
+        version: 3.2.1(@playwright/test@1.53.0)
       axios:
         specifier: 'catalog:'
         version: 1.13.2
@@ -2436,7 +2436,7 @@ importers:
         version: 40.6.0
       playwright:
         specifier: 'catalog:'
-        version: 1.51.1
+        version: 1.53.0
 
   e2e/mobile:
     dependencies:
@@ -10534,7 +10534,7 @@ importers:
         version: link:packages/shared
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.51.1
+        version: 1.53.0
       concurrently:
         specifier: ^8.0.0
         version: 8.2.2
@@ -16586,8 +16586,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.51.1':
-    resolution: {integrity: sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==}
+  '@playwright/test@1.53.0':
+    resolution: {integrity: sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -30374,13 +30374,13 @@ packages:
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
-  playwright-core@1.51.1:
-    resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
+  playwright-core@1.53.0:
+    resolution: {integrity: sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.51.1:
-    resolution: {integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==}
+  playwright@1.53.0:
+    resolution: {integrity: sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -43822,9 +43822,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.51.1':
+  '@playwright/test@1.53.0':
     dependencies:
-      playwright: 1.51.1
+      playwright: 1.53.0
 
   '@pnpm/catalogs.protocol-parser@1000.0.0': {}
 
@@ -51510,16 +51510,16 @@ snapshots:
 
   allure-commandline@2.28.0: {}
 
-  allure-js-commons@3.2.1(allure-playwright@3.2.1(@playwright/test@1.51.1)):
+  allure-js-commons@3.2.1(allure-playwright@3.2.1(@playwright/test@1.53.0)):
     dependencies:
       md5: 2.3.0
     optionalDependencies:
-      allure-playwright: 3.2.1(@playwright/test@1.51.1)
+      allure-playwright: 3.2.1(@playwright/test@1.53.0)
 
-  allure-playwright@3.2.1(@playwright/test@1.51.1):
+  allure-playwright@3.2.1(@playwright/test@1.53.0):
     dependencies:
-      '@playwright/test': 1.51.1
-      allure-js-commons: 3.2.1(allure-playwright@3.2.1(@playwright/test@1.51.1))
+      '@playwright/test': 1.53.0
+      allure-js-commons: 3.2.1(allure-playwright@3.2.1(@playwright/test@1.53.0))
 
   allure-store@1.1.2:
     dependencies:
@@ -63016,11 +63016,11 @@ snapshots:
 
   platform@1.3.6: {}
 
-  playwright-core@1.51.1: {}
+  playwright-core@1.53.0: {}
 
-  playwright@1.51.1:
+  playwright@1.53.0:
     dependencies:
-      playwright-core: 1.51.1
+      playwright-core: 1.53.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -167,8 +167,8 @@ catalog:
   "styled-system": 5.1.5
   "stylis": 4.0.0
   "@tanstack/react-virtual": 3.13.16
-  "@playwright/test": 1.51.1
-  playwright: 1.51.1
+  "@playwright/test": 1.53.0
+  playwright: 1.53.0
   allure-playwright: 3.2.1
   allure-js-commons: 3.2.1
   oxlint: 1.51.0


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Bump playwright to fix rename spec hanging on `exposeFunction()`.

1.53.0: https://github.com/microsoft/playwright/releases/tag/v1.53.0
1.52.0: https://github.com/microsoft/playwright/releases/tag/v1.52.0

Diff: https://github.com/microsoft/playwright/compare/v1.51.1...v1.53.0

Regression 4.0 **ENABLED**:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23414741735
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/f90a18fd-6147-4cf7-a9b1-1baafec9c95d/

Regression 4.0 **DISABLED**:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23414751190
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/8cbe9998-1c3e-4dab-8b07-a8d9c6a5e98b/

ANDROID Regression:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23430634050
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/32bdbe89-c938-4d28-b304-e803eabf09ab/

PLEASE NOTE:
**_prompt:** 
`_prompt-{x}` is no longer attached to the report.
It looks like this was a [conscious decision](https://github.com/microsoft/playwright/pull/34995#discussion_r1978493066) by the playwright contributors.

**Screenshot:**
A screenshot for every open page is added to the report by playwright:
<img width="659" height="621" alt="Screenshot 2026-03-23 at 10 07 08" src="https://github.com/user-attachments/assets/5d69dc01-bd03-4958-907d-7865bcd5bdbd" />
As a result we have an entry for the main view as well as any open WebViews.
This correlates with a [comment](https://github.com/microsoft/playwright/issues/34996#issuecomment-2695888912) on a PR in the playwright repo stating:

> When screenshot is set to only-on-failure, Playwright captures a screenshot of every page that is closing before test finishes.

To avoid multiple results we can turn screenshots OFF in playwright config and keep adding it to the report manually on failure.

Failing run for failure metadata including screenshot:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23443928814
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/bdcfe59b-f9de-4774-aced-9cd90b4a8f14/

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/QAA-1051


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
