### PR TITLE
test(e2e-desktop): include 40 override or legacy in report

### DIFF
--- a/e2e/desktop/tests/utils/global.setup.ts
+++ b/e2e/desktop/tests/utils/global.setup.ts
@@ -34,6 +34,7 @@ export default async function globalSetup(_config: FullConfig) {
     [
       `SPECULOS_DEVICE=${SPECULOS_DEVICE}`,
       `SPECULOS_FIRMWARE_VERSION=${SPECULOS_FIRMWARE_VERSION}`,
+      `WALLET=${process.env.E2E_ENABLE_WALLET40 === "1" ? "4.0" : "Legacy"}`,
       "",
     ].join("\n"),
     { encoding: "utf8", flag: "w" },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add override or legacy in allure report.

Wallet 4.0:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23415587589
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/85535013-0ecc-4fcf-9b19-941c9b1b9af1/

Wallet Legacy:
Build: https://github.com/LedgerHQ/ledger-live/actions/runs/23415608564
Report: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/f54f93b3-3e63-4077-85c5-ceb58db4e024/

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/QAA-1070


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
