### PR TITLE
[LWDM] fix(coin-aleo): workaround to exclude already spent records from private balance

### DIFF
--- a/.changeset/wet-garlics-argue.md
+++ b/.changeset/wet-garlics-argue.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+fix: exclude already spent records from aleo private balance

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
@@ -68,7 +68,7 @@ describe("sync.ts", () => {
     });
     mockAccessProvableApi.mockResolvedValue(null);
     mockGetAccountOwnedRecords.mockResolvedValue([]);
-    mockListPrivateOperations.mockResolvedValue([]);
+    mockListPrivateOperations.mockResolvedValue({ operations: [], consumedRecordTags: new Set() });
     mockGetPrivateBalance.mockResolvedValue({ balance: new BigNumber(0), unspentRecords: [] });
     mockPatchPublicOperations.mockResolvedValue([]);
   });
@@ -510,7 +510,10 @@ describe("sync.ts", () => {
       mockGetAccountOwnedRecords
         .mockResolvedValueOnce(mockPrivateRecords)
         .mockResolvedValueOnce(mockUnspentRecords);
-      mockListPrivateOperations.mockResolvedValueOnce(mockPrivateOps);
+      mockListPrivateOperations.mockResolvedValueOnce({
+        operations: mockPrivateOps,
+        consumedRecordTags: new Set(),
+      });
       mockGetPrivateBalance.mockResolvedValueOnce({
         balance: new BigNumber(50000),
         unspentRecords: mockUnspentResult,
@@ -666,10 +669,14 @@ describe("sync.ts", () => {
 
       const accountWithOps = { ...mockInitialAccount, operations: [oldPublicOp] };
       mockListOperations.mockResolvedValueOnce({
-        operations: [newPublicOp as any],
+        // @ts-expect-error - bridge operation type is expected in this test
+        operations: [newPublicOp],
         nextCursor: null,
       });
-      mockListPrivateOperations.mockResolvedValueOnce([newPrivateOp]);
+      mockListPrivateOperations.mockResolvedValueOnce({
+        operations: [newPrivateOp],
+        consumedRecordTags: new Set(),
+      });
       mockPatchPublicOperations.mockResolvedValueOnce([newPublicOp, oldPublicOp]);
 
       const result = await getAccountShape(
@@ -824,6 +831,40 @@ describe("sync.ts", () => {
       );
 
       expect(mockPatchPublicOperations).not.toHaveBeenCalled();
+    });
+
+    it("should filter unspent records whose tags appear in consumedRecordTags before passing to getPrivateBalance", async () => {
+      mockAccessProvableApi.mockResolvedValueOnce(configuredProvableApi);
+      const consumedTag = "consumed-record-tag";
+      const spentRecord = getMockedRecord({ tag: consumedTag, record_ciphertext: "spent" });
+      const unspentRecord = getMockedRecord({ tag: "unspent-tag", record_ciphertext: "unspent" });
+
+      mockGetAccountOwnedRecords
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([spentRecord, unspentRecord]); // unspent from scanner (with stale data)
+      mockListPrivateOperations.mockResolvedValueOnce({
+        operations: [],
+        consumedRecordTags: new Set([consumedTag]),
+      });
+
+      await getAccountShape(
+        {
+          index: mockAccount.index,
+          derivationPath: mockAccount.freshAddressPath,
+          address: mockAccount.freshAddress,
+          currency: mockCurrency,
+          derivationMode: mockDerivationMode,
+          initialAccount: mockInitialAccount,
+        },
+        mockSyncConfig,
+      );
+
+      expect(mockGetPrivateBalance).toHaveBeenCalledTimes(1);
+      expect(mockGetPrivateBalance).toHaveBeenCalledWith({
+        currency: mockCurrency,
+        viewKey: "AViewKey123",
+        privateRecords: [unspentRecord],
+      });
     });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -116,31 +116,39 @@ export const getAccountShape: GetAccountShape<AleoAccount> = async infos => {
       }),
     ]);
 
-    const [privateOperationsResult, patchedPublicOperationsResult, privateBalanceResult] =
-      await Promise.all([
-        listPrivateOperations({
-          currency,
-          viewKey,
-          address,
-          ledgerAccountId,
-          privateRecords: rawNewPrivateRecords,
-        }),
-        patchPublicOperations({
-          currency,
-          publicOperations,
-          privateRecords: rawNewPrivateRecords,
-          address,
-          ledgerAccountId,
-          viewKey,
-        }),
-        getPrivateBalance({
-          currency,
-          viewKey,
-          privateRecords: rawUnspentPrivateRecords,
-        }),
-      ]);
+    const [privateOperationsResult, patchedPublicOperationsResult] = await Promise.all([
+      listPrivateOperations({
+        currency,
+        viewKey,
+        address,
+        ledgerAccountId,
+        privateRecords: rawNewPrivateRecords,
+      }),
+      patchPublicOperations({
+        currency,
+        publicOperations,
+        privateRecords: rawNewPrivateRecords,
+        address,
+        ledgerAccountId,
+        viewKey,
+      }),
+    ]);
 
-    latestAccountPrivateOperations = privateOperationsResult;
+    // Record scanner API may return already-spent records even with "unspent: true" filter.
+    // This is confirmed and expected behavior for now - scanner relies on two processes that can lag behind each other.
+    // The workaround is to remove records whose tags appear as inputs in currently processed transactions.
+    // Records spent before are expected to have been cleared from the scanner by then.
+    const filteredUnspentRecords = rawUnspentPrivateRecords.filter(
+      record => !privateOperationsResult.consumedRecordTags.has(record.tag),
+    );
+
+    const privateBalanceResult = await getPrivateBalance({
+      currency,
+      viewKey,
+      privateRecords: filteredUnspentRecords,
+    });
+
+    latestAccountPrivateOperations = privateOperationsResult.operations;
     publicOperations = patchedPublicOperationsResult;
     privateBalance = privateBalanceResult.balance;
     unspentPrivateRecords = privateBalanceResult.unspentRecords;

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
@@ -13,6 +13,7 @@ const mockEnrichPrivateRecord = jest.mocked(enrichPrivateRecord);
 const mockToPrivateBridgeOperation = jest.mocked(toPrivateBridgeOperation);
 
 describe("listPrivateOperations", () => {
+  const mockOp = getMockedOperation();
   const mockCurrency = getMockedCurrency();
   const mockViewKey = "AViewKey1mockviewkey";
   const mockAddress = "aleo1test123address456";
@@ -22,7 +23,7 @@ describe("listPrivateOperations", () => {
     jest.clearAllMocks();
   });
 
-  it("should return an empty array when no private records are provided", async () => {
+  it("should return an empty operations array and empty set when no private records are provided", async () => {
     const result = await listPrivateOperations({
       currency: mockCurrency,
       viewKey: mockViewKey,
@@ -32,7 +33,8 @@ describe("listPrivateOperations", () => {
     });
 
     expect(mockEnrichPrivateRecord).not.toHaveBeenCalled();
-    expect(result).toEqual([]);
+    expect(result.operations).toEqual([]);
+    expect(result.consumedRecordTags).toEqual(new Set());
   });
 
   it("should filter out records from non-credits programs", async () => {
@@ -50,7 +52,8 @@ describe("listPrivateOperations", () => {
     });
 
     expect(mockEnrichPrivateRecord).not.toHaveBeenCalled();
-    expect(result).toEqual([]);
+    expect(result.operations).toEqual([]);
+    expect(result.consumedRecordTags).toEqual(new Set());
   });
 
   it("should filter out transfer_public records as they are not private operations", async () => {
@@ -68,7 +71,8 @@ describe("listPrivateOperations", () => {
     });
 
     expect(mockEnrichPrivateRecord).not.toHaveBeenCalled();
-    expect(result).toEqual([]);
+    expect(result.operations).toEqual([]);
+    expect(result.consumedRecordTags).toEqual(new Set());
   });
 
   it("should process transfer_private records", async () => {
@@ -77,7 +81,6 @@ describe("listPrivateOperations", () => {
       function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
     });
     const mockEnriched = getMockedEnrichedPrivateRecord({ rawRecord: record });
-    const mockOp = getMockedOperation();
 
     mockEnrichPrivateRecord.mockResolvedValue(mockEnriched);
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
@@ -97,7 +100,7 @@ describe("listPrivateOperations", () => {
       viewKey: mockViewKey,
       address: mockAddress,
     });
-    expect(result).toEqual([mockOp]);
+    expect(result.operations).toEqual([mockOp]);
   });
 
   it("should process transfer_public_to_private records", async () => {
@@ -106,7 +109,6 @@ describe("listPrivateOperations", () => {
       function_name: EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE,
     });
     const mockEnriched = getMockedEnrichedPrivateRecord({ rawRecord: record });
-    const mockOp = getMockedOperation();
 
     mockEnrichPrivateRecord.mockResolvedValue(mockEnriched);
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
@@ -126,7 +128,7 @@ describe("listPrivateOperations", () => {
       viewKey: mockViewKey,
       address: mockAddress,
     });
-    expect(result).toEqual([mockOp]);
+    expect(result.operations).toEqual([mockOp]);
   });
 
   it("should process transfer_private_to_public records", async () => {
@@ -135,7 +137,6 @@ describe("listPrivateOperations", () => {
       function_name: EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
     });
     const mockEnriched = getMockedEnrichedPrivateRecord({ rawRecord: record });
-    const mockOp = getMockedOperation();
 
     mockEnrichPrivateRecord.mockResolvedValue(mockEnriched);
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
@@ -155,7 +156,7 @@ describe("listPrivateOperations", () => {
       viewKey: mockViewKey,
       address: mockAddress,
     });
-    expect(result).toEqual([mockOp]);
+    expect(result.operations).toEqual([mockOp]);
   });
 
   it("should call toPrivateBridgeOperation with ledgerAccountId, enriched record, and address", async () => {
@@ -164,7 +165,6 @@ describe("listPrivateOperations", () => {
       function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
     });
     const mockEnriched = getMockedEnrichedPrivateRecord({ rawRecord: record });
-    const mockOp = getMockedOperation();
 
     mockEnrichPrivateRecord.mockResolvedValue(mockEnriched);
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
@@ -197,7 +197,6 @@ describe("listPrivateOperations", () => {
       function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
     });
     const mockEnriched = getMockedEnrichedPrivateRecord({ rawRecord: record2 });
-    const mockOp = getMockedOperation({ id: "op2" });
 
     mockEnrichPrivateRecord.mockResolvedValueOnce(null).mockResolvedValueOnce(mockEnriched);
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
@@ -212,7 +211,7 @@ describe("listPrivateOperations", () => {
 
     expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(2);
     expect(mockToPrivateBridgeOperation).toHaveBeenCalledTimes(1);
-    expect(result).toEqual([mockOp]);
+    expect(result.operations).toEqual([mockOp]);
   });
 
   it("should process multiple valid records and return all parsed operations", async () => {
@@ -258,8 +257,8 @@ describe("listPrivateOperations", () => {
 
     expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(3);
     expect(mockToPrivateBridgeOperation).toHaveBeenCalledTimes(3);
-    expect(result).toHaveLength(3);
-    expect(result).toEqual(expect.arrayContaining(ops));
+    expect(result.operations).toHaveLength(3);
+    expect(result.operations).toEqual(expect.arrayContaining(ops));
   });
 
   it("should skip non-native records while still processing valid ones", async () => {
@@ -274,7 +273,6 @@ describe("listPrivateOperations", () => {
       function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
     });
     const mockEnriched = getMockedEnrichedPrivateRecord({ rawRecord: validRecord });
-    const mockOp = getMockedOperation();
 
     mockEnrichPrivateRecord.mockResolvedValue(mockEnriched);
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
@@ -291,7 +289,7 @@ describe("listPrivateOperations", () => {
     expect(mockEnrichPrivateRecord).toHaveBeenCalledWith(
       expect.objectContaining({ rawRecord: validRecord }),
     );
-    expect(result).toEqual([mockOp]);
+    expect(result.operations).toEqual([mockOp]);
   });
 
   it("should return an empty array when all enrichPrivateRecord calls return null", async () => {
@@ -320,6 +318,90 @@ describe("listPrivateOperations", () => {
 
     expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(2);
     expect(mockToPrivateBridgeOperation).not.toHaveBeenCalled();
-    expect(result).toEqual([]);
+    expect(result.operations).toEqual([]);
+  });
+
+  it("should collect consumed record tags from record-type inputs in outgoing transactions", async () => {
+    const record = getMockedRecord({
+      program_name: PROGRAM_ID.CREDITS,
+      function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+    });
+    const mockEnriched = getMockedEnrichedPrivateRecord({
+      rawRecord: { sender: mockAddress },
+      details: {
+        execution: {
+          transitions: [
+            {
+              id: "au1",
+              scm: "s",
+              tcm: "t",
+              tpk: "tpk1",
+              inputs: [
+                { id: "in0", type: "record", tag: "consumed-tag-1" },
+                { id: "in1", type: "private", value: "cipher_recipient" },
+                { id: "in2", type: "private", value: "cipher_amount" },
+              ],
+              outputs: [],
+              program: "credits.aleo",
+              function: "transfer_private",
+            },
+          ],
+        },
+      },
+    });
+
+    mockEnrichPrivateRecord.mockResolvedValue(mockEnriched);
+    mockToPrivateBridgeOperation.mockReturnValue(mockOp);
+
+    const result = await listPrivateOperations({
+      currency: mockCurrency,
+      viewKey: mockViewKey,
+      address: mockAddress,
+      ledgerAccountId: mockLedgerAccountId,
+      privateRecords: [record],
+    });
+
+    expect(result.operations).toEqual([mockOp]);
+    expect(result.consumedRecordTags).toEqual(new Set(["consumed-tag-1"]));
+  });
+
+  it("should not collect tags from incoming transactions where sender is not this address", async () => {
+    const record = getMockedRecord({
+      program_name: PROGRAM_ID.CREDITS,
+      function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+    });
+
+    const mockEnriched = getMockedEnrichedPrivateRecord({
+      sender: "different_address",
+      details: {
+        execution: {
+          transitions: [
+            {
+              id: "au1",
+              scm: "s",
+              tcm: "t",
+              tpk: "tpk1",
+              inputs: [{ id: "in0", type: "record", tag: "incoming-tag" }],
+              outputs: [],
+              program: "credits.aleo",
+              function: "transfer_private",
+            },
+          ],
+        },
+      },
+    });
+
+    mockEnrichPrivateRecord.mockResolvedValue(mockEnriched);
+    mockToPrivateBridgeOperation.mockReturnValue(mockOp);
+
+    const result = await listPrivateOperations({
+      currency: mockCurrency,
+      viewKey: mockViewKey,
+      address: mockAddress,
+      ledgerAccountId: mockLedgerAccountId,
+      privateRecords: [record],
+    });
+
+    expect(result.consumedRecordTags).toEqual(new Set());
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
@@ -1,6 +1,11 @@
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
-import type { AleoOperation, AleoPrivateRecord, EnrichedPrivateRecord } from "../types";
+import type {
+  AleoOperation,
+  AleoPrivateRecord,
+  EnrichedPrivateRecord,
+  AleoTransitionValue,
+} from "../types";
 import { EXPLORER_TRANSFER_TYPES, PROGRAM_ID } from "../constants";
 import { enrichPrivateRecord } from "../network/utils";
 import { toPrivateBridgeOperation } from "./utils";
@@ -17,6 +22,12 @@ function onlyNativeCoinOperations(record: AleoPrivateRecord): boolean {
   );
 }
 
+function onlyRecordValue(
+  value: AleoTransitionValue,
+): value is Extract<AleoTransitionValue, { type: "record" }> {
+  return value.type === "record";
+}
+
 export async function listPrivateOperations({
   currency,
   viewKey,
@@ -29,14 +40,36 @@ export async function listPrivateOperations({
   address: string;
   ledgerAccountId: string;
   privateRecords: AleoPrivateRecord[];
-}): Promise<AleoOperation[]> {
+}): Promise<{
+  operations: AleoOperation[];
+  consumedRecordTags: Set<string>;
+}> {
+  const consumedRecordTags = new Set<string>();
   const nativePrivateRecords = privateRecords.filter(onlyNativeCoinOperations);
-
   const enrichedRecords = await promiseAllBatched(2, nativePrivateRecords, rawRecord =>
     enrichPrivateRecord({ currency, rawRecord, address, viewKey }),
   );
 
-  return enrichedRecords
+  // Build the set of record tags consumed as inputs in outgoing transactions.
+  // This is used to compensate for the record scanner returning already-spent records as unspent.
+  for (const enriched of enrichedRecords) {
+    if (enriched?.rawRecord.sender !== address) continue;
+
+    const txTransitions = [
+      ...(enriched.details.execution?.transitions ?? []),
+      enriched.details.fee.transition,
+    ];
+
+    const inputRecords = txTransitions.flatMap(({ inputs }) => inputs.filter(onlyRecordValue));
+
+    for (const input of inputRecords) {
+      consumedRecordTags.add(input.tag);
+    }
+  }
+
+  const operations = enrichedRecords
     .filter((record): record is EnrichedPrivateRecord => record !== null)
     .map(record => toPrivateBridgeOperation(ledgerAccountId, record, address));
+
+  return { operations, consumedRecordTags };
 }

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -847,6 +847,48 @@ describe("network/utils", () => {
       expect(mockDecryptRecord).not.toHaveBeenCalled();
     });
 
+    it("should return null when sender is this address and transition inputs at recipient/amount indices have no value field (record type)", async () => {
+      const rawRecord = getMockedRecord({
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+        sender: mockEnrichAddress,
+        transition_index: 0,
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(rawRecord.transaction_id, {
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk1",
+                inputs: [
+                  { id: "in0", type: "record", tag: "record_tag_0" }, // index 0
+                  { id: "in1", type: "record", tag: "record_tag_1" }, // RECIPIENT_ARG_INDEX = 1, no value field
+                  { id: "in2", type: "private", value: "ciphertext_amount" }, // AMOUNT_ARG_INDEX = 2
+                ],
+                outputs: [],
+                program: "credits.aleo",
+                function: "transfer_private",
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await enrichPrivateRecord({
+        currency: mockCurrency,
+        rawRecord,
+        address: mockEnrichAddress,
+        viewKey: mockViewKey,
+      });
+
+      expect(result).toBeNull();
+      expect(mockGetTransactionById).toHaveBeenCalledTimes(1);
+      expect(mockDecryptCiphertext).not.toHaveBeenCalled();
+      expect(mockDecryptRecord).not.toHaveBeenCalled();
+    });
+
     it("should return null when PRIVATE_TO_PUBLIC and recipient is own address", async () => {
       const rawRecord = getMockedRecord({
         function_name: EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
@@ -1477,13 +1519,56 @@ describe("network/utils", () => {
       expect(mockDecryptCiphertext).not.toHaveBeenCalled();
     });
 
+    it("should pass PUBLIC_TO_PRIVATE operation through unchanged when recipient input has no value field (record type)", async () => {
+      const txHash = "at1record_type_input";
+      const publicOp = getMockedOperation({
+        hash: txHash,
+        type: "OUT",
+        extra: { functionId: "transfer_public_to_private", transactionType: "public" },
+      });
+      const mockDetails = getMockedTransactionDetails(txHash, {
+        block_height: 100,
+        execution: {
+          transitions: [
+            {
+              id: "au1",
+              scm: "s",
+              tcm: "t",
+              tpk: "tpk1",
+              inputs: [{ id: "in0", type: "record", tag: "some_record_tag" }],
+              outputs: [],
+              program: "credits.aleo",
+              function: "transfer_public_to_private",
+            },
+          ],
+        },
+      });
+
+      mockGetTransactionById.mockResolvedValueOnce(mockDetails);
+
+      const result = await patchPublicOperations({
+        currency: mockCurrency,
+        publicOperations: [publicOp],
+        privateRecords: [],
+        address: patchAddress,
+        ledgerAccountId,
+        viewKey: patchViewKey,
+      });
+
+      expect(result).toEqual([publicOp]);
+      expect(mockDecryptCiphertext).not.toHaveBeenCalled();
+    });
+
     it("should pass PRIVATE_TO_PUBLIC through as-is when no matching private record", async () => {
       const txHash = "at1priv_to_pub_no_match";
       const publicOp = getMockedOperation({
         id: "priv_to_pub_no_match",
         hash: txHash,
         type: "IN",
-        extra: { functionId: "transfer_private_to_public", transactionType: "public" },
+        extra: {
+          functionId: "transfer_private_to_public",
+          transactionType: "public",
+        },
       });
       const mockDetails = getMockedTransactionDetails(txHash, {
         execution: {

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -263,16 +263,29 @@ export async function enrichPrivateRecord({
       return null;
     }
 
+    // Recipient and amount are contract function arguments, so their inputs must have a `value` field.
+    // Other input (missing `value` field) would indicate unexpected API data.
+    // In that case we skip processing rather than crash.
+    const recipientInput = recordTransition.inputs[RECIPIENT_ARG_INDEX] ?? null;
+    const amountInput = recordTransition.inputs[AMOUNT_ARG_INDEX] ?? null;
+    const recipientArgument = recipientInput && "value" in recipientInput ? recipientInput : null;
+    const amountArgument = amountInput && "value" in amountInput ? amountInput : null;
+
+    if (!recipientArgument || !amountArgument) {
+      log("aleo/sync", `enrichPrivateRecord: invalid transition arguments for tx ${transactionId}`);
+      return null;
+    }
+
     if (rawRecord.function_name === EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC) {
-      if (recordTransition.inputs[RECIPIENT_ARG_INDEX].value === address) return null;
+      if (recipientArgument.value === address) return null;
       sender = address;
-      recipient = recordTransition.inputs[RECIPIENT_ARG_INDEX].value;
-      value = new BigNumber(parseMicrocredits(recordTransition.inputs[AMOUNT_ARG_INDEX].value));
+      recipient = recipientArgument.value;
+      value = new BigNumber(parseMicrocredits(amountArgument.value));
     } else {
       const [recipientData, amountData] = await Promise.all([
         sdkClient.decryptCiphertext({
           currency,
-          ciphertext: recordTransition.inputs[RECIPIENT_ARG_INDEX].value,
+          ciphertext: recipientArgument.value,
           tpk: recordTransition.tpk,
           viewKey,
           programId: rawRecord.program_name,
@@ -281,7 +294,7 @@ export async function enrichPrivateRecord({
         }),
         sdkClient.decryptCiphertext({
           currency,
-          ciphertext: recordTransition.inputs[AMOUNT_ARG_INDEX].value,
+          ciphertext: amountArgument.value,
           tpk: recordTransition.tpk,
           viewKey,
           programId: rawRecord.program_name,
@@ -426,15 +439,20 @@ export const patchPublicOperations = async ({
     // - semi-transparent transfer from our own account to another account
     else {
       const txDetails = await apiClient.getTransactionById(currency, operation.hash);
-      const recordTransition = txDetails.execution.transitions[0];
+      const recordTransition = txDetails.execution.transitions[0] ?? null;
+      const recipientInput = recordTransition?.inputs[0] ?? {};
+      const recipientArgument = "value" in recipientInput ? recipientInput : null;
 
       // if this is public to private, our account is sender, so it's possible to decrypt the recipient address
       // arguments of transfer_public_to_private function are (address_ciphertext, amount)
-      if (operation.extra.functionId === EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE) {
+      if (
+        recipientArgument &&
+        operation.extra.functionId === EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE
+      ) {
         const shouldMarkAsPatched = latestPrivateRecordBlockHeight >= txDetails.block_height;
         const recipientData = await sdkClient.decryptCiphertext({
           currency,
-          ciphertext: recordTransition.inputs[0].value,
+          ciphertext: recipientArgument.value,
           tpk: recordTransition.tpk,
           viewKey,
           programId: PROGRAM_ID.CREDITS,

--- a/libs/coin-modules/coin-aleo/src/types/api.ts
+++ b/libs/coin-modules/coin-aleo/src/types/api.ts
@@ -1,20 +1,24 @@
 export type AleoTransactionType = "public" | "private";
 
-interface AleoTransition {
+export type AleoTransitionValue =
+  | {
+      id: string;
+      type: "public" | "private" | "future";
+      value: string;
+    }
+  | {
+      id: string;
+      type: "record";
+      tag: string;
+    };
+
+export interface AleoTransition {
   id: string;
   scm: string;
   tcm: string;
   tpk: string;
-  inputs: Array<{
-    id: string;
-    type: AleoTransactionType;
-    value: string;
-  }>;
-  outputs: Array<{
-    id: string;
-    type: string;
-    value: string;
-  }>;
+  inputs: AleoTransitionValue[];
+  outputs: AleoTransitionValue[];
   program: string;
   function: string;
 }
@@ -53,7 +57,9 @@ export interface AleoPublicTransactionDetailsResponse {
   };
   global_state_root: string;
   proof: string;
-  fee: { transition: AleoTransition };
+  fee: {
+    transition: AleoTransition;
+  };
   fee_value: number;
   block_height: number;
   block_hash: string;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - private balance shouldn't be duplicated between account syncs when private transfers are made

### 📝 Description

This PR fixes a bug with duplicated private balance in Aleo account.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-27594

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
