### PR TITLE
[LWD] feat(desktop): add history page skeleton with operations list

### DIFF
--- a/.changeset/six-kangaroos-grab.md
+++ b/.changeset/six-kangaroos-grab.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Implement Transaction History Page Skeleton with PageHeader

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
@@ -4,7 +4,15 @@
  * - RightPanel (swap sidebar)
  * - Wallet40Layout with pt-32 spacing
  */
-const WALLET_40_PAGES = new Set(["/", "/market", "/analytics", "/cryptos", "/earn", "/perps"]);
+const WALLET_40_PAGES = new Set([
+  "/",
+  "/market",
+  "/analytics",
+  "/cryptos",
+  "/earn",
+  "/perps",
+  "/history",
+]);
 
 const WALLET_40_PREFIXES = ["/card", "/swap", "/exchange"];
 

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import PageHeader from "LLD/components/PageHeader";
+import { useTranslation } from "react-i18next";
+
+export default function HistoryPageHeader({ onBack }: { readonly onBack: () => void }) {
+  const { t } = useTranslation();
+
+  return <PageHeader title={t("history.title")} onBack={onBack} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/index.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import HistoryPageHeader from "./components/HistoryPageHeader";
+import useHistoryViewModel, { HistoryViewModel } from "./useHistoryViewModel";
+import { OperationsList } from "~/renderer/components/OperationsList";
+
+export default function History() {
+  const viewModel = useHistoryViewModel();
+  return <HistoryView viewModel={viewModel} />;
+}
+
+function HistoryView({ viewModel }: { readonly viewModel: HistoryViewModel }) {
+  const { navigateToDashboard, accounts, filterOperations, t } = viewModel;
+  return (
+    <div className="flex flex-col gap-32">
+      <TrackPage category="History" />
+      <HistoryPageHeader onBack={navigateToDashboard} />
+      <OperationsList
+        accounts={accounts}
+        title={t("dashboard.recentActivity")}
+        withAccount
+        withSubAccounts
+        filterOperation={filterOperations}
+        t={t}
+        isWallet40
+      />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/useHistoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/useHistoryViewModel.ts
@@ -1,0 +1,54 @@
+import { useNavigate } from "react-router";
+import { useCallback } from "react";
+import { useSelector } from "LLD/hooks/redux";
+import { useTranslation } from "react-i18next";
+import { AccountLike, Operation } from "@ledgerhq/types-live";
+import { TFunction } from "i18next";
+import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/operation";
+import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
+import { useFilterTokenOperationsZeroAmount } from "~/renderer/actions/settings";
+import { accountsSelector } from "~/renderer/reducers/accounts";
+
+export type HistoryViewModel = {
+  navigateToDashboard: () => void;
+  accounts: AccountLike[];
+  filterOperations: (operation: Operation, account: AccountLike) => boolean;
+  t: TFunction;
+};
+
+export default function useHistoryViewModel(): HistoryViewModel {
+  // NB: This is the same logic as in the PortfolioViewModel & it will be reworked in next iterations
+  // Same for tests
+  const [shouldFilterTokenOpsZeroAmount] = useFilterTokenOperationsZeroAmount();
+  const addressPoisoningFamilies = useAddressPoisoningOperationsFamilies({
+    shouldFilter: shouldFilterTokenOpsZeroAmount,
+  });
+
+  const filterOperations = useCallback(
+    (operation: Operation, account: AccountLike) => {
+      const isOperationPoisoned = isAddressPoisoningOperation(
+        operation,
+        account,
+        addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
+      );
+
+      const shouldFilterOperation = !(shouldFilterTokenOpsZeroAmount && isOperationPoisoned);
+
+      return shouldFilterOperation;
+    },
+    [shouldFilterTokenOpsZeroAmount, addressPoisoningFamilies],
+  );
+  const navigate = useNavigate();
+  const accounts = useSelector(accountsSelector);
+  const { t } = useTranslation();
+
+  const navigateToDashboard = useCallback(() => {
+    navigate("/");
+  }, [navigate]);
+  return {
+    navigateToDashboard,
+    accounts,
+    filterOperations,
+    t,
+  };
+}

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -105,6 +105,7 @@ const Account = lazy(() => import("~/renderer/screens/account"));
 const Analytics = lazy(() => import("LLD/features/Analytics"));
 const Cryptos = lazy(() => import("LLD/features/Cryptos"));
 const CardW40 = lazy(() => import("LLD/features/Card"));
+const History = lazy(() => import("LLD/features/History"));
 
 const LoaderWrapper = styled.div`
   padding: 24px;
@@ -270,6 +271,7 @@ const MainAppContent = ({
         />
         <Route path="/bank/*" element={withSuspense(Bank)({})} />
         <Route path="/analytics" element={withSuspense(Analytics)({})} />
+        <Route path="/history" element={withSuspense(History)({})} />
       </Routes>
     </Page>
     <Drawer />

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8394,5 +8394,8 @@
       "continue": "Continue",
       "explore": "Explore my new portfolio"
     }
+  },
+  "history": {
+    "title": "Transaction"
   }
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _testing will be done in the next iteration_
- [x] **Impact of the changes:**
      - history page rendering and navigation
      - operations list display with filtering (address poisoning, zero-amount tokens)
      - routing and page layout registration

### 📝 Description

this PR introduces a new dedicated history page to the desktop app, extracting the operations list from the portfolio into its own route.

the page includes:
- a `HistoryPageHeader` with back navigation to the dashboard
- the full `OperationsList` with account and sub-account support
- address poisoning and zero-amount token operation filtering
- route registration at `/history` with wallet 4.0 layout support
- i18n entry for the page title

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26179](https://ledgerhq.atlassian.net/browse/LIVE-26179)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26179]: https://ledgerhq.atlassian.net/browse/LIVE-26179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ