### PR TITLE
chore: add domain shared packages to platform CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,6 +33,7 @@ apps/ledger-live-desktop/tools/                          @ledgerhq/platform
 apps/ledger-live-desktop/scripts/                        @ledgerhq/platform
 # Platform — domain
 domain/entity/crypto-asset                               @ledgerhq/platform
+domain/api/crypto-assets                                 @ledgerhq/platform
 # Platform — shared 
 shared/feature-flags                                     @ledgerhq/platform
 # Platform — mobile


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _No changeset needed — CODEOWNERS only, no package changes._
- [x] **Covered by automatic tests.** _N/A — no code changes, only CODEOWNERS ownership rules._
- [x] **Impact of the changes:**
  - CODEOWNERS review assignment for `domain/api/crypto-assets`
  - No runtime impact — this change only affects GitHub code review routing

### 📝 Description

The `domain/api/crypto-assets` package was missing from the CODEOWNERS file, meaning PRs touching this path did not automatically request review from the `@ledgerhq/platform` team.

This PR adds the missing CODEOWNERS entry so that changes to `domain/api/crypto-assets` are automatically assigned to the `@ledgerhq/platform` team for review, consistent with the existing `domain/entity/crypto-asset` ownership.

### ❓ Context

- **JIRA or GitHub link**: N/A — housekeeping task

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)