### PR TITLE
[LWDM] chore(libs): tighten tsconfig.build `types` to minimal explicit sets

### DIFF
--- a/libs/coin-modules/coin-aleo/tsconfig.build.json
+++ b/libs/coin-modules/coin-aleo/tsconfig.build.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
-      "node",
-      "jest"
+      "node"
     ]
   },
   "exclude": [

--- a/libs/coin-modules/coin-aptos/tsconfig.build.json
+++ b/libs/coin-modules/coin-aptos/tsconfig.build.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
-      "node",
-      "jest"
+      "node"
     ]
   },
   "exclude": [

--- a/libs/coin-modules/coin-canton/tsconfig.build.json
+++ b/libs/coin-modules/coin-canton/tsconfig.build.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
-      "node",
-      "jest"
+      "node"
     ]
   },
   "exclude": [

--- a/libs/coin-modules/coin-casper/tsconfig.build.json
+++ b/libs/coin-modules/coin-casper/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": ["node"]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-modules/coin-celo/tsconfig.build.json
+++ b/libs/coin-modules/coin-celo/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-modules/coin-cosmos/tsconfig.build.json
+++ b/libs/coin-modules/coin-cosmos/tsconfig.build.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
-      "node",
-      "jest"
+      "node"
     ]
   },
   "exclude": [

--- a/libs/coin-modules/coin-evm/tsconfig.build.json
+++ b/libs/coin-modules/coin-evm/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": ["node"]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-modules/coin-hedera/tsconfig.build.json
+++ b/libs/coin-modules/coin-hedera/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": ["node"]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-modules/coin-icon/tsconfig.build.json
+++ b/libs/coin-modules/coin-icon/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-modules/coin-internet_computer/tsconfig.build.json
+++ b/libs/coin-modules/coin-internet_computer/tsconfig.build.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
-      "node",
-      "jest"
+      "node"
     ]
   },
   "exclude": [

--- a/libs/coin-modules/coin-kaspa/tsconfig.build.json
+++ b/libs/coin-modules/coin-kaspa/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-modules/coin-module-boilerplate/tsconfig.build.json
+++ b/libs/coin-modules/coin-module-boilerplate/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-modules/coin-polkadot/tsconfig.build.json
+++ b/libs/coin-modules/coin-polkadot/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-modules/coin-stacks/tsconfig.build.json
+++ b/libs/coin-modules/coin-stacks/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-modules/coin-stellar/tsconfig.build.json
+++ b/libs/coin-modules/coin-stellar/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-modules/coin-sui/tsconfig.build.json
+++ b/libs/coin-modules/coin-sui/tsconfig.build.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
-      "node",
-      "jest"
+      "node"
     ]
   },
   "exclude": [

--- a/libs/coin-modules/coin-tezos/tsconfig.build.json
+++ b/libs/coin-modules/coin-tezos/tsconfig.build.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
-      "node",
-      "jest"
+      "node"
     ]
   },
   "exclude": [

--- a/libs/coin-modules/coin-ton/tsconfig.build.json
+++ b/libs/coin-modules/coin-ton/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-modules/coin-tron/tsconfig.build.json
+++ b/libs/coin-modules/coin-tron/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": ["node"]
   },
   "exclude": [
     "src/api/subscan.ts",

--- a/libs/coin-modules/coin-xrp/tsconfig.build.json
+++ b/libs/coin-modules/coin-xrp/tsconfig.build.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
-      "node",
-      "jest"
+      "node"
     ]
   },
   "exclude": [

--- a/libs/coin-modules/zcash-shielded/tsconfig.build.json
+++ b/libs/coin-modules/zcash-shielded/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node",
-      "jest"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/coin-tester-modules/coin-tester-bitcoin/tsconfig.build.json
+++ b/libs/coin-tester-modules/coin-tester-bitcoin/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
+      "node",
       "jest"
     ]
   },

--- a/libs/coin-tester-modules/coin-tester-evm/tsconfig.build.json
+++ b/libs/coin-tester-modules/coin-tester-evm/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
+      "node",
       "jest"
     ]
   },

--- a/libs/coin-tester-modules/coin-tester-polkadot/tsconfig.build.json
+++ b/libs/coin-tester-modules/coin-tester-polkadot/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
+      "node",
       "jest"
     ]
   },

--- a/libs/coin-tester-modules/coin-tester-solana/tsconfig.build.json
+++ b/libs/coin-tester-modules/coin-tester-solana/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
+      "node",
       "jest"
     ]
   },

--- a/libs/disable-network-setup/tsconfig.build.json
+++ b/libs/disable-network-setup/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "customConditions": [],
     "types": [
+      "node",
       "jest"
     ]
   },

--- a/libs/evm-tools/tsconfig.build.json
+++ b/libs/evm-tools/tsconfig.build.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledger-key-ring-protocol/tsconfig.build.json
+++ b/libs/ledger-key-ring-protocol/tsconfig.build.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "rootDir": "src",
     "customConditions": [],
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-btc/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-btc/tsconfig.build.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-celo/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-celo/tsconfig.build.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-helium/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-helium/tsconfig.build.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-multiversx/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-multiversx/tsconfig.build.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node"
-    ]
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-near/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-near/tsconfig.build.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-polkadot/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-polkadot/tsconfig.build.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "customConditions": [],
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-solana/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-solana/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-str/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-str/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-sui/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-sui/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-tezos/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-tezos/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-trx/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-trx/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-vet/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-vet/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-app-xrp/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-app-xrp/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-bolos/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-bolos/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport-http/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport-http/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport-mocker/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport-mocker/tsconfig.build.json
@@ -1,7 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node",
+      "jest"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport-node-hid-noevents/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-noevents/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": ["node"]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": ["node"]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport-node-hid/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": ["node"]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport-node-speculos-http/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos-http/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport-node-speculos/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport-vault/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport-vault/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport-web-ble/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport-web-ble/tsconfig.build.json
@@ -1,7 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node",
+      "web-bluetooth"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport-webhid/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport-webhid/tsconfig.build.json
@@ -1,7 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node",
+      "w3c-web-hid"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport-webusb/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport-webusb/tsconfig.build.json
@@ -1,7 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node",
+      "w3c-web-usb"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/hw-transport/tsconfig.build.json
+++ b/libs/ledgerjs/packages/hw-transport/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/logs/tsconfig.build.json
+++ b/libs/ledgerjs/packages/logs/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/react-native-hid/tsconfig.build.json
+++ b/libs/ledgerjs/packages/react-native-hid/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/tsconfig.build.json
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/swift-bridge-hw-app-eth/tsconfig.build.json
+++ b/libs/ledgerjs/packages/swift-bridge-hw-app-eth/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/swift-bridge-hw-app-solana/tsconfig.build.json
+++ b/libs/ledgerjs/packages/swift-bridge-hw-app-solana/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/swift-bridge-hw-transport-ble/tsconfig.build.json
+++ b/libs/ledgerjs/packages/swift-bridge-hw-transport-ble/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/types-cryptoassets/tsconfig.build.json
+++ b/libs/ledgerjs/packages/types-cryptoassets/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/types-devices/tsconfig.build.json
+++ b/libs/ledgerjs/packages/types-devices/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ledgerjs/packages/types-live/tsconfig.build.json
+++ b/libs/ledgerjs/packages/types-live/tsconfig.build.json
@@ -1,7 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node",
+      "react"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/live-config/tsconfig.build.json
+++ b/libs/live-config/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/live-countervalues/tsconfig.build.json
+++ b/libs/live-countervalues/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/live-network/tsconfig.build.json
+++ b/libs/live-network/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/live-signer-aleo/tsconfig.build.json
+++ b/libs/live-signer-aleo/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/live-signer-canton/tsconfig.build.json
+++ b/libs/live-signer-canton/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/live-signer-evm/tsconfig.build.json
+++ b/libs/live-signer-evm/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/live-signer-hyperliquid/tsconfig.build.json
+++ b/libs/live-signer-hyperliquid/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/live-signer-solana/tsconfig.build.json
+++ b/libs/live-signer-solana/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/promise/tsconfig.build.json
+++ b/libs/promise/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/psbtv2/tsconfig.build.json
+++ b/libs/psbtv2/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/test-utils/tsconfig.build.json
+++ b/libs/test-utils/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",

--- a/libs/ui/packages/icons/tsconfig.build.json
+++ b/libs/ui/packages/icons/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "node_modules",

--- a/libs/ui/packages/shared/tsconfig.build.json
+++ b/libs/ui/packages/shared/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "node_modules",

--- a/libs/wallet-api-acre-module/tsconfig.build.json
+++ b/libs/wallet-api-acre-module/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "customConditions": []
+    "customConditions": [],
+    "types": []
   },
   "exclude": [
     "**/*.test.ts",


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Remove jest and/or @types/node injection where package builds still pass; keep stricter explicit `types` (including `[]`) per verified `pnpm build`.

By making this stricter, we secure the libraries to even less accidentally start depending on types they shouldn't. It also was sometimes necessary for tsgo experimental support.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
