### PR TITLE
[LWD] fix(desktop): register perps custom handlers in PerpsWebView

### DIFF
--- a/.changeset/warm-buses-trade.md
+++ b/.changeset/warm-buses-trade.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix perps custom wallet-api handlers missing in PerpsWebView on desktop

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsWebView/PerpsWebView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsWebView/PerpsWebView.tsx
@@ -12,6 +12,9 @@ import { PerpsLoader } from "LLD/features/Perps/components/PerpsLoader";
 import type { PerpsWebviewInputs } from "../PerpsApp/usePerpsAppViewModel";
 import { useDeeplinkCustomHandlers } from "~/renderer/components/WebPlatformPlayer/CustomHandlers";
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
+import { usePerpsHandlers } from "LLD/features/Perps/hooks/usePerpsHandlers";
+import { useSelector } from "LLD/hooks/redux";
+import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
 
 export type PerpsWebProps = {
   manifest: LiveAppManifest;
@@ -32,12 +35,15 @@ export const PerpsWebView = ({
   enablePlatformDevTools,
   Loader = PerpsLoader,
 }: PerpsWebProps) => {
+  const accounts = useSelector(flattenAccountsSelector);
   const customDeeplinkHandlers = useDeeplinkCustomHandlers();
+  const customPerpsHandlers = usePerpsHandlers(accounts);
   const customHandlers = useMemo<WalletAPICustomHandlers>(() => {
     return {
       ...customDeeplinkHandlers,
+      ...customPerpsHandlers,
     };
-  }, [customDeeplinkHandlers]);
+  }, [customDeeplinkHandlers, customPerpsHandlers]);
   return (
     <>
       {enablePlatformDevTools && (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing unit tests for the perps handlers (`server.test.ts`) cover the handler logic itself. The missing wiring in PerpsWebView is a component integration issue best verified via manual QA._
- [x] **Impact of the changes:**
  - Perps feature on desktop when accessed via STG/remote manifest
  - `custom.perps.signActions` wallet-api method availability
  - No impact on local manifest path (WebPlatformPlayer already had the handlers)

### 📝 Description

**Problem**: The `custom.perps.signActions` wallet-api handler returned "method not found" when the Perps app was loaded via the STG/remote manifest on desktop. However, the same handler worked correctly when using a local manifest.

**Root cause**: Two different code paths render the Perps webview:
- **Local manifest** → routes through `WebPlatformPlayer`, which correctly includes `customPerpsHandlers` in its custom handlers.
- **STG/remote manifest** → routes through `PerpsApp` → `PerpsWebView`, which was **missing** the `usePerpsHandlers` hook entirely — only `customDeeplinkHandlers` were wired up.

**Fix**: Added `usePerpsHandlers` to the desktop `PerpsWebView.tsx`, matching the mobile `PerpsWebView` implementation and the existing `WebPlatformPlayer`/`WebPTXPlayer` patterns.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28036](https://ledgerhq.atlassian.net/browse/LIVE-28036)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-28036]: https://ledgerhq.atlassian.net/browse/LIVE-28036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ