### PR TITLE
[LWM] fix(mobile): do not set read only mode on post welcome selection screen

### DIFF
--- a/.changeset/empty-toys-repair.md
+++ b/.changeset/empty-toys-repair.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix(mobile): do not set read only mode in post welcome selection

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/postWelcomeSelection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/postWelcomeSelection.tsx
@@ -5,7 +5,7 @@ import { Linking } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { useDispatch } from "~/context/hooks";
 import { useTheme } from "styled-components/native";
-import { setOnboardingHasDevice, setReadOnlyMode } from "~/actions/settings";
+import { setOnboardingHasDevice } from "~/actions/settings";
 import { track, updateIdentify } from "~/analytics";
 import { OnboardingNavigatorParamList } from "~/components/RootNavigator/types/OnboardingNavigator";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
@@ -64,18 +64,15 @@ function PostWelcomeSelection() {
   useFocusEffect(() => {
     if (!modalOpen) {
       identifyUser(null);
-      dispatch(setReadOnlyMode(true));
     }
   });
 
   const setupLedger = () => {
-    dispatch(setReadOnlyMode(false));
     identifyUser(null);
     navigation.navigate(ScreenName.OnboardingDeviceSelection);
   };
 
   const accessExistingWallet = () => {
-    dispatch(setReadOnlyMode(false));
     identifyUser(null);
     navigation.navigate(ScreenName.OnboardingWelcomeBack);
   };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
  - The removed code was not covered by unit tests. Existing analytics tests for `readOnlyMode` tracking remain valid and are unaffected.
- [x] **Impact of the changes:**
  - `readOnlyMode` state is no longer prematurely toggled during onboarding, so analytics events emitted from this screen and subsequent screens will carry the correct `readOnlyMode` value.
  - QA should focus on: onboarding flows ("Setup your Ledger" and "Access an existing wallet" paths), ensuring `readOnlyMode` is only set at the appropriate later stages (e.g. when selecting "Explore without a device" or upon device connection).

### 📝 Description

**Problem:**
A PM discovered that `readOnlyMode` analytics tracking was reporting incorrect values during onboarding. Investigation revealed that the `PostWelcomeSelection` screen was incorrectly managing the `readOnlyMode` Redux state:

1. **On screen focus**, `readOnlyMode` was set to `true` — but at this point in the flow the user has not yet made a choice that determines read-only mode. This caused any analytics event fired on or after this screen to incorrectly report `readOnlyMode: true`.
2. **On "Setup your Ledger" / "Access an existing wallet" tap**, `readOnlyMode` was immediately set to `false` — but neither of these actions is the correct point to determine read-only mode. The user hasn't connected a device or completed onboarding yet.

This premature state toggling meant `readOnlyMode` was being flipped `true → false` on every visit to this screen, polluting analytics data and leaving the state in a potentially incorrect value for downstream screens.

**Solution:**
Remove all three `setReadOnlyMode` dispatches from `PostWelcomeSelection`. The `readOnlyMode` state is correctly set at the appropriate downstream points in the onboarding flow:

- **Set to `true`**: when the user explicitly chooses "Explore without a device" (`discoverLiveInfo.tsx`), purchases a device (`PurchaseDevice/index.tsx`), or enters the Reborn flow (`useAnalyticsOptInPromptLogic.ts`).
- **Set to `false`**: when a device is actually connected (`ConnectDevice.tsx`, `SelectDevice2`, `SyncOnboardingCompanion`), or when Wallet Sync activation completes.

By removing the premature state changes, `readOnlyMode` retains its previous correct value until a meaningful user action explicitly sets it.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28018]
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28018]: https://ledgerhq.atlassian.net/browse/LIVE-28018