### PR TITLE
[LWDM] fix(coin-bitcoin): skip coinbase inputs without output_hash in op dedup

### DIFF
--- a/.changeset/real-turtles-guess.md
+++ b/.changeset/real-turtles-guess.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-bitcoin": minor
+---
+
+fix(coin-bitcoin): skip coinbase inputs without output_hash in op dedup

--- a/libs/coin-modules/coin-bitcoin/src/logic.ts
+++ b/libs/coin-modules/coin-bitcoin/src/logic.ts
@@ -217,7 +217,9 @@ export const mapTxToOperations = (
   const inputs = new Set<`${string}-${number}`>(); // txid-outputIndex
 
   for (const input of tx.inputs) {
-    inputs.add(`${input.output_hash}-${input.output_index}`);
+    if (input.output_hash) {
+      inputs.add(`${input.output_hash}-${input.output_index}`);
+    }
     if (input.address) {
       senders.add(syncReplaceAddress ? syncReplaceAddress(input.address) : input.address);
 

--- a/libs/coin-modules/coin-bitcoin/src/logic.unit.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/logic.unit.test.ts
@@ -106,6 +106,85 @@ describe("mapTxToOperations", () => {
     expect(ops[0]?.transactionSequenceNumber).toEqual(new BigNumber(0)); // important: not undefined
   });
 
+  it("should not include coinbase inputs (missing output_hash) in extra.inputs", () => {
+    const ops = mapTxToOperations(
+      {
+        id: "coinbaseTx1",
+        outputs: [
+          {
+            address: " ",
+            value: 0,
+            output_index: 0,
+          },
+          {
+            address: "myAddress",
+            value: 27122076730,
+            output_index: 1,
+          },
+        ],
+        inputs: [
+          {
+            input_index: 0,
+            sequence: 0,
+          },
+        ],
+        received_at: new Date().toISOString(),
+        block: { height: 100, hash: "blockhash", time: new Date().toISOString() },
+      } as unknown as TX,
+      "digibyte",
+      "accountId",
+      new Set(["myAddress"]),
+      new Set(),
+    );
+
+    expect(ops.length).toEqual(1);
+    expect(ops[0]?.type).toBe("IN");
+    expect(ops[0]?.extra.inputs).toEqual([]);
+  });
+
+  it("should keep all coinbase transactions when processed through mapTxToOperations", () => {
+    const makeCoinbaseTx = (id: string, blockHeight: number, value: number) =>
+      ({
+        id,
+        outputs: [
+          { address: " ", value: 0, output_index: 0 },
+          { address: "minerAddress", value, output_index: 1 },
+        ],
+        inputs: [{ input_index: 0, sequence: 0 }],
+        received_at: new Date().toISOString(),
+        block: { height: blockHeight, hash: `hash${blockHeight}`, time: new Date().toISOString() },
+      }) as unknown as TX;
+
+    const accountAddresses = new Set(["minerAddress"]);
+    const changeAddresses = new Set<string>();
+
+    const ops1 = mapTxToOperations(
+      makeCoinbaseTx("cb1", 100, 27100000000),
+      "digibyte",
+      "accountId",
+      accountAddresses,
+      changeAddresses,
+    );
+    const ops2 = mapTxToOperations(
+      makeCoinbaseTx("cb2", 101, 27200000000),
+      "digibyte",
+      "accountId",
+      accountAddresses,
+      changeAddresses,
+    );
+    const ops3 = mapTxToOperations(
+      makeCoinbaseTx("cb3", 102, 27300000000),
+      "digibyte",
+      "accountId",
+      accountAddresses,
+      changeAddresses,
+    );
+
+    const allOps = [...ops1, ...ops2, ...ops3];
+    expect(allOps.length).toEqual(3);
+    expect(allOps.every(op => op?.extra?.inputs?.length === 0)).toBe(true);
+  });
+
   it("should set transactionSequenceNumber to undefined when sequence is missing", () => {
     const ops = mapTxToOperations(
       {

--- a/libs/coin-modules/coin-bitcoin/src/synchronisation.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/synchronisation.test.ts
@@ -407,6 +407,38 @@ describe("removeReplaced", () => {
     expect(result).toEqual([tx2, tx3, tx4]); // ✅ tx1 is removed, but order remains
   });
 
+  it("should keep all coinbase mining transactions with empty inputs (DigiByte mining scenario)", () => {
+    const coinbaseTx1: BtcOperation = {
+      ...baseTx,
+      id: "cb1-IN",
+      hash: "cb1",
+      blockHeight: 23107323,
+      date: new Date("2026-03-09T04:22:22Z"),
+      extra: { inputs: [] },
+    };
+
+    const coinbaseTx2: BtcOperation = {
+      ...baseTx,
+      id: "cb2-IN",
+      hash: "cb2",
+      blockHeight: 23122260,
+      date: new Date("2026-03-11T18:30:23Z"),
+      extra: { inputs: [] },
+    };
+
+    const coinbaseTx3: BtcOperation = {
+      ...baseTx,
+      id: "cb3-IN",
+      hash: "cb3",
+      blockHeight: 23124700,
+      date: new Date("2026-03-12T04:42:34Z"),
+      extra: { inputs: [] },
+    };
+
+    const result = removeReplaced([coinbaseTx1, coinbaseTx2, coinbaseTx3]);
+    expect(result).toEqual([coinbaseTx1, coinbaseTx2, coinbaseTx3]);
+  });
+
   it("should retain only the most confirmed+recent tx among several using same input", () => {
     const tx1 = {
       ...baseTx,

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.storage.unit.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/wallet.storage.unit.test.ts
@@ -1,4 +1,5 @@
 import BitcoinLikeStorage from "../storage";
+import type { Input } from "../storage/types";
 
 describe("Unit tests for bitcoin storage", () => {
   let storage: BitcoinLikeStorage;
@@ -553,6 +554,50 @@ describe("Unit tests for bitcoin storage", () => {
     const utxos = storage.getAddressUnspentUtxos({ address: "race-address", account: 0, index: 0 });
     expect(utxos).toHaveLength(1);
     expect(utxos[0].output_hash).toEqual("tx-race");
+  });
+
+  it("[utxos] should not create a bogus spent bucket for coinbase inputs missing output_hash", () => {
+    const minerAddress = "miner-address";
+    // Coinbase-like input from explorer: no address / output_hash; value/output_index may still be present for typing.
+    const coinbaseLikeInput: Input = {
+      value: "0",
+      output_index: 0,
+      sequence: 0,
+    };
+    storage.appendTxs([
+      {
+        id: "coinbase-tx",
+        inputs: [coinbaseLikeInput],
+        outputs: [
+          {
+            output_index: 0,
+            value: "0",
+            address: " ",
+            output_hash: "coinbase-tx",
+            block_height: 300,
+            rbf: false,
+          },
+          {
+            output_index: 1,
+            value: "27100000000",
+            address: minerAddress,
+            output_hash: "coinbase-tx",
+            block_height: 300,
+            rbf: false,
+          },
+        ],
+        block: { hash: "block-300", height: 300, time: new Date().toISOString() },
+        account: 0,
+        index: 0,
+        address: minerAddress,
+        received_at: new Date().toISOString(),
+      },
+    ]);
+
+    // The reward UTXO must be unspent
+    const utxos = storage.getAddressUnspentUtxos({ address: minerAddress, account: 0, index: 0 });
+    expect(utxos).toHaveLength(1);
+    expect(utxos[0].value).toBe("27100000000");
   });
 
   it("[utxos] should mark UTXOs as spent when spending from multiple addresses", () => {

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/storage/index.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/storage/index.ts
@@ -135,6 +135,7 @@ class BitcoinLikeStorage implements IStorage {
       });
 
       tx.inputs.forEach(input => {
+        if (!input.address || !input.output_hash) return;
         const inputAddress = input.address;
 
         // Initialize arrays if needed

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/storage/types.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/storage/types.ts
@@ -13,8 +13,8 @@ export interface TX {
 
 export interface Input {
   value: string;
-  address: string;
-  output_hash: string;
+  address?: string;
+  output_hash?: string;
   output_index: number;
   sequence: number;
   block_height?: number | null;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Accounts with several mining (coinbase) payouts could show one tx and a wrong balance because missing `output_hash` on those inputs made every coinbase look like the same spent UTXO, so removeReplaced drop the other

Fix: only put real UTXO refs in `extra.inputs` (require `output_hash`) and skip coinbase inputs in storage spend tracking so all rewards stay visible and the balance match explorer

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/BACK-10970) (https://ledgerhq.atlassian.net/browse/LIVE-28305)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
