### PR TITLE
[LWM] feat(mobile): gate top bar transaction history on operationsList flag

### DIFF
--- a/.changeset/yellow-lamps-type.md
+++ b/.changeset/yellow-lamps-type.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Change the lwm4.0 top bar display depending on operationsList feature flag

--- a/apps/ledger-live-mobile/src/mvvm/components/CustomTopBar/CustomTopBar.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/CustomTopBar/CustomTopBar.test.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Text } from "react-native";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { Stax } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { renderWithReactQuery } from "@tests/test-renderer";
 import { State } from "~/reducers/types";
-import { CustomTopBar, TopBarActionIcon } from "./index";
+import { CustomTopBar, TopBarActionIcon, useMyLedgerTopBarAction } from "./index";
 
 jest.mock("@ledgerhq/lumen-ui-rnative/symbols", () => {
   const makeIcon = (testID: string) => () => <Text testID={testID}>{testID}</Text>;
@@ -42,13 +42,30 @@ const withLastConnectedDevice =
     },
   });
 
+const emptyTrailing: readonly TopBarActionIcon[] = [];
+
+function TopBarHarness({
+  trailingIcons,
+  extraLeadingIcons = emptyTrailing,
+}: Readonly<{
+  trailingIcons: readonly TopBarActionIcon[];
+  extraLeadingIcons?: readonly TopBarActionIcon[];
+}>) {
+  const myLedgerAction = useMyLedgerTopBarAction(mockOnMyLedgerPress);
+  const leadingIcons = useMemo(
+    () => [myLedgerAction, ...extraLeadingIcons],
+    [extraLeadingIcons, myLedgerAction],
+  );
+  return <CustomTopBar leadingIcons={leadingIcons} trailingIcons={trailingIcons} />;
+}
+
 describe("CustomTopBar", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("should call expected callbacks when myLedger and custom action buttons are pressed", async () => {
-    const customIcons: readonly TopBarActionIcon[] = [
+  it("should call expected callbacks when myLedger and trailing action buttons are pressed", async () => {
+    const trailingIcons: readonly TopBarActionIcon[] = [
       {
         id: "custom-settings",
         icon: CustomIcon,
@@ -59,7 +76,7 @@ describe("CustomTopBar", () => {
     ];
 
     const { user, getByTestId } = renderWithReactQuery(
-      <CustomTopBar onMyLedgerPress={mockOnMyLedgerPress} customIcons={customIcons} />,
+      <TopBarHarness trailingIcons={trailingIcons} />,
       {
         overrideInitialState: withLastConnectedDevice(DeviceModelId.stax),
       },
@@ -72,9 +89,9 @@ describe("CustomTopBar", () => {
     expect(mockOnCustomActionPress).toHaveBeenCalledTimes(1);
   });
 
-  it("should render only my ledger button when no custom icons are provided", async () => {
+  it("should render only my ledger button when no trailing icons are provided", async () => {
     const { user, getByTestId, queryByTestId } = renderWithReactQuery(
-      <CustomTopBar onMyLedgerPress={mockOnMyLedgerPress} customIcons={[]} />,
+      <TopBarHarness trailingIcons={[]} />,
       {
         overrideInitialState: withLastConnectedDevice(DeviceModelId.stax),
       },
@@ -86,11 +103,35 @@ describe("CustomTopBar", () => {
     expect(queryByTestId("topbar-custom-settings")).toBeNull();
   });
 
-  it("should call the matching callback for each custom icon", async () => {
+  it("should render extra leading icons after my ledger", async () => {
+    const onLeadingPress = jest.fn();
+    const extraLeadingIcons: readonly TopBarActionIcon[] = [
+      {
+        id: "leading-discover",
+        icon: CustomIcon,
+        callback: onLeadingPress,
+        testID: "topbar-leading",
+        accessibilityLabel: "Discover",
+      },
+    ];
+
+    const { user, getByTestId } = renderWithReactQuery(
+      <TopBarHarness trailingIcons={[]} extraLeadingIcons={extraLeadingIcons} />,
+      {
+        overrideInitialState: withLastConnectedDevice(DeviceModelId.stax),
+      },
+    );
+
+    await user.press(getByTestId("topbar-leading"));
+
+    expect(onLeadingPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call the matching callback for each trailing icon", async () => {
     const onFirstPress = jest.fn();
     const onSecondPress = jest.fn();
 
-    const customIcons: readonly TopBarActionIcon[] = [
+    const trailingIcons: readonly TopBarActionIcon[] = [
       {
         id: "custom-first",
         icon: CustomIcon,
@@ -108,7 +149,7 @@ describe("CustomTopBar", () => {
     ];
 
     const { user, getByTestId } = renderWithReactQuery(
-      <CustomTopBar onMyLedgerPress={mockOnMyLedgerPress} customIcons={customIcons} />,
+      <TopBarHarness trailingIcons={trailingIcons} />,
       {
         overrideInitialState: withLastConnectedDevice(DeviceModelId.stax),
       },
@@ -129,20 +170,15 @@ describe("CustomTopBar", () => {
     [DeviceModelId.apex, "device-icon-apex"],
     [DeviceModelId.stax, "device-icon-stax"],
   ])("should render %s icon for model %s", (modelId, expectedIconTestId) => {
-    const { getByTestId } = renderWithReactQuery(
-      <CustomTopBar onMyLedgerPress={mockOnMyLedgerPress} customIcons={[]} />,
-      {
-        overrideInitialState: withLastConnectedDevice(modelId),
-      },
-    );
+    const { getByTestId } = renderWithReactQuery(<TopBarHarness trailingIcons={[]} />, {
+      overrideInitialState: withLastConnectedDevice(modelId),
+    });
 
     expect(getByTestId(expectedIconTestId)).toBeTruthy();
   });
 
   it("should fallback to stax icon when no device is connected", () => {
-    const { getByTestId } = renderWithReactQuery(
-      <CustomTopBar onMyLedgerPress={mockOnMyLedgerPress} customIcons={[]} />,
-    );
+    const { getByTestId } = renderWithReactQuery(<TopBarHarness trailingIcons={[]} />);
 
     expect(getByTestId("device-icon-stax")).toBeTruthy();
   });

--- a/apps/ledger-live-mobile/src/mvvm/components/CustomTopBar/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/CustomTopBar/index.tsx
@@ -1,45 +1,36 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { Box, IconButton } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
-import { lastConnectedDeviceSelector } from "~/reducers/settings";
-import { useSelector } from "~/context/hooks";
-import { getDeviceIcon, IconComponent } from "LLM/utils/getDeviceIcon";
+import type { TopBarActionIcon } from "./useMyLedgerTopBarAction";
 
-export type TopBarActionIcon = {
-  id: string;
-  icon: IconComponent;
-  callback: () => void;
-  testID: string;
-  accessibilityLabel: string;
-  loading?: boolean;
-};
+export type { TopBarActionIcon } from "./useMyLedgerTopBarAction";
+export { useMyLedgerTopBarAction } from "./useMyLedgerTopBarAction";
 
 type CustomTopBarProps = {
-  onMyLedgerPress: () => void;
-  customIcons: readonly TopBarActionIcon[];
+  leadingIcons: readonly TopBarActionIcon[];
+  trailingIcons: readonly TopBarActionIcon[];
 };
 
-export function CustomTopBar({ onMyLedgerPress, customIcons }: Readonly<CustomTopBarProps>) {
-  const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
-
-  const deviceIcon: IconComponent = useCallback(
-    ({ size, style }) => getDeviceIcon(lastConnectedDevice, size, style),
-    [lastConnectedDevice],
-  );
-
+export function CustomTopBar({ leadingIcons, trailingIcons }: Readonly<CustomTopBarProps>) {
   return (
     <Box lx={rowLx}>
-      <IconButton
-        onPress={onMyLedgerPress}
-        testID="topbar-myledger"
-        accessibilityLabel="My Ledger"
-        appearance="transparent"
-        icon={deviceIcon}
-        size="md"
-      />
+      <Box lx={iconsGroupLayout}>
+        {leadingIcons.map(item => (
+          <IconButton
+            key={item.id}
+            onPress={item.callback}
+            testID={item.testID}
+            accessibilityLabel={item.accessibilityLabel}
+            appearance="transparent"
+            icon={item.icon}
+            size="md"
+            loading={item.loading}
+          />
+        ))}
+      </Box>
 
-      <Box lx={rightGroupLx}>
-        {customIcons.map(item => (
+      <Box lx={iconsGroupLayout}>
+        {trailingIcons.map(item => (
           <IconButton
             key={item.id}
             onPress={item.callback}
@@ -63,7 +54,7 @@ const rowLx: LumenViewStyle = {
   justifyContent: "space-between",
 };
 
-const rightGroupLx: LumenViewStyle = {
+const iconsGroupLayout: LumenViewStyle = {
   flexDirection: "row",
   alignItems: "center",
   gap: "s8",

--- a/apps/ledger-live-mobile/src/mvvm/components/CustomTopBar/useMyLedgerTopBarAction.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/CustomTopBar/useMyLedgerTopBarAction.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+import { lastConnectedDeviceSelector } from "~/reducers/settings";
+import { useSelector } from "~/context/hooks";
+import { getDeviceIcon, type IconComponent } from "LLM/utils/getDeviceIcon";
+
+export type TopBarActionIcon = {
+  id: string;
+  icon: IconComponent;
+  callback: () => void;
+  testID: string;
+  accessibilityLabel: string;
+  loading?: boolean;
+};
+
+export function useMyLedgerTopBarAction(onPress: () => void): TopBarActionIcon {
+  const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+
+  const deviceIcon: IconComponent = useCallback(
+    ({ size, style }) => getDeviceIcon(lastConnectedDevice, size, style),
+    [lastConnectedDevice],
+  );
+
+  return {
+    id: "my-ledger",
+    icon: deviceIcon,
+    callback: onPress,
+    testID: "topbar-myledger",
+    accessibilityLabel: "My Ledger",
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
@@ -1,37 +1,35 @@
-import React, { useCallback, useMemo } from "react";
-import { IconButton } from "@ledgerhq/lumen-ui-rnative";
+import React, { useCallback } from "react";
+import type { IconButtonProps } from "@ledgerhq/lumen-ui-rnative";
 import {
   Compass,
   Bell,
   BellNotification,
   Settings,
   Warning,
+  Clock,
 } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { CustomTopBar, TopBarActionIcon } from "LLM/components/CustomTopBar";
+import {
+  CustomTopBar,
+  TopBarActionIcon,
+  useMyLedgerTopBarAction,
+} from "LLM/components/CustomTopBar";
 import { ICON_SIZE } from "LLM/components/TopBar/const";
 import { SyncErrorBottomSheet } from "../components/SyncErrorBottomSheet";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { useTopBarViewModel } from "../useTopBarViewModel";
 
-type TopBarViewProps = {
-  onMyLedgerPress: () => void;
-  onDiscoverPress: () => void;
-  onNotificationsPress: () => void;
-  onSettingsPress: () => void;
-  hasUnreadNotifications: boolean;
-  hasAccounts: boolean;
-  isSyncError: boolean;
-  isSyncPending: boolean;
-  listOfErrorAccountNames: string;
-  syncAccessibilityLabel: string;
-  isSyncDrawerOpen: boolean;
-  openSyncDrawer: () => void;
-  closeSyncDrawer: () => void;
-};
+const syncIcon: IconButtonProps["icon"] = ({ size, style }) => (
+  <Warning size={size ?? ICON_SIZE} style={style} color="base" />
+);
+
+type TopBarViewProps = ReturnType<typeof useTopBarViewModel>;
 
 export function TopBarView({
   onMyLedgerPress,
   onDiscoverPress,
   onNotificationsPress,
   onSettingsPress,
+  onTransactionHistoryPress,
   hasUnreadNotifications,
   hasAccounts,
   isSyncError,
@@ -42,9 +40,10 @@ export function TopBarView({
   openSyncDrawer,
   closeSyncDrawer,
 }: Readonly<TopBarViewProps>) {
-  const notificationIcon = useCallback<
-    NonNullable<React.ComponentProps<typeof IconButton>["icon"]>
-  >(
+  const { shouldDisplayOperationsList } = useWalletFeaturesConfig("mobile");
+  const myLedgerAction = useMyLedgerTopBarAction(onMyLedgerPress);
+
+  const notificationIcon = useCallback<IconButtonProps["icon"]>(
     ({ size, style }) => {
       const Icon = hasUnreadNotifications ? BellNotification : Bell;
       return <Icon size={size ?? ICON_SIZE} style={style} color="base" />;
@@ -52,68 +51,60 @@ export function TopBarView({
     [hasUnreadNotifications],
   );
 
-  const syncIcon = useCallback<NonNullable<React.ComponentProps<typeof IconButton>["icon"]>>(
-    ({ size, style }) => <Warning size={size ?? ICON_SIZE} style={style} color="base" />,
-    [],
-  );
+  const discoverIcon: TopBarActionIcon = {
+    id: "discover",
+    icon: Compass,
+    callback: onDiscoverPress,
+    testID: "topbar-discover",
+    accessibilityLabel: "Discover",
+  };
 
-  const baseIcons = useMemo<TopBarActionIcon[]>(
-    () => [
-      {
-        id: "discover",
-        icon: Compass,
-        callback: onDiscoverPress,
-        testID: "topbar-discover",
-        accessibilityLabel: "Discover",
-      },
-      {
-        id: "notifications",
-        icon: notificationIcon,
-        callback: onNotificationsPress,
-        testID: "topbar-notifications",
-        accessibilityLabel: "Notifications",
-      },
-      {
-        id: "settings",
-        icon: Settings,
-        callback: onSettingsPress,
-        testID: "topbar-settings",
-        accessibilityLabel: "Settings",
-      },
-    ],
-    [notificationIcon, onDiscoverPress, onNotificationsPress, onSettingsPress],
-  );
+  const notificationsIcon: TopBarActionIcon = {
+    id: "notifications",
+    icon: notificationIcon,
+    callback: onNotificationsPress,
+    testID: "topbar-notifications",
+    accessibilityLabel: "Notifications",
+  };
 
-  const customIcons = useMemo(() => {
-    const shouldShowSyncStatus = hasAccounts && isSyncError;
+  const transactionHistoryIcon: TopBarActionIcon = {
+    id: "transaction-history",
+    icon: Clock,
+    callback: onTransactionHistoryPress,
+    testID: "topbar-transaction-history",
+    accessibilityLabel: "Transaction History",
+  };
 
-    if (!shouldShowSyncStatus) {
-      return baseIcons;
-    }
+  const settingsIcon: TopBarActionIcon = {
+    id: "settings",
+    icon: Settings,
+    callback: onSettingsPress,
+    testID: "topbar-settings",
+    accessibilityLabel: "Settings",
+  };
 
-    const syncStatusIcon: TopBarActionIcon = {
-      id: "sync",
-      icon: syncIcon,
-      callback: openSyncDrawer,
-      testID: "topbar-sync",
-      accessibilityLabel: syncAccessibilityLabel,
-      loading: isSyncPending,
-    };
+  const syncStatusIcon: TopBarActionIcon = {
+    id: "sync",
+    icon: syncIcon,
+    callback: openSyncDrawer,
+    testID: "topbar-sync",
+    accessibilityLabel: syncAccessibilityLabel,
+    loading: isSyncPending,
+  };
 
-    return [syncStatusIcon, ...baseIcons];
-  }, [
-    hasAccounts,
-    isSyncError,
-    syncIcon,
-    openSyncDrawer,
-    syncAccessibilityLabel,
-    isSyncPending,
-    baseIcons,
-  ]);
+  const leadingIcons = shouldDisplayOperationsList
+    ? [myLedgerAction, discoverIcon]
+    : [myLedgerAction];
+
+  const baseIcons = shouldDisplayOperationsList
+    ? [notificationsIcon, transactionHistoryIcon, settingsIcon]
+    : [discoverIcon, notificationsIcon, settingsIcon];
+
+  const trailingIcons = hasAccounts && isSyncError ? [syncStatusIcon, ...baseIcons] : baseIcons;
 
   return (
     <>
-      <CustomTopBar onMyLedgerPress={onMyLedgerPress} customIcons={customIcons} />
+      <CustomTopBar leadingIcons={leadingIcons} trailingIcons={trailingIcons} />
 
       <SyncErrorBottomSheet
         isOpen={isSyncDrawerOpen}

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
@@ -94,6 +94,28 @@ describe("TopBar navigation", () => {
 
     expect(track).toHaveBeenCalledWith("menuentry_clicked", {
       button: "Settings",
+      page: ScreenName.Portfolio,
+    });
+  });
+
+  it("should navigate to operations list with expected params when transaction history button is pressed", async () => {
+    const { user, getByTestId } = renderWithReactQuery(<TopBar />, {
+      overrideInitialState: state => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          overriddenFeatureFlags: { lwmWallet40: { enabled: true, params: { operationsList: true } } },
+        },
+      }),
+    });
+
+    await user.press(getByTestId("topbar-transaction-history"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.PortfolioOperationHistory);
+
+    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+      button: "operation_list",
+      page: ScreenName.Portfolio,
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
@@ -12,6 +12,7 @@ jest.mock("@ledgerhq/lumen-ui-rnative/symbols", () => {
     BellNotification: makeIcon("icon-bell-notification"),
     Settings: makeIcon("icon-settings"),
     Warning: makeIcon("icon-warning"),
+    Clock: makeIcon("icon-clock"),
     Nano: makeIcon("device-icon-nano"),
     Flex: makeIcon("device-icon-flex"),
     Apex: makeIcon("device-icon-apex"),
@@ -28,6 +29,7 @@ describe("TopBarView", () => {
   const onDiscoverPress = jest.fn();
   const onNotificationsPress = jest.fn();
   const onSettingsPress = jest.fn();
+  const onTransactionHistoryPress = jest.fn();
 
   const openSyncDrawer = jest.fn();
   const closeSyncDrawer = jest.fn();
@@ -37,6 +39,7 @@ describe("TopBarView", () => {
     onDiscoverPress,
     onNotificationsPress,
     onSettingsPress,
+    onTransactionHistoryPress,
     hasUnreadNotifications: false,
     hasAccounts: false,
     isSyncError: false,
@@ -53,17 +56,41 @@ describe("TopBarView", () => {
   });
 
   it("should call expected callbacks when top bar buttons are pressed", async () => {
-    const { user, getByTestId } = renderWithReactQuery(<TopBarView {...defaultProps} />);
+    const { user, getByTestId } = renderWithReactQuery(<TopBarView {...defaultProps} />, {
+      overrideInitialState: state => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          overriddenFeatureFlags: { lwmWallet40: { enabled: true, params: { operationsList: true } } },
+        },
+      }),
+    });
 
     await user.press(getByTestId("topbar-myledger"));
     await user.press(getByTestId("topbar-discover"));
     await user.press(getByTestId("topbar-notifications"));
     await user.press(getByTestId("topbar-settings"));
+    await user.press(getByTestId("topbar-transaction-history"));
 
     expect(onMyLedgerPress).toHaveBeenCalledTimes(1);
     expect(onDiscoverPress).toHaveBeenCalledTimes(1);
     expect(onNotificationsPress).toHaveBeenCalledTimes(1);
     expect(onSettingsPress).toHaveBeenCalledTimes(1);
+    expect(onTransactionHistoryPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not render transaction history icon when operations list is disabled", () => {
+    const { queryByTestId, getByTestId } = renderWithReactQuery(<TopBarView {...defaultProps} />, {
+      overrideInitialState: state => ({
+        ...state,
+        settings: { ...state.settings, overriddenFeatureFlags: { lwmWallet40: { enabled: true, params: { operationsList: false } } } },
+      }),
+    });
+    expect(queryByTestId("topbar-transaction-history")).toBeNull();
+    expect(getByTestId("topbar-myledger")).toBeVisible();
+    expect(getByTestId("topbar-discover")).toBeVisible();
+    expect(getByTestId("topbar-notifications")).toBeVisible();
+    expect(getByTestId("topbar-settings")).toBeVisible();
   });
 
   it("should render bell icon when there are no unread notifications", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
@@ -117,6 +117,16 @@ describe("useTopBarViewModel", () => {
     expect(mockNavigate).toHaveBeenCalledWith(expectedNavigationParams.settings.name);
   });
 
+  it("should call navigate with expected params when onTransactionHistoryPress is invoked", () => {
+    const { result } = renderHook(() => useTopBarViewModel(mockNavigation as never));
+
+    act(() => {
+      result.current.onTransactionHistoryPress();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+  });
+
   describe("sync drawer", () => {
     it("should open the drawer and track SyncErrorList with error currency ids on openSyncDrawer", () => {
       mockedUseSyncIndicator.mockReturnValue({

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/index.tsx
@@ -16,6 +16,7 @@ export function TopBar({ screenName }: Readonly<TopBarProps>) {
     onDiscoverPress,
     onNotificationsPress,
     onSettingsPress,
+    onTransactionHistoryPress,
     hasUnreadNotifications,
     hasAccounts,
     isSyncError,
@@ -33,6 +34,7 @@ export function TopBar({ screenName }: Readonly<TopBarProps>) {
       onDiscoverPress={onDiscoverPress}
       onNotificationsPress={onNotificationsPress}
       onSettingsPress={onSettingsPress}
+      onTransactionHistoryPress={onTransactionHistoryPress}
       hasUnreadNotifications={hasUnreadNotifications}
       hasAccounts={hasAccounts}
       isSyncError={isSyncError}

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
@@ -81,15 +81,21 @@ export function useTopBarViewModel(
   }, [navigation, page]);
 
   const onSettingsPress = useCallback(() => {
-    track("menuentry_clicked", { button: "Settings" });
+    track("menuentry_clicked", { button: "Settings", page });
     navigation.navigate(NavigatorName.Settings);
-  }, [navigation]);
+  }, [navigation, page]);
+
+  const onTransactionHistoryPress = useCallback(() => {
+    track("menuentry_clicked", { button: "operation_list", page });
+    navigation.navigate(ScreenName.PortfolioOperationHistory);
+  }, [navigation, page]);
 
   return {
     onMyLedgerPress,
     onDiscoverPress,
     onNotificationsPress,
     onSettingsPress,
+    onTransactionHistoryPress,
     hasUnreadNotifications,
     hasAccounts,
     isSyncError: isError,

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
@@ -14,7 +14,7 @@ export const WALLET_40_PARAMS = [
   { key: "assetSection", label: "Asset Section" },
   { key: "onboardingWidget", label: "Post-onboarding Widget" },
   { key: "brazePlacement", label: "Braze Placement (ContentBanner)" },
-  { key: "operationList", label: "TX History" },
+  { key: "operationsList", label: "TX History" },
 ] as const;
 
 type WalletFeatureParamKey = (typeof WALLET_40_PARAMS)[number]["key"];

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/SwapTopBarHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/SwapTopBarHeader.tsx
@@ -7,19 +7,26 @@ import {
   TOP_BAR_WRAPPER_PADDING_TOP,
 } from "LLM/hooks/useNavigationBarHeights";
 import { useSwapTopBarHeaderViewModel } from "./useSwapTopBarHeaderViewModel";
-import { CustomTopBar, TopBarActionIcon } from "LLM/components/CustomTopBar";
+import {
+  CustomTopBar,
+  TopBarActionIcon,
+  useMyLedgerTopBarAction,
+} from "LLM/components/CustomTopBar";
 
 import { Clock } from "@ledgerhq/lumen-ui-rnative/symbols";
 
 export function SwapTopBarHeader() {
   const insets = useSafeAreaInsets();
   const { onMyLedgerPress, onSwapHistoryPress } = useSwapTopBarHeaderViewModel();
+  const myLedgerAction = useMyLedgerTopBarAction(onMyLedgerPress);
   const containerStyle = useMemo(
     () => [styles.container, { marginTop: insets.top + TOP_BAR_WRAPPER_PADDING_TOP }],
     [insets.top],
   );
 
-  const customIcons: readonly TopBarActionIcon[] = useMemo(
+  const leadingIcons = useMemo(() => [myLedgerAction], [myLedgerAction]);
+
+  const trailingIcons: readonly TopBarActionIcon[] = useMemo(
     () => [
       {
         id: "swap-history",
@@ -34,7 +41,7 @@ export function SwapTopBarHeader() {
 
   return (
     <Box style={containerStyle}>
-      <CustomTopBar onMyLedgerPress={onMyLedgerPress} customIcons={customIcons} />
+      <CustomTopBar leadingIcons={leadingIcons} trailingIcons={trailingIcons} />
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/useSwapTopBarHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/useSwapTopBarHeaderViewModel.test.ts
@@ -31,6 +31,7 @@ describe("useSwapTopBarHeaderViewModel", () => {
       onDiscoverPress: noop,
       onNotificationsPress: noop,
       onSettingsPress: noop,
+      onTransactionHistoryPress: noop,
       hasUnreadNotifications: false,
       hasAccounts: false,
       isSyncError: false,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio (and other screens using `TopBar`) when Wallet 4.0 is enabled: leading actions and transaction history entry point
      - Wallet 4.0 feature flag `operationsList` on/off (including Debug → Wallet 4.0 overrides)
      - Swap Live App custom header (`SwapTopBarHeader`) after `CustomTopBar` API change

### 📝 Description

**Problem:** Under Ledger Wallet Mobile 4.0, the main top bar should adapt when the **operations list** capability is enabled: users need a clear way to open transaction/operation history from the bar, while keeping behavior unchanged when that sub-flag is off.

**Solution:**

- **`CustomTopBar`** now takes **`leadingIcons`** and **`trailingIcons`** instead of a fixed My Ledger slot plus `customIcons`. **`useMyLedgerTopBarAction`** builds the My Ledger action (device icon + callback) so callers compose the left group consistently.
- **`TopBarView`** reads Wallet 4.0 config via **`useWalletFeaturesConfig`**. When `operationsList` is true, a **clock** action is added next to My Ledger and **`onTransactionHistoryPress`** navigates to **`PortfolioOperationHistory`** with **`menuentry_clicked`** tracking (`button: "operation_list"`). When the flag is false, that control is not rendered.
- **Debug Wallet 4.0** param key is aligned to **`operationsList`** (was `operationList`) so overrides match the real flag name.
- **Swap** header updated to the new `CustomTopBar` props via `useMyLedgerTopBarAction` + trailing swap history.

The following video has both ff ON at the begining then OFF after

https://github.com/user-attachments/assets/d5f1419b-0259-4433-a7cd-b76cb4a6a818



### ❓ Context

- **JIRA or GitHub link**: [LIVE-26752](https://ledgerhq.atlassian.net/browse/LIVE-26752) and small fix for [LIVE-26751](https://ledgerhq.atlassian.net/browse/LIVE-26751)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26752]: https://ledgerhq.atlassian.net/browse/LIVE-26752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ