### PR TITLE
[LWDM] fix(LIVE-27788): fix for history export

### DIFF
--- a/.changeset/polite-eyes-move.md
+++ b/.changeset/polite-eyes-move.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add fix for history export

--- a/libs/ledger-live-common/src/exchange/swap/csvExport.ts
+++ b/libs/ledger-live-common/src/exchange/swap/csvExport.ts
@@ -73,6 +73,12 @@ const fields: Field[] = [
     },
   },
 ];
+const hasValidParentAccounts = (op: MappedSwapOperation): boolean => {
+  if (op.fromAccount.type === "TokenAccount" && !op.fromParentAccount) return false;
+  if (op.toAccount.type === "TokenAccount" && !op.toParentAccount) return false;
+  return true;
+};
+
 export const mappedSwapOperationsToCSV = (swapHistorySections: SwapHistorySection[]): string => {
   const mappedSwapOperations: MappedSwapOperation[] = [];
 
@@ -80,10 +86,12 @@ export const mappedSwapOperationsToCSV = (swapHistorySections: SwapHistorySectio
     mappedSwapOperations.push(...section.data);
   }
 
+  const validOperations = mappedSwapOperations.filter(hasValidParentAccounts);
+
   return (
     fields.map(field => field.title).join(",") +
     newLine +
-    mappedSwapOperations
+    validOperations
       .map(op => fields.map(field => field.cell(op).replace(/[,\n\r]/g, "")).join(","))
       .join(newLine)
   );

--- a/libs/ledger-live-common/src/exchange/swap/csvExport.ts
+++ b/libs/ledger-live-common/src/exchange/swap/csvExport.ts
@@ -73,12 +73,6 @@ const fields: Field[] = [
     },
   },
 ];
-const hasValidParentAccounts = (op: MappedSwapOperation): boolean => {
-  if (op.fromAccount.type === "TokenAccount" && !op.fromParentAccount) return false;
-  if (op.toAccount.type === "TokenAccount" && !op.toParentAccount) return false;
-  return true;
-};
-
 export const mappedSwapOperationsToCSV = (swapHistorySections: SwapHistorySection[]): string => {
   const mappedSwapOperations: MappedSwapOperation[] = [];
 
@@ -86,12 +80,10 @@ export const mappedSwapOperationsToCSV = (swapHistorySections: SwapHistorySectio
     mappedSwapOperations.push(...section.data);
   }
 
-  const validOperations = mappedSwapOperations.filter(hasValidParentAccounts);
-
   return (
     fields.map(field => field.title).join(",") +
     newLine +
-    validOperations
+    mappedSwapOperations
       .map(op => fields.map(field => field.cell(op).replace(/[,\n\r]/g, "")).join(","))
       .join(newLine)
   );

--- a/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.test.ts
@@ -1,0 +1,66 @@
+import BigNumber from "bignumber.js";
+import type { Account, Operation, SwapOperation, TokenAccount } from "@ledgerhq/types-live";
+import { getCryptoCurrencyById, setSupportedCurrencies } from "../../currencies";
+import { setupMockCryptoAssetsStore } from "../../test-helpers/cryptoAssetsStore";
+import { genAccount } from "../../mock/account";
+import { genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import getCompleteSwapHistory from "./getCompleteSwapHistory";
+
+setupMockCryptoAssetsStore();
+setSupportedCurrencies(["ethereum", "bitcoin"]);
+
+const ethereum = getCryptoCurrencyById("ethereum");
+
+const makeTokenCurrency = (id: string): TokenCurrency => ({
+  type: "TokenCurrency",
+  id,
+  name: "Mock Token",
+  ticker: "MTK",
+  contractAddress: "0x0000000000000000000000000000000000000001",
+  parentCurrency: ethereum,
+  tokenType: "erc20",
+  units: [{ name: "MTK", code: "MTK", magnitude: 18 }],
+});
+
+const makeSwapOperation = (
+  receiverAccountId: string,
+  operation: Operation,
+  tokenId?: string,
+): SwapOperation => ({
+  provider: "changelly",
+  swapId: "swap-id-1",
+  receiverAccountId,
+  operationId: operation.id,
+  fromAmount: new BigNumber(1),
+  toAmount: new BigNumber(1),
+  status: "completed",
+  tokenId,
+});
+
+describe("getCompleteSwapHistory", () => {
+  it("returns valid swaps and keeps resolved sender parent account", async () => {
+    const senderParent = genAccount("sender-parent", { operationsSize: 1, currency: ethereum });
+    const senderToken = genTokenAccount(0, senderParent, makeTokenCurrency("mock:token:sender"));
+    const receiverAccount = genAccount("receiver-account-valid", { operationsSize: 0 });
+    const operation = senderToken.operations[0];
+
+    const senderTokenWithSwapHistory: TokenAccount = {
+      ...senderToken,
+      operations: [operation],
+      pendingOperations: [],
+      swapHistory: [makeSwapOperation(receiverAccount.id, operation)],
+    };
+
+    const result = await getCompleteSwapHistory([
+      senderTokenWithSwapHistory,
+      senderParent,
+      receiverAccount,
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].data).toHaveLength(1);
+    expect(result[0].data[0].fromParentAccount?.id).toBe(senderParent.id);
+    expect(result[0].data[0].toAccount.id).toBe(receiverAccount.id);
+  });
+});

--- a/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import type { Account, Operation, SwapOperation, TokenAccount } from "@ledgerhq/types-live";
+import type { Operation, SwapOperation, TokenAccount } from "@ledgerhq/types-live";
 import { getCryptoCurrencyById, setSupportedCurrencies } from "../../currencies";
 import { setupMockCryptoAssetsStore } from "../../test-helpers/cryptoAssetsStore";
 import { genAccount } from "../../mock/account";

--- a/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.ts
@@ -53,6 +53,16 @@ const getSwapOperationMap =
 
         if (account.type === "TokenAccount") {
           fromParentAccount = accounts.find(a => a.id === account.parentId);
+          if (!fromParentAccount || fromParentAccount.type !== "Account") return null;
+        }
+
+        if (toAccount.type === "TokenAccount" && !toParentAccount) {
+          const toAccountParentId = toAccount.parentId;
+          const foundParent = accounts.find(
+            a => a.type === "Account" && a.id === toAccountParentId,
+          );
+          if (!foundParent || foundParent.type !== "Account") return null;
+          toParentAccount = foundParent;
         }
 
         const toCurrency = getAccountCurrency(toAccount);

--- a/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.ts
@@ -53,7 +53,7 @@ const getSwapOperationMap =
 
         if (account.type === "TokenAccount") {
           fromParentAccount = accounts.find(a => a.id === account.parentId);
-          if (!fromParentAccount || fromParentAccount.type !== "Account") return null;
+          if (fromParentAccount?.type !== "Account") return null;
         }
 
         if (toAccount.type === "TokenAccount" && !toParentAccount) {
@@ -61,7 +61,7 @@ const getSwapOperationMap =
           const foundParent = accounts.find(
             a => a.type === "Account" && a.id === toAccountParentId,
           );
-          if (!foundParent || foundParent.type !== "Account") return null;
+          if (foundParent?.type !== "Account") return null;
           toParentAccount = foundParent;
         }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR resolves the issue with the history export functionality

_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27788

- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


##Before

https://github.com/user-attachments/assets/b3deef9e-726d-4344-bde4-6f52d218a33e

##After

https://github.com/user-attachments/assets/3f002e43-3f08-4118-bedc-31042aa91e97

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
