### PR TITLE
[LWD] fix(desktop): always show distribution percentage in asset allocation

### DIFF
--- a/.changeset/gentle-birds-appear.md
+++ b/.changeset/gentle-birds-appear.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix asset allocation row to always show distribution percentage and bar

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.test.tsx
@@ -17,26 +17,85 @@ jest.mock("~/renderer/components/CounterValue", () => ({
   default: (props: unknown) => mockedCounterValue(props),
 }));
 
+const bitcoin = getCryptoCurrencyById("bitcoin");
+
+function makeItem(overrides: Partial<DistributionItem> = {}): DistributionItem {
+  return {
+    currency: bitcoin,
+    amount: 100000000,
+    countervalue: 50000,
+    distribution: 0.5,
+    accounts: [],
+    ...overrides,
+  };
+}
+
 describe("AssetDistribution Row", () => {
   beforeEach(() => {
     mockedPrice.mockClear();
     mockedCounterValue.mockClear();
   });
-  it("renders price and value components even when distribution is 0", () => {
-    const currency = getCryptoCurrencyById("bitcoin");
-    const item: DistributionItem = {
-      currency,
-      amount: 0.00000001,
-      countervalue: 0,
-      distribution: 0,
-      accounts: [],
-    };
 
-    render(<Row item={item} isVisible={false} isResponsiveLayout={false} />);
+  it("should render price and countervalue components", () => {
+    render(<Row item={makeItem()} isVisible={false} isResponsiveLayout={false} />);
 
-    expect(screen.getByTestId("asset-price")).toBeInTheDocument();
-    expect(screen.getByTestId("asset-countervalue")).toBeInTheDocument();
+    expect(screen.getByTestId("asset-price")).toBeVisible();
+    expect(screen.getByTestId("asset-countervalue")).toBeVisible();
     expect(mockedPrice).toHaveBeenCalledTimes(1);
     expect(mockedCounterValue).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render percentage text and bar even when distribution is 0", () => {
+    render(
+      <Row
+        item={makeItem({ distribution: 0, amount: 1, countervalue: 0 })}
+        isVisible={false}
+        isResponsiveLayout={false}
+      />,
+    );
+
+    expect(screen.getByText("0%")).toBeVisible();
+    expect(screen.getByTestId("asset-price")).toBeVisible();
+    expect(screen.getByTestId("asset-countervalue")).toBeVisible();
+  });
+
+  it("should display the correct percentage for a given distribution", () => {
+    render(
+      <Row
+        item={makeItem({ distribution: 0.4567 })}
+        isVisible={false}
+        isResponsiveLayout={false}
+      />,
+    );
+
+    expect(screen.getByText("45.67%")).toBeVisible();
+  });
+
+  it("should render the currency name", () => {
+    render(<Row item={makeItem()} isVisible={false} isResponsiveLayout={false} />);
+
+    expect(screen.getByText("Bitcoin")).toBeVisible();
+  });
+
+  it("should pass currency and value props to CounterValue", () => {
+    const item = makeItem({ amount: 200000000 });
+    render(<Row item={item} isVisible={false} isResponsiveLayout={false} />);
+
+    expect(mockedCounterValue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currency: bitcoin,
+        value: 200000000,
+      }),
+    );
+  });
+
+  it("should pass from prop to Price", () => {
+    render(<Row item={makeItem()} isVisible={false} isResponsiveLayout={false} />);
+
+    expect(mockedPrice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: bitcoin,
+      }),
+    );
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.tsx
@@ -152,17 +152,13 @@ const Row = ({
         <Price from={currency} color="neutral.c80" fontSize={3} />
       </PriceSection>
       <Distribution $isResponsiveLayout={isResponsiveLayout}>
-        {!!distribution && (
-          <>
-            <Text ff="Inter" color="neutral.c100" fontSize={3}>
-              {`${percentageWording}%`}
-            </Text>
-            <Bar
-              progress={!getEnv("PLAYWRIGHT_RUN") && isVisible ? percentage : 0}
-              progressColor={color}
-            />
-          </>
-        )}
+        <Text ff="Inter" color="neutral.c100" fontSize={3}>
+          {`${percentageWording}%`}
+        </Text>
+        <Bar
+          progress={!getEnv("PLAYWRIGHT_RUN") && isVisible ? percentage : 0}
+          progressColor={color}
+        />
       </Distribution>
       <Amount $isResponsiveLayout={isResponsiveLayout}>
         <Ellipsis>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Asset allocation row on the dashboard portfolio view
      - Distribution percentage and bar visibility for zero-balance assets

### 📝 Description

**Problem**: When an asset had a distribution value of `0` (e.g. a dust amount with no countervalue or an empty account), the distribution percentage text and progress bar were hidden entirely. This left an empty gap in the asset allocation row, making the UI look broken.

**Solution**: Removed the conditional rendering (`!!distribution`) around the percentage text and bar in the `Row` component, so they always render — showing `0%` with an empty bar when distribution is zero, instead of hiding the section.

**Also done**: Add missing test coverage.

| Before | After |
| ------ | ----- |
| <img width="1366" height="717" alt="Screenshot 2026-03-24 at 14 30 00" src="https://github.com/user-attachments/assets/e3f6371e-d721-4abb-a93d-16e21691d8a3" /> | <img width="1378" height="730" alt="Screenshot 2026-03-24 at 14 26 14" src="https://github.com/user-attachments/assets/e82a7325-eb35-474f-8855-05a4e94f3791" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25763](https://ledgerhq.atlassian.net/browse/LIVE-25763)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25763]: https://ledgerhq.atlassian.net/browse/LIVE-25763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ