### PR TITLE
[LWD] feat(desktop): implement transaction history table skeleton

### DIFF
--- a/.changeset/loud-queens-care.md
+++ b/.changeset/loud-queens-care.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Create skeleton page for History

--- a/apps/ledger-live-desktop/src/mvvm/features/History/HistoryView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/HistoryView.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import HistoryPageHeader from "./components/HistoryPageHeader";
+import { HistoryList } from "./screens/HistoryList";
+import type { HistoryViewModel } from "./useHistoryViewModel";
+
+export function HistoryView({
+  navigateToDashboard,
+  table,
+  parentRef,
+  rowVirtualizer,
+  flatItems,
+  onRowClick,
+}: HistoryViewModel) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-24">
+      <TrackPage category="History" />
+      <HistoryPageHeader onBack={navigateToDashboard} />
+      <HistoryList
+        table={table}
+        parentRef={parentRef}
+        rowVirtualizer={rowVirtualizer}
+        flatItems={flatItems}
+        onRowClick={onRowClick}
+      />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/DayHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/DayHeader.tsx
@@ -1,0 +1,16 @@
+import React, { memo } from "react";
+import { TableGroupHeaderRow } from "@ledgerhq/lumen-ui-react";
+import { useCalendarFormatted } from "~/renderer/hooks/useDateFormatter";
+
+type DayHeaderProps = {
+  readonly day: Date;
+  readonly columnCount: number;
+};
+
+function DayHeader({ day, columnCount }: DayHeaderProps) {
+  const label = useCalendarFormatted(day);
+  return <TableGroupHeaderRow colSpan={columnCount}>{label}</TableGroupHeaderRow>;
+}
+
+const MemoizedDayHeader = memo(DayHeader);
+export { MemoizedDayHeader as DayHeader };

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryTableBody.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryTableBody.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { TableBody } from "@ledgerhq/lumen-ui-react";
+import { Virtualizer } from "@tanstack/react-virtual";
+import { DayHeader } from "./DayHeader";
+import type { OperationRow as OperationRowType, VirtualItem } from "../types";
+
+type HistoryTableBodyProps = {
+  readonly rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+  readonly flatItems: VirtualItem[];
+  readonly columnCount: number;
+  readonly onRowClick: (row: OperationRowType) => void;
+};
+
+export function HistoryTableBody({
+  rowVirtualizer,
+  flatItems,
+  columnCount,
+  onRowClick,
+}: HistoryTableBodyProps) {
+  const virtualItems = rowVirtualizer.getVirtualItems();
+
+  // TODO: add empty state (next iteration)
+
+  const totalSize = rowVirtualizer.getTotalSize();
+  const paddingTop = virtualItems[0]?.start ?? 0;
+  const paddingBottom = totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0);
+
+  return (
+    <TableBody>
+      {paddingTop > 0 && (
+        <tr>
+          <td colSpan={columnCount} style={{ height: paddingTop, padding: 0, border: 0 }} />
+        </tr>
+      )}
+      {virtualItems.map(virtualRow => {
+        const item = flatItems[virtualRow.index];
+        if (!item) return null;
+
+        if (item.type === "day-header") {
+          return (
+            <DayHeader
+              key={`day-${item.day.toISOString()}`}
+              day={item.day}
+              columnCount={item.columnCount}
+            />
+          );
+        }
+
+        return (
+          <tr key={item.row.id}>
+            <td colSpan={columnCount}>{/* TODO: Replace with OperationRow component */}</td>
+          </tr>
+        );
+      })}
+      {paddingBottom > 0 && (
+        <tr>
+          <td colSpan={columnCount} style={{ height: paddingBottom, padding: 0, border: 0 }} />
+        </tr>
+      )}
+    </TableBody>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryTableHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryTableHeader.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { TableHeader, TableHeaderRow, TableHeaderCell } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+
+function HistoryTableHeader() {
+  const { t } = useTranslation();
+  return (
+    <TableHeader>
+      <TableHeaderRow className="z-10">
+        <TableHeaderCell>{t("history.columns.type")}</TableHeaderCell>
+        <TableHeaderCell align="end">{t("history.columns.address")}</TableHeaderCell>
+        <TableHeaderCell align="end">{t("history.columns.amount")}</TableHeaderCell>
+        <TableHeaderCell align="end">{t("history.columns.value")}</TableHeaderCell>
+      </TableHeaderRow>
+    </TableHeader>
+  );
+}
+
+export { HistoryTableHeader };

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
@@ -1,0 +1,48 @@
+import { renderHook } from "tests/testSetup";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import { useHistoryOperations } from "../useHistoryOperations";
+
+const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
+const ethereumCurrency = getCryptoCurrencyById("ethereum");
+
+describe("useHistoryOperations", () => {
+  it("returns an empty array when there are no accounts", () => {
+    const { result } = renderHook(() => useHistoryOperations(), {
+      initialState: { accounts: [], settings: INITIAL_STATE },
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("collects, sorts, and shapes operations from multiple accounts", () => {
+    const accounts = [
+      genAccount("btc-1", { currency: bitcoinCurrency, operationsSize: 2 }),
+      genAccount("eth-1", { currency: ethereumCurrency, operationsSize: 2 }),
+    ];
+
+    const { result } = renderHook(() => useHistoryOperations(), {
+      initialState: { accounts, settings: INITIAL_STATE },
+    });
+
+    const items = result.current;
+
+    expect(items.length).toBeGreaterThanOrEqual(4);
+
+    for (let i = 1; i < items.length; i++) {
+      expect(items[i - 1].date.getTime()).toBeGreaterThanOrEqual(items[i].date.getTime());
+    }
+
+    expect(items[0]).toMatchObject({
+      id: expect.any(String),
+      date: expect.any(Date),
+      type: expect.any(String),
+      address: expect.any(String),
+    });
+    expect(items[0].operation).toBeDefined();
+    expect(items[0].account).toBeDefined();
+    expect(items[0].currency).toBeDefined();
+    expect(items[0].amount).toBeDefined();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryVirtualization.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryVirtualization.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from "tests/testSetup";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import { useHistoryOperations } from "../useHistoryOperations";
+import { useHistoryTable } from "../useHistoryTable";
+import { useHistoryVirtualization } from "../useHistoryVirtualization";
+
+const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
+
+function useComposedHook() {
+  const operations = useHistoryOperations();
+  const table = useHistoryTable(operations);
+  return useHistoryVirtualization(table);
+}
+
+describe("useHistoryVirtualization", () => {
+  it("returns empty flatItems when there are no operations", () => {
+    const { result } = renderHook(() => useComposedHook(), {
+      initialState: { accounts: [], settings: INITIAL_STATE },
+    });
+
+    expect(result.current.flatItems).toEqual([]);
+  });
+
+  it("provides virtualizer refs and interleaves day headers with operation rows", () => {
+    const accounts = [genAccount("btc-1", { currency: bitcoinCurrency, operationsSize: 5 })];
+
+    const { result } = renderHook(() => useComposedHook(), {
+      initialState: { accounts, settings: INITIAL_STATE },
+    });
+
+    expect(result.current.parentRef).toBeDefined();
+    expect(result.current.rowVirtualizer).toBeDefined();
+
+    const { flatItems } = result.current;
+    const dayHeaders = flatItems.filter(item => item.type === "day-header");
+    const operations = flatItems.filter(item => item.type === "operation");
+
+    expect(dayHeaders.length).toBeGreaterThan(0);
+    expect(operations.length).toBeGreaterThan(0);
+    expect(flatItems[0].type).toBe("day-header");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryOperations.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryOperations.ts
@@ -1,0 +1,102 @@
+import { useMemo, useCallback } from "react";
+import { useSelector } from "LLD/hooks/redux";
+import { AccountLike, Account, Operation } from "@ledgerhq/types-live";
+import { flattenAccounts, getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import {
+  getOperationAmountNumber,
+  flattenOperationWithInternalsAndNfts,
+} from "@ledgerhq/live-common/operation";
+import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/operation";
+import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
+import { useFilterTokenOperationsZeroAmount } from "~/renderer/actions/settings";
+import { accountsSelector } from "~/renderer/reducers/accounts";
+import { isIncomingType } from "../utils/isIncomingType";
+import type { OperationTableItem } from "../types";
+
+function getOperationAddress(operation: Operation): string {
+  if (isIncomingType(operation.type)) {
+    return operation.senders[0] ?? "";
+  }
+  return operation.recipients[0] ?? "";
+}
+
+export function useHistoryOperations(): OperationTableItem[] {
+  const accounts = useSelector(accountsSelector);
+
+  const [shouldFilterTokenOpsZeroAmount] = useFilterTokenOperationsZeroAmount();
+  const addressPoisoningFamilies = useAddressPoisoningOperationsFamilies({
+    shouldFilter: shouldFilterTokenOpsZeroAmount,
+  });
+
+  const filterOperation = useCallback(
+    (operation: Operation, account: AccountLike) => {
+      if (!shouldFilterTokenOpsZeroAmount) return true;
+      return !isAddressPoisoningOperation(
+        operation,
+        account,
+        addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
+      );
+    },
+    [shouldFilterTokenOpsZeroAmount, addressPoisoningFamilies],
+  );
+
+  return useMemo(() => {
+    const allAccounts = flattenAccounts(accounts);
+    const accountsById = new Map<string, { account: AccountLike; parentAccount?: Account }>();
+
+    for (const acc of allAccounts) {
+      let parentAccount: Account | undefined;
+      if (acc.type !== "Account") {
+        const parent = accounts.find(a => a.id === acc.parentId);
+        if (parent && parent.type === "Account") {
+          parentAccount = parent;
+        }
+      }
+      accountsById.set(acc.id, { account: acc, parentAccount });
+    }
+
+    const items: OperationTableItem[] = [];
+
+    for (const acc of allAccounts) {
+      const info = accountsById.get(acc.id);
+      if (!info) continue;
+      const { account, parentAccount } = info;
+
+      const allOps = [
+        ...acc.pendingOperations.filter(
+          pendingOp => !acc.operations.some(op => op.hash === pendingOp.hash),
+        ),
+        ...acc.operations,
+      ];
+
+      for (const rawOp of allOps) {
+        if (!filterOperation(rawOp, account)) continue;
+
+        const flatOps = flattenOperationWithInternalsAndNfts(rawOp);
+        for (const operation of flatOps) {
+          if (!filterOperation(operation, account)) continue;
+
+          const currency = getAccountCurrency(account);
+          const amount = getOperationAmountNumber(operation);
+          const address = getOperationAddress(operation);
+
+          items.push({
+            id: `${account.id}_${operation.id}`,
+            operation,
+            account,
+            parentAccount,
+            date: operation.date,
+            type: operation.type,
+            address,
+            amount,
+            currency,
+          });
+        }
+      }
+    }
+
+    items.sort((a, b) => b.date.getTime() - a.date.getTime());
+
+    return items;
+  }, [accounts, filterOperation]);
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryTable.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryTable.ts
@@ -1,0 +1,13 @@
+import { useLumenDataTable } from "@ledgerhq/lumen-ui-react";
+import type { OperationTableItem, ColumnDef } from "../types";
+
+const columns: ColumnDef<OperationTableItem>[] = [
+  { accessorKey: "type", enableSorting: false },
+  { accessorKey: "address", enableSorting: false, meta: { align: "end" as const } },
+  { accessorKey: "amount", enableSorting: false, meta: { align: "end" as const } },
+  { id: "value", accessorKey: "amount", enableSorting: false, meta: { align: "end" as const } },
+];
+
+export function useHistoryTable(data: OperationTableItem[]) {
+  return useLumenDataTable({ data, columns });
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryVirtualization.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryVirtualization.ts
@@ -1,0 +1,63 @@
+import { useRef, useMemo } from "react";
+import { useVirtualizer, Virtualizer } from "@tanstack/react-virtual";
+import type { VirtualItem, HistoryTable } from "../types";
+
+const OPERATION_ROW_HEIGHT = 64;
+const DAY_HEADER_HEIGHT = 40;
+const OVERSCAN = 10;
+
+export { OPERATION_ROW_HEIGHT, DAY_HEADER_HEIGHT };
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function buildFlatItems(table: HistoryTable): VirtualItem[] {
+  const rowModel = table.getRowModel();
+  const items: VirtualItem[] = [];
+  let currentDayKey: string | null = null;
+  const columnCount = table.getVisibleFlatColumns().length;
+
+  for (const row of rowModel.rows) {
+    const day = startOfDay(row.original.date);
+    const dayKey = day.toISOString();
+    if (dayKey !== currentDayKey) {
+      items.push({ type: "day-header", day, columnCount });
+      currentDayKey = dayKey;
+    }
+    items.push({ type: "operation", row });
+  }
+
+  return items;
+}
+
+export function useHistoryVirtualization(table: HistoryTable) {
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const rowModel = table.getRowModel();
+  const columns = table.getVisibleFlatColumns();
+  const flatItems = useMemo(() => buildFlatItems(table), [rowModel.rows, columns]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: flatItems.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: index => {
+      const item = flatItems[index];
+      return item?.type === "day-header" ? DAY_HEADER_HEIGHT : OPERATION_ROW_HEIGHT;
+    },
+    overscan: OVERSCAN,
+    paddingEnd: 32,
+  });
+
+  return {
+    parentRef,
+    rowVirtualizer,
+    flatItems,
+  };
+}
+
+export type HistoryVirtualization = {
+  parentRef: React.RefObject<HTMLDivElement | null>;
+  rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+  flatItems: VirtualItem[];
+};

--- a/apps/ledger-live-desktop/src/mvvm/features/History/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/index.tsx
@@ -1,29 +1,7 @@
 import React from "react";
-import TrackPage from "~/renderer/analytics/TrackPage";
-import HistoryPageHeader from "./components/HistoryPageHeader";
-import useHistoryViewModel, { HistoryViewModel } from "./useHistoryViewModel";
-import { OperationsList } from "~/renderer/components/OperationsList";
+import { HistoryView } from "./HistoryView";
+import { useHistoryViewModel } from "./useHistoryViewModel";
 
-export default function History() {
-  const viewModel = useHistoryViewModel();
-  return <HistoryView viewModel={viewModel} />;
-}
+const History = () => <HistoryView {...useHistoryViewModel()} />;
 
-function HistoryView({ viewModel }: { readonly viewModel: HistoryViewModel }) {
-  const { navigateToDashboard, accounts, filterOperations, t } = viewModel;
-  return (
-    <div className="flex flex-col gap-32">
-      <TrackPage category="History" />
-      <HistoryPageHeader onBack={navigateToDashboard} />
-      <OperationsList
-        accounts={accounts}
-        title={t("dashboard.recentActivity")}
-        withAccount
-        withSubAccounts
-        filterOperation={filterOperations}
-        t={t}
-        isWallet40
-      />
-    </div>
-  );
-}
+export default History;

--- a/apps/ledger-live-desktop/src/mvvm/features/History/screens/HistoryList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/screens/HistoryList.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { TableRoot, Table } from "@ledgerhq/lumen-ui-react";
+import { Virtualizer } from "@tanstack/react-virtual";
+import { HistoryTableHeader } from "../components/HistoryTableHeader";
+import { HistoryTableBody } from "../components/HistoryTableBody";
+import type { VirtualItem, HistoryTable, OperationRow } from "../types";
+
+type HistoryListProps = {
+  readonly table: HistoryTable;
+  readonly parentRef: React.RefObject<HTMLDivElement | null>;
+  readonly rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+  readonly flatItems: VirtualItem[];
+  readonly onRowClick: (row: OperationRow) => void;
+};
+
+function HistoryList({
+  table,
+  parentRef,
+  rowVirtualizer,
+  flatItems,
+  onRowClick,
+}: HistoryListProps) {
+  return (
+    <TableRoot ref={parentRef} appearance="plain" className="min-h-0 flex-1 overflow-auto mb-32">
+      <Table>
+        <HistoryTableHeader />
+        <HistoryTableBody
+          rowVirtualizer={rowVirtualizer}
+          flatItems={flatItems}
+          columnCount={table.getVisibleFlatColumns().length}
+          onRowClick={onRowClick}
+        />
+      </Table>
+    </TableRoot>
+  );
+}
+
+export { HistoryList };

--- a/apps/ledger-live-desktop/src/mvvm/features/History/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/types.ts
@@ -1,0 +1,25 @@
+export type { Row, Table, ColumnDef } from "@tanstack/react-table";
+
+import type { Row, Table } from "@tanstack/react-table";
+import type { AccountLike, Account, Operation, OperationType } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { BigNumber } from "bignumber.js";
+
+export type OperationTableItem = {
+  id: string;
+  operation: Operation;
+  account: AccountLike;
+  parentAccount?: Account;
+  date: Date;
+  type: OperationType;
+  address: string;
+  amount: BigNumber;
+  currency: Currency;
+};
+
+export type HistoryTable = Table<OperationTableItem>;
+export type OperationRow = Row<OperationTableItem>;
+
+export type VirtualItem =
+  | { type: "day-header"; day: Date; columnCount: number }
+  | { type: "operation"; row: OperationRow };

--- a/apps/ledger-live-desktop/src/mvvm/features/History/useHistoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/useHistoryViewModel.ts
@@ -1,54 +1,48 @@
 import { useNavigate } from "react-router";
 import { useCallback } from "react";
-import { useSelector } from "LLD/hooks/redux";
-import { useTranslation } from "react-i18next";
-import { AccountLike, Operation } from "@ledgerhq/types-live";
-import { TFunction } from "i18next";
-import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
-import { useFilterTokenOperationsZeroAmount } from "~/renderer/actions/settings";
-import { accountsSelector } from "~/renderer/reducers/accounts";
+import type { Virtualizer } from "@tanstack/react-virtual";
+import { OperationDetails } from "~/renderer/drawers/OperationDetails";
+import { setDrawer } from "~/renderer/drawers/Provider";
+import { useHistoryOperations } from "./hooks/useHistoryOperations";
+import { useHistoryTable } from "./hooks/useHistoryTable";
+import { useHistoryVirtualization } from "./hooks/useHistoryVirtualization";
+import type { HistoryTable, OperationRow, VirtualItem } from "./types";
 
 export type HistoryViewModel = {
   navigateToDashboard: () => void;
-  accounts: AccountLike[];
-  filterOperations: (operation: Operation, account: AccountLike) => boolean;
-  t: TFunction;
+  table: HistoryTable;
+  parentRef: React.RefObject<HTMLDivElement | null>;
+  rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
+  flatItems: VirtualItem[];
+  onRowClick: (row: OperationRow) => void;
 };
 
-export default function useHistoryViewModel(): HistoryViewModel {
-  // NB: This is the same logic as in the PortfolioViewModel & it will be reworked in next iterations
-  // Same for tests
-  const [shouldFilterTokenOpsZeroAmount] = useFilterTokenOperationsZeroAmount();
-  const addressPoisoningFamilies = useAddressPoisoningOperationsFamilies({
-    shouldFilter: shouldFilterTokenOpsZeroAmount,
-  });
-
-  const filterOperations = useCallback(
-    (operation: Operation, account: AccountLike) => {
-      const isOperationPoisoned = isAddressPoisoningOperation(
-        operation,
-        account,
-        addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
-      );
-
-      const shouldFilterOperation = !(shouldFilterTokenOpsZeroAmount && isOperationPoisoned);
-
-      return shouldFilterOperation;
-    },
-    [shouldFilterTokenOpsZeroAmount, addressPoisoningFamilies],
-  );
+export function useHistoryViewModel(): HistoryViewModel {
   const navigate = useNavigate();
-  const accounts = useSelector(accountsSelector);
-  const { t } = useTranslation();
 
   const navigateToDashboard = useCallback(() => {
     navigate("/");
   }, [navigate]);
+
+  const operations = useHistoryOperations();
+  const table = useHistoryTable(operations);
+  const { parentRef, rowVirtualizer, flatItems } = useHistoryVirtualization(table);
+
+  const onRowClick = useCallback((row: OperationRow) => {
+    const { operation, account, parentAccount } = row.original;
+    setDrawer(OperationDetails, {
+      operationId: operation.id,
+      accountId: account.id,
+      parentId: parentAccount?.id,
+    });
+  }, []);
+
   return {
     navigateToDashboard,
-    accounts,
-    filterOperations,
-    t,
+    table,
+    parentRef,
+    rowVirtualizer,
+    flatItems,
+    onRowClick,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/History/utils/__tests__/isIncomingType.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/utils/__tests__/isIncomingType.test.ts
@@ -1,0 +1,13 @@
+import type { OperationType } from "@ledgerhq/types-live";
+import { isIncomingType } from "../isIncomingType";
+
+describe("isIncomingType", () => {
+  it.each<[OperationType, boolean]>([
+    ["IN", true],
+    ["REVEAL", true],
+    ["REWARD_PAYOUT", true],
+    ["OUT", false],
+  ])("isIncomingType(%s) => %s", (type, expected) => {
+    expect(isIncomingType(type)).toBe(expected);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/History/utils/isIncomingType.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/utils/isIncomingType.ts
@@ -1,0 +1,7 @@
+import type { OperationType } from "@ledgerhq/types-live";
+
+const INCOMING_TYPES = new Set<OperationType>(["IN", "REVEAL", "REWARD_PAYOUT"]);
+
+export function isIncomingType(type: OperationType): boolean {
+  return INCOMING_TYPES.has(type);
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8396,6 +8396,16 @@
     }
   },
   "history": {
-    "title": "Transaction"
+    "title": "Transaction",
+    "columns": {
+      "type": "Type",
+      "address": "Address",
+      "amount": "Amount",
+      "value": "Value"
+    },
+    "address": {
+      "from": "From",
+      "to": "To"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Implement the History table skeleton with 4 responsive columns (Type, Address, Amount, Value) using Lumen UI primitives
- Add data pipeline hooks: `useHistoryOperations` (data fetching/filtering), `useHistoryTable` (TanStack table config), `useHistoryVirtualization` (virtual scrolling with day-header interleaving)
- Wire up MVVM structure: `HistoryView` + `useHistoryViewModel` with navigation and operation detail drawer

## Jira

[LIVE-26180](https://ledgerhq.atlassian.net/browse/LIVE-26180)

## Test plan

- [x] Unit tests for `useHistoryOperations` (empty state, multi-account sorting)
- [x] Unit tests for `useHistoryVirtualization` (empty state, day-header interleaving)
- [x] Unit tests for `isIncomingType` utility

[LIVE-26180]: https://ledgerhq.atlassian.net/browse/LIVE-26180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ