### PR TITLE
[LWM] fix(assets): updates assets 

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/ListItem/__tests__/useListItemViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/ListItem/__tests__/useListItemViewModel.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "@tests/test-renderer";
 import { usePortfolioForAccounts } from "~/hooks/portfolio";
 import { useListItemViewModel } from "../useListItemViewModel";
+import { Asset } from "~/types/asset";
 import { bitcoin, createCryptoAsset } from "./shared";
 
 jest.mock("~/hooks/portfolio", () => ({
@@ -25,6 +26,31 @@ describe("useListItemViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockPortfolio(null);
+  });
+
+  describe("placeholder assets", () => {
+    it("should show formatted 0 as counter value", () => {
+      const placeholderAsset: Asset = {
+        ...createCryptoAsset(bitcoin, 0),
+        isPlaceholder: true,
+      };
+
+      const { result } = renderHook(() => useListItemViewModel(placeholderAsset));
+
+      expect(result.current.formattedCounterValue).not.toBeNull();
+    });
+
+    it("should show dash as delta text for placeholder assets", () => {
+      const placeholderAsset: Asset = {
+        ...createCryptoAsset(bitcoin, 0),
+        isPlaceholder: true,
+      };
+
+      const { result } = renderHook(() => useListItemViewModel(placeholderAsset));
+
+      expect(result.current.deltaText).toBe("–");
+      expect(result.current.deltaColor).toBe("muted");
+    });
   });
 
   describe("delta", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/ListItem/useListItemViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/ListItem/useListItemViewModel.ts
@@ -41,12 +41,12 @@ export const useListItemViewModel = (asset: Asset): ListItemViewModelResult => {
   });
 
   const formattedCounterValue = useMemo(() => {
-    if (asset.isPlaceholder && asset.placeholderPrice != null) {
-      const unit = counterValueCurrency.units[0];
-      const value = new BigNumber(asset.placeholderPrice).times(
-        new BigNumber(10).pow(unit.magnitude),
-      );
-      return formatCurrencyUnit(unit, value, { locale, showCode: true, discreet });
+    if (asset.isPlaceholder) {
+      return formatCurrencyUnit(counterValueCurrency.units[0], new BigNumber(0), {
+        locale,
+        showCode: true,
+        discreet,
+      });
     }
     return typeof countervalueRaw === "number"
       ? formatCurrencyUnit(counterValueCurrency.units[0], new BigNumber(countervalueRaw), {
@@ -55,14 +55,7 @@ export const useListItemViewModel = (asset: Asset): ListItemViewModelResult => {
           discreet,
         })
       : null;
-  }, [
-    asset.isPlaceholder,
-    asset.placeholderPrice,
-    countervalueRaw,
-    counterValueCurrency,
-    locale,
-    discreet,
-  ]);
+  }, [asset.isPlaceholder, countervalueRaw, counterValueCurrency, locale, discreet]);
 
   let deltaText = "–";
   let deltaColor: ListItemViewModelResult["deltaColor"] = "muted";

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/__tests__/assetUtils.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/__tests__/assetUtils.test.ts
@@ -1,0 +1,53 @@
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { Asset } from "~/types/asset";
+import { padAssetsWithDefaults } from "../assetUtils";
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const ethereum = getCryptoCurrencyById("ethereum");
+
+const makeAsset = (currency: ReturnType<typeof getCryptoCurrencyById>, amount = 0): Asset => ({
+  currency,
+  accounts: [],
+  amount,
+});
+
+describe("padAssetsWithDefaults", () => {
+  const asset1 = makeAsset(bitcoin);
+  const asset2 = makeAsset(ethereum);
+  const default1 = { ...makeAsset(bitcoin), isPlaceholder: true } as Asset;
+  const default2 = { ...makeAsset(ethereum), isPlaceholder: true } as Asset;
+  const default3 = {
+    ...makeAsset(bitcoin),
+    isPlaceholder: true,
+    currency: { ...bitcoin, id: "litecoin" },
+  } as Asset;
+
+  it("should return owned assets unchanged when already at max", () => {
+    const owned = [asset1, asset2];
+    expect(padAssetsWithDefaults(owned, [default3], 2)).toEqual(owned);
+  });
+
+  it("should pad up to max with defaults when fewer than max are owned", () => {
+    const result = padAssetsWithDefaults([asset1], [default2, default3], 3);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe(asset1);
+  });
+
+  it("should not pad with assets already owned (deduplication by currency id)", () => {
+    const result = padAssetsWithDefaults([asset1], [default1, default3], 2);
+
+    expect(result).toHaveLength(2);
+    expect(result[1].currency.id).toBe(default3.currency.id);
+  });
+
+  it("should return an empty array when both owned and defaults are empty", () => {
+    expect(padAssetsWithDefaults([], [], 4)).toEqual([]);
+  });
+
+  it("should not exceed max even if more defaults are available", () => {
+    const result = padAssetsWithDefaults([], [asset1, asset2, default3], 2);
+
+    expect(result).toHaveLength(2);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/assetUtils.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/assetUtils.ts
@@ -1,0 +1,20 @@
+import { CategorizedAssetItem } from "@ledgerhq/asset-aggregation/assetCategorization/types";
+import { Asset } from "~/types/asset";
+
+export const toAsset = (item: CategorizedAssetItem): Asset => ({
+  currency: item.currency,
+  accounts: item.accounts,
+  amount: item.balance,
+  distribution: item.distribution,
+  isPlaceholder: false,
+});
+
+/**
+ * Pads `owned` with items from `defaults` (deduped by currency id) up to `max` total.
+ */
+export function padAssetsWithDefaults(owned: Asset[], defaults: Asset[], max: number): Asset[] {
+  if (owned.length >= max) return owned;
+  const ownedIds = new Set(owned.map(a => a.currency.id));
+  const padding = defaults.filter(p => !ownedIds.has(p.currency.id)).slice(0, max - owned.length);
+  return [...owned, ...padding];
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
@@ -2,20 +2,10 @@ import { useCallback } from "react";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { CategorizedAssetItem } from "@ledgerhq/asset-aggregation/assetCategorization/types";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { NavigatorName, ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
 import { track } from "~/analytics";
-
-export const toAsset = (item: CategorizedAssetItem): Asset => ({
-  currency: item.currency,
-  accounts: item.accounts,
-  amount: item.balance,
-  countervalue: item.value,
-  distribution: item.distribution,
-  isPlaceholder: false,
-});
 
 interface PortfolioSectionActions {
   onPressShowAll: () => void;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/CryptosSection/__tests__/usePortfolioCryptosSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/CryptosSection/__tests__/usePortfolioCryptosSectionViewModel.test.ts
@@ -15,8 +15,10 @@ jest.mock("@react-navigation/native", () => ({
   useRoute: () => ({ name: "Portfolio" }),
 }));
 
+const mockAssetsData = jest.fn();
+
 jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData", () => ({
-  useAssetsData: () => ({ data: undefined, isLoading: false }),
+  useAssetsData: () => mockAssetsData(),
 }));
 
 const mockCategorizedAssets = jest.fn();
@@ -58,6 +60,7 @@ const mockPortfolioWithCryptos = (
 describe("usePortfolioCryptosSectionViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAssetsData.mockReturnValue({ data: undefined, isLoading: false, isError: false });
     mockPortfolioWithCryptos();
     mockReadOnlyCoins.mockReturnValue({ sortedCryptoCurrencies: [] });
   });
@@ -221,6 +224,27 @@ describe("usePortfolioCryptosSectionViewModel", () => {
       );
 
       expect(result.current.hasMore).toBe(false);
+    });
+  });
+
+  describe("default asset padding when user has fewer than 4 cryptos", () => {
+    it("should show only user assets when user has 4 or more cryptos", () => {
+      const fourCryptos = Array.from({ length: 4 }, () => createCryptoAsset(bitcoin, 1000));
+      mockPortfolioWithCryptos(fourCryptos);
+
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel());
+
+      expect(result.current.assetsToDisplay).toHaveLength(4);
+      expect(result.current.assetsToDisplay.every(a => !a.isPlaceholder)).toBe(true);
+    });
+
+    it("should show user assets first, with no padding when defaults unavailable", () => {
+      mockPortfolioWithCryptos([createCryptoAsset(bitcoin, 100000)]);
+
+      const { result } = renderHook(() => usePortfolioCryptosSectionViewModel());
+
+      expect(result.current.assetsToDisplay).toHaveLength(1);
+      expect(result.current.assetsToDisplay[0].currency).toBe(bitcoin);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/CryptosSection/usePortfolioCryptosSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/CryptosSection/usePortfolioCryptosSectionViewModel.ts
@@ -5,10 +5,8 @@ import { Asset } from "~/types/asset";
 import { useDefaultAssetsByCategory } from "LLM/hooks/useDefaultAssetsByCategory";
 import { useReadOnlyCoins } from "~/hooks/useReadOnlyCoins";
 import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
-import {
-  toAsset,
-  usePortfolioSectionActions,
-} from "LLM/features/WalletAssets/shared/usePortfolioSectionActions";
+import { usePortfolioSectionActions } from "LLM/features/WalletAssets/shared/usePortfolioSectionActions";
+import { toAsset, padAssetsWithDefaults } from "LLM/features/WalletAssets/shared/assetUtils";
 
 export const MAX_ASSETS_TO_DISPLAY = 6;
 export const EMPTY_STATE_MAX_ASSETS = 4;
@@ -51,11 +49,12 @@ const usePortfolioCryptosSectionViewModel = ({
     [categorizedAssets.cryptos, blacklistedTokenIdsSet],
   );
 
+  const needsDefaultAssets = isEmptyState || filteredAssets.length < EMPTY_STATE_MAX_ASSETS;
   const {
     cryptos: defaultAssets,
     isLoading,
     isError,
-  } = useDefaultAssetsByCategory(isEmptyState, stablecoinTickers, EMPTY_STATE_MAX_ASSETS, 0);
+  } = useDefaultAssetsByCategory(needsDefaultAssets, stablecoinTickers, EMPTY_STATE_MAX_ASSETS, 0);
 
   const { sortedCryptoCurrencies } = useReadOnlyCoins({ maxDisplayed: READ_ONLY_MAX_ASSETS });
   const readOnlyAssets = useMemo<Asset[]>(
@@ -69,7 +68,7 @@ const usePortfolioCryptosSectionViewModel = ({
   const assets = useMemo<Asset[]>(() => {
     if (isEmptyState) return defaultAssets;
     if (isReadOnly) return readOnlyAssets;
-    return filteredAssets;
+    return padAssetsWithDefaults(filteredAssets, defaultAssets, EMPTY_STATE_MAX_ASSETS);
   }, [isEmptyState, isReadOnly, defaultAssets, readOnlyAssets, filteredAssets]);
 
   const assetsCount = assets.length;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/__tests__/usePortfolioStablecoinsSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/__tests__/usePortfolioStablecoinsSectionViewModel.test.ts
@@ -4,9 +4,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
 import { State } from "~/reducers/types";
 import { CategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/types";
-import usePortfolioStablecoinsSectionViewModel, {
-  padStablecoins,
-} from "../usePortfolioStablecoinsSectionViewModel";
+import usePortfolioStablecoinsSectionViewModel from "../usePortfolioStablecoinsSectionViewModel";
 import { bitcoin, ethereum, createAsset } from "./shared";
 
 const mockNavigate = jest.fn();
@@ -188,28 +186,4 @@ describe("usePortfolioStablecoinsSectionViewModel", () => {
     });
   });
 
-  describe("padStablecoins", () => {
-    const usdc = createAsset(ethereum, 0);
-    const dai = createAsset(bitcoin, 0);
-    const tether = { ...createAsset(bitcoin, 0), currency: { ...bitcoin, id: "tether" } } as Asset;
-
-    it("should return owned assets unchanged when already at max", () => {
-      const owned = [usdc, dai];
-      expect(padStablecoins(owned, [tether], 2)).toEqual(owned);
-    });
-
-    it("should pad up to max with defaults when fewer than max are owned", () => {
-      const result = padStablecoins([usdc], [dai, tether], 3);
-
-      expect(result).toHaveLength(3);
-      expect(result[0]).toBe(usdc);
-    });
-
-    it("should not pad with assets already owned (deduplication by currency id)", () => {
-      const result = padStablecoins([usdc], [usdc, dai], 2);
-
-      expect(result).toHaveLength(2);
-      expect(result[1].currency.id).toBe(dai.currency.id);
-    });
-  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/usePortfolioStablecoinsSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/usePortfolioStablecoinsSectionViewModel.ts
@@ -4,10 +4,8 @@ import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 import { Asset } from "~/types/asset";
 import { useDefaultAssetsByCategory } from "LLM/hooks/useDefaultAssetsByCategory";
 import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
-import {
-  toAsset,
-  usePortfolioSectionActions,
-} from "LLM/features/WalletAssets/shared/usePortfolioSectionActions";
+import { usePortfolioSectionActions } from "LLM/features/WalletAssets/shared/usePortfolioSectionActions";
+import { toAsset, padAssetsWithDefaults } from "LLM/features/WalletAssets/shared/assetUtils";
 
 export const MAX_STABLECOINS_TO_DISPLAY = 6;
 export const EMPTY_STATE_MAX_STABLECOINS = 2;
@@ -25,16 +23,6 @@ export interface PortfolioStablecoinsSectionViewModelResult {
 interface UsePortfolioStablecoinsSectionViewModelOptions {
   isEmptyState?: boolean;
   isReadOnly?: boolean;
-}
-
-/**
- * Pads `owned` with items from `defaults` (deduped by currency id) up to `max` total.
- */
-export function padStablecoins(owned: Asset[], defaults: Asset[], max: number): Asset[] {
-  if (owned.length >= max) return owned;
-  const ownedIds = new Set(owned.map(a => a.currency.id));
-  const padding = defaults.filter(p => !ownedIds.has(p.currency.id)).slice(0, max - owned.length);
-  return [...owned, ...padding];
 }
 
 const usePortfolioStablecoinsSectionViewModel = ({
@@ -71,7 +59,11 @@ const usePortfolioStablecoinsSectionViewModel = ({
 
   const assets = useMemo<Asset[]>(() => {
     if (isEmptyState || isReadOnly) return defaultStablecoins;
-    return padStablecoins(filteredStablecoins, defaultStablecoins, EMPTY_STATE_MAX_STABLECOINS);
+    return padAssetsWithDefaults(
+      filteredStablecoins,
+      defaultStablecoins,
+      EMPTY_STATE_MAX_STABLECOINS,
+    );
   }, [isEmptyState, isReadOnly, defaultStablecoins, filteredStablecoins]);
 
   const assetsCount = assets.length;

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useDefaultAssetsByCategory.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useDefaultAssetsByCategory.ts
@@ -48,14 +48,12 @@ export function useDefaultAssetsByCategory(
       if (!currency) continue;
 
       const ticker = assetsData.cryptoAssets[id]?.ticker?.toUpperCase() ?? "";
-      const { price, id: marketId } = assetsData.markets?.[currency.id] ?? {};
+      const { id: marketId } = assetsData.markets?.[currency.id] ?? {};
       const item: Asset = {
         currency,
         accounts: [],
         amount: 0,
-        countervalue: 0,
         isPlaceholder: true,
-        placeholderPrice: price,
         marketId: marketId ?? currency.id,
       };
 

--- a/apps/ledger-live-mobile/src/types/asset.ts
+++ b/apps/ledger-live-mobile/src/types/asset.ts
@@ -6,8 +6,6 @@ export type Asset = {
   accounts: AccountLike[];
   distribution?: number;
   amount: number;
-  countervalue?: number;
   isPlaceholder?: boolean;
-  placeholderPrice?: number;
   marketId?: string;
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio screen: verify the Cryptos and Stablecoins sections still display correctly
      - Ensure placeholder assets show \`$0\` instead of the market price in the list
      - Verify padding behaviour when the user owns fewer than 4 cryptos

### 📝 Description

Two focused fixes on top of the `WalletAssets` MVVM extraction:

**1. Placeholder asset counter value (`useListItemViewModel`)**

Placeholder assets (from the DADA API) were displaying their market price as the counter value. This is misleading because the user does not own these assets. The viewmodel now always renders `$0` for placeholders, and `placeholderPrice` is removed from the `useMemo` dependency array.

**2. Crypto section padding utility (`usePortfolioCryptosSectionViewModel`)**

When a user owns fewer than 4 cryptos the section was showing a sparse list with no padding. A `padCryptos` pure utility is added (mirroring the existing `padStablecoins` on the stablecoins side) that fills remaining slots with deduped placeholder assets from the DADA API. The DADA fetch is also now triggered whenever the owned count is below the threshold, not only in empty-state mode.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28087](https://ledgerhq.atlassian.net/browse/LIVE-28087)

---
<img width="603" height="1311" alt="Simulator Screenshot - iOS Simulator - 2026-03-25 at 14 07 54" src="https://github.com/user-attachments/assets/d4b09508-bd57-483b-82c0-379abd1c137e" />
<img width="603" height="1311" alt="Simulator Screenshot - iOS Simulator - 2026-03-25 at 14 08 26" src="https://github.com/user-attachments/assets/69896b2f-b31c-4ac1-937b-9a6120fdbe1f" />

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28087]: https://ledgerhq.atlassian.net/browse/LIVE-28087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ