### PR TITLE
[LWD] fix(exchange): set broadcast guard synchronously in CompleteExchange

### DIFF
--- a/.changeset/cool-queens-vanish.md
+++ b/.changeset/cool-queens-vanish.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(exchange): set broadcast guard synchronously in CompleteExchange

--- a/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
@@ -330,12 +330,11 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
 
   useEffect(() => {
     if (broadcastRef.current || !signedOperation) return;
-    broadcast(signedOperation)
-      .then(onBroadcastSuccess, error => {
-        setError(error);
-      })
-      .finally(() => (broadcastRef.current = true));
-  }, [signedOperation, broadcast, onBroadcastSuccess, setError, broadcastRef, onCancel, onClose]);
+    // Guard must be set synchronously before the async call to prevent
+    // a second broadcast if deps change while the first is still in progress.
+    broadcastRef.current = true;
+    broadcast(signedOperation).then(onBroadcastSuccess, setError);
+  }, [signedOperation, broadcast, onBroadcastSuccess, setError]);
 
   return (
     <Root>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

On platform exchange / swap completion, Solana could return “This transaction has already been processed” when the same signed operation was broadcast twice. The broadcast guard was only set in `.finally()` (after the async `broadcast()` finished), so another useEffect run could start a second broadcast while the first was still in flight. Unused deps (`onCancel`, `onClose`) also caused extra effect runs.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-28148)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
