### PR TITLE
[LWM] chore(lwm): [LIVE-28128] track Datadog startup metric on segment

### DIFF
--- a/.changeset/curly-avocados-drum.md
+++ b/.changeset/curly-avocados-drum.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Track Datadog startup metric on segment

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketList/index.tsx
@@ -24,6 +24,7 @@ import useMarketListViewModel from "./useMarketListViewModel";
 import { LIMIT } from "~/reducers/market";
 import { DdRum } from "@datadog/mobile-react-native";
 import { ScreenName } from "~/const";
+import { ddAddViewLoadingTime } from "LLM/utils/ddAddViewLoadingTime";
 import { MARKET_LIST_VIEW_ID } from "~/utils/constants";
 import { buildFeatureFlagTags } from "~/utils/datadogUtils";
 
@@ -122,7 +123,7 @@ function View({
     DdRum.startView(MARKET_LIST_VIEW_ID, ScreenName.MarketList, {
       featureFlags: buildFeatureFlagTags(),
     });
-    DdRum.addViewLoadingTime(true);
+    ddAddViewLoadingTime();
   }, []);
   /**
    * Try to Refetch data every REFRESH_RATE time

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
@@ -25,6 +25,7 @@ import { useWallet40Theme } from "LLM/hooks/useWallet40Theme";
 import storage from "LLM/storage";
 import { DdRum } from "@datadog/mobile-react-native";
 import { PORTFOLIO_VIEW_ID, TOP_CHAINS } from "~/utils/constants";
+import { ddAddViewLoadingTime } from "LLM/utils/ddAddViewLoadingTime";
 import { buildFeatureFlagTags } from "~/utils/datadogUtils";
 import { ScreenName } from "~/const";
 
@@ -114,7 +115,7 @@ const usePortfolioViewModel = (navigation: {
       { topChains, featureFlags: buildFeatureFlagTags() },
       Date.now(),
     );
-    DdRum.addViewLoadingTime(true);
+    ddAddViewLoadingTime();
   }, [allAccounts, llmDatadog?.enabled]);
 
   const hasTokenAccounts = useSelector(hasTokenAccountsNotBlacklistedSelector);

--- a/apps/ledger-live-mobile/src/mvvm/utils/__tests__/logLastStartupEvents.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/utils/__tests__/logLastStartupEvents.test.ts
@@ -1,10 +1,13 @@
+import { DdRum } from "@datadog/mobile-react-native";
 import { DdRumReactNavigationTracking } from "@datadog/mobile-react-navigation";
 import mmkvStorageWrapper from "LLM/storage/mmkvStorageWrapper";
 import { track } from "~/analytics";
 import { navigationRef } from "~/rootnavigation";
 import { viewNamePredicate } from "~/datadog";
+import { ddAddViewLoadingTime } from "../ddAddViewLoadingTime";
 import { logStartupEvent, startupEvents, startupFirstImportTime } from "../logStartupTime";
 import {
+  LAST_EVENTS_BUFFER,
   logLastStartupEvents,
   type StorageCurrencyData,
   type StoreStorageData,
@@ -14,27 +17,41 @@ import { STARTUP_EVENTS } from "../resolveStartupEvents";
 jest.mock("@datadog/mobile-react-navigation", () => ({
   DdRumReactNavigationTracking: { startTrackingViews: jest.fn() },
 }));
+jest.mock("@datadog/mobile-react-native", () => ({
+  DdRum: { addViewLoadingTime: jest.fn() },
+}));
 jest.mock("~/analytics", () => ({ track: jest.fn() }));
 jest.mock("~/rootnavigation", () => ({ navigationRef: { current: {} } }));
 jest.mock("~/datadog", () => ({ viewNamePredicate: jest.fn() }));
 
 describe("logLastStartupEvents", () => {
-  beforeEach(() => {
-    jest.useRealTimers();
+  beforeEach(async () => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
     startupEvents.splice(0);
+    await mmkvStorageWrapper.deleteAll();
   });
 
-  it("tracks all startup events once both APP_STARTED and NAV_READY are logged", async () => {
+  afterEach(async () => {
+    await mmkvStorageWrapper.deleteAll();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("tracks startup events after the buffer once both APP_STARTED and NAV_READY are logged", async () => {
     logStartupEvent("Step 1");
     await logLastStartupEvents(STARTUP_EVENTS.NAV_READY);
-    const appStartedEvent = await logLastStartupEvents(STARTUP_EVENTS.APP_STARTED);
+    const appStartedEventPromise = logLastStartupEvents(STARTUP_EVENTS.APP_STARTED);
 
     expect(DdRumReactNavigationTracking.startTrackingViews).toHaveBeenCalledTimes(1);
     expect(DdRumReactNavigationTracking.startTrackingViews).toHaveBeenCalledWith(
       navigationRef.current,
       viewNamePredicate,
     );
+    expect(track).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(LAST_EVENTS_BUFFER);
+    const appStartedEvent = await appStartedEventPromise;
 
     expect(track).toHaveBeenCalledTimes(1);
     expect(track).toHaveBeenCalledWith("app_startup_events", {
@@ -65,24 +82,30 @@ describe("logLastStartupEvents", () => {
 
   it("triggers tracking only once", async () => {
     await logLastStartupEvents(STARTUP_EVENTS.APP_STARTED);
-    await logLastStartupEvents(STARTUP_EVENTS.NAV_READY);
+    const navReadyEventPromise = logLastStartupEvents(STARTUP_EVENTS.NAV_READY);
+
+    jest.advanceTimersByTime(LAST_EVENTS_BUFFER);
+    await navReadyEventPromise;
     expect(track).toHaveBeenCalledTimes(1);
+    expect(DdRumReactNavigationTracking.startTrackingViews).toHaveBeenCalledTimes(1);
 
     await logLastStartupEvents(STARTUP_EVENTS.APP_STARTED);
+    await logLastStartupEvents(STARTUP_EVENTS.NAV_READY);
     expect(track).toHaveBeenCalledTimes(1);
+    expect(DdRumReactNavigationTracking.startTrackingViews).toHaveBeenCalledTimes(1);
   });
 
-  it("correctly extracts the LAST_STARTUP_EVENTS time as appStartupTime", async () => {
+  it("captures startup events logged during the buffer while keeping appStartupTime based on the last startup event", async () => {
     logStartupEvent("First");
     logStartupEvent("Second");
     await logLastStartupEvents(STARTUP_EVENTS.APP_STARTED);
     const trackingCallEvent = logLastStartupEvents(STARTUP_EVENTS.NAV_READY);
+    jest.advanceTimersByTime(50);
     const last = logStartupEvent("Last");
-    expect(last).toEqual(expect.objectContaining({ event: "Last" }));
-    last.time += 50; // Make sure the last event is a few ms after NAV_READY
 
+    jest.advanceTimersByTime(LAST_EVENTS_BUFFER - 50);
     const navReadyEvent = await trackingCallEvent;
-    const expectedStartupTime = navReadyEvent!.time - startupFirstImportTime;
+    const expectedStartupTime = navReadyEvent.time - startupFirstImportTime;
     expect(track).toHaveBeenCalledWith("app_startup_events", {
       appStartupTime: expectedStartupTime,
       events: expect.arrayContaining([
@@ -90,13 +113,31 @@ describe("logLastStartupEvents", () => {
         expect.objectContaining({ event: "Second" }),
         expect.objectContaining({ event: STARTUP_EVENTS.APP_STARTED }),
         expect.objectContaining({ event: STARTUP_EVENTS.NAV_READY }),
-        expect.objectContaining({ event: "Last", time: last!.time - startupFirstImportTime }),
+        expect.objectContaining({ event: "Last", time: last.time - startupFirstImportTime }),
+      ]),
+    });
+  });
+
+  it("includes the Datadog view loading marker when the helper runs before startup finalization", async () => {
+    await logLastStartupEvents(STARTUP_EVENTS.APP_STARTED);
+    const navReadyEventPromise = logLastStartupEvents(STARTUP_EVENTS.NAV_READY);
+
+    expect(DdRumReactNavigationTracking.startTrackingViews).toHaveBeenCalledTimes(1);
+    ddAddViewLoadingTime();
+    expect(DdRum.addViewLoadingTime).toHaveBeenCalledWith(true);
+
+    jest.advanceTimersByTime(LAST_EVENTS_BUFFER);
+    await navReadyEventPromise;
+
+    expect(track).toHaveBeenCalledWith("app_startup_events", {
+      appStartupTime: expect.any(Number),
+      events: expect.arrayContaining([
+        expect.objectContaining({ event: "DD view loaded", count: 1 }),
       ]),
     });
   });
 
   it("tracks the time it took to load the storage", async () => {
-    await mmkvStorageWrapper.deleteAll();
     mmkvStorageWrapper.save("ble", "qwerty");
     mmkvStorageWrapper.save("accounts.0", "lorem ipsum");
     mmkvStorageWrapper.save("accounts.1", "lorem ipsum");
@@ -116,7 +157,10 @@ describe("logLastStartupEvents", () => {
 
     logStartupEvent<StoreStorageData>(STARTUP_EVENTS.STORE_STORAGE_READ, storageData);
     await logLastStartupEvents(STARTUP_EVENTS.APP_STARTED);
-    await logLastStartupEvents(STARTUP_EVENTS.NAV_READY);
+    const navReadyEventPromise = logLastStartupEvents(STARTUP_EVENTS.NAV_READY);
+
+    jest.advanceTimersByTime(LAST_EVENTS_BUFFER);
+    await navReadyEventPromise;
 
     expect(track).toHaveBeenCalledWith("app_startup_events", {
       appStartupTime: expect.any(Number),
@@ -133,7 +177,6 @@ describe("logLastStartupEvents", () => {
       fullStorage_keyCount: 5,
       fullStorage_size: expect.any(Number), // MMKV size is not predictable in tests
     });
-    await mmkvStorageWrapper.deleteAll();
   });
 
   it("tracks the time taken by the bridges currency hydration", async () => {
@@ -159,7 +202,10 @@ describe("logLastStartupEvents", () => {
     logStartupEvent<StorageCurrencyData>(STARTUP_EVENTS.CURRENCY_HYDRATED, currencyData);
 
     await logLastStartupEvents(STARTUP_EVENTS.APP_STARTED);
-    await logLastStartupEvents(STARTUP_EVENTS.NAV_READY);
+    const navReadyEventPromise = logLastStartupEvents(STARTUP_EVENTS.NAV_READY);
+
+    jest.advanceTimersByTime(LAST_EVENTS_BUFFER);
+    await navReadyEventPromise;
 
     expect(track).toHaveBeenCalledWith("app_startup_events", {
       appStartupTime: expect.any(Number),

--- a/apps/ledger-live-mobile/src/mvvm/utils/ddAddViewLoadingTime.ts
+++ b/apps/ledger-live-mobile/src/mvvm/utils/ddAddViewLoadingTime.ts
@@ -1,0 +1,7 @@
+import { DdRum } from "@datadog/mobile-react-native";
+import { logStartupEvent } from "./logStartupTime";
+
+export function ddAddViewLoadingTime() {
+  logStartupEvent("DD view loaded");
+  DdRum.addViewLoadingTime(true);
+}

--- a/apps/ledger-live-mobile/src/mvvm/utils/logLastStartupEvents.ts
+++ b/apps/ledger-live-mobile/src/mvvm/utils/logLastStartupEvents.ts
@@ -7,10 +7,9 @@ import { resolveStartupEvents, STARTUP_EVENTS } from "./resolveStartupEvents";
 import mmkvStorageWrapper, { type MMKVMonitoredRead } from "../storage/mmkvStorageWrapper";
 
 type LastStartupEvent = (typeof STARTUP_EVENTS)["APP_STARTED" | "NAV_READY"];
-export const LAST_STARTUP_EVENT_VALUES = new Set<string>([
-  STARTUP_EVENTS.APP_STARTED,
-  STARTUP_EVENTS.NAV_READY,
-]);
+export const LAST_STARTUP_EVENT_VALUES = [STARTUP_EVENTS.APP_STARTED, STARTUP_EVENTS.NAV_READY];
+
+export const LAST_EVENTS_BUFFER = 10_000; // We want to make sure we capture any event that might happen right after the last startup event
 
 /**
  * Logs a startup event and conditionally sends the "app_startup_events" segment event once the startup is complete.
@@ -26,25 +25,26 @@ export const LAST_STARTUP_EVENT_VALUES = new Set<string>([
  * @returns The {@link StartupEvent} instance recorded for this call.
  */
 export async function logLastStartupEvents(eventName: LastStartupEvent): Promise<StartupEvent> {
+  const alreadyLogged = new Set(startupEvents.map(e => e.event));
   const event = logStartupEvent(eventName);
-  const lastEventCalls = startupEvents.flatMap(e =>
-    LAST_STARTUP_EVENT_VALUES.has(e.event) ? e.event : [],
-  );
-  const isStartupDone = new Set(lastEventCalls).size === LAST_STARTUP_EVENT_VALUES.size;
-  const isStartupLastCall = lastEventCalls.filter(e => e === eventName).length === 1;
-  if (isStartupDone && isStartupLastCall) {
+
+  const otherStartupEvents = LAST_STARTUP_EVENT_VALUES.filter(e => e !== eventName);
+  if (!alreadyLogged.has(eventName) && otherStartupEvents.every(e => alreadyLogged.has(e))) {
     try {
       DdRumReactNavigationTracking.startTrackingViews(navigationRef.current, viewNamePredicate);
-      const [events, storageState] = await Promise.all([
-        resolveStartupEvents(),
+      const [storageState] = await Promise.all([
         summarizeStorageData(),
+        new Promise(resolve => setTimeout(resolve, LAST_EVENTS_BUFFER)), // Wait for potential events right after the last startup event to be logged
       ]);
+
+      const events = await resolveStartupEvents();
       const appStartupTime = events.find(e => e.event === eventName)?.time ?? 0;
       await track("app_startup_events", { appStartupTime, ...storageState, events });
     } catch (error) {
       console.error("Error during app startup tracking:", error);
     }
   }
+
   return event;
 }
 

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -50,6 +50,7 @@ import storage from "LLM/storage";
 import type { Feature_LlmMmkvMigration } from "@ledgerhq/types-live";
 import { DdRum } from "@datadog/mobile-react-native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { ddAddViewLoadingTime } from "LLM/utils/ddAddViewLoadingTime";
 import { PORTFOLIO_VIEW_ID, TOP_CHAINS } from "~/utils/constants";
 import { buildFeatureFlagTags } from "~/utils/datadogUtils";
 import { renderItem } from "LLM/utils/renderItem";
@@ -119,7 +120,7 @@ function PortfolioScreen({ navigation }: NavigationProps) {
       { topChains, featureFlags: buildFeatureFlagTags() },
       Date.now(),
     );
-    DdRum.addViewLoadingTime(true);
+    ddAddViewLoadingTime();
   }, [allAccounts, llmDatadog?.enabled]);
 
   const hasTokenAccounts = useSelector(hasTokenAccountsNotBlacklistedSelector);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Performance/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Performance/index.tsx
@@ -11,9 +11,8 @@ export default function Performance() {
 
   useEffect(() => {
     resolveStartupEvents().then(events => {
-      setStartupTime(
-        [...events].reverse().find(e => LAST_STARTUP_EVENT_VALUES.has(e.event))?.time ?? 0,
-      );
+      const lastEvents = new Set<string>(LAST_STARTUP_EVENT_VALUES);
+      setStartupTime([...events].reverse().find(e => lastEvents.has(e.event))?.time ?? 0);
       setStartupEvents(events);
     });
   }, []);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Track the Datadog startup metric both on segment and on the performance screen so we can understand the difference between these.
Simply add a 10sec buffer for when the DD event is triggered later than what we treat as the app started (I could not reproduce this case).  

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28128]
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28128]: https://ledgerhq.atlassian.net/browse/LIVE-28128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ