### PR TITLE
[LWM] feat(mobile): hide portfolio operations when wallet 4.0 list is shown

### DIFF
--- a/.changeset/shaggy-pets-yawn.md
+++ b/.changeset/shaggy-pets-yawn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Remove tx history section for wallet 4.0

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -64,6 +64,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     onBackFromUpdate,
     goToAnalyticsAllocations,
     shouldDisplayWallet40MainNav,
+    shouldDisplayOperationsList,
   } = usePortfolioViewModel(navigation);
 
   const progressViewOffset = getProgressViewOffset(Platform.OS, shouldDisplayWallet40MainNav);
@@ -155,7 +156,9 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
       );
     }
 
-    sections.push(<PortfolioOperationsSection key="operations" />);
+    if (!shouldDisplayOperationsList) {
+      sections.push(<PortfolioOperationsSection key="operations" />);
+    }
 
     return sections;
   }, [
@@ -173,6 +176,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     isAWalletCardDisplayed,
     backgroundColor,
     goToAnalyticsAllocations,
+    shouldDisplayOperationsList,
   ]);
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
@@ -36,6 +36,7 @@ interface UsePortfolioViewModelResult {
   shouldDisplayWallet40MainNav: boolean;
   shouldDisplayAssetSection: boolean;
   shouldDisplayMarketBanner: boolean;
+  shouldDisplayOperationsList: boolean;
   showAssets: boolean;
   isLNSUpsellBannerShown: boolean;
   isAddModalOpened: boolean;
@@ -63,6 +64,7 @@ const usePortfolioViewModel = (navigation: {
     shouldDisplayWallet40MainNav,
     shouldDisplayAssetSection,
     shouldDisplayMarketBanner,
+    shouldDisplayOperationsList,
   } = useWalletFeaturesConfig("mobile");
   const isAccountListUIEnabled = accountListFF?.enabled ?? false;
   const llmDatadog = useFeature("llmDatadog");
@@ -152,6 +154,7 @@ const usePortfolioViewModel = (navigation: {
     shouldDisplayWallet40MainNav,
     shouldDisplayAssetSection,
     shouldDisplayMarketBanner,
+    shouldDisplayOperationsList,
     showAssets,
     isLNSUpsellBannerShown,
     isAddModalOpened,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new mobile tests; `shouldDisplayOperationsList` is covered in `@ledgerhq/live-common` wallet features config tests._
- [x] **Impact of the changes:**
      - Portfolio screen layout and scroll sections when Wallet 4.0 operations list is enabled vs disabled
      - Absence of duplicate transaction history when the dedicated operations entry point is active

### 📝 Description

**Problem:** With Wallet 4.0, transaction history is available via the dedicated operations flow (e.g. top bar). Showing `PortfolioOperationsSection` on the portfolio scroll duplicated that content.

**Solution:** Expose `shouldDisplayOperationsList` from `useWalletFeaturesConfig("mobile")` in the portfolio view model and only render `PortfolioOperationsSection` when that flag is false—matching the desktop portfolio pattern (`shouldRenderLegacyOperationsList`).

Spacing will be fixed with the UI rework of the see all assets button

### 📸 Demo (ff ON then OFF)

https://github.com/user-attachments/assets/46877046-ec8e-485b-9cd7-63171eebf1cf




### ❓ Context

- **JIRA or GitHub link**: [LIVE-26753](https://ledgerhq.atlassian.net/browse/LIVE-26753)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26753]: https://ledgerhq.atlassian.net/browse/LIVE-26753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ