### PR TITLE
[LWD] feat(desktop): add empty state to transaction history

### DIFF
--- a/.changeset/wet-glasses-bake.md
+++ b/.changeset/wet-glasses-bake.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add empty state to transaction history screen

--- a/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen, waitFor, within } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { setDrawer } from "~/renderer/drawers/Provider";
-import { BTC_ACCOUNT } from "../../__mocks__/accounts.mock";
+import { BTC_ACCOUNT, EMPTY_BTC_ACCOUNT } from "../../__mocks__/accounts.mock";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import type { Account } from "@ledgerhq/types-live";
 import History from "../index";
@@ -113,5 +113,20 @@ describe("History integration", () => {
     await waitFor(() => {
       expect(screen.getByText(/pending transaction/i)).toBeVisible();
     });
+  });
+
+  it("should render empty state when there are no operations", async () => {
+    render(<History />, {
+      initialState: {
+        accounts: [EMPTY_BTC_ACCOUNT],
+        settings: AFTER_ONBOARDING_STATE,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("No transactions yet")).toBeVisible();
+    });
+
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/EmptyState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/EmptyState.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { Spot } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+
+export function EmptyState() {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col items-center justify-center min-h-0 flex-1">
+      <Spot appearance="info" />
+      <span className="heading-4-semi-bold text-base mt-24 mb-8">
+        {t("history.emptyState.title")}
+      </span>
+      <span className="body-2 text-muted">{t("history.emptyState.description")}</span>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryTableBody.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryTableBody.tsx
@@ -20,9 +20,6 @@ export function HistoryTableBody({
   onRowClick,
 }: HistoryTableBodyProps) {
   const virtualItems = rowVirtualizer.getVirtualItems();
-
-  // TODO: add empty state (next iteration)
-
   const totalSize = rowVirtualizer.getTotalSize();
   const paddingTop = virtualItems[0]?.start ?? 0;
   const paddingBottom = totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0);

--- a/apps/ledger-live-desktop/src/mvvm/features/History/screens/HistoryList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/screens/HistoryList.tsx
@@ -3,6 +3,7 @@ import { TableRoot, Table } from "@ledgerhq/lumen-ui-react";
 import { Virtualizer } from "@tanstack/react-virtual";
 import { HistoryTableHeader } from "../components/HistoryTableHeader";
 import { HistoryTableBody } from "../components/HistoryTableBody";
+import { EmptyState } from "../components/EmptyState";
 import type { VirtualItem, HistoryTable, OperationRow } from "../types";
 
 type HistoryListProps = {
@@ -20,6 +21,10 @@ function HistoryList({
   flatItems,
   onRowClick,
 }: HistoryListProps) {
+  if (flatItems.length === 0) {
+    return <EmptyState />;
+  }
+
   return (
     <TableRoot ref={parentRef} appearance="plain" className="min-h-0 flex-1 overflow-auto mb-32">
       <Table>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8425,6 +8425,10 @@
     "address": {
       "from": "From",
       "to": "To"
+    },
+    "emptyState": {
+      "title": "No transactions yet",
+      "description": "Come back later to see your transactions."
     }
   }
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - History screen when no operations exist
      - Empty state rendering outside of the table component

### 📝 Description

When a user has no transaction history, the history screen previously showed an empty table. This PR adds a dedicated empty state component that renders outside the `<Table>`, displaying a clear message ("No transactions yet") when there are no operations to show.

Changes:
- Add `EmptyState` component with translated title and description
- Move empty state check from `HistoryTableBody` to `HistoryList` so it renders outside the table
- Add integration test covering the empty state scenario
- Add i18n keys for empty state title and description


<img width="1624" height="975" alt="Screenshot 2026-03-24 at 17 45 43" src="https://github.com/user-attachments/assets/1e798916-71dc-4e3a-9ad8-31427d76853f" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26181](https://ledgerhq.atlassian.net/browse/LIVE-26181)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26181]: https://ledgerhq.atlassian.net/browse/LIVE-26181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ