### PR TITLE
[LWDM] fix(coin-evm): fail when internal txs can't be retrieved

### DIFF
--- a/.changeset/flat-rice-vanish.md
+++ b/.changeset/flat-rice-vanish.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+fix(coin-evm): fail when internal txs can't be retrieved

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
@@ -471,7 +471,7 @@ describe("getBlock", () => {
     );
   });
 
-  it("when traceBlock throws UnsupportedRpcMethodError, returns block with no internal transactions", async () => {
+  it("when traceBlock throws UnsupportedRpcMethodError, the exception is propagated so that the caller can retry to fetch the whole block", async () => {
     setCoinConfig(
       () =>
         ({
@@ -482,12 +482,14 @@ describe("getBlock", () => {
         }) as unknown as EvmCoinConfig,
     );
 
-    const mockTraceBlock = jest.fn().mockRejectedValue(
-      new UnsupportedRpcMethodError("trace_block is not supported by this RPC provider", {
+    const error = new UnsupportedRpcMethodError(
+      "trace_block is not supported by this RPC provider",
+      {
         method: "trace_block",
         rawError: { code: -32601 },
-      }),
+      },
     );
+    const mockTraceBlock = jest.fn().mockRejectedValue(error);
     const mockGetNodeApi = jest.mocked(getNodeApi);
     mockGetNodeApi.mockReturnValue({
       getBlockByHeight: jest.fn().mockResolvedValue(
@@ -502,12 +504,10 @@ describe("getBlock", () => {
     } as any);
     const mockGetInternalTransactionsByBlock = jest.mocked(getInternalTransactionsByBlock);
 
-    const result = await getBlock({} as CryptoCurrency, 12345);
+    await expect(getBlock({} as CryptoCurrency, 12345)).rejects.toThrow(error);
 
     expect(mockGetInternalTransactionsByBlock).not.toHaveBeenCalled();
-
-    expect(result.transactions).toHaveLength(1);
-    expect(result.transactions[0].operations).toHaveLength(0);
+    expect(mockTraceBlock).toHaveBeenCalledWith(expect.anything(), 12345);
   });
 
   it("when explorer.getInternalTransactionsByBlock fails and node.traceBlock is undefined, returns block with no internal transactions", async () => {
@@ -617,5 +617,47 @@ describe("getBlock", () => {
         }),
       ]),
     });
+  });
+
+  it("when explorer.getInternalTransactionsByBlock fails and traceBlock rejects UnsupportedRpcMethodError, propagates the error", async () => {
+    setCoinConfig(
+      () =>
+        ({
+          info: {
+            node: { type: "external" as const, retries: 0 },
+            explorer: { type: "etherscan", uri: "https://api.etherscan.io" },
+          },
+        }) as unknown as EvmCoinConfig,
+    );
+
+    const error = new UnsupportedRpcMethodError(
+      "trace_block is not supported by this RPC provider",
+      {
+        method: "trace_block",
+        rawError: { code: -32601 },
+      },
+    );
+    const mockTraceBlock = jest.fn().mockRejectedValue(error);
+    const mockGetNodeApi = jest.mocked(getNodeApi);
+    mockGetNodeApi.mockReturnValue({
+      getBlockByHeight: jest.fn().mockResolvedValue(
+        makeNodeBlock({
+          transactions: [makeNodeBlockTx({ hash: "0xtx1", value: "0" })],
+        }),
+      ),
+      getBlockReceipts: jest
+        .fn()
+        .mockResolvedValue([makeNodeBlockReceipt({ hash: "0xtx1", erc20Transfers: [] })]),
+      getTransaction: jest.fn(),
+      traceBlock: mockTraceBlock,
+    } as any);
+
+    const mockGetInternalTransactionsByBlock = jest.mocked(getInternalTransactionsByBlock);
+    mockGetInternalTransactionsByBlock.mockRejectedValueOnce(new Error("explorer error"));
+
+    await expect(getBlock({} as CryptoCurrency, 12345)).rejects.toThrow(error);
+
+    expect(mockGetInternalTransactionsByBlock).toHaveBeenCalledWith(expect.anything(), 12345);
+    expect(mockTraceBlock).toHaveBeenCalledWith(expect.anything(), 12345);
   });
 });

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.ts
@@ -36,13 +36,7 @@ function internalTransactionsFetcher(
       });
       return new Map();
     } else {
-      return nodeApi
-        .traceBlock(currency, height)
-        .then(traceBlockItemsToOperationsByHash)
-        .catch(error => {
-          if (error instanceof UnsupportedRpcMethodError) return new Map();
-          throw error;
-        });
+      return nodeApi.traceBlock(currency, height).then(traceBlockItemsToOperationsByHash);
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - bug fix, getBlock may fail more often

### 📝 Description

When internal txs can't be retrieved by either the explorer or the node, getBlock silently returned the block without internal txs.
Consequence of that is that A4 misses operations and compute wrong balance.
With that change the call fails and can be retried until one of the method is available.

### ❓ Context

Test coverage for all coins https://ledgerhq.atlassian.net/wiki/spaces/BE/pages/edit-v2/6904872969?


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
