### PR TITLE
[LWM] perf(lwm): lazily mount global drawers

### DIFF
--- a/.changeset/old-masks-sin.md
+++ b/.changeset/old-masks-sin.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Lazily mount global drawers

--- a/apps/ledger-live-mobile/src/GlobalDrawers/__integrations__/globalDrawers.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/GlobalDrawers/__integrations__/globalDrawers.integration.test.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import { render, waitFor } from "@tests/test-renderer";
+import { act, render, waitFor } from "@tests/test-renderer";
 import { Text, View } from "react-native";
 import GlobalDrawers from "../index";
+import { openModularDrawer, closeModularDrawer } from "~/reducers/modularDrawer";
+import { openReceiveOptionsDrawer } from "~/reducers/receiveOptionsDrawer";
 
 jest.mock("LLM/features/ModularDrawer/ModularDrawerWrapper", () => ({
   ModularDrawerWrapper: jest.fn(() => <View testID="modular-drawer-wrapper" />),
@@ -16,8 +18,8 @@ describe("GlobalDrawers Integration", () => {
     jest.clearAllMocks();
   });
 
-  it("should render children and all drawer wrappers from registry", async () => {
-    const { getByTestId } = render(
+  it("should render children but not mount drawer wrappers before first open", () => {
+    const { getByTestId, queryByTestId } = render(
       <GlobalDrawers>
         <View testID="app-content">
           <Text>App Content</Text>
@@ -26,30 +28,72 @@ describe("GlobalDrawers Integration", () => {
     );
 
     expect(getByTestId("app-content")).toBeTruthy();
-
-    await waitFor(() => {
-      expect(getByTestId("modular-drawer-wrapper")).toBeTruthy();
-      expect(getByTestId("receive-drawer-wrapper")).toBeTruthy();
-    });
+    expect(queryByTestId("modular-drawer-wrapper")).toBeNull();
+    expect(queryByTestId("receive-drawer-wrapper")).toBeNull();
   });
 
-  it("should handle multiple drawer wrappers without conflicts", async () => {
-    const { getByTestId } = render(
+  it("should mount a drawer wrapper after its Redux open action is dispatched", async () => {
+    const { getByTestId, queryByTestId, store } = render(
       <GlobalDrawers>
         <View testID="app-content" />
       </GlobalDrawers>,
     );
 
-    await waitFor(() => {
-      const modularDrawer = getByTestId("modular-drawer-wrapper");
-      const receiveDrawer = getByTestId("receive-drawer-wrapper");
+    expect(queryByTestId("modular-drawer-wrapper")).toBeNull();
 
-      expect(modularDrawer).toBeTruthy();
-      expect(receiveDrawer).toBeTruthy();
+    act(() => {
+      store.dispatch(openModularDrawer({}));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("modular-drawer-wrapper")).toBeTruthy();
     });
   });
 
-  it("should support dynamic children updates while maintaining drawers", async () => {
+  it("should keep a drawer mounted after it is closed so animations and cleanup work", async () => {
+    const { getByTestId, store } = render(
+      <GlobalDrawers>
+        <View testID="app-content" />
+      </GlobalDrawers>,
+    );
+
+    act(() => {
+      store.dispatch(openModularDrawer({}));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("modular-drawer-wrapper")).toBeTruthy();
+    });
+
+    act(() => {
+      store.dispatch(closeModularDrawer());
+    });
+
+    expect(getByTestId("modular-drawer-wrapper")).toBeTruthy();
+  });
+
+  it("should mount drawers independently of each other", async () => {
+    const { getByTestId, queryByTestId, store } = render(
+      <GlobalDrawers>
+        <View testID="app-content" />
+      </GlobalDrawers>,
+    );
+
+    expect(queryByTestId("modular-drawer-wrapper")).toBeNull();
+    expect(queryByTestId("receive-drawer-wrapper")).toBeNull();
+
+    act(() => {
+      store.dispatch(openReceiveOptionsDrawer({ sourceScreenName: "test" }));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("receive-drawer-wrapper")).toBeTruthy();
+    });
+
+    expect(queryByTestId("modular-drawer-wrapper")).toBeNull();
+  });
+
+  it("should support dynamic children updates", () => {
     const { rerender, getByTestId } = render(
       <GlobalDrawers>
         <Text testID="text-1">Initial Content</Text>
@@ -65,14 +109,9 @@ describe("GlobalDrawers Integration", () => {
     );
 
     expect(getByTestId("text-2")).toBeTruthy();
-
-    await waitFor(() => {
-      expect(getByTestId("modular-drawer-wrapper")).toBeTruthy();
-      expect(getByTestId("receive-drawer-wrapper")).toBeTruthy();
-    });
   });
 
-  it("should handle unmounting gracefully", async () => {
+  it("should handle unmounting gracefully", () => {
     const { unmount, getByTestId } = render(
       <GlobalDrawers>
         <Text testID="content">Content</Text>
@@ -80,11 +119,6 @@ describe("GlobalDrawers Integration", () => {
     );
 
     expect(getByTestId("content")).toBeTruthy();
-
-    await waitFor(() => {
-      expect(getByTestId("modular-drawer-wrapper")).toBeTruthy();
-    });
-
     expect(() => unmount()).not.toThrow();
   });
 });

--- a/apps/ledger-live-mobile/src/GlobalDrawers/index.tsx
+++ b/apps/ledger-live-mobile/src/GlobalDrawers/index.tsx
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useRef } from "react";
+import { useSelector } from "~/context/hooks";
 import { DRAWER_ENTRIES } from "./registry";
+import type { DrawerRegistryEntry } from "./registry";
 
 type GlobalDrawersProps = Readonly<{
   children: React.JSX.Element;
@@ -35,12 +37,32 @@ type GlobalDrawersProps = Readonly<{
  * management, and improves maintainability.
  */
 
+type LazyDrawerMountProps = Readonly<{
+  entry: DrawerRegistryEntry & { key: string };
+}>;
+
+/**
+ * Mounts a drawer wrapper only after it has been opened for the first time.
+ * Once mounted, the component stays in the tree so close animations and
+ * internal cleanup work correctly.
+ */
+function LazyDrawerMount({ entry }: LazyDrawerMountProps) {
+  const isOpen = useSelector(entry.selector);
+  const hasMountedOnce = useRef(isOpen);
+  if (isOpen) hasMountedOnce.current = true;
+
+  if (!hasMountedOnce.current) return null;
+
+  const DrawerWrapper = entry.component;
+  return <DrawerWrapper />;
+}
+
 function GlobalDrawers({ children }: GlobalDrawersProps) {
   return (
     <>
       {children}
-      {DRAWER_ENTRIES.map(({ key, component: DrawerWrapper }) => (
-        <DrawerWrapper key={key} />
+      {DRAWER_ENTRIES.map(entry => (
+        <LazyDrawerMount key={entry.key} entry={entry} />
       ))}
     </>
   );

--- a/apps/ledger-live-mobile/src/GlobalDrawers/registry.ts
+++ b/apps/ledger-live-mobile/src/GlobalDrawers/registry.ts
@@ -2,6 +2,11 @@ import { ModularDrawerWrapper } from "LLM/features/ModularDrawer";
 import ReceiveDrawerWrapper from "LLM/features/Receive/drawers/ReceiveFundsOptionsDrawer";
 import RebornBuyDeviceDrawer from "LLM/features/Reborn/drawers/RebornBuyDeviceDrawer";
 import { DeeplinkInstallAppDrawer } from "LLM/features/DeeplinkInstallApp";
+import { modularDrawerIsOpenSelector } from "~/reducers/modularDrawer";
+import { receiveOptionsDrawerIsOpenSelector } from "~/reducers/receiveOptionsDrawer";
+import { rebornBuyDeviceDrawerIsOpenSelector } from "~/reducers/rebornBuyDeviceDrawer";
+import { deeplinkInstallAppDrawerSelector } from "~/reducers/deeplinkInstallApp";
+import { State } from "~/reducers/types";
 
 /**
  * Registry of all global drawers in the application.
@@ -10,20 +15,25 @@ import { DeeplinkInstallAppDrawer } from "LLM/features/DeeplinkInstallApp";
 
 export interface DrawerRegistryEntry {
   component: React.ComponentType;
+  selector: (state: State) => boolean;
 }
 
 export const DRAWER_REGISTRY = {
   modularAssets: {
     component: ModularDrawerWrapper,
+    selector: modularDrawerIsOpenSelector,
   },
   receive: {
     component: ReceiveDrawerWrapper,
+    selector: receiveOptionsDrawerIsOpenSelector,
   },
   reborn: {
     component: RebornBuyDeviceDrawer,
+    selector: rebornBuyDeviceDrawerIsOpenSelector,
   },
   deeplinkInstallApp: {
     component: DeeplinkInstallAppDrawer,
+    selector: deeplinkInstallAppDrawerSelector,
   },
 } as const satisfies Record<string, DrawerRegistryEntry>;
 

--- a/apps/ledger-live-mobile/src/reducers/modularDrawer.ts
+++ b/apps/ledger-live-mobile/src/reducers/modularDrawer.ts
@@ -43,6 +43,7 @@ export const INITIAL_STATE: ModularDrawerState = {
 
 // Selectors
 export const modularDrawerStateSelector = (state: State) => state.modularDrawer;
+export const modularDrawerIsOpenSelector = (state: State): boolean => state.modularDrawer.isOpen;
 
 export const modularDrawerSearchValueSelector = (state: State) => state.modularDrawer.searchValue;
 export const modularDrawerFlowSelector = (state: State) => state.modularDrawer.flow;

--- a/apps/ledger-live-mobile/src/reducers/rebornBuyDeviceDrawer.ts
+++ b/apps/ledger-live-mobile/src/reducers/rebornBuyDeviceDrawer.ts
@@ -11,6 +11,8 @@ export const INITIAL_STATE: RebornBuyDeviceDrawerState = {
 
 // Selectors
 export const rebornBuyDeviceDrawerStateSelector = (state: State) => state.rebornBuyDeviceDrawer;
+export const rebornBuyDeviceDrawerIsOpenSelector = (state: State): boolean =>
+  state.rebornBuyDeviceDrawer.isOpen;
 
 const rebornBuyDeviceDrawerSlice = createSlice({
   name: "rebornBuyDeviceDrawerKey",

--- a/apps/ledger-live-mobile/src/reducers/receiveOptionsDrawer.ts
+++ b/apps/ledger-live-mobile/src/reducers/receiveOptionsDrawer.ts
@@ -18,6 +18,8 @@ export const INITIAL_STATE: ReceiveOptionsDrawerState = {
 
 // Selectors
 export const receiveOptionsDrawerStateSelector = (state: State) => state.receiveOptionsDrawer;
+export const receiveOptionsDrawerIsOpenSelector = (state: State): boolean =>
+  state.receiveOptionsDrawer.isOpen;
 
 const receiveOptionsDrawerSlice = createSlice({
   name: "receiveOptionsDrawerKey",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Draft to load all drawers lazily. This should reduce the load on the app startup.
E.g MAD fetches significant amount of data from Dada on startup which can sometime slow down the startup.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28426]
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28426]: https://ledgerhq.atlassian.net/browse/LIVE-28426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ