### PR TITLE
[LWD] refactor(desktop): replace feature flag mocks with initialState in tests

### DIFF
--- a/.changeset/pink-gorillas-give.md
+++ b/.changeset/pink-gorillas-give.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Replace feature flag jest.mock() with initialState overrides in tests

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/__tests__/useCryptoAddressesViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/__tests__/useCryptoAddressesViewModel.test.ts
@@ -1,8 +1,6 @@
 import { renderHook, act } from "tests/testSetup";
 import { genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
-import type { WalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
-import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useOpenAssetFlow } from "LLD/features/ModularDrawer/hooks/useOpenAssetFlow";
 import useAddAccountAnalytics from "LLD/features/AddAccountDrawer/analytics/useAddAccountAnalytics";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
@@ -24,27 +22,6 @@ jest.mock("react-router", () => ({
   useNavigate: jest.fn(() => mockNavigate),
 }));
 
-const defaultWalletFeaturesConfig: WalletFeaturesConfig = {
-  isEnabled: false,
-  shouldDisplayMarketBanner: false,
-  shouldDisplayGraphRework: false,
-  shouldDisplayQuickActionCtas: false,
-  shouldDisplayNewReceiveDialog: false,
-  shouldDisplayWallet40MainNav: false,
-  shouldUseLazyOnboarding: false,
-  shouldDisplayBalanceRefreshRework: false,
-  shouldDisplayTour: false,
-  shouldDisplayAssetSection: false,
-  shouldDisplayOnboardingWidget: false,
-  shouldDisplayBrazePlacement: false,
-  shouldDisplayOperationsList: false,
-};
-
-jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
-  ...jest.requireActual("@ledgerhq/live-common/featureFlags/index"),
-  useWalletFeaturesConfig: jest.fn(),
-}));
-
 jest.mock("LLD/features/ModularDrawer/hooks/useOpenAssetFlow", () => ({
   useOpenAssetFlow: jest.fn(),
 }));
@@ -62,7 +39,6 @@ jest.mock("../../components/Table/hooks/useCryptoAccountRows", () => ({
   useCryptoAccountRows: jest.fn(),
 }));
 
-const mockUseWalletFeaturesConfig = jest.mocked(useWalletFeaturesConfig);
 const mockUseOpenAssetFlow = jest.mocked(useOpenAssetFlow);
 const mockUseAddAccountAnalytics = jest.mocked(useAddAccountAnalytics);
 const mockUseCryptoAccountRows = jest.mocked(useCryptoAccountRows);
@@ -71,7 +47,6 @@ const mockSetTrackingSource = jest.mocked(setTrackingSource);
 describe("useCryptoAddressesViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseWalletFeaturesConfig.mockReturnValue(defaultWalletFeaturesConfig);
     mockUseOpenAssetFlow.mockReturnValue({
       openAssetFlow: mockOpenAssetFlow,
       openAddAccountFlow: jest.fn(),
@@ -132,10 +107,6 @@ describe("useCryptoAddressesViewModel", () => {
   });
 
   it("should navigate to /accounts when token has no parent and asset section is off", () => {
-    mockUseWalletFeaturesConfig.mockReturnValue({
-      ...defaultWalletFeaturesConfig,
-      shouldDisplayAssetSection: false,
-    });
     const tokenAccount = genTokenAccount(0, ETH_ACCOUNT, usdcToken);
 
     const { result } = renderHook(() => useCryptoAddressesViewModel());
@@ -148,13 +119,17 @@ describe("useCryptoAddressesViewModel", () => {
   });
 
   it("should navigate to /cryptos when token has no parent and asset section is on", () => {
-    mockUseWalletFeaturesConfig.mockReturnValue({
-      ...defaultWalletFeaturesConfig,
-      shouldDisplayAssetSection: true,
-    });
     const tokenAccount = genTokenAccount(0, ETH_ACCOUNT, usdcToken);
 
-    const { result } = renderHook(() => useCryptoAddressesViewModel());
+    const { result } = renderHook(() => useCryptoAddressesViewModel(), {
+      initialState: {
+        settings: {
+          overriddenFeatureFlags: {
+            lwdWallet40: { enabled: true, params: { assetSection: true } },
+          },
+        },
+      },
+    });
 
     act(() => {
       result.current.onAccountClick(tokenAccount, undefined);

--- a/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.test.tsx
@@ -8,18 +8,6 @@ jest.mock("~/datadog/renderer", () => ({
   isDatadogAvailable: jest.fn().mockReturnValue(true),
 }));
 
-const mockGetFeature = jest.fn();
-jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
-  DEFAULT_FEATURES: {},
-  useFeatureFlags: jest.fn(() => ({
-    getFeature: mockGetFeature,
-  })),
-}));
-
-jest.mock("~/renderer/components/FirebaseFeatureFlags", () => ({
-  FirebaseFeatureFlagsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
-
 const initDatadog = jest.mocked(jest.requireMock("~/datadog/renderer").initDatadog);
 const isDatadogAvailable = jest.mocked(jest.requireMock("~/datadog/renderer").isDatadogAvailable);
 
@@ -37,18 +25,26 @@ describe("ConnectEnvsToDatadog", () => {
   });
 
   it("should not call initDatadog when sentryLogs is false", async () => {
-    mockGetFeature.mockReturnValue({ enabled: true, params: {} });
     render(<ConnectEnvsToDatadog />, {
-      initialState: { settings: { sentryLogs: false } },
+      initialState: {
+        settings: {
+          sentryLogs: false,
+          overriddenFeatureFlags: { lldDatadog: { enabled: true, params: {} } },
+        },
+      },
     });
     await new Promise(r => setImmediate(r));
     expect(initDatadog).not.toHaveBeenCalled();
   });
 
   it("should call initDatadog when lldDatadog.enabled, sentryLogs and isDatadogAvailable are true", async () => {
-    mockGetFeature.mockReturnValue({ enabled: true, params: {} });
     render(<ConnectEnvsToDatadog />, {
-      initialState: { settings: { sentryLogs: true } },
+      initialState: {
+        settings: {
+          sentryLogs: true,
+          overriddenFeatureFlags: { lldDatadog: { enabled: true, params: {} } },
+        },
+      },
     });
     await new Promise(r => setImmediate(r));
     expect(initDatadog).toHaveBeenCalledWith(
@@ -59,9 +55,13 @@ describe("ConnectEnvsToDatadog", () => {
   });
 
   it("should pass shouldSend that reads current store so opt-out is respected after init", async () => {
-    mockGetFeature.mockReturnValue({ enabled: true, params: {} });
     const { store } = render(<ConnectEnvsToDatadog />, {
-      initialState: { settings: { sentryLogs: true } },
+      initialState: {
+        settings: {
+          sentryLogs: true,
+          overriddenFeatureFlags: { lldDatadog: { enabled: true, params: {} } },
+        },
+      },
     });
     await new Promise(r => setImmediate(r));
     expect(initDatadog).toHaveBeenCalled();

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.react.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.react.test.tsx
@@ -10,7 +10,6 @@ import {
 } from "@ledgerhq/live-common/currencies/index";
 import { Account } from "@ledgerhq/types-live";
 import { InvalidAddress } from "@ledgerhq/errors";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { DomainServiceProvider } from "@ledgerhq/domain-service/hooks/index";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import RecipientField from "./RecipientField";
@@ -21,17 +20,6 @@ jest.mock("../../../../sentry/install", () => ({
 }));
 
 nock.disableNetConnect();
-
-jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
-  useFeature: jest.fn(),
-}));
-
-jest.mock("../../../components/FirebaseFeatureFlags", () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  FirebaseFeatureFlagsProvider: ({ children }: { children: any }) => children,
-}));
-
-const mockedUseFeature = jest.mocked(useFeature);
 
 const mockedOnChangeTransaction = jest.fn().mockImplementation(t => t);
 
@@ -123,10 +111,19 @@ const baseMockStatus: TransactionStatus = {
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const mockTFunction: jest.Mock<TFunction> = jest.fn(key => key) as unknown as jest.Mock<TFunction>;
 
+const domainInputResolutionOn = {
+  domainInputResolution: { enabled: true, params: { supportedCurrencyIds: ["ethereum"] } },
+};
+
+const domainInputResolutionOff = {
+  domainInputResolution: { enabled: false },
+};
+
 const setup = (
   mockStatus: Partial<TransactionStatus> | null = {},
   mockTransaction: Partial<Transaction> | null = {},
   account = ethMockAccount,
+  overriddenFeatureFlags?: Record<string, unknown>,
 ) => {
   return render(
     <DomainServiceProvider>
@@ -140,6 +137,7 @@ const setup = (
         status={{ ...baseMockStatus, ...mockStatus }}
       />
     </DomainServiceProvider>,
+    overriddenFeatureFlags ? { initialState: { settings: { overriddenFeatureFlags } } } : undefined,
   );
 };
 
@@ -192,15 +190,8 @@ describe("RecipientField", () => {
 
   describe("Feature Flag", () => {
     describe("Flag on", () => {
-      beforeEach(() => {
-        mockedUseFeature.mockReturnValue({
-          enabled: true,
-          params: { supportedCurrencyIds: ["ethereum"] },
-        });
-      });
-
       it("should change domain in transaction", async () => {
-        const { user } = setup();
+        const { user } = setup({}, {}, ethMockAccount, domainInputResolutionOn);
         const input = screen.getByRole("textbox");
 
         await user.type(input, "vitalik.eth");
@@ -219,7 +210,7 @@ describe("RecipientField", () => {
       });
 
       it("should reverse addr to domain name in transaction", async () => {
-        const { user } = setup();
+        const { user } = setup({}, {}, ethMockAccount, domainInputResolutionOn);
         const input = screen.getByRole("textbox");
         await user.type(input, "0x16bb635bc5c398b63a0fbb38dac84da709eb3e86");
         await waitFor(() =>
@@ -237,7 +228,7 @@ describe("RecipientField", () => {
       });
 
       it("should not change domain because invalid recipient name", async () => {
-        const { user } = setup();
+        const { user } = setup({}, {}, ethMockAccount, domainInputResolutionOn);
         const input = screen.getByRole("textbox");
 
         await user.type(input, "vitalik.notadomainservice");
@@ -251,7 +242,7 @@ describe("RecipientField", () => {
       });
 
       it("should not change domain if domain is invalid", async () => {
-        const { user } = setup();
+        const { user } = setup({}, {}, ethMockAccount, domainInputResolutionOn);
         const input = screen.getByRole("textbox");
 
         await user.type(input, "vitalik👋.eth");
@@ -267,7 +258,7 @@ describe("RecipientField", () => {
       });
 
       it("should not change domain if domain has no resolution", async () => {
-        const { user } = setup();
+        const { user } = setup({}, {}, ethMockAccount, domainInputResolutionOn);
         const input = screen.getByRole("textbox");
 
         await user.type(input, "anything-not-existing.eth");
@@ -297,6 +288,8 @@ describe("RecipientField", () => {
               type: "forward",
             },
           },
+          ethMockAccount,
+          domainInputResolutionOn,
         );
         const input = screen.getByRole("textbox");
 
@@ -311,8 +304,7 @@ describe("RecipientField", () => {
       });
 
       it("should add then remove domain on input change", async () => {
-        const { user } = setup();
-
+        const { user } = setup({}, {}, ethMockAccount, domainInputResolutionOn);
         const input = screen.getByRole("textbox");
 
         await user.type(input, "vitalik.eth");
@@ -341,7 +333,7 @@ describe("RecipientField", () => {
 
       it("should not change domain because currency not supported", async () => {
         const spy = jest.spyOn(axios, "request");
-        const { user } = setup(null, null, polygonMockAccount);
+        const { user } = setup(null, null, polygonMockAccount, domainInputResolutionOn);
         const input = screen.getByRole("textbox");
         await user.type(input, "0x16bb635bc5c398b63a0fbb38dac84da709eb3e86");
         await waitFor(() =>
@@ -356,12 +348,8 @@ describe("RecipientField", () => {
     });
 
     describe("Flag off", () => {
-      beforeEach(() => {
-        mockedUseFeature.mockReturnValue({ enabled: false });
-      });
-
       it("should not change domain", async () => {
-        const { user } = setup();
+        const { user } = setup({}, {}, ethMockAccount, domainInputResolutionOff);
         const input = screen.getByRole("textbox");
         await user.type(input, "vitalik.eth");
         await waitFor(() =>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Test files only — no production code modified
      - Feature flag behavior in tests now uses the real provider chain instead of mocked hooks

### 📝 Description

Three desktop test files were mocking `useFeature`, `useFeatureFlags`, or `useWalletFeaturesConfig` via `jest.mock()`. This bypasses the real feature flag infrastructure and makes tests less representative of production behavior.

This PR replaces those mocks with `initialState.settings.overriddenFeatureFlags` passed to `render()` / `renderHook()`, which flows through the existing test infrastructure (`configureStore` bridge → `FirebaseFeatureFlagsProvider` → React context).

**Files changed:**
- `RecipientField.react.test.tsx` — removed `useFeature` + `FirebaseFeatureFlagsProvider` mocks, flags now via `setup()` parameter
- `ConnectEnvsToDatadog.test.tsx` — removed `useFeatureFlags` + `FirebaseFeatureFlagsProvider` mocks, `lldDatadog` flag via `initialState`
- `useCryptoAddressesViewModel.test.ts` — removed `useWalletFeaturesConfig` mock, `lwdWallet40` flag via `initialState`

### ❓ Context

- **JIRA or GitHub link**: Standalone cleanup — no ticket

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)