### PR TITLE
feat: add crypto assets page and navigation

### DIFF
--- a/.changeset/moody-mayflies-allow.md
+++ b/.changeset/moody-mayflies-allow.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fest(lwd): add crypto assets page and navigation

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
@@ -2,30 +2,48 @@ import { isWallet40Page, shouldDisplayRightPanel } from "../utils";
 
 describe("Page utils", () => {
   describe("isWallet40Page", () => {
-    it("returns true for wallet 4.0 root pages", () => {
+    it("returns true for each wallet 4.0 exact-match route", () => {
       expect(isWallet40Page("/")).toBe(true);
       expect(isWallet40Page("/market")).toBe(true);
       expect(isWallet40Page("/analytics")).toBe(true);
       expect(isWallet40Page("/cryptos")).toBe(true);
+      expect(isWallet40Page("/assets")).toBe(true);
+      expect(isWallet40Page("/earn")).toBe(true);
+      expect(isWallet40Page("/perps")).toBe(true);
+      expect(isWallet40Page("/history")).toBe(true);
     });
 
-    it("returns true for wallet 4.0 prefixed pages", () => {
+    it("returns true for wallet 4.0 prefix routes and nested paths", () => {
       expect(isWallet40Page("/card")).toBe(true);
+      expect(isWallet40Page("/card/foo")).toBe(true);
       expect(isWallet40Page("/swap")).toBe(true);
       expect(isWallet40Page("/swap/bridge")).toBe(true);
+      expect(isWallet40Page("/exchange")).toBe(true);
+      expect(isWallet40Page("/exchange/foo")).toBe(true);
     });
 
-    it("returns false for non wallet 4.0 pages", () => {
+    it("returns false for routes outside wallet 4.0", () => {
       expect(isWallet40Page("/accounts")).toBe(false);
+      expect(isWallet40Page("/settings")).toBe(false);
+    });
+
+    it("returns false when pathname is not an exact match and does not start with a known prefix", () => {
+      expect(isWallet40Page("/market/trending")).toBe(false);
+      expect(isWallet40Page("/cryptos/extra")).toBe(false);
     });
   });
 
   describe("shouldDisplayRightPanel", () => {
-    it("returns true only for right panel pages", () => {
+    it("returns true only for routes that show the swap sidebar", () => {
       expect(shouldDisplayRightPanel("/")).toBe(true);
       expect(shouldDisplayRightPanel("/analytics")).toBe(true);
       expect(shouldDisplayRightPanel("/cryptos")).toBe(true);
+    });
+
+    it("returns false for other wallet 4.0 pages", () => {
       expect(shouldDisplayRightPanel("/market")).toBe(false);
+      expect(shouldDisplayRightPanel("/assets")).toBe(false);
+      expect(shouldDisplayRightPanel("/earn")).toBe(false);
     });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
@@ -9,6 +9,7 @@ const WALLET_40_PAGES = new Set([
   "/market",
   "/analytics",
   "/cryptos",
+  "/assets",
   "/earn",
   "/perps",
   "/history",

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/__integrations__/assets.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/__integrations__/assets.integration.test.tsx
@@ -107,6 +107,19 @@ describe("Assets", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/cryptos");
   });
 
+  it("should not navigate when stablecoins section header is clicked with few items", async () => {
+    const { user } = renderWithMockedCounterValuesProvider(<Assets />, {
+      initialState: { ...initialState, accounts: [BTC_ACCOUNT, ETH_ACCOUNT_WITH_USDC] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Stablecoins")).toBeVisible();
+    });
+
+    await user.click(screen.getByTestId("stablecoins-section-header-button"));
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it("should show placeholder assets when user has no accounts", async () => {
     renderWithMockedCounterValuesProvider(<Assets />, {
       initialState: initialState,

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAssetsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAssetsViewModel.test.ts
@@ -221,6 +221,16 @@ describe("useAssetsViewModel", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/cryptos");
   });
 
+  it("should navigate to /assets when stablecoins onNavigate is called", () => {
+    const { result } = renderHook(() => useAssetsViewModel());
+
+    act(() => {
+      result.current.sections[1].onNavigate();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/assets");
+  });
+
   it("should navigate to /asset when onItemClick is called with a real item", () => {
     const { result } = renderHook(() => useAssetsViewModel());
     const realItem: AssetTableItem = { ...BITCOIN_ASSET, isPlaceholder: false };

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAssetsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAssetsViewModel.ts
@@ -73,7 +73,7 @@ export function useAssetsViewModel(): AssetsViewProps {
     navigate("/cryptos");
   }, [navigate]);
 
-  const onNavigate = useCallback(() => {
+  const onNavigateToCryptoAssets = useCallback(() => {
     navigate("/assets");
   }, [navigate]);
 
@@ -143,7 +143,7 @@ export function useAssetsViewModel(): AssetsViewProps {
         title: t("assets.stablecoins"),
         items: paddedStablecoins,
         totalCount: isEmptyState ? paddedStablecoins.length : categorizedAssets.stablecoins.length,
-        onNavigate,
+        onNavigate: onNavigateToCryptoAssets,
         onItemClick,
       },
     ];
@@ -151,7 +151,7 @@ export function useAssetsViewModel(): AssetsViewProps {
     isEmptyState,
     categorizedAssets,
     resolvedDefaults,
-    onNavigate,
+    onNavigateToCryptoAssets,
     onNavigateToCryptos,
     onItemClick,
     t,

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAddressesView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAddressesView.tsx
@@ -14,7 +14,11 @@ import type { CryptoAddressesViewModel } from "./types";
 import { CryptoTable } from "./components/Table/CryptoTable";
 import { CryptoTableEmptyState } from "./components/Table/CryptoTableEmptyState";
 
-export function CryptoAddressesView({ viewModel }: { readonly viewModel: CryptoAddressesViewModel }) {
+export function CryptoAddressesView({
+  viewModel,
+}: {
+  readonly viewModel: CryptoAddressesViewModel;
+}) {
   const {
     searchValue,
     setSearchValue,
@@ -29,14 +33,14 @@ export function CryptoAddressesView({ viewModel }: { readonly viewModel: CryptoA
   return (
     <div className="flex flex-col gap-32">
       <TrackPage category="Crypto" />
-      <PageHeader title={t("crypto.title")} />
+      <PageHeader title={t("cryptoAddresses.title")} />
       <div data-testid="crypto-page-content" className="flex flex-col gap-12">
         <TableActionBar>
           <TableActionBarLeading>
             <div className="max-w-[350px] flex-auto pt-4">
               <SearchInput
                 value={searchValue}
-                placeholder={t("crypto.tableActions.searchAddress")}
+                placeholder={t("cryptoAddresses.tableActions.searchAddress")}
                 onChange={e => setSearchValue(e.target.value)}
               />
             </div>
@@ -49,7 +53,7 @@ export function CryptoAddressesView({ viewModel }: { readonly viewModel: CryptoA
               onClick={onAddAddressClick}
               data-testid="crypto-add-address-button"
             >
-              {t("crypto.tableActions.addAddress")}
+              {t("cryptoAddresses.tableActions.addAddress")}
             </Button>
           </TableActionBarTrailing>
         </TableActionBar>

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAssets.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAssets.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { CryptoAssetsView } from "./CryptoAssetsView";
+import useCryptoAssetsViewModel from "./hooks/useCryptoAssetsViewModel";
+
+export default function CryptoAssets() {
+  const viewModel = useCryptoAssetsViewModel();
+  return <CryptoAssetsView viewModel={viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAssetsView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAssetsView.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import PageHeader from "LLD/components/PageHeader";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import type { CryptoAssetsViewModel } from "./types";
+
+export function CryptoAssetsView({ viewModel }: { readonly viewModel: CryptoAssetsViewModel }) {
+  const { title, onBack } = viewModel;
+
+  return (
+    <div className="flex flex-col gap-32">
+      <TrackPage category="Crypto assets" />
+      <PageHeader title={title} onBack={onBack} />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
@@ -59,7 +59,7 @@ export function useCryptoDataTable({
             sortDirection={column.getIsSorted() || undefined}
             onClick={column.getToggleSortingHandler()}
           >
-            {t("crypto.table.columns.name")}
+            {t("cryptoAddresses.table.columns.name")}
           </TableSortButton>
         ),
         cell: ({ row }) => (
@@ -72,7 +72,7 @@ export function useCryptoDataTable({
       {
         id: "address",
         enableSorting: false,
-        header: t("crypto.table.columns.address"),
+        header: t("cryptoAddresses.table.columns.address"),
         cell: ({ row }) => (
           <AccountAddressCell account={row.original} lookupParentAccount={lookupParentAccount} />
         ),
@@ -93,7 +93,7 @@ export function useCryptoDataTable({
             sortDirection={column.getIsSorted() || undefined}
             onClick={column.getToggleSortingHandler()}
           >
-            {t("crypto.table.columns.value")}
+            {t("cryptoAddresses.table.columns.value")}
           </TableSortButton>
         ),
         cell: ({ row }) => <AccountValueCell account={row.original} />,
@@ -106,7 +106,7 @@ export function useCryptoDataTable({
         cell: ({ row }) => (
           <AccountRowActionCell
             account={row.original}
-            editNameAriaLabel={t("crypto.table.editName")}
+            editNameAriaLabel={t("cryptoAddresses.table.editName")}
           />
         ),
         meta: { align: "end" },

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/__tests__/useCryptoAssetsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/__tests__/useCryptoAssetsViewModel.test.ts
@@ -1,0 +1,25 @@
+import { renderHook, act } from "tests/testSetup";
+import useCryptoAssetsViewModel from "../useCryptoAssetsViewModel";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: () => mockNavigate,
+}));
+
+describe("useCryptoAssetsViewModel", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it("should navigate to home when onBack is called", () => {
+    const { result } = renderHook(() => useCryptoAssetsViewModel());
+
+    act(() => {
+      result.current.onBack();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAddressesViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAddressesViewModel.ts
@@ -24,7 +24,9 @@ export default function useCryptoAddressesViewModel(): CryptoAddressesViewModel 
 
   const emptyTableMessage = useMemo(
     () =>
-      searchValue.trim() === "" ? t("crypto.table.emptyState") : t("crypto.table.emptySearchState"),
+      searchValue.trim() === ""
+        ? t("cryptoAddresses.table.emptyState")
+        : t("cryptoAddresses.table.emptySearchState"),
     [searchValue, t],
   );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAssetsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAssetsViewModel.ts
@@ -1,0 +1,18 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
+import type { CryptoAssetsViewModel } from "../types";
+
+export default function useCryptoAssetsViewModel(): CryptoAssetsViewModel {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const onBack = useCallback(() => {
+    navigate("/");
+  }, [navigate]);
+
+  return {
+    title: t("cryptoAssets.title"),
+    onBack,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/types.ts
@@ -9,3 +9,8 @@ export type CryptoAddressesViewModel = {
   readonly rows: AccountLike[];
   readonly lookupParentAccount: (id: string) => Account | undefined | null;
 };
+
+export type CryptoAssetsViewModel = {
+  readonly title: string;
+  readonly onBack: () => void;
+};

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -103,7 +103,8 @@ const USBTroubleshooting = lazy(() => import("~/renderer/screens/USBTroubleshoot
 const Asset = lazy(() => import("~/renderer/screens/asset"));
 const Account = lazy(() => import("~/renderer/screens/account"));
 const Analytics = lazy(() => import("LLD/features/Analytics"));
-const Cryptos = lazy(() => import("LLD/features/CryptoAddresses"));
+const CryptoAddresses = lazy(() => import("LLD/features/CryptoAddresses"));
+const CryptoAssets = lazy(() => import("LLD/features/CryptoAddresses/CryptoAssets"));
 const CardW40 = lazy(() => import("LLD/features/Card"));
 const History = lazy(() => import("LLD/features/History"));
 
@@ -245,7 +246,17 @@ const MainAppContent = ({
           path="/cryptos"
           element={
             shouldDisplayAssetSection ? (
-              withSuspense(Cryptos)({})
+              withSuspense(CryptoAddresses)({})
+            ) : (
+              <Navigate to="/accounts" replace />
+            )
+          }
+        />
+        <Route
+          path="/assets"
+          element={
+            shouldDisplayAssetSection ? (
+              withSuspense(CryptoAssets)({})
             ) : (
               <Navigate to="/accounts" replace />
             )

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8166,17 +8166,6 @@
     }
   },
   "cryptoAddresses": {
-    "editName": {
-      "title": "Edit address name",
-      "input": "Address name",
-      "suggestions": {
-        "trading": "{{asset}} trading",
-        "savings": "{{asset}} savings"
-      },
-      "cta": "Confirm"
-    }
-  },
-  "crypto": {
     "title": "Crypto accounts",
     "tableActions": {
       "searchAddress": "Search address",
@@ -8191,7 +8180,19 @@
       "editName": "Edit name",
       "emptyState": "No crypto address yet",
       "emptySearchState": "No accounts match your search"
+    },
+    "editName": {
+      "title": "Edit address name",
+      "input": "Address name",
+      "suggestions": {
+        "trading": "{{asset}} trading",
+        "savings": "{{asset}} savings"
+      },
+      "cta": "Confirm"
     }
+  },
+  "cryptoAssets": {
+    "title": "Crypto assets"
   },
   "nftEntryPoint": {
     "title": "NFT (Non Fungible Tokens)",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
This pull request introduces a new "Crypto assets" page to Ledger Live Desktop and updates the navigation and related tests to support it. The main focus is on enabling users to navigate to the new `/assets` route from the stablecoins section and providing the necessary view model, UI components, and translations for the new page. The changes are grouped into navigation updates, feature implementation, and testing.


https://github.com/user-attachments/assets/bb88cf4b-31ce-45c3-a34f-f1b997c5e00b



### ❓ Context

[LIVE-26379](https://ledgerhq.atlassian.net/browse/LIVE-26379)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26379]: https://ledgerhq.atlassian.net/browse/LIVE-26379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ