### PR TITLE
chore(codeowners): apply engagement ownership optimisation plan

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,16 +28,14 @@ apps/ledger-live-desktop/src/main/                       @ledgerhq/platform
 apps/ledger-live-desktop/src/preloader/                  @ledgerhq/platform
 apps/ledger-live-desktop/src/sentry/                     @ledgerhq/platform
 apps/ledger-live-desktop/src/renderer/logger/            @ledgerhq/platform
-apps/ledger-live-desktop/src/renderer/analytics/         @ledgerhq/platform
 apps/ledger-live-desktop/tools/                          @ledgerhq/platform
 apps/ledger-live-desktop/scripts/                        @ledgerhq/platform
 # Platform — domain
 domain/entity/crypto-asset                               @ledgerhq/platform
 domain/api/crypto-assets                                 @ledgerhq/platform
-# Platform — shared 
+# Platform — shared
 shared/feature-flags                                     @ledgerhq/platform
 # Platform — mobile
-apps/ledger-live-mobile/src/analytics/                   @ledgerhq/platform
 apps/ledger-live-mobile/android/                         @ledgerhq/platform
 apps/ledger-live-mobile/ios/                             @ledgerhq/platform
 # Platform — libs
@@ -49,7 +47,6 @@ libs/promise/                                            @ledgerhq/platform
 libs/ledger-key-ring-protocol/                           @ledgerhq/platform
 libs/hw-ledger-key-ring-protocol/                        @ledgerhq/platform
 libs/ledger-live-common/src/featureFlags/                @ledgerhq/platform
-libs/ledger-live-common/src/analytics/                   @ledgerhq/platform
 # Wallet — libs
 libs/live-countervalues-react/                           @ledgerhq/wallet-xp
 libs/live-countervalues/                                 @ledgerhq/wallet-xp
@@ -287,36 +284,55 @@ libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts                         
 apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/recover.handler.ts        @ledgerhq/recover-software
 
 # Engagement team
-apps/ledger-live-mobile/src/screens/SyncOnboarding/TwoStepStepper/                             @ledgerhq/engagement
+
+# Desktop
+apps/ledger-live-desktop/src/renderer/analytics/                                               @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/                               @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/components/Onboarding/                                   @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/                            @ledgerhq/engagement
-apps/ledger-live-mobile/src/mvvm/features/WelcomePage/                                         @ledgerhq/engagement
-apps/ledger-live-mobile/src/screens/Onboarding/                                                @ledgerhq/engagement
-apps/ledger-live-mobile/src/screens/PostOnboarding/                                            @ledgerhq/engagement
-apps/ledger-live-mobile/src/logic/postOnboarding/                                              @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/postOnboarding.handler.ts  @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/hooks/useBuyDeviceIntercept.ts                           @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/hooks/useBuyDeviceIntercept.test.ts                      @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/hooks/useNavigateToMyLedger.ts                           @ledgerhq/engagement
-apps/ledger-live-mobile/src/contentCards/                                                      @ledgerhq/engagement
-apps/ledger-live-mobile/src/dynamicContent/                                                    @ledgerhq/engagement
-apps/ledger-live-mobile/src/mvvm/features/DynamicContent/                                      @ledgerhq/engagement
-apps/ledger-live-mobile/src/mvvm/features/LandingPages/                                        @ledgerhq/engagement
-apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/                                 @ledgerhq/engagement
-apps/ledger-live-mobile/src/notifications/                                                     @ledgerhq/engagement
-apps/ledger-live-mobile/src/reducers/dynamicContent.ts                                         @ledgerhq/engagement
-apps/ledger-live-mobile/src/reducers/largeMover.ts                                             @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/hooks/useActionCards.tsx                                 @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/screens/dashboard/ActionContentCards.tsx                 @ledgerhq/engagement
+apps/ledger-live-desktop/src/renderer/components/ContentCards/                                 @ledgerhq/engagement
+apps/ledger-live-desktop/src/reducers/dynamicContent.ts                                        @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/DynamicContent/                                     @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/                                          @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/                               @ledgerhq/engagement
-apps/ledger-live-desktop/src/reducers/dynamicContent.ts                                        @ledgerhq/engagement
-apps/ledger-live-desktop/src/renderer/components/ContentCards/                                 @ledgerhq/engagement
-apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/                                        @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/WalletV4Tour/                                       @ledgerhq/engagement
+apps/ledger-live-desktop/src/mvvm/features/BuyDevice/                                          @ledgerhq/engagement
+
+# Mobile
+apps/ledger-live-mobile/src/notifications/                                                     @ledgerhq/engagement
+apps/ledger-live-mobile/src/analytics/                                                         @ledgerhq/engagement
+apps/ledger-live-mobile/src/screens/SyncOnboarding/TwoStepStepper/                             @ledgerhq/engagement
+apps/ledger-live-mobile/src/screens/Onboarding/                                                @ledgerhq/engagement
+apps/ledger-live-mobile/src/screens/PostOnboarding/                                            @ledgerhq/engagement
+apps/ledger-live-mobile/src/screens/Settings/Notifications                                     @ledgerhq/engagement
+apps/ledger-live-mobile/src/logic/postOnboarding/                                              @ledgerhq/engagement
+apps/ledger-live-mobile/src/contentCards/                                                      @ledgerhq/engagement
+apps/ledger-live-mobile/src/dynamicContent/                                                    @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/WelcomePage/                                         @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/Onboarding/                                          @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/DynamicContent/                                      @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/LandingPages/                                        @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/                                 @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/WalletV4Tour/                                        @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/Reborn/                                              @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/OnboardingWidget/               @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/        @ledgerhq/engagement
+apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCarouselSection/       @ledgerhq/engagement
+apps/ledger-live-mobile/src/reducers/dynamicContent.ts                                         @ledgerhq/engagement
+apps/ledger-live-mobile/src/reducers/largeMover.ts                                             @ledgerhq/engagement
+
+# Common
+libs/ledger-live-common/src/analytics/                                                         @ledgerhq/engagement
 libs/ledger-live-common/src/onboarding/                                                        @ledgerhq/engagement
 libs/ledger-live-common/src/postOnboarding/                                                    @ledgerhq/engagement
 libs/ledger-live-common/src/transactionsAlerts/                                                @ledgerhq/engagement
+libs/ui/packages/native/src/components/Layout/Slides/                                          @ledgerhq/engagement
 
 
 # UI tests


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. (not required for `CODEOWNERS` only changes)
- [ ] **Covered by automatic tests.** (not applicable, ownership metadata only)
- [x] **Impact of the changes:**
  - Aligns `CODEOWNERS` with the ownership rebalancing proposed in the Engagement optimisation analysis.
  - Adds explicit Engagement ownership on onboarding, dynamic content, notifications, analytics, and Reborn/BuyDevice related paths.
  - Reduces review routing friction by moving active engagement areas away from broad catchall ownership.

### 📝 Description

This PR implements the CODEOWNERS ownership rebalance proposed in an optimisation report produced by @cfloume.

The report analysed 120 merged PRs over 3 months and found that 81% of Engagement PRs triggered cross-team ownership reviews, with the highest friction from Wallet XP and Platform owned paths. This change updates `CODEOWNERS` so actively maintained Engagement areas are explicitly owned by `@ledgerhq/engagement`, especially around onboarding, dynamic content, notifications, analytics, and Reborn/BuyDevice surfaces.

Expected impact from the report: remove Wallet XP as required reviewer on an estimated 30 to 40 PRs per quarter, reducing wallet-xp review trigger rate from 69% to around 35 to 40%.

No runtime behaviour changes. `CODEOWNERS` only.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)