### PR TITLE
[LWM] feat(mobile): add operations history navigator and stack v4 config

### DIFF
--- a/.changeset/few-carrots-bake.md
+++ b/.changeset/few-carrots-bake.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add operations history native stack with v4 header config and placeholder OperationsList screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -93,6 +93,7 @@ import AddAccountsV2Navigator from "LLM/features/Accounts/Navigator";
 import DeviceSelectionNavigator from "LLM/features/DeviceSelection/Navigator";
 import AssetsListNavigator from "LLM/features/Assets/Navigator";
 import AnalyticsNavigator from "LLM/features/Analytics/Navigator";
+import OperationsHistoryNavigator from "LLM/features/OperationsHistory/Navigator";
 import FeesNavigator from "./FeesNavigator";
 import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
 import SignRawTransactionNavigator from "./SignRawTransactionNavigator";
@@ -670,6 +671,12 @@ export default function BaseNavigator() {
         <Stack.Screen
           name={NavigatorName.Analytics}
           component={AnalyticsNavigator}
+          options={{ headerShown: false }}
+        />
+
+        <Stack.Screen
+          name={NavigatorName.OperationsHistory}
+          component={OperationsHistoryNavigator}
           options={{ headerShown: false }}
         />
       </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -14,6 +14,7 @@ import type { SendFlowInitParams } from "@ledgerhq/live-common/flows/send/types"
 import type { AssetsNavigatorParamsList } from "LLM/features/Assets/types";
 import type { DeviceSelectionNavigatorParamsList } from "LLM/features/DeviceSelection/types";
 import type { AnalyticsNavigatorParamsList } from "LLM/features/Analytics/types";
+import type { OperationsHistoryNavigatorParamsList } from "LLM/features/OperationsHistory/types";
 import type { Web3HubStackParamList, Web3HubTabStackParamList } from "LLM/features/Web3Hub/types";
 import type { DiscoverNavigatorStackParamList } from "./DiscoverNavigator";
 import type { MyLedgerNavigatorStackParamList } from "./MyLedgerNavigator";
@@ -351,6 +352,7 @@ export type BaseNavigatorStackParamList = {
   >;
   [NavigatorName.Assets]?: Partial<NavigatorScreenParams<AssetsNavigatorParamsList>>;
   [NavigatorName.Analytics]?: Partial<NavigatorScreenParams<AnalyticsNavigatorParamsList>>;
+  [NavigatorName.OperationsHistory]?: NavigatorScreenParams<OperationsHistoryNavigatorParamsList>;
   [NavigatorName.SwapSubScreens]?: NavigatorScreenParams<SwapSubScreensNavigatorParamList>;
   [ScreenName.LedgerSyncDeepLinkHandler]: undefined;
 };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -567,6 +567,7 @@ export enum ScreenName {
   AddAccountsWarning = "AddAccountsWarning",
   NoAssociatedAccounts = "NoAssociatedAccounts",
   LargeMoverLandingPage = "LargeMoverLandingPage",
+  OperationsList = "OperationsList",
 }
 
 export enum NavigatorName {
@@ -701,4 +702,5 @@ export enum NavigatorName {
   DeviceSelection = "DeviceSelection",
   Assets = "Assets",
   Analytics = "Analytics",
+  OperationsHistory = "OperationsHistory",
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/Navigation/HeaderCloseButton.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/Navigation/HeaderCloseButton.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useNavigation, ParamListBase } from "@react-navigation/native";
+import { IconButton } from "@ledgerhq/lumen-ui-rnative";
+import { Close } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+
+type Props = {
+  onClose?: () => void;
+};
+
+function NavigationHeaderCloseButton({ onClose }: Readonly<Props>) {
+  const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
+
+  const handlePress = () => {
+    if (onClose) {
+      onClose();
+    } else {
+      navigation.popToTop();
+    }
+  };
+
+  return (
+    <IconButton
+      appearance="no-background"
+      size="md"
+      icon={Close}
+      testID="navigation-header-close-button"
+      accessibilityLabel="Close"
+      onPress={handlePress}
+    />
+  );
+}
+
+export default NavigationHeaderCloseButton;

--- a/apps/ledger-live-mobile/src/mvvm/components/Navigation/HeaderTitle.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/Navigation/HeaderTitle.tsx
@@ -4,14 +4,16 @@ import { Text } from "@ledgerhq/lumen-ui-rnative";
 
 type HeaderTitleProps = {
   testID?: string;
-  titleKey: string;
+  titleKey?: string;
+  children?: React.ReactNode;
 };
 
-const HeaderTitle = ({ testID, titleKey }: Readonly<HeaderTitleProps>) => {
+const HeaderTitle = ({ testID, titleKey, children }: Readonly<HeaderTitleProps>) => {
   const { t } = useTranslation();
+  const label = titleKey === undefined ? children : t(titleKey);
   return (
     <Text typography="heading3SemiBold" lx={{ color: "base" }} testID={testID}>
-      {t(titleKey)}
+      {label}
     </Text>
   );
 };

--- a/apps/ledger-live-mobile/src/mvvm/components/Navigation/__tests__/getStackNavigationConfigV4.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/Navigation/__tests__/getStackNavigationConfigV4.test.tsx
@@ -1,0 +1,67 @@
+import type { ReactElement } from "react";
+import { ledgerLiveThemes } from "@ledgerhq/lumen-design-core";
+import {
+  defaultNavigationOptions,
+  getStackNavigationConfigV4,
+} from "../getStackNavigationConfigV4";
+
+const theme = ledgerLiveThemes.light;
+
+describe("defaultNavigationOptions", () => {
+  it("uses minimal native chrome and custom header render props", () => {
+    expect(defaultNavigationOptions.headerBackButtonDisplayMode).toBe("minimal");
+    expect(defaultNavigationOptions.headerLargeTitleShadowVisible).toBe(false);
+    expect(defaultNavigationOptions.headerShadowVisible).toBe(false);
+    expect(defaultNavigationOptions.headerBackVisible).toBe(false);
+    expect(typeof defaultNavigationOptions.headerTitle).toBe("function");
+    expect(typeof defaultNavigationOptions.headerLeft).toBe("function");
+    expect(typeof defaultNavigationOptions.header).toBe("function");
+  });
+});
+
+describe("getStackNavigationConfigV4", () => {
+  it("applies theme to stack surfaces and spreads default navigation options", () => {
+    const config = getStackNavigationConfigV4(theme);
+
+    expect(config.contentStyle).toEqual({ backgroundColor: theme.colors.bg.canvas });
+    expect(config.cardStyle).toEqual({ backgroundColor: theme.colors.bg.canvas });
+    expect(config.headerStyle).toEqual({
+      backgroundColor: theme.colors.bg.canvas,
+      borderBottomColor: theme.colors.border.mutedSubtle,
+    });
+    expect(config.headerTitleStyle).toEqual({ color: theme.colors.text.base });
+    expect(config.headerTitleAlign).toBe("center");
+    expect(config.headerBackButtonDisplayMode).toBe("minimal");
+    expect(config.headerShadowVisible).toBe(false);
+    expect(config.headerBackVisible).toBe(false);
+    expect(typeof config.header).toBe("function");
+  });
+
+  describe("closable", () => {
+    it("omits close control when not closable", () => {
+      expect(getStackNavigationConfigV4(theme).headerRight).toBeUndefined();
+      expect(getStackNavigationConfigV4(theme, false, undefined, true).headerLeft).toBeUndefined();
+    });
+
+    it("puts close on headerRight outside onboarding", () => {
+      const config = getStackNavigationConfigV4(theme, true);
+      expect(typeof config.headerRight).toBe("function");
+    });
+
+    it("puts close on headerLeft during onboarding", () => {
+      const config = getStackNavigationConfigV4(theme, true, undefined, true);
+      expect(typeof config.headerLeft).toBe("function");
+      expect(config.headerRight).toBeUndefined();
+    });
+  });
+
+  it("passes onClose to NavigationHeaderCloseButton (right or left)", () => {
+    const onClose = jest.fn();
+
+    const right = getStackNavigationConfigV4(theme, true, onClose).headerRight!({});
+    expect((right as ReactElement<{ onClose: () => void }>).props.onClose).toBe(onClose);
+
+    const left = getStackNavigationConfigV4(theme, true, onClose, true).headerLeft!({});
+    expect((left as ReactElement<{ onClose: () => void }>).props.onClose).toBe(onClose);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/Navigation/getStackNavigationConfigV4.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/Navigation/getStackNavigationConfigV4.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import type { LumenStyleSheetTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+import type { NativeStackNavigationOptions } from "@react-navigation/native-stack";
+import styles from "~/navigation/styles";
+import HeaderTitle from "./HeaderTitle";
+import HeaderBackButton from "./HeaderBackButton";
+import CustomNavigationHeader from "../CustomNavigationHeader";
+import NavigationHeaderCloseButton from "./HeaderCloseButton";
+
+export const defaultNavigationOptions: Partial<NativeStackNavigationOptions> = {
+  headerStyle: styles.header,
+  headerTitle: props => (
+    <HeaderTitle testID="navigation-header-title">{props.children}</HeaderTitle>
+  ),
+  headerLeft: () => <HeaderBackButton testID="navigation-header-back-button" />,
+  headerBackButtonDisplayMode: "minimal" as const,
+  headerLargeTitleShadowVisible: false,
+  headerShadowVisible: false,
+  headerBackVisible: false,
+  header: props => <CustomNavigationHeader {...props} />,
+};
+
+export const getStackNavigationConfigV4 = (
+  theme: Pick<LumenStyleSheetTheme, "colors">,
+  closable = false,
+  onClose?: () => void,
+  isOnboarding?: boolean,
+) => ({
+  ...defaultNavigationOptions,
+  contentStyle: {
+    backgroundColor: theme.colors.bg.canvas,
+  },
+  cardStyle: {
+    backgroundColor: theme.colors.bg.canvas,
+  },
+  headerStyle: {
+    backgroundColor: theme.colors.bg.canvas,
+    borderBottomColor: theme.colors.border.mutedSubtle,
+  },
+  headerTitleAlign: "center" as const,
+  headerTitleStyle: {
+    color: theme.colors.text.base,
+  },
+  ...(isOnboarding
+    ? {
+        headerLeft: closable ? () => <NavigationHeaderCloseButton onClose={onClose} /> : undefined,
+      }
+    : {
+        headerRight: closable ? () => <NavigationHeaderCloseButton onClose={onClose} /> : undefined,
+      }),
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__integrations__/TopBar.integration.test.tsx
@@ -3,7 +3,7 @@ import { renderWithReactQuery, withReadOnlyDisabled } from "@tests/test-renderer
 import { expectedNavigationParams } from "../const";
 import { TopBar } from "../index";
 import { track } from "~/analytics";
-import { ScreenName } from "~/const/navigation";
+import { NavigatorName, ScreenName } from "~/const/navigation";
 import { useSyncIndicator } from "../hooks/useSyncIndicator";
 
 const mockNavigate = jest.fn();
@@ -104,14 +104,18 @@ describe("TopBar navigation", () => {
         ...state,
         settings: {
           ...state.settings,
-          overriddenFeatureFlags: { lwmWallet40: { enabled: true, params: { operationsList: true } } },
+          overriddenFeatureFlags: {
+            lwmWallet40: { enabled: true, params: { operationsList: true } },
+          },
         },
       }),
     });
 
     await user.press(getByTestId("topbar-transaction-history"));
 
-    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.PortfolioOperationHistory);
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.OperationsHistory, {
+      screen: ScreenName.OperationsList,
+    });
 
     expect(track).toHaveBeenCalledWith("menuentry_clicked", {
       button: "operation_list",

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
@@ -87,7 +87,9 @@ export function useTopBarViewModel(
 
   const onTransactionHistoryPress = useCallback(() => {
     track("menuentry_clicked", { button: "operation_list", page });
-    navigation.navigate(ScreenName.PortfolioOperationHistory);
+    navigation.navigate(NavigatorName.OperationsHistory, {
+      screen: ScreenName.OperationsList,
+    });
   }, [navigation, page]);
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/Navigator.tsx
@@ -1,0 +1,41 @@
+import React, { useMemo } from "react";
+import { Platform } from "react-native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+import { ScreenName } from "~/const";
+import { useTranslation } from "~/context/Locale";
+import { OperationsHistoryNavigatorParamsList } from "./types";
+import OperationsList from "./screens/OperationsList";
+import { getStackNavigationConfigV4 } from "LLM/components/Navigation/getStackNavigationConfigV4";
+
+export default function Navigator() {
+  const { theme } = useTheme();
+  const { t } = useTranslation();
+
+  const stackNavigationConfig = useMemo(
+    () => ({
+      ...getStackNavigationConfigV4(theme, true),
+    }),
+    [theme],
+  );
+
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        ...stackNavigationConfig,
+        gestureEnabled: Platform.OS === "ios",
+      }}
+    >
+      <Stack.Screen
+        name={ScreenName.OperationsList}
+        component={OperationsList}
+        options={{
+          title: t("analytics.operations.title"),
+          headerRight: () => null,
+        }}
+      />
+    </Stack.Navigator>
+  );
+}
+
+const Stack = createNativeStackNavigator<OperationsHistoryNavigatorParamsList>();

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { render } from "@tests/test-renderer";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { screen } from "~/analytics/segment";
+import OperationsList from "../index";
+import { ScreenName } from "~/const/navigation";
+import { OperationsListNavigator } from "../types";
+
+const Stack = createNativeStackNavigator<OperationsListNavigator>();
+
+const MockNavigator = () => (
+  <Stack.Navigator>
+    <Stack.Screen name={ScreenName.OperationsList} component={OperationsList} />
+  </Stack.Navigator>
+);
+
+describe("OperationsList", () => {
+  it("tracks the OperationsList screen on focus", () => {
+    render(<MockNavigator />);
+
+    expect(screen).toHaveBeenCalledWith(undefined, "OperationsList", {}, true, true, false, false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { TrackScreen } from "~/analytics";
+import { ScreenName } from "~/const";
+import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { OperationsListNavigator } from "./types";
+
+type Props = StackNavigatorProps<OperationsListNavigator, ScreenName.OperationsList>;
+
+export default function OperationsList(_: Props) {
+  return <TrackScreen name="OperationsList" />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/types.ts
@@ -1,0 +1,5 @@
+import { ScreenName } from "~/const";
+
+export type OperationsListNavigator = {
+  [ScreenName.OperationsList]: undefined;
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/types.ts
@@ -1,0 +1,6 @@
+import { ScreenName } from "~/const";
+import { OperationsListNavigator } from "./screens/OperationsList/types";
+
+export type OperationsHistoryNavigatorParamsList = {
+  [ScreenName.OperationsList]: OperationsListNavigator[ScreenName.OperationsList];
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Open portfolio TopBar → transaction history entry navigates to the new operations history stack
      - Native stack header (title, theme colors, iOS gesture back)
      - Placeholder `OperationsList` screen analytics (`TrackScreen`)

### 📝 Description

This PR adds a dedicated **Operations history** flow on mobile: a new native stack navigator registered in the base navigator, opened from the portfolio TopBar when the transaction history affordance is enabled.

**Approach:** Shared stack options are centralized in `getStackNavigationConfigV4` (theme-aware header/content backgrounds, optional closable header via `HeaderCloseButton`). The first screen is a minimal `OperationsList` route that only fires screen tracking so follow-up work can plug in the real list UI.


https://github.com/user-attachments/assets/b1f0d6b9-1574-48ea-a6ba-a8a506642eb6



### ❓ Context

- **JIRA or GitHub link**: [LIVE-26754](https://ledgerhq.atlassian.net/browse/LIVE-26754)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26754]: https://ledgerhq.atlassian.net/browse/LIVE-26754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ