### PR TITLE
[LWM] fix(mobile): update padding in OS update banner for LW4.0

### DIFF
--- a/.changeset/quick-cheetahs-admire.md
+++ b/.changeset/quick-cheetahs-admire.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update spacing pills os update

--- a/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/Wallet40PortfolioBanner.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FirmwareUpdate/components/UpdateBanner/Wallet40PortfolioBanner.tsx
@@ -19,7 +19,7 @@ const Wallet40PortfolioBanner = ({
   const { t } = useTranslation();
   return (
     <>
-      <Box lx={{ alignItems: "center", paddingTop: "s16", gap: "s10" }}>
+      <Box lx={{ alignItems: "center", paddingTop: "s24" }}>
         <Button
           appearance="transparent"
           size="sm"

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioHeaderSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioHeaderSection/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { View, type LayoutChangeEvent } from "react-native";
-import { Flex } from "@ledgerhq/native-ui";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
 import FirmwareUpdateBanner from "LLM/features/FirmwareUpdate/components/UpdateBanner";
 import PortfolioGraphCard from "~/screens/Portfolio/PortfolioGraphCard";
 import { PortfolioBalanceSection } from "../PortfolioBalanceSection";
@@ -37,11 +37,9 @@ export const PortfolioHeaderSection = ({
     return (
       <View key="portfolioHeaderElements" style={{ paddingTop: safeAreaTop }}>
         {shouldDisplayBalanceRefreshRework && <PortfolioRefreshStatus />}
-        <View onLayout={onBannerLayout}>
-          <Flex px={6} key="FirmwareUpdateBanner">
-            <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
-          </Flex>
-        </View>
+        <Box onLayout={onBannerLayout} lx={{ paddingHorizontal: "s16" }} key="FirmwareUpdateBanner">
+          <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
+        </Box>
         <ScreenHeroSectionView ctas={ctas} minContentHeight={minContentHeight}>
           <PortfolioBalanceSection showAssets={showAssets} isReadOnlyMode={isReadOnlyMode} />
         </ScreenHeroSectionView>
@@ -51,9 +49,9 @@ export const PortfolioHeaderSection = ({
 
   return (
     <View key="portfolioHeaderElements" style={{ paddingTop: 24 }}>
-      <Flex px={6} key="FirmwareUpdateBanner">
+      <Box lx={{ paddingHorizontal: "s16" }} key="FirmwareUpdateBanner">
         <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
-      </Flex>
+      </Box>
       <PortfolioGraphCard
         key="PortfolioGraphCard"
         showAssets={showAssets}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This is a visual/spacing fix — no unit tests required._
- [x] **Impact of the changes:**
      - Verify the OS update banner on LW4.0 (Ledger Wallet Mobile) has proper spacing (not too close to icons above)
      - Test with an outdated device connected and LW4.0 feature flag enabled

### 📝 Description

When an OS update is available and the banner is displayed in LW4.0 on Ledger Wallet Mobile, the banner and balance section appear slightly too high — almost touching the icons above it.

The fix increases the `paddingTop` of the `Wallet40PortfolioBanner` component from `s16` (16px) to `s24` (24px), giving the banner and balance a bit more breathing room and aligning with the Figma design spec.

<img width="603" height="1311" alt="Simulator Screenshot - iOS Simulator - 2026-03-25 at 15 16 24" src="https://github.com/user-attachments/assets/fd329daf-8ca6-4230-8915-b348c29a0181" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27792](https://ledgerhq.atlassian.net/browse/LIVE-27792)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27792]: https://ledgerhq.atlassian.net/browse/LIVE-27792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ