### PR TITLE
[LWDM] feat(LIVE-26446): update getTransactionStatus for private

### DIFF
--- a/.changeset/fifty-spoons-play.md
+++ b/.changeset/fifty-spoons-play.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+add aleo getTransactionStatus for private

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7241,6 +7241,12 @@
     "TonMinimumRequired": {
       "title": "Insufficient funds. The minimum required balance is 0.02 TON."
     },
+    "AleoAmountRecordRequired": {
+      "title": "Select a valid private record for the amount."
+    },
+    "AleoFeeRecordRequired": {
+      "title": "Select a valid private record for the fee."
+    },
     "BackupAppDataError": {
       "title": "Error during app data backup"
     },

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
@@ -6,13 +6,19 @@ import {
   NotEnoughBalance,
   RecipientRequired,
 } from "@ledgerhq/errors";
-import { getMockedAccount, mockAleoResources } from "../__tests__/fixtures/account.fixture";
+import {
+  getMockedAccount,
+  mockAleoResources,
+  mockUnspentRecord1,
+  mockUnspentRecord2,
+} from "../__tests__/fixtures/account.fixture";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { estimateFees, validateAddress } from "../logic";
 import { calculateAmount } from "../logic/utils";
 import type { Transaction } from "../types";
 import aleoCoinConfig from "../config";
 import { TRANSACTION_TYPE } from "../constants";
+import { AleoAmountRecordRequired, AleoFeeRecordRequired } from "../errors";
 import { getTransactionStatus } from "./getTransactionStatus";
 
 jest.mock("../config");
@@ -255,6 +261,101 @@ describe("getTransactionStatus", () => {
       const result = await getTransactionStatus(sufficientAccount, transaction);
 
       expect(result.errors.amount).toBeUndefined();
+    });
+  });
+
+  describe("private record validation", () => {
+    const privateAccount = getMockedAccount({
+      aleoResources: {
+        ...mockAleoResources,
+        privateBalance: new BigNumber(2000000),
+        unspentPrivateRecords: [mockUnspentRecord1, mockUnspentRecord2],
+      },
+    });
+
+    const privateTransaction: Transaction = {
+      ...mockTransaction,
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitment: mockUnspentRecord1.commitment,
+        feeRecordCommitment: mockUnspentRecord2.commitment,
+      },
+    };
+
+    it("adds error when private amount record commitment is missing", async () => {
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: {
+          ...privateTransaction.properties,
+          amountRecordCommitment: null,
+        },
+      };
+
+      const result = await getTransactionStatus(privateAccount, transaction);
+
+      expect(result.errors.amountRecord).toBeInstanceOf(AleoAmountRecordRequired);
+    });
+
+    it("adds error when private amount record cannot be resolved", async () => {
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: {
+          ...privateTransaction.properties,
+          amountRecordCommitment: "missing-amount-record",
+        },
+      };
+
+      const result = await getTransactionStatus(privateAccount, transaction);
+
+      expect(result.errors.amountRecord).toBeInstanceOf(AleoAmountRecordRequired);
+    });
+
+    it("adds error when private fee record is missing and fee is not sponsored", async () => {
+      mockAleoConfig.getCoinConfig.mockReturnValue({ ...mockConfig, isFeeSponsored: false });
+
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: {
+          ...privateTransaction.properties,
+          feeRecordCommitment: null,
+        },
+      };
+
+      const result = await getTransactionStatus(privateAccount, transaction);
+
+      expect(result.errors.feeRecord).toBeInstanceOf(AleoFeeRecordRequired);
+    });
+
+    it("adds error when private fee record cannot be resolved and fee is not sponsored", async () => {
+      mockAleoConfig.getCoinConfig.mockReturnValue({ ...mockConfig, isFeeSponsored: false });
+
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: {
+          ...privateTransaction.properties,
+          feeRecordCommitment: "missing-fee-record",
+        },
+      };
+
+      const result = await getTransactionStatus(privateAccount, transaction);
+
+      expect(result.errors.feeRecord).toBeInstanceOf(AleoFeeRecordRequired);
+    });
+
+    it("does not add fee-record error for sponsored private fees", async () => {
+      mockAleoConfig.getCoinConfig.mockReturnValue({ ...mockConfig, isFeeSponsored: true });
+
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: {
+          ...privateTransaction.properties,
+          feeRecordCommitment: null,
+        },
+      };
+
+      const result = await getTransactionStatus(privateAccount, transaction);
+
+      expect(result.errors.feeRecord).toBeUndefined();
     });
   });
 

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
@@ -10,16 +10,40 @@ import { BigNumber } from "bignumber.js";
 import type {
   AleoAccount,
   Transaction as AleoTransaction,
+  TransactionPrivate,
   TransactionStatus as AleoTransactionStatus,
   TransactionSelfTransfer,
   TransactionTransfer,
 } from "../types";
 import { estimateFees, validateAddress } from "../logic";
-import { calculateAmount, getAvailableBalance, isSelfTransferTransaction } from "../logic/utils";
+import {
+  calculateAmount,
+  getAvailableBalance,
+  getRecordByCommitment,
+  isPrivateTransaction,
+  isSelfTransferTransaction,
+} from "../logic/utils";
 import aleoCoinConfig from "../config";
+import { AleoAmountRecordRequired, AleoFeeRecordRequired } from "../errors";
 
 type Errors = Record<string, Error>;
 type Warnings = Record<string, Error>;
+
+function validateRecord({
+  account,
+  commitment,
+  error,
+}: {
+  account: AleoAccount;
+  commitment: TransactionPrivate["properties"]["amountRecordCommitment"];
+  error: Error;
+}): Error | null {
+  if (!commitment || !getRecordByCommitment({ account, commitment })) {
+    return error;
+  }
+
+  return null;
+}
 
 async function validateRecipient({
   account,
@@ -85,6 +109,28 @@ async function handleTransferTransaction({
 
   if (transaction.amount.eq(0) && !transaction.useAllAmount) {
     errors.amount = new AmountRequired();
+  }
+
+  if (isPrivateTransaction(transaction)) {
+    const amountRecordError = validateRecord({
+      account,
+      commitment: transaction.properties.amountRecordCommitment,
+      error: new AleoAmountRecordRequired(),
+    });
+    if (amountRecordError) {
+      errors.amountRecord = amountRecordError;
+    }
+
+    if (!config.isFeeSponsored) {
+      const feeRecordError = validateRecord({
+        account,
+        commitment: transaction.properties.feeRecordCommitment,
+        error: new AleoFeeRecordRequired(),
+      });
+      if (feeRecordError) {
+        errors.feeRecord = feeRecordError;
+      }
+    }
   }
 
   if (availableBalance.isLessThan(calculatedAmount.totalSpent)) {

--- a/libs/coin-modules/coin-aleo/src/errors.ts
+++ b/libs/coin-modules/coin-aleo/src/errors.ts
@@ -1,0 +1,4 @@
+import { createCustomErrorClass } from "@ledgerhq/errors";
+
+export const AleoAmountRecordRequired = createCustomErrorClass("AleoAmountRecordRequired");
+export const AleoFeeRecordRequired = createCustomErrorClass("AleoFeeRecordRequired");

--- a/libs/coin-modules/coin-aleo/src/index.ts
+++ b/libs/coin-modules/coin-aleo/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./types";
+export * from "./errors";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - getTransactionStatus for private transactions method added to coin-aleo module

### 📝 Description

This PR adds getTransactionStatus for private transactions method to coin-aleo package.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-26446

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
