### PR TITLE
[LWM] fix(mobile): recompute cosmos redelegation fees after amount selection

### DIFF
--- a/.changeset/famous-beans-return.md
+++ b/.changeset/famous-beans-return.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix: Cosmos redelegation gas estimation in mobile by preparing the final transaction after amount selection.

--- a/apps/ledger-live-mobile/src/families/cosmos/shared/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/shared/02-SelectAmount.tsx
@@ -66,8 +66,8 @@ function DelegationAmount({ navigation, route }: Props) {
     [initialValue, initialMax, value],
   );
   const min = useMemo(() => route?.params?.min ?? BigNumber(0), [route]);
-  const onNext = useCallback(() => {
-    const validators = tx.validators;
+  const onNext = useCallback(async () => {
+    const validators = [...tx.validators];
     const validatorAddress = route.params.validator ? route.params.validator.validatorAddress : "";
     const i = validators.findIndex(({ address }) => address === validatorAddress);
 
@@ -93,14 +93,17 @@ function DelegationAmount({ navigation, route }: Props) {
             validators: filteredValidators,
           },
     );
+    const preparedTransaction = await bridge
+      .prepareTransaction(account as CosmosAccount, transaction)
+      .catch(() => transaction);
     // @ts-expect-error navigate cannot infer the correct navigator + route
     navigation.navigate(route.params.nextScreen, {
       ...route.params,
       validatorName: route.params.validator ? route.params.validator.name : "",
-      transaction,
+      transaction: preparedTransaction,
       fromSelectAmount: true,
     });
-  }, [navigation, route.params, bridge, tx, value]);
+  }, [navigation, route.params, bridge, account, tx, value]);
   const [ratioButtons] = useState(
     [0.25, 0.5, 0.75, 1].map(ratio => ({
       label: `${ratio * 100}%`,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- fixes a Ledger Live Mobile issue where Cosmos redelegation could fail with `out of gas` when started from the Redelegate action
- updates the redelegation amount step to re-prepare the transaction after destination validator/amount are set, so gas and fees are computed from the final tx payload
- avoids mutating `tx.validators` in-place by cloning before update, then navigates with the prepared transaction


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28187(https://ledgerhq.atlassian.net/browse/LIVE-28187)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
