### PR TITLE
feat: lwm add image action card variant

### DIFF
--- a/.changeset/hot-parents-brake.md
+++ b/.changeset/hot-parents-brake.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat: lwm add image action card variant

--- a/apps/ledger-live-mobile/src/contentCards/cards/contentBannerAction/index.test.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/contentBannerAction/index.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { ContentCardsType } from "~/dynamicContent/types";
+import { ContentBannerActionCard } from "./index";
+
+const IMAGE_BG_URL = "https://example.com/banner.png";
+
+type Variant = "icon" | "image";
+
+function setupContentBannerActionCard(variant: Variant) {
+  const id = "test-card";
+  const actions = {
+    onView: jest.fn(),
+    onClick: jest.fn(),
+    onDismiss: jest.fn(),
+  };
+
+  const base = {
+    type: ContentCardsType.action,
+    id,
+    createdAt: 1,
+    viewed: false,
+    title: "Promo title",
+    description: "Promo body",
+    metadata: { id, actions },
+  };
+
+  const props =
+    variant === "icon"
+      ? { ...base, icon: "Plus" as const }
+      : { ...base, image_background: IMAGE_BG_URL };
+
+  return { props, actions };
+}
+
+describe("ContentBannerActionCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("when Braze sends `icon` only (no image_background): ContentBanner + Spot, view/CTA/dismiss", async () => {
+    const { props, actions } = setupContentBannerActionCard("icon");
+    const { user } = render(<ContentBannerActionCard {...props} />);
+
+    expect(actions.onView).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Promo title")).toBeVisible();
+    expect(screen.getByText("Promo body")).toBeVisible();
+
+    await user.press(screen.getByText("Promo title"));
+    expect(actions.onClick).toHaveBeenCalledTimes(1);
+
+    await user.press(screen.getByTestId("content-banner-close-button"));
+    expect(actions.onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("when Braze sends `image_background`: MediaBanner, close must not fire CTA", async () => {
+    const { props, actions } = setupContentBannerActionCard("image");
+    const { user } = render(<ContentBannerActionCard {...props} />);
+
+    expect(actions.onView).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Promo title")).toBeVisible();
+    expect(screen.getByText("Promo body")).toBeVisible();
+
+    await user.press(screen.getByTestId("media-banner-close-button"));
+    expect(actions.onDismiss).toHaveBeenCalledTimes(1);
+    expect(actions.onClick).not.toHaveBeenCalled();
+
+    await user.press(screen.getByText("Promo title"));
+    expect(actions.onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/contentCards/cards/contentBannerAction/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/contentBannerAction/index.tsx
@@ -5,6 +5,9 @@ import {
   ContentBannerContent,
   ContentBannerDescription,
   ContentBannerTitle,
+  MediaBanner,
+  MediaBannerDescription,
+  MediaBannerTitle,
   Pressable,
   Spot,
 } from "@ledgerhq/lumen-ui-rnative";
@@ -39,16 +42,15 @@ const ContentBannerActionCard = ContentCardBuilder<ContentCardProps>(props => {
 
   if (imageBackground && imageBackground.length > 0) {
     return (
-      <Pressable onPress={metadata.actions?.onClick} key={metadata.id}>
-        <ContentBanner onClose={handleDismiss}>
-          <ContentBannerContent>
-            <ContentBannerTitle>{title ?? ""}</ContentBannerTitle>
-            {description ? (
-              <ContentBannerDescription>{description}</ContentBannerDescription>
-            ) : null}
-          </ContentBannerContent>
-        </ContentBanner>
-      </Pressable>
+      <MediaBanner
+        key={metadata.id}
+        imageUrl={imageBackground}
+        onClose={handleDismiss}
+        onPress={metadata.actions?.onClick}
+      >
+        {title ? <MediaBannerTitle>{title}</MediaBannerTitle> : null}
+        {description ? <MediaBannerDescription>{description}</MediaBannerDescription> : null}
+      </MediaBanner>
     );
   }
 

--- a/apps/ledger-live-mobile/src/dynamicContent/buildLocalContentCards.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/buildLocalContentCards.ts
@@ -79,12 +79,20 @@ export function buildSampleBanner(): {
   return { category, cards: [heroCard] };
 }
 
-const ACTION_SAMPLES = [
+/** Braze action card layout for Portfolio: `ContentBanner` + Spot (icon) vs `MediaBanner` (image_background). */
+export type SampleActionBannerVariant = "icon" | "imageBackground";
+
+const ACTION_SAMPLE_ITEMS: {
+  title: string;
+  description: string;
+  link: string;
+  icon: string;
+}[] = [
   {
     title: "Buy",
     description: "Buy crypto with card or bank transfer",
     link: "ledgerlive://buy",
-    image: SAMPLE_IMAGE,
+    icon: "Plus",
   },
   {
     title: "Swap",
@@ -100,7 +108,9 @@ const ACTION_SAMPLES = [
   },
 ];
 
-export function buildSampleActionCarousel(): {
+export function buildSampleActionCarousel(
+  variant: SampleActionBannerVariant = "icon",
+): {
   category: CategoryContentCard;
   cards: BrazeContentCard[];
 } {
@@ -120,7 +130,7 @@ export function buildSampleActionCarousel(): {
     isDismissable: true,
   };
 
-  const cards = ACTION_SAMPLES.map((item, index) =>
+  const cards = ACTION_SAMPLE_ITEMS.map((item, index) =>
     createBrazeLikeCard(
       `local-action-${ts}-${index}`,
       categoryId,
@@ -131,10 +141,11 @@ export function buildSampleActionCarousel(): {
       {
         title: item.title,
         description: item.description,
-        ...(item.image ? { image: item.image } : {}),
-        ...(item.icon ? { icon: item.icon } : {}),
         link: item.link,
         order: String(index),
+        ...(variant === "imageBackground"
+          ? { image_background: SAMPLE_IMAGE }
+          : { icon: item.icon }),
       },
     ),
   );

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3575,8 +3575,10 @@
         "description": "Local cards appear on Portfolio (and other locations) without Braze. They persist until you dismiss them or clear here.",
         "addSampleBanner": "Add sample banner",
         "addSampleBannerDesc": "Add a sample hero banner on Portfolio.",
-        "addSampleActionCarousel": "Add sample action carousel",
-        "addSampleActionCarouselDesc": "Add a carousel of action cards (Buy, Swap, Stake) on Portfolio.",
+        "addSampleActionCarouselIcon": "Add action carousel (icon)",
+        "addSampleActionCarouselIconDesc": "ContentBanner with Spot icons — Buy, Swap, Stake. Requires Braze placement flag.",
+        "addSampleActionCarouselImageBackground": "Add action carousel (image)",
+        "addSampleActionCarouselImageBackgroundDesc": "MediaBanner with image_background — Buy, Swap, Stake. Requires Braze placement flag.",
         "dismissAll": "Dismiss all local cards",
         "dismissAllDesc": "Remove all locally generated content cards."
       }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.tsx
@@ -19,8 +19,13 @@ export default function DebugContentCards() {
     dispatch(addLocalContentCards({ category, cards }));
   }, [dispatch]);
 
-  const onAddSampleActionCarousel = useCallback(() => {
-    const { category, cards } = buildSampleActionCarousel();
+  const onAddSampleActionCarouselIcon = useCallback(() => {
+    const { category, cards } = buildSampleActionCarousel("icon");
+    dispatch(addLocalContentCards({ category, cards }));
+  }, [dispatch]);
+
+  const onAddSampleActionCarouselImageBackground = useCallback(() => {
+    const { category, cards } = buildSampleActionCarousel("imageBackground");
     dispatch(addLocalContentCards({ category, cards }));
   }, [dispatch]);
 
@@ -41,10 +46,16 @@ export default function DebugContentCards() {
         onPress={onAddSampleBanner}
       />
       <SettingsRow
-        title={t("settings.debug.contentCards.addSampleActionCarousel")}
-        desc={t("settings.debug.contentCards.addSampleActionCarouselDesc")}
+        title={t("settings.debug.contentCards.addSampleActionCarouselIcon")}
+        desc={t("settings.debug.contentCards.addSampleActionCarouselIconDesc")}
         iconLeft={<IconsLegacy.BoxMedium size={24} color="black" />}
-        onPress={onAddSampleActionCarousel}
+        onPress={onAddSampleActionCarouselIcon}
+      />
+      <SettingsRow
+        title={t("settings.debug.contentCards.addSampleActionCarouselImageBackground")}
+        desc={t("settings.debug.contentCards.addSampleActionCarouselImageBackgroundDesc")}
+        iconLeft={<IconsLegacy.LayersMedium size={24} color="black" />}
+        onPress={onAddSampleActionCarouselImageBackground}
       />
       <SettingsRow
         title={t("settings.debug.contentCards.dismissAll")}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- add image variant action card using image_background props
- delete icon props because icon variant must use image props

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26632]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->
<img width="377" height="774" alt="Screenshot 2026-03-25 at 17 14 52" src="https://github.com/user-attachments/assets/b4f9bb42-3ae3-49cd-bddf-d7655ac6629b" />


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26632]: https://ledgerhq.atlassian.net/browse/LIVE-26632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ