### PR TITLE
[LWD] fix(os update banner): impression tracking

### DIFF
--- a/.changeset/soft-roses-vanish.md
+++ b/.changeset/soft-roses-vanish.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix impression tracking on OS update banner

--- a/apps/ledger-live-desktop/src/renderer/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/FirmwareUpdateBanner.tsx
@@ -136,6 +136,7 @@ const FirmwareUpdateBanner = ({ old, right }: { old?: boolean; right?: React.Rea
 
   useEffect(() => {
     if (
+      latestFirmware &&
       !hasTrackedImpressionRef.current &&
       shouldDisplayWallet40MainNav &&
       (isOnDashboard || inManager)
@@ -146,7 +147,7 @@ const FirmwareUpdateBanner = ({ old, right }: { old?: boolean; right?: React.Rea
         page: inManager ? "my ledger" : "portfolio",
       });
     }
-  }, [shouldDisplayWallet40MainNav, isOnDashboard, inManager]);
+  }, [latestFirmware, shouldDisplayWallet40MainNav, isOnDashboard, inManager]);
 
   const onClick = () => {
     if (shouldDisplayWallet40MainNav) {

--- a/apps/ledger-live-desktop/src/renderer/components/__tests__/FirmwareUpdateBannerEntry.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/__tests__/FirmwareUpdateBannerEntry.test.tsx
@@ -50,7 +50,7 @@ describe("FirmwareUpdateBannerEntry", () => {
         expect(screen.getByTestId("topbar-os-update-button")).toBeVisible();
       });
 
-      it("tracks banner_impression on portfolio page", () => {
+      it("tracks banner_impression on portfolio page when latestFirmware is set", () => {
         jest.mocked(track).mockClear();
         render(<FirmwareUpdateBannerEntry />, {
           initialState: initialState({
@@ -63,6 +63,15 @@ describe("FirmwareUpdateBannerEntry", () => {
           banner: "OS update",
           page: "portfolio",
         });
+      });
+
+      it("does not track banner_impression on portfolio page when latestFirmware is null", () => {
+        jest.mocked(track).mockClear();
+        render(<FirmwareUpdateBannerEntry />, {
+          initialState: initialState(),
+          initialRoute: "/",
+        });
+        expect(track).not.toHaveBeenCalledWith("banner_impression", expect.anything());
       });
 
       it("tracks button_clicked and navigates when topbar button is clicked", async () => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) 

### 📝 Description

Fix impression tracking trigger on OS update banner

### ❓ Context

- **JIRA**: [LIVE-28078](https://ledgerhq.atlassian.net/browse/LIVE-28078)
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28078]: https://ledgerhq.atlassian.net/browse/LIVE-28078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ