### PR TITLE
test(e2e): add BTC send test spec for mobile

### DIFF
--- a/e2e/mobile/specs/send/sendBTC.spec.ts
+++ b/e2e/mobile/specs/send/sendBTC.spec.ts
@@ -1,0 +1,14 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSendTest } from "./send";
+
+const transaction = new Transaction(
+  Account.BTC_NATIVE_SEGWIT_1,
+  Account.BTC_NATIVE_SEGWIT_2,
+  "0.00001",
+  Fee.SLOW,
+);
+runSendTest(
+  transaction,
+  ["B2CQA-4714"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@bitcoin", "@family-bitcoin"],
+);


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - BTC send flow in mobile e2e (native segwit accounts)
  - Device coverage: NanoSP, LNS, NanoX, Stax, Flex, NanoGen5

### 📝 Description

Adds a new mobile e2e test spec for the BTC send flow using two native segwit accounts.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1014](https://ledgerhq.atlassian.net/browse/QAA-1014)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1014]: https://ledgerhq.atlassian.net/browse/QAA-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ