### PR TITLE
[LWM] feat(mobile): add CryptoAddressesButton support for users without accounts

### DIFF
--- a/.changeset/swift-coins-address.md
+++ b/.changeset/swift-coins-address.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add CryptoAddressesButton support for users without accounts, showing an add account flow instead of navigating

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2753,7 +2753,8 @@
     "cryptoAddresses": {
       "title": "Crypto accounts",
       "count_one": "{{count}} account",
-      "count_other": "{{count}} accounts"
+      "count_other": "{{count}} accounts",
+      "noAccountsYet": "No accounts yet"
     },
     "seeAllAccounts": "See all accounts",
     "assetSection": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioAssetsSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioAssetsSection/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Box } from "@ledgerhq/native-ui";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import PortfolioAssets from "~/screens/Portfolio/PortfolioAssets";
 import AnimatedContainer from "~/screens/Portfolio/AnimatedContainer";
 
@@ -8,6 +9,7 @@ interface PortfolioAssetsSectionProps {
   readonly hideEmptyTokenAccount: boolean;
   readonly openAddModal: () => void;
   readonly onHeightChange: (height: number) => void;
+  readonly shouldAddBottomPadding?: boolean;
 }
 
 export const PortfolioAssetsSection = ({
@@ -15,9 +17,16 @@ export const PortfolioAssetsSection = ({
   hideEmptyTokenAccount,
   openAddModal,
   onHeightChange,
+  shouldAddBottomPadding = false,
 }: PortfolioAssetsSectionProps) => {
+  const { bottom } = useSafeAreaInsets();
+
   const content = (
-    <Box px={6} key="PortfolioAssets">
+    <Box
+      px={6}
+      key="PortfolioAssets"
+      style={shouldAddBottomPadding ? { paddingBottom: bottom + 16 } : undefined}
+    >
       <PortfolioAssets hideEmptyTokenAccount={hideEmptyTokenAccount} openAddModal={openAddModal} />
     </Box>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioEmptyAssetSections.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioEmptyAssetSections.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { PortfolioCryptosSection } from "LLM/features/WalletAssets/views/CryptosSection";
+import { PortfolioStablecoinsSection } from "LLM/features/WalletAssets/views/StablecoinsSection";
+
+interface PortfolioEmptyAssetSectionsProps {
+  readonly shouldDisplayAssetSection: boolean;
+  readonly isEmptyState?: boolean;
+}
+
+export const PortfolioEmptyAssetSections = ({
+  shouldDisplayAssetSection,
+  isEmptyState = true,
+}: PortfolioEmptyAssetSectionsProps) => {
+  if (shouldDisplayAssetSection) {
+    return (
+      <Box lx={{ rowGap: "s24" }}>
+        <PortfolioCryptosSection isEmptyState={isEmptyState} />
+        <PortfolioStablecoinsSection isEmptyState={isEmptyState} />
+      </Box>
+    );
+  }
+
+  return <PortfolioCryptosSection isReadOnly />;
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoAccountsContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoAccountsContent.tsx
@@ -4,11 +4,11 @@ import { QuickActionsCtas, TransferDrawer } from "LLM/features/QuickActions";
 import MarketBanner from "LLM/features/MarketBanner";
 import { ScreenName } from "~/const";
 import { PortfolioBannersSection } from "../PortfolioBannersSection";
-import { PortfolioCryptosSection } from "LLM/features/WalletAssets/views/CryptosSection";
-import { PortfolioStablecoinsSection } from "LLM/features/WalletAssets/views/StablecoinsSection";
+import { CryptoAddressesButton } from "LLM/features/WalletAssets/components/CryptoAddressesButton";
 import AddAccountDrawer from "LLM/features/Accounts/screens/AddAccount";
-import { useTranslation } from "~/context/Locale";
 import TrackScreen from "~/analytics/TrackScreen";
+import { useTranslation } from "~/context/Locale";
+import { PortfolioEmptyAssetSections } from "./PortfolioEmptyAssetSections";
 
 type PortfolioNoAccountsContentProps = {
   readonly isLNSUpsellBannerShown: boolean;
@@ -34,30 +34,29 @@ const PortfolioNoAccountsContent = ({
       <TransferDrawer />
       <PortfolioBannersSection isFirst={true} isLNSUpsellBannerShown={isLNSUpsellBannerShown} />
       <MarketBanner />
+      <PortfolioEmptyAssetSections shouldDisplayAssetSection={shouldDisplayAssetSection} />
       {shouldDisplayAssetSection ? (
-        <>
-          <PortfolioCryptosSection isEmptyState />
-          <Box lx={{ marginTop: "s24" }}>
-            <PortfolioStablecoinsSection isEmptyState />
-          </Box>
-        </>
+        <Box lx={{ marginTop: "s24", marginBottom: "s48" }}>
+          <CryptoAddressesButton />
+        </Box>
       ) : (
-        <PortfolioCryptosSection isReadOnly />
+        <>
+          <Button
+            appearance="gray"
+            size="lg"
+            lx={{ width: "full", marginTop: "s24", marginBottom: "s48" }}
+            onPress={openAddModal}
+            testID="add-account-cta"
+          >
+            {t("account.emptyState.addCryptoAccount")}
+          </Button>
+          <AddAccountDrawer
+            isOpened={isAddModalOpened}
+            onClose={closeAddModal}
+            doesNotHaveAccount
+          />
+        </>
       )}
-      <Button
-        appearance="gray"
-        size="lg"
-        lx={{
-          width: "full",
-          marginTop: "s24",
-          marginBottom: "s48",
-        }}
-        onPress={openAddModal}
-        testID="add-account-cta"
-      >
-        {t("account.emptyState.addCryptoAccount")}
-      </Button>
-      <AddAccountDrawer isOpened={isAddModalOpened} onClose={closeAddModal} doesNotHaveAccount />
     </Box>
   );
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoSignerContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioEmptySection/PortfolioNoSignerContent.tsx
@@ -2,12 +2,11 @@ import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { QuickActionsCtas, TransferDrawer } from "LLM/features/QuickActions";
 import { ScreenName, NavigatorName } from "~/const";
-import { PortfolioCryptosSection } from "LLM/features/WalletAssets/views/CryptosSection";
-import { PortfolioStablecoinsSection } from "LLM/features/WalletAssets/views/StablecoinsSection";
 import { PortfolioBannersSection } from "../PortfolioBannersSection";
 import MarketBanner from "LLM/features/MarketBanner";
 import TrackScreen from "~/analytics/TrackScreen";
 import { TRACKING_LABEL_MAP } from "LLM/components/MainTabBar/constants";
+import { PortfolioEmptyAssetSections } from "./PortfolioEmptyAssetSections";
 
 interface PortfolioNoSignerContentProps {
   readonly isLNSUpsellBannerShown: boolean;
@@ -26,15 +25,9 @@ export const PortfolioNoSignerContent = ({
     <TransferDrawer />
     <PortfolioBannersSection isFirst={true} isLNSUpsellBannerShown={isLNSUpsellBannerShown} />
     <MarketBanner />
-    {shouldDisplayAssetSection ? (
-      <>
-        <PortfolioCryptosSection isEmptyState={isEmptyState} />
-        <Box lx={{ marginTop: "s24" }}>
-          <PortfolioStablecoinsSection isEmptyState={isEmptyState} />
-        </Box>
-      </>
-    ) : (
-      <PortfolioCryptosSection isReadOnly />
-    )}
+    <PortfolioEmptyAssetSections
+      shouldDisplayAssetSection={shouldDisplayAssetSection}
+      isEmptyState={isEmptyState}
+    />
   </Box>
 );

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -131,6 +131,8 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     if (shouldDisplayAssetSection) {
       sections.push(<WalletAssetsView key="categorizedAssets" />);
     } else {
+      const isAssetSectionLast =
+        !isAWalletCardDisplayed && shouldDisplayGraphRework && shouldDisplayOperationsList;
       sections.push(
         <PortfolioAssetsSection
           key="assets"
@@ -138,6 +140,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
           hideEmptyTokenAccount={hideEmptyTokenAccount}
           openAddModal={openAddModal}
           onHeightChange={handleHeightChange}
+          shouldAddBottomPadding={isAssetSectionLast}
         />,
       );
     }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/__tests__/useCryptoAddressesButtonViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/__tests__/useCryptoAddressesButtonViewModel.test.ts
@@ -5,6 +5,8 @@ import { genAccount } from "@ledgerhq/live-common/mock/account";
 import { CategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/types";
 import { NavigatorName, ScreenName } from "~/const";
 import { State } from "~/reducers/types";
+import { track } from "~/analytics";
+import { replaceAccounts } from "~/actions/accounts";
 import { useCryptoAddressesButtonViewModel } from "../useCryptoAddressesButtonViewModel";
 
 const mockNavigate = jest.fn();
@@ -12,6 +14,7 @@ const mockNavigate = jest.fn();
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => ({ name: "Portfolio" }),
 }));
 
 const mockCategorizedAssets = jest.fn();
@@ -136,7 +139,7 @@ describe("useCryptoAddressesButtonViewModel", () => {
     });
   });
 
-  describe("onPress — navigation", () => {
+  describe("onPress — with accounts (view)", () => {
     it("should navigate to AssetsList", () => {
       const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
         overrideInitialState: withAccounts([btcAccount]),
@@ -154,6 +157,109 @@ describe("useCryptoAddressesButtonViewModel", () => {
           isSyncEnabled: true,
         },
       });
+    });
+
+    it("should track account_cta with type view", () => {
+      const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
+        overrideInitialState: withAccounts([btcAccount]),
+      });
+
+      act(() => {
+        result.current.onPress();
+      });
+
+      expect(jest.mocked(track)).toHaveBeenCalledWith("button_clicked", {
+        button: "account_cta",
+        type: "view",
+        page: "Portfolio",
+      });
+    });
+  });
+
+  describe("onPress — without accounts (add)", () => {
+    it("should open add account drawer when no accounts", () => {
+      const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
+        overrideInitialState: withAccounts([]),
+      });
+
+      act(() => {
+        result.current.onPress();
+      });
+
+      expect(result.current.isAddAccountOpen).toBe(true);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it("should track account_cta with type add", () => {
+      const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
+        overrideInitialState: withAccounts([]),
+      });
+
+      act(() => {
+        result.current.onPress();
+      });
+
+      expect(jest.mocked(track)).toHaveBeenCalledWith("button_clicked", {
+        button: "account_cta",
+        type: "add",
+        page: "Portfolio",
+      });
+    });
+
+    it("should close add account drawer on onCloseAddAccount", () => {
+      const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
+        overrideInitialState: withAccounts([]),
+      });
+
+      act(() => {
+        result.current.onPress();
+      });
+
+      expect(result.current.isAddAccountOpen).toBe(true);
+
+      act(() => {
+        result.current.onCloseAddAccount();
+      });
+
+      expect(result.current.isAddAccountOpen).toBe(false);
+    });
+  });
+
+  describe("hasAccounts", () => {
+    it("should be true when accounts exist", () => {
+      const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
+        overrideInitialState: withAccounts([btcAccount]),
+      });
+
+      expect(result.current.hasAccounts).toBe(true);
+    });
+
+    it("should be false when no accounts", () => {
+      const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
+        overrideInitialState: withAccounts([]),
+      });
+
+      expect(result.current.hasAccounts).toBe(false);
+    });
+  });
+
+  describe("drawer auto-close on account added", () => {
+    it("should close the add account drawer when hasAccounts flips to true", () => {
+      const { result, store } = renderHook(() => useCryptoAddressesButtonViewModel(), {
+        overrideInitialState: withAccounts([]),
+      });
+
+      act(() => {
+        result.current.onPress();
+      });
+
+      expect(result.current.isAddAccountOpen).toBe(true);
+
+      act(() => {
+        store.dispatch(replaceAccounts([btcAccount] as Parameters<typeof replaceAccounts>[0]));
+      });
+
+      expect(result.current.isAddAccountOpen).toBe(false);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/index.tsx
@@ -12,30 +12,55 @@ import {
 import { Wallet } from "@ledgerhq/lumen-ui-rnative/symbols";
 import CurrencyIcon from "~/components/CurrencyIcon";
 import { useTranslation } from "~/context/Locale";
+import AddAccountDrawer from "LLM/features/Accounts/screens/AddAccount";
 import { useCryptoAddressesButtonViewModel } from "./useCryptoAddressesButtonViewModel";
 
 export const CryptoAddressesButton: React.FC = () => {
   const { t } = useTranslation();
-  const { accountsCount, firstThreeCurrencies, onPress } = useCryptoAddressesButtonViewModel();
+  const {
+    accountsCount,
+    hasAccounts,
+    firstThreeCurrencies,
+    onPress,
+    isAddAccountOpen,
+    onCloseAddAccount,
+  } = useCryptoAddressesButtonViewModel();
 
   return (
-    <Card onPress={onPress} testID="crypto-addresses-button">
-      <CardHeader>
-        <CardLeading>
-          <Spot appearance="icon" icon={Wallet} />
-          <CardContent>
-            <CardContentTitle>{t("portfolio.cryptoAddresses.title")}</CardContentTitle>
-            <CardContentRow>
-              <CardContentDescription>
-                {t("portfolio.cryptoAddresses.count", { count: accountsCount })}
-              </CardContentDescription>
-              {firstThreeCurrencies.map(currency => (
-                <CurrencyIcon key={currency.id} currency={currency} size={20} squared />
-              ))}
-            </CardContentRow>
-          </CardContent>
-        </CardLeading>
-      </CardHeader>
-    </Card>
+    <>
+      <Card onPress={onPress} testID="crypto-addresses-button">
+        <CardHeader>
+          <CardLeading>
+            <Spot appearance="icon" icon={Wallet} />
+            <CardContent>
+              <CardContentTitle>{t("portfolio.cryptoAddresses.title")}</CardContentTitle>
+              <CardContentRow>
+                {hasAccounts ? (
+                  <>
+                    <CardContentDescription>
+                      {t("portfolio.cryptoAddresses.count", { count: accountsCount })}
+                    </CardContentDescription>
+                    {firstThreeCurrencies.map(currency => (
+                      <CurrencyIcon key={currency.id} currency={currency} size={20} squared />
+                    ))}
+                  </>
+                ) : (
+                  <CardContentDescription>
+                    {t("portfolio.cryptoAddresses.noAccountsYet")}
+                  </CardContentDescription>
+                )}
+              </CardContentRow>
+            </CardContent>
+          </CardLeading>
+        </CardHeader>
+      </Card>
+      {!hasAccounts && (
+        <AddAccountDrawer
+          isOpened={isAddAccountOpen}
+          onClose={onCloseAddAccount}
+          doesNotHaveAccount
+        />
+      )}
+    </>
   );
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/useCryptoAddressesButtonViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/useCryptoAddressesButtonViewModel.ts
@@ -1,6 +1,6 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { NavigatorName, ScreenName } from "~/const";
@@ -11,16 +11,23 @@ import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAsset
 
 interface CryptoAddressesButtonViewModelResult {
   accountsCount: number;
+  hasAccounts: boolean;
   firstThreeCurrencies: (CryptoCurrency | TokenCurrency)[];
   onPress: () => void;
+  isAddAccountOpen: boolean;
+  onCloseAddAccount: () => void;
 }
 
 export function useCryptoAddressesButtonViewModel(): CryptoAddressesButtonViewModelResult {
   const accounts = useSelector(shallowAccountsSelector);
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const route = useRoute();
   const { categorizedAssets } = useCategorizedAssetsFromPortfolio();
+  const [isAddAccountOpen, setIsAddAccountOpen] = useState(false);
 
   const accountsCount = accounts.length;
+  const hasAccounts = accountsCount > 0;
+  const shouldShowAddAccount = isAddAccountOpen && !hasAccounts;
 
   const firstThreeCurrencies = useMemo(
     () =>
@@ -32,19 +39,38 @@ export function useCryptoAddressesButtonViewModel(): CryptoAddressesButtonViewMo
   );
 
   const onPress = useCallback(() => {
-    track("button_clicked", {
-      button: "crypto_accounts",
-      page: "Wallet",
-    });
-    navigation.navigate(NavigatorName.Assets, {
-      screen: ScreenName.AssetsList,
-      params: {
-        sourceScreenName: ScreenName.Portfolio,
-        showHeader: true,
-        isSyncEnabled: true,
-      },
-    });
-  }, [navigation]);
+    if (hasAccounts) {
+      track("button_clicked", {
+        button: "account_cta",
+        type: "view",
+        page: route.name,
+      });
+      navigation.navigate(NavigatorName.Assets, {
+        screen: ScreenName.AssetsList,
+        params: {
+          sourceScreenName: ScreenName.Portfolio,
+          showHeader: true,
+          isSyncEnabled: true,
+        },
+      });
+    } else {
+      track("button_clicked", {
+        button: "account_cta",
+        type: "add",
+        page: route.name,
+      });
+      setIsAddAccountOpen(true);
+    }
+  }, [hasAccounts, navigation, route.name]);
 
-  return { accountsCount, firstThreeCurrencies, onPress };
+  const onCloseAddAccount = useCallback(() => setIsAddAccountOpen(false), []);
+
+  return {
+    accountsCount,
+    hasAccounts,
+    firstThreeCurrencies,
+    onPress,
+    isAddAccountOpen: shouldShowAddAccount,
+    onCloseAddAccount,
+  };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - The `CryptoAddressesButton` on the Portfolio empty state now adapts to whether the user has accounts or not
      - When accounts exist, tapping the button navigates to the assets list as before
      - When no accounts exist, tapping opens the Add Account drawer directly from the button
      - Analytics tracking updated: `button: "account_cta"` with `type: "view"` or `type: "add"` depending on account state

### 📝 Description

Previously, the `CryptoAddressesButton` always navigated to the assets list when tapped, regardless of whether the user had any accounts. This was problematic for users in an empty-state who had no accounts yet — clicking the button would lead to an empty or unexpected screen.

This PR enhances the button to detect whether the user has accounts. When they do, the behavior is unchanged (navigate to assets list). When they don't, pressing the button now opens the `AddAccountDrawer` inline, guiding the user to add their first account. The button subtitle also updates to "No address yet" when no accounts exist. Additionally, the `PortfolioEmptyAssetSections` component is extracted to avoid duplication between `PortfolioNoAccountsContent` and `PortfolioNoSignerContent`.

No accounts :
<img width="300" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-03-26 at 10 06 32" src="https://github.com/user-attachments/assets/f084586e-d592-43b2-bb06-b0e49d287712" />
<img width="300" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-03-26 at 10 06 05" src="https://github.com/user-attachments/assets/84f8a890-2c10-41fa-925b-2022988a055c" />


Accounts :
<img width="300" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-03-26 at 10 06 53" src="https://github.com/user-attachments/assets/eb38accd-f130-4449-9657-4506a95b8c9e" />
<img width="300" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-03-26 at 10 38 12" src="https://github.com/user-attachments/assets/1e74f9ed-0986-47d8-8161-e2bd2f7cf6dd" />


Read-only:
<img width="300" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-03-26 at 10 39 16" src="https://github.com/user-attachments/assets/c767167c-f635-4783-95c4-425a7359ebd2" />



### ❓ Context

- **JIRA or GitHub link**: [LIVE-26978](https://ledgerhq.atlassian.net/browse/LIVE-26978)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26978]: https://ledgerhq.atlassian.net/browse/LIVE-26978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ