### PR TITLE
[LWD] feat: add analytics consent date storage flags

### DIFF
--- a/.changeset/flat-lobsters-sniff.md
+++ b/.changeset/flat-lobsters-sniff.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add analytics info storage flags

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/const/policyVersion.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/const/policyVersion.ts
@@ -1,0 +1,1 @@
+export const CURRENT_PRIVACY_POLICY_VERSION = 1;

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
@@ -5,7 +5,10 @@ import {
   trackingEnabledSelector,
 } from "~/renderer/reducers/settings";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { setHasSeenAnalyticsOptInPrompt } from "~/renderer/actions/settings";
+import {
+  setAnalyticsConsentInfo,
+  setHasSeenAnalyticsOptInPrompt,
+} from "~/renderer/actions/settings";
 import { EntryPoint } from "../types/AnalyticsOptInPromptNavigator";
 import { ABTestingVariants } from "@ledgerhq/types-live";
 import { urls } from "~/config/urls";
@@ -72,6 +75,7 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
 
   const onSubmit = async () => {
     setIsAnalyticsOptInPromptOpened(false);
+    dispatch(setAnalyticsConsentInfo());
     dispatch(setHasSeenAnalyticsOptInPrompt(true));
     try {
       await updateIdentify({ force: true });

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -29,6 +29,7 @@ import {
   TOGGLE_MEV,
   UPDATE_ANONYMOUS_USER_NOTIFICATIONS,
 } from "./constants";
+import { CURRENT_PRIVACY_POLICY_VERSION } from "LLD/features/AnalyticsOptInPrompt/const/policyVersion";
 export type SaveSettings = (a: Partial<Settings>) => {
   type: string;
   payload: Partial<Settings>;
@@ -396,4 +397,12 @@ export const updateAnonymousUserNotifications = (payload: {
 export const setHasSeenWalletV4Tour = (hasSeenWalletV4Tour: boolean) => ({
   type: "SET_HAS_SEEN_WALLET_V4_TOUR",
   payload: hasSeenWalletV4Tour,
+});
+
+export const setAnalyticsConsentInfo = () => ({
+  type: "SET_ANALYTICS_CONSENT_INFO",
+  payload: {
+    consentDate: new Date(),
+    privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+  },
 });

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -22,6 +22,7 @@ import { getVersionedRedirects } from "LLD/hooks/useVersionedStakePrograms";
 import logger from "~/renderer/logger";
 import type { State } from "~/renderer/reducers";
 import {
+  analyticsConsentInfoSelector,
   developerModeSelector,
   devicesModelListSelector,
   hasCompletedOnboardingSelector,
@@ -192,6 +193,7 @@ const getMandatoryProperties = (store: ReduxStore) => {
   const hasSeenAnalyticsOptInPrompt = hasSeenAnalyticsOptInPromptSelector(state);
   const devModeEnabled = developerModeSelector(state);
   const readOnlyMode = !hasOnboardedDeviceSelector(state);
+  const analyticsInfo = analyticsConsentInfoSelector(state);
 
   return {
     devModeEnabled,
@@ -199,6 +201,7 @@ const getMandatoryProperties = (store: ReduxStore) => {
     optInPersonalRecommendations: personalizedRecommendationsEnabled,
     hasSeenAnalyticsOptInPrompt,
     readOnlyMode,
+    analyticsInfo,
   };
 };
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -130,6 +130,8 @@ export type SettingsState = {
   hasSeenWalletV4Tour: boolean;
   doNotAskAgainSkipMemo: boolean;
   deprecationDoNotRemind: string[];
+  lastAnalyticsConsentDate: string | null;
+  privacyPolicyVersion: number | null;
 };
 
 export const getInitialLanguageAndLocale = (): { language: Language; locale: Locale } => {
@@ -231,6 +233,8 @@ export const INITIAL_STATE: SettingsState = {
   hasSeenWalletV4Tour: false,
   doNotAskAgainSkipMemo: false,
   deprecationDoNotRemind: [],
+  lastAnalyticsConsentDate: null,
+  privacyPolicyVersion: null,
 };
 
 export const AFTER_ONBOARDING_STATE: SettingsState = {
@@ -301,6 +305,10 @@ type HandlersPayloads = {
     notifications: Record<string, number>;
   };
   SET_HAS_SEEN_WALLET_V4_TOUR: boolean;
+  SET_ANALYTICS_CONSENT_INFO: {
+    consentDate: Date;
+    privacyPolicyVersion: number;
+  };
 };
 type SettingsHandlers<PreciseKey = true> = Handlers<SettingsState, HandlersPayloads, PreciseKey>;
 
@@ -527,6 +535,14 @@ const handlers: SettingsHandlers = {
   SET_HAS_SEEN_WALLET_V4_TOUR: (state: SettingsState, { payload }) => ({
     ...state,
     hasSeenWalletV4Tour: payload,
+  }),
+  SET_ANALYTICS_CONSENT_INFO: (
+    state: SettingsState,
+    { payload: { consentDate, privacyPolicyVersion } },
+  ) => ({
+    ...state,
+    lastAnalyticsConsentDate: consentDate.toISOString(),
+    privacyPolicyVersion: privacyPolicyVersion,
   }),
 };
 
@@ -799,8 +815,7 @@ export const swapSelectableCurrenciesSelector = (state: State) =>
   state.settings.swap.selectableCurrencies;
 export const showClearCacheBannerSelector = (state: State) => state.settings.showClearCacheBanner;
 export const overriddenFeatureFlagsSelector = (state: State) => state.featureFlags.overrides;
-export const featureFlagsButtonVisibleSelector = (state: State) =>
-  state.featureFlags.bannerVisible;
+export const featureFlagsButtonVisibleSelector = (state: State) => state.featureFlags.bannerVisible;
 export const vaultSignerSelector = (state: State) => state.settings.vaultSigner;
 export const supportedCounterValuesSelector = (state: State) =>
   state.settings.supportedCounterValues;
@@ -826,3 +841,11 @@ export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasS
 // Last seen device is the device set when a user performs a device action (e.g. pairing, firmware update, etc.).
 export const hasOnboardedDeviceSelector = (state: State) =>
   !!lastOnboardedDeviceSelector(state) || lastSeenDeviceSelector(state) !== null;
+
+export const analyticsConsentInfoSelector = (state: State) => ({
+  consentDate:
+    state.settings.lastAnalyticsConsentDate !== null
+      ? new Date(state.settings.lastAnalyticsConsentDate)
+      : null,
+  privacyPolicyVersion: state.settings.privacyPolicyVersion,
+});


### PR DESCRIPTION
feat: add analytics info state

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add analytics info storage flags to keep a record of what privacy policy version that has been consented to and the date that the user consented.

<img width="678" height="186" alt="image" src="https://github.com/user-attachments/assets/abfb5033-91f5-4b08-a0f3-e44de418fc0e" />
### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-27480


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
