### PR TITLE
[LWDM] fix(coin-bitcoin): forward broadcastConfig in bridge broadcast wrapper

### DIFF
--- a/.changeset/great-spoons-repair.md
+++ b/.changeset/great-spoons-repair.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-bitcoin": minor
+---
+
+fix(coin-bitcoin): forward broadcastConfig in bridge broadcast wrapper

--- a/libs/coin-modules/coin-bitcoin/src/bridge/js.ts
+++ b/libs/coin-modules/coin-bitcoin/src/bridge/js.ts
@@ -62,11 +62,13 @@ function buildAccountBridge(signerContext: SignerContext) {
   const wrappedBroadcast: AccountBridge<Transaction, BitcoinAccount>["broadcast"] = async ({
     account,
     signedOperation,
+    broadcastConfig,
   }) => {
     calculateFees.reset();
     return broadcast({
       account,
       signedOperation,
+      ...(broadcastConfig ? { broadcastConfig } : {}),
     });
   };
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- Existing tests in broadcast.test.ts and wallet.explorer.unit.test.ts already cover source forwarding and header injection -->
- [x] **Impact of the changes:**
  - Bitcoin broadcast requests will now include `X-Ledger-Source-Type` and `X-Ledger-Source-Name` headers

### 📝 Description

PR #13790 added transaction source tagging to track broadcast origins (`dApp`, `live-app`, `coin-module`, `swap`) via `X-Ledger-Source-Type` and `X-Ledger-Source-Name` HTTP headers. The feature works correctly on EVM but **is broken on Bitcoin** — all BTC broadcasts show `N/A` for both source name and source type.

**Root cause:** In `libs/coin-modules/coin-bitcoin/src/bridge/js.ts`, the `wrappedBroadcast` function destructures only `account` and `signedOperation` from the bridge arguments, silently dropping `broadcastConfig`. The entire downstream chain (`broadcast.ts` → `wallet.ts` → `xpub.ts` → `explorer/index.ts`) was correctly wired to forward `broadcastConfig.source` and set the headers on the HTTP request, but it never received the data.

**Fix:** Added `broadcastConfig` to the destructured parameters and forwarded it to the inner `broadcast()` call. A conditional spread is used to satisfy `exactOptionalPropertyTypes`.


### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-27083

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)