### PR TITLE
[LWM] Add analytics consent info storage flags

### DIFF
--- a/.changeset/twelve-mice-wait.md
+++ b/.changeset/twelve-mice-wait.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add analytics consent info storage flags

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -67,6 +67,7 @@ import {
   SettingsIsOnboardingFlowReceiveSuccessPayload,
   SettingsIsPostOnboardingFlowPayload,
   SettingsSetHasSeenWalletV4TourPayload,
+  SettingsSetAnalyticsConsentInfoPayload,
 } from "./types";
 import { ImageType } from "~/components/CustomImage/types";
 
@@ -260,6 +261,10 @@ export const setSupportedCounterValues = createAction<SettingsSetSupportedCounte
 
 export const setHasSeenAnalyticsOptInPrompt = createAction<SettingsSetHasSeenAnalyticsOptInPrompt>(
   SettingsActionTypes.SET_HAS_SEEN_ANALYTICS_OPT_IN_PROMPT,
+);
+
+export const setAnalyticsConsentInfo = createAction<SettingsSetAnalyticsConsentInfoPayload>(
+  SettingsActionTypes.SET_ANALYTICS_CONSENT_INFO,
 );
 
 export const setDismissedContentCard = createAction<SettingsSetDismissedContentCardsPayload>(

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -306,6 +306,7 @@ export enum SettingsActionTypes {
   REMOVE_STARRED_MARKET_COINS = "REMOVE_STARRED_MARKET_COINS",
   SET_HAS_SEEN_WALLET_V4_TOUR = "SET_HAS_SEEN_WALLET_V4_TOUR",
   DEPRECATION_DO_NOT_REMIND = "DEPRECATION_DO_NOT_REMIND",
+  SET_ANALYTICS_CONSENT_INFO = "SET_ANALYTICS_CONSENT_INFO",
 }
 
 export type SettingsImportPayload = Partial<SettingsState>;
@@ -393,6 +394,7 @@ export type SettingsSetGeneralTermsVersionAccepted = SettingsState["generalTerms
 export type SettingsSetUserNps = number;
 export type SettingsSetSupportedCounterValues = SettingsState["supportedCounterValues"];
 export type SettingsSetHasSeenAnalyticsOptInPrompt = SettingsState["hasSeenAnalyticsOptInPrompt"];
+export type SettingsSetAnalyticsConsentInfoPayload = SettingsState["analyticsConsentInfo"];
 export type SettingsSetHasSeenWalletV4TourPayload = SettingsState["hasSeenWalletV4Tour"];
 export type SettingsSetDismissedContentCardsPayload = SettingsState["dismissedContentCards"];
 export type SettingsClearDismissedContentCardsPayload = string[];
@@ -454,6 +456,7 @@ export type SettingsPayload =
   | SettingsSetUserNps
   | SettingsSetSupportedCounterValues
   | SettingsSetHasSeenAnalyticsOptInPrompt
+  | SettingsSetAnalyticsConsentInfoPayload
   | SettingsSetDismissedContentCardsPayload
   | SettingsClearDismissedContentCardsPayload
   | SettingsSetFromLedgerSyncOnboardingPayload

--- a/apps/ledger-live-mobile/src/analytics/privacyConsent.ts
+++ b/apps/ledger-live-mobile/src/analytics/privacyConsent.ts
@@ -1,0 +1,6 @@
+/**
+ * Version of the privacy policy the user consented to for tracking / analytics (Segment).
+ * Increment when the policy changes in a way that requires users to accept again
+ * (stored in settings.analyticsConsentInfo).
+ */
+export const CURRENT_PRIVACY_POLICY_VERSION = 1;

--- a/apps/ledger-live-mobile/src/hooks/analyticsOptInPrompt/useAnalyticsOptInPromptLogic.ts
+++ b/apps/ledger-live-mobile/src/hooks/analyticsOptInPrompt/useAnalyticsOptInPromptLogic.ts
@@ -1,6 +1,7 @@
 import { useSelector, useDispatch } from "~/context/hooks";
 import {
   completeOnboarding,
+  setAnalyticsConsentInfo,
   setHasSeenAnalyticsOptInPrompt,
   setIsReborn,
   setOnboardingHasDevice,
@@ -22,6 +23,7 @@ import { EntryPoint } from "~/components/RootNavigator/types/AnalyticsOptInPromp
 import { ABTestingVariants } from "@ledgerhq/types-live";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useNotifications } from "LLM/features/NotificationsPrompt";
+import { CURRENT_PRIVACY_POLICY_VERSION } from "~/analytics/privacyConsent";
 
 const trackingKeysByFlow: Record<EntryPoint, string> = {
   Onboarding: "consent onboarding",
@@ -84,6 +86,12 @@ const useAnalyticsOptInPromptLogic = ({ entryPoint, variant }: Props) => {
 
   const continueOnboarding = () => {
     dispatch(setHasSeenAnalyticsOptInPrompt(true));
+    dispatch(
+      setAnalyticsConsentInfo({
+        consentDate: new Date().toISOString(),
+        privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+      }),
+    );
 
     switch (entryPoint) {
       case "Portfolio":

--- a/apps/ledger-live-mobile/src/hooks/analyticsOptInPrompt/useAnalyticsOptInPromptLogicVariantB.ts
+++ b/apps/ledger-live-mobile/src/hooks/analyticsOptInPrompt/useAnalyticsOptInPromptLogicVariantB.ts
@@ -1,10 +1,15 @@
 import { useDispatch } from "~/context/hooks";
-import { setAnalytics, setPersonalizedRecommendations } from "~/actions/settings";
+import {
+  setAnalytics,
+  setAnalyticsConsentInfo,
+  setPersonalizedRecommendations,
+} from "~/actions/settings";
 import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { EntryPoint } from "~/components/RootNavigator/types/AnalyticsOptInPromptNavigator";
 import useAnalyticsOptInPromptLogic from "./useAnalyticsOptInPromptLogic";
 import { ABTestingVariants } from "@ledgerhq/types-live";
+import { CURRENT_PRIVACY_POLICY_VERSION } from "~/analytics/privacyConsent";
 
 type Props = {
   entryPoint: EntryPoint;
@@ -25,8 +30,18 @@ const useAnalyticsOptInPromptLogicVariantB = ({ entryPoint }: Props) => {
     });
   };
 
+  const updateAnalyticsConsentInfo = () => {
+    dispatch(
+      setAnalyticsConsentInfo({
+        consentDate: new Date().toISOString(),
+        privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+      }),
+    );
+  };
+
   const clickOnRefuseAnalytics = () => {
     dispatch(setAnalytics(false));
+    updateAnalyticsConsentInfo();
     goToPersonalizedRecommendationsStep();
     track(
       "button_clicked",
@@ -41,6 +56,7 @@ const useAnalyticsOptInPromptLogicVariantB = ({ entryPoint }: Props) => {
   };
   const clickOnAllowAnalytics = () => {
     dispatch(setAnalytics(true));
+    updateAnalyticsConsentInfo();
     goToPersonalizedRecommendationsStep();
     track(
       "button_clicked",

--- a/apps/ledger-live-mobile/src/reducers/settings.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.test.ts
@@ -1,5 +1,6 @@
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import reducer, {
+  analyticsConsentInfoSelector,
   lastConnectedDeviceSelector,
   lastSeenDeviceSelector,
   resolvedThemeSelector,
@@ -9,7 +10,8 @@ import reducer, {
 } from "./settings";
 import { State, Theme, SettingsState } from "./types";
 import { aDeviceInfoBuilder } from "@ledgerhq/live-common/mock/fixtures/aDeviceInfo";
-import { importSettings, setTheme } from "../actions/settings";
+import { importSettings, setAnalyticsConsentInfo, setTheme } from "../actions/settings";
+import { SettingsActionTypes } from "../actions/types";
 
 const invalidDeviceModelIds = ["nanoFTS", undefined, "whatever"];
 const validDeviceModelIds: DeviceModelId[] = Object.values(DeviceModelId);
@@ -230,6 +232,69 @@ describe("filterValidSettings", () => {
     expect(filtered.language).toBe("en");
     expect("obsoleteField1" in filtered).toBe(false);
     expect("obsoleteField2" in filtered).toBe(false);
+  });
+});
+
+describe("analyticsConsentInfo initial state", () => {
+  it("should default consentDate and privacyPolicyVersion to null", () => {
+    expect(SETTINGS_INITIAL_STATE.analyticsConsentInfo).toEqual({
+      consentDate: null,
+      privacyPolicyVersion: null,
+    });
+  });
+
+  it("should set analyticsConsentInfo from action payload", () => {
+    const payload = {
+      consentDate: "2025-03-26T12:00:00.000Z",
+      privacyPolicyVersion: 1,
+    };
+    const action = setAnalyticsConsentInfo(payload);
+
+    expect(action.type).toBe(SettingsActionTypes.SET_ANALYTICS_CONSENT_INFO);
+    expect(action.payload).toEqual(payload);
+
+    const newState = reducer(SETTINGS_INITIAL_STATE, action);
+    expect(newState.analyticsConsentInfo).toEqual(payload);
+  });
+
+  it("should replace analyticsConsentInfo when dispatched again", () => {
+    const first = {
+      consentDate: "2025-01-01T00:00:00.000Z",
+      privacyPolicyVersion: 1,
+    };
+    const second = {
+      consentDate: "2025-06-01T00:00:00.000Z",
+      privacyPolicyVersion: 2,
+    };
+
+    const afterFirst = reducer(SETTINGS_INITIAL_STATE, setAnalyticsConsentInfo(first));
+    const afterSecond = reducer(afterFirst, setAnalyticsConsentInfo(second));
+
+    expect(afterSecond.analyticsConsentInfo).toEqual(second);
+  });
+
+  it("should expose stored value via analyticsConsentInfoSelector", () => {
+    const payload = {
+      consentDate: "2025-03-26T12:00:00.000Z",
+      privacyPolicyVersion: 3,
+    };
+    const settings = reducer(SETTINGS_INITIAL_STATE, setAnalyticsConsentInfo(payload));
+    const state = { ...({} as State), settings };
+
+    expect(analyticsConsentInfoSelector(state)).toEqual(payload);
+  });
+});
+
+describe("filterValidSettings for analyticsConsentInfo", () => {
+  it("should keep analyticsConsentInfo when importing partial settings", () => {
+    const importedSettings: Partial<SettingsState> = {
+      analyticsConsentInfo: {
+        consentDate: "2025-02-01T10:00:00.000Z",
+        privacyPolicyVersion: 2,
+      },
+    };
+
+    expect(filterValidSettings(importedSettings)).toEqual(importedSettings);
   });
 });
 

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -77,6 +77,7 @@ import type {
   SettingsIsOnboardingFlowReceiveSuccessPayload,
   SettingsIsPostOnboardingFlowPayload,
   SettingsSetHasSeenWalletV4TourPayload,
+  SettingsSetAnalyticsConsentInfoPayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -174,6 +175,10 @@ export const INITIAL_STATE: SettingsState = {
   generalTermsVersionAccepted: undefined,
   hasSeenWalletV4Tour: false,
   deprecationDoNotRemind: [],
+  analyticsConsentInfo: {
+    consentDate: null,
+    privacyPolicyVersion: null,
+  },
 };
 
 const pairHash = (from: { ticker: string }, to: { ticker: string }) =>
@@ -659,6 +664,13 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     };
   },
 
+  [SettingsActionTypes.SET_ANALYTICS_CONSENT_INFO]: (state: SettingsState, action) => {
+    return {
+      ...state,
+      analyticsConsentInfo: (action as Action<SettingsSetAnalyticsConsentInfoPayload>).payload,
+    };
+  },
+
   [SettingsActionTypes.SET_SELECTED_TAB_PORTFOLIO_ASSETS]: (state, action) => ({
     ...state,
     selectedTabPortfolioAssets: (action as Action<SettingsSetSelectedTabPortfolioAssetsPayload>)
@@ -894,3 +906,4 @@ export const mevProtectionSelector = (state: State) => state.settings.mevProtect
 export const selectedTabPortfolioAssetsSelector = (state: State) =>
   state.settings.selectedTabPortfolioAssets;
 export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasSeenWalletV4Tour;
+export const analyticsConsentInfoSelector = (state: State) => state.settings.analyticsConsentInfo;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -293,6 +293,12 @@ export type SettingsState = {
   selectedTabPortfolioAssets: TabPortfolioAssetsType;
   hasSeenWalletV4Tour: boolean;
   deprecationDoNotRemind: string[];
+  analyticsConsentInfo: AnalyticsConsentInfo;
+};
+
+export type AnalyticsConsentInfo = {
+  consentDate: string | null;
+  privacyPolicyVersion: number | null;
 };
 
 export type NotificationsSettings = {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add analytics consent info storage.

### 📝 Description
This pull request introduces a new mechanism for storing and managing user consent information related to analytics in the mobile app. It adds a new `analyticsConsentInfo` field to the settings state, provides actions and reducers for updating this information, and ensures it is properly handled throughout the onboarding and analytics opt-in flows. Tests and selectors for the new field are also included.

**Analytics Consent Info Storage and Management:**

* Added a new `analyticsConsentInfo` field to the `SettingsState` to store the consent date and privacy policy version accepted by the user. This includes updates to the type definitions, initial state, and reducers to support this new field. [[1]](diffhunk://#diff-3a9d526549d14cc03a053891acdb3ddc7ddaf0ba7d6af47e6656d532b97f8864R296-R301) [[2]](diffhunk://#diff-9c7c063676734221568d94978946b4fd989a15211119770825089c98e6104686L14-R14) [[3]](diffhunk://#diff-9c7c063676734221568d94978946b4fd989a15211119770825089c98e6104686R175-R178) [[4]](diffhunk://#diff-9c7c063676734221568d94978946b4fd989a15211119770825089c98e6104686R660-R666)
* Created a new action and corresponding action type, `SET_ANALYTICS_CONSENT_INFO`, along with its payload type, to allow updating the analytics consent info in the state. [[1]](diffhunk://#diff-a95594973fb2045a5f60e8b18bf629c24cd4b63dec30e3757288774f14d36590R309) [[2]](diffhunk://#diff-a95594973fb2045a5f60e8b18bf629c24cd4b63dec30e3757288774f14d36590R397) [[3]](diffhunk://#diff-a95594973fb2045a5f60e8b18bf629c24cd4b63dec30e3757288774f14d36590R459) [[4]](diffhunk://#diff-458e29d777cb04a162da49bb4bc9d332aa77a0ebdaa0da024a5de8da62d5223cR70) [[5]](diffhunk://#diff-458e29d777cb04a162da49bb4bc9d332aa77a0ebdaa0da024a5de8da62d5223cR266-R269)
* Added a selector, `analyticsConsentInfoSelector`, to access the analytics consent info from the state. [[1]](diffhunk://#diff-9c7c063676734221568d94978946b4fd989a15211119770825089c98e6104686R902) [[2]](diffhunk://#diff-406fb376c63a65af21a1394755d144e0dcde2770637de6c531c1607814444dd9R3)

**Integration with Onboarding and Analytics Opt-In Flows:**

* Updated onboarding and analytics opt-in logic to dispatch the new action and record the current privacy policy version and consent date when the user interacts with analytics consent prompts, using a new constant `CURRENT_PRIVACY_POLICY_VERSION`. [[1]](diffhunk://#diff-9d289b75897849ff5468b21a32008e2beb50412aa5e24be15bda6efeae888838R4) [[2]](diffhunk://#diff-9d289b75897849ff5468b21a32008e2beb50412aa5e24be15bda6efeae888838R26) [[3]](diffhunk://#diff-9d289b75897849ff5468b21a32008e2beb50412aa5e24be15bda6efeae888838R89-R94) [[4]](diffhunk://#diff-9fb7257a637cfd67e3e7fae7ae654e5f632e7f4b8d811b94b6f4fffc65dbd6b1L2-R12) [[5]](diffhunk://#diff-9fb7257a637cfd67e3e7fae7ae654e5f632e7f4b8d811b94b6f4fffc65dbd6b1R33-R45) [[6]](diffhunk://#diff-9fb7257a637cfd67e3e7fae7ae654e5f632e7f4b8d811b94b6f4fffc65dbd6b1R60-R61) [[7]](diffhunk://#diff-9432c7340036740c9dfeefcc7f9bdfebbee204aedeb8272e1d70e7aca02a9130R3-R5)

**Testing and Validation:**

* Added tests to ensure `analyticsConsentInfo` is properly initialized, updated, and imported/exported, and that the selector works as expected. [[1]](diffhunk://#diff-406fb376c63a65af21a1394755d144e0dcde2770637de6c531c1607814444dd9L12-R13) [[2]](diffhunk://#diff-406fb376c63a65af21a1394755d144e0dcde2770637de6c531c1607814444dd9R237-R279)

**Documentation and Changelog:**

* Added a changeset documenting the addition of analytics consent info storage flags.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27481]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-27481]: https://ledgerhq.atlassian.net/browse/LIVE-27481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ