### PR TITLE
[LWD] chore(desktop): bump ledger-live-desktop to v3.0.0

### DIFF
--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "private": true,
   "main": "./.webpack/main.bundle.js",
-  "version": "2.146.0",
+  "version": "3.0.0",
   "scripts": {
     "start:prod": "electron ./.webpack/main.bundle.js",
     "start": "cross-env NODE_ENV=development TS_NODE_PROJECT=tools/rspack/tsconfig.json node --require ts-node/register ./tools/main-rspack.ts",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _No code change — version bump only._
- [x] **Impact of the changes:**
      - Version number in `apps/ledger-live-desktop/package.json` bumped from `2.145.0` to `3.0.0`

### 📝 Description

Bumps `ledger-live-desktop` version to `3.0.0` ahead of the next release branch creation.

This must be merged **before** the release branch is cut so that the LWM backmerge major bump does not condense with this one into a single major increment.

The major changeset (`.changeset/stale-ears-mix.md`) is already present in the repo.

### ❓ Context

- Pre-release version bump coordinated with the release team.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)