### PR TITLE
ci (draft): workflow pins for rsdoctor stack

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -43,7 +43,7 @@ jobs:
     name: "Affected"
     needs: pre_job
     if: ${{!github.event.pull_request.head.repo.fork && needs.pre_job.outputs.should_skip != 'true'}}
-    uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@feat/rsdoctor-optimized-pinned
     with:
       head_branch: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
       base_branch: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
@@ -52,29 +52,29 @@ jobs:
   build-desktop:
     name: "Build Desktop"
     needs: determine-affected
-    if: ${{ !github.event.pull_request.head.repo.fork && contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') }}
-    uses: LedgerHQ/ledger-live/.github/workflows/build-desktop-reusable.yml@develop
+    if: ${{ !github.event.pull_request.head.repo.fork && (contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') || contains(github.event.pull_request.head.ref, 'rsdoctor-optimized') || contains(github.event.merge_group.head_ref, 'rsdoctor-optimized')) }}
+    uses: LedgerHQ/ledger-live/.github/workflows/build-desktop-reusable.yml@feat/rsdoctor-optimized-pinned
     secrets: inherit
 
   test-desktop:
     name: "Test Desktop"
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') && !github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-reusable.yml@feat/rsdoctor-optimized-pinned
     secrets: inherit
 
   test-mobile:
     name: "Test Mobile"
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-reusable.yml@feat/rsdoctor-optimized-pinned
     secrets: inherit
 
   build-test-mobile:
     name: "Build & Test Mobile"
     needs: determine-affected
-    if: ${{ !github.event.pull_request.head.repo.fork && contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') }}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-mock-reusable.yml@develop
+    if: ${{ !github.event.pull_request.head.repo.fork && (contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') || contains(github.event.pull_request.head.ref, 'rsdoctor-optimized') || contains(github.event.merge_group.head_ref, 'rsdoctor-optimized')) }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-mock-reusable.yml@feat/rsdoctor-optimized-pinned
     secrets: inherit
     with:
       macos-specificity-runner-label: "performance-pool"
@@ -85,28 +85,28 @@ jobs:
     name: "Test Libraries"
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'libs') && !github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-libs-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-libs-reusable.yml@feat/rsdoctor-optimized-pinned
     secrets: inherit
 
   test-features:
     name: "Test Features"
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'features') && !github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-features-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-features-reusable.yml@feat/rsdoctor-optimized-pinned
     secrets: inherit
 
   test-design-system:
     name: "Test UI Libs"
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'libs/ui') && !github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-design-system-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-design-system-reusable.yml@feat/rsdoctor-optimized-pinned
     secrets: inherit
 
   build-web-tools:
     name: "Build Web Tools"
     needs: determine-affected
     if: ${{!github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/build-web-tools-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/build-web-tools-reusable.yml@feat/rsdoctor-optimized-pinned
     secrets: inherit
     with:
       build-web-tools: ${{ contains(needs.determine-affected.outputs.paths, 'apps/web-tools') }}
@@ -117,20 +117,20 @@ jobs:
     name: "Test CLI"
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'apps/cli') && !github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-cli-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-cli-reusable.yml@feat/rsdoctor-optimized-pinned
     secrets: inherit
 
   test-additional:
     name: "Test Additional"
     if: ${{!github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-additional.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-additional.yml@feat/rsdoctor-optimized-pinned
     secrets: inherit
 
   notify-e2e-required:
     name: "Notify E2E Required"
     needs: determine-affected
     if: ${{ always() && needs.determine-affected.result == 'success' && github.event_name == 'pull_request' && github.event.pull_request.draft == false && !github.event.pull_request.head.repo.fork }}
-    uses: LedgerHQ/ledger-live/.github/workflows/notify-e2e-required-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/notify-e2e-required-reusable.yml@feat/rsdoctor-optimized-pinned
     secrets: inherit
     with:
       affected_paths: ${{ needs.determine-affected.outputs.paths }}
@@ -143,7 +143,7 @@ jobs:
       - build-test-mobile
     runs-on: ubuntu-22.04
     timeout-minutes: 15
-    if: ${{ always() && !cancelled() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.determine-affected.result == 'success' && ((contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') && needs.build-desktop.result == 'success') || (contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && needs.build-test-mobile.result == 'success')) }}
+    if: ${{ always() && !cancelled() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.determine-affected.result == 'success' && (((contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') || contains(github.event.pull_request.head.ref, 'rsdoctor-optimized') || contains(github.event.merge_group.head_ref, 'rsdoctor-optimized')) && needs.build-desktop.result == 'success') || ((contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') || contains(github.event.pull_request.head.ref, 'rsdoctor-optimized') || contains(github.event.merge_group.head_ref, 'rsdoctor-optimized')) && needs.build-test-mobile.result == 'success')) }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
@@ -151,8 +151,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           target_branch: ${{ github.event.merge_group.base_ref || github.event.pull_request.base.ref || 'develop' }}
-          desktop_artifact_name: ${{ contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') && needs.build-desktop.result == 'success' && 'rsdoctor-desktop' || '' }}
-          mobile_artifact_name: ${{ contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && needs.build-test-mobile.result == 'success' && 'rsdoctor-mobile' || '' }}
+          desktop_artifact_name: ${{ (contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') || contains(github.event.pull_request.head.ref, 'rsdoctor-optimized') || contains(github.event.merge_group.head_ref, 'rsdoctor-optimized')) && needs.build-desktop.result == 'success' && 'rsdoctor-desktop' || '' }}
+          mobile_artifact_name: ${{ (contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') || contains(github.event.pull_request.head.ref, 'rsdoctor-optimized') || contains(github.event.merge_group.head_ref, 'rsdoctor-optimized')) && needs.build-test-mobile.result == 'success' && 'rsdoctor-mobile' || '' }}
 
   scan-sonar:
     name: "Sonar Cloud"
@@ -162,7 +162,7 @@ jobs:
       - test-libraries
       - test-features
       - determine-affected
-    uses: LedgerHQ/ledger-live/.github/workflows/scan-sonar-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/scan-sonar-reusable.yml@feat/rsdoctor-optimized-pinned
     if: ${{ always() && !cancelled() && !github.event.pull_request.head.repo.fork && (needs.test-desktop.result == 'success' || needs.test-mobile.result == 'success' || needs.test-libraries.result == 'success' || needs.test-features.result == 'success' || contains(needs.determine-affected.outputs.paths, 'e2e')) }}
     secrets: inherit
     with:

--- a/.github/workflows/build-desktop-reusable.yml
+++ b/.github/workflows/build-desktop-reusable.yml
@@ -52,10 +52,10 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup git user
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@feat/rsdoctor-optimized-pinned
 
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build desktop
         id: build-desktop
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-build-desktop@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-build-desktop@feat/rsdoctor-optimized-pinned
         with:
           os: ${{ matrix.config.platform }}
 
@@ -157,7 +157,7 @@ jobs:
             }
             return JSON.stringify(obj);
 
-      - uses: LedgerHQ/ledger-live/tools/actions/build-checks@develop
+      - uses: LedgerHQ/ledger-live/tools/actions/build-checks@feat/rsdoctor-optimized-pinned
         if: ${{ !cancelled() && github.event.number != '' }}
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -165,7 +165,7 @@ jobs:
           prNumber: ${{ github.event.number}}
           mode: desktop
 
-      - uses: LedgerHQ/ledger-live/tools/actions/desktop-report-build@develop
+      - uses: LedgerHQ/ledger-live/tools/actions/desktop-report-build@feat/rsdoctor-optimized-pinned
         name: Report summary
         with:
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/build-web-tools-reusable.yml
+++ b/.github/workflows/build-web-tools-reusable.yml
@@ -60,7 +60,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build and Deploy
         id: build-deploy
-        uses: LedgerHQ/ledger-live/tools/actions/composites/vercel-deploy@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/vercel-deploy@feat/rsdoctor-optimized-pinned
         with:
           turbo-port: ${{ steps.setup-caches.outputs.port }}
           vercel-token: ${{ secrets.VERCEL_LEDGER_WALLET_TOKEN }}
@@ -101,7 +101,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true
@@ -114,7 +114,7 @@ jobs:
 
       - name: Build and Deploy
         id: build-deploy
-        uses: LedgerHQ/ledger-live/tools/actions/composites/vercel-deploy@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/vercel-deploy@feat/rsdoctor-optimized-pinned
         with:
           turbo-port: ${{ steps.setup-caches.outputs.port }}
           vercel-token: ${{ secrets.VERCEL_LEDGER_WALLET_TOKEN }}
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true
@@ -146,7 +146,7 @@ jobs:
 
       - name: Build and Deploy
         id: build-deploy
-        uses: LedgerHQ/ledger-live/tools/actions/composites/vercel-deploy@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/vercel-deploy@feat/rsdoctor-optimized-pinned
         with:
           turbo-port: ${{ steps.setup-caches.outputs.port }}
           vercel-token: ${{ secrets.VERCEL_LEDGER_WALLET_TOKEN }}

--- a/.github/workflows/scan-sonar-reusable.yml
+++ b/.github/workflows/scan-sonar-reusable.yml
@@ -40,7 +40,7 @@ jobs:
           git fetch origin develop
 
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true

--- a/.github/workflows/test-additional.yml
+++ b/.github/workflows/test-additional.yml
@@ -27,11 +27,11 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Install pnpm
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true
           gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate Changesets
-        uses: LedgerHQ/ledger-live/tools/actions/composites/validate-changesets@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/validate-changesets@feat/rsdoctor-optimized-pinned

--- a/.github/workflows/test-cli-reusable.yml
+++ b/.github/workflows/test-cli-reusable.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true

--- a/.github/workflows/test-design-system-reusable.yml
+++ b/.github/workflows/test-design-system-reusable.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true

--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true
@@ -57,7 +57,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
           turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
 
-      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-test-desktop@develop
+      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-test-desktop@feat/rsdoctor-optimized-pinned
         id: setup-test-desktop
         with:
           skip_builds: true
@@ -90,7 +90,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true
@@ -101,7 +101,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
           turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
 
-      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-test-desktop@develop
+      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-test-desktop@feat/rsdoctor-optimized-pinned
         id: setup-test-desktop
         with:
           skip_builds: true
@@ -136,7 +136,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Setup caches
         id: caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         with:
           use-mise: true
           gh-token: ${{ secrets.GITHUB_TOKEN }}
@@ -145,20 +145,20 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
           turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
-      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-test-desktop@develop
+      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-test-desktop@feat/rsdoctor-optimized-pinned
         id: setup-test-desktop
         with:
           build_type: testing
           turborepo-server-port: ${{ steps.caches.outputs.port }}
       - name: Setup Speculos image and Coin Apps
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-speculos_image@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-speculos_image@feat/rsdoctor-optimized-pinned
         with:
           coinapps_path: coin-apps
           speculos_tag: ${{ env.SPECULOS_IMAGE_TAG }}
           bot_id: ${{ secrets.GH_BOT_APP_ID }}
           bot_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - name: Set test environment variables
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-env@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-env@feat/rsdoctor-optimized-pinned
         with:
           enable_broadcast: false
           build_type: testing
@@ -167,7 +167,7 @@ jobs:
         run: echo "filter=@smoke" >> $GITHUB_OUTPUT
         shell: bash
       - name: UI e2e smoke tests
-        uses: LedgerHQ/ledger-live/tools/actions/composites/run-e2e-playwright-tests@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/run-e2e-playwright-tests@feat/rsdoctor-optimized-pinned
         with:
           speculos_device: nanoSP
           test_filter: ${{ steps.test-filter.outputs.filter }}
@@ -189,7 +189,7 @@ jobs:
       - name: Publish Allure report
         id: publish-allure
         if: ${{ !cancelled() }}
-        uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report@feat/rsdoctor-optimized-pinned
         with:
           login: ${{ vars.ALLURE_USERNAME }}
           password: ${{ secrets.ALLURE_LEDGER_LIVE_PASSWORD }}
@@ -218,7 +218,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Setup caches
         id: caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         with:
           use-mise: true
           gh-token: ${{ secrets.GITHUB_TOKEN }}
@@ -227,7 +227,7 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
           turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
-      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-test-desktop@develop
+      - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-test-desktop@feat/rsdoctor-optimized-pinned
         id: setup-test-desktop
         with:
           skip_ruby: true
@@ -239,7 +239,7 @@ jobs:
           xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm desktop test:playwright
       - name: upload diffs to s3
         if: ${{ !cancelled() }}
-        uses: LedgerHQ/ledger-live/tools/actions/upload-images@develop
+        uses: LedgerHQ/ledger-live/tools/actions/upload-images@feat/rsdoctor-optimized-pinned
         id: s3
         with:
           path: apps/ledger-live-desktop/tests/artifacts/test-results
@@ -298,7 +298,7 @@ jobs:
             fs.writeFileSync("./images.json", JSON.stringify(result, null, 2));
       - name: prepare comment with screenshots
         id: comment
-        uses: LedgerHQ/ledger-live/tools/actions/prepare-comment-screenshots@develop
+        uses: LedgerHQ/ledger-live/tools/actions/prepare-comment-screenshots@feat/rsdoctor-optimized-pinned
         with:
           images: images.json
           no-actor: true

--- a/.github/workflows/test-features-reusable.yml
+++ b/.github/workflows/test-features-reusable.yml
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           skip-turbo-cache: "false"

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -41,7 +41,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           skip-turbo-cache: "false"
@@ -150,7 +150,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 2
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true
@@ -209,7 +209,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true

--- a/.github/workflows/test-mobile-build-android-reusable.yml
+++ b/.github/workflows/test-mobile-build-android-reusable.yml
@@ -102,7 +102,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true
@@ -138,7 +138,7 @@ jobs:
           pnpm i --filter="live-mobile..." --filter="ledger-live" --filter="live-cli*..." --filter="@ledgerhq/dummy-*-app..." --unsafe-perm
 
       - name: Build dependencies
-        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@feat/rsdoctor-optimized-pinned
         with:
           command: pnpm turbo build --filter="live-mobile^..."
           turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
@@ -146,7 +146,7 @@ jobs:
           disable_cache: ${{ inputs.disable-turbo-cache || false }}
 
       - name: Build Dummy Live SDK and Dummy Wallet API apps for testing
-        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@feat/rsdoctor-optimized-pinned
         with:
           command: pnpm turbo build --filter="@ledgerhq/dummy-*-app"
           turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
@@ -161,7 +161,7 @@ jobs:
           SKIP_JS_BUNDLING: true
 
       - name: Upload Detox Native Build
-        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@feat/rsdoctor-optimized-pinned
         with:
           path: |
             ${{ github.workspace }}/${{ env.ANDROID_APK_PATH }}
@@ -196,7 +196,7 @@ jobs:
 
       - name: setup caches
         id: setup-caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         with:
           use-mise: true
           gh-token: ${{ secrets.GITHUB_TOKEN }}
@@ -218,7 +218,7 @@ jobs:
           new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="ledger-live" --filter="@ledgerhq/dummy-*-app..." --unsafe-perm
 
       - name: Build dependencies
-        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@feat/rsdoctor-optimized-pinned
         with:
           command: pnpm turbo build --filter="live-mobile^..."
           turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
@@ -238,7 +238,7 @@ jobs:
           echo size=`ls -l apps/ledger-live-mobile/main.jsbundle.minified | cut -d " " -f5` >> $GITHUB_OUTPUT
 
       - name: Upload Detox JS Build
-        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@feat/rsdoctor-optimized-pinned
         with:
           path: ${{ github.workspace }}/${{ env.ANDROID_JSBUNDLE_PATH }}
           key: ${{ inputs.android-js-cache-key }}

--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: setup caches
         id: setup-caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         with:
           skip-pod-cache: "true"
           skip-turbo-cache: "false"
@@ -143,21 +143,21 @@ jobs:
           new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="ledger-live" --filter="@ledgerhq/dummy-*-app..." --unsafe-perm
 
       - name: Flake alert - ArgumentError
-        uses: LedgerHQ/ledger-live/tools/actions/composites/ci-flake-notifier@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/ci-flake-notifier@feat/rsdoctor-optimized-pinned
         if: failure() && steps.install-dependencies.outputs.error == 'ArgumentError - pathname contains null byte'
         with:
           live_bot_token: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}
           halt_runner: true
 
       - name: Flake alert - Reruns
-        uses: LedgerHQ/ledger-live/tools/actions/composites/ci-flake-notifier@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/ci-flake-notifier@feat/rsdoctor-optimized-pinned
         if: success() && steps.install-dependencies.outputs.total_attempts == 2
         with:
           live_bot_token: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}
           custom_message: "${{ steps.install-dependencies.outputs.total_attempts }} attempts happened on install dependencies and it was eventually successful :face_with_raised_eyebrow:"
 
       - name: Build dependencies
-        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@feat/rsdoctor-optimized-pinned
         with:
           command: pnpm turbo build --filter="live-mobile^..."
           turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
@@ -171,7 +171,7 @@ jobs:
           PRODUCTION: ${{ inputs.production_firebase }}
 
       - name: Upload Detox Build
-        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@feat/rsdoctor-optimized-pinned
         with:
           endpoint: ${{ secrets.S3_DIRECTCONNECT_ENDPOINT }}
           path: ${{ github.workspace }}/${{ env.IOS_NATIVE_PATH }}
@@ -210,7 +210,7 @@ jobs:
 
       - name: setup caches
         id: setup-caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         with:
           use-mise: true
           gh-token: ${{ secrets.GITHUB_TOKEN }}
@@ -232,7 +232,7 @@ jobs:
           new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="ledger-live" --filter="@ledgerhq/dummy-*-app..." --unsafe-perm
 
       - name: Build dependencies
-        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@feat/rsdoctor-optimized-pinned
         with:
           command: pnpm turbo build --filter="live-mobile^..."
           turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
@@ -266,7 +266,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Detox JS Build
-        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@feat/rsdoctor-optimized-pinned
         with:
           path: apps/ledger-live-mobile/main.jsbundle
           key: ${{ inputs.ios-js-cache-key }}

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Generate shards matrix and test files
         id: generate-shards
-        uses: LedgerHQ/ledger-live/tools/actions/composites/generate-shards-matrix@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/generate-shards-matrix@feat/rsdoctor-optimized-pinned
         with:
           test_directory: apps/ledger-live-mobile/e2e
           test_filter: ${{ inputs.test_filter || '' }}
@@ -212,7 +212,7 @@ jobs:
   build-ios:
     name: "iOS Build"
     needs: [determine-builds]
-    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-build-ios-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-build-ios-reusable.yml@feat/rsdoctor-optimized-pinned
     with:
       ref: ${{ inputs.ref || github.sha }}
       macos-specificity-runner-label: ${{ inputs.macos-specificity-runner-label }}
@@ -226,7 +226,7 @@ jobs:
   build-android:
     name: "Android Build"
     needs: [determine-builds]
-    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-build-android-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-build-android-reusable.yml@feat/rsdoctor-optimized-pinned
     with:
       ref: ${{ inputs.ref || github.sha }}
       disable-turbo-cache: ${{ inputs.disable-turbo-cache || false }}
@@ -264,7 +264,7 @@ jobs:
 
       - name: setup caches
         id: setup-caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         with:
           skip-pod-cache: "true"
           skip-turbo-cache: "false"
@@ -303,7 +303,7 @@ jobs:
         run: node apps/ledger-live-mobile/node_modules/detox/scripts/postinstall.js
 
       - name: Download Native Build
-        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@feat/rsdoctor-optimized-pinned
         with:
           endpoint: ${{ secrets.S3_DIRECTCONNECT_ENDPOINT }}
           key: ${{ needs.determine-builds.outputs.ios_native_key }}
@@ -314,7 +314,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Download JS Build
-        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@feat/rsdoctor-optimized-pinned
         with:
           endpoint: ${{ secrets.S3_DIRECTCONNECT_ENDPOINT }}
           key: ${{ needs.determine-builds.outputs.ios_js_key }}
@@ -330,7 +330,7 @@ jobs:
           cp apps/ledger-live-mobile/main.jsbundle ${{ env.IOS_NATIVE_PATH }}/main.jsbundle
 
       - name: Build dependencies
-        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@feat/rsdoctor-optimized-pinned
         with:
           command: pnpm turbo build --filter="live-mobile^..."
           turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
@@ -345,7 +345,7 @@ jobs:
       - name: Test iOS app
         id: detox
         timeout-minutes: 75
-        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@feat/rsdoctor-optimized-pinned
         with:
           command: pnpm mobile e2e:ci -- -p ios -t $SHARD_TEST_FILES --outputFile=artifacts/e2e-test-results-ios-shard-${{ matrix.shard }}.json
           turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
@@ -427,7 +427,7 @@ jobs:
           aws-region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Download Native Build
-        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@feat/rsdoctor-optimized-pinned
         with:
           key: ${{ needs.determine-builds.outputs.android_native_key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
@@ -437,7 +437,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Download JS Bundle
-        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@feat/rsdoctor-optimized-pinned
         with:
           key: ${{ needs.determine-builds.outputs.android_js_key }}
           accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
@@ -464,7 +464,7 @@ jobs:
           echo "Using pre-computed shard ${{ matrix.shard }}/${{ matrix.total }} with $(echo '${{ matrix.files }}' | wc -w) test files"
 
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true
@@ -494,7 +494,7 @@ jobs:
         run: node apps/ledger-live-mobile/node_modules/detox/scripts/postinstall.js
 
       - name: Build dependencies
-        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@feat/rsdoctor-optimized-pinned
         with:
           command: pnpm turbo build --filter="live-mobile^..."
           turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
@@ -502,7 +502,7 @@ jobs:
           disable_cache: ${{ inputs.disable-turbo-cache || false }}
 
       - name: Build Dummy Live SDK and Dummy Wallet API apps for testing
-        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@feat/rsdoctor-optimized-pinned
         with:
           command: pnpm turbo build --filter="@ledgerhq/dummy-*-app"
           turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
@@ -511,7 +511,7 @@ jobs:
 
       - name: Download android emulator
         timeout-minutes: 5
-        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@feat/rsdoctor-optimized-pinned
         id: detox-avd
         with:
           key: ${{ runner.os }}-detox-avd-${{ env.AVD_NAME }}-${{ env.AVD_PROFILE }}-${{ env.AVD_TARGET }}-${{ env.AVD_API }}-${{ env.AVD_ARCH }}-r2-v8
@@ -540,7 +540,7 @@ jobs:
           script: ./tools/scripts/wait_emulator_idle.sh
 
       - name: Cache android emulator
-        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@feat/rsdoctor-optimized-pinned
         if: steps.detox-avd.outputs.cache-hit != 'true'
         with:
           path: |
@@ -555,7 +555,7 @@ jobs:
           region: auto
 
       - name: Duplicate AVDs for parallel testing
-        uses: LedgerHQ/ledger-live/tools/actions/composites/duplicate-avd@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/duplicate-avd@feat/rsdoctor-optimized-pinned
         with:
           source_avd_name: ${{ env.AVD_NAME }}
           target_suffixes: "_2"
@@ -613,7 +613,7 @@ jobs:
               \"main.ios.jsbundle\" : { \"size\": ${{ needs.build-ios.outputs.js-bundle-size }}},
               \"main.android.jsbundle\" : { \"size\": ${{ needs.build-android.outputs.js-bundle-size }}}
           }" > mobile.metafile.json
-      - uses: LedgerHQ/ledger-live/tools/actions/build-checks@develop
+      - uses: LedgerHQ/ledger-live/tools/actions/build-checks@feat/rsdoctor-optimized-pinned
         if: ${{ !inputs.skip-bundle-size-reporting }}
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -640,7 +640,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID_PROD }}:role/${{ secrets.AWS_CACHE_ROLE_NAME }}
           aws-region: ${{ secrets.AWS_CACHE_REGION }}
 
-      - uses: LedgerHQ/ledger-live/tools/actions/composites/merge-e2e-detox-timings@develop
+      - uses: LedgerHQ/ledger-live/tools/actions/composites/merge-e2e-detox-timings@feat/rsdoctor-optimized-pinned
         with:
           platform: ios
           artifacts_dir: apps/ledger-live-mobile/e2e/artifacts
@@ -668,7 +668,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID_PROD }}:role/${{ secrets.AWS_CACHE_ROLE_NAME }}
           aws-region: ${{ secrets.AWS_CACHE_REGION }}
 
-      - uses: LedgerHQ/ledger-live/tools/actions/composites/merge-e2e-detox-timings@develop
+      - uses: LedgerHQ/ledger-live/tools/actions/composites/merge-e2e-detox-timings@feat/rsdoctor-optimized-pinned
         with:
           platform: android
           artifacts_dir: apps/ledger-live-mobile/e2e/artifacts
@@ -705,7 +705,7 @@ jobs:
 
       - name: setup caches
         id: setup-caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         with:
           skip-pod-cache: "true"
           skip-pnpm-cache: "true"
@@ -726,7 +726,7 @@ jobs:
           echo "pod-lockfile-validated=true" > pod-lockfile-cache.txt
 
       - name: Write cache
-        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@feat/rsdoctor-optimized-pinned
         with:
           path: pod-lockfile-cache.txt
           key: ${{ needs.determine-builds.outputs.pod_check_key }}

--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feat/rsdoctor-optimized-pinned
         id: setup-caches
         with:
           use-mise: true

--- a/.github/workflows/turbo-affected-reusable.yml
+++ b/.github/workflows/turbo-affected-reusable.yml
@@ -55,7 +55,7 @@ jobs:
             core.exportVariable("head_branch", newHeadBranch);
             core.exportVariable("base_branch", newBaseBranch);
 
-      - uses: LedgerHQ/ledger-live/tools/actions/turbo-affected@develop
+      - uses: LedgerHQ/ledger-live/tools/actions/turbo-affected@feat/rsdoctor-optimized-pinned
         id: affected
         with:
           ref: ${{ format('origin/{0}', env.base_branch) }}


### PR DESCRIPTION
Draft — **not for `develop`.**

Pins Ledger reusable / composite refs to **`feat/rsdoctor-optimized-pinned`** so Actions loads the rsdoctor workflow definitions from this branch when you open PRs against **`feat/rsdoctor-optimized`**.

**Stack:** [#15818](https://github.com/LedgerHQ/ledger-live/pull/15818) (feature → `develop`) → [#15824](https://github.com/LedgerHQ/ledger-live/pull/15824) (this draft) → [#15819](https://github.com/LedgerHQ/ledger-live/pull/15819) (test).

Drop this commit when the feature is on `develop` and everything uses `@develop` again.
