### PR TITLE
feat(mobile): transaction history screen for wallet 4.0

### DIFF
--- a/.changeset/hip-steaks-own.md
+++ b/.changeset/hip-steaks-own.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+New operations history UI for wallet 4.0

--- a/apps/ledger-live-mobile/src/hooks/__tests__/useDateFormatter.test.ts
+++ b/apps/ledger-live-mobile/src/hooks/__tests__/useDateFormatter.test.ts
@@ -1,0 +1,212 @@
+import { renderHook } from "@tests/test-renderer";
+import { State } from "~/reducers/types";
+import { Format } from "~/components/DateFormat/formatter.util";
+import { useFormatDate, useFormatDaySection } from "../useDateFormatter";
+
+// Fixed reference date used across tests: January 15, 2024
+const REFERENCE_DATE = new Date(2024, 0, 15);
+
+describe("useFormatDate", () => {
+  describe("Format.default", () => {
+    it("formats using the language from settings", () => {
+      const { result } = renderHook(() => useFormatDate(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            language: "en",
+            dateFormat: Format.default,
+          },
+        }),
+      });
+
+      const expected = new Intl.DateTimeFormat("en", {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+      }).format(REFERENCE_DATE);
+
+      expect(result.current(REFERENCE_DATE)).toBe(expected);
+    });
+
+    it("changes output when language changes", () => {
+      const { result: enResult } = renderHook(() => useFormatDate(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: { ...state.settings, language: "en", dateFormat: Format.default },
+        }),
+      });
+
+      const { result: frResult } = renderHook(() => useFormatDate(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: { ...state.settings, language: "fr", dateFormat: Format.default },
+        }),
+      });
+
+      // Both format the same date but the locale-specific output differs
+      const enOutput = enResult.current(REFERENCE_DATE);
+      const frOutput = frResult.current(REFERENCE_DATE);
+      expect(enOutput).not.toBe(frOutput);
+    });
+  });
+
+  describe("Format.ddmmyyyy", () => {
+    it("formats as DD/MM/YYYY regardless of language setting", () => {
+      const { result } = renderHook(() => useFormatDate(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            language: "en",
+            dateFormat: Format.ddmmyyyy,
+          },
+        }),
+      });
+
+      // ddmmyyyyFormatter uses fr-FR locale: 15/01/2024
+      const expected = new Intl.DateTimeFormat("fr-FR", {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+      }).format(REFERENCE_DATE);
+
+      expect(result.current(REFERENCE_DATE)).toBe(expected);
+    });
+
+    it("produces day-first order", () => {
+      const { result } = renderHook(() => useFormatDate(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: { ...state.settings, dateFormat: Format.ddmmyyyy },
+        }),
+      });
+
+      // REFERENCE_DATE is Jan 15 → day "15" should appear at the start
+      expect(result.current(REFERENCE_DATE)).toMatch(/^15/);
+    });
+  });
+
+  describe("Format.mmddyyyy", () => {
+    it("formats as MM/DD/YYYY regardless of language setting", () => {
+      const { result } = renderHook(() => useFormatDate(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            language: "fr",
+            dateFormat: Format.mmddyyyy,
+          },
+        }),
+      });
+
+      // mmddyyyyFormatter uses en-US locale: 1/15/2024
+      const expected = new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+      }).format(REFERENCE_DATE);
+
+      expect(result.current(REFERENCE_DATE)).toBe(expected);
+    });
+
+    it("produces month-first order", () => {
+      const { result } = renderHook(() => useFormatDate(), {
+        overrideInitialState: (state: State) => ({
+          ...state,
+          settings: { ...state.settings, dateFormat: Format.mmddyyyy },
+        }),
+      });
+
+      const output = result.current(REFERENCE_DATE);
+      // Month (1) appears before day (15) in the string
+      expect(output.indexOf("1")).toBeLessThan(output.indexOf("15"));
+    });
+  });
+});
+
+describe("useFormatDaySection", () => {
+  // Freeze time at Jan 15, 2024, noon
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2024, 0, 15, 12, 0, 0));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns 'Today' for the current day", () => {
+    const today = new Date(2024, 0, 15, 8, 30, 0);
+    const { result } = renderHook(() => useFormatDaySection());
+    expect(result.current(today)).toBe("Today");
+  });
+
+  it("returns 'Today' even when the time differs within the same calendar day", () => {
+    const lateToday = new Date(2024, 0, 15, 23, 59, 59);
+    const { result } = renderHook(() => useFormatDaySection());
+    expect(result.current(lateToday)).toBe("Today");
+  });
+
+  it("returns 'Yesterday' for the previous calendar day", () => {
+    const yesterday = new Date(2024, 0, 14);
+    const { result } = renderHook(() => useFormatDaySection());
+    expect(result.current(yesterday)).toBe("Yesterday");
+  });
+
+  it("returns a formatted long date for 2 days ago", () => {
+    const twoDaysAgo = new Date(2024, 0, 13);
+    const { result } = renderHook(() => useFormatDaySection(), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: { ...state.settings, language: "en" },
+      }),
+    });
+
+    const expected = new Intl.DateTimeFormat("en", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }).format(twoDaysAgo);
+
+    expect(result.current(twoDaysAgo)).toBe(expected);
+  });
+
+  it("returns a formatted long date for a date far in the past", () => {
+    const oldDate = new Date(2020, 5, 20); // Jun 20, 2020
+    const { result } = renderHook(() => useFormatDaySection(), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: { ...state.settings, language: "en" },
+      }),
+    });
+
+    const expected = new Intl.DateTimeFormat("en", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }).format(oldDate);
+
+    expect(result.current(oldDate)).toBe(expected);
+  });
+
+  it("uses the language from settings for the long date format", () => {
+    const olderDate = new Date(2024, 0, 10);
+
+    const { result: enResult } = renderHook(() => useFormatDaySection(), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: { ...state.settings, language: "en" },
+      }),
+    });
+
+    const { result: frResult } = renderHook(() => useFormatDaySection(), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: { ...state.settings, language: "fr" },
+      }),
+    });
+
+    expect(enResult.current(olderDate)).not.toBe(frResult.current(olderDate));
+  });
+});

--- a/apps/ledger-live-mobile/src/hooks/useDateFormatter.ts
+++ b/apps/ledger-live-mobile/src/hooks/useDateFormatter.ts
@@ -1,5 +1,7 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
+import { differenceInCalendarDays } from "date-fns";
 import { useSelector } from "~/context/hooks";
+import { useTranslation } from "~/context/Locale";
 import {
   ddmmyyyyFormatter,
   Format,
@@ -21,4 +23,29 @@ export function useFormatDate() {
 
   const f = useCallback((date: Date) => intlOpts.format(date), [intlOpts]);
   return f;
+}
+
+export function useFormatDaySection() {
+  const { t } = useTranslation();
+  const language = useSelector(languageSelector);
+
+  const longDateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(language, {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      }),
+    [language],
+  );
+
+  return useCallback(
+    (day: Date): string => {
+      const dayDiff = differenceInCalendarDays(Date.now(), day);
+      if (dayDiff === 0) return t("common.today");
+      if (dayDiff === 1) return t("common.yesterday");
+      return longDateFormatter.format(day);
+    },
+    [t, longDateFormatter],
+  );
 }

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2925,6 +2925,10 @@
       "UPDATE_ACCOUNT": "Updated account"
     }
   },
+  "operationsList": {
+    "to": "To",
+    "from": "From"
+  },
   "operationDetails": {
     "title": "Transaction details",
     "account": "Account",
@@ -3001,6 +3005,8 @@
   },
   "operationList": {
     "noOperations": "No Operations",
+    "emptyTitle": "No transactions yet",
+    "emptySubtitle": "Come back later to see your transactions.",
     "noMoreTransactions": "No other transactions"
   },
   "selectableAccountsList": {

--- a/apps/ledger-live-mobile/src/mvvm/components/Navigation/HeaderBackButton.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/Navigation/HeaderBackButton.tsx
@@ -3,6 +3,7 @@ import { IconButton } from "@ledgerhq/lumen-ui-rnative";
 import { ArrowLeft } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "~/context/Locale";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 
 type HeaderBackButtonProps = {
   testID?: string;
@@ -26,6 +27,7 @@ const HeaderBackButton = ({ testID, overrideOnPress, track }: Readonly<HeaderBac
   return (
     <IconButton
       appearance="no-background"
+      lx={buttonStyle}
       size="md"
       icon={ArrowLeft}
       testID={testID}
@@ -33,6 +35,10 @@ const HeaderBackButton = ({ testID, overrideOnPress, track }: Readonly<HeaderBac
       onPress={handlePress}
     />
   );
+};
+
+const buttonStyle: LumenViewStyle = {
+  marginLeft: "-s4",
 };
 
 export default HeaderBackButton;

--- a/apps/ledger-live-mobile/src/mvvm/components/Navigation/HeaderCloseButton.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/Navigation/HeaderCloseButton.tsx
@@ -3,6 +3,7 @@ import { useNavigation, ParamListBase } from "@react-navigation/native";
 import { IconButton } from "@ledgerhq/lumen-ui-rnative";
 import { Close } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 
 type Props = {
   onClose?: () => void;
@@ -22,6 +23,7 @@ function NavigationHeaderCloseButton({ onClose }: Readonly<Props>) {
   return (
     <IconButton
       appearance="no-background"
+      lx={buttonStyle}
       size="md"
       icon={Close}
       testID="navigation-header-close-button"
@@ -30,5 +32,9 @@ function NavigationHeaderCloseButton({ onClose }: Readonly<Props>) {
     />
   );
 }
+
+const buttonStyle: LumenViewStyle = {
+  marginRight: "-s4",
+};
 
 export default NavigationHeaderCloseButton;

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/Navigator.tsx
@@ -12,12 +12,7 @@ export default function Navigator() {
   const { theme } = useTheme();
   const { t } = useTranslation();
 
-  const stackNavigationConfig = useMemo(
-    () => ({
-      ...getStackNavigationConfigV4(theme, true),
-    }),
-    [theme],
-  );
+  const stackNavigationConfig = useMemo(() => getStackNavigationConfigV4(theme, false), [theme]);
 
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/const.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/const.ts
@@ -1,0 +1,1 @@
+export const GRADIENT_HEIGHT = 80;

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -1,12 +1,38 @@
 import React from "react";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { render } from "@tests/test-renderer";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { screen } from "~/analytics/segment";
-import OperationsList from "../index";
+import { screen, track } from "~/analytics";
+import type { OperationsHistoryNavigatorParamsList } from "LLM/features/OperationsHistory/types";
+import type { State } from "~/reducers/types";
 import { ScreenName } from "~/const/navigation";
-import { OperationsListNavigator } from "../types";
+import OperationsList from "../index";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 
-const Stack = createNativeStackNavigator<OperationsListNavigator>();
+const accountWithOperations = genAccount("operations-list-non-empty", {
+  currency: getCryptoCurrencyById("bitcoin"),
+  operationsSize: 5,
+});
+
+function stateWithAccountsAndOperations(base: State): State {
+  return {
+    ...base,
+    accounts: {
+      ...base.accounts,
+      active: [accountWithOperations],
+    },
+  };
+}
+
+const operation = accountWithOperations.operations[1];
+
+const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const Stack = createNativeStackNavigator<OperationsHistoryNavigatorParamsList>();
 
 const MockNavigator = () => (
   <Stack.Navigator>
@@ -17,7 +43,59 @@ const MockNavigator = () => (
 describe("OperationsList", () => {
   it("tracks the OperationsList screen on focus", () => {
     render(<MockNavigator />);
-
     expect(screen).toHaveBeenCalledWith(undefined, "OperationsList", {}, true, true, false, false);
+  });
+
+  describe("when the list is empty", () => {
+    it("renders the empty state", () => {
+      const { getByTestId } = render(<MockNavigator />);
+      expect(getByTestId("operations-empty-state")).toBeVisible();
+    });
+
+    it("blocks the swipe", () => {
+      const { getByTestId } = render(<MockNavigator />);
+      expect(getByTestId("operations-list-section-list")).toHaveProp("scrollEnabled", false);
+    });
+
+    it("doesn't render the bottom fade gradient", () => {
+      const { queryByTestId } = render(<MockNavigator />);
+      expect(queryByTestId("bottom-fade-gradient")).not.toBeVisible();
+    });
+  });
+
+  describe("when the list is not empty", () => {
+    const renderWithOperations = () =>
+      render(<MockNavigator />, { overrideInitialState: stateWithAccountsAndOperations });
+
+    it("renders the list with correct components", () => {
+      const { getByTestId, queryByTestId } = renderWithOperations();
+      expect(getByTestId("operations-list-section-list")).toBeVisible();
+      expect(queryByTestId("operations-empty-state")).not.toBeVisible();
+      expect(getByTestId("bottom-fade-gradient")).toBeVisible();
+      expect(getByTestId("operations-section-header")).toBeVisible();
+    });
+
+    it("renders five items", () => {
+      const { getAllByTestId } = renderWithOperations();
+      expect(getAllByTestId("operations-list-item")).toHaveLength(5);
+    });
+
+    it("triggers analytics and navigation when an item is pressed", async () => {
+      mockNavigate.mockClear();
+      const { queryAllByTestId, user } = renderWithOperations();
+      const operationItems = queryAllByTestId("operations-list-item");
+      await user.press(operationItems[1]);
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(ScreenName.OperationDetails, {
+        accountId: accountWithOperations.id,
+        parentId: undefined,
+        operation,
+        key: operation.id,
+      });
+      expect(track).toHaveBeenCalledWith("transaction_clicked", {
+        transaction: operation.type,
+      });
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/BottomFadeGradient/__tests__/BottomFadeGradient.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/BottomFadeGradient/__tests__/BottomFadeGradient.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Platform, StyleSheet } from "react-native";
+import { render } from "@tests/test-renderer";
+import { ledgerLiveThemes } from "@ledgerhq/lumen-design-core";
+import { rgba } from "@ledgerhq/native-ui/styles/helpers";
+import LinearGradient from "react-native-linear-gradient";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import { BottomFadeGradient, GRADIENT_LOCATIONS } from "../index";
+import { GRADIENT_HEIGHT } from "LLM/features/OperationsHistory/const";
+
+const TEST_ID = "bottom-fade-gradient";
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const linearGradientMock = LinearGradient as unknown as jest.Mock;
+
+function renderWithBottomInset(bottom: number) {
+  return render(
+    <SafeAreaProvider
+      initialMetrics={{
+        frame: { x: 0, y: 0, width: 375, height: 812 },
+        insets: { top: 0, left: 0, right: 0, bottom },
+      }}
+    >
+      <BottomFadeGradient />
+    </SafeAreaProvider>,
+  );
+}
+
+function containerHeight(getByTestId: ReturnType<typeof render>["getByTestId"]) {
+  return StyleSheet.flatten(getByTestId(TEST_ID).props.style).height;
+}
+
+describe("BottomFadeGradient", () => {
+  const platform = Platform.OS;
+
+  beforeEach(() => {
+    linearGradientMock.mockClear();
+    Platform.OS = "ios";
+  });
+
+  afterEach(() => {
+    Platform.OS = platform;
+  });
+
+  it("feeds LinearGradient theme fade colors and stop positions", () => {
+    const base = ledgerLiveThemes.dark.colors.bg.base;
+    renderWithBottomInset(0);
+
+    const gradientProps = linearGradientMock.mock.calls.at(-1)?.[0];
+    expect(gradientProps).toMatchObject({
+      colors: [rgba(base, 0), rgba(base, 0.3), rgba(base, 0.75), rgba(base, 1)],
+      locations: GRADIENT_LOCATIONS,
+      pointerEvents: "none",
+    });
+  });
+
+  it("extends container height with bottom inset on iOS", () => {
+    const { getByTestId } = renderWithBottomInset(34);
+    expect(containerHeight(getByTestId)).toBe(GRADIENT_HEIGHT + 34);
+  });
+
+  it("keeps container height fixed on Android", () => {
+    Platform.OS = "android";
+    const { getByTestId } = renderWithBottomInset(48);
+    expect(containerHeight(getByTestId)).toBe(GRADIENT_HEIGHT);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/BottomFadeGradient/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/BottomFadeGradient/index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import LinearGradient from "react-native-linear-gradient";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { useBottomFadeGradientViewModel } from "./useBottomFadeGradientViewModel";
+import { GRADIENT_HEIGHT } from "LLM/features/OperationsHistory/const";
+
+export const GRADIENT_LOCATIONS: number[] = [0, 0.35, 0.7, 1];
+
+export function BottomFadeGradient() {
+  const { colors, bottomInset } = useBottomFadeGradientViewModel();
+
+  return (
+    <Box
+      testID="bottom-fade-gradient"
+      pointerEvents="none"
+      style={[styles.container, { height: GRADIENT_HEIGHT + bottomInset }]}
+    >
+      <LinearGradient
+        colors={colors}
+        locations={GRADIENT_LOCATIONS}
+        style={StyleSheet.absoluteFillObject}
+        pointerEvents="none"
+      />
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+  },
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/BottomFadeGradient/useBottomFadeGradientViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/BottomFadeGradient/useBottomFadeGradientViewModel.ts
@@ -1,0 +1,22 @@
+import { useMemo } from "react";
+import { Platform } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+import { rgba } from "@ledgerhq/native-ui/styles/helpers";
+
+export function useBottomFadeGradientViewModel() {
+  const { theme } = useTheme();
+  const { bottom } = useSafeAreaInsets();
+  const bgBase = theme.colors.bg.base;
+
+  const colors = useMemo(
+    () => [rgba(bgBase, 0), rgba(bgBase, 0.3), rgba(bgBase, 0.75), rgba(bgBase, 1)],
+    [bgBase],
+  );
+
+  // On Android, the nav bar is opaque and doesn't need the gradient to extend into it
+  // like iOS does for the transparent home indicator area.
+  const bottomInset = Platform.OS === "ios" ? bottom : 0;
+
+  return { colors, bottomInset };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsEmptyState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsEmptyState.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Box, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle, LumenTextStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
+
+export function OperationsEmptyState() {
+  const { t } = useTranslation();
+
+  return (
+    <Box lx={containerStyle} testID="operations-empty-state">
+      <Spot appearance="info" size={72} />
+      <Box lx={textContainerStyle}>
+        <Text typography="heading4SemiBold" lx={titleStyle}>
+          {t("operationList.emptyTitle")}
+        </Text>
+        <Text typography="body2" lx={subtitleStyle}>
+          {t("operationList.emptySubtitle")}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+const containerStyle: LumenViewStyle = {
+  flex: 1,
+  justifyContent: "center",
+  alignItems: "center",
+  gap: "s24",
+  width: "full",
+};
+
+const textContainerStyle: LumenViewStyle = {
+  gap: "s8",
+  alignItems: "center",
+  width: "full",
+};
+
+const titleStyle: LumenTextStyle = {
+  color: "base",
+  textAlign: "center",
+  width: "full",
+};
+
+const subtitleStyle: LumenTextStyle = {
+  color: "muted",
+  textAlign: "center",
+  width: "full",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListFooter.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListFooter.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Spinner } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+
+type Props = {
+  completed: boolean;
+};
+
+export function OperationsListFooter({ completed }: Readonly<Props>) {
+  if (!completed)
+    return <Spinner size={24} lx={spinnerStyle} testID="operations-list-footer-spinner" />;
+  return null;
+}
+
+const spinnerStyle: LumenViewStyle = {
+  // Workaround to remove once we have bumped Lumen
+  alignSelf: "center",
+  marginVertical: "s24",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/__tests__/OperationsListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/__tests__/OperationsListItem.test.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { Operation } from "@ledgerhq/types-live";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { render } from "@tests/test-renderer";
+import { track } from "~/analytics";
+import { ScreenName } from "~/const";
+import OperationsListItem from "..";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const account = genAccount("operations-list-item-test", { currency: bitcoin });
+
+function buildOperation(overrides: Partial<Operation>): Operation {
+  return {
+    id: "operations-list-item-op",
+    hash: "abc",
+    type: "IN",
+    value: new BigNumber(0),
+    fee: new BigNumber(0),
+    senders: [],
+    recipients: [],
+    blockHeight: 1,
+    blockHash: "block",
+    accountId: account.id,
+    date: new Date("2024-06-01T12:00:00.000Z"),
+    extra: {},
+    ...overrides,
+  };
+}
+
+describe("OperationsListItem", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render the translated title for the operation type", () => {
+    const operation = buildOperation({ type: "IN" });
+    const { getByText } = render(
+      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+    );
+    expect(getByText("Received")).toBeVisible();
+  });
+
+  it("should render send or receive subtitle with from label when incoming and sender is present", () => {
+    const operation = buildOperation({
+      type: "IN",
+      value: new BigNumber(1),
+      senders: ["12345678901234567890"],
+    });
+    const { getByText } = render(
+      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+    );
+    expect(getByText("From 123456...7890")).toBeVisible();
+  });
+
+  it("should render send or receive subtitle with to label when outgoing and recipient is present", () => {
+    const operation = buildOperation({
+      type: "OUT",
+      value: new BigNumber(1),
+      recipients: ["abcdefghijklmnopqrs"],
+    });
+    const { getByText } = render(
+      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+    );
+    expect(getByText("To abcdef...pqrs")).toBeVisible();
+  });
+
+  it("should render only the formatted address when the operation is not send or receive", () => {
+    const operation = buildOperation({
+      type: "REGISTER",
+      senders: ["12345678901234567890"],
+    });
+    const { getByText } = render(
+      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+    );
+    expect(getByText("123456...7890")).toBeVisible();
+  });
+
+  it("should not render the amount column when the operation amount is zero", () => {
+    const operation = buildOperation({ type: "REGISTER" });
+    const { queryByText } = render(
+      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+    );
+    expect(queryByText(/^\+1(\.0+)?\s*BTC$/)).toBeNull();
+  });
+
+  it("should render the amount when the operation amount is not zero", () => {
+    const operation = buildOperation({
+      type: "IN",
+      value: new BigNumber(100000000),
+    });
+    const { getByText } = render(
+      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+    );
+    expect(getByText(/^\+1(\.0+)?\s*BTC$/)).toBeVisible();
+  });
+
+  it("should navigate to operation details and track when the row is pressed", async () => {
+    const operation = buildOperation({
+      type: "IN",
+      value: new BigNumber(1),
+      senders: ["s"],
+    });
+    const { getByText, user } = render(
+      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+    );
+    await user.press(getByText("Received"));
+    expect(track).toHaveBeenCalledWith("transaction_clicked", { transaction: "IN" });
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.OperationDetails, {
+      accountId: account.id,
+      parentId: undefined,
+      operation,
+      key: operation.id,
+    });
+  });
+
+  it("should not navigate when the operation is optimistic", async () => {
+    const operation = buildOperation({
+      type: "IN",
+      value: new BigNumber(1),
+      senders: ["s"],
+      blockHeight: null,
+    });
+    const { getByText, user } = render(
+      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+    );
+    await user.press(getByText("Received"));
+    expect(track).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should pass parentId when parentAccount is provided", async () => {
+    const parentAccount = { ...account, id: "parent-account-id" };
+    const operation = buildOperation({
+      type: "IN",
+      value: new BigNumber(1),
+      senders: ["s"],
+    });
+    const { getByText, user } = render(
+      <OperationsListItem operation={operation} account={account} parentAccount={parentAccount} />,
+    );
+    await user.press(getByText("Received"));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      ScreenName.OperationDetails,
+      expect.objectContaining({ parentId: "parent-account-id" }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/index.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import {
+  Box,
+  ListItem as LumenListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle, LumenTextStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
+import { useTranslation } from "~/context/Locale";
+import CurrencyIcon from "~/components/CurrencyIcon";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
+import CounterValue from "~/components/CounterValue";
+import { useOperationsListItemViewModel } from "./useOperationsListItemViewModel";
+
+type Props = {
+  operation: Operation;
+  account: AccountLike;
+  parentAccount: Account | undefined;
+};
+
+function OperationsListItem({ operation, account, parentAccount }: Readonly<Props>) {
+  const { t } = useTranslation();
+  const {
+    operationType,
+    isOutgoing,
+    isASendOrReceive,
+    formattedAddress,
+    currency,
+    unit,
+    amount,
+    amountColor,
+    isOptimistic,
+    onPress,
+  } = useOperationsListItemViewModel({ operation, account, parentAccount });
+
+  const title = t(`operations.types.${operationType}`);
+  const directionLabel = isOutgoing ? t("operationsList.to") : t("operationsList.from");
+  let subtitle = "";
+  if (!isASendOrReceive) subtitle = formattedAddress;
+  else if (formattedAddress) subtitle = `${directionLabel} ${formattedAddress}`;
+
+  return (
+    <LumenListItem
+      onPress={onPress}
+      disabled={isOptimistic}
+      lx={listItemStyle}
+      testID="operations-list-item"
+    >
+      <ListItemLeading>
+        <CurrencyIcon currency={currency} size={48} hideNetwork />
+        <ListItemContent>
+          <ListItemTitle>{title}</ListItemTitle>
+          <ListItemDescription>{subtitle}</ListItemDescription>
+        </ListItemContent>
+      </ListItemLeading>
+      {!amount.isZero() && (
+        <ListItemTrailing>
+          <Box lx={trailingContainerStyle}>
+            <Text typography="body2SemiBold" lx={{ color: amountColor }}>
+              <CurrencyUnitValue showCode unit={unit} value={amount} alwaysShowSign />
+            </Text>
+            <Text typography="body3" lx={counterValueStyle}>
+              <CounterValue
+                showCode
+                date={operation.date}
+                currency={currency}
+                value={amount}
+                alwaysShowSign
+                withPlaceholder
+              />
+            </Text>
+          </Box>
+        </ListItemTrailing>
+      )}
+    </LumenListItem>
+  );
+}
+
+const listItemStyle: LumenViewStyle = {
+  marginHorizontal: "-s8",
+};
+
+const trailingContainerStyle: LumenViewStyle = {
+  flexDirection: "column",
+  alignItems: "flex-end",
+  gap: "s4",
+};
+
+const counterValueStyle: LumenTextStyle = {
+  color: "muted",
+};
+
+export default React.memo(OperationsListItem);

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/useOperationsListItemViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/useOperationsListItemViewModel.ts
@@ -1,0 +1,71 @@
+import { useCallback } from "react";
+import { useNavigation } from "@react-navigation/native";
+import { getOperationAmountNumber, isConfirmedOperation } from "@ledgerhq/live-common/operation";
+import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
+import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
+import { ScreenName } from "~/const";
+import { track } from "~/analytics";
+import { BaseNavigation } from "~/components/RootNavigator/types/helpers";
+import { useCurrencySettingsForAccount } from "LLM/hooks/useCurrencySettingsForAccount";
+import { useAccountUnit } from "LLM/hooks/useAccountUnit";
+
+type Params = {
+  operation: Operation;
+  account: AccountLike;
+  parentAccount: Account | undefined;
+};
+
+type AmountColorType = "base" | "success" | "warning";
+
+export function useOperationsListItemViewModel({ operation, account, parentAccount }: Params) {
+  const navigation = useNavigation<BaseNavigation>();
+
+  const unit = useAccountUnit(account);
+  const currency = getAccountCurrency(account);
+  const mainAccount = getMainAccount(account, parentAccount);
+  const currencySettings = useCurrencySettingsForAccount(mainAccount);
+  const amount = getOperationAmountNumber(operation);
+  const isOptimistic = operation.blockHeight === null;
+  const isConfirmed = isConfirmedOperation(
+    operation,
+    mainAccount,
+    currencySettings.confirmationsNb,
+  );
+
+  const operationType = operation.type;
+  const isOutgoing = amount.isNegative();
+  const isASendOrReceive = operationType === "IN" || operationType === "OUT";
+
+  const address = isOutgoing ? operation.recipients[0] : operation.senders[0];
+  const formattedAddress = address
+    ? formatAddress(address, { prefixLength: 6, suffixLength: 4 })
+    : "";
+
+  let amountColor: AmountColorType = "warning";
+  if (isOutgoing) amountColor = "base";
+  else if (isConfirmed) amountColor = "success";
+
+  const onPress = useCallback(() => {
+    track("transaction_clicked", { transaction: operation.type });
+    navigation.navigate(ScreenName.OperationDetails, {
+      accountId: account.id,
+      parentId: parentAccount?.id,
+      operation,
+      key: operation.id,
+    });
+  }, [operation, account.id, parentAccount?.id, navigation]);
+
+  return {
+    operationType,
+    isOutgoing,
+    isASendOrReceive,
+    formattedAddress,
+    currency,
+    unit,
+    amount,
+    amountColor,
+    isOptimistic,
+    onPress,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/__tests__/useOperationsSectionHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/__tests__/useOperationsSectionHeaderViewModel.test.ts
@@ -1,0 +1,35 @@
+import { renderHook } from "@tests/test-renderer";
+import { useOperationsSectionHeaderViewModel } from "../useOperationsSectionHeaderViewModel";
+
+describe("useOperationsSectionHeaderViewModel", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2024, 0, 15, 12, 0, 0));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns 'Today' for today's date", () => {
+    const today = new Date(2024, 0, 15, 8, 30, 0);
+    const { result } = renderHook(() => useOperationsSectionHeaderViewModel(today));
+    expect(result.current.formattedDay).toBe("Today");
+  });
+
+  it("returns 'Yesterday' for yesterday's date", () => {
+    const yesterday = new Date(2024, 0, 14);
+    const { result } = renderHook(() => useOperationsSectionHeaderViewModel(yesterday));
+    expect(result.current.formattedDay).toBe("Yesterday");
+  });
+
+  it("returns a long formatted date string for older dates", () => {
+    const oldDate = new Date(2023, 5, 20); // Jun 20, 2023
+    const { result } = renderHook(() => useOperationsSectionHeaderViewModel(oldDate));
+    const { formattedDay } = result.current;
+    expect(typeof formattedDay).toBe("string");
+    expect(formattedDay.length).toBeGreaterThan(0);
+    expect(formattedDay).not.toBe("Today");
+    expect(formattedDay).not.toBe("Yesterday");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/index.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Box, Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useOperationsSectionHeaderViewModel } from "./useOperationsSectionHeaderViewModel";
+
+type Props = {
+  day: Date;
+};
+
+function OperationsSectionHeader({ day }: Readonly<Props>) {
+  const { formattedDay } = useOperationsSectionHeaderViewModel(day);
+
+  return (
+    <Box lx={containerStyle} testID="operations-section-header">
+      <Subheader>
+        <SubheaderRow>
+          <SubheaderTitle>{formattedDay}</SubheaderTitle>
+        </SubheaderRow>
+      </Subheader>
+    </Box>
+  );
+}
+
+const containerStyle: LumenViewStyle = {
+  backgroundColor: "canvas",
+  flex: 1,
+};
+
+export default React.memo(OperationsSectionHeader);

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/useOperationsSectionHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsSectionHeader/useOperationsSectionHeaderViewModel.ts
@@ -1,0 +1,9 @@
+import { useFormatDaySection } from "~/hooks/useDateFormatter";
+
+export function useOperationsSectionHeaderViewModel(day: Date) {
+  const formatDay = useFormatDaySection();
+
+  return {
+    formattedDay: formatDay(day),
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/__tests__/OperationsEmptyState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/__tests__/OperationsEmptyState.test.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { render } from "@tests/test-renderer";
+import { OperationsEmptyState } from "../OperationsEmptyState";
+
+describe("OperationsEmptyState", () => {
+  it("renders the empty state title and subtitle", () => {
+    const { getByText } = render(<OperationsEmptyState />);
+    expect(getByText(/no transactions yet/i)).toBeVisible();
+    expect(getByText(/come back later to see your transactions/i)).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/__tests__/OperationsListFooter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/__tests__/OperationsListFooter.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { render } from "@tests/test-renderer";
+import { OperationsListFooter } from "../OperationsListFooter";
+
+const SPINNER_TEST_ID = "operations-list-footer-spinner";
+
+describe("OperationsListFooter", () => {
+  it("renders the loading spinner when completed is false", () => {
+    const { getByTestId } = render(<OperationsListFooter completed={false} />);
+    expect(getByTestId(SPINNER_TEST_ID)).toBeVisible();
+  });
+
+  it("renders nothing when completed is true", () => {
+    const { queryByTestId } = render(<OperationsListFooter completed={true} />);
+    expect(queryByTestId(SPINNER_TEST_ID)).not.toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -1,11 +1,111 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
+import { SectionList, SectionListData, SectionListRenderItem } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Account, DailyOperationsSection, Operation } from "@ledgerhq/types-live";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { TrackScreen } from "~/analytics";
 import { ScreenName } from "~/const";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
-import { OperationsListNavigator } from "./types";
+import type { OperationsHistoryNavigatorParamsList } from "LLM/features/OperationsHistory/types";
+import OperationsListItem from "./components/OperationsListItem";
+import OperationsSectionHeader from "./components/OperationsSectionHeader";
+import { OperationsEmptyState } from "./components/OperationsEmptyState";
+import { OperationsListFooter } from "./components/OperationsListFooter";
+import { BottomFadeGradient } from "./components/BottomFadeGradient";
+import { useOperationsListViewModel } from "./useOperationsListViewModel";
+import { GRADIENT_HEIGHT } from "LLM/features/OperationsHistory/const";
 
-type Props = StackNavigatorProps<OperationsListNavigator, ScreenName.OperationsList>;
+type Props = StackNavigatorProps<OperationsHistoryNavigatorParamsList, ScreenName.OperationsList>;
+
+function keyExtractor(item: Operation) {
+  return `${item.accountId}_${item.id}`;
+}
+
+function SectionSeparator() {
+  return <Box lx={sectionSeparatorStyle} />;
+}
 
 export default function OperationsList(_: Props) {
-  return <TrackScreen name="OperationsList" />;
+  const { bottom } = useSafeAreaInsets();
+  const { accounts, flattenedAccounts, sections, completed, isEmpty, onEndReached } =
+    useOperationsListViewModel();
+
+  const listContentStyle = useMemo(
+    () => ({
+      ...contentContainerStyle,
+      paddingBottom: isEmpty ? 0 : GRADIENT_HEIGHT + bottom,
+    }),
+    [isEmpty, bottom],
+  );
+
+  const renderItem: SectionListRenderItem<Operation, DailyOperationsSection> = useCallback(
+    ({ item }) => {
+      const account = flattenedAccounts.find(a => a.id === item.accountId);
+      const parentAccount: Account | undefined =
+        account && account.type !== "Account"
+          ? accounts.find(a => a.id === account.parentId)
+          : undefined;
+
+      if (!account) return null;
+
+      return (
+        <OperationsListItem operation={item} account={account} parentAccount={parentAccount} />
+      );
+    },
+    [flattenedAccounts, accounts],
+  );
+
+  const renderSectionHeader = useCallback(
+    (info: { section: SectionListData<Operation, DailyOperationsSection> }) => (
+      <OperationsSectionHeader day={info.section.day} />
+    ),
+    [],
+  );
+
+  const ListFooterComponent = useMemo(
+    () => <OperationsListFooter completed={completed} />,
+    [completed],
+  );
+
+  const ListEmptyComponent = useCallback(() => {
+    if (!isEmpty) return null;
+    return <OperationsEmptyState />;
+  }, [isEmpty]);
+
+  return (
+    <Box lx={rootStyle}>
+      <TrackScreen name="OperationsList" />
+      <SectionList
+        sections={sections}
+        testID="operations-list-section-list"
+        style={listStyle}
+        contentContainerStyle={listContentStyle}
+        overScrollMode="never"
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        SectionSeparatorComponent={SectionSeparator}
+        renderSectionHeader={renderSectionHeader}
+        stickySectionHeadersEnabled={false}
+        onEndReached={onEndReached}
+        onEndReachedThreshold={0.5}
+        scrollEnabled={!isEmpty}
+        showsVerticalScrollIndicator={false}
+        ListFooterComponent={ListFooterComponent}
+        ListEmptyComponent={ListEmptyComponent}
+      />
+      {!isEmpty && <BottomFadeGradient />}
+    </Box>
+  );
 }
+
+const rootStyle: LumenViewStyle = {
+  flex: 1,
+};
+
+const sectionSeparatorStyle: LumenViewStyle = {
+  height: "s24",
+};
+
+const listStyle = { flex: 1 } as const;
+const contentContainerStyle = { flexGrow: 1, paddingHorizontal: 16 } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/types.ts
@@ -1,5 +1,0 @@
-import { ScreenName } from "~/const";
-
-export type OperationsListNavigator = {
-  [ScreenName.OperationsList]: undefined;
-};

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -1,0 +1,46 @@
+import { useState, useCallback, useMemo } from "react";
+import { useSelector } from "~/context/hooks";
+import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/accounts";
+import { useOperationsV1 } from "~/screens/Analytics/Operations/useOperationsV1";
+
+const INITIAL_OP_COUNT = 50;
+const OP_COUNT_INCREMENT = 50;
+
+export function useOperationsListViewModel() {
+  const accounts = useSelector(shallowAccountsSelector);
+  const flattenedAccounts = useSelector(flattenAccountsSelector);
+  const [opCount, setOpCount] = useState(INITIAL_OP_COUNT);
+
+  const { sections, completed } = useOperationsV1(accounts, opCount);
+
+  const deduplicatedSections = useMemo(() => {
+    const seenIds = new Set<string>();
+    return sections
+      .map(section => ({
+        ...section,
+        data: section.data.filter(op => {
+          if (seenIds.has(op.id)) return false;
+          seenIds.add(op.id);
+          return true;
+        }),
+      }))
+      .filter(section => section.data.length > 0);
+  }, [sections]);
+
+  const onEndReached = useCallback(() => {
+    if (!completed) {
+      setOpCount(count => count + OP_COUNT_INCREMENT);
+    }
+  }, [completed]);
+
+  const isEmpty = completed && sections.length === 0;
+
+  return {
+    accounts,
+    flattenedAccounts,
+    sections: deduplicatedSections,
+    completed,
+    isEmpty,
+    onEndReached,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/types.ts
@@ -1,6 +1,5 @@
 import { ScreenName } from "~/const";
-import { OperationsListNavigator } from "./screens/OperationsList/types";
 
 export type OperationsHistoryNavigatorParamsList = {
-  [ScreenName.OperationsList]: OperationsListNavigator[ScreenName.OperationsList];
+  [ScreenName.OperationsList]: undefined;
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Transaction history list screen (operations list rendering, pagination, empty state)
  - Stack navigation header (standard Wallet 4.0 stack config — opaque canvas header, same as other V4 flows)
  - Bottom fade gradient when the list has operations (iOS extends into the bottom safe area for the home-indicator region; Android keeps the gradient above the opaque system nav bar)
  - Safe area insets (list bottom padding when the gradient is shown; gradient height includes bottom inset on iOS)
  - Tapping a row opens operation details and emits `transaction_clicked` analytics

### 📝 Description

Implements the transaction history screen for Wallet 4.0, aligned with the Figma design.

**What's new:**

- **OperationsList screen** — paginated `SectionList` grouped by day, with deduplication, infinite scroll, and loading / complete / empty states (`testID`s on the list, empty state, and gradient for tests and automation)
- **OperationsListItem** — operation type, direction (to/from), formatted address, amount with confirmation-based color coding, counter value; press navigates to operation details and tracks `transaction_clicked`
- **OperationsEmptyState** — centered info `Spot` with title and subtitle (no custom header treatment or radial glow behind the nav bar)
- **OperationsSectionHeader** — date-grouped section headers using Lumen `Subheader`
- **BottomFadeGradient** — linear gradient fade-to-background at the bottom when the list has operations; `useBottomFadeGradientViewModel` applies the bottom safe-area inset on iOS only (Android skips extra inset because the system navigation bar is treated as opaque)
- **Navigator** — uses shared `getStackNavigationConfigV4` for a consistent opaque header and canvas background;

**Tests:**

- **OperationsList** — screen tracking on focus; empty vs non-empty (empty state, scroll disabled when empty, gradient hidden when empty); with operations — list, section headers, five items, gradient visible, row press → navigation args + `transaction_clicked`
- **BottomFadeGradient**, **OperationsListItem**, **OperationsEmptyState**, **OperationsListFooter**, **OperationsSectionHeader** view model — focused unit tests

**Architecture:**

- MVVM: screen and list components use `index.tsx` (view) + `useXViewModel.ts` where logic warrants it
- Lumen UI: `Box`, `Text`, `Spot`, `ListItem`, `LumenViewStyle` / `LumenTextStyle` style constants
- Single `types.ts` at the feature root

**IOS**

https://github.com/user-attachments/assets/2a98c38c-dc12-4cf0-82c5-0095ff4cb6f6

**ANDROID WITHOUT Native nav bar**

https://github.com/user-attachments/assets/68abfd4c-4e39-464e-b9dc-62a749bbcd2f


**ANDROID WITH Native nav bar**

https://github.com/user-attachments/assets/327680c0-89b5-4994-83a1-7f2d191e1d17



### ❓ Context

- **JIRA or GitHub link**:  [LIVE-26757](https://ledgerhq.atlassian.net/browse/LIVE-26757) & [LIVE-26756](https://ledgerhq.atlassian.net/browse/LIVE-26756) & [LIVE-26755](https://ledgerhq.atlassian.net/browse/LIVE-26755)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26757]: https://ledgerhq.atlassian.net/browse/LIVE-26757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
