### PR TITLE
[LWM] fix(mobile): use fixed three columns for market quick actions

### DIFF
--- a/.changeset/quiet-maps-align.md
+++ b/.changeset/quiet-maps-align.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix market detail quick actions grid to use a fixed three-column layout

--- a/apps/ledger-live-mobile/src/components/MarketQuickActions/index.tsx
+++ b/apps/ledger-live-mobile/src/components/MarketQuickActions/index.tsx
@@ -65,7 +65,7 @@ export const MarketQuickActions = (quickActionsProps: Required<QuickActionProps>
       <QuickActionList
         data={quickActionsData}
         key={quickActionsData.length}
-        numColumns={quickActionsData.length}
+        numColumns={3}
         id="asset_five_columns"
         testID="market-quick-action-button"
       />


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Market → asset detail screen quick actions (Buy, Sell, Swap, Send, Receive, Stake, etc.)
      - Layout when several actions are visible (grid wraps in three columns instead of one row of N narrow columns)

### 📝 Description

**Problem:** On the market asset detail screen, `QuickActionList` used `numColumns` equal to the number of visible actions. With many actions enabled, every button shared one row as its own column, producing overly narrow tiles and a poor layout.

**Solution:** Set `numColumns` to `3` so quick actions use a stable three-column grid and wrap to additional rows as needed.


https://github.com/user-attachments/assets/f9a3d0aa-f544-4a85-b562-d0a86910e23c



### ❓ Context

- **JIRA or GitHub link**: [LIVE-28109](https://ledgerhq.atlassian.net/browse/LIVE-28109)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28109]: https://ledgerhq.atlassian.net/browse/LIVE-28109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ