### PR TITLE
fix(cli): move types-cryptoassets and types-live to dependencies

### DIFF
--- a/.changeset/cli-add-types-deps.md
+++ b/.changeset/cli-add-types-deps.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-cli": minor
+---
+
+Move `@ledgerhq/types-cryptoassets` and `@ledgerhq/types-live` from devDependencies to dependencies

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -50,7 +50,9 @@
     "@ledgerhq/live-network": "workspace:^",
     "@ledgerhq/live-wallet": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
+    "@ledgerhq/types-cryptoassets": "workspace:^",
     "@ledgerhq/types-devices": "workspace:^",
+    "@ledgerhq/types-live": "workspace:^",
     "asciichart": "1.5.25",
     "bigint-buffer": "*",
     "bignumber.js": "9.1.2",
@@ -77,8 +79,6 @@
     "@zondax/ledger-live-icp": "1.4.1"
   },
   "devDependencies": {
-    "@ledgerhq/types-cryptoassets": "workspace:^",
-    "@ledgerhq/types-live": "workspace:^",
     "@pnpm/exportable-manifest": "1000.0.7",
     "@pnpm/read-project-manifest": "1000.0.6",
     "@types/asciichart": "1.5.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -685,9 +685,15 @@ importers:
       '@ledgerhq/logs':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/logs
+      '@ledgerhq/types-cryptoassets':
+        specifier: workspace:^
+        version: link:../../libs/ledgerjs/packages/types-cryptoassets
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/types-devices
+      '@ledgerhq/types-live':
+        specifier: workspace:^
+        version: link:../../libs/ledgerjs/packages/types-live
       '@zondax/ledger-live-icp':
         specifier: 1.4.1
         version: 1.4.1
@@ -761,12 +767,6 @@ importers:
         specifier: 'catalog:'
         version: 8.18.3
     devDependencies:
-      '@ledgerhq/types-cryptoassets':
-        specifier: workspace:^
-        version: link:../../libs/ledgerjs/packages/types-cryptoassets
-      '@ledgerhq/types-live':
-        specifier: workspace:^
-        version: link:../../libs/ledgerjs/packages/types-live
       '@pnpm/exportable-manifest':
         specifier: 1000.0.7
         version: 1000.0.7
@@ -19577,7 +19577,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.0.0
       react-dom: 19.0.0
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- dependency-only change, no logic modified -->
- [x] **Impact of the changes:**
  - `@ledgerhq/types-cryptoassets` and `@ledgerhq/types-live` are now declared as runtime `dependencies` instead of `devDependencies` in `@ledgerhq/live-cli`, ensuring they are available when the package is installed by consumers.

### 📝 Description

`@ledgerhq/types-cryptoassets` and `@ledgerhq/types-live` were missing from the `dependencies` of `apps/cli` — they were only listed under `devDependencies`. This means downstream consumers of the published package would not have those types available at runtime, potentially causing missing-module errors.

This PR moves both packages to `dependencies` (alongside the existing `@ledgerhq/types-devices` entry).

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)