### PR TITLE
[LWM] ci(e2e): fix empty last shard and optimize runner parallelization

### DIFF
--- a/apps/ledger-live-mobile/scripts/shard-tests.mjs
+++ b/apps/ledger-live-mobile/scripts/shard-tests.mjs
@@ -97,11 +97,13 @@ function loadTimingData(platform, testRootDir) {
 
 function distributeFilesByTiming(files, timingData, shardIndex, shardTotal) {
   if (!timingData.testResults || Object.keys(timingData.testResults).length === 0) {
-    // No timing data available, use simple round-robin distribution
-    const filesPerShard = Math.ceil(files.length / shardTotal);
-    const startIndex = (shardIndex - 1) * filesPerShard;
-    const endIndex = Math.min(startIndex + filesPerShard, files.length);
-    return files.slice(startIndex, endIndex);
+    if (shardTotal <= 0) return [];
+    // Distribute evenly using floor + remainder to avoid empty last shards.
+    const baseCount = Math.floor(files.length / shardTotal);
+    const remainder = files.length % shardTotal;
+    const startIndex = (shardIndex - 1) * baseCount + Math.min(shardIndex - 1, remainder);
+    const count = baseCount + (shardIndex <= remainder ? 1 : 0);
+    return files.slice(startIndex, startIndex + count);
   }
 
   // Sort files by estimated duration (from timing data)

--- a/tools/actions/composites/generate-shards-matrix/action.yml
+++ b/tools/actions/composites/generate-shards-matrix/action.yml
@@ -65,16 +65,20 @@ runs:
       run: |
         TEST_COUNT=$(echo "${{ steps.test-files.outputs.test_files_for_sharding }}" | wc -w)
 
+        # Target one shard per group of 3 tests (matches 3 emulators/simulators per runner).
+        # This ensures all emulators are kept busy without spinning up unnecessary runners.
+        EMULATORS_PER_RUNNER=3
+        BASE_SHARD=$(( TEST_COUNT > 0 ? (TEST_COUNT + EMULATORS_PER_RUNNER - 1) / EMULATORS_PER_RUNNER : 1 ))
+
         if [ "${{ inputs.event_name }}" = "schedule" ]; then
-          SHARD_COUNT_IOS=12
-          SHARD_COUNT_ANDROID=12
+          SHARD_COUNT_IOS=$(( BASE_SHARD < 12 ? BASE_SHARD : 12 ))
+          SHARD_COUNT_ANDROID=$(( BASE_SHARD < 12 ? BASE_SHARD : 12 ))
         elif [[ "${{ inputs.ref }}" == *"release"* || "${{ inputs.ref }}" == *"hotfix"* ]]; then
-          SHARD_COUNT_IOS=6
-          SHARD_COUNT_ANDROID=12
+          SHARD_COUNT_IOS=$(( BASE_SHARD < 6 ? BASE_SHARD : 6 ))
+          SHARD_COUNT_ANDROID=$(( BASE_SHARD < 12 ? BASE_SHARD : 12 ))
         else
-          SHARD_COUNT=$(( (TEST_COUNT + 14) / 15 ))
-          SHARD_COUNT_IOS=$(( SHARD_COUNT > 3 ? 3 : SHARD_COUNT ))
-          SHARD_COUNT_ANDROID=$(( SHARD_COUNT > 12 ? 12 : SHARD_COUNT ))
+          SHARD_COUNT_IOS=$(( BASE_SHARD < 3 ? BASE_SHARD : 3 ))
+          SHARD_COUNT_ANDROID=$(( BASE_SHARD < 12 ? BASE_SHARD : 12 ))
         fi
         
         if [ "${{ inputs.max_shards }}" -gt 0 ]; then


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
  _Validated by running the CI workflow directly on this branch with filtered test runs._
- [x] **Impact of the changes:**
  - E2E shard distribution logic for Android and iOS (`shard-tests.mjs`)
  - `generate-shards-matrix` composite action shard count calculation
  - Both `test-mobile-e2e-reusable.yml` and `test-mobile-mock-reusable.yml` temporarily point to this branch — **must be reverted to `@develop` before merging**

### 📝 Description

- Two bugs caused the last Android shard to run all tests instead of none when a `test_filter` was applied on release/hotfix branches:
  - (1) the shard count was hardcoded (12 for Android) regardless of how many files matched the filter, leaving trailing shards with zero files; 
  - (2) the `Math.ceil`-based round-robin could produce an empty last shard even when `TEST_COUNT >= SHARD_COUNT` (e.g. 33 files / 12 shards → shard 12 empty). 
  - Both are fixed, and shard count is now derived from `ceil(TEST_COUNT / 3)` to match the 3 emulators per runner, eliminating wasted runners (e.g. 9 files → 3 shards of 3, not 9 shards of 1).

### ❓ Context

- **JIRA or GitHub link**: [QAA-1062](https://ledgerhq.atlassian.net/browse/QAA-1062)
- **CI run without release on branch name**: https://github.com/LedgerHQ/ledger-live/actions/runs/23644025651/job/68871575129#step:8:388
- **CI run with release on branch name**: https://github.com/LedgerHQ/ledger-live/actions/runs/23643465341/job/68869672169#step:8:388

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[QAA-1062]: https://ledgerhq.atlassian.net/browse/QAA-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ