### PR TITLE
[LWM] feat(mobile): add try to refresh button in sync error bottom sheet

### DIFF
--- a/.changeset/hot-walls-own.md
+++ b/.changeset/hot-walls-own.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update the syncError modal with a try to refresh button

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8741,6 +8741,7 @@
     "bottomSheet": {
       "title": "Some account data couldn’t load",
       "description": "Your assets are safe. This is a temporary sync issue.\nAffected accounts: {{accounts}}",
+      "tryToRefresh": "Try to refresh",
       "close": "Close"
     }
   },

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
@@ -39,6 +39,7 @@ export function TopBarView({
   isSyncDrawerOpen,
   openSyncDrawer,
   closeSyncDrawer,
+  onTryRefresh,
 }: Readonly<TopBarViewProps>) {
   const { shouldDisplayOperationsList } = useWalletFeaturesConfig("mobile");
   const myLedgerAction = useMyLedgerTopBarAction(onMyLedgerPress);
@@ -110,6 +111,7 @@ export function TopBarView({
         isOpen={isSyncDrawerOpen}
         onClose={closeSyncDrawer}
         listOfErrorAccountNames={listOfErrorAccountNames}
+        onTryRefresh={onTryRefresh}
       />
     </>
   );

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
@@ -33,6 +33,7 @@ describe("TopBarView", () => {
 
   const openSyncDrawer = jest.fn();
   const closeSyncDrawer = jest.fn();
+  const onTryRefresh = jest.fn();
 
   const defaultProps = {
     onMyLedgerPress,
@@ -49,6 +50,7 @@ describe("TopBarView", () => {
     isSyncDrawerOpen: false,
     openSyncDrawer,
     closeSyncDrawer,
+    onTryRefresh,
   };
 
   beforeEach(() => {

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/SyncErrorBottomSheet/SyncErrorBottomSheetContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/SyncErrorBottomSheet/SyncErrorBottomSheetContent.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Text, Button, Spot, Box } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+
+export type SyncErrorBottomSheetContentProps = {
+  onClose: () => void;
+  listOfErrorAccountNames: string;
+  onTryRefresh: () => void;
+};
+
+export function SyncErrorBottomSheetContent({
+  onClose,
+  listOfErrorAccountNames,
+  onTryRefresh,
+}: Readonly<SyncErrorBottomSheetContentProps>) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Box lx={{ alignItems: "center", gap: "s24", marginBottom: "s32" }}>
+        <Spot size={72} appearance="warning" />
+        <Box lx={{ alignItems: "center" }}>
+          <Text lx={{ marginBottom: "s12", color: "base" }} typography="heading4">
+            {t("syncIndicator.bottomSheet.title")}
+          </Text>
+          {listOfErrorAccountNames.length > 0 && (
+            <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+              {t("syncIndicator.bottomSheet.description", {
+                accounts: listOfErrorAccountNames,
+              })}
+            </Text>
+          )}
+        </Box>
+      </Box>
+      <Box lx={{ gap: "s16" }}>
+        <Button appearance="base" size="lg" onPress={onTryRefresh}>
+          {t("syncIndicator.bottomSheet.tryToRefresh")}
+        </Button>
+        <Button appearance="transparent" size="lg" onPress={onClose}>
+          {t("syncIndicator.bottomSheet.close")}
+        </Button>
+      </Box>
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/SyncErrorBottomSheet/__tests__/SyncErrorBottomSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/SyncErrorBottomSheet/__tests__/SyncErrorBottomSheet.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { renderWithReactQuery } from "@tests/test-renderer";
+import { SyncErrorBottomSheetContent } from "../SyncErrorBottomSheetContent";
+
+describe("SyncErrorBottomSheetContent", () => {
+  const onClose = jest.fn();
+  const onTryRefresh = jest.fn();
+
+  const defaultProps = {
+    onClose,
+    onTryRefresh,
+    listOfErrorAccountNames: "BTC1/ETH1",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders title, account names and both buttons, and handles interactions correctly", async () => {
+    const { user, getByText } = renderWithReactQuery(
+      <SyncErrorBottomSheetContent {...defaultProps} />,
+    );
+
+    expect(getByText("Some account data couldn\u2019t load")).toBeVisible();
+    expect(getByText(/BTC1\/ETH1/)).toBeVisible();
+    expect(getByText("Try to refresh")).toBeVisible();
+    expect(getByText("Close")).toBeVisible();
+
+    await user.press(getByText("Try to refresh"));
+    expect(onTryRefresh).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+
+    jest.clearAllMocks();
+
+    await user.press(getByText("Close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onTryRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/SyncErrorBottomSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/SyncErrorBottomSheet/index.tsx
@@ -1,52 +1,35 @@
 import React from "react";
-import {
-  Text,
-  BottomSheetHeader,
-  BottomSheetView,
-  Button,
-  Spot,
-  Box,
-} from "@ledgerhq/lumen-ui-rnative";
+import { BottomSheetHeader, BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useTranslation } from "~/context/Locale";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import {
+  SyncErrorBottomSheetContent,
+  type SyncErrorBottomSheetContentProps,
+} from "./SyncErrorBottomSheetContent";
 
-type SyncErrorBottomSheetProps = {
+export { SyncErrorBottomSheetContent } from "./SyncErrorBottomSheetContent";
+
+type SyncErrorBottomSheetProps = SyncErrorBottomSheetContentProps & {
   isOpen: boolean;
-  onClose: () => void;
-  listOfErrorAccountNames: string;
 };
 
 export function SyncErrorBottomSheet({
   isOpen,
   onClose,
   listOfErrorAccountNames,
+  onTryRefresh,
 }: Readonly<SyncErrorBottomSheetProps>) {
-  const { t } = useTranslation();
   const { bottom: bottomInset } = useSafeAreaInsets();
 
   return (
     <QueuedDrawerBottomSheet isRequestingToBeOpened={isOpen} onClose={onClose} enableDynamicSizing>
       <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
         <BottomSheetHeader appearance="compact" />
-        <Box lx={{ alignItems: "center", gap: "s24", marginBottom: "s32" }}>
-          <Spot size={72} appearance="warning" />
-          <Box lx={{ alignItems: "center" }}>
-            <Text lx={{ marginBottom: "s12", color: "base" }} typography="heading4">
-              {t("syncIndicator.bottomSheet.title")}
-            </Text>
-            {listOfErrorAccountNames.length > 0 && (
-              <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
-                {t("syncIndicator.bottomSheet.description", {
-                  accounts: listOfErrorAccountNames,
-                })}
-              </Text>
-            )}
-          </Box>
-        </Box>
-        <Button appearance="base" size="lg" onPress={onClose}>
-          {t("syncIndicator.bottomSheet.close")}
-        </Button>
+        <SyncErrorBottomSheetContent
+          onClose={onClose}
+          listOfErrorAccountNames={listOfErrorAccountNames}
+          onTryRefresh={onTryRefresh}
+        />
       </BottomSheetView>
     </QueuedDrawerBottomSheet>
   );

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/index.tsx
@@ -26,6 +26,7 @@ export function TopBar({ screenName }: Readonly<TopBarProps>) {
     isSyncDrawerOpen,
     openSyncDrawer,
     closeSyncDrawer,
+    onTryRefresh,
   } = useTopBarViewModel(navigation, screenName);
 
   return (
@@ -44,6 +45,7 @@ export function TopBar({ screenName }: Readonly<TopBarProps>) {
       isSyncDrawerOpen={isSyncDrawerOpen}
       openSyncDrawer={openSyncDrawer}
       closeSyncDrawer={closeSyncDrawer}
+      onTryRefresh={onTryRefresh}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
@@ -10,6 +10,7 @@ import { readOnlyModeEnabledSelector } from "~/reducers/settings";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { useRebornFlow } from "LLM/features/Reborn/hooks/useRebornFlow";
 import { useSyncIndicator } from "./hooks/useSyncIndicator";
+import { usePortfolioBalance } from "LLM/hooks/usePortfolioBalance";
 
 export function useTopBarViewModel(
   navigation: NativeStackNavigationProp<{ [key: string]: object | undefined }>,
@@ -28,6 +29,8 @@ export function useTopBarViewModel(
     syncAccessibilityLabel,
     errorCurrencyIds,
   } = useSyncIndicator();
+  const { triggerRefresh, isBridgeSyncPending } = usePortfolioBalance();
+
   const [isSyncDrawerOpen, setIsSyncDrawerOpen] = useState(false);
   const openSyncDrawer = useCallback(() => {
     setIsSyncDrawerOpen(true);
@@ -37,6 +40,15 @@ export function useTopBarViewModel(
     });
   }, [errorCurrencyIds, page]);
   const closeSyncDrawer = useCallback(() => setIsSyncDrawerOpen(false), []);
+
+  const [hasTryRefreshBeenRequested, setHasTryRefreshBeenRequested] = useState(false);
+  const isTryRefreshPending = hasTryRefreshBeenRequested && isBridgeSyncPending;
+
+  const onTryRefresh = useCallback(() => {
+    setHasTryRefreshBeenRequested(true);
+    triggerRefresh();
+    closeSyncDrawer();
+  }, [triggerRefresh, closeSyncDrawer]);
 
   const hasUnreadNotifications = useMemo(
     () => notificationCards.some(n => !n.viewed),
@@ -101,11 +113,12 @@ export function useTopBarViewModel(
     hasUnreadNotifications,
     hasAccounts,
     isSyncError: isError,
-    isSyncPending: isPending,
+    isSyncPending: isPending || isTryRefreshPending,
     listOfErrorAccountNames,
     syncAccessibilityLabel,
     isSyncDrawerOpen,
     openSyncDrawer,
     closeSyncDrawer,
+    onTryRefresh,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
@@ -46,6 +46,8 @@ function makeReturn(
     areAllAccountsUpToDate: true,
     hasAccounts: true,
     handleSync: jest.fn(),
+    isBridgeSyncPending: false,
+    triggerRefresh: jest.fn(),
     ...overrides,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalance.ts
@@ -126,6 +126,7 @@ export function usePortfolioBalance() {
     isBalanceLoading,
     isColdStart,
     isManualRefreshLoading,
+    isBridgeSyncPending: syncSources.stablePending,
     allAccounts,
     accountsWithError,
     accountsImpactedByError,
@@ -134,5 +135,6 @@ export function usePortfolioBalance() {
     areAllAccountsUpToDate,
     hasAccounts,
     handleSync,
+    triggerRefresh,
   };
 }

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/useSwapTopBarHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/useSwapTopBarHeaderViewModel.test.ts
@@ -41,6 +41,7 @@ describe("useSwapTopBarHeaderViewModel", () => {
       isSyncDrawerOpen: false,
       openSyncDrawer: noop,
       closeSyncDrawer: noop,
+      onTryRefresh: noop,
     }));
   });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Sync error bottom sheet (rendering, button interactions)
  - TopBar sync drawer open/close flow
  - Portfolio sync refresh trigger

### 📝 Description

When a sync error occurs, users had no direct way to retry syncing from the error bottom sheet — they had to close it and manually trigger a refresh.

This PR adds a permanent **"Try to refresh"** button to the `SyncErrorBottomSheet`. Pressing it triggers a portfolio sync (`handleSync`) and closes the drawer. The button is always visible since the bottom sheet itself is already gated behind the `lwmWallet40` feature flag. The `onTryRefresh` prop is now required (non-optional) to enforce this invariant at the type level.
<img width="603" height="1311" alt="Simulator Screenshot - iOS Simulator - 2026-03-27 at 14 37 55" src="https://github.com/user-attachments/assets/b7e8f2ca-73a4-46fb-8a68-9da525505a93" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27899](https://ledgerhq.atlassian.net/browse/LIVE-27899)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27899]: https://ledgerhq.atlassian.net/browse/LIVE-27899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ