### PR TITLE
[LWM] feat(mobile): show offline banner on pull-to-refresh without internet

### DIFF
--- a/.changeset/fuzzy-bears-sleep.md
+++ b/.changeset/fuzzy-bears-sleep.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Show offline banner when pull-to-refresh is attempted without internet connection

--- a/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
+++ b/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
@@ -4,6 +4,7 @@ import { useBridgeSync } from "@ledgerhq/live-common/bridge/react/index";
 import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useIsFocused, useRoute, useTheme } from "@react-navigation/native";
+import { useNetInfo } from "@react-native-community/netinfo";
 import { SYNC_DELAY } from "~/utils/constants";
 import { track } from "~/analytics";
 import { useWalletSyncUserState } from "LLM/features/WalletSync/components/WalletSyncContext";
@@ -13,6 +14,7 @@ import {
   setRefreshStarted,
   setRefreshCompleted,
   setLastUserSyncClickTimestamp,
+  setOfflineRefreshAttempt,
   selectLastSyncTimestamp,
 } from "~/reducers/portfolioRefresh";
 
@@ -43,6 +45,7 @@ function globalSyncRefreshControl<P>(
     const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
     const hasNoAccounts = useSelector(hasNoAccountsSelector);
     const route = useRoute();
+    const { isConnected, isInternetReachable } = useNetInfo();
     const refreshingRef = useRef(refreshing);
     refreshingRef.current = refreshing;
 
@@ -69,6 +72,10 @@ function globalSyncRefreshControl<P>(
     function handleRefresh() {
       if (refreshingRef.current) return;
       if (shouldDisplayBalanceRefreshRework && hasNoAccounts) return;
+      if (shouldDisplayBalanceRefreshRework && (isConnected === false || isInternetReachable === false)) {
+        dispatch(setOfflineRefreshAttempt(Date.now()));
+        return;
+      }
       onRefresh();
     }
 

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2807,7 +2807,8 @@
     "refreshStatus": {
       "refreshing": "Refreshing...",
       "upToDate": "Portfolio up to date",
-      "syncError": "Some account data couldn’t load"
+      "syncError": "Some account data couldn’t load",
+      "offline": "You’re offline. Please check your connection"
     }
   },
   "addAccountsModal": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__integrations__/PortfolioRefreshStatus.integration.test.tsx
@@ -32,7 +32,7 @@ jest.mock("react-native-reanimated", () => {
 import React from "react";
 import { render, screen, act } from "@tests/test-renderer";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
-import { UP_TO_DATE_VISIBLE_DURATION_MS } from "../usePortfolioRefreshStatusViewModel";
+import { REFRESH_STATUS_VISIBLE_DURATION_MS } from "../usePortfolioRefreshStatusViewModel";
 import { PortfolioRefreshStatus } from "../index";
 import { setRefreshCompleted } from "~/reducers/portfolioRefresh";
 import { State } from "~/reducers/types";
@@ -46,6 +46,17 @@ const makeAccount = (lastSyncDate: Date) => ({
   lastSyncDate,
 });
 
+const withBalanceRefreshRework = (state: State): State => ({
+  ...state,
+  settings: {
+    ...state.settings,
+    overriddenFeatureFlags: {
+      ...state.settings.overriddenFeatureFlags,
+      lwmWallet40: { enabled: true, params: { balanceRefreshRework: true } },
+    },
+  },
+});
+
 const withRefreshing = (): ((state: State) => State) => state => ({
   ...state,
   portfolioRefresh: {
@@ -53,6 +64,7 @@ const withRefreshing = (): ((state: State) => State) => state => ({
     lastSyncTimestampSnapshot: null,
     hasCompletedInitialSync: false,
     lastUserSyncClickTimestamp: 0,
+    lastOfflineRefreshAttemptTimestamp: 0,
   },
 });
 
@@ -69,6 +81,19 @@ const withIdle =
       lastSyncTimestampSnapshot: null,
       hasCompletedInitialSync: false,
       lastUserSyncClickTimestamp: 0,
+      lastOfflineRefreshAttemptTimestamp: 0,
+    },
+  });
+
+const withOfflineAttempt = (): ((state: State) => State) => state =>
+  withBalanceRefreshRework({
+    ...state,
+    portfolioRefresh: {
+      isRefreshing: false,
+      lastSyncTimestampSnapshot: null,
+      hasCompletedInitialSync: false,
+      lastUserSyncClickTimestamp: 0,
+      lastOfflineRefreshAttemptTimestamp: FIXED_NOW,
     },
   });
 
@@ -115,6 +140,29 @@ describe("PortfolioRefreshStatus", () => {
     });
   });
 
+  describe("offline state", () => {
+    it("should show warning icon and offline message when a pull-to-refresh is attempted offline", () => {
+      render(<PortfolioRefreshStatus />, { overrideInitialState: withOfflineAttempt() });
+
+      const offlineEl = screen.getByTestId("portfolio-refresh-status-offline");
+      expect(offlineEl).toBeVisible();
+      expect(offlineEl).toHaveTextContent(/offline/i);
+      expect(screen.queryByTestId("portfolio-refresh-status-spinner")).toBeNull();
+    });
+
+    it("should hide the offline message after the visibility duration elapses", () => {
+      render(<PortfolioRefreshStatus />, { overrideInitialState: withOfflineAttempt() });
+
+      expect(screen.getByTestId("portfolio-refresh-status-offline")).toBeVisible();
+
+      act(() => {
+        jest.advanceTimersByTime(REFRESH_STATUS_VISIBLE_DURATION_MS);
+      });
+
+      expect(screen.queryByTestId("portfolio-refresh-status-offline")).toBeNull();
+    });
+  });
+
   describe("up-to-date state", () => {
     it("should show checkmark and 'You're up to date' without spinner right after refresh completes", () => {
       const { store } = renderRefreshing();
@@ -133,7 +181,7 @@ describe("PortfolioRefreshStatus", () => {
       expect(screen.getByTestId("portfolio-refresh-status-up-to-date")).toBeVisible();
 
       act(() => {
-        jest.advanceTimersByTime(UP_TO_DATE_VISIBLE_DURATION_MS);
+        jest.advanceTimersByTime(REFRESH_STATUS_VISIBLE_DURATION_MS);
       });
 
       expect(screen.queryByTestId("portfolio-refresh-status-up-to-date")).toBeNull();

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__tests__/usePortfolioRefreshStatusViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/__tests__/usePortfolioRefreshStatusViewModel.test.ts
@@ -1,9 +1,12 @@
-import { renderHook } from "@tests/test-renderer";
+import { renderHook, act } from "@tests/test-renderer";
 import * as usePortfolioBalanceModule from "LLM/hooks/usePortfolioBalance";
 import * as useWalletFeaturesConfigModule from "@ledgerhq/live-common/featureFlags/index";
 import type { WalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/types";
 import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/index";
-import { usePortfolioRefreshStatusViewModel } from "../usePortfolioRefreshStatusViewModel";
+import {
+  usePortfolioRefreshStatusViewModel,
+  REFRESH_STATUS_VISIBLE_DURATION_MS,
+} from "../usePortfolioRefreshStatusViewModel";
 
 jest.mock("LLM/hooks/usePortfolioBalance");
 jest.mock("@ledgerhq/live-common/featureFlags/index");
@@ -62,4 +65,43 @@ it("outcome becomes error when syncPhase is failed after user refresh", () => {
   rerender({});
   expect(result.current.isRefreshing).toBe(false);
   expect(result.current.outcome).toBe("error");
+});
+
+it("outcome becomes success when syncPhase is synced after user refresh", () => {
+  mockSync("syncing", true);
+  const { result, rerender } = renderHook(() => usePortfolioRefreshStatusViewModel());
+
+  mockSync("synced");
+  rerender({});
+  expect(result.current.outcome).toBe("success");
+  expect(result.current.isVisible).toBe(true);
+});
+
+it("corrects outcome from success to error when syncPhase becomes failed during post-refresh window", () => {
+  mockSync("syncing", true);
+  const { result, rerender } = renderHook(() => usePortfolioRefreshStatusViewModel());
+
+  mockSync("synced");
+  rerender({});
+  expect(result.current.outcome).toBe("success");
+
+  mockSync("failed");
+  rerender({});
+  expect(result.current.outcome).toBe("error");
+});
+
+it("clears outcome to null after REFRESH_STATUS_VISIBLE_DURATION_MS elapses", () => {
+  mockSync("syncing", true);
+  const { result, rerender } = renderHook(() => usePortfolioRefreshStatusViewModel());
+
+  mockSync("synced");
+  rerender({});
+  expect(result.current.outcome).toBe("success");
+
+  act(() => {
+    jest.advanceTimersByTime(REFRESH_STATUS_VISIBLE_DURATION_MS);
+  });
+
+  expect(result.current.outcome).toBeNull();
+  expect(result.current.isVisible).toBe(false);
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/index.tsx
@@ -30,8 +30,15 @@ const StatusText = ({ testID, children }: { testID: string; children: string }) 
 );
 
 export const PortfolioRefreshStatus = () => {
-  const { isVisible, isRefreshing, outcome, refreshingLabel, upToDateLabel, syncErrorLabel } =
-    usePortfolioRefreshStatusViewModel();
+  const {
+    isVisible,
+    isRefreshing,
+    outcome,
+    refreshingLabel,
+    upToDateLabel,
+    syncErrorLabel,
+    offlineLabel,
+  } = usePortfolioRefreshStatusViewModel();
 
   const opacity = useSharedValue(0);
   const height = useSharedValue(0);
@@ -90,6 +97,15 @@ export const PortfolioRefreshStatus = () => {
         <>
           <Warning size={16} color="error" />
           <StatusText testID="portfolio-refresh-status-error">{syncErrorLabel}</StatusText>
+        </>
+      );
+    }
+
+    if (outcome === "offline") {
+      return (
+        <>
+          <Warning size={16} color="warning" />
+          <StatusText testID="portfolio-refresh-status-offline">{offlineLabel}</StatusText>
         </>
       );
     }

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/usePortfolioRefreshStatusViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioRefreshStatus/usePortfolioRefreshStatusViewModel.ts
@@ -2,12 +2,15 @@ import { useState, useEffect, useRef } from "react";
 import { useSelector } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
-import { selectIsRefreshing } from "~/reducers/portfolioRefresh";
+import {
+  selectIsRefreshing,
+  selectLastOfflineRefreshAttemptTimestamp,
+} from "~/reducers/portfolioRefresh";
 import { usePortfolioBalance } from "LLM/hooks/usePortfolioBalance";
 
-export const UP_TO_DATE_VISIBLE_DURATION_MS = 3_000;
+export const REFRESH_STATUS_VISIBLE_DURATION_MS = 3_000;
 
-type RefreshOutcome = "success" | "error" | null;
+type RefreshOutcome = "success" | "error" | "offline" | null;
 
 interface UsePortfolioRefreshStatusViewModelResult {
   isVisible: boolean;
@@ -15,6 +18,7 @@ interface UsePortfolioRefreshStatusViewModelResult {
   refreshingLabel: string;
   upToDateLabel: string;
   syncErrorLabel: string;
+  offlineLabel: string;
   outcome: RefreshOutcome;
 }
 
@@ -22,6 +26,7 @@ export const usePortfolioRefreshStatusViewModel = (): UsePortfolioRefreshStatusV
   const { t } = useTranslation();
   const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
   const legacyIsRefreshing = useSelector(selectIsRefreshing);
+  const lastOfflineRefreshAttemptTimestamp = useSelector(selectLastOfflineRefreshAttemptTimestamp);
   const { syncPhase, isManualRefreshLoading } = usePortfolioBalance();
 
   // Stays true for the entire sync cycle once the user triggers a refresh;
@@ -53,7 +58,7 @@ export const usePortfolioRefreshStatusViewModel = (): UsePortfolioRefreshStatusV
     const result: RefreshOutcome = syncPhase === "failed" ? "error" : "success";
     setOutcome(result);
 
-    const timer = setTimeout(() => setOutcome(null), UP_TO_DATE_VISIBLE_DURATION_MS);
+    const timer = setTimeout(() => setOutcome(null), REFRESH_STATUS_VISIBLE_DURATION_MS);
     return () => clearTimeout(timer);
   }, [isSyncing, syncPhase]);
 
@@ -64,6 +69,13 @@ export const usePortfolioRefreshStatusViewModel = (): UsePortfolioRefreshStatusV
     }
   }, [syncPhase, outcome, shouldDisplayBalanceRefreshRework]);
 
+  useEffect(() => {
+    if (!shouldDisplayBalanceRefreshRework || !lastOfflineRefreshAttemptTimestamp) return;
+    setOutcome("offline");
+    const timer = setTimeout(() => setOutcome(null), REFRESH_STATUS_VISIBLE_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [lastOfflineRefreshAttemptTimestamp, shouldDisplayBalanceRefreshRework]);
+
   return {
     isVisible: isSyncing || outcome !== null,
     isRefreshing: isSyncing,
@@ -71,5 +83,6 @@ export const usePortfolioRefreshStatusViewModel = (): UsePortfolioRefreshStatusV
     refreshingLabel: t("portfolio.refreshStatus.refreshing"),
     upToDateLabel: t("portfolio.refreshStatus.upToDate"),
     syncErrorLabel: t("portfolio.refreshStatus.syncError"),
+    offlineLabel: t("portfolio.refreshStatus.offline"),
   };
 };

--- a/apps/ledger-live-mobile/src/reducers/portfolioRefresh.ts
+++ b/apps/ledger-live-mobile/src/reducers/portfolioRefresh.ts
@@ -7,6 +7,7 @@ export interface PortfolioRefreshState {
   lastSyncTimestampSnapshot: number | null;
   hasCompletedInitialSync: boolean;
   lastUserSyncClickTimestamp: number;
+  lastOfflineRefreshAttemptTimestamp: number;
 }
 
 export const INITIAL_STATE: PortfolioRefreshState = {
@@ -14,6 +15,7 @@ export const INITIAL_STATE: PortfolioRefreshState = {
   lastSyncTimestampSnapshot: null,
   hasCompletedInitialSync: false,
   lastUserSyncClickTimestamp: 0,
+  lastOfflineRefreshAttemptTimestamp: 0,
 };
 
 const portfolioRefreshSlice = createSlice({
@@ -34,6 +36,9 @@ const portfolioRefreshSlice = createSlice({
     setLastUserSyncClickTimestamp: (state, action: PayloadAction<number>) => {
       state.lastUserSyncClickTimestamp = action.payload;
     },
+    setOfflineRefreshAttempt: (state, action: PayloadAction<number>) => {
+      state.lastOfflineRefreshAttemptTimestamp = action.payload;
+    },
   },
 });
 
@@ -42,6 +47,7 @@ export const {
   setRefreshCompleted,
   setHasCompletedInitialSync,
   setLastUserSyncClickTimestamp,
+  setOfflineRefreshAttempt,
 } = portfolioRefreshSlice.actions;
 
 export const selectIsRefreshing = (state: State) => state.portfolioRefresh.isRefreshing;
@@ -54,6 +60,9 @@ export const selectHasCompletedInitialSync = (state: State) =>
 
 export const selectLastUserSyncClickTimestamp = (state: State) =>
   state.portfolioRefresh.lastUserSyncClickTimestamp;
+
+export const selectLastOfflineRefreshAttemptTimestamp = (state: State) =>
+  state.portfolioRefresh.lastOfflineRefreshAttemptTimestamp;
 
 export const selectLastSyncTimestamp = createSelector(
   (state: State) => state.accounts.active,

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/useSwapTopBarHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/useSwapTopBarHeaderViewModel.test.ts
@@ -41,6 +41,7 @@ describe("useSwapTopBarHeaderViewModel", () => {
       isSyncDrawerOpen: false,
       openSyncDrawer: noop,
       closeSyncDrawer: noop,
+      onTryRefresh: noop,
     }));
   });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Pull-to-refresh behavior when device is offline
      - Display of the new offline warning banner
      - Verify banner disappears after ~3 seconds
      - Verify normal refresh still works when online

### 📝 Description

When a user pulls to refresh the portfolio screen while offline, no feedback was shown — the gesture was silently ignored.

This adds an offline detection step at the start of `handleRefresh` in `globalSyncRefreshControl`. If the device has no internet connection and the `balanceRefreshRework` feature flag is enabled, a Redux action (`setOfflineRefreshAttempt`) is dispatched instead of triggering a sync. The `PortfolioRefreshStatus` component reacts to this timestamp and displays a warning icon with an "You're offline" message for 3 seconds.

<img width="603" height="1311" alt="Simulator Screenshot - iOS Simulator - 2026-03-27 at 12 00 25" src="https://github.com/user-attachments/assets/4a10c0bd-f462-4711-9af4-d0c955230819" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28322](https://ledgerhq.atlassian.net/browse/LIVE-28322)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28322]: https://ledgerhq.atlassian.net/browse/LIVE-28322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ