### PR TITLE
test(mobile): disable ETH to DOT swap e2e test

### DIFF
--- a/.changeset/gentle-dots-sleep.md
+++ b/.changeset/gentle-dots-sleep.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Disable ETH to DOT swap e2e test while DOT is deactivated on swap prod

--- a/e2e/mobile/specs/swap/swapETH_DOT.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_DOT.spec.ts
@@ -1,6 +1,3 @@
-import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { runSwapTest } from "./swap";
-
 //TODO: Reactivate when DOT is reactivated on swap prod
 // const swap = new Swap(Account.ETH_1, Account.DOT_1, "0.02", Fee.MEDIUM);
 // runSwapTest(


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This PR disables an existing test — DOT is currently deactivated on swap prod, causing false failures._
- [x] **Impact of the changes:**
      - Mobile E2E swap test suite: the ETH→DOT swap test is temporarily commented out
      - No impact on production code or other tests

### 📝 Description

DOT is currently deactivated on the swap production environment. The ETH→DOT swap E2E test (`swapETH_DOT.spec.ts`) was failing because the swap pair is unavailable.

This PR comments out the test with a TODO marker to reactivate it once DOT is back on swap prod, preventing false CI failures in the meantime.

### ❓ Context

- **JIRA or GitHub link**: N/A — operational change to keep CI green while DOT swap is disabled.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)