### PR TITLE
[LWD] fix: add async to storage retrieval

### DIFF
--- a/.changeset/happy-tables-buy.md
+++ b/.changeset/happy-tables-buy.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add async storage flag retrieval for desktop

--- a/apps/ledger-live-desktop/src/renderer/hooks/useRecoverRestoreOnboarding.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useRecoverRestoreOnboarding.ts
@@ -24,7 +24,7 @@ export const useRecoverRestoreOnboarding = (seedPathStatus?: SeedPathStatus) => 
 
   const confirmRecoverOnboardingStatus = useCallback(async () => {
     const id = userId.exportUserIdForRecover();
-    const status = getStoreValue(
+    const status = await getStoreValue(
       `${ONBOARDED_VIA_RECOVER_RESTORE_USER_PREFIX}${id}`,
       recoverStoreId,
     );

--- a/apps/ledger-live-desktop/src/renderer/store.ts
+++ b/apps/ledger-live-desktop/src/renderer/store.ts
@@ -6,8 +6,9 @@ const store = new ElectronStore({
   encryptionKey: "this_only_obfuscates",
 });
 
-export function getStoreValue<T>(key: string, storeId: string): T | undefined {
-  const value = store.get(`${storeId}-${key}`);
+export async function getStoreValue<T>(key: string, storeId: string): Promise<T | undefined> {
+  const value = await store.get(`${storeId}-${key}`);
+
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return isEmpty(value) ? undefined : (value as T);
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Retrieval of storage flags is async but the lodash isEmpty will always default to true as the promise has not resolved. This results in the recover banner not showing.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-27983


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
