### PR TITLE
feat(concordium): Introduce @ledgerhq/live-signer-concordium package

### DIFF
--- a/.changeset/old-feet-confess.md
+++ b/.changeset/old-feet-confess.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-signer-concordium": minor
+---
+
+Initial DmkSignerConcordium implementation

--- a/libs/live-signer-concordium/README.md
+++ b/libs/live-signer-concordium/README.md
@@ -1,0 +1,9 @@
+<img src="https://user-images.githubusercontent.com/4631227/191834116-59cf590e-25cc-4956-ae5c-812ea464f324.png" height="100" />
+
+[GitHub](https://github.com/LedgerHQ/ledger-live/),
+[Ledger Devs Discord](https://developers.ledger.com/discord-pro),
+[Developer Portal](https://developers.ledger.com/)
+
+## @ledgerhq/live-signer-concordium
+
+Ledger Hardware Wallet Concordium JavaScript bindings via DMK.

--- a/libs/live-signer-concordium/jest.config.js
+++ b/libs/live-signer-concordium/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: "node",
+  testPathIgnorePatterns: ["lib/", "lib-es/"],
+  transform: {
+    "^.+\\.(ts|tsx)?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  collectCoverageFrom: ["src/**/*.ts", "!src/**/*.d.ts"],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/libs/live-signer-concordium/package.json
+++ b/libs/live-signer-concordium/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@ledgerhq/live-signer-concordium",
+  "version": "0.1.0",
+  "description": "Ledger Hardware Wallet Concordium Signer",
+  "keywords": [
+    "Ledger",
+    "LedgerWallet",
+    "CCD",
+    "Concordium",
+    "Hardware Wallet"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/ledger-live.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LedgerHQ/ledger-live/issues"
+  },
+  "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/live-signer-concordium",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/index.js",
+  "module": "lib-es/index.js",
+  "types": "lib-es/index.d.ts",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@ledgerhq/coin-concordium": "workspace:^",
+    "@ledgerhq/concordium-core": "workspace:^",
+    "@ledgerhq/device-management-kit": "catalog:",
+    "@ledgerhq/device-signer-kit-concordium": "0.0.0-develop-20260407153739",
+    "@ledgerhq/errors": "workspace:^",
+    "rxjs": "catalog:"
+  },
+  "scripts": {
+    "clean": "rimraf lib lib-es",
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "prewatch": "pnpm build",
+    "watch": "tsc --watch --project tsconfig.build.json",
+    "watch:es": "tsc --watch --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --cache",
+    "lint:fix": "pnpm lint --fix",
+    "test": "jest",
+    "coverage": "jest --coverage"
+  },
+  "devDependencies": {
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "rimraf": "^4.4.1",
+    "@swc/jest": "catalog:",
+    "@swc/core": "catalog:",
+    "ts-node": "^10.4.0"
+  },
+  "exports": {
+    ".": {
+      "@ledgerhq/source": "./src/index.ts",
+      "import": "./lib-es/index.js",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
+    },
+    "./lib-es/*": "./lib-es/*.js",
+    "./lib/*": "./lib/*.js",
+    "./*": {
+      "@ledgerhq/source": "./src/*.ts",
+      "import": "./lib-es/*.js",
+      "require": "./lib/*.js",
+      "default": "./lib/*.js"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/libs/live-signer-concordium/src/DmkSignerConcordium.ts
+++ b/libs/live-signer-concordium/src/DmkSignerConcordium.ts
@@ -1,0 +1,141 @@
+import { lastValueFrom } from "rxjs";
+import type { ConcordiumSigner } from "@ledgerhq/coin-concordium/types";
+import {
+  serializeTransaction,
+  serializeCredentialDeploymentValues,
+  serializeIdOwnershipProofs,
+  encodeWord64,
+  type Address,
+  type VerifyAddressResponse,
+  type CredentialDeploymentTransaction,
+  type Transaction,
+  type SigningResult,
+} from "@ledgerhq/concordium-core";
+import {
+  DeviceActionStatus,
+  type DeviceActionState,
+  type DeviceManagementKit,
+} from "@ledgerhq/device-management-kit";
+import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import {
+  type SignerConcordium,
+  SignerConcordiumBuilder,
+  type GetPublicKeyDAError,
+  type SignTransactionDAError,
+  type SignCredentialDeploymentTransactionDAError,
+} from "@ledgerhq/device-signer-kit-concordium";
+
+type DAError =
+  | GetPublicKeyDAError
+  | SignTransactionDAError
+  | SignCredentialDeploymentTransactionDAError;
+
+export class DmkSignerConcordium implements ConcordiumSigner {
+  private readonly signer: SignerConcordium;
+
+  constructor(dmk: DeviceManagementKit, sessionId: string) {
+    this.signer = new SignerConcordiumBuilder({ dmk, sessionId }).build();
+  }
+
+  async getPublicKey(path: string, confirm = false): Promise<string> {
+    const { observable } = this.signer.getPublicKey(path, {
+      checkOnDevice: confirm,
+      skipOpenApp: true,
+    });
+
+    const result = this.mapResult(await lastValueFrom(observable));
+    return Buffer.from(result.publicKey).toString("hex");
+  }
+
+  async getAddress(
+    path: string,
+    display = false,
+    _id?: number,
+    _cred?: number,
+    _idp?: number,
+  ): Promise<Address> {
+    if (display) {
+      throw new Error(
+        "getAddress(display=true) is not yet supported via DMK signer: on-device address verification is unavailable",
+      );
+    }
+
+    const publicKey = await this.getPublicKey(path, false);
+    return { address: publicKey, publicKey };
+  }
+
+  async signTransaction(tx: Transaction, path: string): Promise<SigningResult> {
+    const serialized = serializeTransaction(tx);
+
+    const { observable } = this.signer.signTransaction(path, new Uint8Array(serialized), {
+      skipOpenApp: true,
+    });
+
+    const result = this.mapResult(await lastValueFrom(observable));
+    const signature = Buffer.from(result).toString("hex");
+
+    return { signature, serialized: serialized.toString("hex") };
+  }
+
+  async signCredentialDeployment(
+    tx: CredentialDeploymentTransaction,
+    path: string,
+  ): Promise<string> {
+    const transaction = this.serializeCredentialDeploymentToBytes(tx);
+
+    const { observable } = this.signer.signCredentialDeploymentTransaction(path, transaction, {
+      skipOpenApp: true,
+    });
+
+    const result = this.mapResult(await lastValueFrom(observable));
+    return Buffer.from(result).toString("hex");
+  }
+
+  async verifyAddress(
+    _identityIndex: number,
+    _credNumber: number,
+    _ipIdentity: number,
+    _credId?: string,
+  ): Promise<VerifyAddressResponse> {
+    throw new Error("verifyAddress is not yet supported via DMK signer");
+  }
+
+  private serializeCredentialDeploymentToBytes(tx: CredentialDeploymentTransaction): Uint8Array {
+    const credentialValues = serializeCredentialDeploymentValues(tx);
+    const proofs = serializeIdOwnershipProofs(tx.proofs);
+    const proofLength = Buffer.alloc(4);
+    proofLength.writeUInt32BE(proofs.length, 0);
+    const expiry = encodeWord64(tx.expiry);
+    const newOrExisting = Buffer.from([0x00]);
+
+    return new Uint8Array(
+      Buffer.concat([credentialValues, proofLength, proofs, newOrExisting, expiry]),
+    );
+  }
+
+  private mapResult<T, E extends DAError>(actionState: DeviceActionState<T, E, unknown>): T {
+    switch (actionState.status) {
+      case DeviceActionStatus.Completed:
+        return actionState.output;
+      case DeviceActionStatus.Error:
+        throw this.mapError(actionState.error);
+      default:
+        throw new Error("Unexpected device action status");
+    }
+  }
+
+  private mapError<E extends DAError>(error: E): Error {
+    if (!("errorCode" in error)) {
+      return new Error(error._tag);
+    }
+
+    switch (error.errorCode) {
+      case "5515":
+        return new LockedDeviceError();
+      case "6985":
+        return new UserRefusedOnDevice();
+      default:
+        return new Error(error._tag);
+    }
+  }
+}

--- a/libs/live-signer-concordium/src/index.ts
+++ b/libs/live-signer-concordium/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./DmkSignerConcordium";

--- a/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
+++ b/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
@@ -1,0 +1,272 @@
+import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
+import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { SignerConcordiumBuilder } from "@ledgerhq/device-signer-kit-concordium";
+import { TransactionType, AccountAddress } from "@ledgerhq/concordium-core";
+import type { Transaction, CredentialDeploymentTransaction } from "@ledgerhq/concordium-core";
+import { of } from "rxjs";
+import { DmkSignerConcordium } from "../src/DmkSignerConcordium";
+
+jest.mock("@ledgerhq/device-signer-kit-concordium", () => {
+  return {
+    SignerConcordiumBuilder: jest.fn(),
+  };
+});
+
+describe("DmkSignerConcordium", () => {
+  let signer: DmkSignerConcordium;
+  const mockPath = "44'/919'/0'/0'/0'";
+
+  const mockSignerConcordium = {
+    getPublicKey: jest.fn(),
+    signTransaction: jest.fn(),
+    signCredentialDeploymentTransaction: jest.fn(),
+  };
+
+  const dmkMock = {
+    executeDeviceAction: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(SignerConcordiumBuilder).mockImplementation(() => {
+      return {
+        build: () => mockSignerConcordium,
+      } as unknown as SignerConcordiumBuilder;
+    });
+
+    signer = new DmkSignerConcordium(dmkMock as unknown as DeviceManagementKit, "sessionId");
+  });
+
+  describe("getPublicKey", () => {
+    it("should return hex public key", async () => {
+      const pubKeyBytes = new Uint8Array(32).fill(0xaa);
+      mockSignerConcordium.getPublicKey.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Completed,
+          output: { publicKey: pubKeyBytes },
+        }),
+      });
+
+      const result = await signer.getPublicKey(mockPath);
+
+      expect(result).toBe("aa".repeat(32));
+      expect(mockSignerConcordium.getPublicKey).toHaveBeenCalledWith(mockPath, {
+        checkOnDevice: false,
+        skipOpenApp: true,
+      });
+    });
+
+    it("should pass confirm flag to checkOnDevice", async () => {
+      mockSignerConcordium.getPublicKey.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Completed,
+          output: { publicKey: new Uint8Array(32) },
+        }),
+      });
+
+      await signer.getPublicKey(mockPath, true);
+
+      expect(mockSignerConcordium.getPublicKey).toHaveBeenCalledWith(mockPath, {
+        checkOnDevice: true,
+        skipOpenApp: true,
+      });
+    });
+
+    it("should throw LockedDeviceError when device is locked", async () => {
+      mockSignerConcordium.getPublicKey.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Error,
+          error: { _tag: "LockedDevice", errorCode: "5515" },
+        }),
+      });
+
+      await expect(signer.getPublicKey(mockPath)).rejects.toThrow(LockedDeviceError);
+    });
+
+    it("should throw UserRefusedOnDevice when user refuses", async () => {
+      mockSignerConcordium.getPublicKey.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Error,
+          error: { _tag: "UserRejected", errorCode: "6985" },
+        }),
+      });
+
+      await expect(signer.getPublicKey(mockPath)).rejects.toThrow(UserRefusedOnDevice);
+    });
+
+    it("should throw generic error for unknown error code", async () => {
+      mockSignerConcordium.getPublicKey.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Error,
+          error: { _tag: "UnknownError", errorCode: "6f00" },
+        }),
+      });
+
+      await expect(signer.getPublicKey(mockPath)).rejects.toThrow("UnknownError");
+    });
+
+    it("should throw generic error when no errorCode", async () => {
+      mockSignerConcordium.getPublicKey.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Error,
+          error: { _tag: "SomeDAError" },
+        }),
+      });
+
+      await expect(signer.getPublicKey(mockPath)).rejects.toThrow("SomeDAError");
+    });
+
+    it.each([DeviceActionStatus.NotStarted, DeviceActionStatus.Pending, DeviceActionStatus.Stopped])(
+      "should throw for unexpected status %s",
+      async (status) => {
+        mockSignerConcordium.getPublicKey.mockReturnValue({
+          observable: of({ status }),
+        });
+
+        await expect(signer.getPublicKey(mockPath)).rejects.toThrow(
+          "Unexpected device action status",
+        );
+      },
+    );
+  });
+
+  describe("getAddress", () => {
+    it("should return address and publicKey using getPublicKey under the hood", async () => {
+      const pubKeyBytes = new Uint8Array(32).fill(0xbb);
+      mockSignerConcordium.getPublicKey.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Completed,
+          output: { publicKey: pubKeyBytes },
+        }),
+      });
+
+      const result = await signer.getAddress(mockPath, false, 0, 0, 0);
+
+      const expectedHex = "bb".repeat(32);
+      expect(result).toEqual({ address: expectedHex, publicKey: expectedHex });
+    });
+
+    it("should throw when display=true (not yet supported)", async () => {
+      await expect(signer.getAddress(mockPath, true, 0, 0, 0)).rejects.toThrow(
+        "getAddress(display=true) is not yet supported via DMK signer",
+      );
+    });
+  });
+
+  describe("signTransaction", () => {
+    const mockTx: Transaction = {
+      header: {
+        sender: AccountAddress.fromBase58("3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G"),
+        nonce: 1n,
+        expiry: 1000n,
+        energyAmount: 1000n,
+      },
+      type: TransactionType.Transfer,
+      payload: {
+        toAddress: AccountAddress.fromBase58("3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G"),
+        amount: 1000000n,
+      },
+    };
+
+    it("should return signature and serialized transaction", async () => {
+      const signatureBytes = new Uint8Array(64).fill(0xcc);
+      mockSignerConcordium.signTransaction.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Completed,
+          output: signatureBytes,
+        }),
+      });
+
+      const result = await signer.signTransaction(mockTx, mockPath);
+
+      expect(result.signature).toBe("cc".repeat(64));
+      expect(typeof result.serialized).toBe("string");
+      expect(mockSignerConcordium.signTransaction).toHaveBeenCalledWith(
+        mockPath,
+        expect.any(Uint8Array),
+        { skipOpenApp: true },
+      );
+    });
+
+    it("should throw UserRefusedOnDevice when user refuses", async () => {
+      mockSignerConcordium.signTransaction.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Error,
+          error: { _tag: "UserRejected", errorCode: "6985" },
+        }),
+      });
+
+      await expect(signer.signTransaction(mockTx, mockPath)).rejects.toThrow(UserRefusedOnDevice);
+    });
+  });
+
+  describe("signCredentialDeployment", () => {
+    const mockCredDeployTx: CredentialDeploymentTransaction = {
+      credentialPublicKeys: {
+        keys: { "0": { schemeId: "Ed25519", verifyKey: "aa".repeat(32) } },
+        threshold: 1,
+      },
+      credId: "bb".repeat(48),
+      ipIdentity: 0,
+      revocationThreshold: 1,
+      arData: {
+        "1": { encIdCredPubShare: "cc".repeat(96) },
+      },
+      policy: {
+        validTo: "202612",
+        createdAt: "202601",
+        revealedAttributes: {},
+      },
+      proofs: {
+        sig: "dd".repeat(64),
+        commitments: "ee".repeat(32),
+        challenge: "ff".repeat(32),
+        proofIdCredPub: {},
+        proofIpSig: "aa".repeat(32),
+        proofRegId: "bb".repeat(32),
+        credCounterLessThanMaxAccounts: "cc".repeat(32),
+      },
+      expiry: 2000n,
+    };
+
+    it("should return hex signature", async () => {
+      const signatureBytes = new Uint8Array(64).fill(0xdd);
+      mockSignerConcordium.signCredentialDeploymentTransaction.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Completed,
+          output: signatureBytes,
+        }),
+      });
+
+      const result = await signer.signCredentialDeployment(mockCredDeployTx, mockPath);
+
+      expect(result).toBe("dd".repeat(64));
+      expect(mockSignerConcordium.signCredentialDeploymentTransaction).toHaveBeenCalledWith(
+        mockPath,
+        expect.any(Uint8Array),
+        { skipOpenApp: true },
+      );
+    });
+
+    it("should throw UserRefusedOnDevice when user refuses", async () => {
+      mockSignerConcordium.signCredentialDeploymentTransaction.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Error,
+          error: { _tag: "UserRejected", errorCode: "6985" },
+        }),
+      });
+
+      await expect(signer.signCredentialDeployment(mockCredDeployTx, mockPath)).rejects.toThrow(
+        UserRefusedOnDevice,
+      );
+    });
+  });
+
+  describe("verifyAddress", () => {
+    it("should throw not supported error", async () => {
+      await expect(signer.verifyAddress(0, 0, 0)).rejects.toThrow(
+        "verifyAddress is not yet supported via DMK signer",
+      );
+    });
+  });
+});

--- a/libs/live-signer-concordium/tests/tsconfig.json
+++ b/libs/live-signer-concordium/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": null,
+    "types": ["node", "jest"]
+  },
+  "include": ["."]
+}

--- a/libs/live-signer-concordium/tsconfig.build.json
+++ b/libs/live-signer-concordium/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "customConditions": []
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**/*",
+    "**/tests/**/*",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx"
+  ]
+}

--- a/libs/live-signer-concordium/tsconfig.json
+++ b/libs/live-signer-concordium/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "lib": ["es2020", "dom"],
+    "outDir": "lib",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10440,6 +10440,49 @@ importers:
         specifier: ^10.4.0
         version: 10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2)
 
+  libs/live-signer-concordium:
+    dependencies:
+      '@ledgerhq/coin-concordium':
+        specifier: workspace:^
+        version: link:../coin-modules/coin-concordium
+      '@ledgerhq/concordium-core':
+        specifier: workspace:^
+        version: link:../concordium-core
+      '@ledgerhq/device-management-kit':
+        specifier: 'catalog:'
+        version: 1.2.0(rxjs@7.8.2)
+      '@ledgerhq/device-signer-kit-concordium':
+        specifier: 0.0.0-develop-20260407153739
+        version: 0.0.0-develop-20260407153739(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+      '@ledgerhq/errors':
+        specifier: workspace:^
+        version: link:../ledgerjs/packages/errors
+      rxjs:
+        specifier: 'catalog:'
+        version: 7.8.2
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2))
+      rimraf:
+        specifier: ^4.4.1
+        version: 4.4.1
+      ts-node:
+        specifier: ^10.4.0
+        version: 10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(typescript@6.0.2)
+
   libs/live-signer-evm:
     dependencies:
       '@ledgerhq/coin-evm':
@@ -16048,6 +16091,11 @@ packages:
       '@ledgerhq/context-module': 1.15.0
       '@ledgerhq/device-management-kit': 0.0.0-develop-20260401001841
 
+  '@ledgerhq/device-signer-kit-concordium@0.0.0-develop-20260407153739':
+    resolution: {integrity: sha512-xyWcBBaX/I+CDRm5AmG5bkW+j893JK1GOPmmd91U11PnYv12/GOcE5HIwPMzm7OnkqrR1Hi2X+dK/eYWsEmlhg==}
+    peerDependencies:
+      '@ledgerhq/device-management-kit': 0.0.0-develop-20260407153739
+
   '@ledgerhq/device-signer-kit-ethereum@1.12.0':
     resolution: {integrity: sha512-Uj3C3UaoaX/pcqSuCHgfQZn1lwqqp60eQr8wyQOY5OCV4zttoWKmB1MRBn+t4LB08eBRAgokcFdsG2dGwFEhiA==}
     peerDependencies:
@@ -16200,6 +16248,11 @@ packages:
     resolution: {integrity: sha512-ct6OSX5ExBn69pJ3cSBygBJ3SE4DJXV+TCLerqyI+iyO/0L1Mgf0LRmNeSXlFrHXQmmuPw18BISvQA+5J2Cp0w==}
     peerDependencies:
       react: 19.0.0
+
+  '@ledgerhq/signer-utils@0.0.0-develop-20260407153739':
+    resolution: {integrity: sha512-fm3eg8Gkx3ldwt/mxUOlXtGOJGkSruIUQeBuREjrhFi4jbq175V5IYmn5hff8oMJkSy6+Nr9/HP+l/as67Fyzw==}
+    peerDependencies:
+      '@ledgerhq/device-management-kit': 0.0.0-develop-20260407153739
 
   '@ledgerhq/signer-utils@1.1.3':
     resolution: {integrity: sha512-3Y1ove1TyMVuCTKxM1eB9QMXpmrnYVjRc0fEPr5F+I6YJ0DX/yRc+t38ZFJw6m/IkVl8NN1TtmDyaFWJb+xXnQ==}
@@ -43841,6 +43894,15 @@ snapshots:
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
+  '@ledgerhq/device-signer-kit-concordium@0.0.0-develop-20260407153739(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))':
+    dependencies:
+      '@ledgerhq/device-management-kit': 1.2.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 0.0.0-develop-20260407153739(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+      inversify: 7.5.1(reflect-metadata@0.2.2)
+      purify-ts: 2.1.0
+      reflect-metadata: 0.2.2
+      xstate: 5.19.2
+
   '@ledgerhq/device-signer-kit-ethereum@1.12.0(@ledgerhq/context-module@1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/context-module': 1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
@@ -44116,6 +44178,11 @@ snapshots:
       clsx: 2.1.1
       react: 19.0.0
       tailwind-merge: 2.6.0
+
+  '@ledgerhq/signer-utils@0.0.0-develop-20260407153739(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))':
+    dependencies:
+      '@ledgerhq/device-management-kit': 1.2.0(rxjs@7.8.2)
+      semver: 7.7.2
 
   '@ledgerhq/signer-utils@1.1.3(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))':
     dependencies:


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** none. this is the initial implementation of the package. actual wiring will happen in subsequent PRs

### 📝 Description

Create `@ledgerhq/live-signer-concordium` package with `DmkSignerConcordium` — a DMK-based implementation of the `ConcordiumSigner` interface.

Wraps `@ledgerhq/device-signer-kit-concordium` to provide the following methods: 
* getPublicKey, 
* getAddress, 
* signTransaction (Transfer and TransferWithMemo)
* signCredentialDeployment. 
 
Methods not yet available in the device-signer-kit (`verifyAddress`, `getAddress` with display=true) throw explicit not-supported errors.

Includes 16 unit tests covering all methods and error mapping.
### ❓ Context

- **JIRA or GitHub link**: [LIVE-26522](https://ledgerhq.atlassian.net/browse/LIVE-26522)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26522]: https://ledgerhq.atlassian.net/browse/LIVE-26522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ