### PR TITLE
[LWM] fix(mobile): update portfolio CTA tracking and navigation

### DIFF
--- a/.changeset/warm-ducks-wave.md
+++ b/.changeset/warm-ducks-wave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix portfolio CTA tracking and navigation to accounts list

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/__tests__/useCryptoAddressesButtonViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/__tests__/useCryptoAddressesButtonViewModel.test.ts
@@ -140,7 +140,7 @@ describe("useCryptoAddressesButtonViewModel", () => {
   });
 
   describe("onPress — with accounts (view)", () => {
-    it("should navigate to AssetsList", () => {
+    it("should navigate to AccountsList", () => {
       const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
         overrideInitialState: withAccounts([btcAccount]),
       });
@@ -149,8 +149,8 @@ describe("useCryptoAddressesButtonViewModel", () => {
         result.current.onPress();
       });
 
-      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Assets, {
-        screen: ScreenName.AssetsList,
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
+        screen: ScreenName.AccountsList,
         params: {
           sourceScreenName: ScreenName.Portfolio,
           showHeader: true,

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/useCryptoAddressesButtonViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/useCryptoAddressesButtonViewModel.ts
@@ -46,8 +46,8 @@ export function useCryptoAddressesButtonViewModel(): CryptoAddressesButtonViewMo
         page: route.name,
       });
 
-      navigation.navigate(NavigatorName.Assets, {
-        screen: ScreenName.AssetsList,
+      navigation.navigate(NavigatorName.Accounts, {
+        screen: ScreenName.AccountsList,
         params: {
           sourceScreenName: ScreenName.Portfolio,
           showHeader: true,

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/__tests__/useAddAccountCta.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/__tests__/useAddAccountCta.test.ts
@@ -6,6 +6,11 @@ jest.mock("~/analytics", () => ({
   track: jest.fn(),
 }));
 
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useRoute: jest.fn().mockReturnValue({ name: "WalletAssets", params: {} }),
+}));
+
 describe("useAddAccountCta", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -48,7 +53,11 @@ describe("useAddAccountCta", () => {
     });
 
     expect(track).toHaveBeenCalledTimes(1);
-    expect(track).toHaveBeenCalledWith("button_clicked", { button: "add_account_cta" });
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "account_cta",
+      type: "add",
+      page: "WalletAssets",
+    });
   });
 
   it("should not fire track when close is called", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useAddAccountCta.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useAddAccountCta.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { useRoute } from "@react-navigation/native";
 import { track } from "~/analytics";
 
 interface UseAddAccountCtaResult {
@@ -9,11 +10,12 @@ interface UseAddAccountCtaResult {
 
 export function useAddAccountCta(): UseAddAccountCtaResult {
   const [isOpen, setOpen] = useState(false);
+  const route = useRoute();
 
   const open = useCallback(() => {
-    track("button_clicked", { button: "add_account_cta" });
+    track("button_clicked", { button: "account_cta", type: "add", page: route.name });
     setOpen(true);
-  }, []);
+  }, [route.name]);
 
   const close = useCallback(() => setOpen(false), []);
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio "Crypto accounts" CTA button now navigates to the accounts/addresses page instead of the asset list
      - Portfolio "Add account" CTA button tracking event is now consistent with the tracking plan
      - Verify tracking events fire correctly with `button: "account_cta"` and proper `type` field

### 📝 Description

The tracking events for the Portfolio CTA buttons ("Add account" / "Crypto accounts") were inconsistent with the tracking plan, and the "Crypto accounts" button was navigating to the wrong screen.

**Tracking fix:** The empty-state "Add account" CTA was firing `button_clicked` with `{ button: "add_account_cta" }` instead of the expected `{ button: "account_cta", type: "add", page: route.name }`. Updated `useAddAccountCta` to mathe tracking plan and be consistent with `CryptoAddressesButton`.

**Navigation fix:** The "Crypto accounts" CTA was navigating to `AssetsList` (assets grouped by coin type) instead of `AccountsList` (individual accounts/addresses). Updated `useCryptoAddressesButtonViewModel` to navigate to the correct destination.

https://github.com/user-attachments/assets/2a8b94e3-3344-45b3-a0d1-07c617c277c0


### ❓ Context

- **JIRA or GitHub link**: [LIVE-26977](https://ledgerhq.atlassian.net/browse/LIVE-26977)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profior benchmarked if necessary)

[LIVE-26977]: https://ledgerhq.atlassian.net/browse/LIVE-26977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ