### PR TITLE
[LWM] fix(mobile): card landing top inset with experimental header

### DIFF
--- a/.changeset/quiet-moons-wait.md
+++ b/.changeset/quiet-moons-wait.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix Card landing top inset under experimental header (safe area)

--- a/apps/ledger-live-mobile/src/mvvm/features/Card/screens/CardLandingScreen/useCardLandingScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Card/screens/CardLandingScreen/useCardLandingScreenViewModel.ts
@@ -11,6 +11,8 @@ import { NavigatorName, ScreenName } from "~/const";
 import { useNavigation } from "@react-navigation/core";
 import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
 import { ImageSourcePropType } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useExperimental } from "~/experimental";
 
 const HEADER_HEIGHT = 48;
 
@@ -36,6 +38,8 @@ export const useCardLandingScreenViewModel = (): CardLandingScreenViewModelResul
   const [imageLoaded, setImageLoaded] = useState(false);
   const navigation = useNavigation();
   const { bottomBarHeight } = useNavigationBarHeights();
+  const { top: safeAreaTop } = useSafeAreaInsets();
+  const hasExperimentalHeader = useExperimental();
 
   const onImageLoaded = useCallback(() => setImageLoaded(true), []);
 
@@ -95,7 +99,7 @@ export const useCardLandingScreenViewModel = (): CardLandingScreenViewModelResul
     return require("~/images/portfolio/v4-light.webp");
   }, [isWallet40DarkMode]);
 
-  const topInset = HEADER_HEIGHT;
+  const topInset = hasExperimentalHeader ? safeAreaTop + HEADER_HEIGHT : HEADER_HEIGHT;
   const bottomInset = bottomBarHeight;
 
   return {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Card landing screen tests still pass; `topInset` with `useExperimental()` + safe area is not asserted explicitly._
- [x] **Impact of the changes:**
  - Card landing screen layout when experimental navigation / header is enabled
  - Devices with a top safe area (notch, Dynamic Island)

### 📝 Description

**Problem:** On the Card landing screen, content could sit under the system status area when the experimental header stack is active, because vertical padding only used a fixed header height.

**Solution:** When `useExperimental()` is true, `topInset` is now `safeAreaTop + HEADER_HEIGHT` (from `useSafeAreaInsets()`), so the hero aligns correctly below the status bar and header. The non-experimental path is unchanged (`HEADER_HEIGHT` only).

| Before | After |
| ------ | ----- |
| <img width="320" height="627" alt="image" src="https://github.com/user-attachments/assets/299ed6ce-baff-4ddf-bf90-635627fac815" />_ |<img width="320" height="2868" alt="image" src="https://github.com/user-attachments/assets/c419d3d8-bbbc-4df7-854d-175c1b8a577a" />|

DEMO

https://github.com/user-attachments/assets/8b732cc5-9044-4443-a5d9-2b01c573775c



### ❓ Context

- **JIRA or GitHub link**: [LIVE-28108](https://ledgerhq.atlassian.net/browse/LIVE-28108)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28108]: https://ledgerhq.atlassian.net/browse/LIVE-28108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ