### PR TITLE
[LWM] fix(mobile): close installed apps modal before dependency uninstall

### DIFF
--- a/.changeset/calm-apps-modal-close.md
+++ b/.changeset/calm-apps-modal-close.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Close installed apps modal when starting uninstall with dependencies

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/AppsList/AppUninstallButton.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/AppsList/AppUninstallButton.tsx
@@ -15,6 +15,7 @@ type Props = {
   state: State;
   dispatch: (_: Action) => void;
   size?: number;
+  onBeforeUninstallWithDependencies?: () => void;
 };
 
 const ButtonContainer = styled(Box).attrs({
@@ -23,7 +24,13 @@ const ButtonContainer = styled(Box).attrs({
   justifyContent: "center",
 })``;
 
-const AppUninstallButton = ({ app, state, dispatch, size = 48 }: Props) => {
+const AppUninstallButton = ({
+  app,
+  state,
+  dispatch,
+  size = 48,
+  onBeforeUninstallWithDependencies,
+}: Props) => {
   const { name } = app;
 
   const needsDependencies = useAppUninstallNeedsDeps(state, app);
@@ -32,10 +39,19 @@ const AppUninstallButton = ({ app, state, dispatch, size = 48 }: Props) => {
     useSetAppsWithDependenciesToInstallUninstall();
 
   const uninstallApp = useCallback(() => {
-    if (needsDependencies && setAppUninstallWithDependencies)
+    if (needsDependencies && setAppUninstallWithDependencies) {
+      onBeforeUninstallWithDependencies?.();
       setAppUninstallWithDependencies(needsDependencies);
-    else dispatch({ type: "uninstall", name });
-  }, [needsDependencies, setAppUninstallWithDependencies, dispatch, name]);
+    } else {
+      dispatch({ type: "uninstall", name });
+    }
+  }, [
+    needsDependencies,
+    setAppUninstallWithDependencies,
+    dispatch,
+    name,
+    onBeforeUninstallWithDependencies,
+  ]);
 
   return (
     <TouchableOpacity onPress={uninstallApp} testID={`app-${name}-installed`}>

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Modals/InstalledAppsModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Modals/InstalledAppsModal.tsx
@@ -28,9 +28,10 @@ type UninstallButtonProps = {
   app: App;
   state: State;
   dispatch: (_: Action) => void;
+  onClose: () => void;
 };
 
-const UninstallButton = ({ app, state, dispatch }: UninstallButtonProps) => {
+const UninstallButton = ({ app, state, dispatch, onClose }: UninstallButtonProps) => {
   const { uninstallQueue } = state;
   const uninstalling = useMemo(() => uninstallQueue.includes(app.name), [uninstallQueue, app.name]);
   const renderAppState = () => {
@@ -38,7 +39,15 @@ const UninstallButton = ({ app, state, dispatch }: UninstallButtonProps) => {
       case uninstalling:
         return <AppProgressButton state={state} name={app.name} size={34} />;
       default:
-        return <AppUninstallButton app={app} state={state} dispatch={dispatch} size={34} />;
+        return (
+          <AppUninstallButton
+            app={app}
+            state={state}
+            dispatch={dispatch}
+            size={34}
+            onBeforeUninstallWithDependencies={onClose}
+          />
+        );
     }
   };
 
@@ -50,9 +59,10 @@ type RowProps = {
   state: State;
   dispatch: (_: Action) => void;
   deviceInfo: DeviceInfo;
+  onClose: () => void;
 };
 
-const Row = ({ app, state, dispatch, deviceInfo }: RowProps) => (
+const Row = ({ app, state, dispatch, deviceInfo, onClose }: RowProps) => (
   <Flex flexDirection="row" py={4} alignItems="center" justifyContent="space-between">
     <Flex flexDirection="row" alignItems="center">
       <AppIcon app={app} size={24} />
@@ -68,7 +78,7 @@ const Row = ({ app, state, dispatch, deviceInfo }: RowProps) => (
           firmwareVersion={deviceInfo.version}
         />
       </Text>
-      <UninstallButton app={app} state={state} dispatch={dispatch} />
+      <UninstallButton app={app} state={state} dispatch={dispatch} onClose={onClose} />
     </Flex>
   </Flex>
 );
@@ -96,9 +106,9 @@ const InstalledAppsModal = ({
 
   const renderItem = useCallback(
     ({ item }: { item: App }) => (
-      <Row app={item} state={state} dispatch={dispatch} deviceInfo={deviceInfo} />
+      <Row app={item} state={state} dispatch={dispatch} deviceInfo={deviceInfo} onClose={onClose} />
     ),
-    [deviceInfo, dispatch, state],
+    [deviceInfo, dispatch, state, onClose],
   );
 
   useEffect(() => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new automated tests; callback wiring only._
- [x] **Impact of the changes:**
  - My Ledger device screen → Installed apps modal
  - Uninstalling an app that triggers the “uninstall with dependencies” flow

### 📝 Description

**Problem**: Starting an uninstall with dependencies from the Installed apps modal could leave the modal open while the dependency uninstall flow appears, which hurts clarity and stacking behavior ([LIVE-25877](https://ledgerhq.atlassian.net/browse/LIVE-25877)).

**Solution**:
- Extended `AppUninstallButton` with optional `onBeforeUninstallWithDependencies`, invoked immediately before `setAppUninstallWithDependencies` when the app has dependencies to remove first.
- `InstalledAppsModal` passes `onClose` so the modal dismisses before that flow starts.

### 📸 Screenshots


https://github.com/user-attachments/assets/4a2a236c-c02c-4aad-a0df-62a446071439



### ❓ Context

- **JIRA or GitHub link**: [LIVE-25877](https://ledgerhq.atlassian.net/browse/LIVE-25877)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25877]: https://ledgerhq.atlassian.net/browse/LIVE-25877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-25877]: https://ledgerhq.atlassian.net/browse/LIVE-25877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ