### PR TITLE
[LWDM] chore(coin-solana): intercept `-32020` on method `getSignaturesForAdd…

### DIFF
--- a/.changeset/five-dancers-retire.md
+++ b/.changeset/five-dancers-retire.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+chore(coin-solana): intercept error code -32020 on `getSignaturesForAddress`

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type { ParsedInstruction, PartiallyDecodedInstruction } from "@solana/web3.js";
 import { PublicKey } from "@solana/web3.js";
+import { http, HttpResponse } from "msw";
 import { listOperations } from "../listOperations";
-import { server, rpcHandler, createTestChainApi } from "./helpers/msw-rpc.mock";
+import { server, rpcHandler, createTestChainApi, TEST_ENDPOINT } from "./helpers/msw-rpc.mock";
 
 const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
 const TEST_RECIPIENT = "AjmMiagw33Ad4WdPR3y2QWsDXaLxmsiSZEpMfpT1Q9uZ";
@@ -68,6 +69,30 @@ describe("listOperations (MSW integration)", () => {
 
     expect(result.items).toEqual([]);
     expect(result.next).toBeUndefined();
+  });
+
+  it("intercepts error code -32020", async () => {
+    server.use(
+      http.post(TEST_ENDPOINT, async ({ request }) => {
+        const body: unknown = await request.clone().json();
+        if (
+          typeof body === "object" &&
+          body !== null &&
+          "method" in body &&
+          body.method === "getSignaturesForAddress"
+        ) {
+          return HttpResponse.json({
+            jsonrpc: "2.0",
+            error: { code: -32020, message: "Invalid param: until" },
+            id: "1",
+          });
+        }
+      }),
+    );
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result).toEqual({ items: [] });
   });
 
   it("should parse an OUT operation from RPC data", async () => {

--- a/libs/coin-modules/coin-solana/src/network/chain/index.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/index.ts
@@ -21,6 +21,7 @@ import {
   BlockhashWithExpiryBlockHeight,
   Commitment,
   GetLatestBlockhashConfig,
+  SolanaJSONRPCError,
 } from "@solana/web3.js";
 import ky from "ky";
 import { getTokenAccountProgramId } from "../../helpers/token";
@@ -141,6 +142,9 @@ const kyNoTimeout = ky.create({
   },
 });
 
+// https://github.com/anza-xyz/agave/blob/abfc33086c3eda73f89c0105e329a31c6b147ed0/rpc-client-api/src/custom_error.rs#L31
+const JSON_RPC_SERVER_ERROR_FILTER_TRANSACTION_NOT_FOUND = -32020;
+
 export function getChainAPI(
   config: Config,
   logger?: (url: string, options: any) => void,
@@ -224,7 +228,15 @@ export function getChainAPI(
 
     getSignaturesForAddress: (address: string, opts?: SignaturesForAddressOptions) => {
       const callback = () => {
-        return connection.getSignaturesForAddress(new PublicKey(address), opts);
+        return connection.getSignaturesForAddress(new PublicKey(address), opts).catch(err => {
+          if (
+            err instanceof SolanaJSONRPCError &&
+            err.code === JSON_RPC_SERVER_ERROR_FILTER_TRANSACTION_NOT_FOUND
+          ) {
+            return [];
+          }
+          throw err;
+        });
       };
       return callback().catch(remapErrorsWithRetry(callback));
     },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Solana sync / listOperations

### 📝 Description

Starting with Agave v4.0, getSignaturesForAddress returns a JSON-RPC error with code -32020 when the before or until cursor signature is not found, instead of returning an empty array.
This is catching the error and returning an empty array to reproduce the same behaviour.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
