### PR TITLE
[LWD] feat(desktop): gate tracking on consent date and privacy policy version

### DIFF
--- a/.changeset/fluffy-yaks-hope.md
+++ b/.changeset/fluffy-yaks-hope.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+LWD: change tracking enabled logic to check on last analytics consent date and privacy policy version

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
@@ -6,6 +6,7 @@ import { BottomCarouselContentCards } from "../components/BottomCarouselContentC
 import { ClassicCard, logCardDismissal, logContentCardClick } from "@braze/web-sdk";
 import { track } from "~/renderer/analytics/segment";
 import { LocationContentCard } from "~/types/dynamicContent";
+import { CURRENT_PRIVACY_POLICY_VERSION } from "LLD/features/AnalyticsOptInPrompt/const/policyVersion";
 
 const brazeExtrasById: Record<string, { canvas_name: string; canvas_step_name: string }> = {
   "0": {
@@ -102,6 +103,8 @@ describe("PortfolioContentCards", () => {
         settings: {
           shareAnalytics: true,
           sharePersonalizedRecommandations: true,
+          lastAnalyticsConsentDate: new Date().toISOString(),
+          privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
         },
       },
     });
@@ -213,6 +216,8 @@ describe("BottomCarouselContentCards", () => {
         settings: {
           shareAnalytics: true,
           sharePersonalizedRecommandations: true,
+          lastAnalyticsConsentDate: new Date().toISOString(),
+          privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
         },
       },
     });

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
@@ -13,10 +13,20 @@ import reducer, {
   INITIAL_STATE as SETTINGS_INITIAL_STATE,
   SettingsState,
   filterValidSettings,
+  trackingEnabledSelector,
 } from "./settings";
+import { CURRENT_PRIVACY_POLICY_VERSION } from "LLD/features/AnalyticsOptInPrompt/const/policyVersion";
 
 const invalidDeviceModelIds = ["nanoFTS", undefined, "whatever"];
 const validDeviceModelIds: DeviceModelId[] = Object.values(DeviceModelId);
+
+const mockStateWithSettings = (settings: Partial<SettingsState>): State => ({
+  ...({} as State),
+  settings: {
+    ...SETTINGS_INITIAL_STATE,
+    ...settings,
+  },
+});
 
 describe("lastSeenDeviceSelector", () => {
   it("should return the last seen device if the deviceModelId is valid", () => {
@@ -306,5 +316,133 @@ describe("SAVE_SETTINGS action", () => {
     expect(newState.counterValue).toBe("AUD");
     expect(newState.theme).toBe("light");
     expect("nftCollectionsStatusByNetwork" in newState).toBe(false);
+  });
+});
+
+describe("trackingEnabledSelector", () => {
+  /** Frozen clock; consent offsets use UTC setters to match `trackingEnabledSelector` (UTC year cutoff). */
+  const FIXED_NOW = new Date("2024-06-15T12:00:00.000Z");
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  beforeEach(() => {
+    jest.setSystemTime(FIXED_NOW);
+  });
+
+  it("should not track if lastAnalyticsConsentDate is not set", () => {
+    expect(
+      trackingEnabledSelector(
+        mockStateWithSettings({
+          lastAnalyticsConsentDate: null,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("should not track if privacyPolicyVersion is not set", () => {
+    expect(
+      trackingEnabledSelector(
+        mockStateWithSettings({
+          privacyPolicyVersion: null,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  describe("opt-in analytics", () => {
+    it("should track if lastAnalyticsConsentDate is set and privacyPolicyVersion is set and is the current version", () => {
+      expect(
+        trackingEnabledSelector(
+          mockStateWithSettings({
+            lastAnalyticsConsentDate: FIXED_NOW.toISOString(),
+            privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+            shareAnalytics: true,
+            sharePersonalizedRecommandations: true,
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it("should not track if lastAnalyticsConsentDate is more than one year ago", () => {
+      const consentDate = new Date(FIXED_NOW);
+      consentDate.setUTCFullYear(consentDate.getUTCFullYear() - 1);
+      consentDate.setUTCMonth(consentDate.getUTCMonth() - 1);
+      expect(
+        trackingEnabledSelector(
+          mockStateWithSettings({
+            shareAnalytics: true,
+            sharePersonalizedRecommandations: true,
+            lastAnalyticsConsentDate: consentDate.toISOString(),
+            privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it("should track if lastAnalyticsConsentDate is exactly one year ago", () => {
+      const consentDate = new Date(FIXED_NOW);
+      consentDate.setUTCFullYear(consentDate.getUTCFullYear() - 1);
+      expect(
+        trackingEnabledSelector(
+          mockStateWithSettings({
+            shareAnalytics: true,
+            sharePersonalizedRecommandations: true,
+            lastAnalyticsConsentDate: consentDate.toISOString(),
+            privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it("should track if lastAnalyticsConsentDate is less than one year ago", () => {
+      const consentDate = new Date(FIXED_NOW);
+      consentDate.setUTCMonth(consentDate.getUTCMonth() - 11);
+      expect(
+        trackingEnabledSelector(
+          mockStateWithSettings({
+            shareAnalytics: true,
+            sharePersonalizedRecommandations: true,
+            lastAnalyticsConsentDate: consentDate.toISOString(),
+            privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it("should not track if lastAnalyticsConsentDate less than a year ago but privacyPolicyVersion is older than the current version", () => {
+      const consentDate = new Date(FIXED_NOW);
+      consentDate.setUTCMonth(consentDate.getUTCMonth() - 11);
+      expect(
+        trackingEnabledSelector(
+          mockStateWithSettings({
+            shareAnalytics: true,
+            sharePersonalizedRecommandations: true,
+            lastAnalyticsConsentDate: consentDate.toISOString(),
+            privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION - 1,
+          }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("opt-out analytics", () => {
+    it("should not track even if lastAnalyticsConsentDate is set and privacyPolicyVersion is set and is the current version", () => {
+      expect(
+        trackingEnabledSelector(
+          mockStateWithSettings({
+            lastAnalyticsConsentDate: FIXED_NOW.toISOString(),
+            privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+            shareAnalytics: false,
+            sharePersonalizedRecommandations: false,
+          }),
+        ),
+      ).toBe(false);
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -41,6 +41,7 @@ import {
 } from "../actions/constants";
 import { OnboardingUseCase } from "../components/Onboarding/OnboardingUseCase";
 import { Handlers } from "./types";
+import { CURRENT_PRIVACY_POLICY_VERSION } from "LLD/features/AnalyticsOptInPrompt/const/policyVersion";
 
 /* Initial state */
 
@@ -776,10 +777,37 @@ export const autoLockTimeoutSelector = (state: State) => state.settings.autoLock
 export const shareAnalyticsSelector = (state: State) => state.settings.shareAnalytics;
 export const sharePersonalizedRecommendationsSelector = (state: State) =>
   state.settings.sharePersonalizedRecommandations;
-export const trackingEnabledSelector = createSelector(
-  settingsStoreSelector,
-  s => s.shareAnalytics || s.sharePersonalizedRecommandations,
-);
+
+// Plain selector (not createSelector): wall-clock "now" is not in Redux, so the one-year cutoff must be recomputed on every read.
+export const trackingEnabledSelector = (state: State) => {
+  const s = state.settings;
+
+  if (!s.lastAnalyticsConsentDate || !s.privacyPolicyVersion) {
+    return false;
+  }
+
+  const lastAnalyticsConsentDate = new Date(s.lastAnalyticsConsentDate);
+  if (Number.isNaN(lastAnalyticsConsentDate.getTime())) {
+    return false;
+  }
+
+  const now = new Date();
+  // Copy `now`: `setUTCFullYear` mutates its receiver; the cutoff must be a separate Date from "right now".
+  const oneYearAgo = new Date(now.getTime());
+
+  oneYearAgo.setUTCFullYear(oneYearAgo.getUTCFullYear() - 1);
+
+  if (lastAnalyticsConsentDate.getTime() < oneYearAgo.getTime()) {
+    return false;
+  }
+
+  if (s.privacyPolicyVersion < CURRENT_PRIVACY_POLICY_VERSION) {
+    return false;
+  }
+
+  return s.shareAnalytics || s.sharePersonalizedRecommandations;
+};
+
 export const selectedTimeRangeSelector = (state: State) => state.settings.selectedTimeRange;
 export const hasInstalledAppsSelector = (state: State) => state.settings.hasInstalledApps;
 export const USBTroubleshootingIndexSelector = (state: State) =>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ShareAnalyticsButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ShareAnalyticsButton.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { useSelector, useDispatch } from "LLD/hooks/redux";
-import { trackingEnabledSelector } from "~/renderer/reducers/settings";
+import {
+  shareAnalyticsSelector,
+  sharePersonalizedRecommendationsSelector,
+} from "~/renderer/reducers/settings";
 import {
   setShareAnalytics,
   setSharePersonalizedRecommendations,
@@ -10,7 +13,10 @@ import Track from "~/renderer/analytics/Track";
 import Switch from "~/renderer/components/Switch";
 
 const ShareAnalyticsButton = () => {
-  const shareAnalytics = useSelector(trackingEnabledSelector);
+  const shareAnalytics = useSelector(shareAnalyticsSelector);
+  const sharePersonalizedRecommendations = useSelector(sharePersonalizedRecommendationsSelector);
+  const isChecked = shareAnalytics && sharePersonalizedRecommendations;
+
   const dispatch = useDispatch();
 
   const toggleShareAnalytics = async (value: boolean) => {
@@ -21,9 +27,9 @@ const ShareAnalyticsButton = () => {
 
   return (
     <>
-      <Track mandatory onUpdate event={shareAnalytics ? "AnalyticsEnabled" : "AnalyticsDisabled"} />
+      <Track mandatory onUpdate event={isChecked ? "AnalyticsEnabled" : "AnalyticsDisabled"} />
       <Switch
-        isChecked={shareAnalytics}
+        isChecked={isChecked}
         onChange={toggleShareAnalytics}
         data-e2e="shareAnalytics_button"
       />

--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -3,6 +3,7 @@ import fsPromises from "fs/promises";
 import merge from "lodash/merge";
 import * as path from "path";
 import { OptionalFeatureMap } from "@ledgerhq/types-live";
+import { CURRENT_PRIVACY_POLICY_VERSION } from "LLD/features/AnalyticsOptInPrompt/const/policyVersion";
 
 import { Application } from "tests/page";
 import { safeAppendFile } from "tests/utils/fileUtils";
@@ -33,7 +34,8 @@ export const test = base.extend<TestFixtures>({
   lang: "en-US",
   theme: "dark",
   userdata: undefined,
-  settings: { shareAnalytics: true, hasSeenAnalyticsOptInPrompt: true },
+  /** Merged in `electronApp` with consent defaults so `trackingEnabledSelector` can be true in E2E. */
+  settings: {},
   featureFlags: undefined,
   simulateCamera: undefined,
 
@@ -73,7 +75,15 @@ export const test = base.extend<TestFixtures>({
       ? await fsPromises.readFile(userdataOriginalFile, { encoding: "utf-8" }).then(JSON.parse)
       : {};
 
-    const userData = merge({ data: { settings } }, fileUserData);
+    const settingsWithConsentDefaults = {
+      shareAnalytics: true,
+      hasSeenAnalyticsOptInPrompt: true,
+      lastAnalyticsConsentDate: new Date().toISOString(),
+      privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+      ...settings,
+    };
+
+    const userData = merge(fileUserData, { data: { settings: settingsWithConsentDefaults } });
     await fsPromises.writeFile(`${userdataDestinationPath}/app.json`, JSON.stringify(userData));
 
     // default environment variables


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - **`trackingEnabledSelector` (Segment / Braze / dynamic content / webviews, etc.)**: Consent + eligibility first (valid `lastAnalyticsConsentDate`, ≤ 1 calendar year in UTC vs “now”, `privacyPolicyVersion` ≥ current), then `shareAnalytics || sharePersonalizedRecommandations`.
  - **Settings → “Share analytics”**: Switch reflects **`shareAnalytics` ∧ `sharePersonalizedRecommandations`** (legacy combined control), **not** `trackingEnabledSelector`.
  - **Upgrades**: No consent metadata in persisted settings → not trackable until a flow writes `lastAnalyticsConsentDate` / `privacyPolicyVersion` (e.g. opt-in prompt). Toggling in General only updates the two share flags.
  - **Playwright / E2E**: `tests/fixtures/common.ts` merges **`settingsWithConsentDefaults`** into `app.json` so `SEGMENT_TEST` / `waitForTracking` flows keep working without editing every userdata snapshot.
  - **Tests**: `PortfolioContentCards.test.tsx` adjusted for the new consent gate where relevant.

### 📝 Description

#### Scope (amended)

This PR is intentionally **narrow**: `settings` gate + selectors, **Share analytics** switch wiring, **`settings.test.ts`**, **E2E settings merge**, one **Dynamic Content** integration test tweak, and the **changeset**. *Playwright drawer helper changes are not part of this branch.*

#### `trackingEnabledSelector` — what it is

`trackingEnabledSelector` is the **“may we send behavioural analytics?”** gate. It must **not** drive the analytics toggle UI.

It returns `true` only if:

1. **`lastAnalyticsConsentDate`** is set and parses to a valid date.
2. **Freshness**: consent is **not older than one calendar year** vs “now”, using **UTC** `setUTCFullYear` on a **copy** of `now` (avoids mutating the live `Date`).
3. **`privacyPolicyVersion`** is set and **≥ `CURRENT_PRIVACY_POLICY_VERSION`**.
4. **Opt-in**: `shareAnalytics || sharePersonalizedRecommandations`.

**Implementation:** plain `(state) => boolean`, not `createSelector`, so the year cutoff is recomputed every read (time is not in Redux).

**Historical note:** “Tracking on” used to line up with the **OR** of both toggles. The gate still uses that OR **after** consent + policy checks, which is easy to confuse with switch position—hence splitting **UI state** from **`trackingEnabledSelector`**.

#### Settings switch vs gate

`trackingEnabledSelector` for `isChecked` broke the UX: the switch looked **off** when consent was missing/stale even after toggle, because toggles do not update consent fields.

**Change:** `ShareAnalyticsButton` uses **`shareAnalyticsSelector` ∧ `sharePersonalizedRecommendationsSelector`** for `isChecked`. Segment and other call sites keep **`trackingEnabledSelector`** for real tracking permission.

#### Tests

- **`settings.test.ts`**: missing consent, invalid date, stale consent (~13 months), old policy version, one-year boundary (fake timers, UTC), both toggles off → no tracking.
- **`common.ts`**: default consent + policy version + opt-in flags merged when composing persisted settings for tests.

<table>
<tr>
 <td><video src="https://github.com/user-attachments/assets/232daf1d-9db1-40cc-a6ac-353720fdf563"/>
 <td><video src="https://github.com/user-attachments/assets/c01e5c43-7adc-432d-905f-e751bd1d147f"/>
 <td><video src="https://github.com/user-attachments/assets/586788dd-df67-46c3-bb83-9ac4f124b0fa"/>
<tr>
 <td><video src="https://github.com/user-attachments/assets/78c855e2-970f-4763-b9a3-a824c424a8af"/>
 <td><video src="https://github.com/user-attachments/assets/6bcea36d-d959-4264-a5e5-100a1ace4a8d"/>
<td><video src="https://github.com/user-attachments/assets/7c7ddb88-59b9-4dde-9d17-949df78fc011" />

</table>

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25920](https://ledgerhq.atlassian.net/browse/LIVE-25920)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-25920]: https://ledgerhq.atlassian.net/browse/LIVE-25920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ