### PR TITLE
[LWM] feat: lwm update bottom braze carousel card component

### DIFF
--- a/.changeset/silver-students-brush.md
+++ b/.changeset/silver-students-brush.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat: lwm update bottom braze carousel card component

--- a/apps/ledger-live-mobile/src/actions/dynamicContent.ts
+++ b/apps/ledger-live-mobile/src/actions/dynamicContent.ts
@@ -1,6 +1,6 @@
 import { createAction } from "redux-actions";
 import {
-  WalletContentCard,
+  type WalletContentCard,
   AssetContentCard,
   NotificationContentCard,
   CategoryContentCard,
@@ -16,6 +16,7 @@ import {
   DynamicContentSetLandingStickyCtaCardsPayload,
   DynamicContentAddLocalCardsPayload,
   DynamicContentRemoveLocalCardPayload,
+  DynamicContentAddLocalWalletCarouselPayload,
 } from "./types";
 
 const setDynamicContentWalletCardsAction = createAction<DynamicContentSetWalletCardsPayload>(
@@ -85,3 +86,11 @@ const removeLocalCardAction = createAction<DynamicContentRemoveLocalCardPayload>
 );
 
 export const removeLocalCard = (cardId: string) => removeLocalCardAction(cardId);
+
+const addLocalWalletCarouselCardsAction =
+  createAction<DynamicContentAddLocalWalletCarouselPayload>(
+    DynamicContentActionTypes.DYNAMIC_CONTENT_ADD_LOCAL_WALLET_CAROUSEL_CARDS,
+  );
+
+export const addLocalWalletCarouselCards = (cards: DynamicContentAddLocalWalletCarouselPayload) =>
+  addLocalWalletCarouselCardsAction(cards);

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -36,6 +36,11 @@ import type { ImportAccountsReduceInput } from "@ledgerhq/live-wallet/liveqr/imp
 import type { Steps } from "LLM/features/WalletSync/types/Activation";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import type { UnknownAction } from "redux";
+import type {
+  BrazeContentCard,
+  CategoryContentCard,
+  WalletContentCard,
+} from "../dynamicContent/types";
 
 //  === ACCOUNTS ACTIONS ===
 
@@ -184,6 +189,7 @@ export enum DynamicContentActionTypes {
   DYNAMIC_CONTENT_ADD_LOCAL_CARDS = "DYNAMIC_CONTENT_ADD_LOCAL_CARDS",
   DYNAMIC_CONTENT_CLEAR_LOCAL_CARDS = "DYNAMIC_CONTENT_CLEAR_LOCAL_CARDS",
   DYNAMIC_CONTENT_REMOVE_LOCAL_CARD = "DYNAMIC_CONTENT_REMOVE_LOCAL_CARD",
+  DYNAMIC_CONTENT_ADD_LOCAL_WALLET_CAROUSEL_CARDS = "DYNAMIC_CONTENT_ADD_LOCAL_WALLET_CAROUSEL_CARDS",
 }
 
 export type DynamicContentSetWalletCardsPayload = DynamicContentState["walletCards"];
@@ -199,11 +205,13 @@ export type DynamicContentSetLandingStickyCtaCardsPayload =
 export type DynamicContentSetMobileCardsPayload = DynamicContentState["mobileCards"];
 
 export type DynamicContentAddLocalCardsPayload = {
-  category: import("../dynamicContent/types").CategoryContentCard;
-  cards: import("../dynamicContent/types").BrazeContentCard[];
+  category: CategoryContentCard;
+  cards: BrazeContentCard[];
 };
 
 export type DynamicContentRemoveLocalCardPayload = string;
+
+export type DynamicContentAddLocalWalletCarouselPayload = WalletContentCard[];
 
 export type DynamicContentPayload =
   | DynamicContentSetWalletCardsPayload
@@ -213,7 +221,8 @@ export type DynamicContentPayload =
   | DynamicContentSetLandingStickyCtaCardsPayload
   | DynamicContentSetMobileCardsPayload
   | DynamicContentAddLocalCardsPayload
-  | DynamicContentRemoveLocalCardPayload;
+  | DynamicContentRemoveLocalCardPayload
+  | DynamicContentAddLocalWalletCarouselPayload;
 
 // === RATINGS ACTIONS ===
 

--- a/apps/ledger-live-mobile/src/components/Carousel/CarouselCard.tsx
+++ b/apps/ledger-live-mobile/src/components/Carousel/CarouselCard.tsx
@@ -1,6 +1,8 @@
 import React, { memo, useCallback } from "react";
 import { Linking } from "react-native";
 import { Flex, FullBackgroundCard } from "@ledgerhq/native-ui";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { MediaCard, MediaCardTitle, Tag } from "@ledgerhq/lumen-ui-rnative";
 import { useTheme } from "styled-components/native";
 import { WalletContentCard } from "~/dynamicContent/types";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
@@ -15,6 +17,7 @@ type CarouselCardProps = {
 
 const CarouselCard = ({ id, cardProps, index, width }: CarouselCardProps) => {
   const { theme } = useTheme();
+  const { shouldDisplayBrazePlacement } = useWalletFeaturesConfig("mobile");
   const { logClickCard, dismissCard, trackContentCardEvent } = useDynamicContent();
 
   const onPress = useCallback(async () => {
@@ -42,6 +45,21 @@ const CarouselCard = ({ id, cardProps, index, width }: CarouselCardProps) => {
     });
     dismissCard(cardProps.id);
   }, [cardProps, trackContentCardEvent, dismissCard]);
+
+  if (shouldDisplayBrazePlacement) {
+    return (
+      <Flex key={`container_${id}`} mr={6} ml={index === 0 ? 6 : 0} width={width}>
+        <MediaCard
+          imageUrl={cardProps.image ?? ""}
+          onPress={cardProps.link ? onPress : undefined}
+          onClose={onHide}
+        >
+          {cardProps.tag ? <Tag label={cardProps.tag} size="md" /> : null}
+          {cardProps.title ? <MediaCardTitle>{cardProps.title}</MediaCardTitle> : null}
+        </MediaCard>
+      </Flex>
+    );
+  }
 
   return (
     <Flex key={`container_${id}`} mr={6} ml={index === 0 ? 6 : 0} width={width}>

--- a/apps/ledger-live-mobile/src/dynamicContent/brazeContentCard.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/brazeContentCard.ts
@@ -1,41 +1,49 @@
 import Braze from "@braze/react-native-sdk";
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { track } from "~/analytics";
 import { setDismissedContentCard } from "~/actions/settings";
 import { trackingEnabledSelector } from "~/reducers/settings";
-import { localMobileCardsSelector } from "~/reducers/dynamicContent";
+import { localMobileCardsSelector, localWalletCardsSelector } from "~/reducers/dynamicContent";
 
-const isLocalCard = (cardId: string, localMobileCards: Braze.ContentCard[]) =>
-  localMobileCards.some(c => c.id === cardId);
+const isLocalCard = (
+  cardId: string,
+  localMobileCards: Braze.ContentCard[],
+  localWalletCardIds: Set<string>,
+) => localMobileCards.some(c => c.id === cardId) || localWalletCardIds.has(cardId);
 
 export const useBrazeContentCard = (mobileCards: Braze.ContentCard[]) => {
   const isTrackedUser = useSelector(trackingEnabledSelector);
   const localMobileCards = useSelector(localMobileCardsSelector);
+  const localWalletCards = useSelector(localWalletCardsSelector);
+  const localWalletCardIds = useMemo(
+    () => new Set(localWalletCards.map(c => c.id)),
+    [localWalletCards],
+  );
   const mobileCardRef = useRef(mobileCards);
   const dispatch = useDispatch();
 
   const logDismissCard = useCallback(
     (cardId: string) => {
       if (isTrackedUser) {
-        const isLocal = isLocalCard(cardId, localMobileCards);
+        const isLocal = isLocalCard(cardId, localMobileCards, localWalletCardIds);
         if (isLocal) return;
         Braze.logContentCardDismissed(cardId);
       } else {
         dispatch(setDismissedContentCard({ [cardId]: Date.now() }));
       }
     },
-    [isTrackedUser, dispatch, localMobileCards],
+    [isTrackedUser, dispatch, localMobileCards, localWalletCardIds],
   );
 
   const logClickCard = useCallback(
     (cardId: string) => {
       if (!isTrackedUser) return;
-      const isLocal = isLocalCard(cardId, localMobileCards);
+      const isLocal = isLocalCard(cardId, localMobileCards, localWalletCardIds);
       if (isLocal) return;
       Braze.logContentCardClicked(cardId);
     },
-    [isTrackedUser, localMobileCards],
+    [isTrackedUser, localMobileCards, localWalletCardIds],
   );
 
   const logImpressionCard = useCallback(
@@ -44,7 +52,7 @@ export const useBrazeContentCard = (mobileCards: Braze.ContentCard[]) => {
 
       const card = mobileCardRef.current.find(card => card.id === cardId);
 
-      const isLocal = isLocalCard(cardId, localMobileCards);
+      const isLocal = isLocalCard(cardId, localMobileCards, localWalletCardIds);
 
       if (isLocal) return;
 
@@ -57,7 +65,7 @@ export const useBrazeContentCard = (mobileCards: Braze.ContentCard[]) => {
         displayedPosition,
       });
     },
-    [isTrackedUser, localMobileCards],
+    [isTrackedUser, localMobileCards, localWalletCardIds],
   );
 
   const refreshDynamicContent = () => Braze.requestContentCardsRefresh();

--- a/apps/ledger-live-mobile/src/dynamicContent/buildLocalContentCards.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/buildLocalContentCards.ts
@@ -1,9 +1,11 @@
 import {
+  Background,
   ContentCardLocation,
   ContentCardsLayout,
   ContentCardsType,
   type BrazeContentCard,
   type CategoryContentCard,
+  type WalletContentCard,
 } from "./types";
 
 const SAMPLE_IMAGE =
@@ -151,4 +153,24 @@ export function buildSampleActionCarousel(
   );
 
   return { category, cards };
+}
+
+/** Bottom Portfolio wallet carousel (`location: wallet`) — one slide with the same shape as Braze wallet cards. */
+export function buildSampleWalletCarousel(): WalletContentCard[] {
+  const ts = Date.now();
+  return [
+    {
+      id: `local-wallet-carousel-${ts}`,
+      location: ContentCardLocation.Wallet,
+      createdAt: ts,
+      viewed: false,
+      order: 0,
+      tag: "Discover",
+      title: "Sample bottom carousel",
+      link: "https://www.ledger.com/",
+      image: SAMPLE_IMAGE,
+      background: Background.purple,
+      extras: { source: "local-debug" },
+    },
+  ];
 }

--- a/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.tsx
@@ -8,6 +8,7 @@ import {
   mobileCardsSelector,
   mobileCardsFromBrazeSelector,
   localMobileCardsSelector,
+  localWalletCardsSelector,
   notificationsCardsSelector,
   walletCardsSelector,
   landingPageStickyCtaCardsSelector,
@@ -33,6 +34,7 @@ const useDynamicContent = () => {
   const mobileCards = useSelector(mobileCardsSelector);
   const mobileCardsFromBraze = useSelector(mobileCardsFromBrazeSelector);
   const localMobileCards = useSelector(localMobileCardsSelector);
+  const localWalletCards = useSelector(localWalletCardsSelector);
   const hiddenCards: string[] = useSelector(dismissedDynamicCardsSelector);
 
   const { logClickCard, logDismissCard, logImpressionCard, refreshDynamicContent } =
@@ -75,7 +77,8 @@ const useDynamicContent = () => {
   const dismissCard = useCallback(
     (cardId: string) => {
       dispatch(setDismissedDynamicCards([...hiddenCards, cardId]));
-      const isLocal = localMobileCards.some(c => c.id === cardId);
+      const isLocal =
+        localMobileCards.some(c => c.id === cardId) || localWalletCards.some(c => c.id === cardId);
       if (isLocal) {
         dispatch(removeLocalCard(cardId));
       } else {
@@ -83,7 +86,7 @@ const useDynamicContent = () => {
       }
       logDismissCard(cardId);
     },
-    [dispatch, hiddenCards, localMobileCards, mobileCardsFromBraze, logDismissCard],
+    [dispatch, hiddenCards, localMobileCards, localWalletCards, mobileCardsFromBraze, logDismissCard],
   );
 
   const trackContentCardEvent = useCallback(
@@ -92,7 +95,11 @@ const useDynamicContent = () => {
       params: Record<string, string | number | undefined>,
     ) => {
       const cardId = params.campaign;
-      if (typeof cardId === "string" && localMobileCards.some(c => c.id === cardId)) return;
+      if (
+        typeof cardId === "string" &&
+        (localMobileCards.some(c => c.id === cardId) || localWalletCards.some(c => c.id === cardId))
+      )
+        return;
       try {
         await track(event, params);
         if (event === "contentcard_clicked") {
@@ -104,7 +111,7 @@ const useDynamicContent = () => {
         // Analytics must never block the user action that follows.
       }
     },
-    [localMobileCards],
+    [localMobileCards, localWalletCards],
   );
 
   return {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3592,6 +3592,8 @@
         "addSampleActionCarouselIconDesc": "ContentBanner with Spot icons — Buy, Swap, Stake. Requires Braze placement flag.",
         "addSampleActionCarouselImageBackground": "Add action carousel (image)",
         "addSampleActionCarouselImageBackgroundDesc": "MediaBanner with image_background — Buy, Swap, Stake. Requires Braze placement flag.",
+        "addSampleWalletCarousel": "Add bottom wallet carousel (mock)",
+        "addSampleWalletCarouselDesc": "One mock card in the Portfolio bottom carousel (tag, title, image, link). No Braze.",
         "dismissAll": "Dismiss all local cards",
         "dismissAllDesc": "Remove all locally generated content cards."
       }

--- a/apps/ledger-live-mobile/src/reducers/dynamicContent.ts
+++ b/apps/ledger-live-mobile/src/reducers/dynamicContent.ts
@@ -12,6 +12,7 @@ import {
   DynamicContentSetLandingStickyCtaCardsPayload,
   DynamicContentAddLocalCardsPayload,
   DynamicContentRemoveLocalCardPayload,
+  DynamicContentAddLocalWalletCarouselPayload,
 } from "../actions/types";
 import { createSelector } from "~/context/selectors";
 
@@ -25,6 +26,7 @@ export const INITIAL_STATE: DynamicContentState = {
   isLoading: true,
   localCategoriesCards: [],
   localMobileCards: [],
+  localWalletCards: [],
 };
 
 const handlers: ReducerMap<DynamicContentState, DynamicContentPayload> = {
@@ -69,10 +71,19 @@ const handlers: ReducerMap<DynamicContentState, DynamicContentPayload> = {
     ...state,
     localCategoriesCards: [],
     localMobileCards: [],
+    localWalletCards: [],
+  }),
+  [DynamicContentActionTypes.DYNAMIC_CONTENT_ADD_LOCAL_WALLET_CAROUSEL_CARDS]: (state, action) => ({
+    ...state,
+    localWalletCards: [
+      ...state.localWalletCards,
+      ...(action as Action<DynamicContentAddLocalWalletCarouselPayload>).payload,
+    ],
   }),
   [DynamicContentActionTypes.DYNAMIC_CONTENT_REMOVE_LOCAL_CARD]: (state, action) => {
     const cardId = (action as Action<DynamicContentRemoveLocalCardPayload>).payload;
     const localMobileCards = state.localMobileCards.filter(c => c.id !== cardId);
+    const localWalletCards = state.localWalletCards.filter(c => c.id !== cardId);
     const categoryIdsWithCards = new Set(
       localMobileCards.map(c => (c.extras as { categoryId?: string })?.categoryId).filter(Boolean),
     );
@@ -82,6 +93,7 @@ const handlers: ReducerMap<DynamicContentState, DynamicContentPayload> = {
     return {
       ...state,
       localMobileCards,
+      localWalletCards,
       localCategoriesCards,
     };
   },
@@ -90,7 +102,13 @@ const handlers: ReducerMap<DynamicContentState, DynamicContentPayload> = {
 // Selectors
 export const assetsCardsSelector = (s: State) => s.dynamicContent.assetsCards;
 
-export const walletCardsSelector = (s: State) => s.dynamicContent.walletCards;
+export const walletCardsSelector = createSelector(
+  (s: State) => s.dynamicContent.walletCards,
+  (s: State) => s.dynamicContent.localWalletCards,
+  (walletCards, localWalletCards) => walletCards.concat(localWalletCards),
+);
+
+export const localWalletCardsSelector = (s: State) => s.dynamicContent.localWalletCards;
 
 export const notificationsCardsSelector = (s: State) => s.dynamicContent.notificationCards;
 

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -154,6 +154,8 @@ export type DynamicContentState = {
   localCategoriesCards: CategoryContentCard[];
   /** Local/debug mobile cards (merged in selectors, not from Braze) */
   localMobileCards: BrazeContentCard[];
+  /** Local/debug wallet carousel cards (bottom Portfolio carousel, merged in selector) */
+  localWalletCards: WalletContentCard[];
 };
 
 // === IN VIEW STATE ===

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.tsx
@@ -4,10 +4,15 @@ import { Alert, Flex, IconsLegacy } from "@ledgerhq/native-ui";
 import { useDispatch } from "~/context/hooks";
 import SettingsNavigationScrollView from "../../SettingsNavigationScrollView";
 import SettingsRow from "~/components/SettingsRow";
-import { addLocalContentCards, clearLocalContentCards } from "~/actions/dynamicContent";
+import {
+  addLocalContentCards,
+  addLocalWalletCarouselCards,
+  clearLocalContentCards,
+} from "~/actions/dynamicContent";
 import {
   buildSampleBanner,
   buildSampleActionCarousel,
+  buildSampleWalletCarousel,
 } from "~/dynamicContent/buildLocalContentCards";
 
 export default function DebugContentCards() {
@@ -27,6 +32,10 @@ export default function DebugContentCards() {
   const onAddSampleActionCarouselImageBackground = useCallback(() => {
     const { category, cards } = buildSampleActionCarousel("imageBackground");
     dispatch(addLocalContentCards({ category, cards }));
+  }, [dispatch]);
+
+  const onAddSampleWalletCarousel = useCallback(() => {
+    dispatch(addLocalWalletCarouselCards(buildSampleWalletCarousel()));
   }, [dispatch]);
 
   const onDismissAll = useCallback(() => {
@@ -56,6 +65,12 @@ export default function DebugContentCards() {
         desc={t("settings.debug.contentCards.addSampleActionCarouselImageBackgroundDesc")}
         iconLeft={<IconsLegacy.LayersMedium size={24} color="black" />}
         onPress={onAddSampleActionCarouselImageBackground}
+      />
+      <SettingsRow
+        title={t("settings.debug.contentCards.addSampleWalletCarousel")}
+        desc={t("settings.debug.contentCards.addSampleWalletCarouselDesc")}
+        iconLeft={<IconsLegacy.WalletMedium size={24} color="black" />}
+        onPress={onAddSampleWalletCarousel}
       />
       <SettingsRow
         title={t("settings.debug.contentCards.dismissAll")}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- update bottom braze carousel card component with lumen
- add a button in braze tool to generate mock
<img width="377" height="774" alt="Screenshot 2026-03-31 at 13 23 42" src="https://github.com/user-attachments/assets/7bb63302-4539-4da7-a64c-684dd859581a" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26628]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26628]: https://ledgerhq.atlassian.net/browse/LIVE-26628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ