### PR TITLE
[LWDM] fix(e2e): add missing confirm step for btc-based coins on non-touch devices

### DIFF
--- a/.changeset/fix-btc-like-e2e.md
+++ b/.changeset/fix-btc-like-e2e.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix(e2e): add missing confirm step for btc-based coins on non-touch devices

--- a/libs/ledger-live-common/src/e2e/families/bitcoin.ts
+++ b/libs/ledger-live-common/src/e2e/families/bitcoin.ts
@@ -40,6 +40,11 @@ export const sendBTCBasedCoin = withDeviceController(
       if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
       } else {
+        if (currencyId !== Currency.ZEC.id) {
+          await buttons.both();
+          await waitFor(DeviceLabels.CONFIRM);
+          await pressUntilTextFound(DeviceLabels.ACCEPT);
+        }
         await buttons.both();
       }
     },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - BTC-based coin e2e send flows on non-touch devices (Nano S, Nano X, Nano S Plus)
  - ZEC is unaffected (its signing flow differs and is handled separately)

### 📝 Description

On non-touch devices, BTC-based coins (excluding ZEC) require an intermediate confirmation step during transaction signing: after navigating to the sign screen, the device displays a `CONFIRM` screen before the final `ACCEPT` prompt. This step was missing in the e2e helper, causing test failures for those coins.

This fix adds the missing `buttons.both()` → `waitFor(CONFIRM)` → `pressUntilTextFound(ACCEPT)` sequence for all non-ZEC BTC-based coins on non-touch devices. ZEC is excluded because it uses a different signing label (`SIGN_TRANSACTION`) and does not go through this intermediate step.

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)