### PR TITLE
[LWDM] fix(common): share dadaIdToMarketId for market detail navigation

### DIFF
--- a/.changeset/wise-otters-walk.md
+++ b/.changeset/wise-otters-walk.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add shared dadaIdToMarketId helper and use it for placeholder market navigation

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAssetsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAssetsViewModel.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { useAssetsViewModel } from "../useAssetsViewModel";
-import { padItems, resolveMarketId } from "../../utils/assetTableHelpers";
+import { padItems, dadaIdToMarketId } from "../../utils/assetTableHelpers";
 import {
   createMockCategorizedAssets,
   BITCOIN_ASSET,
@@ -171,21 +171,21 @@ describe("padItems", () => {
   });
 });
 
-describe("resolveMarketId", () => {
+describe("dadaIdToMarketId", () => {
   it("should return the last segment of a URN", () => {
-    expect(resolveMarketId("urn:crypto:meta-currency:ethereum")).toBe("ethereum");
+    expect(dadaIdToMarketId("urn:crypto:meta-currency:ethereum")).toBe("ethereum");
   });
 
   it("should return the id as-is when it has no colons", () => {
-    expect(resolveMarketId("bitcoin")).toBe("bitcoin");
+    expect(dadaIdToMarketId("bitcoin")).toBe("bitcoin");
   });
 
   it("should replace underscores with hyphens in URN last segment", () => {
-    expect(resolveMarketId("urn:crypto:meta-currency:usd_coin")).toBe("usd-coin");
+    expect(dadaIdToMarketId("urn:crypto:meta-currency:usd_coin")).toBe("usd-coin");
   });
 
   it("should not replace underscores in plain ids", () => {
-    expect(resolveMarketId("usd_coin")).toBe("usd_coin");
+    expect(dadaIdToMarketId("usd_coin")).toBe("usd_coin");
   });
 });
 
@@ -617,7 +617,7 @@ describe("useCryptoAssetsViewModel", () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      `/market/${encodeURIComponent(resolveMarketId(placeholder!.marketId ?? placeholder!.currency.id))}`,
+      `/market/${encodeURIComponent(dadaIdToMarketId(placeholder!.marketId ?? placeholder!.currency.id))}`,
     );
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAssetsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAssetsViewModel.ts
@@ -17,12 +17,13 @@ import {
   MAX_ITEM_DISPLAYED,
 } from "../constants";
 import { buildAssetsPagePath } from "../utils/buildAssetsPagePath";
-import { padItems, resolveMarketId } from "../utils/assetTableHelpers";
+import { padItems } from "../utils/assetTableHelpers";
 import { track } from "~/renderer/analytics/segment";
 import {
   ASSETS_TRACKING_PAGE_NAME,
   CRYPTO_TRACKING_PAGE_NAME,
 } from "../../CryptoAddresses/constants";
+import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
 
 export function useAssetsViewModel(): AssetsViewProps {
   const hasOnboardedDevice = useSelector(hasOnboardedDeviceSelector);
@@ -69,7 +70,7 @@ export function useAssetsViewModel(): AssetsViewProps {
       setTrackingSource("asset allocation");
       navigate(
         item.isPlaceholder
-          ? `/market/${encodeURIComponent(resolveMarketId(item.marketId ?? item.currency.id))}`
+          ? `/market/${encodeURIComponent(dadaIdToMarketId(item.marketId ?? item.currency.id))}`
           : `/asset/${item.currency.id}`,
       );
     },

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/utils/assetTableHelpers.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/utils/assetTableHelpers.ts
@@ -1,11 +1,5 @@
 import type { AssetTableItem } from "../types";
-
-/** @FIXME workaround for main tokens & also until we have asset aggregation */
-export function resolveMarketId(id: string): string {
-  if (!id.includes(":")) return id;
-  const lastSegment = id.split(":").pop();
-  return lastSegment?.replaceAll("_", "-") ?? id;
-}
+export { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
 
 export function padItems(
   realItems: AssetTableItem[],

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAssetsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAssetsViewModel.ts
@@ -9,7 +9,7 @@ import { useAccountStatus } from "LLD/hooks/useAccountStatus";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { buildPlaceholderAssetItemsFromAssetsData } from "LLD/features/Assets/utils/buildPlaceholderAssetItemsFromAssetsData";
 import { parseAssetsPageCategory } from "LLD/features/Assets/utils/buildAssetsPagePath";
-import { padItems, resolveMarketId } from "LLD/features/Assets/utils/assetTableHelpers";
+import { padItems, dadaIdToMarketId } from "LLD/features/Assets/utils/assetTableHelpers";
 import {
   ASSETS_PAGE_CATEGORY_CRYPTOS,
   ASSETS_PAGE_CATEGORY_STABLECOINS,
@@ -103,7 +103,7 @@ export default function useCryptoAssetsViewModel(): CryptoAssetsViewModel {
       });
       navigate(
         item.isPlaceholder
-          ? `/market/${encodeURIComponent(resolveMarketId(item.marketId ?? item.currency.id))}`
+          ? `/market/${encodeURIComponent(dadaIdToMarketId(item.marketId ?? item.currency.id))}`
           : `/asset/${item.currency.id}`,
       );
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
@@ -6,6 +6,7 @@ import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/Ba
 import { NavigatorName, ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
 import { track } from "~/analytics";
+import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
 
 interface PortfolioSectionActions {
   onPressShowAll: () => void;
@@ -45,8 +46,9 @@ export function usePortfolioSectionActions(isReadOnly: boolean): PortfolioSectio
         page: "Wallet",
       });
       if (asset.isPlaceholder) {
+        const currencyId = dadaIdToMarketId(asset.marketId ?? asset.currency.id);
         navigation.navigate(ScreenName.MarketDetail, {
-          currencyId: asset.marketId ?? asset.currency.id,
+          currencyId,
         });
       } else {
         navigation.navigate(NavigatorName.Accounts, {

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useDefaultAssetsByCategory.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useDefaultAssetsByCategory.ts
@@ -54,7 +54,7 @@ export function useDefaultAssetsByCategory(
         accounts: [],
         amount: 0,
         isPlaceholder: true,
-        marketId: marketId ?? currency.id,
+        marketId: marketId ?? id,
       };
 
       if (stablecoinTickers.has(ticker)) {

--- a/libs/ledger-live-common/src/market/utils/__tests__/index.test.ts
+++ b/libs/ledger-live-common/src/market/utils/__tests__/index.test.ts
@@ -2,9 +2,28 @@ import {
   getChangePercentage,
   isAvailableForTrading,
   filterMarketPerformersByAvailability,
+  dadaIdToMarketId,
   IsCurrencyAvailable,
 } from "../index";
 import { createMockMarketPerformer, MOCK_MARKET_PERFORMERS } from "../fixtures";
+
+describe("dadaIdToMarketId", () => {
+  it("returns the id unchanged when it has no colon", () => {
+    expect(dadaIdToMarketId("bitcoin")).toBe("bitcoin");
+  });
+
+  it("strips the chain prefix and keeps the last segment", () => {
+    expect(dadaIdToMarketId("ethereum:usd-coin")).toBe("usd-coin");
+  });
+
+  it("replaces underscores with dashes in the last segment", () => {
+    expect(dadaIdToMarketId("ethereum:usd_coin")).toBe("usd-coin");
+  });
+
+  it("handles multiple colons by taking only the last segment", () => {
+    expect(dadaIdToMarketId("ethereum:erc20:usd_tether")).toBe("usd-tether");
+  });
+});
 
 describe("getChangePercentage", () => {
   const mockData = createMockMarketPerformer({

--- a/libs/ledger-live-common/src/market/utils/index.ts
+++ b/libs/ledger-live-common/src/market/utils/index.ts
@@ -81,6 +81,13 @@ export function getRange(range: PortfolioRange | string) {
   }
 }
 
+/** @FIXME workaround for main tokens & also until we have asset aggregation */
+export function dadaIdToMarketId(id: string): string {
+  if (!id.includes(":")) return id;
+  const lastSegment = id.split(":").pop();
+  return lastSegment?.replaceAll("_", "-") ?? id;
+}
+
 export const getSortParam = (order: Order, range: PortfolioRange | string) => {
   switch (order) {
     default:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Partial: new unit tests for `dadaIdToMarketId` in `@ledgerhq/live-common` and updated desktop tests; mobile navigation path not covered by new tests._
- [x] **Impact of the changes:**
      - Opening **Market** from **placeholder rows** on the Assets table (desktop) and from the **Wallet** portfolio sections (mobile)
      - **Crypto addresses** assets list on desktop (placeholder → market)
      - Default assets by category: `marketId` fallback uses the compound **`id`** when `marketId` is missing

### 📝 Description

**Problem:** Compound DADA-style currency identifiers (e.g. `ethereum:usd-coin`) were not always normalized to the market id the Market feature expects when users tap placeholder assets. Desktop kept a local `resolveMarketId` workaround; mobile could pass raw ids through navigation and default asset building.

**Solution:**

- Added `dadaIdToMarketId` in `@ledgerhq/live-common` (same behavior as the former desktop helper: last segment after `:`, underscores → hyphens in that segment) with Jest coverage.
- Desktop re-exports it from `assetTableHelpers` and uses it for `/market/...` navigation from Assets and Crypto addresses.
- Mobile imports the shared helper for `ScreenName.MarketDetail` when the row is a placeholder.
- `useDefaultAssetsByCategory` sets `marketId` to `marketId ?? id` so the fallback matches the compound id when needed.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28442](https://ledgerhq.atlassian.net/browse/LIVE-28442)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28442]: https://ledgerhq.atlassian.net/browse/LIVE-28442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ