### PR TITLE
[LWM] fix(mobile): hide network badge on wallet assets icons

### DIFF
--- a/.changeset/calm-icons-hide-network.md
+++ b/.changeset/calm-icons-hide-network.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Hide network badge on wallet assets list and crypto addresses icon stack

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/index.tsx
@@ -45,7 +45,13 @@ export const CryptoAddressesButton: React.FC = () => {
                     </CardContentDescription>
                     <IconStack size={20} borderRadius={5}>
                       {firstThreeCurrencies.map(currency => (
-                        <CurrencyIcon key={currency.id} currency={currency} size={20} squared />
+                        <CurrencyIcon
+                          key={currency.id}
+                          currency={currency}
+                          size={20}
+                          squared
+                          hideNetwork
+                        />
                       ))}
                     </IconStack>
                   </>

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/ListItem/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/ListItem/index.tsx
@@ -15,16 +15,19 @@ import { useListItemViewModel, type ListItemViewModelResult } from "./useListIte
 
 interface ListItemProps {
   asset: Asset;
+  hideNetwork?: boolean;
   onPress: (asset: Asset) => void;
 }
 
 interface ListItemViewProps extends ListItemViewModelResult {
   asset: Asset;
+  hideNetwork?: boolean;
   onPress: () => void;
 }
 
 const ListItemView: React.FC<ListItemViewProps> = ({
   asset,
+  hideNetwork,
   onPress,
   formattedBalance,
   formattedCounterValue,
@@ -37,7 +40,7 @@ const ListItemView: React.FC<ListItemViewProps> = ({
     style={{ marginHorizontal: -8 }} // offsets ListItem's internal paddingHorizontal: s8
   >
     <ListItemLeading>
-      <CurrencyIcon currency={asset.currency} size={48} />
+      <CurrencyIcon currency={asset.currency} size={48} hideNetwork={hideNetwork} />
       <ListItemContent>
         <ListItemTitle>{asset.currency.name}</ListItemTitle>
         <ListItemDescription>{formattedBalance}</ListItemDescription>
@@ -58,11 +61,13 @@ const ListItemView: React.FC<ListItemViewProps> = ({
   </LumenListItem>
 );
 
-const ListItem: React.FC<ListItemProps> = ({ asset, onPress }) => {
+const ListItem: React.FC<ListItemProps> = ({ asset, onPress, hideNetwork }) => {
   const vmResult = useListItemViewModel(asset);
   const handlePress = useCallback(() => onPress(asset), [asset, onPress]);
 
-  return <ListItemView asset={asset} onPress={handlePress} {...vmResult} />;
+  return (
+    <ListItemView asset={asset} onPress={handlePress} hideNetwork={hideNetwork} {...vmResult} />
+  );
 };
 
 export default ListItem;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/SectionListContent/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/SectionListContent/index.tsx
@@ -28,6 +28,6 @@ export const SectionListContent = ({
     return <SectionErrorState message={errorMessage} />;
   }
   return assetsToDisplay.map(item => (
-    <ListItem key={item.currency.id} asset={item} onPress={onItemPress} />
+    <ListItem key={item.currency.id} asset={item} onPress={onItemPress} hideNetwork />
   ));
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new or updated tests; change is prop wiring to existing `CurrencyIcon`._
- [x] **Impact of the changes:**
      - Wallet Assets section list rows: currency icon should no longer show the network badge overlay.
      - Crypto addresses entry point: overlapping currency icons in the icon stack should match (no network badge).

### 📝 Description

**Problem:** Network badges on currency icons in the Wallet Assets list and on the crypto addresses shortcut were redundant or visually inconsistent with the product expectation for this surface ([LIVE-28368](https://ledgerhq.atlassian.net/browse/LIVE-28368)).

**Solution:** Thread an optional `hideNetwork` prop through `ListItem` and pass `hideNetwork` from `SectionListContent`. Set `hideNetwork` on `CurrencyIcon` inside `CryptoAddressesButton`’s `IconStack` so those stacked icons stay consistent with the list.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28368](https://ledgerhq.atlassian.net/browse/LIVE-28368)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28368]: https://ledgerhq.atlassian.net/browse/LIVE-28368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-28368]: https://ledgerhq.atlassian.net/browse/LIVE-28368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ