### PR TITLE
test(e2e): fix modular drawer account validation in deeplinks spec

### DIFF
--- a/e2e/mobile/specs/deeplinks.spec.ts
+++ b/e2e/mobile/specs/deeplinks.spec.ts
@@ -8,19 +8,19 @@ $TmsLink("B2CQA-1837");
 const tags: string[] = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"];
 tags.forEach(tag => $Tag(tag));
 describe("DeepLinks Tests", () => {
-  const nanoApp = AppInfos.ETHEREUM;
+  const account = Account.ETH_2;
   const ethereumLong = "ethereum";
   const bitcoinLong = "bitcoin";
   const randomLiveApp = app.discover.getRandomLiveApp();
 
   beforeAll(async () => {
     await app.init({
-      speculosApp: nanoApp,
+      speculosApp: account.currency.speculosApp,
       cliCommands: [
         async (userdataPath?: string) => {
           return CLI.liveData({
-            currency: nanoApp.name,
-            index: 0,
+            currency: account.currency.id,
+            index: account.index,
             appjson: userdataPath,
             add: true,
           });
@@ -146,7 +146,7 @@ describe("DeepLinks Tests", () => {
       await app.portfolio.openViaDeeplink();
       await app.portfolio.waitForPortfolioPageToLoad();
       await app.receive.receiveViaDeeplink(ethereumLong);
-      await app.modularDrawer.validateAccountsScreen([Account.ETH_1.accountName]);
+      await app.modularDrawer.validateAccountsScreen([account.accountName]);
     });
   });
 });


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Modular drawer account validation in the deeplinks e2e spec

### 📝 Description

The `validateAccountsScreen` assertion was failing because `ETH_1` have
accumulated extra accounts, causing the drawer to
render unexpected accounts. Switched to `Account.ETH_2` and derived the
`speculosApp`, `currency`, and `index` from the account object to keep
the setup consistent.

### ❓ Context

- **JIRA or GitHub link**:
- **Mobile e2e CI run**:
- **ADR link (if any)**:

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)