### PR TITLE
feat: add E2E_FEATURE_FLAGS_JSON param for desktop E2E CI

### DIFF
--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -68,6 +68,11 @@ on:
         description: "Enable Wallet 4.0 feature"
         type: boolean
         default: false
+      feature_flags_json:
+        description: "JSON to override feature flags"
+        required: false
+        type: string
+        default: ""
 
   workflow_call:
     inputs:
@@ -111,6 +116,11 @@ on:
         description: "Enable Wallet 4.0 feature"
         type: boolean
         default: false
+      feature_flags_json:
+        description: "JSON to override feature flags"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   id-token: write
@@ -163,6 +173,7 @@ jobs:
       SPECULOS_IMAGE_TAG: ghcr.io/ledgerhq/speculos:${{ matrix.device == 'nanoS' && '1be65b91a8e0691866f880fd437ac05fce78af9d' || 'latest' }}
       SPECULOS_DEVICE: ${{ matrix.device }}
       COINAPPS: ${{ github.workspace }}/coin-apps
+      E2E_FEATURE_FLAGS_JSON: ${{ inputs.feature_flags_json || '' }}
     outputs:
       test_passed: ${{ steps.run-playwright.outputs.passed }}
       test_failed: ${{ steps.run-playwright.outputs.failed }}
@@ -259,9 +270,13 @@ jobs:
           BUILD_TYPE="${{ inputs.build_type || 'testing' }}"
           TEST_EXECUTION="${{ inputs.test_execution || '(not provided)' }}"
           BROADCAST_ENABLED="${{ inputs.enable_broadcast }}"
+          EXTRA_FEATURE_FLAGS="$E2E_FEATURE_FLAGS_JSON"
 
           if [ -z "$FILTER_PATTERN" ]; then
             FILTER_PATTERN="(none)"
+          fi
+          if [ -z "$EXTRA_FEATURE_FLAGS" ]; then
+            EXTRA_FEATURE_FLAGS="(none)"
           fi
           {
             echo "## Workflow Context"
@@ -274,7 +289,25 @@ jobs:
             echo "- **Test Execution ticket ID:** $TEST_EXECUTION"
             echo "- **Firebase env to target:** $BUILD_TYPE"
             echo "- **Broadcast enabled:** $BROADCAST_ENABLED"
+            echo "- **Extra feature flags:** $EXTRA_FEATURE_FLAGS"
           } >> $GITHUB_STEP_SUMMARY
+
+      - name: Validate feature flags JSON input
+        shell: bash
+        run: |
+          raw="$E2E_FEATURE_FLAGS_JSON"
+          if [ -z "$raw" ]; then
+            exit 0
+          fi
+          node -e '
+            try {
+              JSON.parse(process.argv[1]);
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              console.error(`Invalid E2E_FEATURE_FLAGS_JSON: ${message}`);
+              process.exit(1);
+            }
+          ' "$raw"
 
       - name: Run Playwright E2E tests
         id: run-playwright

--- a/e2e/desktop/README.md
+++ b/e2e/desktop/README.md
@@ -88,7 +88,7 @@ pnpm e2e:desktop test:playwright <testFileName>
 For detailed setup, debugging, and contribution guidelines, see:
 [Ledger Wallet Desktop E2E Wiki](https://github.com/LedgerHQ/ledger-live/wiki/LLD:E2ETesting)
 
-### 5. Wallet 4.0
+### 6. Wallet 4.0
 
 To reduce noise in test reports the Wallet 4.0 feature is OFF by default (regardless of Firebase).
 You can force Wallet 4.0 ON by setting the E2E environment variable:
@@ -100,3 +100,34 @@ export E2E_ENABLE_WALLET40=1
 Individual tests can still switch the feature ON explicitly passing the flag and parameters.
 
 To switch Wallet 4.0 on for all tests please use the checkbox on the Workflow.
+
+### 7. Custom feature flags with E2E_FEATURE_FLAGS_JSON
+
+You can inject extra feature flags globally for Desktop E2E by setting `E2E_FEATURE_FLAGS_JSON`.
+
+Example shape:
+
+```json
+{
+  "myFeature": {
+    "enabled": true,
+    "params": {
+      "foo": "bar"
+    }
+  }
+}
+```
+
+Usage examples:
+
+```bash
+# Enable one feature with params
+export E2E_FEATURE_FLAGS_JSON='{"myFeature":{"enabled":true,"params":{"foo":"bar"}}}'
+
+```
+
+Notes:
+
+- Arrays, scalars, or invalid JSON are rejected.
+- `E2E_FEATURE_FLAGS_JSON` is merged with default E2E flags.
+- Per-test `featureFlags` fixture values still override env-provided values when both set the same key.

--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -8,7 +8,7 @@ import { setEnv } from "@ledgerhq/live-env";
 import { Application } from "tests/page";
 import { safeAppendFile, NANO_APP_CATALOG_PATH } from "tests/utils/fileUtils";
 import { launchApp } from "tests/utils/electronUtils";
-import { captureArtifacts, addTeamOwner } from "tests/utils/allureUtils";
+import { captureArtifacts, addTeamOwner, attachMergedFeatureFlags } from "tests/utils/allureUtils";
 import { isLastRetry } from "tests/utils/testInfoUtils";
 import { WebviewLogCollector } from "tests/utils/webviewLogCollector";
 import { randomUUID } from "crypto";
@@ -21,6 +21,7 @@ import { attachNetworkLogging } from "../utils/networkLogging";
 import { LWD_WALLET_40_FF_DISABLED, LWD_WALLET_40_FF_ENABLED } from "tests/utils/featureFlagUtils";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { unregisterAllTransportModules } from "@ledgerhq/live-common/hw/index";
+import { parseExtraFeatureFlags } from "../utils/featureFlagsJsonUtils";
 
 type CliCommand = (appjsonPath: string) => Observable<unknown> | Promise<unknown> | string;
 
@@ -60,6 +61,10 @@ const IS_DEBUG_MODE = !!process.env.PWDEBUG;
 
 setEnv("DISABLE_APP_VERSION_REQUIREMENTS", true);
 setEnv("SWAP_API_BASE", process.env.SWAP_API_BASE || "https://swap-stg.ledger-test.com/v5");
+
+const EXTRA_FEATURE_FLAGS: OptionalFeatureMap = parseExtraFeatureFlags(
+  process.env.E2E_FEATURE_FLAGS_JSON,
+);
 
 const DEFAULT_FEATURE_FLAGS: OptionalFeatureMap = {
   lldModularDrawer: {
@@ -214,7 +219,8 @@ export const test = base.extend<TestFixtures>({
     use,
     testInfo,
   ) => {
-    const mergedFeatureFlags = merge({}, DEFAULT_FEATURE_FLAGS, featureFlags);
+    const mergedFeatureFlags = merge({}, DEFAULT_FEATURE_FLAGS, EXTRA_FEATURE_FLAGS, featureFlags);
+    await attachMergedFeatureFlags(testInfo, mergedFeatureFlags);
 
     // default environment variables
     env = Object.assign(

--- a/e2e/desktop/tests/utils/allureUtils.ts
+++ b/e2e/desktop/tests/utils/allureUtils.ts
@@ -44,6 +44,16 @@ export async function addTeamOwner(team: Team) {
   await allure.feature(teamString);
 }
 
+export async function attachMergedFeatureFlags(
+  testInfo: TestInfo,
+  mergedFeatureFlags: unknown,
+): Promise<void> {
+  await testInfo.attach("Merged Feature Flags", {
+    body: Buffer.from(JSON.stringify(mergedFeatureFlags, null, 2)),
+    contentType: "application/json",
+  });
+}
+
 async function attachSpeculosScreenshots(testInfo: TestInfo): Promise<void> {
   const speculosPort = getEnv("SPECULOS_API_PORT");
   const navigatedScreenshots = drainSpeculosScreenshots(speculosPort);

--- a/e2e/desktop/tests/utils/featureFlagsJsonUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagsJsonUtils.ts
@@ -1,0 +1,35 @@
+import type { OptionalFeatureMap } from "@ledgerhq/types-live";
+
+function isOptionalFeatureMap(value: unknown): value is OptionalFeatureMap {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function parseExtraFeatureFlags(
+  rawExtraFeatureFlags: string | undefined,
+): OptionalFeatureMap {
+  const normalizedValue = rawExtraFeatureFlags?.trim();
+  if (!normalizedValue) return {};
+
+  const helpText =
+    "Expected E2E_FEATURE_FLAGS_JSON to be a JSON object. For example: " +
+    '`{"myFeature":{"enabled":true,"params":{"foo":"bar"}}}`';
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(normalizedValue);
+  } catch (error) {
+    throw new Error(
+      `Invalid E2E_FEATURE_FLAGS_JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }. ${helpText}`,
+    );
+  }
+
+  if (!isOptionalFeatureMap(parsed)) {
+    throw new Error(
+      `Invalid E2E_FEATURE_FLAGS_JSON: E2E_FEATURE_FLAGS_JSON must be a JSON object mapping feature flag keys to configuration objects. ${helpText}`,
+    );
+  }
+
+  return parsed;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
## Context

We now have a QA environment that can run feature branches before merge.  
For large refactors, we need to run QAA against a different Live App manifest ID (for example Swap) without changing test code per spec.

## What this PR changes (vs `develop`)

- Adds support for a new env var: `E2E_FEATURE_FLAGS_JSON` in Desktop E2E flow.
- Updates Desktop E2E workflow (`.github/workflows/test-ui-e2e-only-desktop.yml`) to pass custom feature flags through CI.
- Updates E2E fixture loading (`e2e/desktop/tests/fixtures/common.ts`) to parse and merge extra feature flags from env.
- Adds robust parsing/validation helper (`e2e/desktop/tests/fixtures/featureFlags.ts`) with clear error messages for invalid values.
- Documents usage in `e2e/desktop/README.md`, including format, constraints, and examples.

## Why this is useful

- Enables QAA on branch deployments without waiting for merge.
- Allows pointing to alternate manifest IDs (e.g. QA Swap app) through env only.
- Reduces risk for major refactors by testing realistic pre-merge configurations.
- Keeps default behavior unchanged when `E2E_FEATURE_FLAGS_JSON` is not provided.

## `E2E_FEATURE_FLAGS_JSON` format

Expected value: a JSON object mapping feature-flag keys to Feature objects.

- Feature object:
  - `enabled`: `boolean` (required)
  - `params`: `object` (optional)

Example:

```json
{
  "swapLiveApp": {
    "enabled": true,
    "params": {
      "manifest_id": "swap-live-app-qa-aws"
    }
  }
}
```

CLI usage:

```bash
export E2E_FEATURE_FLAGS_JSON='{"swapLiveApp":{"enabled":true,"params":{"manifest_id":"swap-live-app-qa-aws"}}}'
```

## Validation behavior

- Empty/missing value => `{}` (no extra flags).
- Invalid JSON => explicit error with usage hint.
- Non-object JSON values (array/string/number/null) => rejected with clear error.

 
 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
