### PR TITLE
[LWD] feat: disable name editing while syncing

### DIFF
--- a/.changeset/seven-baboons-bow.md
+++ b/.changeset/seven-baboons-bow.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): disable name editing while syncing

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/__integrations__/EditName.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/__integrations__/EditName.integration.test.tsx
@@ -1,8 +1,11 @@
 import React from "react";
-import { render, screen, waitFor } from "tests/testSetup";
+import { render, screen, waitFor, fireEvent } from "tests/testSetup";
 import { Button } from "@ledgerhq/lumen-ui-react";
 import { ETH_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
 import { EditName } from "LLD/features/CryptoAddresses/components/EditName";
+
+/** How long the ghost-click guard blocks outside-click closes (must match the component). */
+const GHOST_CLICK_GUARD_MS = 300;
 
 const ASSET_NAME = "Ethereum";
 
@@ -16,6 +19,40 @@ const renderEditName = () => {
 };
 
 describe("EditName", () => {
+  it("stays open when outside is clicked within the ghost-click guard window", async () => {
+    const { user } = renderEditName();
+
+    await user.click(screen.getByTestId("edit-name-trigger"));
+    await waitFor(() => {
+      expect(screen.getByTestId("edit-crypto-address-name-dialog-content")).toBeVisible();
+    });
+
+    // Immediately fire an outside pointerdown (within the 300ms guard window)
+    fireEvent.pointerDown(document);
+
+    // Dialog must still be open
+    expect(screen.getByTestId("edit-crypto-address-name-dialog-content")).toBeVisible();
+  });
+
+  it("closes when outside is clicked after the ghost-click guard window", async () => {
+    const { user } = renderEditName();
+
+    await user.click(screen.getByTestId("edit-name-trigger"));
+    await waitFor(() => {
+      expect(screen.getByTestId("edit-crypto-address-name-dialog-content")).toBeVisible();
+    });
+
+    // Wait past the guard window then simulate an outside click
+    await new Promise(r => setTimeout(r, GHOST_CLICK_GUARD_MS + 50));
+    fireEvent.pointerDown(document);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("edit-crypto-address-name-dialog-content"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("should open dialog, interact with chips and input, confirm, then reopen and close via X", async () => {
     const { user, store } = renderEditName();
 
@@ -30,17 +67,12 @@ describe("EditName", () => {
     expect(input).toBeVisible();
     expect(input).toHaveValue("Ethereum 2");
 
-    const tradingChip = screen.getByRole("button", { name: "Ethereum trading" });
+    expect(screen.getByRole("button", { name: "Ethereum trading" })).toBeVisible();
     const savingsChip = screen.getByRole("button", { name: "Ethereum savings" });
-    expect(tradingChip).toBeVisible();
     expect(savingsChip).toBeVisible();
 
     const confirmButton = screen.getByTestId("edit-crypto-address-name-dialog-cta");
     expect(confirmButton).toBeDisabled();
-
-    await user.click(tradingChip);
-    expect(input).toHaveValue("Ethereum trading");
-    expect(confirmButton).toBeEnabled();
 
     await user.click(savingsChip);
     expect(input).toHaveValue("Ethereum savings");

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/components/EditCryptoAddressNameDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/components/EditCryptoAddressNameDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import {
   Dialog,
   DialogTrigger,
@@ -14,6 +14,9 @@ import { normalizeName, MAX_ACCOUNT_NAME_LENGTH } from "@ledgerhq/live-wallet/ac
 import { Chip } from "./Chip";
 import { track } from "~/renderer/analytics/segment";
 import { CRYPTO_TRACKING_PAGE_NAME } from "../../../constants";
+
+/** How long after opening to ignore outside-click closes (ghost-click guard). */
+const GHOST_CLICK_GUARD_MS = 300;
 
 type EditCryptoAddressNameDialogProps = {
   children: React.ReactNode;
@@ -31,44 +34,27 @@ export const EditCryptoAddressNameDialog = ({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState(initialValue);
-  const clickGuardRef = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    return () => {
-      clickGuardRef.current?.abort();
-    };
-  }, []);
+  const openedAtRef = useRef(0);
 
   const normalizedValue = normalizeName(value);
   const isConfirmDisabled = normalizedValue.length === 0 || normalizedValue === initialValue.trim();
 
   const handleOpenChange = (newOpen: boolean) => {
-    clickGuardRef.current?.abort();
-    clickGuardRef.current = null;
     if (newOpen) {
+      openedAtRef.current = Date.now();
       setValue(initialValue);
       track("button_clicked", { button: "edit_account_name", page: CRYPTO_TRACKING_PAGE_NAME });
     }
     setOpen(newOpen);
   };
 
-  /** Prevents Radix "ghost click": swallow the resulting click before closing. */
+  /** Prevents ghost click: the same click that opens the dialog would immediately close it. */
   const handlePointerDownOutside: NonNullable<
     React.ComponentProps<typeof DialogContent>["onPointerDownOutside"]
   > = e => {
-    e.preventDefault();
-    clickGuardRef.current?.abort();
-    const ac = new AbortController();
-    clickGuardRef.current = ac;
-    globalThis.addEventListener(
-      "click",
-      ev => {
-        ev.stopPropagation();
-        ev.preventDefault();
-        handleOpenChange(false);
-      },
-      { capture: true, once: true, signal: ac.signal },
-    );
+    if (Date.now() - openedAtRef.current < GHOST_CLICK_GUARD_MS) {
+      e.preventDefault();
+    }
   };
 
   const handleConfirm = () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountRowActionCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountRowActionCell.tsx
@@ -1,27 +1,54 @@
 import React from "react";
-import { IconButton } from "@ledgerhq/lumen-ui-react";
+import { IconButton, Tooltip, TooltipTrigger, TooltipContent } from "@ledgerhq/lumen-ui-react";
 import { PenEdit } from "@ledgerhq/lumen-ui-react/symbols";
 import type { AccountLike } from "@ledgerhq/types-live";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
+import { useTranslation } from "react-i18next";
 import { EditName } from "../../EditName";
 
 type AccountRowActionCellProps = {
   readonly account: AccountLike;
   readonly editNameAriaLabel: string;
+  readonly isSyncing: boolean;
 };
 
-export function AccountRowActionCell({ account, editNameAriaLabel }: AccountRowActionCellProps) {
+export function AccountRowActionCell({
+  account,
+  editNameAriaLabel,
+  isSyncing,
+}: AccountRowActionCellProps) {
+  const { t } = useTranslation();
   const currency = getAccountCurrency(account);
+
   return (
-    <div className="flex justify-end">
-      <EditName account={account} asset={currency.name}>
-        <IconButton
-          appearance="transparent"
-          size="sm"
-          icon={PenEdit}
-          aria-label={editNameAriaLabel}
-        />
-      </EditName>
+    <div className="flex justify-end" onClick={e => e.stopPropagation()}>
+      {isSyncing ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <IconButton
+                appearance="transparent"
+                size="sm"
+                icon={PenEdit}
+                aria-label={editNameAriaLabel}
+                disabled
+              />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {t("cryptoAddresses.editName.syncingTooltip")}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <EditName account={account} asset={currency.name}>
+          <IconButton
+            appearance="transparent"
+            size="sm"
+            icon={PenEdit}
+            aria-label={editNameAriaLabel}
+          />
+        </EditName>
+      )}
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/__tests__/AccountRowActionCell.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/__tests__/AccountRowActionCell.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { render, screen, waitFor } from "tests/testSetup";
+import { ETH_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
+import { AccountRowActionCell } from "../AccountRowActionCell";
+import { createWalletState } from "../../../../testUtils/createWalletState";
+
+const ARIA_LABEL = "Edit name";
+
+const renderCell = (isSyncing: boolean) =>
+  render(
+    <AccountRowActionCell
+      account={ETH_ACCOUNT}
+      editNameAriaLabel={ARIA_LABEL}
+      isSyncing={isSyncing}
+    />,
+    { initialState: createWalletState(new Map([[ETH_ACCOUNT.id, "My ETH"]])) },
+  );
+
+describe("AccountRowActionCell", () => {
+  describe("when not syncing", () => {
+    it("renders an enabled edit button", () => {
+      renderCell(false);
+      expect(screen.getByRole("button", { name: ARIA_LABEL })).toBeEnabled();
+    });
+
+    it("opens the edit name dialog when clicked", async () => {
+      const { user } = renderCell(false);
+      expect(
+        screen.queryByTestId("edit-crypto-address-name-dialog-content"),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: ARIA_LABEL }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("edit-crypto-address-name-dialog-content")).toBeVisible();
+      });
+    });
+  });
+
+  describe("when syncing", () => {
+    it("renders a disabled edit button", () => {
+      renderCell(true);
+      expect(screen.getByRole("button", { name: ARIA_LABEL })).toBeDisabled();
+    });
+
+    it("shows a tooltip explaining sync is in progress on hover", async () => {
+      const { user } = renderCell(true);
+
+      await user.hover(screen.getByRole("button", { name: ARIA_LABEL }));
+
+      await waitFor(() => {
+        const tooltips = screen.getAllByText("Sync in progress, please wait");
+        expect(tooltips.some(el => el.closest("[role='tooltip']"))).toBe(true);
+      });
+    });
+  });
+
+  it("does not propagate clicks to the parent", async () => {
+    const parentClick = jest.fn();
+    const { user } = render(
+      <div onClick={parentClick}>
+        <AccountRowActionCell
+          account={ETH_ACCOUNT}
+          editNameAriaLabel={ARIA_LABEL}
+          isSyncing={false}
+        />
+      </div>,
+      { initialState: createWalletState(new Map([[ETH_ACCOUNT.id, "My ETH"]])) },
+    );
+
+    await user.click(screen.getByRole("button", { name: ARIA_LABEL }));
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
@@ -17,6 +17,7 @@ import {
   AccountRowActionCell,
   AccountValueCell,
 } from "../Cell";
+import { useSyncPhase } from "LLD/hooks/useSyncPhase";
 
 type UseCryptoDataTableParams = {
   readonly rows: AccountLike[];
@@ -32,6 +33,8 @@ export function useCryptoDataTable({
   const { t } = useTranslation();
   const walletState = useSelector(walletSelector);
   const calculateCountervalue = useCalculateCountervalueCallback();
+  const syncPhase = useSyncPhase();
+  const isSyncing = syncPhase === "syncing";
 
   /** One countervalue per row; avoids recalculations in sorting. */
   const balanceSortFiatByAccountId = useMemo(() => {
@@ -91,12 +94,13 @@ export function useCryptoDataTable({
           <AccountRowActionCell
             account={row.original}
             editNameAriaLabel={t("cryptoAddresses.table.editName")}
+            isSyncing={isSyncing}
           />
         ),
         meta: { align: "end" },
       },
     ],
-    [t, walletState, lookupParentAccount, balanceSortFiatByAccountId],
+    [t, walletState, lookupParentAccount, balanceSortFiatByAccountId, isSyncing],
   );
 
   const [sorting, setSorting] = useState<SortingState>([{ id: "balance", desc: true }]);

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useSyncPhase.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useSyncPhase.test.ts
@@ -1,0 +1,170 @@
+import { act, renderHook } from "tests/testSetup";
+import { useSyncPhase } from "../useSyncPhase";
+import { SYNC_SETTLE_GUARD_MS } from "@ledgerhq/live-common/bridge/react/useSyncLifecycle";
+import { BTC_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
+import { mockPoll, mockOnUserRefresh, mockBridgeSync } from "./fixtures";
+import { setLastUserSyncClickTimestamp } from "~/renderer/reducers/syncRefresh";
+
+const mockTriggerRefresh = jest.fn(() => {
+  mockOnUserRefresh();
+  mockPoll();
+  mockBridgeSync({
+    type: "SYNC_ALL_ACCOUNTS",
+    priority: 5,
+    reason: "user-click",
+  });
+});
+
+const mockUseSyncSources = jest.fn().mockReturnValue({
+  isPending: false,
+  stablePending: false,
+  hasCvOrBridgeError: false,
+  hasWalletSyncError: false,
+  triggerRefresh: mockTriggerRefresh,
+});
+
+jest.mock("../useSyncSources", () => ({
+  useSyncSources: () => mockUseSyncSources(),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/react/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/bridge/react/index"),
+  useBatchAccountsSyncState: jest.fn(({ accounts }: { accounts: { id: string }[] }) =>
+    accounts.map(account => ({ syncState: { pending: false, error: null }, account })),
+  ),
+}));
+
+const defaultInitialState = {
+  accounts: [],
+  settings: {
+    ...INITIAL_STATE,
+    counterValue: "USD",
+    selectedTimeRange: "day" as const,
+  },
+};
+
+const syncingState = {
+  isPending: true,
+  stablePending: true,
+  hasCvOrBridgeError: false,
+  hasWalletSyncError: false,
+  triggerRefresh: mockTriggerRefresh,
+};
+
+describe("useSyncPhase", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSyncSources.mockReturnValue({
+      isPending: false,
+      stablePending: false,
+      hasCvOrBridgeError: false,
+      hasWalletSyncError: false,
+      triggerRefresh: mockTriggerRefresh,
+    });
+  });
+
+  it("should return synced when not syncing and no errors", () => {
+    const { result } = renderHook(() => useSyncPhase(), {
+      initialState: defaultInitialState,
+    });
+
+    expect(result.current).toBe("synced");
+  });
+
+  it("should return syncing during initial loading", () => {
+    mockUseSyncSources.mockReturnValue(syncingState);
+
+    const { result } = renderHook(() => useSyncPhase(), {
+      initialState: {
+        ...defaultInitialState,
+        accounts: [BTC_ACCOUNT],
+        syncRefresh: { lastUserSyncClickTimestamp: 0, hasCompletedInitialSync: false },
+      },
+    });
+
+    expect(result.current).toBe("syncing");
+  });
+
+  it("should return synced after initial sync completes", () => {
+    jest.useFakeTimers();
+    mockUseSyncSources.mockReturnValue(syncingState);
+
+    const { result, rerender } = renderHook(() => useSyncPhase(), {
+      initialState: {
+        ...defaultInitialState,
+        accounts: [BTC_ACCOUNT],
+        syncRefresh: { lastUserSyncClickTimestamp: 0, hasCompletedInitialSync: false },
+      },
+    });
+
+    expect(result.current).toBe("syncing");
+
+    mockUseSyncSources.mockReturnValue({
+      isPending: false,
+      stablePending: false,
+      hasCvOrBridgeError: false,
+      hasWalletSyncError: false,
+      triggerRefresh: mockTriggerRefresh,
+    });
+
+    act(() => {
+      rerender();
+    });
+    act(() => {
+      jest.advanceTimersByTime(SYNC_SETTLE_GUARD_MS);
+    });
+
+    expect(result.current).toBe("synced");
+
+    jest.useRealTimers();
+  });
+
+  it("should return syncing during manual refresh", () => {
+    mockUseSyncSources.mockReturnValue(syncingState);
+
+    const { result, store } = renderHook(() => useSyncPhase(), {
+      initialState: {
+        ...defaultInitialState,
+        syncRefresh: { lastUserSyncClickTimestamp: 0, hasCompletedInitialSync: true },
+      },
+    });
+
+    expect(result.current).toBe("synced");
+
+    act(() => {
+      store.dispatch(setLastUserSyncClickTimestamp(Date.now()));
+    });
+
+    expect(result.current).toBe("syncing");
+  });
+
+  it("should not show syncing during auto-refresh (no recent user click)", () => {
+    mockUseSyncSources.mockReturnValue(syncingState);
+
+    const { result } = renderHook(() => useSyncPhase(), {
+      initialState: {
+        ...defaultInitialState,
+        syncRefresh: { lastUserSyncClickTimestamp: 0, hasCompletedInitialSync: true },
+      },
+    });
+
+    expect(result.current).toBe("synced");
+  });
+
+  it("should return failed when there is a sync error", () => {
+    mockUseSyncSources.mockReturnValue({
+      isPending: false,
+      stablePending: false,
+      hasCvOrBridgeError: true,
+      hasWalletSyncError: false,
+      triggerRefresh: mockTriggerRefresh,
+    });
+
+    const { result } = renderHook(() => useSyncPhase(), {
+      initialState: defaultInitialState,
+    });
+
+    expect(result.current).toBe("failed");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useSyncPhase.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useSyncPhase.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react";
+import { useSelector } from "LLD/hooks/redux";
+import { hasAccountsSelector, isUpToDateSelector } from "~/renderer/reducers/accounts";
+import {
+  selectHasCompletedInitialSync,
+  selectLastUserSyncClickTimestamp,
+} from "~/renderer/reducers/syncRefresh";
+import {
+  useSyncLifecycle,
+  type SyncPhase,
+} from "@ledgerhq/live-common/bridge/react/useSyncLifecycle";
+import { useManualRefresh } from "@ledgerhq/live-common/bridge/react/useManualRefresh";
+import { useAccountsSyncStatus } from "LLD/components/TopBar/hooks/useAccountsSyncStatus";
+import { useSyncSources } from "./useSyncSources";
+
+/**
+ * Lightweight alternative to usePortfolioBalance for consumers that only need
+ * the current SyncPhase. Skips usePortfolioThrottled entirely, avoiding the
+ * full portfolio computation and its subscriptions.
+ *
+ * isColdStart is intentionally omitted: isInitialLoading
+ * (hasAccounts && !hasCompletedInitialSync) covers the same "no data yet"
+ * window without requiring portfolio data.
+ */
+export function useSyncPhase(): SyncPhase {
+  const hasAccounts = useSelector(hasAccountsSelector);
+  const hasCompletedInitialSync = useSelector(selectHasCompletedInitialSync);
+  const lastUserSyncClickTimestamp = useSelector(selectLastUserSyncClickTimestamp);
+
+  const syncSources = useSyncSources();
+
+  const isManualRefreshLoading = useManualRefresh(
+    syncSources.stablePending,
+    lastUserSyncClickTimestamp,
+  );
+  const isInitialLoading = hasAccounts && !hasCompletedInitialSync;
+  const isBalanceLoading = isInitialLoading || isManualRefreshLoading;
+
+  const accountsWithUpToDateCheck = useSelector(isUpToDateSelector);
+  const { areAllAccountsUpToDate } = useAccountsSyncStatus(accountsWithUpToDateCheck);
+
+  const hasEverBeenUpToDateRef = useRef(areAllAccountsUpToDate);
+  useEffect(() => {
+    if (areAllAccountsUpToDate) {
+      hasEverBeenUpToDateRef.current = true;
+    }
+  }, [areAllAccountsUpToDate]);
+
+  const hasAccountDegradation = hasEverBeenUpToDateRef.current && !areAllAccountsUpToDate;
+  const hasAnySyncError =
+    syncSources.hasCvOrBridgeError || hasAccountDegradation || syncSources.hasWalletSyncError;
+
+  return useSyncLifecycle(isBalanceLoading, syncSources.stablePending, hasAnySyncError);
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8207,7 +8207,8 @@
         "trading": "{{asset}} trading",
         "savings": "{{asset}} savings"
       },
-      "cta": "Confirm"
+      "cta": "Confirm",
+      "syncingTooltip": "Sync in progress, please wait"
     }
   },
   "cryptoAssets": {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a minor feature to Ledger Live Desktop that disables the ability to edit crypto address names while the application is syncing. The UI now provides clear feedback by disabling the edit button and showing a tooltip during sync. The main changes involve updating the relevant components to respect the syncing state and improving user experience with appropriate messaging.

<img width="1440" height="510" alt="Screenshot 2026-04-01 at 08 34 17" src="https://github.com/user-attachments/assets/7b90d0be-d2b1-4548-95d5-4e7d5349e78a" />


### ❓ Context

[LIVE-28456](https://ledgerhq.atlassian.net/browse/LIVE-28456)
[LIVE-28443](https://ledgerhq.atlassian.net/browse/LIVE-28443)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28456]: https://ledgerhq.atlassian.net/browse/LIVE-28456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ