### PR TITLE
[LWD] fix(desktop): fix breadcrumb accounts redirect when v4 enabled

### DIFF
--- a/.changeset/heavy-pandas-dress.md
+++ b/.changeset/heavy-pandas-dress.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix Breadcrumb redirection on accounts when v4 enabled

--- a/apps/ledger-live-desktop/src/renderer/components/Breadcrumb/AccountCrumb.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Breadcrumb/AccountCrumb.tsx
@@ -27,6 +27,8 @@ import { Separator, Item, TextLink, AngleDown, Check } from "./common";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { walletSelector } from "~/renderer/reducers/wallet";
 import { accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { getAccountsSidebarPath } from "LLD/components/SideBar/utils";
 
 type ItemShape = {
   key: string;
@@ -55,6 +57,8 @@ const AccountCrumb = () => {
       id: segments.slice(1).join("/"),
     };
   }, [splat]);
+
+  const { shouldDisplayAssetSection } = useWalletFeaturesConfig("desktop");
 
   const accounts = useSelector(accountsSelector);
 
@@ -196,7 +200,7 @@ const AccountCrumb = () => {
         <Button
           onClick={() => {
             setTrackingSource("account breadcrumb");
-            navigate("/accounts/");
+            navigate(getAccountsSidebarPath(shouldDisplayAssetSection));
           }}
         >
           {t("accounts.title")}
@@ -211,7 +215,7 @@ const AccountCrumb = () => {
         <Button
           onClick={() => {
             setTrackingSource("account breadcrumb");
-            navigate("/accounts/");
+            navigate(getAccountsSidebarPath(shouldDisplayAssetSection));
           }}
         >
           {t("accounts.title")}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Simple navigation fix — manually verified._
- [x] **Impact of the changes:**
      - Breadcrumb "Accounts" link on account detail pages
      - Only affects navigation when wallet v4 feature flag is enabled

### 📝 Description

**Problem**: When the wallet v4 feature flag is enabled, clicking the "Accounts" breadcrumb link on an account detail page navigates to `/accounts/` instead of the correct v4 accounts path, leading to an incorrect page.

**Solution**: Use `getAccountsSidebarPath(shouldDisplayAssetSection)` to resolve the correct accounts route based on the active feature flag, matching the sidebar navigation behavior.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28453](https://ledgerhq.atlassian.net/browse/LIVE-28453)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28453]: https://ledgerhq.atlassian.net/browse/LIVE-28453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ