### PR TITLE
[LWD] fix(desktop): respect hide empty token accounts setting in categorized assets

### DIFF
--- a/.changeset/proud-moose-sniff.md
+++ b/.changeset/proud-moose-sniff.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix categorized assets to respect hide empty token accounts user setting

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useCategorizedAssets.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useCategorizedAssets.ts
@@ -1,9 +1,12 @@
 import { useDistribution } from "~/renderer/actions/general";
 import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
 import { useCategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/index";
+import { useSelector } from "LLD/hooks/redux";
+import { hideEmptyTokenAccountsSelector } from "~/renderer/reducers/settings";
 
 export function useCategorizedAssetsFromPortfolio() {
-  const distribution = useDistribution({ hideEmptyTokenAccount: true });
+  const hideEmptyTokenAccount = useSelector(hideEmptyTokenAccountsSelector);
+  const distribution = useDistribution({ showEmptyAccounts: true, hideEmptyTokenAccount });
   const { tickers: stablecoinTickers, isLoading: isLoadingStablecoinTickers } =
     useStablecoinTickers("lld", __APP_VERSION__);
   const categorizedAssets = useCategorizedAssets(distribution, stablecoinTickers);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new tests added — existing behavior fix using already-tested selector._
- [x] **Impact of the changes:**
      - Portfolio asset count display (SubHeader should show correct total, e.g. "(8)")
      - Token visibility in crypto list (e.g. WETH now appears when hide empty token accounts is disabled)
      - Allocation section asset listing consistency

### 📝 Description

**Problem**: The `useCategorizedAssetsFromPortfolio` hook was hardcoding `hideEmptyTokenAccount: true`, ignoring the user's actual setting. This caused two issues:
1. The portfolio SubHeader showed an incorrect asset count (missing tokens like WETH)
2. Tokens visible on mobile were not appearing in the desktop crypto list

**Solution**: Read the `hideEmptyTokenAccount` value from the Redux settings selector (`hideEmptyTokenAccountsSelector`) instead of hardcoding `true`, aligning behavior with `AssetCrumb` and `useAllocationData` which already use this pattern.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28457](https://ledgerhq.atlassian.net/browse/LIVE-28457)
- https://ledgerhq.atlassian.net/browse/LIVE-28445

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28457]: https://ledgerhq.atlassian.net/browse/LIVE-28457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ