### PR TITLE
[LWD] fix(desktop): load on-demand countervalues for asset table placeholder prices

### DIFF
--- a/.changeset/chilled-adults-attend.md
+++ b/.changeset/chilled-adults-attend.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix asset table prices not adapting when changing countervalue currency by loading on-demand countervalue rates for placeholder currencies

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/__tests__/usePriceCellViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/__tests__/usePriceCellViewModel.test.ts
@@ -14,6 +14,7 @@ jest.mock("@ledgerhq/live-common/currencies/index", () => ({
 }));
 
 jest.mock("~/renderer/hooks/usePrice");
+jest.mock("~/renderer/actions/deprecated/ondemand-countervalues");
 
 const mockedFormatCurrencyUnit = jest.mocked(formatCurrencyUnit);
 const mockedUsePrice = jest.mocked(usePrice);
@@ -74,7 +75,8 @@ describe("usePriceCellViewModel", () => {
     );
   });
 
-  it("should format placeholderPrice when provided with a high value", () => {
+  it("should fall back to placeholderPrice (high value) when counterValue is undefined", () => {
+    mockedUsePrice.mockReturnValue(mockUsePriceReturn(undefined));
     mockedFormatCurrencyUnit.mockReturnValue("USD 43,000.00");
 
     const { result } = renderHook(() => usePriceCellViewModel(mockCurrency, 43000));
@@ -88,7 +90,8 @@ describe("usePriceCellViewModel", () => {
     );
   });
 
-  it("should format placeholderPrice with subMagnitude for small values", () => {
+  it("should fall back to placeholderPrice with subMagnitude for small values when counterValue is undefined", () => {
+    mockedUsePrice.mockReturnValue(mockUsePriceReturn(undefined));
     mockedFormatCurrencyUnit.mockReturnValue("USD 0.07");
 
     const { result } = renderHook(() => usePriceCellViewModel(mockCurrency, 0.07));
@@ -102,17 +105,16 @@ describe("usePriceCellViewModel", () => {
     );
   });
 
-  it("should use placeholderPrice over counterValue when both are available", () => {
+  it("should use counterValue over placeholderPrice when both are available", () => {
     mockedUsePrice.mockReturnValue(mockUsePriceReturn(new BigNumber(50000)));
-    mockedFormatCurrencyUnit.mockReturnValue("USD 43,000.00");
+    mockedFormatCurrencyUnit.mockReturnValue("$50,000.00");
 
     const { result } = renderHook(() => usePriceCellViewModel(mockCurrency, 43000));
 
-    expect(result.current.formattedPrice).toBe("USD 43,000.00");
-    const expectedValue = new BigNumber(43000).times(10 ** usdMagnitude);
+    expect(result.current.formattedPrice).toBe("$50,000.00");
     expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(
       mockCounterValueCurrency.units[0],
-      expectedValue,
+      new BigNumber(50000),
       expect.objectContaining({ showCode: true }),
     );
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/usePriceCellViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/usePriceCellViewModel.ts
@@ -2,6 +2,7 @@ import { Currency, Unit } from "@ledgerhq/types-cryptoassets";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import BigNumber from "bignumber.js";
 import { usePrice } from "~/renderer/hooks/usePrice";
+import { useOnDemandCurrencyCountervalues } from "~/renderer/actions/deprecated/ondemand-countervalues";
 
 function formatPrice(unit: Unit, value: BigNumber): string {
   const subMagnitude = value.lt(10 ** unit.magnitude) ? 1 : 0;
@@ -16,14 +17,16 @@ export function usePriceCellViewModel(currency: Currency, placeholderPrice?: num
   const { counterValue, counterValueCurrency } = usePrice(currency);
   const unit = counterValueCurrency.units[0];
 
+  useOnDemandCurrencyCountervalues(currency, counterValueCurrency);
+
+  if (counterValue) {
+    return { formattedPrice: formatPrice(unit, counterValue) };
+  }
+
   if (placeholderPrice != null) {
     const value = new BigNumber(placeholderPrice).times(10 ** unit.magnitude);
     return { formattedPrice: formatPrice(unit, value) };
   }
 
-  if (!counterValue) {
-    return { formattedPrice: "-" };
-  }
-
-  return { formattedPrice: formatPrice(unit, counterValue) };
+  return { formattedPrice: "-" };
 }


### PR DESCRIPTION
## Summary

Fixes asset table prices not adapting when users change their countervalue currency (e.g. USD → EUR).

- Add `useOnDemandCurrencyCountervalues` in `usePriceCellViewModel` to register tracking pairs for placeholder currencies, ensuring `useCalculate` returns correct rates for the selected fiat
- Fix priority: counterValue from the countervalues engine is now used over `placeholderPrice` (DADA fallback) when available
- Remove leftover `console.log` debug statements
- Update tests to reflect correct behavior

**Root cause**: Placeholder currencies had no `TrackingPair` registered, so `useCalculate` returned `undefined` and the fallback `placeholderPrice` (always in USD from DADA API) was displayed with the wrong fiat symbol.

## Jira

[LIVE-28474](https://ledgerhq.atlassian.net/browse/LIVE-28474)

## Test plan

- [ ] Have stablecoins in portfolio
- [ ] Change countervalue currency (e.g. USD → EUR)
- [ ] Verify crypto table prices update correctly
- [ ] Verify stablecoin table prices update correctly
- [ ] Verify placeholder rows (empty state / padding) show prices in the correct countervalue

[LIVE-28474]: https://ledgerhq.atlassian.net/browse/LIVE-28474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ