### PR TITLE
feat(error): add an invalid parameter error

### DIFF
--- a/.changeset/famous-crabs-glow.md
+++ b/.changeset/famous-crabs-glow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/errors": minor
+---
+
+add an invalid parameter error

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -230,6 +230,8 @@ export const DisabledTransactionBroadcastError = createCustomErrorClass(
   "DisabledTransactionBroadcastError",
 );
 
+export const InvalidParameterError = createCustomErrorClass("InvalidParameterError");
+
 // Represents the type of all the classes created with createCustomErrorClass
 export type CustomErrorClassType = ReturnType<typeof createCustomErrorClass>;
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

add an invalid parameter error

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> [LIVE-28487](https://ledgerhq.atlassian.net/browse/LIVE-28487?atlOrigin=eyJpIjoiZmNiMDU2M2UxNzBkNDEyNjkzNDQxMzYwM2U2MDE2MGEiLCJwIjoiaiJ9)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28487]: https://ledgerhq.atlassian.net/browse/LIVE-28487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ