### PR TITLE
[LWDM] feat(perps): add device interaction sign flow

### DIFF
--- a/.changeset/itchy-roses-remember.md
+++ b/.changeset/itchy-roses-remember.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+fix device interaction modal for perps

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, lazy } from "react";
 import ModularDialogRoot from "LLD/features/ModularDialog/ModularDialogRoot";
 import SendFlowRoot from "LLD/features/Send/SendFlowRoot";
+import PerpsSignRoot from "LLD/features/Perps/screens/PerpsSign/PerpsSignDialog";
 
 const ReleaseNotes = lazy(() => import("LLD/features/ReleaseNotes"));
 const BuyDevice = lazy(() => import("LLD/features/BuyDevice"));
@@ -10,6 +11,7 @@ const GlobalDialogs = () => (
   <>
     <ModularDialogRoot />
     <SendFlowRoot />
+    <PerpsSignRoot />
     <Suspense fallback={null}>
       <ReleaseNotes />
     </Suspense>

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsHandlers.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsHandlers.test.ts
@@ -1,0 +1,48 @@
+import { renderHook } from "tests/testSetup";
+import { usePerpsHandlers } from "../usePerpsHandlers";
+import { handlers as perpsHandlers } from "@ledgerhq/live-common/wallet-api/Perps/server";
+
+jest.mock("@ledgerhq/live-common/wallet-api/Perps/server", () => ({
+  handlers: jest.fn().mockReturnValue({ "custom.perps.signActions": jest.fn() }),
+}));
+
+const mockOpenPerpsSign = jest.fn();
+jest.mock("../../screens/PerpsSign/PerpsSignDialog", () => ({
+  openPerpsSign: (...args: unknown[]) => mockOpenPerpsSign(...args),
+}));
+
+const mockedPerpsHandlers = jest.mocked(perpsHandlers);
+
+describe("usePerpsHandlers", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should call perps handlers with signing.execute ui hook", () => {
+    const accounts = [{ id: "acc-1" }] as never[];
+
+    renderHook(() => usePerpsHandlers(accounts));
+
+    expect(mockedPerpsHandlers).toHaveBeenCalledWith({
+      accounts,
+      uiHooks: { "signing.execute": expect.any(Function) },
+    });
+  });
+
+  it("should call openPerpsSign with data when signing.execute is called", () => {
+    const accounts = [{ id: "acc-1" }] as never[];
+    renderHook(() => usePerpsHandlers(accounts));
+
+    const signingExecute = mockedPerpsHandlers.mock.calls[0][0].uiHooks["signing.execute"];
+    const params = {
+      appName: "Hyperliquid",
+      appOptions: undefined,
+      signFactory: jest.fn(),
+      onSuccess: jest.fn(),
+      onError: jest.fn(),
+      onCancel: jest.fn(),
+    };
+
+    signingExecute(params);
+
+    expect(mockOpenPerpsSign).toHaveBeenCalledWith(params);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsHandlers.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsHandlers.ts
@@ -1,19 +1,21 @@
-import { handlers as perpsHandlers } from "@ledgerhq/live-common/wallet-api/Perps/server";
-import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
-import { AccountLike } from "@ledgerhq/types-live";
+import {
+  handlers as perpsHandlers,
+  type PerpsSignResult,
+} from "@ledgerhq/live-common/wallet-api/Perps/server";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import type { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
+import type { AccountLike } from "@ledgerhq/types-live";
 import { useCallback, useMemo } from "react";
-import { useDispatch } from "LLD/hooks/redux";
-import { openModal } from "~/renderer/actions/modals";
-import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
+import { openPerpsSign } from "../screens/PerpsSign/PerpsSignDialog";
 
 export function usePerpsHandlers(accounts: AccountLike[]) {
-  const dispatch = useDispatch();
-
-  const uiDeviceSelect = useCallback(
+  const uiSigningExecute = useCallback(
     ({
       appName,
       appOptions,
+      signFactory,
       onSuccess,
+      onError,
       onCancel,
     }: {
       appName: string | undefined;
@@ -22,29 +24,22 @@ export function usePerpsHandlers(accounts: AccountLike[]) {
         allowPartialDependencies: boolean;
         skipAppInstallIfNotFound: boolean;
       };
-      onSuccess: (result: AppResult) => void;
+      signFactory: (device: Device) => Promise<PerpsSignResult>;
+      onSuccess: (result: PerpsSignResult) => void;
+      onError: (error: Error) => void;
       onCancel: () => void;
     }) => {
-      dispatch(
-        openModal("MODAL_CONNECT_DEVICE", {
-          appName,
-          requireLatestFirmware: appOptions?.requireLatestFirmware,
-          allowPartialDependencies: appOptions?.allowPartialDependencies,
-          skipAppInstallIfNotFound: appOptions?.skipAppInstallIfNotFound,
-          onResult: onSuccess,
-          onCancel,
-        }),
-      );
+      openPerpsSign({ appName, appOptions, signFactory, onSuccess, onError, onCancel });
     },
-    [dispatch],
+    [],
   );
 
   return useMemo<WalletAPICustomHandlers>(() => {
     return perpsHandlers({
       accounts,
       uiHooks: {
-        "device.select": uiDeviceSelect,
+        "signing.execute": uiSigningExecute,
       },
     });
-  }, [accounts, uiDeviceSelect]);
+  }, [accounts, uiSigningExecute]);
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/PerpsSignDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/PerpsSignDialog.tsx
@@ -1,0 +1,53 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Dialog, DialogContent } from "@ledgerhq/lumen-ui-react";
+import { usePerpsSignViewModel, type PerpsSignData } from "./usePerpsSignViewModel";
+import { PerpsSignView } from "./PerpsSignView";
+
+let _opener: ((data: PerpsSignData) => void) | null = null;
+
+function registerPerpsSignOpener(fn: (data: PerpsSignData) => void): () => void {
+  _opener = fn;
+  return () => {
+    _opener = null;
+  };
+}
+
+export function openPerpsSign(data: PerpsSignData) {
+  _opener?.(data);
+}
+
+function PerpsSignBody({ data, onClose }: Readonly<{ data: PerpsSignData; onClose: () => void }>) {
+  const viewModel = usePerpsSignViewModel(data, onClose);
+  return <PerpsSignView {...viewModel} />;
+}
+
+function PerpsSignInnerDialog({
+  data,
+  onClose,
+}: Readonly<{ data: PerpsSignData | null; onClose: () => void }>) {
+  const isOpen = data !== null;
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onClose();
+    },
+    [onClose],
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent onInteractOutside={e => e.preventDefault()}>
+        {data ? <PerpsSignBody data={data} onClose={onClose} /> : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function PerpsSignRoot() {
+  const [data, setData] = useState<PerpsSignData | null>(null);
+  const close = useCallback(() => setData(null), []);
+
+  useEffect(() => registerPerpsSignOpener(setData), []);
+
+  return <PerpsSignInnerDialog data={data} onClose={close} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/PerpsSignView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/PerpsSignView.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { DialogHeader, DialogBody } from "@ledgerhq/lumen-ui-react";
+import DeviceAction from "~/renderer/components/DeviceAction";
+import { SimplifiedTransactionConfirm } from "LLD/features/Send/screens/Signature/components/SimplifiedTransactionConfirm";
+import type { PerpsSignViewModel } from "./usePerpsSignViewModel";
+
+export function PerpsSignView({
+  phase,
+  device,
+  action,
+  request,
+  handleDeviceResult,
+  handleDeviceError,
+}: Readonly<PerpsSignViewModel>) {
+  if (phase === "sign" && device) {
+    return (
+      <>
+        <DialogHeader />
+        <SimplifiedTransactionConfirm device={device} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <DialogHeader />
+      <DialogBody>
+        <DeviceAction
+          action={action}
+          request={request}
+          onResult={handleDeviceResult}
+          onError={handleDeviceError}
+        />
+      </DialogBody>
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/__integrations__/perpsSign.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/__integrations__/perpsSign.integration.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen, act } from "tests/testSetup";
+import PerpsSignRoot, { openPerpsSign } from "../PerpsSignDialog";
+
+jest.mock("~/renderer/hooks/useConnectAppAction", () => ({
+  __esModule: true,
+  default: () => ({ connectApp: jest.fn() }),
+}));
+
+jest.mock("~/renderer/components/DeviceAction", () => ({
+  __esModule: true,
+  default: (props: { onResult: (r: unknown) => void }) => (
+    <div data-testid="device-action" onClick={() => props.onResult({ device: {} })}>
+      DeviceAction
+    </div>
+  ),
+}));
+
+jest.mock(
+  "LLD/features/Send/screens/Signature/components/SimplifiedTransactionConfirm",
+  () => ({
+    SimplifiedTransactionConfirm: () => <div data-testid="sign-confirm">SignConfirm</div>,
+  }),
+);
+
+const perpsSignData = {
+  appName: "Hyperliquid",
+  signFactory: jest.fn().mockResolvedValue({ signatures: [] }),
+  onSuccess: jest.fn(),
+  onError: jest.fn(),
+  onCancel: jest.fn(),
+};
+
+describe("PerpsSign integration", () => {
+  it("should render DeviceAction after openPerpsSign is called", () => {
+    render(<PerpsSignRoot />);
+
+    expect(screen.queryByTestId("device-action")).not.toBeInTheDocument();
+
+    act(() => {
+      openPerpsSign(perpsSignData);
+    });
+
+    expect(screen.getByTestId("device-action")).toBeVisible();
+  });
+
+  it("should not render content when no data is set", () => {
+    render(<PerpsSignRoot />);
+
+    expect(screen.queryByTestId("device-action")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/__tests__/usePerpsSignViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/__tests__/usePerpsSignViewModel.test.ts
@@ -1,0 +1,164 @@
+import { renderHook, act, waitFor } from "tests/testSetup";
+import { usePerpsSignViewModel, type PerpsSignData } from "../usePerpsSignViewModel";
+
+jest.mock("~/renderer/hooks/useConnectAppAction", () => ({
+  __esModule: true,
+  default: () => ({ connectApp: jest.fn() }),
+}));
+
+const mockDevice = { modelId: "stax", deviceId: "device-1", wired: true } as never;
+
+function createMockData(overrides?: Partial<PerpsSignData>): PerpsSignData {
+  return {
+    appName: "Hyperliquid",
+    appOptions: {
+      requireLatestFirmware: false,
+      allowPartialDependencies: false,
+      skipAppInstallIfNotFound: false,
+    },
+    signFactory: jest.fn().mockResolvedValue({ signatures: [] }),
+    onSuccess: jest.fn(),
+    onError: jest.fn(),
+    onCancel: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("usePerpsSignViewModel", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should start in connect phase with no device", () => {
+    const data = createMockData();
+    const onClose = jest.fn();
+    const { result } = renderHook(() => usePerpsSignViewModel(data, onClose));
+
+    expect(result.current.phase).toBe("connect");
+    expect(result.current.device).toBeNull();
+    expect(result.current.closing).toBe(false);
+  });
+
+  it("should transition to sign phase and call signFactory when device is set", async () => {
+    const data = createMockData();
+    const onClose = jest.fn();
+    const { result } = renderHook(() => usePerpsSignViewModel(data, onClose));
+
+    act(() => {
+      result.current.handleDeviceResult({ device: mockDevice } as never);
+    });
+
+    expect(result.current.phase).toBe("sign");
+    expect(result.current.device).toBe(mockDevice);
+    await waitFor(() => expect(data.signFactory).toHaveBeenCalledWith(mockDevice));
+  });
+
+  it("should call onSuccess and onClose when signFactory resolves", async () => {
+    const signatures = [{ r: "0x1", s: "0x2", v: 27 }];
+    const data = createMockData({
+      signFactory: jest.fn().mockResolvedValue({ signatures }),
+    });
+    const onClose = jest.fn();
+    const { result } = renderHook(() => usePerpsSignViewModel(data, onClose));
+
+    act(() => {
+      result.current.handleDeviceResult({ device: mockDevice } as never);
+    });
+
+    await waitFor(() => {
+      expect(data.onSuccess).toHaveBeenCalledWith({ signatures });
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("should call onError and onClose when signFactory rejects", async () => {
+    const error = new Error("signing failed");
+    const data = createMockData({
+      signFactory: jest.fn().mockRejectedValue(error),
+    });
+    const onClose = jest.fn();
+    const { result } = renderHook(() => usePerpsSignViewModel(data, onClose));
+
+    act(() => {
+      result.current.handleDeviceResult({ device: mockDevice } as never);
+    });
+
+    await waitFor(() => {
+      expect(data.onError).toHaveBeenCalledWith(error);
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("should call onCancel on unmount when signing has not completed", () => {
+    const data = createMockData();
+    const onClose = jest.fn();
+    const { unmount } = renderHook(() => usePerpsSignViewModel(data, onClose));
+
+    unmount();
+
+    expect(data.onCancel).toHaveBeenCalled();
+  });
+
+  it("should not call onCancel on unmount after successful signing", async () => {
+    const data = createMockData();
+    const onClose = jest.fn();
+    const { result, unmount } = renderHook(() => usePerpsSignViewModel(data, onClose));
+
+    act(() => {
+      result.current.handleDeviceResult({ device: mockDevice } as never);
+    });
+
+    await waitFor(() => expect(data.onSuccess).toHaveBeenCalled());
+
+    unmount();
+
+    expect(data.onCancel).not.toHaveBeenCalled();
+  });
+
+  it("should call onError, onClose and set closing on handleDeviceError", () => {
+    const data = createMockData();
+    const onClose = jest.fn();
+    const { result } = renderHook(() => usePerpsSignViewModel(data, onClose));
+    const error = new Error("device error");
+
+    act(() => {
+      result.current.handleDeviceError(error);
+    });
+
+    expect(data.onError).toHaveBeenCalledWith(error);
+    expect(onClose).toHaveBeenCalled();
+    expect(result.current.closing).toBe(true);
+  });
+
+  it("should not call onCancel after handleDeviceError + unmount", () => {
+    const data = createMockData();
+    const onClose = jest.fn();
+    const { result, unmount } = renderHook(() => usePerpsSignViewModel(data, onClose));
+
+    act(() => {
+      result.current.handleDeviceError(new Error("fail"));
+    });
+
+    unmount();
+
+    expect(data.onCancel).not.toHaveBeenCalled();
+  });
+
+  it("should build request from data app options", () => {
+    const data = createMockData({
+      appName: "TestApp",
+      appOptions: {
+        requireLatestFirmware: true,
+        allowPartialDependencies: true,
+        skipAppInstallIfNotFound: true,
+      },
+    });
+    const onClose = jest.fn();
+    const { result } = renderHook(() => usePerpsSignViewModel(data, onClose));
+
+    expect(result.current.request).toEqual({
+      appName: "TestApp",
+      requireLatestFirmware: true,
+      allowPartialDependencies: true,
+      skipAppInstallIfNotFound: true,
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/usePerpsSignViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsSign/usePerpsSignViewModel.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
+import type { PerpsSignResult } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import useConnectAppAction from "~/renderer/hooks/useConnectAppAction";
+
+export type PerpsSignData = {
+  appName: string | undefined;
+  appOptions?: {
+    requireLatestFirmware: boolean;
+    allowPartialDependencies: boolean;
+    skipAppInstallIfNotFound: boolean;
+  };
+  signFactory: (device: Device) => Promise<PerpsSignResult>;
+  onSuccess: (result: PerpsSignResult) => void;
+  onError: (error: Error) => void;
+  onCancel: () => void;
+};
+
+type ConnectAppAction = ReturnType<typeof useConnectAppAction>;
+
+export type PerpsSignViewModel = {
+  phase: "connect" | "sign";
+  device: Device | null;
+  action: ConnectAppAction;
+  request: {
+    appName: string | undefined;
+    requireLatestFirmware?: boolean;
+    allowPartialDependencies?: boolean;
+    skipAppInstallIfNotFound?: boolean;
+  };
+  closing: boolean;
+  handleDeviceResult: (result: AppResult) => void;
+  handleDeviceError: (error: Error) => void;
+};
+
+export function usePerpsSignViewModel(
+  data: PerpsSignData,
+  onClose: () => void,
+): PerpsSignViewModel {
+  const [device, setDevice] = useState<Device | null>(null);
+  const [closing, setClosing] = useState(false);
+  const completedRef = useRef(false);
+
+  const action = useConnectAppAction();
+  const request = useMemo(
+    () => ({
+      appName: data.appName,
+      requireLatestFirmware: data.appOptions?.requireLatestFirmware,
+      allowPartialDependencies: data.appOptions?.allowPartialDependencies,
+      skipAppInstallIfNotFound: data.appOptions?.skipAppInstallIfNotFound,
+    }),
+    [data.appName, data.appOptions],
+  );
+
+  useEffect(() => {
+    if (!device) return;
+
+    let cancelled = false;
+
+    data
+      .signFactory(device)
+      .then(result => {
+        if (cancelled) return;
+        completedRef.current = true;
+        data.onSuccess(result);
+        onClose();
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        completedRef.current = true;
+        const e = err instanceof Error ? err : new Error(String(err));
+        data.onError(e);
+        onClose();
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [device, data, onClose]);
+
+  useEffect(() => {
+    return () => {
+      if (!completedRef.current) {
+        data.onCancel();
+      }
+    };
+  }, [data]);
+
+  const handleDeviceResult = useCallback((result: AppResult) => {
+    setDevice(result.device);
+  }, []);
+
+  const handleDeviceError = useCallback(
+    (error: Error) => {
+      setClosing(true);
+      completedRef.current = true;
+      data.onError(error);
+      onClose();
+    },
+    [data, onClose],
+  );
+
+  return {
+    phase: device ? "sign" : "connect",
+    closing,
+    device,
+    action,
+    request,
+    handleDeviceResult,
+    handleDeviceError,
+  };
+}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -63,6 +63,7 @@ import { readOnlyModeEnabledSelector } from "~/reducers/settings";
 import { hasNoAccountsSelector } from "~/reducers/accounts";
 import { BaseNavigatorStackParamList } from "./types/BaseNavigator";
 import DeviceConnect, { deviceConnectHeaderOptions } from "~/screens/DeviceConnect";
+import PerpsSign from "LLM/features/Perps/screens/PerpsSign/PerpsSignScreen";
 import NoFundsFlowNavigator from "./NoFundsFlowNavigator";
 import StakeFlowNavigator from "./StakeFlowNavigator";
 import { RecoverPlayer } from "~/screens/Protect/Player";
@@ -570,6 +571,11 @@ export default function BaseNavigator() {
           listeners={({ route }) => ({
             beforeRemove: () => handleOnClose(route),
           })}
+        />
+        <Stack.Screen
+          name={ScreenName.PerpsSign}
+          component={PerpsSign}
+          options={{ headerShown: false }}
         />
         <Stack.Screen
           name={ScreenName.RedirectToOnboardingRecoverFlow}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -10,6 +10,7 @@ import type { NavigatorScreenParams } from "@react-navigation/native";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import type { PerpsSignResult } from "@ledgerhq/live-common/wallet-api/Perps/server";
 import type { SendFlowInitParams } from "@ledgerhq/live-common/flows/send/types";
 import type { AssetsNavigatorParamsList } from "LLM/features/Assets/types";
 import type { DeviceSelectionNavigatorParamsList } from "LLM/features/DeviceSelection/types";
@@ -319,6 +320,18 @@ export type BaseNavigatorStackParamList = {
     skipAppInstallIfNotFound?: boolean;
     onSuccess: (result: AppResult) => void;
     onClose: () => void;
+  };
+  [ScreenName.PerpsSign]: {
+    appName: string | undefined;
+    appOptions?: {
+      requireLatestFirmware: boolean;
+      allowPartialDependencies: boolean;
+      skipAppInstallIfNotFound: boolean;
+    };
+    signFactory: (device: Device) => Promise<PerpsSignResult>;
+    onSuccess: (result: PerpsSignResult) => void;
+    onError: (error: Error) => void;
+    onCancel: () => void;
   };
   [ScreenName.DeeplinkInstallAppDeviceSelection]: {
     appKey: string;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -82,6 +82,7 @@ export enum ScreenName {
   DeveloperCustomManifest = "DeveloperCustomManifest",
   DeveloperSettings = "DeveloperSettings",
   DeviceConnect = "DeviceConnect",
+  PerpsSign = "PerpsSign",
   EditAccountName = "EditAccountName",
   EditDeviceName = "EditDeviceName",
   Card = "Card",

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsHandlers.test.ts
@@ -1,0 +1,56 @@
+import { renderHook } from "@tests/test-renderer";
+import { usePerpsHandlers } from "../usePerpsHandlers";
+import { handlers as perpsHandlers } from "@ledgerhq/live-common/wallet-api/Perps/server";
+
+jest.mock("@ledgerhq/live-common/wallet-api/Perps/server", () => ({
+  handlers: jest.fn().mockReturnValue({ "custom.perps.signActions": jest.fn() }),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const mockedPerpsHandlers = jest.mocked(perpsHandlers);
+
+describe("usePerpsHandlers", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should call perps handlers with signing.execute ui hook", () => {
+    const accounts = [{ id: "acc-1" }] as never[];
+
+    renderHook(() => usePerpsHandlers(accounts));
+
+    expect(mockedPerpsHandlers).toHaveBeenCalledWith({
+      accounts,
+      uiHooks: { "signing.execute": expect.any(Function) },
+    });
+  });
+
+  it("should navigate to PerpsSign screen when signing.execute is called", () => {
+    const accounts = [{ id: "acc-1" }] as never[];
+    renderHook(() => usePerpsHandlers(accounts));
+
+    const signingExecute = mockedPerpsHandlers.mock.calls[0][0].uiHooks["signing.execute"];
+    const params = {
+      appName: "Hyperliquid",
+      appOptions: undefined,
+      signFactory: jest.fn(),
+      onSuccess: jest.fn(),
+      onError: jest.fn(),
+      onCancel: jest.fn(),
+    };
+
+    signingExecute(params);
+
+    expect(mockNavigate).toHaveBeenCalledWith("PerpsSign", {
+      appName: "Hyperliquid",
+      appOptions: undefined,
+      signFactory: params.signFactory,
+      onSuccess: params.onSuccess,
+      onError: params.onError,
+      onCancel: params.onCancel,
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsHandlers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsHandlers.ts
@@ -1,9 +1,10 @@
 import { useCallback, useMemo } from "react";
 import { useNavigation } from "@react-navigation/native";
-import { AccountLike } from "@ledgerhq/types-live";
-import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
+import type { AccountLike } from "@ledgerhq/types-live";
+import type { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
 import { handlers as perpsHandlers } from "@ledgerhq/live-common/wallet-api/Perps/server";
-import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
+import type { PerpsSignResult } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { ScreenName } from "~/const";
 import { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
@@ -11,11 +12,13 @@ import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/Ba
 export function usePerpsHandlers(accounts: AccountLike[]): WalletAPICustomHandlers {
   const navigation = useNavigation<StackNavigatorNavigation<BaseNavigatorStackParamList>>();
 
-  const uiDeviceSelect = useCallback(
+  const uiSigningExecute = useCallback(
     ({
       appName,
       appOptions,
+      signFactory,
       onSuccess,
+      onError,
       onCancel,
     }: {
       appName: string | undefined;
@@ -24,16 +27,18 @@ export function usePerpsHandlers(accounts: AccountLike[]): WalletAPICustomHandle
         allowPartialDependencies: boolean;
         skipAppInstallIfNotFound: boolean;
       };
-      onSuccess: (result: AppResult) => void;
+      signFactory: (device: Device) => Promise<PerpsSignResult>;
+      onSuccess: (result: PerpsSignResult) => void;
+      onError: (error: Error) => void;
       onCancel: () => void;
     }) => {
-      navigation.navigate(ScreenName.DeviceConnect, {
+      navigation.navigate(ScreenName.PerpsSign, {
         appName,
-        requireLatestFirmware: appOptions?.requireLatestFirmware,
-        allowPartialDependencies: appOptions?.allowPartialDependencies,
-        skipAppInstallIfNotFound: appOptions?.skipAppInstallIfNotFound,
+        appOptions,
+        signFactory,
         onSuccess,
-        onClose: onCancel,
+        onError,
+        onCancel,
       });
     },
     [navigation],
@@ -44,9 +49,9 @@ export function usePerpsHandlers(accounts: AccountLike[]): WalletAPICustomHandle
       perpsHandlers({
         accounts,
         uiHooks: {
-          "device.select": uiDeviceSelect,
+          "signing.execute": uiSigningExecute,
         },
       }),
-    [accounts, uiDeviceSelect],
+    [accounts, uiSigningExecute],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/PerpsSignScreen.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/PerpsSignScreen.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { ScreenName } from "~/const";
+import { PerpsSignView } from ".";
+import { usePerpsSignViewModel } from "./usePerpsSignViewModel";
+
+type NavigationProps = RootComposite<
+  StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PerpsSign>
+>;
+
+export default function PerpsSignScreen(props: NavigationProps) {
+  const viewModel = usePerpsSignViewModel(props);
+  return <PerpsSignView {...viewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/__integrations__/perpsSign.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/__integrations__/perpsSign.integration.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import PerpsSignScreen from "../PerpsSignScreen";
+
+jest.mock("~/hooks/deviceActions", () => ({
+  useAppDeviceAction: () => ({ action: "mock-action" }),
+}));
+
+jest.mock("~/components/SelectDevice2", () => {
+  const { View, Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: () => (
+      <View testID="select-device">
+        <Text>SelectDevice</Text>
+      </View>
+    ),
+  };
+});
+
+const mockNavigation = {
+  goBack: jest.fn(),
+  setOptions: jest.fn(),
+  addListener: jest.fn(),
+};
+
+const mockRoute = {
+  params: {
+    appName: "Hyperliquid",
+    appOptions: {
+      requireLatestFirmware: false,
+      allowPartialDependencies: false,
+      skipAppInstallIfNotFound: false,
+    },
+    signFactory: jest.fn().mockResolvedValue({ signatures: [] }),
+    onSuccess: jest.fn(),
+    onError: jest.fn(),
+    onCancel: jest.fn(),
+  },
+};
+
+describe("PerpsSign integration", () => {
+  it("should render the device selection screen", () => {
+    render(
+      <PerpsSignScreen navigation={mockNavigation as never} route={mockRoute as never} />,
+    );
+
+    expect(screen.getByTestId("select-device")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/__tests__/usePerpsSignViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/__tests__/usePerpsSignViewModel.test.ts
@@ -1,0 +1,205 @@
+import { renderHook, act, waitFor } from "@tests/test-renderer";
+import { usePerpsSignViewModel } from "../usePerpsSignViewModel";
+
+jest.mock("~/hooks/deviceActions", () => ({
+  useAppDeviceAction: () => ({ action: "mock-action" }),
+}));
+
+const mockDevice = { modelId: "stax", deviceId: "device-1", wired: true } as never;
+
+function createNavigationProps(overrides: Record<string, unknown> = {}) {
+  return {
+    navigation: {
+      goBack: jest.fn(),
+      setOptions: jest.fn(),
+    },
+    route: {
+      params: {
+        appName: "Hyperliquid",
+        appOptions: {
+          requireLatestFirmware: false,
+          allowPartialDependencies: false,
+          skipAppInstallIfNotFound: false,
+        },
+        signFactory: jest.fn().mockResolvedValue({ signatures: [] }),
+        onSuccess: jest.fn(),
+        onError: jest.fn(),
+        onCancel: jest.fn(),
+        onClose: jest.fn(),
+        ...overrides,
+      },
+    },
+  } as never;
+}
+
+describe("usePerpsSignViewModel", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should start with no selected device and drawer closed", () => {
+    const props = createNavigationProps();
+    const { result } = renderHook(() => usePerpsSignViewModel(props));
+
+    expect(result.current.selectedDevice).toBeUndefined();
+    expect(result.current.connectedDevice).toBeNull();
+    expect(result.current.drawerOpen).toBe(false);
+  });
+
+  it("should open drawer when a device is selected", () => {
+    const props = createNavigationProps();
+    const { result } = renderHook(() => usePerpsSignViewModel(props));
+
+    act(() => {
+      result.current.setSelectedDevice(mockDevice);
+    });
+
+    expect(result.current.drawerOpen).toBe(true);
+  });
+
+  it("should call signFactory when device connects via handleAppResult", async () => {
+    const signFactory = jest.fn().mockResolvedValue({ signatures: [] });
+    const props = createNavigationProps({ signFactory });
+    const { result } = renderHook(() => usePerpsSignViewModel(props));
+
+    act(() => {
+      result.current.setSelectedDevice(mockDevice);
+    });
+
+    act(() => {
+      result.current.handleAppResult({ device: mockDevice } as never);
+    });
+
+    await waitFor(() => expect(signFactory).toHaveBeenCalledWith(mockDevice));
+  });
+
+  it("should call onSuccess when signFactory resolves", async () => {
+    const signatures = [{ r: "0x1", s: "0x2", v: 27 }];
+    const onSuccess = jest.fn();
+    const props = createNavigationProps({
+      signFactory: jest.fn().mockResolvedValue({ signatures }),
+      onSuccess,
+    });
+    const { result } = renderHook(() => usePerpsSignViewModel(props));
+
+    act(() => {
+      result.current.handleAppResult({ device: mockDevice } as never);
+    });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith({ signatures });
+    });
+  });
+
+  it("should call onError when signFactory rejects", async () => {
+    const error = new Error("signing failed");
+    const onError = jest.fn();
+    const props = createNavigationProps({
+      signFactory: jest.fn().mockRejectedValue(error),
+      onError,
+    });
+    const { result } = renderHook(() => usePerpsSignViewModel(props));
+
+    act(() => {
+      result.current.handleAppResult({ device: mockDevice } as never);
+    });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(error);
+    });
+  });
+
+  it("should call onCancel on unmount when signing has not completed", () => {
+    const props = createNavigationProps();
+    const { unmount } = renderHook(() => usePerpsSignViewModel(props));
+
+    unmount();
+
+    expect((props as { route: { params: { onCancel: jest.Mock } } }).route.params.onCancel).toHaveBeenCalled();
+  });
+
+  it("should not call onCancel after successful signing + unmount", async () => {
+    const onSuccess = jest.fn();
+    const onCancel = jest.fn();
+    const props = createNavigationProps({ onSuccess, onCancel });
+    const { result, unmount } = renderHook(() => usePerpsSignViewModel(props));
+
+    act(() => {
+      result.current.handleAppResult({ device: mockDevice } as never);
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+
+    unmount();
+
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("should reset device state and call onCancel on handleDrawerClose", () => {
+    const onCancel = jest.fn();
+    const props = createNavigationProps({ onCancel });
+    const { result } = renderHook(() => usePerpsSignViewModel(props));
+
+    act(() => {
+      result.current.setSelectedDevice(mockDevice);
+    });
+    expect(result.current.drawerOpen).toBe(true);
+
+    act(() => {
+      result.current.handleDrawerClose();
+    });
+
+    expect(result.current.selectedDevice).toBeUndefined();
+    expect(result.current.connectedDevice).toBeNull();
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("should not call onCancel on handleDrawerClose after successful signing", async () => {
+    const onCancel = jest.fn();
+    const onSuccess = jest.fn();
+    const props = createNavigationProps({ onCancel, onSuccess });
+    const { result } = renderHook(() => usePerpsSignViewModel(props));
+
+    act(() => {
+      result.current.handleAppResult({ device: mockDevice } as never);
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+
+    act(() => {
+      result.current.handleDrawerClose();
+    });
+
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("should navigate back on handleDrawerHidden when signing completed", async () => {
+    const onSuccess = jest.fn();
+    const navigation = { goBack: jest.fn(), setOptions: jest.fn() };
+    const props = {
+      navigation,
+      route: {
+        params: {
+          appName: "Hyperliquid",
+          signFactory: jest.fn().mockResolvedValue({ signatures: [] }),
+          onSuccess,
+          onError: jest.fn(),
+          onCancel: jest.fn(),
+          onClose: jest.fn(),
+        },
+      },
+    } as never;
+
+    const { result } = renderHook(() => usePerpsSignViewModel(props));
+
+    act(() => {
+      result.current.handleAppResult({ device: mockDevice } as never);
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+
+    act(() => {
+      result.current.handleDrawerHidden();
+    });
+
+    expect(navigation.goBack).toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/index.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { BottomSheetView, Box, Tag, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { Device, Action } from "@ledgerhq/live-common/hw/actions/types";
+import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
+import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
+import Animation from "~/components/Animation";
+import { getDeviceAnimation, getDeviceAnimationStyles } from "~/helpers/getDeviceAnimation";
+import { getProductName } from "LLM/utils/getProductName";
+import SelectDevice2 from "~/components/SelectDevice2";
+import DeviceAction from "~/components/DeviceAction";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { PartialNullable } from "~/types/helpers";
+import type { PerpsSignViewModel } from "./usePerpsSignViewModel";
+
+function SigningConfirmation({
+  device,
+  theme,
+  t,
+}: Readonly<{
+  device: Device;
+  theme: "dark" | "light";
+  t: PerpsSignViewModel["t"];
+}>) {
+  return (
+    <Box lx={{ alignItems: "center", padding: "s24", gap: "s16" }}>
+      <Animation
+        source={getDeviceAnimation({ modelId: device.modelId, key: "sign", theme })}
+        style={getDeviceAnimationStyles(device.modelId)}
+      />
+      {device.deviceName ? (
+        <Tag size="md" appearance="gray" label={device.deviceName} />
+      ) : null}
+      <Text typography="heading3SemiBold" lx={{ color: "base", textAlign: "center" }}>
+        {t("send.newSendFlow.sign.title", { wording: getProductName(device.modelId) })}
+      </Text>
+      <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+        {t("send.newSendFlow.sign.description")}
+      </Text>
+    </Box>
+  );
+}
+
+function ConnectDeviceAction({
+  action,
+  request,
+  device,
+  onResult,
+  onClose,
+}: Readonly<{
+  action: PerpsSignViewModel["action"];
+  request: PerpsSignViewModel["request"];
+  device: Device;
+  onResult: (result: AppResult) => void;
+  onClose: () => void;
+}>) {
+  return (
+    <Box lx={{ alignItems: "center" }} testID="device-action-modal">
+      <Box lx={{ flexDirection: "row", marginBottom: "s16" }}>
+        <DeviceAction
+          action={
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion
+            action as unknown as Action<
+              typeof request,
+              PartialNullable<Record<string, unknown>>,
+              AppResult
+            >
+          }
+          device={device}
+          request={request}
+          onResult={onResult}
+          analyticsPropertyFlow="perps sign"
+          onClose={onClose}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+export function PerpsSignView({
+  t,
+  backgroundColor,
+  theme,
+  selectedDevice,
+  connectedDevice,
+  drawerOpen,
+  action,
+  request,
+  setSelectedDevice,
+  handleAppResult,
+  handleDrawerClose,
+  handleDrawerHidden,
+  requestToSetHeaderOptions,
+}: Readonly<PerpsSignViewModel>) {
+  return (
+    <SafeAreaView edges={["bottom"]} style={[styles.root, { backgroundColor }]}>
+      <Box lx={{ paddingHorizontal: "s16", paddingVertical: "s8", flex: 1 }}>
+        <SelectDevice2
+          onSelect={setSelectedDevice}
+          stopBleScanning={!!selectedDevice}
+          requestToSetHeaderOptions={requestToSetHeaderOptions}
+          autoSelectLastConnectedDevice
+        />
+      </Box>
+      <QueuedDrawerBottomSheet
+        isRequestingToBeOpened={drawerOpen}
+        onClose={handleDrawerClose}
+        onModalHide={handleDrawerHidden}
+        preventBackdropClick={!!connectedDevice}
+        enableDynamicSizing
+      >
+        <BottomSheetView>
+          {connectedDevice ? (
+            <SigningConfirmation device={connectedDevice} theme={theme} t={t} />
+          ) : (
+            selectedDevice && (
+              <ConnectDeviceAction
+                action={action}
+                request={request}
+                device={selectedDevice}
+                onResult={handleAppResult}
+                onClose={handleDrawerClose}
+              />
+            )
+          )}
+          {selectedDevice && <SyncSkipUnderPriority priority={100} />}
+        </BottomSheetView>
+      </QueuedDrawerBottomSheet>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/usePerpsSignViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsSign/usePerpsSignViewModel.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "~/context/Locale";
+import { useTheme } from "@react-navigation/native";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import type { AppResult } from "@ledgerhq/live-common/hw/actions/app";
+import type { PerpsSignResult } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import type { SetHeaderOptionsRequest } from "~/components/SelectDevice2";
+import { useAppDeviceAction } from "~/hooks/deviceActions";
+import type { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import type { ScreenName } from "~/const";
+
+type NavigationProps = RootComposite<
+  StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PerpsSign>
+>;
+
+type AppDeviceAction = ReturnType<typeof useAppDeviceAction>;
+
+export type PerpsSignViewModel = {
+  t: ReturnType<typeof useTranslation>["t"];
+  backgroundColor: string;
+  theme: "dark" | "light";
+  selectedDevice: Device | null | undefined;
+  connectedDevice: Device | null;
+  drawerOpen: boolean;
+  action: AppDeviceAction;
+  request: {
+    appName: string | undefined;
+    requireLatestFirmware?: boolean;
+    allowPartialDependencies?: boolean;
+    skipAppInstallIfNotFound?: boolean;
+  };
+  setSelectedDevice: (device: Device | null | undefined) => void;
+  handleAppResult: (result: AppResult) => void;
+  handleDrawerClose: () => void;
+  handleDrawerHidden: () => void;
+  requestToSetHeaderOptions: (req: SetHeaderOptionsRequest) => void;
+};
+
+export function usePerpsSignViewModel({ navigation, route }: NavigationProps): PerpsSignViewModel {
+  const { t } = useTranslation();
+  const { colors, dark } = useTheme();
+  const theme: "dark" | "light" = dark ? "dark" : "light";
+  const { appName, appOptions, signFactory, onSuccess, onError, onCancel } = route.params;
+
+  const [selectedDevice, setSelectedDevice] = useState<Device | null | undefined>();
+  const [connectedDevice, setConnectedDevice] = useState<Device | null>(null);
+  const completedRef = useRef(false);
+
+  const action = useAppDeviceAction();
+  const request = useMemo(
+    () => ({
+      appName,
+      requireLatestFirmware: appOptions?.requireLatestFirmware,
+      allowPartialDependencies: appOptions?.allowPartialDependencies,
+      skipAppInstallIfNotFound: appOptions?.skipAppInstallIfNotFound,
+    }),
+    [appName, appOptions],
+  );
+
+  const drawerOpen = !!selectedDevice;
+
+  const handleAppResult = useCallback((result: AppResult) => {
+    setConnectedDevice(result.device);
+  }, []);
+
+  const handleDrawerClose = useCallback(() => {
+    setConnectedDevice(null);
+    setSelectedDevice(undefined);
+    if (!completedRef.current) {
+      completedRef.current = true;
+      onCancel();
+    }
+  }, [onCancel]);
+
+  const handleDrawerHidden = useCallback(() => {
+    if (completedRef.current) {
+      navigation.goBack();
+    }
+  }, [navigation]);
+
+  const requestToSetHeaderOptions = useCallback(
+    (req: SetHeaderOptionsRequest) => {
+      if (req.type === "set") {
+        navigation.setOptions({
+          headerShown: true,
+          headerLeft: req.options.headerLeft,
+          headerRight: req.options.headerRight,
+        });
+      } else {
+        navigation.setOptions({
+          headerShown: false,
+          headerLeft: () => null,
+          headerRight: () => null,
+        });
+      }
+    },
+    [navigation],
+  );
+
+  useEffect(() => {
+    if (!connectedDevice) return;
+
+    let cancelled = false;
+
+    signFactory(connectedDevice)
+      .then((result: PerpsSignResult) => {
+        if (cancelled) return;
+        completedRef.current = true;
+        onSuccess(result);
+        setSelectedDevice(undefined);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        completedRef.current = true;
+        const e = err instanceof Error ? err : new Error(String(err));
+        onError(e);
+        setSelectedDevice(undefined);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [connectedDevice, signFactory, onSuccess, onError]);
+
+  useEffect(() => {
+    return () => {
+      if (!completedRef.current) {
+        onCancel();
+      }
+    };
+  }, [onCancel]);
+
+  return {
+    t,
+    backgroundColor: colors.background,
+    theme,
+    selectedDevice,
+    connectedDevice,
+    drawerOpen,
+    action,
+    request,
+    setSelectedDevice,
+    handleAppResult,
+    handleDrawerClose,
+    handleDrawerHidden,
+    requestToSetHeaderOptions,
+  };
+}

--- a/libs/ledger-live-common/src/wallet-api/Perps/server.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Perps/server.test.ts
@@ -77,7 +77,7 @@ describe("Perps handlers", () => {
   };
 
   let mockSignActions: jest.Mock;
-  let mockUiDeviceSelect: jest.Mock;
+  let mockUiSigningExecute: jest.Mock;
   let serverHandlers: MockedHandlers;
 
   beforeEach(() => {
@@ -106,14 +106,19 @@ describe("Perps handlers", () => {
       .mocked(withDevice)
       .mockReturnValue(job => from(job({ dmk: {}, sessionId: "session-1" } as never)));
 
-    // UI hook
-    mockUiDeviceSelect = jest
-      .fn()
-      .mockImplementation(({ onSuccess }) => onSuccess({ device: mockDevice }));
+    // UI hook — simulates the modal calling signFactory(device) then onSuccess/onError
+    mockUiSigningExecute = jest.fn().mockImplementation(async ({ signFactory, onSuccess, onError }) => {
+      try {
+        const result = await signFactory(mockDevice);
+        onSuccess(result);
+      } catch (err) {
+        onError(err);
+      }
+    });
 
     serverHandlers = handlers({
       accounts: [mockAccount],
-      uiHooks: { "device.select": mockUiDeviceSelect },
+      uiHooks: { "signing.execute": mockUiSigningExecute },
     }) as unknown as MockedHandlers;
   });
 
@@ -186,13 +191,13 @@ describe("Perps handlers", () => {
       );
     });
 
-    it("should reject when the user cancels the device selection", async () => {
+    it("should reject when the user cancels signing", async () => {
       // GIVEN
-      mockUiDeviceSelect.mockImplementation(({ onCancel }) => onCancel());
+      mockUiSigningExecute.mockImplementation(({ onCancel }) => onCancel());
 
       // WHEN & THEN
       await expect(serverHandlers["custom.perps.signActions"](baseParams)).rejects.toThrow(
-        "User cancelled device selection",
+        "User cancelled signing",
       );
     });
 

--- a/libs/ledger-live-common/src/wallet-api/Perps/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/Perps/server.ts
@@ -7,7 +7,6 @@ import { getAccountIdFromWalletAccountId } from "../converters";
 import { createAccountNotFound, createUnknownError, ServerError } from "@ledgerhq/wallet-api-core";
 import { getMainAccount, getParentAccount } from "../../account";
 import { firstValueFrom, from } from "rxjs";
-import { AppResult } from "../../hw/actions/app";
 import { Device } from "../../hw/actions/types";
 import { withDevice } from "../../hw/deviceAccess";
 import { isDmkTransport } from "../../hw/dmkUtils";
@@ -19,10 +18,12 @@ type AppOption = {
   skipAppInstallIfNotFound: boolean;
 };
 export type PerpsUiHooks = {
-  "device.select": (params: {
+  "signing.execute": (params: {
     appName: string | undefined;
     appOptions?: AppOption;
-    onSuccess: (result: Pick<AppResult, "device">) => void;
+    signFactory: (device: Device) => Promise<PerpsSignResult>;
+    onSuccess: (result: PerpsSignResult) => void;
+    onError: (error: Error) => void;
     onCancel: () => void;
   }) => void;
 };
@@ -46,7 +47,7 @@ const PERPS_APP_NAME = "Hyperliquid";
 
 export const handlers = ({
   accounts,
-  uiHooks: { "device.select": uiDeviceSelect },
+  uiHooks: { "signing.execute": uiSigningExecute },
 }: {
   accounts: AccountLike[];
   uiHooks: PerpsUiHooks;
@@ -74,44 +75,47 @@ export const handlers = ({
         );
       }
 
-      // Ask user to select a device via the UI
-      const device = await new Promise<Device>((resolve, reject) => {
-        uiDeviceSelect({
+      return new Promise<PerpsSignResult>((resolve, reject) => {
+        uiSigningExecute({
           appName: PERPS_APP_NAME,
           appOptions: params.options,
-          onSuccess: ({ device }) => resolve(device),
-          onCancel: () => reject(new Error("User cancelled device selection")),
+          signFactory: (device: Device) =>
+            firstValueFrom(
+              withDevice(
+                device.deviceId,
+                device.deviceName ? { matchDeviceByName: device.deviceName } : undefined,
+              )(transport =>
+                from(
+                  (async () => {
+                    if (!isDmkTransport(transport)) {
+                      throw new Error("Not DMK transport");
+                    }
+                    const { dmk, sessionId } = transport;
+
+                    const certificate = await calService.getCertificate(
+                      device.modelId,
+                      "perps_data",
+                    );
+                    const hyperliquidSigner = new DmkSignerHyperliquid(dmk, sessionId);
+                    const signatures = await hyperliquidSigner.signActions(
+                      derivationPath,
+                      convertCertificateToDeviceData(certificate),
+                      new Uint8Array(
+                        Buffer.from(stripHexPrefix(params.metadataWithSignature), "hex"),
+                      ),
+                      params.actions.map(convertAction),
+                    );
+
+                    return { signatures };
+                  })(),
+                ),
+              ),
+            ),
+          onSuccess: resolve,
+          onError: reject,
+          onCancel: () => reject(new Error("User cancelled signing")),
         });
       });
-
-      // CALL Cal Service
-      const certificate = await calService.getCertificate(device.modelId, "perps_data");
-
-      return firstValueFrom(
-        withDevice(
-          device.deviceId,
-          device.deviceName ? { matchDeviceByName: device.deviceName } : undefined,
-        )(transport =>
-          from(
-            (async () => {
-              if (!isDmkTransport(transport)) {
-                throw new Error("Not DMK transport");
-              }
-              const { dmk, sessionId } = transport;
-
-              const hyperliquidSigner = new DmkSignerHyperliquid(dmk, sessionId);
-              const signatures = await hyperliquidSigner.signActions(
-                derivationPath,
-                convertCertificateToDeviceData(certificate),
-                new Uint8Array(Buffer.from(stripHexPrefix(params.metadataWithSignature), "hex")),
-                params.actions.map(convertAction),
-              );
-
-              return { signatures };
-            })(),
-          ),
-        ),
-      );
     }),
   };
 };


### PR DESCRIPTION
Implement MVVM-based perps sign screens for both desktop and mobile, including view models, views, dialogs, integration tests and unit tests. Refactor wallet-api perps server and usePerpsHandlers hook.

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  -

### 📝 Description

Add Lumen Dialog/Bottomsheet drawers for perps integration


https://github.com/user-attachments/assets/58dbc271-1136-4e8b-9f1f-66c25e63a7f7

https://github.com/user-attachments/assets/7a30fcc4-2711-4b72-8f13-f44b2493fb71





### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->
https://ledgerhq.atlassian.net/browse/LIVE-28179

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
