### PR TITLE
[LWM] test(e2e): replace waitSwapReady with web assertions in swap tests

### DIFF
--- a/apps/ledger-live-mobile/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/client.ts
@@ -192,7 +192,8 @@ async function onMessage(event: WebSocketMessageEvent) {
       }
       case "swapSetup":
         setEnv("SWAP_DISABLE_APPS_INSTALL", true);
-        setEnv("SWAP_API_BASE", "https://swap-stg.ledger-test.com/v5");
+        setEnv("SWAP_API_BASE", msg.swapApiBase ?? "https://swap-stg.ledger-test.com/v5");
+        postMessage({ type: "swapSetupDone" });
         break;
       default:
         break;

--- a/apps/ledger-live-mobile/e2e/bridge/types.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/types.ts
@@ -42,6 +42,7 @@ export type ServerData =
       payload: string;
     }
   | { type: "ACK"; id: string }
+  | { type: "swapSetupDone" }
   | { type: "swapLiveAppReady" }
   | { type: "earnLiveAppReady" };
 
@@ -74,7 +75,7 @@ export type MessageData =
   | { type: "overrideFeatureFlags"; id: string; payload: SettingsSetOverriddenFeatureFlagsPlayload }
   | { type: "overrideFeatureFlag"; id: string; payload: SettingsSetOverriddenFeatureFlagPlayload }
   | { type: "setGlobals"; id: string; payload: { [key: string]: unknown } }
-  | { type: "swapSetup"; id: string }
+  | { type: "swapSetup"; id: string; swapApiBase?: string }
   | { type: "waitSwapReady"; id: string }
   | { type: "waitEarnReady"; id: string }
   | { type: "ACK"; id: string };

--- a/e2e/mobile/bridge/server.ts
+++ b/e2e/mobile/bridge/server.ts
@@ -142,7 +142,10 @@ async function navigate(name: string) {
 }
 
 export async function swapSetup() {
-  postMessage({ type: "swapSetup", id: uniqueId() });
+  if (!process.env.SWAP_API_BASE) {
+    console.warn("[swapSetup] SWAP_API_BASE env var is not set, will use client-side default");
+  }
+  return fetchData({ type: "swapSetup", id: uniqueId(), swapApiBase: process.env.SWAP_API_BASE });
 }
 
 export async function waitSwapReady() {
@@ -229,6 +232,14 @@ function onMessage(messageStr: string) {
       if (pending) {
         global.pendingCallbacks.delete("getEnvs");
         pending.callback(msg.payload);
+      }
+      break;
+    }
+    case "swapSetupDone": {
+      const pending = global.pendingCallbacks?.get("swapSetup");
+      if (pending) {
+        global.pendingCallbacks.delete("swapSetup");
+        pending.callback("swapSetup done");
       }
       break;
     }

--- a/e2e/mobile/specs/deeplinks.spec.ts
+++ b/e2e/mobile/specs/deeplinks.spec.ts
@@ -1,5 +1,5 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { waitSwapReady } from "../bridge/server";
+import { swapSetup } from "../bridge/server";
 import { isWallet40 } from "../helpers/commonHelpers";
 
 const isSmokeTestRun = process.env.INPUTS_TEST_FILTER?.includes("@smoke");
@@ -93,9 +93,9 @@ describe("DeepLinks Tests", () => {
   );
 
   (isSmokeTestRun ? it.skip : it)("should open Swap Form page", async () => {
+    await swapSetup();
     await app.swap.openViaDeeplink();
-    await waitSwapReady();
-    await app.swap.expectSwapPage();
+    await app.swapLiveApp.expectSwapLiveApp();
   });
 
   (isSmokeTestRun ? it.skip : it)("should open Market Detail page for Bitcoin", async () => {

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -1,5 +1,4 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { waitSwapReady } from "../../../bridge/server";
 import { SwapType } from "@ledgerhq/live-common/e2e/models/Swap";
 import { performSwapUntilQuoteSelectionStep } from "../../../utils/swapUtils";
 import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
@@ -449,28 +448,22 @@ export function runSwapEntryPoints(account: Account, tmsLinks: string[], tags: s
     tags.forEach(tag => $Tag(tag));
     it("Access Swap from different entry points", async () => {
       await app.portfolio.openViaDeeplink();
-      let readyPromise = waitSwapReady();
       if (isWallet40) {
         await app.mainNavigation.tapWallet40Tab("swap");
       } else {
         await app.transferMenuDrawer.open();
         await app.transferMenuDrawer.navigateToSwap();
       }
-      await readyPromise;
       await validateSwapAssetsPage(account.currency.ticker, "");
 
       await app.account.openViaDeeplink();
-      readyPromise = waitSwapReady();
       await app.account.goToAccountByName(account.accountName);
       await app.account.tapSwap();
-      await readyPromise;
       await validateSwapAssetsPage("", account.currency.ticker);
 
       await app.portfolio.openViaDeeplink();
       await app.portfolio.goToSpecificAsset(account.currency.name);
-      readyPromise = waitSwapReady();
       await app.assetAccountsPage.tapOnAssetQuickActionButton("swap");
-      await readyPromise;
       await validateSwapAssetsPage("", account.currency.ticker);
     });
   });

--- a/e2e/mobile/specs/swap/swap.setup.ts
+++ b/e2e/mobile/specs/swap/swap.setup.ts
@@ -1,5 +1,5 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { swapSetup, waitSwapReady } from "../../bridge/server";
+import { swapSetup } from "../../bridge/server";
 import { ApplicationOptions } from "page";
 import { ABTestingVariants } from "@ledgerhq/types-live";
 
@@ -57,8 +57,7 @@ export async function beforeAllFunctionSwap(options: ApplicationOptions) {
     cliCommandsOnApp: options.cliCommandsOnApp,
   });
   await app.portfolio.waitForPortfolioPageToLoad();
-  const readyPromise = waitSwapReady();
-  await app.swap.openViaDeeplink();
   await swapSetup();
-  await readyPromise;
+  await app.swap.openViaDeeplink();
+  await app.swapLiveApp.expectSwapLiveApp();
 }


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Replace waitSwapReady() with app.swapLiveApp.expectSwapLiveApp() across all swap test files
- waits for WebView UI elements instead of relying on the custom.isReady WalletAPI event from the external live app.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [QAA-1092](https://ledgerhq.atlassian.net/browse/QAA-1092)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1092]: https://ledgerhq.atlassian.net/browse/QAA-1092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ