### PR TITLE
[LWD] fix(desktop): align starred account rows when sidebar collapsed

### DIFF
--- a/.changeset/quiet-stars-center.md
+++ b/.changeset/quiet-stars-center.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix starred account sidebar item layout when the main sidebar is collapsed

--- a/apps/ledger-live-desktop/src/renderer/components/Stars/Item.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Stars/Item.tsx
@@ -12,22 +12,28 @@ import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { useAccountName } from "~/renderer/reducers/wallet";
 const ParentCryptoCurrencyIconWrapper = styled.div`
-  width: 20px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 const ItemWrapper = styled.div.attrs<{
   active: boolean;
+  collapsed?: boolean;
 }>(p => ({
   style: {
     backgroundColor: p.active ? p.theme.colors.opacityDefault.c10 : p.theme.colors.background.card,
   },
 }))<{
   active: boolean;
+  collapsed?: boolean;
 }>`
   flex: 1;
   align-items: center;
   display: flex;
-  padding: 6px 15px;
-  width: 200px;
+  padding: 6px 12px;
+  width: ${p => (p.collapsed ? "auto" : "200px")};
+  justify-content: ${p => (p.collapsed ? "center" : "flex-start")};
   border-radius: 4px;
   border: 1px solid transparent;
   cursor: pointer;
@@ -57,7 +63,7 @@ const Item = ({ account, pathname, collapsed }: Props) => {
   }, [account, navigate]);
   const unit = useAccountUnit(account);
   return (
-    <ItemWrapper active={active} onClick={onAccountClick}>
+    <ItemWrapper active={active} collapsed={collapsed} onClick={onAccountClick}>
       <Box horizontal ff="Inter|SemiBold" flex={1} flow={3} alignItems="center">
         <ParentCryptoCurrencyIconWrapper>
           <ParentCryptoCurrencyIcon currency={getAccountCurrency(account)} />


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Layout-only styled-components change; not covered by new unit tests._
- [x] **Impact of the changes:**
  - Starred accounts in the main sidebar when it is **collapsed** (icon-only rail)
  - Row width, horizontal alignment, and crypto icon centering for starred items
  - Regression check: expanded sidebar starred list (labels and balances) and navigation on click

### 📝 Description

**Problem:** Starred account rows still used a fixed width and left-aligned flex layout when the sidebar was collapsed, so the visible crypto icon did not sit cleanly in the narrow rail.

**Solution:** `Item` now forwards `collapsed` to `ItemWrapper`, which uses `width: auto` and centers content when collapsed. The currency icon wrapper is non-shrinking and flex-centered so the icon aligns with the collapsed sidebar pattern.

https://github.com/user-attachments/assets/475e502e-9b01-4731-9198-bef2b3e47663




### ❓ Context

- **JIRA or GitHub link**: [LIVE-28492](https://ledgerhq.atlassian.net/browse/LIVE-28492)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28492]: https://ledgerhq.atlassian.net/browse/LIVE-28492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ