### PR TITLE
[LWD] test: fix e2e test

### DIFF
--- a/.changeset/strong-students-taste.md
+++ b/.changeset/strong-students-taste.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+fix e2e test onboarding

--- a/apps/ledger-live-desktop/tests/page/onboarding.page.ts
+++ b/apps/ledger-live-desktop/tests/page/onboarding.page.ts
@@ -49,8 +49,20 @@ export class OnboardingPage extends AppPage {
 
   async hoverDevice(device: "nanoS" | "nanoX" | "nanoSP" | "stax") {
     const locator = this.page.getByTestId(`v3-container-device-${device}`);
-    await locator.waitFor({ state: "attached" });
-    await locator.hover();
+    await locator.waitFor({ state: "visible" });
+    await locator.scrollIntoViewIfNeeded();
+    const box = await locator.boundingBox();
+    if (!box) {
+      throw new Error(`No bounding box for device column v3-container-device-${device}`);
+    }
+    // Electron/Linux: locator.hover() can miss CSS :hover; explicit mouse path is more reliable.
+    await this.page.mouse.move(0, 0);
+    await this.page.mouse.move(
+      Math.round(box.x + box.width / 2),
+      Math.round(box.y + box.height / 2),
+      { steps: 5 },
+    );
+    await this.selectDeviceButton(device).waitFor({ state: "visible" });
   }
 
   async waitForDeviceToBeVisible(device: "nanoS" | "nanoX" | "nanoSP" | "stax") {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached. <!-- N/A if this PR is test-only / no consumer-facing package bump — otherwise add one. -->
- [x] **Covered by automatic tests.** Onboarding mocked E2E (`setup-device`, `connect-device`, `restore-device`) exercise `hoverDevice`; fix targets the failure mode seen in CI (screenshot mismatch on device selection).
- [ ] **Impact of the changes:**
  - **Product / UX:** None (test harness only).
  - **QA focus:** No extra manual QA for the app; CI Playwright onboarding flows should be stable on device selection screenshots. Optional: run mocked onboarding E2E locally or trust CI.

### 📝 Description

Onboarding device selection shows the **Select** button only under CSS `:hover` on each device column (`DeviceSelectorOption`). In CI (Electron on Linux), `locator.hover()` after `waitFor({ state: "attached" })` often did not leave the pointer in a state where `:hover` applied, so the page stayed in the **idle** layout (no **Select**) while snapshots expected the **hovered** Nano S column — causing `toHaveScreenshot("v3-device-selection.png")` to fail (~1% pixel diff, above `maxDiffPixelRatio`).

**Fix:** In `tests/page/onboarding.page.ts`, `hoverDevice` now waits for **visibility**, scrolls the column into view, moves the mouse with **`page.mouse.move`** to the bounding-box center (with steps), and waits until the Select control is **visible**, so hover is reliable before screenshots and device clicks.

<!--
| Before        | After         |
| ------------- | ------------- |
| Idle device row in screenshot / flaky hover | Hovered column + Select visible, aligned with baselines |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- e.g. LL-XXXX or #issue -->
- **ADR link (if any)**: <!-- N/A -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)