### PR TITLE
fix(e2e): reset modular drawer flags cache on app init

### DIFF
--- a/e2e/mobile/bridge/server.ts
+++ b/e2e/mobile/bridge/server.ts
@@ -124,9 +124,10 @@ export async function loadConfig(fileName: string, agreed: true = true): Promise
 export async function setFeatureFlags(flags: SettingsSetOverriddenFeatureFlagsPlayload) {
   for (const id in flags) {
     if (isFeatureId(id, flags)) {
-      await setFeatureFlag({ id, value: flags[id] });
+      setFeatureFlag({ id, value: flags[id] });
     }
   }
+  await getFlags();
 }
 
 export async function setFeatureFlag(flag: SettingsSetOverriddenFeatureFlagPlayload) {

--- a/e2e/mobile/page/drawer/modular.drawer.ts
+++ b/e2e/mobile/page/drawer/modular.drawer.ts
@@ -40,6 +40,10 @@ export default class ModularDrawer {
 
   private flags: Feature_ModularDrawer | null = null;
 
+  resetFlags(): void {
+    this.flags = null;
+  }
+
   private async loadFlags(): Promise<void> {
     this.flags ??= JSON.parse(await getFlags()).llmModularDrawer;
   }

--- a/e2e/mobile/page/index.ts
+++ b/e2e/mobile/page/index.ts
@@ -87,6 +87,7 @@ export class Application {
 
   @Step("Account initialization")
   public async init(options: ApplicationOptions) {
+    this.modularDrawer.resetFlags();
     const userdataSpeculos = `temp-userdata-${randomUUID()}`;
     const userdataPath = getUserdataPath(userdataSpeculos);
     fs.copyFileSync(getUserdataPath(options.userdata || "skip-onboarding"), userdataPath);


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- The flags field was cached indefinitely via ??= — since ModularDrawer is a singleton (lazyInit), stale flags from a prior test suite bled into subsequent suites that initialized with different feature flags.

- Add resetFlags() and call it at the start of app.init() so loadFlags() re-fetches after each reinitialization.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->
- [CI](https://github.com/LedgerHQ/ledger-live/actions/runs/23867719998)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
