### PR TITLE
[LWD] fix: prevent icon shrinking and handle text truncation in table

### DIFF
--- a/.changeset/happy-mirrors-shake.md
+++ b/.changeset/happy-mirrors-shake.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(lwd): prevent icon shrinking and handle text truncation in table

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
@@ -58,6 +58,7 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
             }
             title={row.original.currency.name}
             description={row.original.currency.ticker}
+            className="[&>div:first-child]:shrink-0 [&>div:last-child]:min-w-0"
           />
         ),
       },

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountAddressCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountAddressCell.tsx
@@ -12,7 +12,7 @@ export function AccountAddressCell({ account, lookupParentAccount }: AccountAddr
   const address =
     account.type === "Account"
       ? account.freshAddress
-      : (lookupParentAccount(account.parentId)?.freshAddress ?? "");
+      : lookupParentAccount(account.parentId)?.freshAddress ?? "";
   const formatted = formatAddress(address, { prefixLength: 5, suffixLength: 5 });
   return <TableCellContent title={formatted} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountNameCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountNameCell.tsx
@@ -13,6 +13,7 @@ export function AccountNameCell({ account, displayName }: AccountNameCellProps) 
   const currency = getAccountCurrency(account);
   return (
     <TableCellContent
+      className="[&>div:first-child]:shrink-0 [&>div:last-child]:min-w-0"
       leadingContent={<CryptoCurrencyIcon currency={currency} size={32} />}
       title={displayName}
       description={currency.ticker}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a minor update to the `ledger-live-desktop` app, focusing on improving the display of account names within the crypto addresses table. The main enhancement is to prevent the account icon from shrinking and to ensure that text is properly truncated, which improves the table's appearance and usability.


https://github.com/user-attachments/assets/9c0b0ec5-a057-4c52-9952-0ed4a81ddd74


### ❓ Context

[LIVE-28454](https://ledgerhq.atlassian.net/browse/LIVE-28454)
[LIVE-28454](https://ledgerhq.atlassian.net/browse/LIVE-28454)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28454]: https://ledgerhq.atlassian.net/browse/LIVE-28454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ