### PR TITLE
[LWD] fix(desktop): check lastOnboardedDevice for ledger sync banner eligibility

### DIFF
--- a/.changeset/brave-walls-glow.md
+++ b/.changeset/brave-walls-glow.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix Ledger Sync activation banner not showing in settings when no accounts added

--- a/apps/ledger-live-desktop/src/mvvm/features/LedgerSyncEntryPoints/hooks/useEntryPoint.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LedgerSyncEntryPoints/hooks/useEntryPoint.test.ts
@@ -3,6 +3,7 @@ import { useEntryPoint } from "./useEntryPoint";
 import { EntryPoint } from "../types";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { DeviceModelInfo } from "@ledgerhq/types-live";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { INITIAL_STATE } from "../__tests__/shared";
 
 describe("useEntryPoint", () => {
@@ -91,13 +92,52 @@ describe("useEntryPoint", () => {
     expect(result.current.shouldDisplayEntryPoint).toBe(false);
   });
 
-  it("shouldDisplayEntryPoint should be false when lastSeenDevice is unset", async () => {
+  it("shouldDisplayEntryPoint should be false when lastSeenDevice and lastOnboardedDevice are both unset", async () => {
     const { result } = renderHook(() => useEntryPoint(EntryPoint.accounts), {
       initialState: {
         ...INITIAL_STATE,
         settings: {
           ...INITIAL_STATE.settings,
           lastSeenDevice: null,
+          lastOnboardedDevice: null,
+        },
+      },
+    });
+
+    expect(result.current.shouldDisplayEntryPoint).toBe(false);
+  });
+
+  it("shouldDisplayEntryPoint should be true when lastSeenDevice is unset but lastOnboardedDevice is eligible", async () => {
+    const { result } = renderHook(() => useEntryPoint(EntryPoint.accounts), {
+      initialState: {
+        ...INITIAL_STATE,
+        settings: {
+          ...INITIAL_STATE.settings,
+          lastSeenDevice: null,
+          lastOnboardedDevice: {
+            deviceId: "",
+            modelId: DeviceModelId.stax,
+            wired: false,
+          } as Device,
+        },
+      },
+    });
+
+    expect(result.current.shouldDisplayEntryPoint).toBe(true);
+  });
+
+  it("shouldDisplayEntryPoint should be false when lastSeenDevice is unset and lastOnboardedDevice is a nanoS", async () => {
+    const { result } = renderHook(() => useEntryPoint(EntryPoint.accounts), {
+      initialState: {
+        ...INITIAL_STATE,
+        settings: {
+          ...INITIAL_STATE.settings,
+          lastSeenDevice: null,
+          lastOnboardedDevice: {
+            deviceId: "",
+            modelId: DeviceModelId.nanoS,
+            wired: false,
+          } as Device,
         },
       },
     });

--- a/apps/ledger-live-desktop/src/mvvm/features/LedgerSyncEntryPoints/hooks/useEntryPoint.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LedgerSyncEntryPoints/hooks/useEntryPoint.ts
@@ -2,7 +2,7 @@ import { useSelector } from "LLD/hooks/redux";
 import { useNavigate } from "react-router";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
-import { lastSeenDeviceSelector } from "~/renderer/reducers/settings";
+import { lastSeenDeviceSelector, lastOnboardedDeviceSelector } from "~/renderer/reducers/settings";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/renderer/analytics/segment";
 import { EntryPoint, EntryPointsData } from "../types";
@@ -14,19 +14,21 @@ import { AnalyticsPage } from "../../WalletSync/hooks/useLedgerSyncAnalytics";
 import PostOnboardingEntryPoint from "../components/PostOnboardingEntryPoint";
 import { LedgerSyncBanner } from "../components/LedgerSyncBanner/LedgerSyncBanner";
 
+const isEligibleModelId = (id?: DeviceModelId) => id != null && id !== DeviceModelId.nanoS;
+
 export function useEntryPoint(entryPoint: EntryPoint, needEligibleDevice = true) {
   const navigate = useNavigate();
   const featureLedgerSyncEntryPoints = useFeature("lldLedgerSyncEntryPoints");
   const featureWalletSync = useFeature("lldWalletSync");
   const trustchain = useSelector(trustchainSelector);
   const lastSeenDevice = useSelector(lastSeenDeviceSelector);
+  const lastOnboardedDevice = useSelector(lastOnboardedDeviceSelector);
 
   const isLedgerSyncEnabled = featureWalletSync?.enabled ?? false;
   const areEntryPointsEnabled = featureLedgerSyncEntryPoints?.enabled ?? false;
   const isLedgerSyncActivated = Boolean(trustchain && trustchain?.rootId);
-  const isDeviceEligible = Boolean(
-    lastSeenDevice && lastSeenDevice.modelId !== DeviceModelId.nanoS,
-  );
+  const isDeviceEligible =
+    isEligibleModelId(lastSeenDevice?.modelId) || isEligibleModelId(lastOnboardedDevice?.modelId);
   const isOptimisationEnabled = useFeature("lwdLedgerSyncOptimisation");
 
   const entryPointsData: EntryPointsData = {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Ledger Sync activation banner visibility in Settings
      - Device eligibility check now considers both `lastSeenDevice` and `lastOnboardedDevice`

### 📝 Description

**Problem**: The Ledger Sync activation banner was not displayed in Settings when the user completed onboarding but hadn't added any account yet. Instead, the "Manage" button was shown as if Ledger Sync were already activated.

**Root cause**: The `useEntryPoint` hook only checked `lastSeenDevice` for device eligibility. However, `lastSeenDevice` is only set during device actions (pairing, firmware update, etc.), not during onboarding. Users who completed onboarding but hadn't performed any device action had `lastSeenDevice = null`, making them "ineligible" and hiding the banner.

**Solution**: Extended the device eligibility check to also consider `lastOnboardedDevice` (set during the onboarding flow). If either the last seen device or the last onboarded device is a non-Nano S model, the user is now considered eligible and the activation banner is displayed correctly.

<img width="1624" height="976" alt="Screenshot 2026-04-02 at 10 21 49" src="https://github.com/user-attachments/assets/818238fb-d557-4224-a5e4-d15dae4b552d" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28516](https://ledgerhq.atlassian.net/browse/LIVE-28516)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28516]: https://ledgerhq.atlassian.net/browse/LIVE-28516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ