### PR TITLE
test(e2e): add shard parameter to allure report

### DIFF
--- a/e2e/mobile/helpers/allure/allure-helper.ts
+++ b/e2e/mobile/helpers/allure/allure-helper.ts
@@ -7,6 +7,8 @@ export function setAllureDescription(): void {
   // Remove when Wallet 4.0 is default
   const isWallet40Test = isWallet40 || testPath.includes("/wallet40/");
   const mode = isWallet40Test ? "🆕 Wallet 4.0" : "Legacy Wallet";
+  const shardIndex = process.env.SHARD_INDEX;
+  const shardLine = shardIndex ? `\n🔢 Shard: ${shardIndex}` : "";
 
-  allure.description(`📄 Test file: ${testFileName}\n🏷️ Test run on: ${mode}`);
+  allure.description(`📄 Test file: ${testFileName}\n🏷️ Test run on: ${mode}${shardLine}`);
 }


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Exposes the CI shard index in test description, to make it easier to debug ci, instead of guessing wich shard the test was.
<img width="595" height="460" alt="image" src="https://github.com/user-attachments/assets/76e775a2-0be3-45ac-84c1-38fba1c6d35a" />

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
