### PR TITLE
[LWM] feat(mobile): update reborn buy device private keys copy in english

### DIFF
--- a/.changeset/gentle-memorabilia-launch.md
+++ b/.changeset/gentle-memorabilia-launch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Update English copy for private keys line on connect Ledger device screen ([LIVE-28545](https://ledgerhq.atlassian.net/browse/LIVE-28545))

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1598,7 +1598,7 @@
     "desc": "To unlock the full potential of your Ledger Wallet, connect a Ledger device.",
     "0": {
       "title": "Full ownership",
-      "desc": "Your private keys never leave the device."
+      "desc": "You have control over your private keys."
     },
     "1": {
       "title": "Trade securely",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Copy-only change; no logic or tests updated._
- [x] **Impact of the changes:**
      - English locale only (Connect a Ledger device / reborn buy device screen)
      - First carousel bullet under “Full ownership” on the connect-device screen
      - Other locales unchanged

### 📝 Description

**Problem:** The product copy for the “Full ownership” bullet said private keys never leave the device; the ticket asked to replace it with wording that emphasizes user control over private keys (mobile, English).

**Solution:** Updated `rebornBuyDevice.0.desc` in `apps/ledger-live-mobile/src/locelles/en/common.json`:

<img width="327" height="111" alt="image" src="https://github.com/user-attachments/assets/2dd28c75-5aef-466c-8d3c-962022ee9ce2" />

_Click the **⋯** menu on the PR description → **Edit**, then add screenshots to the table if you want a visual diff._

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28545](https://ledgerhq.atlassian.net/browse/LIVE-28545)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28545]: https://ledgerhq.atlassian.net/browse/LIVE-28545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ