### PR TITLE
[LWD] feat(desktop): add stablecoin preset to mock account generator

### DIFF
--- a/.changeset/healthy-eggs-shake.md
+++ b/.changeset/healthy-eggs-shake.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/ledger-wallet-framework": minor
+"ledger-live-desktop": minor
+---
+
+Add stablecoin preset to desktop mock account generator for 7 networks (Ethereum, Arbitrum, Optimism, Base, Solana, Tron, Algorand) with top stablecoins per network

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/MockAccountGeneratorSection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/MockAccountGeneratorSection.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Flex, Text } from "@ledgerhq/react-ui/index";
+import { Flex } from "@ledgerhq/react-ui/index";
 import { SettingsSectionRow as Row } from "../../../SettingsSection";
 import { Button } from "@ledgerhq/lumen-ui-react";
 import MockAccountGenerator from "./MockAccountGenerator";
 import CustomMockAccountGenerator from "./CustomMockAccountGenerator";
 import EmptyAccountGenerator from "./EmptyAccountGenerator";
+import StablecoinMockAccountGenerator from "./StablecoinMockAccountGenerator";
 
 type MockAccountGeneratorSectionContentProps = {
   expanded: boolean;
@@ -18,7 +19,7 @@ export const MockAccountGeneratorSectionContent = ({
 
   return (
     <Flex flexDirection="column" pt={2} rowGap={2} alignSelf="stretch">
-      <Text>{t("settings.developer.mockAccounts.description")}</Text>
+      <div>{t("settings.developer.mockAccounts.description")}</div>
       {expanded && (
         <Flex flexDirection="column" columnGap={4} mt={2} flexWrap="wrap">
           <CustomMockAccountGenerator
@@ -33,6 +34,10 @@ export const MockAccountGeneratorSectionContent = ({
           <EmptyAccountGenerator
             title={t("settings.developer.mockAccounts.emptyGenerate.title")}
             desc={t("settings.developer.mockAccounts.emptyGenerate.desc")}
+          />
+          <StablecoinMockAccountGenerator
+            title={t("settings.developer.mockAccounts.stablecoinGenerate.title")}
+            desc={t("settings.developer.mockAccounts.stablecoinGenerate.desc")}
           />
         </Flex>
       )}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StablecoinMockAccountGenerator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/StablecoinMockAccountGenerator.tsx
@@ -1,0 +1,39 @@
+import React, { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { SettingsSectionRow } from "~/renderer/screens/settings/SettingsSection";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { generateStablecoinAccounts, injectMockAccounts, STABLECOIN_PRESET } from "./utils";
+
+type Props = {
+  title: string;
+  desc: string;
+};
+
+export default function StablecoinMockAccountGenerator({ title, desc }: Props) {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(false);
+
+  const handleGenerate = useCallback(async () => {
+    if (!window.confirm(t("settings.developer.mockAccounts.alerts.confirmErase"))) return;
+    setLoading(true);
+    try {
+      const accounts = await generateStablecoinAccounts();
+      await injectMockAccounts(accounts, true);
+    } catch (error) {
+      console.error("Failed to generate stablecoin accounts:", error);
+      alert(t("settings.developer.mockAccounts.alerts.generateError"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  return (
+    <SettingsSectionRow title={title} desc={desc}>
+      <Button appearance="accent" size="sm" disabled={loading} onClick={handleGenerate}>
+        {t("settings.developer.mockAccounts.buttons.generateStablecoinAccounts", {
+          count: STABLECOIN_PRESET.length,
+        })}
+      </Button>
+    </SettingsSectionRow>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/GenerateMockAccounts/utils.ts
@@ -1,6 +1,8 @@
 import { genAccount } from "@ledgerhq/live-common/mock/account";
+import { genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { listSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { initAccounts } from "~/renderer/actions/accounts";
 import {
   initialState as liveWalletInitialState,
@@ -8,7 +10,7 @@ import {
 } from "@ledgerhq/live-wallet/store";
 import { getKey } from "~/renderer/storage";
 import { Account, AccountUserData } from "@ledgerhq/types-live";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { v4 as uuidv4 } from "uuid";
 import sample from "lodash/sample";
 import BigNumber from "bignumber.js";
@@ -83,3 +85,83 @@ export const createEmptyAccount = (id = "eth-empty"): [Account, AccountUserData]
   const userData = accountUserDataExportSelector(liveWalletInitialState, { account });
   return [account, userData];
 };
+
+export const STABLECOIN_PRESET: { currencyId: string; tokenIds: string[] }[] = [
+  {
+    currencyId: "ethereum",
+    tokenIds: [
+      "ethereum/erc20/usd_tether__erc20_",
+      "ethereum/erc20/usd__coin",
+      "ethereum/erc20/usds_stablecoin_0xdc035d45d973e3ec169d2276ddab16f1e407384f",
+      "ethereum/erc20/usde",
+      "ethereum/erc20/dai_stablecoin_v2_0",
+    ],
+  },
+  {
+    currencyId: "arbitrum",
+    tokenIds: [
+      "arbitrum/erc20/tether_usd",
+      "arbitrum/erc20/usd_coin",
+      "arbitrum/erc20/usde",
+      "arbitrum/erc20/paypal_usd_0x46850ad61c2b7d64d08c9c754f45254596696984",
+    ],
+  },
+  {
+    currencyId: "optimism",
+    tokenIds: [
+      "optimism/erc20/tether_usd",
+      "optimism/erc20/usd_coin",
+      "optimism/erc20/usde_0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+    ],
+  },
+  {
+    currencyId: "base",
+    tokenIds: [
+      "base/erc20/usd_coin",
+      "base/erc20/usds_stablecoin_0x820c137fa70c8691f0e44dc420a5e53c168921dc",
+      "base/erc20/usde_0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+    ],
+  },
+  {
+    currencyId: "solana",
+    tokenIds: [
+      "solana/spl/es9vmfrzacermjfrf4h2fyd4kconky11mcce8benwnyb",
+      "solana/spl/epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v",
+      "solana/spl/usds_usdswr9apdhk5bvjkmjzff41ffux8bsxdkcr81vtwca",
+      "solana/spl/usde_dekqhypn7gmrj5cartqfawefqbzb33hyf6s5icwjeont",
+      "solana/spl/paypal_usd_2b1kv6dkpanxd5ixfnxcpjxmkwqjjaymczfhsfu24gxo",
+    ],
+  },
+  {
+    currencyId: "tron",
+    tokenIds: [
+      "tron/trc20/tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t",
+      "tron/trc20/tekxitehnzsmse2xqrbj4w32run966rdz8",
+    ],
+  },
+  {
+    currencyId: "algorand",
+    tokenIds: ["algorand/asa/312769", "algorand/asa/31566704"],
+  },
+];
+
+async function resolveTokens(tokenIds: string[]): Promise<TokenCurrency[]> {
+  const store = getCryptoAssetsStore();
+  const resolved = await Promise.all(tokenIds.map(id => store.findTokenById(id)));
+  return resolved.filter((t): t is TokenCurrency => t !== null);
+}
+
+export async function generateStablecoinAccounts(): Promise<[Account, AccountUserData][]> {
+  const results: [Account, AccountUserData][] = [];
+
+  for (const entry of STABLECOIN_PRESET) {
+    const currency = getCryptoCurrencyById(entry.currencyId);
+    const tokens = await resolveTokens(entry.tokenIds);
+    const account = genAccount(uuidv4(), { currency });
+    account.subAccounts = tokens.map((token, i) => genTokenAccount(i, account, token));
+    const userData = accountUserDataExportSelector(liveWalletInitialState, { account });
+    results.push([account, userData]);
+  }
+
+  return results;
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4672,6 +4672,10 @@
           "title": "Empty generation",
           "desc": "Generate an empty account"
         },
+        "stablecoinGenerate": {
+          "title": "Stablecoin preset",
+          "desc": "Generate Ethereum, Arbitrum, Optimism, Base, Solana, Tron and Algorand accounts with top stablecoins (max 5 per network)"
+        },
         "currencySelector": {
           "placeholder": "Choose currencies...",
           "searchPlaceholder": "Search",
@@ -4688,7 +4692,9 @@
           "generateAccounts": "Generate {{count}} account",
           "generateAccounts_other": "Generate {{count}} accounts",
           "generateAccountsQuick": "Generate {{count}} accounts",
-          "generateEmptyAccount": "Generate empty account"
+          "generateEmptyAccount": "Generate empty account",
+          "generateStablecoinAccounts": "Generate {{count}} stablecoin account",
+          "generateStablecoinAccounts_other": "Generate {{count}} stablecoin accounts"
         },
         "alerts": {
           "selectCurrency": "Please select at least one currency",

--- a/libs/ledger-wallet-framework/src/mocks/account.ts
+++ b/libs/ledger-wallet-framework/src/mocks/account.ts
@@ -361,7 +361,7 @@ export function genAccount(
     }),
   };
 
-  if (["ethereum", "ethereum_sepolia", "tron", "algorand"].includes(currency.id)) {
+  if (["ethereum", "ethereum_sepolia", "tron", "algorand", "solana"].includes(currency.id)) {
     const tokenCount =
       typeof opts.subAccountsCount === "number" ? opts.subAccountsCount : rng.nextInt(0, 8);
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Developer tooling only — no production impact._
- [x] **Impact of the changes:**
      - Developer settings > Mock account generator section
      - New "Stablecoin preset" button generates 7 accounts with top stablecoins

### 📝 Description

Adds a new preset entry in the desktop Developer settings mock account generator that creates 7 parent accounts (Ethereum, Arbitrum, Optimism, Base, Solana, Tron, Algorand) pre-filled with top stablecoins (max 5 per network).

**Changes:**
- New `StablecoinMockAccountGenerator` component with loading state and error handling
- `STABLECOIN_PRESET` config with hardcoded token IDs per network
- Async `generateStablecoinAccounts` helper that resolves tokens via crypto assets store
- Added Solana to `genAccount` native token sub-account support in the framework
- i18n keys (EN)


https://github.com/user-attachments/assets/9575bc61-000d-4347-8515-cb81ddf8411a



### ❓ Context

- **JIRA or GitHub link**: [LIVE-28336](https://ledgerhq.atlassian.net/browse/LIVE-28336)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-28336]: https://ledgerhq.atlassian.net/browse/LIVE-28336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ