### PR TITLE
fix(e2e): retry tap in selectAccount when element shifts during search

### DIFF
--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -216,6 +216,24 @@ export const NativeElementHelpers = {
     await elem.tap();
   },
 
+  async tapByIdAndExpectToDisappear(
+    id: string | RegExp,
+    opts: { index?: number; timeout?: number; disappearTimeout?: number } = {},
+  ) {
+    const { index = 0, timeout = 60000, disappearTimeout = 1000 } = opts;
+    let tapped = false;
+    await retryUntilTimeout(async () => {
+      if (tapped) {
+        const visible = await NativeElementHelpers.isIdVisible(id);
+        if (!visible) return;
+      }
+      await NativeElementHelpers.tapById(id, index);
+      tapped = true;
+      const stillVisible = await NativeElementHelpers.isIdVisible(id, disappearTimeout);
+      if (stillVisible) throw new Error(`Element "${id}" is still visible after tap`);
+    }, timeout);
+  },
+
   async typeTextById(
     id: string | RegExp,
     text: string,

--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -93,6 +93,7 @@ export default class TestEnvironment extends DetoxEnvironment {
       scrollToText: NativeElementHelpers.scrollToText,
       tapByElement: NativeElementHelpers.tapByElement,
       tapById: NativeElementHelpers.tapById,
+      tapByIdAndExpectToDisappear: NativeElementHelpers.tapByIdAndExpectToDisappear,
       tapByText: NativeElementHelpers.tapByText,
       typeTextByElement: NativeElementHelpers.typeTextByElement,
       typeTextById: NativeElementHelpers.typeTextById,

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -45,7 +45,7 @@ export default class CommonPage {
   async selectAccount(account: Account) {
     const accountId = this.accountId(account);
     await waitForElementById(accountId);
-    await tapById(accountId);
+    await tapByIdAndExpectToDisappear(accountId);
   }
 
   @Step("Expect search")

--- a/e2e/mobile/types/global.d.ts
+++ b/e2e/mobile/types/global.d.ts
@@ -71,6 +71,7 @@ declare global {
   var scrollToText: typeof NativeElementHelpers.scrollToText;
   var tapByElement: typeof NativeElementHelpers.tapByElement;
   var tapById: typeof NativeElementHelpers.tapById;
+  var tapByIdAndExpectToDisappear: typeof NativeElementHelpers.tapByIdAndExpectToDisappear;
   var tapByText: typeof NativeElementHelpers.tapByText;
   var typeTextByElement: typeof NativeElementHelpers.typeTextByElement;
   var typeTextById: typeof NativeElementHelpers.typeTextById;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- When selecting SOL/GIGA accounts after a search, the FlatList can re-render mid-tap (due to keyboard dismissal triggering a layout resize), causing the tap to silently miss. Add tapByIdAndExpectToDisappear helper that retries the tap until the element disappears, confirming the action took effect.
- Fixes [this](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/cfc5138c-bcd1-47d4-9e02-ab1b5d50216f/#/testresult/aa58b3e32fae095) flakiness 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
