### PR TITLE
[LWM] fix(mobile): swap assertion order in queued drawer test

### DIFF
--- a/.changeset/mighty-taxis-exercise.md
+++ b/.changeset/mighty-taxis-exercise.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix QueuedDrawer test assertion order to avoid race condition

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/__integrations__/openSuccessiveDrawers.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/__integrations__/openSuccessiveDrawers.test.tsx
@@ -137,8 +137,8 @@ describe("QueuedDrawer", () => {
     await user.press(elements.inDrawer1Drawer2Button());
     expect(queryByText(drawer2Text)).toBeNull();
     await user.press(elements.closeButton());
-    expect(queryByText(drawer1Text)).toBeNull();
     expect(await findByText(drawer2Text)).toBeVisible();
+    expect(queryByText(drawer1Text)).toBeNull();
     await user.press(elements.closeButton());
     helpers.expectAllDrawersClosed();
     await helpers.openDrawer1();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - QueuedDrawer integration test stability
  - No production code changes

### 📝 Description

The test `opens two drawers, then request to close the second one, then close the first one` was flaky because the assertion `expect(queryByText(drawer1Text)).toBeNull()` ran synchronously before the drawer transition completed.

The fix swaps the two assertions so the test waits for Drawer 2 to appear (`findByText` retries async) before asserting Drawer 1 is gone. By the time Drawer 2 is visible, Drawer 1 has already been removed — since the queue system closes Drawer 1 first, then opens Drawer 2 in the same synchronous call chain.

**Root cause:** `handleCloseUserEvent` calls `closeAnim()` which defers the actual `handleDismiss()` via `setTimeout(callback, ANIMATION_DURATION + 50)`. With `jest.useRealTimers()`, `await user.press()` returns immediately before this timer fires, so Drawer 1 is still mounted. The identical test at line 119 never had this problem because it only used `await findByText(drawer2Text)` (which retries async).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28555](https://ledgerhq.atlassian.net/browse/LIVE-28555)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28555]: https://ledgerhq.atlassian.net/browse/LIVE-28555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ