### PR TITLE
test(e2e): normalize provider name for URL verification

### DIFF
--- a/e2e/mobile/page/trade/buySell.page.ts
+++ b/e2e/mobile/page/trade/buySell.page.ts
@@ -189,8 +189,9 @@ export default class BuySellPage {
   @Step("Verify provider page loaded with correct URL")
   async verifyProviderPageLoadedWithCorrectUrl(provider: string) {
     try {
-      const currentUrl = await waitForCurrentWebviewUrlToContain(provider.toLowerCase());
-      jestExpect(currentUrl.toLowerCase()).toContain(provider.toLowerCase());
+      const normalizedProvider = provider.toLowerCase().replace(/\s/g, "");
+      const currentUrl = await waitForCurrentWebviewUrlToContain(normalizedProvider);
+      jestExpect(currentUrl.toLowerCase()).toContain(normalizedProvider);
     } catch (error) {
       throw new Error(`Provider page verification failed: ${sanitizeError(error)}`);
     }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Buy/sell provider URL verification in mobile e2e tests
  - Providers with spaces in their name (e.g. "Ramp Network") now match URL correctly

### 📝 Description

The `verifyProviderPageLoadedWithCorrectUrl` method only lowercased the provider name before checking the webview URL, causing failures for providers with spaces in their name (e.g. "Ramp Network" wouldn't match "rampnetwork" in the URL). This change strips whitespace in addition to lowercasing.

### ❓ Context

- **JIRA or GitHub link**:
- **Mobile e2e CI run**:
- **ADR link (if any)**:

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)