### PR TITLE
[LWM] fix(live-mobile): fix analytics tracking on CryptoAddresses screen

### DIFF
--- a/.changeset/fix-crypto-addresses-tracking.md
+++ b/.changeset/fix-crypto-addresses-tracking.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix(tracking): fix analytics events on CryptoAddresses screen — correct page name, remove PII from account_clicked, fix button value

--- a/apps/ledger-live-mobile/src/components/WalletTab/WalletTabNavigatorTabBar.tsx
+++ b/apps/ledger-live-mobile/src/components/WalletTab/WalletTabNavigatorTabBar.tsx
@@ -33,7 +33,7 @@ function getAnalyticsEvent(route: string) {
       return "Market";
     case ScreenName.Portfolio:
     default:
-      return "Crypto";
+      return ScreenName.Crypto;
   }
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__integrations__/CryptoAddressesScreen.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__integrations__/CryptoAddressesScreen.integration.test.tsx
@@ -1,15 +1,14 @@
 import React from "react";
 import { fireEvent, render, screen } from "@tests/test-renderer";
 import type { Account } from "@ledgerhq/types-live";
+import { ScreenName } from "~/const";
 import useCryptoAddressesViewModel from "../useCryptoAddressesViewModel";
 
 jest.mock("../useCryptoAddressesViewModel", () => jest.fn());
 
 jest.mock("~/components/globalSyncRefreshControl", () => {
   const { FlatList } = jest.requireActual("react-native");
-  return <T,>(
-    _Component: React.ComponentType<T>,
-  ): React.ComponentType<T & { testID?: string }> =>
+  return <T,>(_Component: React.ComponentType<T>): React.ComponentType<T & { testID?: string }> =>
     function SyncListMock(props: T & { testID?: string }) {
       return <FlatList {...props} />;
     };
@@ -32,7 +31,6 @@ jest.mock("LLM/features/Accounts/screens/AddAccount", () => {
   };
 });
 
-
 const mockedViewModel = jest.mocked(useCryptoAddressesViewModel);
 
 const mockAccount = { type: "Account", id: "account-1" } as Account;
@@ -50,19 +48,18 @@ const baseViewModel: ReturnType<typeof useCryptoAddressesViewModel> = {
   title: "Accounts",
   addAccountLabel: "Add account",
   emptyStateLabel: "No accounts yet",
-  trackingPage: "CryptoAddresses",
+  trackingPage: ScreenName.Accounts,
   sourceScreenName: undefined,
 };
 
 function renderScreen(vmOverrides: Partial<ReturnType<typeof useCryptoAddressesViewModel>> = {}) {
   mockedViewModel.mockReturnValue({ ...baseViewModel, ...vmOverrides });
 
-  const CryptoAddressesScreen =
-    jest.requireActual("../index").default;
+  const CryptoAddressesScreen = jest.requireActual("../index").default;
 
   return render(
     <CryptoAddressesScreen
-      route={{ params: {}, key: "test", name: "CryptoAddresses" }}
+      route={{ params: {}, key: "test", name: ScreenName.CryptoAddresses }}
       navigation={{} as never}
     />,
   );
@@ -145,9 +142,7 @@ describe("CryptoAddressesScreen", () => {
         error: new Error("sync failed"),
       });
 
-      expect(
-        screen.getByText("An error occurred while loading your accounts"),
-      ).toBeVisible();
+      expect(screen.getByText("An error occurred while loading your accounts")).toBeVisible();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__tests__/useCryptoAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__tests__/useCryptoAddressesViewModel.test.ts
@@ -13,7 +13,7 @@ const mockNavigate = jest.fn();
 jest.mock("@react-navigation/core", () => ({
   ...jest.requireActual("@react-navigation/core"),
   useNavigation: () => ({ navigate: mockNavigate }),
-  useRoute: () => ({ name: "CryptoAddresses" }),
+  useRoute: () => ({ name: ScreenName.CryptoAddresses }),
 }));
 
 jest.mock("@ledgerhq/live-common/bridge/react/useGlobalSyncState", () => ({
@@ -54,7 +54,7 @@ describe("useCryptoAddressesViewModel", () => {
     expect(result.current.title).toBe("Accounts");
     expect(result.current.addAccountLabel).toBe("Add account");
     expect(result.current.emptyStateLabel).toBe("No accounts yet");
-    expect(result.current.trackingPage).toBe("CryptoAddresses");
+    expect(result.current.trackingPage).toBe(ScreenName.Accounts);
     expect(result.current.sourceScreenName).toBe(ScreenName.Portfolio);
   });
 
@@ -123,8 +123,8 @@ describe("useCryptoAddressesViewModel", () => {
 
       expect(result.current.isAddAccountOpen).toBe(true);
       expect(jest.mocked(track)).toHaveBeenCalledWith("button_clicked", {
-        button: "add a new account",
-        page: "CryptoAddresses",
+        button: "add_account",
+        page: ScreenName.Accounts,
       });
 
       act(() => result.current.onCloseAddAccount());
@@ -146,8 +146,7 @@ describe("useCryptoAddressesViewModel", () => {
       });
       expect(jest.mocked(track)).toHaveBeenCalledWith("account_clicked", {
         currency: "Bitcoin",
-        account: expect.any(String),
-        page: "CryptoAddresses",
+        page: ScreenName.Accounts,
       });
     });
 
@@ -170,8 +169,7 @@ describe("useCryptoAddressesViewModel", () => {
       });
       expect(jest.mocked(track)).toHaveBeenCalledWith("account_clicked", {
         currency: tokenAccount.token.parentCurrency.name,
-        account: expect.any(String),
-        page: "CryptoAddresses",
+        page: ScreenName.Accounts,
       });
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/useCryptoAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/useCryptoAddressesViewModel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useSelector } from "~/context/hooks";
-import { useFocusEffect, useNavigation, useRoute } from "@react-navigation/core";
+import { useFocusEffect, useNavigation } from "@react-navigation/core";
 import { useRefreshAccountsOrdering } from "~/actions/general";
 import { useGlobalSyncState } from "@ledgerhq/live-common/bridge/react/useGlobalSyncState";
 import { flattenAccountsSelector, isUpToDateSelector } from "~/reducers/accounts";
@@ -12,8 +12,6 @@ import {
 } from "~/components/RootNavigator/types/helpers";
 import { AccountsNavigatorParamList } from "~/components/RootNavigator/types/AccountsNavigator";
 import { Account, TokenAccount } from "@ledgerhq/types-live";
-import { accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
-import { walletSelector } from "~/reducers/wallet";
 import isEqual from "lodash/isEqual";
 import { orderAccountsByFiatValue } from "@ledgerhq/live-countervalues/portfolio";
 import { useCountervaluesState } from "@ledgerhq/live-countervalues-react/index";
@@ -30,9 +28,7 @@ export default function useCryptoAddressesViewModel(sourceScreenName?: ScreenNam
   const countervalueState = useCountervaluesState();
   const toCurrency = useSelector(counterValueCurrencySelector);
   const allAccounts = useSelector(flattenAccountsSelector, isEqual);
-  const walletState = useSelector(walletSelector, isEqual);
   const orderedAccounts = orderAccountsByFiatValue(allAccounts, countervalueState, toCurrency);
-  const route = useRoute();
 
   const excludedTokenIds = useSelector(blacklistedTokenIdsSelector);
   const accounts = useMemo(
@@ -59,21 +55,18 @@ export default function useCryptoAddressesViewModel(sourceScreenName?: ScreenNam
   const [isAddAccountOpen, setIsAddAccountOpen] = useState(false);
 
   const onAddAccountPress = useCallback(() => {
-    track("button_clicked", { button: "add a new account", page: route.name });
+    track("button_clicked", { button: "add_account", page: ScreenName.Accounts });
     setIsAddAccountOpen(true);
-  }, [route.name]);
+  }, []);
 
   const onCloseAddAccount = useCallback(() => setIsAddAccountOpen(false), []);
 
   const onAccountPress = useCallback(
     (account: Account | TokenAccount) => {
-      const defaultAccountName = accountNameWithDefaultSelector(walletState, account);
-
       if (account.type === "Account") {
         track("account_clicked", {
           currency: account.currency.name,
-          account: defaultAccountName,
-          page: route.name,
+          page: ScreenName.Accounts,
         });
         navigation.navigate(ScreenName.Account, {
           accountId: account.id,
@@ -81,8 +74,7 @@ export default function useCryptoAddressesViewModel(sourceScreenName?: ScreenNam
       } else if (account.type === "TokenAccount") {
         track("account_clicked", {
           currency: account.token.parentCurrency.name,
-          account: defaultAccountName,
-          page: route.name,
+          page: ScreenName.Accounts,
         });
         navigation.navigate(NavigatorName.Accounts, {
           screen: ScreenName.Account,
@@ -94,7 +86,7 @@ export default function useCryptoAddressesViewModel(sourceScreenName?: ScreenNam
         });
       }
     },
-    [navigation, walletState, route.name],
+    [navigation],
   );
 
   return {
@@ -110,7 +102,7 @@ export default function useCryptoAddressesViewModel(sourceScreenName?: ScreenNam
     title: t("cryptoAddresses.title"),
     addAccountLabel: t("cryptoAddresses.addAccount"),
     emptyStateLabel: t("cryptoAddresses.emptyState"),
-    trackingPage: route.name,
+    trackingPage: ScreenName.Accounts,
     sourceScreenName,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Verify page view event fires with `page="Accounts"` on the CryptoAddresses screen
  - Verify `account_clicked` event no longer includes account name field (PII removed)
  - Verify `button_clicked` fires with `button="add_account"` when tapping the Add address CTA

### 📝 Description

Three analytics events on the CryptoAddresses screen (Address list) were firing with incorrect values.

- **Page view**: page name was `"CryptoAddresses"` (the route name) instead of `"Accounts"`
- **account_clicked**: included `account: <name>` which is PII — field removed
- **button_clicked** on "Add address" CTA: button value was `"add a new account"` instead of `"add_account"`

All three are fixed in `useCryptoAddressesViewModel.ts`. The unused `walletState` / `accountNameWithDefaultSelector` imports were also cleaned up.

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.