### PR TITLE
[LWD] feat: lwd braze placement portfolio refactor

### DIFF
--- a/.changeset/mighty-snakes-melt.md
+++ b/.changeset/mighty-snakes-melt.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat: lwd braze placement portfolio refactor

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
@@ -7,6 +7,20 @@ import { ClassicCard, logCardDismissal, logContentCardClick } from "@braze/web-s
 import { track } from "~/renderer/analytics/segment";
 import { LocationContentCard } from "~/types/dynamicContent";
 import { CURRENT_PRIVACY_POLICY_VERSION } from "@ledgerhq/live-common/privacyConsent";
+import { CONTENT_BANNER_ACTION_CARD_CLOSE_LABEL } from "../components/ContentBannerActionCard/types";
+
+let mockShouldDisplayBrazePlacement = false;
+
+jest.mock("@ledgerhq/live-common/featureFlags/index", () => {
+  const actual = jest.requireActual("@ledgerhq/live-common/featureFlags/index");
+  return {
+    ...actual,
+    useWalletFeaturesConfig: (platform: "desktop" | "mobile") => {
+      const config = actual.useWalletFeaturesConfig(platform);
+      return { ...config, shouldDisplayBrazePlacement: mockShouldDisplayBrazePlacement };
+    },
+  };
+});
 
 const brazeExtrasById: Record<string, { canvas_name: string; canvas_step_name: string }> = {
   "0": {
@@ -35,6 +49,28 @@ const Cards = [
     description: "Consectetur adipiscing elit.",
     path: "ledger-live://deep-link",
     location: LocationContentCard.Portfolio,
+  },
+];
+
+/** Eligible for Lumen grid: `image_background` and/or `icon` (not legacy `image` alone). */
+const CardsForBrazeGrid = [
+  {
+    id: "0",
+    title: "Foo",
+    description: "Lorem ipsum dolor sit amet.",
+    cta: "Click me",
+    tag: "New",
+    path: "ledger-live://deep-link",
+    location: LocationContentCard.Portfolio,
+    image_background: "https://example.com/bg.png",
+  },
+  {
+    id: "1",
+    title: "Bar",
+    description: "Consectetur adipiscing elit.",
+    path: "ledger-live://deep-link",
+    location: LocationContentCard.Portfolio,
+    icon: "Settings",
   },
 ];
 
@@ -82,7 +118,9 @@ jest.mock("~/renderer/analytics/segment", () => ({
   track: jest.fn(),
 }));
 
-function asClassicBrazeCard(card: (typeof Cards)[number] | (typeof BottomCards)[number]) {
+function asClassicBrazeCard(
+  card: (typeof Cards)[number] | (typeof BottomCards)[number] | (typeof CardsForBrazeGrid)[number],
+) {
   const { id, ...rest } = card;
   const extras = { ...brazeExtrasById[id], ...rest };
   return Object.assign(Object.create(ClassicCard.prototype), { id, extras });
@@ -90,9 +128,11 @@ function asClassicBrazeCard(card: (typeof Cards)[number] | (typeof BottomCards)[
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockShouldDisplayBrazePlacement = false;
 });
 
 const desktopCardsForTopCarousel = Cards.map(asClassicBrazeCard);
+const desktopCardsForBrazeGrid = CardsForBrazeGrid.map(asClassicBrazeCard);
 const desktopCardsWithBottomPlacements = [...Cards, ...BottomCards].map(asClassicBrazeCard);
 
 describe("PortfolioContentCards", () => {
@@ -201,6 +241,77 @@ describe("PortfolioContentCards", () => {
         location: LocationContentCard.Portfolio,
       }),
     );
+  });
+
+  test("renders Braze placement grid with ContentBanner when brazePlacement flag is on", async () => {
+    mockShouldDisplayBrazePlacement = true;
+
+    const { user } = render(<PortfolioContentCards />, {
+      initialState: {
+        dynamicContent: {
+          desktopCards: desktopCardsForBrazeGrid,
+          portfolioCards: CardsForBrazeGrid,
+        },
+        settings: {
+          shareAnalytics: true,
+          sharePersonalizedRecommandations: true,
+          lastAnalyticsConsentDate: new Date().toISOString(),
+          privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+        },
+      },
+    });
+
+    const title0 = await screen.findByText("Foo");
+    const title1 = screen.getByText("Bar");
+    expect(title0).toBeVisible();
+    expect(title1).toBeVisible();
+    expect(screen.queryByTestId("carousel-arrow-next")).not.toBeInTheDocument();
+
+    expect(logCardDismissal).not.toHaveBeenCalled();
+    const closeButtons = screen.getAllByRole("button", {
+      name: CONTENT_BANNER_ACTION_CARD_CLOSE_LABEL,
+    });
+    await user.click(closeButtons[1]);
+    expect(logCardDismissal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: CardsForBrazeGrid[1].id,
+        extras: expect.objectContaining(brazeExtrasById[CardsForBrazeGrid[1].id]),
+      }),
+    );
+    expect(title1).not.toBeInTheDocument();
+
+    expect(logContentCardClick).not.toHaveBeenCalled();
+    await user.click(title0);
+    expect(logContentCardClick).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith(
+      "contentcard_clicked",
+      expect.objectContaining({
+        contentcard: "Foo",
+        campaign: "0",
+        page: "Portfolio",
+        type: "portfolio_carousel",
+        location: LocationContentCard.Portfolio,
+      }),
+    );
+  });
+
+  test("renders nothing in Braze placement mode when no card has image_background or icon", () => {
+    mockShouldDisplayBrazePlacement = true;
+
+    render(<PortfolioContentCards />, {
+      initialState: {
+        dynamicContent: { desktopCards: desktopCardsForTopCarousel, portfolioCards: Cards },
+        settings: {
+          shareAnalytics: true,
+          sharePersonalizedRecommandations: true,
+          lastAnalyticsConsentDate: new Date().toISOString(),
+          privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+        },
+      },
+    });
+
+    expect(screen.queryByText("Foo")).toBeNull();
+    expect(screen.queryByText("Bar")).toBeNull();
   });
 });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
@@ -1,11 +1,17 @@
-import React from "react";
+import React, { memo } from "react";
+import { useNavigate } from "react-router";
 import styled from "styled-components";
 
 import { Carousel } from "@ledgerhq/react-ui";
-import { track } from "~/renderer/analytics/segment";
-import { usePortfolioCarouselCards } from "../../hooks/usePortfolioCarouselCards";
-import Slide from "./Slide";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { track } from "~/renderer/analytics/segment";
+import { openURL } from "~/renderer/linking";
+import type { PortfolioContentCard as PortfolioCardType } from "~/types/dynamicContent";
+import { usePortfolioCarouselCards } from "../../hooks/usePortfolioCarouselCards";
+import type { CarouselActions } from "../../types";
+import { ContentBannerActionCard } from "../ContentBannerActionCard";
+import LogContentCardWrapper from "../LogContentCardWrapper";
+import Slide from "./Slide";
 
 export default PortfolioContentCards;
 
@@ -21,13 +27,98 @@ const CarouselWrapper = styled.div<{ $isWallet40Enabled: boolean }>`
   }
 `;
 
+/** 2 columns, max 2 cards (Braze placement portfolio) */
+const BrazePlacementGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  width: 100%;
+  & > * {
+    min-width: 0;
+  }
+`;
+
+type BrazeSlideProps = {
+  card: PortfolioCardType;
+  index: number;
+} & CarouselActions;
+
+/** Braze placement grid: only cards with at least one of these (extras) are shown when FF is on. */
+function isPortfolioCardEligibleForLumenGrid(card: PortfolioCardType): boolean {
+  return Boolean(card.image_background?.trim()) || Boolean(card.icon?.trim());
+}
+
+/** MediaBanner URL from `image_background` only (`image` is not used as fallback). */
+function lumenImageBackgroundForPortfolio(card: PortfolioCardType): string | undefined {
+  const bg = card.image_background?.trim();
+  return bg || undefined;
+}
+
+const PortfolioBrazePlacementSlide = memo(function PortfolioBrazePlacementSlide({
+  card,
+  index,
+  logSlideClick,
+  dismissCard,
+}: BrazeSlideProps) {
+  const navigate = useNavigate();
+
+  const handleClose = () => dismissCard(index);
+  const handleClick = () => {
+    logSlideClick(card.id);
+    if (card.path) {
+      navigate(card.path, { state: { source: "banner" } });
+    } else if (card.url) {
+      openURL(card.url);
+    }
+  };
+
+  const imageBackground = lumenImageBackgroundForPortfolio(card);
+
+  return (
+    <LogContentCardWrapper id={card.id} location={card.location}>
+      <ContentBannerActionCard
+        title={card.title}
+        description={card.description}
+        onClose={handleClose}
+        onClick={handleClick}
+        icon={card.icon}
+        image_background={imageBackground}
+      />
+    </LogContentCardWrapper>
+  );
+});
+
 function PortfolioContentCards() {
   const { portfolioCards, logSlideClick, dismissCard } = usePortfolioCarouselCards("top");
-  const { isEnabled: isWallet40Enabled } = useWalletFeaturesConfig("desktop");
+  const { isEnabled: isWallet40Enabled, shouldDisplayBrazePlacement } =
+    useWalletFeaturesConfig("desktop");
   const handlePrevButton = () => trackSlide("prev");
   const handleNextButton = () => trackSlide("next");
 
   if (portfolioCards.length === 0) return null;
+
+  if (shouldDisplayBrazePlacement) {
+    const eligibleEntries = portfolioCards
+      .map((card, portfolioIndex) => ({ card, portfolioIndex }))
+      .filter(({ card }) => isPortfolioCardEligibleForLumenGrid(card))
+      .slice(0, 2);
+
+    if (eligibleEntries.length === 0) return null;
+
+    return (
+      <BrazePlacementGrid>
+        {eligibleEntries.map(({ card, portfolioIndex }) => (
+          <PortfolioBrazePlacementSlide
+            key={card.id}
+            card={card}
+            index={portfolioIndex}
+            logSlideClick={logSlideClick}
+            dismissCard={dismissCard}
+          />
+        ))}
+      </BrazePlacementGrid>
+    );
+  }
 
   return (
     <CarouselWrapper $isWallet40Enabled={isWallet40Enabled}>

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -24,7 +24,7 @@ jest.mock("~/renderer/analytics/segment", () => ({
   track: jest.fn(),
 }));
 
-// Prevent loading ESM-only @braze/web-sdk (pulled in by BottomCarouselContentCards via usePortfolioCarouselCards)
+// Prevent loading ESM-only @braze/web-sdk (pulled in by dynamic content hooks if imported)
 jest.mock("@braze/web-sdk", () => ({
   getCachedContentCards: jest.fn(() => ({ cards: [] })),
   logCardDismissal: jest.fn(),

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -82,6 +82,8 @@ const mapBrazeCardToPortfolioContentCard = (
   description: card.extras?.description,
   id: String(card.id),
   image: card.extras?.image,
+  image_background: card.extras?.image_background,
+  icon: card.extras?.icon,
   location,
   order: parseOrder(card.extras?.order),
   path: card.extras?.path,

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/ActionContentCards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/ActionContentCards.tsx
@@ -1,4 +1,4 @@
-import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Carousel } from "@ledgerhq/react-ui";
 import { ABTestingVariants } from "@ledgerhq/types-live";
 import React, { PropsWithChildren, useMemo } from "react";
@@ -7,7 +7,6 @@ import { useRefreshAccountsOrderingEffect } from "~/renderer/actions/general";
 import { Card } from "~/renderer/components/Box";
 import useActionCards from "~/renderer/hooks/useActionCards";
 import ActionCard from "~/renderer/components/ContentCards/ActionCard";
-import { ContentBannerActionCard } from "LLD/features/DynamicContent/components/ContentBannerActionCard";
 import LogContentCardWrapper from "LLD/features/DynamicContent/components/LogContentCardWrapper";
 
 // Classic variants (carousel with background)
@@ -37,45 +36,12 @@ const ActionVariantB = ({ children }: PropsWithChildren) => (
   </ActionVariantBContainer>
 );
 
-/** 2 columns, max 2 cards */
-const BrazePlacementGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
-  width: 100%;
-  & > * {
-    min-width: 0;
-  }
-`;
-
 const ActionContentCards = ({ variant }: { variant: ABTestingVariants }) => {
   const { actionCards, onClick, onDismiss } = useActionCards();
   const lldActionCarousel = useFeature("lldActionCarousel");
-  const { shouldDisplayBrazePlacement } = useWalletFeaturesConfig("desktop");
   const additionalProps = useMemo(() => ({ variant }), [variant]);
 
-  const brazeCards = shouldDisplayBrazePlacement ? actionCards.slice(0, 2) : [];
-  const brazeSlides = brazeCards.map((slide, index) => (
-    <LogContentCardWrapper
-      key={slide.id}
-      id={slide.id}
-      additionalProps={additionalProps}
-      displayedPosition={index}
-      location={slide.location}
-    >
-      <ContentBannerActionCard
-        title={slide.title}
-        description={slide.description}
-        onClose={() => onDismiss(slide.id, index)}
-        onClick={() => onClick(slide.id, slide.link, index)}
-        icon={slide.icon}
-        image_background={slide.image_background}
-      />
-    </LogContentCardWrapper>
-  ));
-
-  // Classic carousel: all cards
-  const classicSlides = actionCards.map((slide, index) => (
+  const slides = actionCards.map((slide, index) => (
     <LogContentCardWrapper
       key={slide.id}
       id={slide.id}
@@ -105,12 +71,7 @@ const ActionContentCards = ({ variant }: { variant: ABTestingVariants }) => {
     onMount: true,
   });
 
-  // grid 2 cols, max 2 cards
-  if (shouldDisplayBrazePlacement && lldActionCarousel?.enabled && brazeSlides.length > 0) {
-    return <BrazePlacementGrid>{brazeSlides}</BrazePlacementGrid>;
-  }
-
-  if (!lldActionCarousel?.enabled || classicSlides.length === 0) return null;
+  if (!lldActionCarousel?.enabled || slides.length === 0) return null;
 
   if (
     lldActionCarousel?.params?.variant === ABTestingVariants.variantB &&
@@ -118,7 +79,7 @@ const ActionContentCards = ({ variant }: { variant: ABTestingVariants }) => {
   ) {
     return (
       <ActionVariantB>
-        <Carousel variant="content-card">{classicSlides}</Carousel>
+        <Carousel variant="content-card">{slides}</Carousel>
       </ActionVariantB>
     );
   } else if (
@@ -127,7 +88,7 @@ const ActionContentCards = ({ variant }: { variant: ABTestingVariants }) => {
   ) {
     return (
       <ActionVariantA>
-        <Carousel variant="content-card">{classicSlides}</Carousel>
+        <Carousel variant="content-card">{slides}</Carousel>
       </ActionVariantA>
     );
   }

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Hooks/useGenerateLocalBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Hooks/useGenerateLocalBraze.ts
@@ -28,6 +28,9 @@ const generateNewPortfolioContentCard = (
   cta?: string,
   tag?: string,
   picto?: string,
+  path?: string,
+  icon?: string,
+  image_background?: string,
 ): PortfolioContentCard => ({
   id: String(Date.now()),
   title,
@@ -41,6 +44,9 @@ const generateNewPortfolioContentCard = (
   cta,
   tag,
   picto,
+  ...(path !== undefined && path !== "" && { path }),
+  ...(icon !== undefined && icon !== "" && { icon }),
+  ...(image_background !== undefined && image_background !== "" && { image_background }),
 });
 
 const generateNewActionCard = (
@@ -108,6 +114,9 @@ export const useGenerateLocalBraze = () => {
     cta?: string,
     tag?: string,
     picto?: string,
+    path?: string,
+    icon?: string,
+    image_background?: string,
   ) => {
     const newCard = generateNewPortfolioContentCard(
       title,
@@ -119,6 +128,9 @@ export const useGenerateLocalBraze = () => {
       cta,
       tag,
       picto,
+      path,
+      icon,
+      image_background,
     );
     dispatch(setPortfolioCards([...portfolioCards, newCard]));
   };
@@ -132,6 +144,9 @@ export const useGenerateLocalBraze = () => {
     cta?: string,
     tag?: string,
     picto?: string,
+    path?: string,
+    icon?: string,
+    image_background?: string,
   ) => {
     const newCard = generateNewPortfolioContentCard(
       title,
@@ -143,6 +158,9 @@ export const useGenerateLocalBraze = () => {
       cta,
       tag,
       picto,
+      path,
+      icon,
+      image_background,
     );
     dispatch(setBottomPortfolioCards([...bottomPortfolioCards, newCard]));
   };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Modal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Modal/Body.tsx
@@ -104,7 +104,19 @@ export const ModalBody: React.FC = () => {
       order,
     } = formData;
     if (selectedTab === "PortfolioContentCard") {
-      addLocalPortfolioCard(title, description, image, order, url, cta, tag, picto || undefined);
+      addLocalPortfolioCard(
+        title,
+        description,
+        image,
+        order,
+        url,
+        cta,
+        tag,
+        picto,
+        path,
+        icon,
+        image_background,
+      );
     } else if (selectedTab === "BottomPortfolioContentCard") {
       addLocalBottomPortfolioCard(
         title,
@@ -114,7 +126,10 @@ export const ModalBody: React.FC = () => {
         url,
         cta,
         tag,
-        picto || undefined,
+        picto,
+        path,
+        icon,
+        image_background,
       );
     } else if (selectedTab === "ActionContentCard") {
       addLocalActionCard(
@@ -179,13 +194,28 @@ export const ModalBody: React.FC = () => {
     PortfolioContentCard: [
       {
         field: "image",
-        placeholder: "Image URL",
+        placeholder: "Image URL (carousel / ContentBanner fallback)",
         label: t("settings.developer.brazeTools.modal.fields.image"),
+      },
+      {
+        field: "image_background",
+        placeholder: "Image background URL (Lumen MediaBanner when brazePlacement on)",
+        label: "Image background",
+      },
+      {
+        field: "icon",
+        placeholder: "Icon name for ContentBanner variant (e.g. Settings, Wallet)",
+        label: "Icon",
       },
       {
         field: "url",
         placeholder: "URL",
         label: t("settings.developer.brazeTools.modal.fields.url"),
+      },
+      {
+        field: "path",
+        placeholder: "In-app path (deep link)",
+        label: t("settings.developer.brazeTools.modal.fields.path"),
       },
       {
         field: "cta",
@@ -210,9 +240,24 @@ export const ModalBody: React.FC = () => {
         label: t("settings.developer.brazeTools.modal.fields.image"),
       },
       {
+        field: "image_background",
+        placeholder: "Image background URL (optional)",
+        label: "Image background",
+      },
+      {
+        field: "icon",
+        placeholder: "Icon name (optional)",
+        label: "Icon",
+      },
+      {
         field: "url",
         placeholder: "URL",
         label: t("settings.developer.brazeTools.modal.fields.url"),
+      },
+      {
+        field: "path",
+        placeholder: "In-app path (deep link)",
+        label: t("settings.developer.brazeTools.modal.fields.path"),
       },
       {
         field: "cta",
@@ -238,7 +283,7 @@ export const ModalBody: React.FC = () => {
       },
       {
         field: "image_background",
-        placeholder: "Image background URL (braze placement)",
+        placeholder: "Image background URL (MediaBanner variant)",
         label: "Image background",
       },
       {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Modal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Modal/index.tsx
@@ -13,7 +13,6 @@ const BrazeToolsGenerator = () => (
         onClose={onClose}
         onBack={undefined}
         title={<Trans i18nKey="settings.developer.brazeTools.modal.title" />}
-        noScroll
         render={() => <BrazeModalBody />}
       />
     )}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
@@ -11,7 +11,10 @@ export const WALLET_FEATURES_PARAMS = [
   { key: "newReceiveDialog", label: "New Receive Dialog" },
   { key: "balanceRefreshRework", label: "Balance Refresh Rework" },
   { key: "assetSection", label: "Asset Section" },
-  { key: "brazePlacement", label: "Braze Placement (Lumen content banner)" },
+  {
+    key: "brazePlacement",
+    label: "Braze Placement",
+  },
   { key: "operationsList", label: "TX History" },
   { key: "aggregatedAssets", label: "Aggregated Assets" },
   { key: "myWallet", label: "My Wallet" },

--- a/apps/ledger-live-desktop/src/types/dynamicContent.ts
+++ b/apps/ledger-live-desktop/src/types/dynamicContent.ts
@@ -42,6 +42,8 @@ export type PortfolioContentCard = ContentCard & {
   url?: string;
   path?: string;
   image?: string;
+  image_background?: string;
+  icon?: string;
   cta?: string;
   tag?: string;
   picto?: string;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

At the top of the portfolio desktop we have 2 braze placements:
- actions cards with location "action"
- carousel with location "portfolio"

the new braze placement from lumen with grid (2 cards) should replace the "portfolio" carousel not the actions cards, so this PR move the new placement from action card to the carousel
<img width="1512" height="949" alt="Screenshot 2026-04-03 at 10 50 47" src="https://github.com/user-attachments/assets/c46c1cbe-478d-4bc6-95a0-62bbd22fb512" />

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
