### PR TITLE
[LWDM] fix: add proper error on limit > 200 on tron listOperations

### DIFF
--- a/.changeset/tame-ligers-serve.md
+++ b/.changeset/tame-ligers-serve.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": patch
+---
+
+proper error on limit > 200 on tron listOperations

--- a/libs/coin-modules/coin-tron/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.test.ts
@@ -89,4 +89,16 @@ describe("createApi", () => {
       cursor: undefined,
     });
   });
+
+  it("should throw when limit > 200", async () => {
+    const api: AlpacaApi = createApi(mockTronConfig);
+    await expect(api.listOperations("address", { minHeight: 0, limit: 201 })).rejects.toThrow(
+      "limit must be <= 200 for Tron (TronGrid API restriction)",
+    );
+  });
+
+  it("should not throw when limit is exactly 200", async () => {
+    const api: AlpacaApi = createApi(mockTronConfig);
+    await expect(api.listOperations("address", { minHeight: 0, limit: 200 })).resolves.not.toThrow();
+  });
 });

--- a/libs/coin-modules/coin-tron/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.test.ts
@@ -35,6 +35,10 @@ describe("createApi", () => {
   const mockTronConfig: TronConfig = { explorer: { url: "iamaurl" } } as TronConfig;
   let setCoinConfigSpy: jest.SpyInstance;
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should set the coin config value", () => {
     setCoinConfigSpy = jest.spyOn(coinConfig, "setCoinConfig");
 
@@ -95,6 +99,7 @@ describe("createApi", () => {
     await expect(api.listOperations("address", { minHeight: 0, limit: 201 })).rejects.toThrow(
       "limit must be <= 200 for Tron (TronGrid API restriction)",
     );
+    expect(listOperations).not.toHaveBeenCalled();
   });
 
   it("should not throw when limit is exactly 200", async () => {

--- a/libs/coin-modules/coin-tron/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.test.ts
@@ -99,6 +99,13 @@ describe("createApi", () => {
 
   it("should not throw when limit is exactly 200", async () => {
     const api: AlpacaApi = createApi(mockTronConfig);
-    await expect(api.listOperations("address", { minHeight: 0, limit: 200 })).resolves.not.toThrow();
+    await expect(api.listOperations("address", { minHeight: 0, limit: 200 })).resolves.toEqual({
+      items: [],
+      next: undefined,
+    });
+    expect(listOperations).toHaveBeenCalledWith(
+      "address",
+      expect.objectContaining({ limit: 200, minTimestamp: 0 }),
+    );
   });
 });

--- a/libs/coin-modules/coin-tron/src/api/index.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.ts
@@ -82,6 +82,9 @@ async function listOperations(
   address: string,
   { minHeight, order, cursor, limit }: ListOperationsOptions,
 ): Promise<Page<Operation>> {
+  if (limit !== undefined && limit > 200) {
+    throw new Error("limit must be <= 200 for Tron (TronGrid API restriction)");
+  }
   const effectiveLimit = limit ?? 200;
   const effectiveOrder = order ?? "asc";
 

--- a/libs/coin-modules/coin-tron/src/api/index.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.ts
@@ -29,6 +29,8 @@ import {
 import { defaultFetchParams, getBlock as getBlockNetwork } from "../network";
 import type { TronMemo } from "../types";
 
+const MAX_TRONGRID_LIMIT = 200;
+
 export function createApi(config: TronConfig): AlpacaApi<TronMemo> {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
 
@@ -82,10 +84,10 @@ async function listOperations(
   address: string,
   { minHeight, order, cursor, limit }: ListOperationsOptions,
 ): Promise<Page<Operation>> {
-  if (limit !== undefined && limit > 200) {
-    throw new Error("limit must be <= 200 for Tron (TronGrid API restriction)");
+  if (limit !== undefined && limit > MAX_TRONGRID_LIMIT) {
+    throw new Error(`limit must be <= ${MAX_TRONGRID_LIMIT} for Tron (TronGrid API restriction)`);
   }
-  const effectiveLimit = limit ?? 200;
+  const effectiveLimit = limit ?? MAX_TRONGRID_LIMIT;
   const effectiveOrder = order ?? "asc";
 
   let minTimestamp = defaultFetchParams.minTimestamp;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** 
  - coin-tron listOperations

### 📝 Description

Adds explicit input validation to Tron listOperations so callers get a clear error when requesting more than TronGrid’s max page size (200), and introduces regression tests for the new behavior.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
