### PR TITLE
[LWDM] Feat/live 26472 private transfer sign operation

### DIFF
--- a/.changeset/new-rabbits-mix.md
+++ b/.changeset/new-rabbits-mix.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Handle fee sponsoring for private transfers

--- a/libs/coin-modules/coin-aleo/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/signOperation.test.ts
@@ -86,6 +86,32 @@ describe("buildSignOperation", () => {
     ]);
   });
 
+  it("should emit device-signature-requested with only a type key", async () => {
+    const events = await firstValueFrom(
+      mockSignOperation({
+        account: mockAccount,
+        transaction: mockTransaction,
+        deviceId: "test-device",
+      }).pipe(toArray()),
+    );
+
+    const event = events.find(e => e.type === "device-signature-requested");
+    expect(Object.keys(event!)).toEqual(["type"]);
+  });
+
+  it("should emit device-signature-granted with only a type key", async () => {
+    const events = await firstValueFrom(
+      mockSignOperation({
+        account: mockAccount,
+        transaction: mockTransaction,
+        deviceId: "test-device",
+      }).pipe(toArray()),
+    );
+
+    const event = events.find(e => e.type === "device-signature-granted");
+    expect(Object.keys(event!)).toEqual(["type"]);
+  });
+
   it("should emit a signed event with the optimistic operation and the encoded signed transaction", async () => {
     const events = await firstValueFrom(
       mockSignOperation({
@@ -146,6 +172,33 @@ describe("buildSignOperation", () => {
       mockAccount.freshAddressPath,
       expect.any(Buffer),
     );
+  });
+
+  it("should call signer.signFeeIntent once for non-sponsored transactions", async () => {
+    await firstValueFrom(
+      mockSignOperation({
+        account: mockAccount,
+        transaction: mockTransaction,
+        deviceId: "test-device",
+      }).pipe(toArray()),
+    );
+
+    expect(mockSigner.signFeeIntent).toHaveBeenCalledTimes(1);
+    expect(mockSigner.signFeeIntent).toHaveBeenCalledWith(expect.any(Buffer));
+  });
+
+  it("should not call signer.signFeeIntent when fee is sponsored", async () => {
+    mockAleoConfig.getCoinConfig.mockReturnValue({ ...mockConfig, isFeeSponsored: true });
+
+    await firstValueFrom(
+      mockSignOperation({
+        account: mockAccount,
+        transaction: mockTransaction,
+        deviceId: "test-device",
+      }).pipe(toArray()),
+    );
+
+    expect(mockSigner.signFeeIntent).not.toHaveBeenCalled();
   });
 
   it("should use fee_private function name when transaction is private", async () => {

--- a/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
@@ -33,22 +33,31 @@ interface SigningParams {
   viewKey: string;
 }
 
-async function executeSigningFlow(signer: AleoSigner, params: SigningParams): Promise<string> {
-  const { account, transaction, request, config, baseFee, priorityFee, viewKey } = params;
-
-  // sign root request
-  const rootIntentSignature = await signer.signRootIntent(
+async function buildRootAuthorization(
+  signer: AleoSigner,
+  account: AleoAccount,
+  request: PreparedRequestResponse,
+  viewKey: string,
+) {
+  const { signature } = await signer.signRootIntent(
     account.freshAddressPath,
     Buffer.from(request.tlv, "hex"),
   );
 
-  // create authorization
-  const authorization = await sdkClient.createAuthorization({
+  return sdkClient.createAuthorization({
     currency: account.currency,
     request,
-    signatures: rootIntentSignature.signature,
+    signatures: signature,
     viewKey,
   });
+}
+
+async function buildFeeAuthorization(
+  signer: AleoSigner,
+  params: SigningParams,
+  executionId: string,
+): Promise<string> {
+  const { account, transaction, config, baseFee, priorityFee, viewKey } = params;
 
   // craft fee request even if it's zero, because device needs the second APDU in signing flow to move forward
   const craftedFeeRequest = await craftTransaction({
@@ -58,30 +67,35 @@ async function executeSigningFlow(signer: AleoSigner, params: SigningParams): Pr
     txIntent: createFeeTransactionIntent({
       account,
       transaction,
-      executionId: authorization.execution_id,
+      executionId,
       baseFee,
       priorityFee,
+      isFeeSponsored: config.isFeeSponsored,
     }),
   });
 
   const feeRequest = fromHex<PreparedRequestResponse>(craftedFeeRequest.transaction);
 
-  // sign fee request
-  const feeIntentSignature = await signer.signFeeIntent(Buffer.from(feeRequest.tlv, "hex"));
+  const { signature } = await signer.signFeeIntent(Buffer.from(feeRequest.tlv, "hex"));
 
-  // create fee authorization, but only if fee is not zero
-  let feeAuthorization: string | null = null;
+  const result = await sdkClient.createAuthorization({
+    currency: account.currency,
+    request: feeRequest,
+    signatures: signature,
+    viewKey,
+  });
 
-  if (!config.isFeeSponsored) {
-    const result = await sdkClient.createAuthorization({
-      currency: account.currency,
-      request: feeRequest,
-      signatures: feeIntentSignature.signature,
-      viewKey,
-    });
+  return result.authorization;
+}
 
-    feeAuthorization = result.authorization;
-  }
+async function executeSigningFlow(signer: AleoSigner, params: SigningParams): Promise<string> {
+  const { account, request, config, viewKey } = params;
+
+  const authorization = await buildRootAuthorization(signer, account, request, viewKey);
+
+  const feeAuthorization = config.isFeeSponsored
+    ? null
+    : await buildFeeAuthorization(signer, params, authorization.execution_id);
 
   const signedTransaction = {
     authorization: authorization.authorization,

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -1212,6 +1212,34 @@ describe("createTransactionIntent", () => {
       },
     });
   });
+
+  it("should throw when amountRecordCommitment is null for a private transaction", () => {
+    const transaction = getMockedTransaction({
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitment: null,
+        feeRecordCommitment: null,
+      },
+    });
+
+    expect(() => createTransactionIntent({ account: mockAccount, transaction })).toThrow(
+      "aleo: missing amount record commitment",
+    );
+  });
+
+  it("should throw when amountRecordCommitment does not match any unspent record", () => {
+    const transaction = getMockedTransaction({
+      mode: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+      properties: {
+        amountRecordCommitment: "non-existent-commitment",
+        feeRecordCommitment: null,
+      },
+    });
+
+    expect(() => createTransactionIntent({ account: mockAccount, transaction })).toThrow(
+      "aleo: no amount record found for commitment non-existent-commitment",
+    );
+  });
 });
 
 describe("createFeeTransactionIntent", () => {
@@ -1235,6 +1263,7 @@ describe("createFeeTransactionIntent", () => {
       executionId,
       baseFee,
       priorityFee,
+      isFeeSponsored: false,
     });
 
     expect(result).toEqual({
@@ -1269,6 +1298,7 @@ describe("createFeeTransactionIntent", () => {
       executionId,
       baseFee,
       priorityFee,
+      isFeeSponsored: false,
     });
 
     expect(result).toEqual({
@@ -1305,6 +1335,7 @@ describe("createFeeTransactionIntent", () => {
         executionId,
         baseFee,
         priorityFee,
+        isFeeSponsored: false,
       }),
     ).toThrow("aleo: missing fee record commitment");
   });
@@ -1325,6 +1356,7 @@ describe("createFeeTransactionIntent", () => {
         executionId,
         baseFee,
         priorityFee,
+        isFeeSponsored: false,
       }),
     ).toThrow("aleo: missing fee record commitment");
   });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -530,12 +530,14 @@ export function createFeeTransactionIntent({
   executionId,
   baseFee,
   priorityFee,
+  isFeeSponsored,
 }: {
   account: AleoAccount;
   transaction: Transaction;
   executionId: string;
   baseFee: BigNumber;
   priorityFee: BigNumber;
+  isFeeSponsored: boolean;
 }): TransactionIntent<MemoNotSupported, AleoTransactionIntentData> {
   const isPrivateTx = isPrivateTransaction(transaction);
   const commonFields = {
@@ -546,7 +548,7 @@ export function createFeeTransactionIntent({
     sender: account.freshAddress,
   } as const;
 
-  if (isPrivateTx) {
+  if (isPrivateTx && !isFeeSponsored) {
     const commitment = transaction.properties.feeRecordCommitment;
     invariant(commitment, "aleo: missing fee record commitment");
     const feeRecord = getRecordByCommitment({ account, commitment });


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - coin aleo now handles private transfers with fee sponsoring
  - public transfers shouldnt be affected 

### 📝 Description

This PR changes how we handle creating the fee authorization. When the fee sponsoring is enabled we ignore fees completely - delegate provers gets only the root authorization

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26472
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
