### PR TITLE
[LWDM] feat: lwd update bottom carousel card component

### DIFF
--- a/.changeset/orange-cycles-breathe.md
+++ b/.changeset/orange-cycles-breathe.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+feat: lwd update bottom carousel card component

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { act, render, screen } from "tests/testSetup";
+import { render, screen } from "tests/testSetup";
 import PortfolioContentCards from "../components/PortfolioContentCards";
 import { BottomCarouselContentCards } from "../components/BottomCarouselContentCards";
 import { ClassicCard, logCardDismissal, logContentCardClick } from "@braze/web-sdk";
@@ -97,7 +97,7 @@ const desktopCardsWithBottomPlacements = [...Cards, ...BottomCards].map(asClassi
 
 describe("PortfolioContentCards", () => {
   test("render slides", async () => {
-    render(<PortfolioContentCards />, {
+    const { user } = render(<PortfolioContentCards />, {
       initialState: {
         dynamicContent: { desktopCards: desktopCardsForTopCarousel, portfolioCards: Cards },
         settings: {
@@ -139,13 +139,13 @@ describe("PortfolioContentCards", () => {
       type: "portfolio_carousel",
     });
 
-    act(() => screen.getByTestId("carousel-arrow-next").click());
+    await user.click(screen.getByTestId("carousel-arrow-next"));
     expect(track).toHaveBeenCalledWith("contentcards_slide", {
       button: "next",
       page: "Portfolio",
       type: "carousel_portfolio",
     });
-    act(() => screen.getByTestId("carousel-arrow-prev").click());
+    await user.click(screen.getByTestId("carousel-arrow-prev"));
     expect(track).toHaveBeenCalledWith("contentcards_slide", {
       button: "prev",
       page: "Portfolio",
@@ -155,7 +155,7 @@ describe("PortfolioContentCards", () => {
     // Test dismiss button
     expect(logCardDismissal).not.toHaveBeenCalled();
     expect(track).not.toHaveBeenCalledWith("contentcard_dismissed", expect.any(Object));
-    act(() => screen.getAllByTestId("portfolio-card-close-button")[1].click());
+    await user.click(screen.getAllByTestId("portfolio-card-close-button")[1]);
     expect(logCardDismissal).toHaveBeenCalledWith(
       expect.objectContaining({
         id: Cards[1].id,
@@ -179,7 +179,7 @@ describe("PortfolioContentCards", () => {
     // Test click button
     expect(logContentCardClick).not.toHaveBeenCalled();
     expect(track).not.toHaveBeenCalledWith("contentcard_clicked", expect.any(Object));
-    act(() => cta0.click());
+    await user.click(cta0);
     expect(logContentCardClick).toHaveBeenCalledTimes(1);
     expect(logContentCardClick).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -206,7 +206,7 @@ describe("PortfolioContentCards", () => {
 
 describe("BottomCarouselContentCards", () => {
   test("render slides", async () => {
-    render(<BottomCarouselContentCards />, {
+    const { user } = render(<BottomCarouselContentCards />, {
       initialState: {
         dynamicContent: {
           desktopCards: desktopCardsWithBottomPlacements,
@@ -223,21 +223,16 @@ describe("BottomCarouselContentCards", () => {
     });
 
     const title0 = await screen.findByText("Foo");
-    const description0 = screen.getByText("Lorem ipsum dolor sit amet.");
-    const cta0 = screen.getByText("Click me");
     const tag0 = screen.getByText("New");
     const title1 = screen.getByText("Bar");
-    const description1 = screen.getByText("Consectetur adipiscing elit.");
 
     expect(title0).toBeVisible();
-    expect(description0).toBeVisible();
-    expect(cta0).toBeVisible();
     expect(tag0).toBeVisible();
     expect(title1).toBeVisible();
-    expect(description1).toBeVisible();
 
     expect(logCardDismissal).not.toHaveBeenCalled();
-    act(() => screen.getAllByTestId("portfolio-card-close-button")[1].click());
+    const closeButtons = screen.getAllByRole("button", { name: /close/i });
+    await user.click(closeButtons[1]);
     expect(logCardDismissal).toHaveBeenCalledWith(
       expect.objectContaining({ id: BottomCards[1].id }),
     );
@@ -251,10 +246,9 @@ describe("BottomCarouselContentCards", () => {
       }),
     );
     expect(title1).not.toBeInTheDocument();
-    expect(description1).not.toBeInTheDocument();
 
     expect(logContentCardClick).not.toHaveBeenCalled();
-    act(() => cta0.click());
+    await user.click(title0);
     expect(logContentCardClick).toHaveBeenCalledTimes(1);
     expect(logContentCardClick).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/BottomCarouselContentCards/BottomCarouselSlide.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/BottomCarouselContentCards/BottomCarouselSlide.tsx
@@ -1,0 +1,68 @@
+import React, { memo } from "react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { MediaCard, MediaCardTitle, Tag } from "@ledgerhq/lumen-ui-react";
+
+import { getValidCryptoIconSize } from "~/renderer/utils/cryptoIconSize";
+import type { PortfolioContentCard } from "~/types/dynamicContent";
+import type { CarouselActions } from "../../types";
+import LogContentCardWrapper from "../LogContentCardWrapper";
+
+import { useBottomCarouselSlideModel } from "./useBottomCarouselSlideModel";
+
+export default memo(BottomCarouselSlide);
+
+type Props = PortfolioContentCard &
+  CarouselActions & {
+    index: number;
+  };
+
+function BottomCarouselSlide({
+  id,
+  path,
+  url,
+  title,
+  tag,
+  picto,
+  image,
+  index,
+  location,
+  logSlideClick,
+  dismissCard,
+}: Props) {
+  const { handleClick, handleClose, hasClickTarget, mediaHeader } = useBottomCarouselSlideModel({
+    id,
+    path,
+    url,
+    tag,
+    picto,
+    index,
+    logSlideClick,
+    dismissCard,
+  });
+
+  let header: React.ReactNode = null;
+  if (mediaHeader?.kind === "picto") {
+    header = (
+      <CryptoIcon
+        ledgerId={mediaHeader.ledgerId}
+        ticker={mediaHeader.ledgerId}
+        size={getValidCryptoIconSize(32)}
+      />
+    );
+  } else if (mediaHeader?.kind === "tag") {
+    header = <Tag label={mediaHeader.label} size="md" />;
+  }
+
+  return (
+    <LogContentCardWrapper id={id} location={location}>
+      <MediaCard
+        imageUrl={image ?? ""}
+        onClick={hasClickTarget ? handleClick : undefined}
+        onClose={handleClose}
+      >
+        {header}
+        {title ? <MediaCardTitle>{title}</MediaCardTitle> : null}
+      </MediaCard>
+    </LogContentCardWrapper>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/BottomCarouselContentCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/BottomCarouselContentCards/index.tsx
@@ -1,12 +1,10 @@
-// Temporary component to display the bottom carousel content cards
-// TODO: Remove this component and use the Lumen bottom carousel component when available
-
 import React from "react";
 
 import { cn } from "LLD/utils/cn";
 import { usePortfolioCarouselCards } from "../../hooks/usePortfolioCarouselCards";
-import Slide from "../PortfolioContentCards/Slide";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+
+import BottomCarouselSlide from "./BottomCarouselSlide";
 
 export const BottomCarouselContentCards = () => {
   const { portfolioCards, logSlideClick, dismissCard } = usePortfolioCarouselCards("bottom");
@@ -20,7 +18,7 @@ export const BottomCarouselContentCards = () => {
         data-testid="scroll-container"
         className="scrollbar-none flex flex-col overflow-x-scroll py-2"
       >
-        <div className="flex items-stretch gap-4">
+        <div className="flex items-stretch gap-14">
           {portfolioCards.map((card, index) => (
             <div
               key={card.id}
@@ -29,12 +27,11 @@ export const BottomCarouselContentCards = () => {
                 isWallet40Enabled && "overflow-hidden rounded-xl",
               )}
             >
-              <Slide
+              <BottomCarouselSlide
                 {...card}
                 index={index}
                 logSlideClick={logSlideClick}
                 dismissCard={dismissCard}
-                isWallet40Enabled={isWallet40Enabled}
               />
             </div>
           ))}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/BottomCarouselContentCards/useBottomCarouselSlideModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/BottomCarouselContentCards/useBottomCarouselSlideModel.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from "react";
+import { useNavigate } from "react-router";
+
+import { openURL } from "~/renderer/linking";
+import type { PortfolioContentCard } from "~/types/dynamicContent";
+import type { CarouselActions } from "../../types";
+
+export type BottomCarouselMediaHeader =
+  | { kind: "picto"; ledgerId: string }
+  | { kind: "tag"; label: string }
+  | null;
+
+type Args = Pick<PortfolioContentCard, "id" | "path" | "url" | "tag" | "picto"> &
+  Pick<CarouselActions, "logSlideClick" | "dismissCard"> & {
+    index: number;
+  };
+
+export function useBottomCarouselSlideModel({
+  id,
+  path,
+  url,
+  tag,
+  picto,
+  index,
+  logSlideClick,
+  dismissCard,
+}: Args) {
+  const navigate = useNavigate();
+
+  const handleClose = useCallback(() => {
+    dismissCard(index);
+  }, [dismissCard, index]);
+
+  const handleClick = useCallback(() => {
+    logSlideClick(id);
+    if (path) {
+      navigate(path, { state: { source: "banner" } });
+    } else if (url) {
+      openURL(url);
+    }
+  }, [id, logSlideClick, navigate, path, url]);
+
+  const hasClickTarget = Boolean(path || url);
+
+  const mediaHeader = useMemo((): BottomCarouselMediaHeader => {
+    if (picto != null && picto !== "") {
+      return { kind: "picto", ledgerId: picto };
+    }
+    if (tag) {
+      return { kind: "tag", label: tag };
+    }
+    return null;
+  }, [picto, tag]);
+
+  return {
+    handleClick,
+    handleClose,
+    hasClickTarget,
+    mediaHeader,
+  };
+}

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -86,8 +86,9 @@ const mapBrazeCardToPortfolioContentCard = (
   order: parseOrder(card.extras?.order),
   path: card.extras?.path,
   tag: card.extras?.tag,
+  picto: card.extras?.picto,
   title: card.extras?.title,
-  url: card.extras?.url,
+  url: card.extras?.url || card.extras?.link,
 });
 
 export const mapAsPortfolioContentCard = (card: ClassicCard): PortfolioContentCard =>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Hooks/useGenerateLocalBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Hooks/useGenerateLocalBraze.ts
@@ -27,6 +27,7 @@ const generateNewPortfolioContentCard = (
   url?: string,
   cta?: string,
   tag?: string,
+  picto?: string,
 ): PortfolioContentCard => ({
   id: String(Date.now()),
   title,
@@ -39,6 +40,7 @@ const generateNewPortfolioContentCard = (
   url,
   cta,
   tag,
+  picto,
 });
 
 const generateNewActionCard = (
@@ -105,6 +107,7 @@ export const useGenerateLocalBraze = () => {
     url?: string,
     cta?: string,
     tag?: string,
+    picto?: string,
   ) => {
     const newCard = generateNewPortfolioContentCard(
       title,
@@ -115,6 +118,7 @@ export const useGenerateLocalBraze = () => {
       url,
       cta,
       tag,
+      picto,
     );
     dispatch(setPortfolioCards([...portfolioCards, newCard]));
   };
@@ -127,6 +131,7 @@ export const useGenerateLocalBraze = () => {
     url?: string,
     cta?: string,
     tag?: string,
+    picto?: string,
   ) => {
     const newCard = generateNewPortfolioContentCard(
       title,
@@ -137,6 +142,7 @@ export const useGenerateLocalBraze = () => {
       url,
       cta,
       tag,
+      picto,
     );
     dispatch(setBottomPortfolioCards([...bottomPortfolioCards, newCard]));
   };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Modal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Modal/Body.tsx
@@ -36,6 +36,7 @@ interface FormState {
   secondaryCta: string;
   cta: string;
   tag?: string;
+  picto?: string;
   url: string;
   path: string;
   order?: number;
@@ -56,6 +57,7 @@ const initialState: FormState = {
   link: "https://www.ledger.com/",
   secondaryCta: "Dummy Dismiss CTA",
   cta: "Dummy CTA",
+  picto: "",
   url: "https://www.ledger.com/",
   path: "https://www.ledger.com/",
   order: undefined,
@@ -96,14 +98,24 @@ export const ModalBody: React.FC = () => {
       secondaryCta,
       cta,
       tag,
+      picto,
       url,
       path,
       order,
     } = formData;
     if (selectedTab === "PortfolioContentCard") {
-      addLocalPortfolioCard(title, description, image, order, url, cta, tag);
+      addLocalPortfolioCard(title, description, image, order, url, cta, tag, picto || undefined);
     } else if (selectedTab === "BottomPortfolioContentCard") {
-      addLocalBottomPortfolioCard(title, description, image, order, url, cta, tag);
+      addLocalBottomPortfolioCard(
+        title,
+        description,
+        image,
+        order,
+        url,
+        cta,
+        tag,
+        picto || undefined,
+      );
     } else if (selectedTab === "ActionContentCard") {
       addLocalActionCard(
         title,
@@ -185,6 +197,11 @@ export const ModalBody: React.FC = () => {
         placeholder: "TAG",
         label: t("settings.developer.brazeTools.modal.fields.tag"),
       },
+      {
+        field: "picto",
+        placeholder: "e.g. bitcoin",
+        label: t("settings.developer.brazeTools.modal.fields.picto"),
+      },
     ],
     BottomPortfolioContentCard: [
       {
@@ -206,6 +223,11 @@ export const ModalBody: React.FC = () => {
         field: "tag",
         placeholder: "TAG",
         label: t("settings.developer.brazeTools.modal.fields.tag"),
+      },
+      {
+        field: "picto",
+        placeholder: "e.g. bitcoin",
+        label: t("settings.developer.brazeTools.modal.fields.picto"),
       },
     ],
     ActionContentCard: [

--- a/apps/ledger-live-desktop/src/types/dynamicContent.ts
+++ b/apps/ledger-live-desktop/src/types/dynamicContent.ts
@@ -44,4 +44,5 @@ export type PortfolioContentCard = ContentCard & {
   image?: string;
   cta?: string;
   tag?: string;
+  picto?: string;
 };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4652,6 +4652,7 @@
             "secondaryCta": "Secondary CTA",
             "cta": "CTA",
             "tag": "Tag",
+            "picto": "Picto (ledger id)",
             "url": "URL",
             "path": "Path"
           }

--- a/apps/ledger-live-mobile/src/actions/dynamicContent.ts
+++ b/apps/ledger-live-mobile/src/actions/dynamicContent.ts
@@ -15,6 +15,7 @@ import {
   DynamicContentSetMobileCardsPayload,
   DynamicContentSetLandingStickyCtaCardsPayload,
   DynamicContentAddLocalCardsPayload,
+  DynamicContentAppendLocalCardsPayload,
   DynamicContentRemoveLocalCardPayload,
   DynamicContentAddLocalWalletCarouselPayload,
 } from "./types";
@@ -74,6 +75,13 @@ const addLocalContentCardsAction = createAction<DynamicContentAddLocalCardsPaylo
 
 export const addLocalContentCards = (payload: DynamicContentAddLocalCardsPayload) =>
   addLocalContentCardsAction(payload);
+
+const appendLocalContentCardsAction = createAction<DynamicContentAppendLocalCardsPayload>(
+  DynamicContentActionTypes.DYNAMIC_CONTENT_APPEND_LOCAL_CARDS,
+);
+
+export const appendLocalContentCards = (cards: DynamicContentAppendLocalCardsPayload) =>
+  appendLocalContentCardsAction(cards);
 
 const clearLocalContentCardsAction = createAction(
   DynamicContentActionTypes.DYNAMIC_CONTENT_CLEAR_LOCAL_CARDS,

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -187,6 +187,7 @@ export enum DynamicContentActionTypes {
   DYNAMIC_CONTENT_SET_MOBILE_CARDS = "DYNAMIC_CONTENT_SET_MOBILE_CARDS",
   DYNAMIC_CONTENT_IS_LOADING = "DYNAMIC_CONTENT_IS_LOADING",
   DYNAMIC_CONTENT_ADD_LOCAL_CARDS = "DYNAMIC_CONTENT_ADD_LOCAL_CARDS",
+  DYNAMIC_CONTENT_APPEND_LOCAL_CARDS = "DYNAMIC_CONTENT_APPEND_LOCAL_CARDS",
   DYNAMIC_CONTENT_CLEAR_LOCAL_CARDS = "DYNAMIC_CONTENT_CLEAR_LOCAL_CARDS",
   DYNAMIC_CONTENT_REMOVE_LOCAL_CARD = "DYNAMIC_CONTENT_REMOVE_LOCAL_CARD",
   DYNAMIC_CONTENT_ADD_LOCAL_WALLET_CAROUSEL_CARDS = "DYNAMIC_CONTENT_ADD_LOCAL_WALLET_CAROUSEL_CARDS",
@@ -209,6 +210,9 @@ export type DynamicContentAddLocalCardsPayload = {
   cards: BrazeContentCard[];
 };
 
+/** Appends Braze-like cards to `localMobileCards` (same `extras.categoryId` as an existing local category). */
+export type DynamicContentAppendLocalCardsPayload = BrazeContentCard[];
+
 export type DynamicContentRemoveLocalCardPayload = string;
 
 export type DynamicContentAddLocalWalletCarouselPayload = WalletContentCard[];
@@ -221,6 +225,7 @@ export type DynamicContentPayload =
   | DynamicContentSetLandingStickyCtaCardsPayload
   | DynamicContentSetMobileCardsPayload
   | DynamicContentAddLocalCardsPayload
+  | DynamicContentAppendLocalCardsPayload
   | DynamicContentRemoveLocalCardPayload
   | DynamicContentAddLocalWalletCarouselPayload;
 

--- a/apps/ledger-live-mobile/src/components/Carousel/CarouselCard.tsx
+++ b/apps/ledger-live-mobile/src/components/Carousel/CarouselCard.tsx
@@ -1,12 +1,14 @@
-import React, { memo, useCallback } from "react";
-import { Linking } from "react-native";
+import React, { memo } from "react";
 import { Flex, FullBackgroundCard } from "@ledgerhq/native-ui";
+import { CryptoIcon } from "@ledgerhq/native-ui/pre-ldls";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { MediaCard, MediaCardTitle, Tag } from "@ledgerhq/lumen-ui-rnative";
 import { useTheme } from "styled-components/native";
 import { WalletContentCard } from "~/dynamicContent/types";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
 import ForceTheme from "../theme/ForceTheme";
+
+import { useCarouselCardModel } from "./useCarouselCardModel";
 
 type CarouselCardProps = {
   id: string;
@@ -20,41 +22,36 @@ const CarouselCard = ({ id, cardProps, index, width }: CarouselCardProps) => {
   const { shouldDisplayBrazePlacement } = useWalletFeaturesConfig("mobile");
   const { logClickCard, dismissCard, trackContentCardEvent } = useDynamicContent();
 
-  const onPress = useCallback(async () => {
-    if (!cardProps) return;
-    if (!cardProps.link) return;
+  const { handleHide, handlePress, mediaHeader } = useCarouselCardModel({
+    cardProps,
+    logClickCard,
+    dismissCard,
+    trackContentCardEvent,
+  });
 
-    await trackContentCardEvent("contentcard_clicked", {
-      ...cardProps.extras,
-      screen: cardProps.location,
-      campaign: cardProps.id,
-    });
+  const useMediaCardLayout = shouldDisplayBrazePlacement || mediaHeader != null;
 
-    // Notify Braze that the card has been clicked by the user
-    logClickCard(cardProps.id);
-    await Linking.openURL(cardProps.link);
-  }, [cardProps, logClickCard, trackContentCardEvent]);
+  const backgroundImageUrl =
+    cardProps.image_background?.trim() || cardProps.image?.trim() || "";
 
-  const onHide = useCallback(() => {
-    if (!cardProps) return;
+  if (useMediaCardLayout) {
+    let header: React.ReactNode = null;
+    if (mediaHeader?.kind === "picto") {
+      header = (
+        <CryptoIcon ledgerId={mediaHeader.ledgerId} ticker={mediaHeader.ledgerId} size={32} />
+      );
+    } else if (mediaHeader?.kind === "tag") {
+      header = <Tag label={mediaHeader.label} size="md" />;
+    }
 
-    trackContentCardEvent("contentcard_dismissed", {
-      ...cardProps.extras,
-      screen: cardProps.location,
-      campaign: cardProps.id,
-    });
-    dismissCard(cardProps.id);
-  }, [cardProps, trackContentCardEvent, dismissCard]);
-
-  if (shouldDisplayBrazePlacement) {
     return (
       <Flex key={`container_${id}`} mr={6} ml={index === 0 ? 6 : 0} width={width}>
         <MediaCard
-          imageUrl={cardProps.image ?? ""}
-          onPress={cardProps.link ? onPress : undefined}
-          onClose={onHide}
+          imageUrl={backgroundImageUrl}
+          onPress={cardProps.link ? handlePress : undefined}
+          onClose={handleHide}
         >
-          {cardProps.tag ? <Tag label={cardProps.tag} size="md" /> : null}
+          {header}
           {cardProps.title ? <MediaCardTitle>{cardProps.title}</MediaCardTitle> : null}
         </MediaCard>
       </Flex>
@@ -69,8 +66,8 @@ const CarouselCard = ({ id, cardProps, index, width }: CarouselCardProps) => {
           backgroundImage={cardProps.image}
           tag={cardProps.tag}
           description={cardProps.title}
-          onPress={onPress}
-          onDismiss={onHide}
+          onPress={handlePress}
+          onDismiss={handleHide}
         />
       </ForceTheme>
     </Flex>

--- a/apps/ledger-live-mobile/src/components/Carousel/index.tsx
+++ b/apps/ledger-live-mobile/src/components/Carousel/index.tsx
@@ -2,6 +2,7 @@ import React, { memo, useMemo, useCallback, useRef, useState } from "react";
 import { NativeScrollEvent, NativeSyntheticEvent, ScrollView } from "react-native";
 import LogContentCardWrapper from "LLM/features/DynamicContent/components/LogContentCardWrapper";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
+import { WalletContentCard } from "~/dynamicContent/types";
 import { width } from "~/helpers/normalizeSize";
 import CarouselCard from "./CarouselCard";
 
@@ -48,7 +49,7 @@ const Carousel = () => {
       snapToInterval={WIDTH + 16}
       decelerationRate={"fast"}
     >
-      {walletCardsDisplayed.map((cardProps, index) => (
+      {walletCardsDisplayed.map((cardProps: WalletContentCard, index: number) => (
         <LogContentCardWrapper
           key={cardProps.id + index}
           id={cardProps.id}

--- a/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.ts
+++ b/apps/ledger-live-mobile/src/components/Carousel/useCarouselCardModel.ts
@@ -1,0 +1,66 @@
+import { useCallback, useMemo } from "react";
+import { Linking } from "react-native";
+
+import type { WalletContentCard } from "~/dynamicContent/types";
+
+export type WalletCarouselMediaHeader =
+  | { kind: "picto"; ledgerId: string }
+  | { kind: "tag"; label: string }
+  | null;
+
+type TrackContentCardEvent = (
+  event: "contentcard_clicked" | "contentcard_dismissed",
+  params: Record<string, string | number | undefined>,
+) => Promise<void>;
+
+type Args = {
+  cardProps: WalletContentCard;
+  logClickCard: (cardId: string) => void;
+  dismissCard: (cardId: string) => void;
+  trackContentCardEvent: TrackContentCardEvent;
+};
+
+export function useCarouselCardModel({
+  cardProps,
+  logClickCard,
+  dismissCard,
+  trackContentCardEvent,
+}: Args) {
+  const handlePress = useCallback(async () => {
+    if (!cardProps.link) return;
+
+    await trackContentCardEvent("contentcard_clicked", {
+      ...cardProps.extras,
+      screen: cardProps.location,
+      campaign: cardProps.id,
+    });
+
+    logClickCard(cardProps.id);
+    await Linking.openURL(cardProps.link);
+  }, [cardProps, logClickCard, trackContentCardEvent]);
+
+  const handleHide = useCallback(() => {
+    trackContentCardEvent("contentcard_dismissed", {
+      ...cardProps.extras,
+      screen: cardProps.location,
+      campaign: cardProps.id,
+    });
+    dismissCard(cardProps.id);
+  }, [cardProps, dismissCard, trackContentCardEvent]);
+
+  const mediaHeader = useMemo((): WalletCarouselMediaHeader => {
+    if (cardProps.picto != null && cardProps.picto !== "") {
+      return { kind: "picto", ledgerId: cardProps.picto };
+    }
+    if (cardProps.tag) {
+      return { kind: "tag", label: cardProps.tag };
+    }
+    return null;
+  }, [cardProps.picto, cardProps.tag]);
+
+  return {
+    handleHide,
+    handlePress,
+    mediaHeader,
+  };
+}

--- a/apps/ledger-live-mobile/src/contentCards/layouts/carousel/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/layouts/carousel/index.tsx
@@ -18,10 +18,12 @@ import useDynamicContent from "~/dynamicContent/useDynamicContent";
 import { useInViewContext } from "LLM/contexts/InViewContext";
 import { track } from "~/analytics";
 import { currentRouteNameRef } from "~/analytics/screenRefs";
+import { Box, PageIndicator } from "@ledgerhq/lumen-ui-rnative";
 
 const CONTAINER_IMPRESSION_THRESHOLD = 0.8;
 
 type Props = {
+  showLumenPageIndicator?: boolean;
   styles?: {
     gap?: number;
     pagination?: boolean;
@@ -35,7 +37,8 @@ const defaultStyles = {
   widthFactor: WidthFactor.Full,
 };
 
-const Carousel = ContentLayoutBuilder<Props>(({ items, styles: _styles = defaultStyles }) => {
+const Carousel = ContentLayoutBuilder<Props>(
+  ({ items, showLumenPageIndicator = false, styles: _styles = defaultStyles }) => {
   const styles = {
     gap: _styles.gap ?? defaultStyles.gap,
     pagination: _styles.pagination ?? defaultStyles.pagination,
@@ -48,7 +51,9 @@ const Carousel = ContentLayoutBuilder<Props>(({ items, styles: _styles = default
 
   const separatorWidth = useTheme().space[styles.gap];
 
-  const isPaginationEnabled = styles.pagination;
+  const isPaginationEnabled = styles.pagination && !showLumenPageIndicator;
+  const showDots =
+    showLumenPageIndicator && items.length > 1;
 
   const carouselRef = useRef<FlatList>(null);
   const [carouselIndex, setCarouselIndex] = useState(0);
@@ -128,7 +133,15 @@ const Carousel = ContentLayoutBuilder<Props>(({ items, styles: _styles = default
         )}
       />
 
-      {isPaginationEnabled && <Pagination items={items} carouselIndex={carouselIndex} />}
+      {isPaginationEnabled ? <Pagination items={items} carouselIndex={carouselIndex} /> : null}
+      {showDots ? (
+        <Box lx={{ alignItems: "center", marginTop: "s8" }}>
+          <PageIndicator
+            currentPage={Math.min(carouselIndex + 1, items.length)}
+            totalPages={items.length}
+          />
+        </Box>
+      ) : null}
     </View>
   );
 });

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
@@ -150,6 +150,7 @@ const Layout = ({ category, cards }: LayoutProps) => {
       return (
         <Carousel
           items={items}
+          showLumenPageIndicator={isContentBannerVariant && cardsSorted.length > 1}
           styles={{
             widthFactor: cardsSorted[0].carouselWidthFactor || WidthFactor.Full,
             pagination: category.hasPagination,

--- a/apps/ledger-live-mobile/src/dynamicContent/buildLocalContentCards.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/buildLocalContentCards.ts
@@ -11,6 +11,9 @@ import {
 const SAMPLE_IMAGE =
   "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQec1piP0de4iTT4LlWAg_SSU8DRv12XEfqwQ&s";
 
+const WALLET_CAROUSEL_MOCK_BACKGROUND_IMAGE =
+  "https://images.unsplash.com/photo-1621761191319-6eefa01365c0?auto=format&fit=crop&w=1200&q=80";
+
 function createBrazeLikeCard(
   id: string,
   categoryId: string,
@@ -110,7 +113,33 @@ const ACTION_SAMPLE_ITEMS: {
   },
 ];
 
-export function buildSampleActionCarousel(
+function buildSampleActionCarouselCard(
+  categoryId: string,
+  variant: SampleActionBannerVariant,
+  itemIndex: number,
+  cardId: string,
+): BrazeContentCard {
+  const item = ACTION_SAMPLE_ITEMS[itemIndex % ACTION_SAMPLE_ITEMS.length];
+  return createBrazeLikeCard(
+    cardId,
+    categoryId,
+    ContentCardLocation.TopWallet,
+    ContentCardsType.action,
+    ContentCardsLayout.carousel,
+    ContentCardsType.action,
+    {
+      title: item.title,
+      description: item.description,
+      link: item.link,
+      order: String(itemIndex),
+      ...(variant === "imageBackground"
+        ? { image_background: SAMPLE_IMAGE }
+        : { icon: item.icon }),
+    },
+  );
+}
+
+export function buildSampleActionCarouselInitial(
   variant: SampleActionBannerVariant = "icon",
 ): {
   category: CategoryContentCard;
@@ -132,43 +161,55 @@ export function buildSampleActionCarousel(
     isDismissable: true,
   };
 
-  const cards = ACTION_SAMPLE_ITEMS.map((item, index) =>
-    createBrazeLikeCard(
-      `local-action-${ts}-${index}`,
-      categoryId,
-      ContentCardLocation.TopWallet,
-      ContentCardsType.action,
-      ContentCardsLayout.carousel,
-      ContentCardsType.action,
-      {
-        title: item.title,
-        description: item.description,
-        link: item.link,
-        order: String(index),
-        ...(variant === "imageBackground"
-          ? { image_background: SAMPLE_IMAGE }
-          : { icon: item.icon }),
-      },
-    ),
-  );
-
+  const cards = [buildSampleActionCarouselCard(categoryId, variant, 0, `local-action-${ts}-0`)];
   return { category, cards };
 }
 
-/** Bottom Portfolio wallet carousel (`location: wallet`) — one slide with the same shape as Braze wallet cards. */
-export function buildSampleWalletCarousel(): WalletContentCard[] {
+export function buildSampleActionCarouselAppendCard(
+  categoryId: string,
+  variant: SampleActionBannerVariant,
+  itemIndex: number,
+): BrazeContentCard {
+  const id = `local-action-${categoryId}-${itemIndex}-${Date.now()}`;
+  return buildSampleActionCarouselCard(categoryId, variant, itemIndex, id);
+}
+
+/** Bottom Portfolio wallet carousel (`location: wallet`) — mock with Braze `picto` (crypto icon). */
+export function buildSampleWalletCarouselPicto(): WalletContentCard[] {
   const ts = Date.now();
   return [
     {
-      id: `local-wallet-carousel-${ts}`,
+      id: `local-wallet-carousel-picto-${ts}`,
+      location: ContentCardLocation.Wallet,
+      createdAt: ts,
+      viewed: false,
+      order: 0,
+      picto: "bitcoin",
+      title: "Sample bottom carousel (picto)",
+      link: "https://www.ledger.com/",
+      image: WALLET_CAROUSEL_MOCK_BACKGROUND_IMAGE,
+      image_background: WALLET_CAROUSEL_MOCK_BACKGROUND_IMAGE,
+      background: Background.purple,
+      extras: { source: "local-debug" },
+    },
+  ];
+}
+
+/** Same placement, mock with `tag` only (no picto). */
+export function buildSampleWalletCarouselTag(): WalletContentCard[] {
+  const ts = Date.now();
+  return [
+    {
+      id: `local-wallet-carousel-tag-${ts}`,
       location: ContentCardLocation.Wallet,
       createdAt: ts,
       viewed: false,
       order: 0,
       tag: "Discover",
-      title: "Sample bottom carousel",
+      title: "Sample bottom carousel (tag)",
       link: "https://www.ledger.com/",
-      image: SAMPLE_IMAGE,
+      image: WALLET_CAROUSEL_MOCK_BACKGROUND_IMAGE,
+      image_background: WALLET_CAROUSEL_MOCK_BACKGROUND_IMAGE,
       background: Background.purple,
       extras: { source: "local-debug" },
     },

--- a/apps/ledger-live-mobile/src/dynamicContent/types.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/types.ts
@@ -97,9 +97,11 @@ type CategoryContentCard = ContentCardCommonProperties & {
 
 type WalletContentCard = ContentCardCommonProperties & {
   tag?: string;
+  picto?: string;
   title?: string;
   link?: string;
   image?: string;
+  image_background?: string;
   background?: Background;
 };
 

--- a/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
@@ -92,9 +92,11 @@ export const mapAsCategoryContentCard = (card: BrazeContentCard): CategoryConten
 export const mapAsWalletContentCard = (card: BrazeContentCard): WalletContentCard => ({
   id: card.id,
   tag: card.extras.tag,
+  picto: card.extras.picto,
   title: card.extras.title,
   location: ContentCardLocation.Wallet,
   image: card.extras.image,
+  image_background: card.extras.image_background,
   link: card.extras.link,
   background: Background[card.extras.background as Background] || Background.purple,
   viewed: card.viewed,

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3595,11 +3595,13 @@
         "addSampleBanner": "Add sample banner",
         "addSampleBannerDesc": "Add a sample hero banner on Portfolio.",
         "addSampleActionCarouselIcon": "Add action carousel (icon)",
-        "addSampleActionCarouselIconDesc": "ContentBanner with Spot icons — Buy, Swap, Stake. Requires Braze placement flag.",
+        "addSampleActionCarouselIconDesc": "Adds one ContentBanner card per tap. Same row as the image variant — mix icon and image cards in one carousel. Cycles Buy → Swap → Stake. Requires Braze placement flag.",
         "addSampleActionCarouselImageBackground": "Add action carousel (image)",
-        "addSampleActionCarouselImageBackgroundDesc": "MediaBanner with image_background — Buy, Swap, Stake. Requires Braze placement flag.",
-        "addSampleWalletCarousel": "Add bottom wallet carousel (mock)",
-        "addSampleWalletCarouselDesc": "One mock card in the Portfolio bottom carousel (tag, title, image, link). No Braze.",
+        "addSampleActionCarouselImageBackgroundDesc": "Adds one MediaBanner card per tap. Same row as the icon variant — mix both in one carousel. Cycles Buy → Swap → Stake. Requires Braze placement flag.",
+        "addSampleWalletCarouselPicto": "Add bottom wallet carousel (picto)",
+        "addSampleWalletCarouselPictoDesc": "One mock card with crypto icon (picto), title, image, link. No Braze.",
+        "addSampleWalletCarouselTag": "Add bottom wallet carousel (tag)",
+        "addSampleWalletCarouselTagDesc": "One mock card with tag, title, image, link. No Braze.",
         "dismissAll": "Dismiss all local cards",
         "dismissAllDesc": "Remove all locally generated content cards."
       }

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCarouselSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCarouselSection/index.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { Box } from "@ledgerhq/native-ui";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { Box, Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
 import Carousel from "~/components/Carousel";
-import SectionTitle from "~/screens/WalletCentricSections/SectionTitle";
-import SectionContainer from "~/screens/WalletCentricSections/SectionContainer";
 
 interface PortfolioCarouselSectionProps {
   readonly backgroundColor: string;
@@ -11,13 +12,36 @@ interface PortfolioCarouselSectionProps {
 
 export const PortfolioCarouselSection = ({ backgroundColor }: PortfolioCarouselSectionProps) => {
   const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
+  const { shouldDisplayOperationsList } = useWalletFeaturesConfig("mobile");
+
+  /** Tx History in header: this section is last — safe area + s24 below cards (section only mounts when cards exist). */
+  const carouselBottomPadding = shouldDisplayOperationsList ? bottom + 24 : undefined;
+
+  const styles = useStyleSheet(
+    theme => ({
+      container: {
+        backgroundColor,
+        ...(carouselBottomPadding === undefined ? {} : { paddingBottom: carouselBottomPadding }),
+      },
+    }),
+    [backgroundColor, carouselBottomPadding],
+  );
 
   return (
-    <Box backgroundColor={backgroundColor} key="CarouselTitle">
-      <SectionContainer px={0} minHeight={240} isFirst>
-        <SectionTitle title={t("portfolio.carousel.title")} containerProps={{ mb: 7, mx: 6 }} />
-        <Carousel />
-      </SectionContainer>
+    <Box
+      style={styles.container}
+      lx={{
+        paddingTop: "s32",
+        ...(carouselBottomPadding === undefined ? { paddingBottom: "s24" } : {}),
+      }}
+    >
+      <Subheader>
+        <SubheaderRow lx={{ marginBottom: "s12", marginHorizontal: "s16" }}>
+          <SubheaderTitle>{t("portfolio.carousel.title")}</SubheaderTitle>
+        </SubheaderRow>
+      </Subheader>
+      <Carousel />
     </Box>
   );
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/hooks/useWalletAssetsViewModel.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useSelector } from "~/context/hooks";
 import { blacklistedTokenIdsSelector } from "~/reducers/settings";
+import useDynamicContent from "~/dynamicContent/useDynamicContent";
 import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
 import { usePortfolioSectionActions } from "LLM/features/WalletAssets/shared/usePortfolioSectionActions";
 import { MAX_ASSETS_TO_DISPLAY } from "LLM/features/WalletAssets/views/CryptosSection/usePortfolioCryptosSectionViewModel";
@@ -17,8 +18,12 @@ interface WalletAssetsViewModelResult {
 export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
   const { onPressShowAll } = usePortfolioSectionActions(false);
   const { categorizedAssets } = useCategorizedAssetsFromPortfolio();
-  const { shouldDisplayOperationsList, shouldDisplayAssetSection } =
-    useWalletFeaturesConfig("mobile");
+  const { walletCardsDisplayed } = useDynamicContent();
+  const {
+    shouldDisplayOperationsList,
+    shouldDisplayAssetSection,
+    shouldDisplayGraphRework,
+  } = useWalletFeaturesConfig("mobile");
 
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
   const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
@@ -33,12 +38,15 @@ export function useWalletAssetsViewModel(): WalletAssetsViewModelResult {
     return cryptosCount > MAX_ASSETS_TO_DISPLAY || stablecoinsCount > MAX_STABLECOINS_TO_DISPLAY;
   }, [categorizedAssets, blacklistedTokenIdsSet]);
 
-  // When the operations list section is hidden, WalletAssetsView is the last section and
-  // the tab bar (rendered without safe area) would overlap the bottom content.
+  // Tx History in header: extra space under the last block — Accounts when carousel is absent and
+  // nothing is rendered below (no allocations row when graph rework is off).
   return {
     hasMore,
     onPressShowAll,
-    shouldAddBottomPadding: shouldDisplayOperationsList,
+    shouldAddBottomPadding:
+      shouldDisplayOperationsList &&
+      walletCardsDisplayed.length === 0 &&
+      shouldDisplayGraphRework,
     shouldDisplayAssetSection,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/index.tsx
@@ -24,7 +24,7 @@ export const WalletAssetsView: React.FC<WalletAssetsViewProps> = ({
       lx={noPaddingHorizontal ? undefined : { paddingHorizontal: "s16" }}
       style={
         variant !== "readOnly" && shouldAddBottomPadding
-          ? { paddingBottom: bottom + 16 }
+          ? { paddingBottom: bottom + 24 }
           : undefined
       }
     >

--- a/apps/ledger-live-mobile/src/reducers/dynamicContent.ts
+++ b/apps/ledger-live-mobile/src/reducers/dynamicContent.ts
@@ -11,6 +11,7 @@ import {
   DynamicContentSetMobileCardsPayload,
   DynamicContentSetLandingStickyCtaCardsPayload,
   DynamicContentAddLocalCardsPayload,
+  DynamicContentAppendLocalCardsPayload,
   DynamicContentRemoveLocalCardPayload,
   DynamicContentAddLocalWalletCarouselPayload,
 } from "../actions/types";
@@ -64,6 +65,13 @@ const handlers: ReducerMap<DynamicContentState, DynamicContentPayload> = {
     return {
       ...state,
       localCategoriesCards: [...state.localCategoriesCards, category],
+      localMobileCards: [...state.localMobileCards, ...cards],
+    };
+  },
+  [DynamicContentActionTypes.DYNAMIC_CONTENT_APPEND_LOCAL_CARDS]: (state, action) => {
+    const cards = (action as Action<DynamicContentAppendLocalCardsPayload>).payload;
+    return {
+      ...state,
       localMobileCards: [...state.localMobileCards, ...cards],
     };
   },

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/index.tsx
@@ -1,44 +1,96 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useRef } from "react";
 import { useTranslation } from "~/context/Locale";
 import { Alert, Flex, IconsLegacy } from "@ledgerhq/native-ui";
-import { useDispatch } from "~/context/hooks";
+import { useDispatch, useSelector } from "~/context/hooks";
 import SettingsNavigationScrollView from "../../SettingsNavigationScrollView";
 import SettingsRow from "~/components/SettingsRow";
 import {
   addLocalContentCards,
+  appendLocalContentCards,
   addLocalWalletCarouselCards,
   clearLocalContentCards,
 } from "~/actions/dynamicContent";
 import {
   buildSampleBanner,
-  buildSampleActionCarousel,
-  buildSampleWalletCarousel,
+  buildSampleActionCarouselInitial,
+  buildSampleActionCarouselAppendCard,
+  buildSampleWalletCarouselPicto,
+  buildSampleWalletCarouselTag,
+  type SampleActionBannerVariant,
 } from "~/dynamicContent/buildLocalContentCards";
+import { localCategoriesCardsSelector } from "~/reducers/dynamicContent";
+
+type ActionCarouselSession = {
+  categoryId: string;
+  nextIndex: number;
+};
 
 export default function DebugContentCards() {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const localCategories = useSelector(localCategoriesCardsSelector);
+
+  /** Single shared top_wallet action carousel: icon + image_background taps append to the same row. */
+  const actionCarouselSessionRef = useRef<ActionCarouselSession | null>(null);
 
   const onAddSampleBanner = useCallback(() => {
     const { category, cards } = buildSampleBanner();
     dispatch(addLocalContentCards({ category, cards }));
   }, [dispatch]);
 
+  const handleSampleActionCarouselPress = useCallback(
+    (variant: SampleActionBannerVariant) => {
+      let session = actionCarouselSessionRef.current;
+      const sessionCategoryId = session?.categoryId;
+      const categoryStillExists =
+        sessionCategoryId != null &&
+        localCategories.some(c => c.categoryId === sessionCategoryId);
+
+      if (!categoryStillExists) {
+        actionCarouselSessionRef.current = null;
+        session = null;
+      }
+
+      if (session == null) {
+        const { category, cards } = buildSampleActionCarouselInitial(variant);
+        dispatch(addLocalContentCards({ category, cards }));
+        const categoryId = category.categoryId ?? category.id;
+        actionCarouselSessionRef.current = { categoryId, nextIndex: 1 };
+        return;
+      }
+
+      const card = buildSampleActionCarouselAppendCard(
+        session.categoryId,
+        variant,
+        session.nextIndex,
+      );
+      dispatch(appendLocalContentCards([card]));
+      actionCarouselSessionRef.current = {
+        categoryId: session.categoryId,
+        nextIndex: session.nextIndex + 1,
+      };
+    },
+    [dispatch, localCategories],
+  );
+
   const onAddSampleActionCarouselIcon = useCallback(() => {
-    const { category, cards } = buildSampleActionCarousel("icon");
-    dispatch(addLocalContentCards({ category, cards }));
-  }, [dispatch]);
+    handleSampleActionCarouselPress("icon");
+  }, [handleSampleActionCarouselPress]);
 
   const onAddSampleActionCarouselImageBackground = useCallback(() => {
-    const { category, cards } = buildSampleActionCarousel("imageBackground");
-    dispatch(addLocalContentCards({ category, cards }));
+    handleSampleActionCarouselPress("imageBackground");
+  }, [handleSampleActionCarouselPress]);
+
+  const onAddSampleWalletCarouselPicto = useCallback(() => {
+    dispatch(addLocalWalletCarouselCards(buildSampleWalletCarouselPicto()));
   }, [dispatch]);
 
-  const onAddSampleWalletCarousel = useCallback(() => {
-    dispatch(addLocalWalletCarouselCards(buildSampleWalletCarousel()));
+  const onAddSampleWalletCarouselTag = useCallback(() => {
+    dispatch(addLocalWalletCarouselCards(buildSampleWalletCarouselTag()));
   }, [dispatch]);
 
   const onDismissAll = useCallback(() => {
+    actionCarouselSessionRef.current = null;
     dispatch(clearLocalContentCards());
   }, [dispatch]);
 
@@ -67,10 +119,16 @@ export default function DebugContentCards() {
         onPress={onAddSampleActionCarouselImageBackground}
       />
       <SettingsRow
-        title={t("settings.debug.contentCards.addSampleWalletCarousel")}
-        desc={t("settings.debug.contentCards.addSampleWalletCarouselDesc")}
+        title={t("settings.debug.contentCards.addSampleWalletCarouselPicto")}
+        desc={t("settings.debug.contentCards.addSampleWalletCarouselPictoDesc")}
         iconLeft={<IconsLegacy.WalletMedium size={24} color="black" />}
-        onPress={onAddSampleWalletCarousel}
+        onPress={onAddSampleWalletCarouselPicto}
+      />
+      <SettingsRow
+        title={t("settings.debug.contentCards.addSampleWalletCarouselTag")}
+        desc={t("settings.debug.contentCards.addSampleWalletCarouselTagDesc")}
+        iconLeft={<IconsLegacy.WalletMedium size={24} color="black" />}
+        onPress={onAddSampleWalletCarouselTag}
       />
       <SettingsRow
         title={t("settings.debug.contentCards.dismissAll")}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Desktop:

update bottom carousel card component
add the "picto" variant (insteed of the tag)
Mobile:

add the "picto" variant (insteed of the tag)
fix padding for last component on wallet
update braze tool
add dots for carousel top ("wallet")
update carousel bottom title

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26626]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26626]: https://ledgerhq.atlassian.net/browse/LIVE-26626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ