### PR TITLE
[LWDM] feat(LIVE-27355): add fee records errors in cases when fee record is insufficient…

### DIFF
--- a/.changeset/silver-clocks-breathe.md
+++ b/.changeset/silver-clocks-breathe.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/live-common": minor
+"@shared/feature-flags": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add myWallet feature flag param to lwdWallet40 and lwmWallet40 for targeted rollout control of the My Wallet navigation component

--- a/.changeset/two-dodos-roll.md
+++ b/.changeset/two-dodos-roll.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Add fee records errors in cases when fee record is insufficient and only one record present

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.test.tsx
@@ -281,6 +281,7 @@ describe("StepRecordPicker", () => {
     const updaterFn = updateTransaction.mock.calls[0][0];
     const result = updaterFn(privateTransaction);
     expect(result.properties?.amountRecordCommitment).toBe(record2.commitment);
+    expect(result.properties?.feeRecordCommitment).toBeNull();
   });
 
   it("should call updateTransaction with the lower-value record when the second button is clicked", async () => {
@@ -302,6 +303,7 @@ describe("StepRecordPicker", () => {
     const updaterFn = updateTransaction.mock.calls[0][0];
     const result = updaterFn(privateTransaction);
     expect(result.properties?.amountRecordCommitment).toBe(record1.commitment);
+    expect(result.properties?.feeRecordCommitment).toBeNull();
   });
 
   it("should render records sorted in descending order by value", () => {
@@ -330,7 +332,7 @@ describe("StepRecordPicker", () => {
     expect(screen.getByTestId("aleo-pick-records-alert")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "The maximum spendable amount depends on the maximum value of your selected record. Fees are sponsored by Provable for Ledger users.",
+        /The maximum spendable amount depends on the maximum value of your selected record/,
       ),
     ).toBeInTheDocument();
   });
@@ -416,6 +418,119 @@ describe("StepRecordPicker", () => {
     expect(screen.getByText(/Available records:.*15/)).toBeInTheDocument();
   });
 
+  it("should render the translated two-records error from status", () => {
+    const feeRecordError = new Error("Aleo two records required");
+    feeRecordError.name = "AleoTwoRecordsRequired";
+
+    const statusWithError: TransactionStatus = {
+      ...mockStatus,
+      errors: {
+        feeRecord: feeRecordError,
+      },
+    };
+
+    render(
+      <StepRecordPicker
+        {...defaultProps}
+        account={mockAleoAccount}
+        status={statusWithError}
+        transaction={privateTransaction}
+      />,
+    );
+
+    expect(screen.getByTestId("aleo-record-picker-error")).toBeInTheDocument();
+    expect(screen.getByText("Private send requires at least two records.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /You need one record for the transfer amount and another one to cover the network fee/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should render the translated insufficient-fees error from status", () => {
+    const feeRecordError = new Error("Aleo fee record insufficient balance");
+    feeRecordError.name = "AleoFeeRecordInsufficientBalance";
+
+    const statusWithError: TransactionStatus = {
+      ...mockStatus,
+      errors: {
+        feeRecord: feeRecordError,
+      },
+    };
+
+    render(
+      <StepRecordPicker
+        {...defaultProps}
+        account={mockAleoAccount}
+        status={statusWithError}
+        transaction={privateTransaction}
+      />,
+    );
+
+    expect(screen.getByTestId("aleo-record-picker-error")).toBeInTheDocument();
+    expect(screen.getByText("No private record can cover the network fee.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Select a different record for the transfer amount or top up your balance with additional funds/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should render the translated fee-record error from status", () => {
+    const feeRecordError = new Error("Aleo fee record required");
+    feeRecordError.name = "AleoFeeRecordRequired";
+
+    const statusWithError: TransactionStatus = {
+      ...mockStatus,
+      errors: {
+        feeRecord: feeRecordError,
+      },
+    };
+
+    render(
+      <StepRecordPicker
+        {...defaultProps}
+        account={mockAleoAccount}
+        status={statusWithError}
+        transaction={privateTransaction}
+      />,
+    );
+
+    expect(screen.getByTestId("aleo-record-picker-error")).toBeInTheDocument();
+    expect(screen.getByText("Select a valid private record for the fee.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /One private record is used for the transfer amount and another one must be able to cover the network fee/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should fall back to the amount-record error when no fee-record error is present", () => {
+    const amountRecordError = new Error("Aleo amount record required");
+    amountRecordError.name = "AleoAmountRecordRequired";
+
+    const statusWithError: TransactionStatus = {
+      ...mockStatus,
+      errors: {
+        amountRecord: amountRecordError,
+      },
+    };
+
+    render(
+      <StepRecordPicker
+        {...defaultProps}
+        account={mockAleoAccount}
+        status={statusWithError}
+        transaction={privateTransaction}
+      />,
+    );
+
+    expect(screen.getByTestId("aleo-record-picker-error")).toBeInTheDocument();
+    expect(screen.getByText("Select a valid private record for the amount.")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Choose one of your available private records to fund the transfer amount/i),
+    ).toBeInTheDocument();
+  });
   it("should exclude zero-value records from the displayed list", () => {
     const zeroRecord = makeUnspentRecord("commitment-zero", "0", mockDecryptedData1);
     const accountWithZeroRecord: AleoAccount = {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepRecordPicker.tsx
@@ -19,12 +19,12 @@ import Box from "~/renderer/components/Box/Box";
 import { Flex } from "@ledgerhq/react-ui/index";
 import { dayFormat, hourFormat, useDateFormatter } from "~/renderer/hooks/useDateFormatter";
 import Alert from "~/renderer/components/Alert";
+import ErrorBanner from "~/renderer/components/ErrorBanner";
 import { isAleoAccount } from "./utils";
 
-interface Props {
+interface Props extends Pick<StepProps, "status" | "updateTransaction"> {
   account: AleoAccount;
   transaction: AleoTransaction;
-  updateTransaction: StepProps["updateTransaction"];
 }
 
 interface ButtonState {
@@ -95,12 +95,13 @@ const RecordsLimitDescription = styled.p`
 
 const MAX_RECORDS_DISPLAYED = 10;
 
-const AleoStepRecordPicker = ({ account, transaction, updateTransaction }: Props) => {
+const AleoStepRecordPicker = ({ account, transaction, status, updateTransaction }: Props) => {
   const { t } = useTranslation();
   const locale = useSelector(localeSelector);
   const unit = useAccountUnit(account);
   const formatDate = useDateFormatter(dayFormat);
   const formatHours = useDateFormatter(hourFormat);
+  const recordError = status.errors.feeRecord ?? status.errors.amountRecord;
 
   const allUnspentRecords = (account.aleoResources?.unspentPrivateRecords ?? []).filter(r =>
     new BigNumber(r.microcredits).isGreaterThan(0),
@@ -152,9 +153,13 @@ const AleoStepRecordPicker = ({ account, transaction, updateTransaction }: Props
 
   return (
     <Box flow={1}>
-      <Alert data-testid="aleo-pick-records-alert" type="secondary" mb={4}>
-        {t("aleo.shared.recordPicker.alert")}
-      </Alert>
+      {recordError ? (
+        <ErrorBanner dataTestId="aleo-record-picker-error" error={recordError} warning />
+      ) : (
+        <Alert data-testid="aleo-pick-records-alert" type="secondary" mb={4}>
+          {t("aleo.shared.recordPicker.alert")}
+        </Alert>
+      )}
       <Label>
         {t("aleo.shared.recordPicker.label")}: {allUnspentRecords.length}
       </Label>
@@ -193,13 +198,14 @@ const AleoStepRecordPicker = ({ account, transaction, updateTransaction }: Props
   );
 };
 
-const StepRecordPicker = ({ account, transaction, updateTransaction }: StepProps) => {
+const StepRecordPicker = ({ account, transaction, status, updateTransaction }: StepProps) => {
   if (transaction?.family !== "aleo" || !account || !isAleoAccount(account)) return null;
 
   return (
     <AleoStepRecordPicker
       account={account}
       transaction={transaction}
+      status={status}
       updateTransaction={updateTransaction}
     />
   );

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/utils.ts
@@ -1,4 +1,3 @@
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
 import type { AccountLike } from "@ledgerhq/types-live";
-
 export const isAleoAccount = (acc: AccountLike): acc is AleoAccount => "aleoResources" in acc;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
@@ -14,6 +14,7 @@ export const WALLET_FEATURES_PARAMS = [
   { key: "brazePlacement", label: "Braze Placement (Lumen content banner)" },
   { key: "operationsList", label: "TX History" },
   { key: "aggregatedAssets", label: "Aggregated Assets" },
+  { key: "myWallet", label: "My Wallet" },
 ] as const;
 
 export type WalletFeatureParamKey = (typeof WALLET_FEATURES_PARAMS)[number]["key"];

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7252,10 +7252,20 @@
       "title": "Insufficient funds. The minimum required balance is 0.02 TON."
     },
     "AleoAmountRecordRequired": {
-      "title": "Select a valid private record for the amount."
+      "title": "Select a valid private record for the amount.",
+      "description": "Choose one of your available private records to fund the transfer amount."
     },
     "AleoFeeRecordRequired": {
-      "title": "Select a valid private record for the fee."
+      "title": "Select a valid private record for the fee.",
+      "description": "Top up your balance if needed. One private record is used for the transfer amount and another one must be able to cover the network fee."
+    },
+    "AleoTwoRecordsRequired": {
+      "title": "Private send requires at least two records.",
+      "description": "You need one record for the transfer amount and another one to cover the network fee."
+    },
+    "AleoFeeRecordInsufficientBalance": {
+      "title": "No private record can cover the network fee.",
+      "description": "Select a different record for the transfer amount or top up your balance with additional funds."
     },
     "BackupAppDataError": {
       "title": "Error during app data backup"

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
@@ -17,6 +17,7 @@ export const WALLET_40_PARAMS = [
   { key: "brazePlacement", label: "Braze Placement (ContentBanner)" },
   { key: "operationsList", label: "TX History" },
   { key: "aggregatedAssets", label: "Aggregated Assets" },
+  { key: "myWallet", label: "My Wallet" },
 ] as const;
 
 type WalletFeatureParamKey = (typeof WALLET_40_PARAMS)[number]["key"];

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
@@ -18,7 +18,12 @@ import { calculateAmount } from "../logic/utils";
 import type { Transaction } from "../types";
 import aleoCoinConfig from "../config";
 import { TRANSACTION_TYPE } from "../constants";
-import { AleoAmountRecordRequired, AleoFeeRecordRequired } from "../errors";
+import {
+  AleoAmountRecordRequired,
+  AleoFeeRecordInsufficientBalance,
+  AleoFeeRecordRequired,
+  AleoTwoRecordsRequired,
+} from "../errors";
 import { getTransactionStatus } from "./getTransactionStatus";
 
 jest.mock("../config");
@@ -357,6 +362,64 @@ describe("getTransactionStatus", () => {
       const result = await getTransactionStatus(privateAccount, transaction);
 
       expect(result.errors.feeRecord).toBeInstanceOf(AleoFeeRecordRequired);
+    });
+
+    it("adds a two-records error when only one non-zero private record is available", async () => {
+      mockAleoConfig.getCoinConfig.mockReturnValue({ ...mockConfig, isFeeSponsored: false });
+
+      const singleRecordAccount = getMockedAccount({
+        aleoResources: {
+          ...mockAleoResources,
+          privateBalance: new BigNumber(800000),
+          unspentPrivateRecords: [mockUnspentRecord1],
+        },
+      });
+
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: {
+          amountRecordCommitment: mockUnspentRecord1.commitment,
+          feeRecordCommitment: null,
+        },
+      };
+
+      const result = await getTransactionStatus(singleRecordAccount, transaction);
+
+      expect(result.errors.feeRecord).toBeInstanceOf(AleoTwoRecordsRequired);
+    });
+
+    it("adds an insufficient-balance fee-record error when no remaining record can cover fees", async () => {
+      mockAleoConfig.getCoinConfig.mockReturnValue({ ...mockConfig, isFeeSponsored: false });
+
+      const smallFeeRecord = {
+        ...mockUnspentRecord2,
+        commitment: "small-fee-record",
+        microcredits: "1000",
+        decryptedData: {
+          ...mockUnspentRecord2.decryptedData,
+          data: { microcredits: "1000u64.private" },
+        },
+      };
+
+      const limitedAccount = getMockedAccount({
+        aleoResources: {
+          ...mockAleoResources,
+          privateBalance: new BigNumber(801000),
+          unspentPrivateRecords: [mockUnspentRecord1, smallFeeRecord],
+        },
+      });
+
+      const transaction: Transaction = {
+        ...privateTransaction,
+        properties: {
+          amountRecordCommitment: mockUnspentRecord1.commitment,
+          feeRecordCommitment: null,
+        },
+      };
+
+      const result = await getTransactionStatus(limitedAccount, transaction);
+
+      expect(result.errors.feeRecord).toBeInstanceOf(AleoFeeRecordInsufficientBalance);
     });
 
     it("does not add fee-record error for sponsored private fees", async () => {

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
@@ -18,13 +18,19 @@ import type {
 import { estimateFees, validateAddress } from "../logic";
 import {
   calculateAmount,
+  findBestRecordForFee,
   getAvailableBalance,
   getRecordByCommitment,
   isPrivateTransaction,
   isSelfTransferTransaction,
 } from "../logic/utils";
 import aleoCoinConfig from "../config";
-import { AleoAmountRecordRequired, AleoFeeRecordRequired } from "../errors";
+import {
+  AleoAmountRecordRequired,
+  AleoFeeRecordInsufficientBalance,
+  AleoFeeRecordRequired,
+  AleoTwoRecordsRequired,
+} from "../errors";
 
 type Errors = Record<string, Error>;
 type Warnings = Record<string, Error>;
@@ -47,17 +53,18 @@ function validatePrivateTransaction({
   account,
   transaction,
   amount,
+  estimatedFees,
   isFeeSponsored,
 }: {
   account: AleoAccount;
   transaction: TransactionPrivate;
   amount: BigNumber;
+  estimatedFees: BigNumber;
   isFeeSponsored: boolean;
 }): Errors {
   const errors: Errors = {};
-  const { amountRecordCommitment, feeRecordCommitment } = transaction.properties;
+  const { amountRecordCommitment } = transaction.properties;
   const amountRecord = getValidRecord({ account, commitment: amountRecordCommitment });
-  const feeRecord = getValidRecord({ account, commitment: feeRecordCommitment });
 
   if (!amountRecord) {
     errors.amountRecord = new AleoAmountRecordRequired();
@@ -65,11 +72,71 @@ function validatePrivateTransaction({
     errors.amount = new NotEnoughBalance();
   }
 
-  if (!isFeeSponsored && !feeRecord) {
-    errors.feeRecord = new AleoFeeRecordRequired();
+  const feeRecordError = validateFeeRecordStatus({
+    account,
+    transaction,
+    estimatedFees,
+    isFeeSponsored,
+  });
+
+  if (feeRecordError) {
+    errors.feeRecord = feeRecordError;
   }
 
   return errors;
+}
+
+function validateFeeRecordStatus({
+  account,
+  transaction,
+  estimatedFees,
+  isFeeSponsored,
+}: {
+  account: AleoAccount;
+  transaction: TransactionPrivate;
+  estimatedFees: BigNumber;
+  isFeeSponsored: boolean;
+}): Error | null {
+  if (isFeeSponsored) {
+    return null;
+  }
+
+  const availableRecords = (account.aleoResources?.unspentPrivateRecords ?? []).filter(record =>
+    new BigNumber(record.microcredits).isGreaterThan(0),
+  );
+
+  if (availableRecords.length <= 1) {
+    return new AleoTwoRecordsRequired();
+  }
+
+  const bestFeeRecord = findBestRecordForFee({
+    unspentRecords: availableRecords,
+    selectedAmountRecordCommitment: transaction.properties.amountRecordCommitment ?? null,
+    targetFee: estimatedFees,
+  });
+
+  if (!bestFeeRecord) {
+    return new AleoFeeRecordInsufficientBalance();
+  }
+
+  if (!transaction.properties.amountRecordCommitment) {
+    return null;
+  }
+
+  const feeRecordCommitment = transaction.properties.feeRecordCommitment;
+  const feeRecord = feeRecordCommitment
+    ? getRecordByCommitment({ account, commitment: feeRecordCommitment })
+    : null;
+
+  if (
+    !feeRecord ||
+    feeRecord.commitment === transaction.properties.amountRecordCommitment ||
+    new BigNumber(feeRecord.microcredits).lt(estimatedFees)
+  ) {
+    return new AleoFeeRecordRequired();
+  }
+
+  return null;
 }
 
 async function validateRecipient({
@@ -145,6 +212,7 @@ async function handleTransferTransaction({
         account,
         transaction,
         amount: calculatedAmount.amount,
+        estimatedFees,
         isFeeSponsored: config.isFeeSponsored,
       }),
     );

--- a/libs/coin-modules/coin-aleo/src/errors.ts
+++ b/libs/coin-modules/coin-aleo/src/errors.ts
@@ -2,3 +2,7 @@ import { createCustomErrorClass } from "@ledgerhq/errors";
 
 export const AleoAmountRecordRequired = createCustomErrorClass("AleoAmountRecordRequired");
 export const AleoFeeRecordRequired = createCustomErrorClass("AleoFeeRecordRequired");
+export const AleoTwoRecordsRequired = createCustomErrorClass("AleoTwoRecordsRequired");
+export const AleoFeeRecordInsufficientBalance = createCustomErrorClass(
+  "AleoFeeRecordInsufficientBalance",
+);

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -824,6 +824,7 @@ export const DEFAULT_FEATURES: Features = {
       brazePlacement: true,
       operationsList: true,
       aggregatedAssets: true,
+      myWallet: true,
     },
   },
   lwdWallet40: {
@@ -842,6 +843,7 @@ export const DEFAULT_FEATURES: Features = {
       operationsList: true,
       brazePlacement: true,
       aggregatedAssets: true,
+      myWallet: true,
     },
   },
   addressPoisoningOperationsFilter: {

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
@@ -15,6 +15,7 @@ export type Wallet40Params = {
   readonly brazePlacement?: boolean;
   readonly operationsList?: boolean;
   readonly aggregatedAssets?: boolean;
+  readonly myWallet?: boolean;
 };
 
 export const FEATURE_FLAG_KEYS = {
@@ -54,4 +55,6 @@ export interface WalletFeaturesConfig {
   readonly shouldDisplayOperationsList: boolean;
   /** Whether to show the aggregated assets */
   readonly shouldDisplayAggregatedAssets: boolean;
+  /** Whether to show the My Wallet component */
+  readonly shouldDisplayMyWallet: boolean;
 }

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
@@ -49,6 +49,7 @@ const makeConfig = (
   shouldDisplayOnboardingWidget: value,
   shouldDisplayBrazePlacement: value,
   shouldDisplayOperationsList: value,
+  shouldDisplayMyWallet: value,
   shouldDisplayAggregatedAssets: value,
   ...overrides,
 });
@@ -68,6 +69,7 @@ const makeParams = (value: boolean): Wallet40Params => ({
   brazePlacement: value,
   operationsList: value,
   aggregatedAssets: value,
+  myWallet: value,
 });
 
 const DISABLED_CONFIG = makeConfig(false);
@@ -134,6 +136,7 @@ describe("useWalletFeaturesConfig hook", () => {
         ["brazePlacement", { brazePlacement: true }, { shouldDisplayBrazePlacement: true }],
         ["operationsList", { operationsList: true }, { shouldDisplayOperationsList: true }],
         ["aggregatedAssets", { aggregatedAssets: true }, { shouldDisplayAggregatedAssets: true }],
+        ["myWallet", { myWallet: true }, { shouldDisplayMyWallet: true }],
       ])("should return correct config when only %s is enabled", (_, params, expectedOverrides) => {
         const { result } = renderWalletFeaturesConfig(platform, {
           [flagKey]: createFeatureFlag(true, params),

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
@@ -47,6 +47,7 @@ export const useWalletFeaturesConfig = (platform: WalletPlatform): WalletFeature
       shouldDisplayBrazePlacement: isEnabled && Boolean(params?.brazePlacement),
       shouldDisplayOperationsList: isEnabled && Boolean(params?.operationsList),
       shouldDisplayAggregatedAssets: isEnabled && Boolean(params?.aggregatedAssets),
+      shouldDisplayMyWallet: isEnabled && Boolean(params?.myWallet),
     };
   }, [walletFeatureFlag]);
 };

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -846,6 +846,7 @@ type Feature_Wallet40_Params = {
   assetSection: boolean;
   operationsList: boolean;
   aggregatedAssets: boolean;
+  myWallet: boolean;
   // Specifics
   brazePlacement?: boolean;
   newReceiveDialog?: boolean;

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
@@ -15,6 +15,7 @@ export const lwdWallet40 = flagWith(
     operationsList: z.boolean(),
     brazePlacement: z.boolean().optional(),
     aggregatedAssets: z.boolean(),
+    myWallet: z.boolean(),
   },
   {
     enabled: false,
@@ -31,6 +32,7 @@ export const lwdWallet40 = flagWith(
       operationsList: true,
       brazePlacement: true,
       aggregatedAssets: true,
+      myWallet: true,
     },
   },
 );

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
@@ -15,6 +15,7 @@ export const lwmWallet40 = flagWith(
     newReceiveDialog: z.boolean().optional(),
     operationsList: z.boolean(),
     aggregatedAssets: z.boolean(),
+    myWallet: z.boolean(),
     quickActionsCtasVariant: z.boolean().optional(),
     brazePlacement: z.boolean().optional(),
   },
@@ -32,6 +33,7 @@ export const lwmWallet40 = flagWith(
       onboardingWidget: true,
       operationsList: true,
       aggregatedAssets: true,
+      myWallet: true,
     },
   },
 );


### PR DESCRIPTION
… and only one record present

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add fee records errors in cases when fee record is insufficient and only one record present.

### 📝 Description

This PR adds fee records errors in cases when fee record is insufficient and only one record present.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-27355

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
