### PR TITLE
[LWDM] Concordium Send E2E test

### DIFF
--- a/.changeset/strange-pugs-fly.md
+++ b/.changeset/strange-pugs-fly.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Add E2E send test for Concordium testnet (mobile)

--- a/e2e/mobile/specs/send/send.ts
+++ b/e2e/mobile/specs/send/send.ts
@@ -59,6 +59,29 @@ const beforeAllInvalidAddressFunction = async (
   await app.portfolio.waitForPortfolioPageToLoad();
 };
 
+export async function verifySendAndOperationDetails(
+  transaction: TransactionType,
+  amountWithCode: string,
+) {
+  await app.send.expectSummaryAmount(amountWithCode);
+  await app.send.expectSummaryRecipient(transaction.accountToCredit.address);
+  await app.send.expectSummaryMemoTag(transaction.memoTag);
+  await app.send.chooseFeeStrategy(transaction.speed);
+  await app.send.summaryContinue();
+  await app.send.dismissHighFeeModal();
+
+  await verifyAppValidationSendInfo(transaction, amountWithCode);
+
+  await device.disableSynchronization();
+  await app.speculos.signSendTransaction(transaction);
+  await app.common.successViewDetails();
+
+  await app.operationDetails.waitForOperationDetails();
+  await app.operationDetails.checkAccount(transaction.accountToDebit.accountName);
+  await app.operationDetails.checkRecipientAddress(transaction.accountToCredit);
+  await app.operationDetails.checkTransactionType("OUT");
+}
+
 export function runSendTest(transaction: TransactionType, tmsLinks: string[], tags: string[]) {
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
@@ -74,23 +97,7 @@ export function runSendTest(transaction: TransactionType, tmsLinks: string[], ta
       await app.send.setAmountAndContinue(transaction.amount);
 
       const amountWithCode = transaction.amount + " " + transaction.accountToCredit.currency.ticker;
-      await app.send.expectSummaryAmount(amountWithCode);
-      await app.send.expectSummaryRecipient(addressToCredit);
-      await app.send.expectSummaryMemoTag(transaction.memoTag);
-      await app.send.chooseFeeStrategy(transaction.speed);
-      await app.send.summaryContinue();
-      await app.send.dismissHighFeeModal();
-
-      await verifyAppValidationSendInfo(transaction, amountWithCode);
-
-      await device.disableSynchronization();
-      await app.speculos.signSendTransaction(transaction);
-      await app.common.successViewDetails();
-
-      await app.operationDetails.waitForOperationDetails();
-      await app.operationDetails.checkAccount(transaction.accountToDebit.accountName);
-      await app.operationDetails.checkRecipientAddress(transaction.accountToCredit);
-      await app.operationDetails.checkTransactionType("OUT");
+      await verifySendAndOperationDetails(transaction, amountWithCode);
     });
   });
 }

--- a/e2e/mobile/specs/send/send.ts
+++ b/e2e/mobile/specs/send/send.ts
@@ -5,16 +5,29 @@ import { device } from "detox";
 import invariant from "invariant";
 import { TransactionType } from "@ledgerhq/live-common/e2e/models/Transaction";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import type { LiveDataCommandOptions } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
+import type { InitOptions } from "../../utils/initUtil";
 
-const beforeAllFunction = async (transaction: TransactionType) => {
+export type SendTestOptions = {
+  featureFlags?: InitOptions["featureFlags"];
+  userdata?: InitOptions["userdata"];
+  liveDataOptions?: LiveDataCommandOptions;
+};
+
+const beforeAllFunction = async (transaction: TransactionType, options?: SendTestOptions) => {
   await app.init({
     speculosApp: transaction.accountToDebit.currency.speculosApp,
+    ...(options?.userdata !== undefined ? { userdata: options.userdata } : {}),
     featureFlags: {
       llmAccountListUI: { enabled: true },
+      ...options?.featureFlags,
     },
     cliCommands: [
       async (userdataPath?: string) => {
-        await liveDataWithAddressCommand(transaction.accountToDebit)(userdataPath);
+        await liveDataWithAddressCommand(
+          transaction.accountToDebit,
+          options?.liveDataOptions,
+        )(userdataPath);
         transaction.accountToCredit.address = await getAccountAddress(transaction.accountToCredit);
         transaction.recipientAddress = transaction.accountToCredit.address;
       },
@@ -82,12 +95,17 @@ export async function verifySendAndOperationDetails(
   await app.operationDetails.checkTransactionType("OUT");
 }
 
-export function runSendTest(transaction: TransactionType, tmsLinks: string[], tags: string[]) {
+export function runSendTest(
+  transaction: TransactionType,
+  tmsLinks: string[],
+  tags: string[],
+  options?: SendTestOptions,
+) {
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Send from 1 account to another", () => {
     beforeAll(async () => {
-      await beforeAllFunction(transaction);
+      await beforeAllFunction(transaction, options);
     });
 
     it(`Send from ${transaction.accountToDebit.accountName} to ${transaction.accountToCredit.accountName}`, async () => {

--- a/e2e/mobile/specs/send/sendCCD.spec.ts
+++ b/e2e/mobile/specs/send/sendCCD.spec.ts
@@ -4,7 +4,7 @@ import { runSendTest } from "./send";
 const transaction = new Transaction(Account.CCD_TESTNET_1, Account.CCD_TESTNET_2, "50", undefined);
 runSendTest(
   transaction,
-  [],
+  ["B2CQA-2949"],
   ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@concordium", "@family-concordium"],
   {
     featureFlags: { currencyConcordiumTestnet: { enabled: true } },

--- a/e2e/mobile/specs/send/sendCCD.spec.ts
+++ b/e2e/mobile/specs/send/sendCCD.spec.ts
@@ -1,85 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { log } from "detox";
-import { verifySendAndOperationDetails } from "./send";
-
-const WALLET_PROXY_URL = "https://ccd-wallet-proxy-testnet.coin.ledger-test.com";
-const WALLET_PROXY_TIMEOUT_MS = 10_000;
-
-// Resolve on-chain address from public key via wallet-proxy API.
-// Concordium addresses are NOT derived from BIP32 paths — they come from on-chain credential deployment.
-async function resolveAddressFromPublicKey(publicKey: string): Promise<string> {
-  const res = await fetch(`${WALLET_PROXY_URL}/v0/keyAccounts/${publicKey}`, {
-    signal: AbortSignal.timeout(WALLET_PROXY_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    throw new Error(
-      `[CCD] Wallet-proxy error ${res.status} ${res.statusText} for public key ${publicKey.slice(0, 16)}...`,
-    );
-  }
-  const accounts = await res.json();
-  if (!accounts?.length) {
-    throw new Error(`No on-chain accounts found for public key ${publicKey}`);
-  }
-  log.info(
-    `[CCD] Resolved address ${accounts[0].address} from public key ${publicKey.slice(0, 16)}...`,
-  );
-  return accounts[0].address;
-}
+import { runSendTest } from "./send";
 
 const transaction = new Transaction(Account.CCD_TESTNET_1, Account.CCD_TESTNET_2, "50", undefined);
-
-$Tag("@NanoSP", "@concordium", "@family-concordium");
-describe("Send from 1 account to another", () => {
-  beforeAll(async () => {
-    await app.init({
-      speculosApp: transaction.accountToDebit.currency.speculosApp,
-      userdata: "concordium-account",
-      featureFlags: {
-        llmAccountListUI: { enabled: true },
-        currencyConcordiumTestnet: { enabled: true },
-      },
-      cliCommands: [
-        async (userdataPath?: string) => {
-          await CLI.liveData({
-            currency: transaction.accountToDebit.currency.id,
-            index: transaction.accountToDebit.index,
-            add: true,
-            appjson: userdataPath,
-          });
-
-          // Resolve on-chain addresses via speculos + wallet-proxy.
-          // Concordium addresses are SHA256(credId), not derived from BIP32 paths.
-          const debitInfo = await CLI.getAddress({
-            currency: transaction.accountToDebit.currency.speculosApp.name,
-            path: transaction.accountToDebit.accountPath,
-          });
-          transaction.accountToDebit.address = await resolveAddressFromPublicKey(
-            debitInfo.publicKey,
-          );
-
-          const creditInfo = await CLI.getAddress({
-            currency: transaction.accountToCredit.currency.speculosApp.name,
-            path: transaction.accountToCredit.accountPath,
-          });
-          transaction.accountToCredit.address = await resolveAddressFromPublicKey(
-            creditInfo.publicKey,
-          );
-          transaction.recipientAddress = transaction.accountToCredit.address;
-        },
-      ],
-    });
-
-    await app.portfolio.waitForPortfolioPageToLoad();
-  });
-
-  it(`Send from ${transaction.accountToDebit.accountName} to ${transaction.accountToCredit.accountName}`, async () => {
-    const addressToCredit = transaction.accountToCredit.address;
-    await app.send.navigateToSendScreen(transaction.accountToDebit.accountName);
-    await app.send.setRecipientAndContinue(addressToCredit, transaction.memoTag);
-    await app.send.setAmountAndContinue(transaction.amount);
-
-    const amountWithCode =
-      transaction.amount + "\u00a0" + transaction.accountToCredit.currency.ticker;
-    await verifySendAndOperationDetails(transaction, amountWithCode);
-  });
+runSendTest(transaction, [], ["@NanoSP", "@concordium", "@family-concordium"], {
+  featureFlags: { currencyConcordiumTestnet: { enabled: true } },
+  userdata: "concordium-account",
+  liveDataOptions: { currency: Account.CCD_TESTNET_1.currency.id },
 });

--- a/e2e/mobile/specs/send/sendCCD.spec.ts
+++ b/e2e/mobile/specs/send/sendCCD.spec.ts
@@ -5,7 +5,7 @@ const transaction = new Transaction(Account.CCD_TESTNET_1, Account.CCD_TESTNET_2
 runSendTest(
   transaction,
   [],
-  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@concordium", "@family-concordium"],
+  ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@concordium", "@family-concordium"],
   {
     featureFlags: { currencyConcordiumTestnet: { enabled: true } },
     userdata: "concordium-account",

--- a/e2e/mobile/specs/send/sendCCD.spec.ts
+++ b/e2e/mobile/specs/send/sendCCD.spec.ts
@@ -1,0 +1,82 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { log } from "detox";
+import { verifySendAndOperationDetails } from "./send";
+
+const WALLET_PROXY_URL = "https://ccd-wallet-proxy-testnet.coin.ledger-test.com";
+
+// Resolve on-chain address from public key via wallet-proxy API.
+// Concordium addresses are NOT derived from BIP32 paths — they come from on-chain credential deployment.
+async function resolveAddressFromPublicKey(publicKey: string): Promise<string> {
+  const res = await fetch(`${WALLET_PROXY_URL}/v0/keyAccounts/${publicKey}`);
+  if (!res.ok) {
+    throw new Error(
+      `[CCD] Wallet-proxy error ${res.status} ${res.statusText} for public key ${publicKey.slice(0, 16)}...`,
+    );
+  }
+  const accounts = await res.json();
+  if (!accounts?.length) {
+    throw new Error(`No on-chain accounts found for public key ${publicKey}`);
+  }
+  log.info(
+    `[CCD] Resolved address ${accounts[0].address} from public key ${publicKey.slice(0, 16)}...`,
+  );
+  return accounts[0].address;
+}
+
+const transaction = new Transaction(Account.CCD_TESTNET_1, Account.CCD_TESTNET_2, "50", undefined);
+
+$Tag("@NanoSP", "@concordium", "@family-concordium");
+describe("Send from 1 account to another", () => {
+  beforeAll(async () => {
+    await app.init({
+      speculosApp: transaction.accountToDebit.currency.speculosApp,
+      userdata: "concordium-account",
+      featureFlags: {
+        llmAccountListUI: { enabled: true },
+        currencyConcordiumTestnet: { enabled: true },
+      },
+      cliCommands: [
+        async (userdataPath?: string) => {
+          await CLI.liveData({
+            currency: transaction.accountToDebit.currency.id,
+            index: transaction.accountToDebit.index,
+            add: true,
+            appjson: userdataPath,
+          });
+
+          // Resolve on-chain addresses via speculos + wallet-proxy.
+          // Concordium addresses are SHA256(credId), not derived from BIP32 paths.
+          const debitInfo = await CLI.getAddress({
+            currency: transaction.accountToDebit.currency.speculosApp.name,
+            path: transaction.accountToDebit.accountPath,
+          });
+          transaction.accountToDebit.address = await resolveAddressFromPublicKey(
+            debitInfo.publicKey,
+          );
+
+          const creditInfo = await CLI.getAddress({
+            currency: transaction.accountToCredit.currency.speculosApp.name,
+            path: transaction.accountToCredit.accountPath,
+          });
+          transaction.accountToCredit.address = await resolveAddressFromPublicKey(
+            creditInfo.publicKey,
+          );
+          transaction.recipientAddress = transaction.accountToCredit.address;
+        },
+      ],
+    });
+
+    await app.portfolio.waitForPortfolioPageToLoad();
+  });
+
+  it(`Send from ${transaction.accountToDebit.accountName} to ${transaction.accountToCredit.accountName}`, async () => {
+    const addressToCredit = transaction.accountToCredit.address;
+    await app.send.navigateToSendScreen(transaction.accountToDebit.accountName);
+    await app.send.setRecipientAndContinue(addressToCredit, transaction.memoTag);
+    await app.send.setAmountAndContinue(transaction.amount);
+
+    const amountWithCode =
+      transaction.amount + "\u00a0" + transaction.accountToCredit.currency.ticker;
+    await verifySendAndOperationDetails(transaction, amountWithCode);
+  });
+});

--- a/e2e/mobile/specs/send/sendCCD.spec.ts
+++ b/e2e/mobile/specs/send/sendCCD.spec.ts
@@ -2,8 +2,13 @@ import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runSendTest } from "./send";
 
 const transaction = new Transaction(Account.CCD_TESTNET_1, Account.CCD_TESTNET_2, "50", undefined);
-runSendTest(transaction, [], ["@NanoSP", "@concordium", "@family-concordium"], {
-  featureFlags: { currencyConcordiumTestnet: { enabled: true } },
-  userdata: "concordium-account",
-  liveDataOptions: { currency: Account.CCD_TESTNET_1.currency.id },
-});
+runSendTest(
+  transaction,
+  [],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@concordium", "@family-concordium"],
+  {
+    featureFlags: { currencyConcordiumTestnet: { enabled: true } },
+    userdata: "concordium-account",
+    liveDataOptions: { currency: Account.CCD_TESTNET_1.currency.id },
+  },
+);

--- a/e2e/mobile/specs/send/sendCCD.spec.ts
+++ b/e2e/mobile/specs/send/sendCCD.spec.ts
@@ -3,11 +3,14 @@ import { log } from "detox";
 import { verifySendAndOperationDetails } from "./send";
 
 const WALLET_PROXY_URL = "https://ccd-wallet-proxy-testnet.coin.ledger-test.com";
+const WALLET_PROXY_TIMEOUT_MS = 10_000;
 
 // Resolve on-chain address from public key via wallet-proxy API.
 // Concordium addresses are NOT derived from BIP32 paths — they come from on-chain credential deployment.
 async function resolveAddressFromPublicKey(publicKey: string): Promise<string> {
-  const res = await fetch(`${WALLET_PROXY_URL}/v0/keyAccounts/${publicKey}`);
+  const res = await fetch(`${WALLET_PROXY_URL}/v0/keyAccounts/${publicKey}`, {
+    signal: AbortSignal.timeout(WALLET_PROXY_TIMEOUT_MS),
+  });
   if (!res.ok) {
     throw new Error(
       `[CCD] Wallet-proxy error ${res.status} ${res.statusText} for public key ${publicKey.slice(0, 16)}...`,

--- a/e2e/mobile/userdata/concordium-account.json
+++ b/e2e/mobile/userdata/concordium-account.json
@@ -1,0 +1,58 @@
+{
+  "data": {
+    "SPECTRON_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2019-12-04"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": "light",
+      "region": null,
+      "locale": "en-US",
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": true,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sharePersonalizedRecommandations": false,
+      "hasSeenAnalyticsOptInPrompt": true,
+      "analyticsEnabled": false,
+      "personalizedRecommendationsEnabled": false,
+      "trackingEnabled": false,
+      "sentryLogs": true,
+      "readOnlyModeEnabled": false,
+      "hasOrderedNano": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "nanoS",
+      "hasInstalledApps": true,
+      "dismissedDynamicCards": [],
+      "seenDevices": [],
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [],
+    "countervalues": {}
+  }
+}

--- a/e2e/mobile/utils/cliUtils.ts
+++ b/e2e/mobile/utils/cliUtils.ts
@@ -177,4 +177,23 @@ export const CLI = {
   getTokenAllowance: function (opts: GetTokenAllowanceOpts) {
     return runCliGetTokenAllowance(opts);
   },
+  getAddressForAccount: async (account: Account) => {
+    if (account.currency.id === Currency.HBAR.id) {
+      invariant(account.address, "hedera: account address must be pre-set");
+      return account.address;
+    }
+
+    if (account.currency.id === Currency.CCD_TESTNET.id) {
+      invariant(account.address, "concordium: account address must be pre-set");
+      return account.address;
+    }
+
+    const addressInfo = await CLI.getAddress({
+      currency: account.currency.speculosApp.name,
+      path: account.accountPath,
+      derivationMode: account.derivationMode,
+    });
+    account.address = addressInfo.address;
+    return addressInfo.address;
+  },
 };

--- a/e2e/mobile/utils/cliUtils.ts
+++ b/e2e/mobile/utils/cliUtils.ts
@@ -1,5 +1,3 @@
-import invariant from "invariant";
-import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { getSdk } from "@ledgerhq/ledger-key-ring-protocol";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import { CloudSyncSDK, type UpdateEvent } from "@ledgerhq/live-wallet/cloudsync/index";
@@ -178,24 +176,5 @@ export const CLI = {
   },
   getTokenAllowance: function (opts: GetTokenAllowanceOpts) {
     return runCliGetTokenAllowance(opts);
-  },
-  getAddressForAccount: async (account: Account) => {
-    if (account.currency.id === Currency.HBAR.id) {
-      invariant(account.address, "hedera: account address must be pre-set");
-      return account.address;
-    }
-
-    if (account.currency.id === Currency.CCD_TESTNET.id) {
-      invariant(account.address, "concordium: account address must be pre-set");
-      return account.address;
-    }
-
-    const addressInfo = await CLI.getAddress({
-      currency: account.currency.speculosApp.name,
-      path: account.accountPath,
-      derivationMode: account.derivationMode,
-    });
-    account.address = addressInfo.address;
-    return addressInfo.address;
   },
 };

--- a/e2e/mobile/utils/cliUtils.ts
+++ b/e2e/mobile/utils/cliUtils.ts
@@ -1,3 +1,5 @@
+import invariant from "invariant";
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { getSdk } from "@ledgerhq/ledger-key-ring-protocol";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import { CloudSyncSDK, type UpdateEvent } from "@ledgerhq/live-wallet/cloudsync/index";

--- a/libs/ledger-live-common/src/e2e/cliCommandsUtils.ts
+++ b/libs/ledger-live-common/src/e2e/cliCommandsUtils.ts
@@ -8,6 +8,7 @@ import {
   runCliLiveData,
   runCliTokenApproval,
 } from "./runCli";
+import { getCcdAccountAddress } from "./families/concordium";
 import { approveToken } from "./families/evm";
 import { parseCurrencyUnit } from "../currencies/index";
 
@@ -20,6 +21,12 @@ export const getAccountAddress = async (account: Account | TokenAccount): Promis
   if (account.currency.id === Currency.HBAR.id) {
     invariant(account.address, "hedera: account address must be pre-set");
     return account.address;
+  }
+
+  if (account.currency.id === Currency.CCD_TESTNET.id) {
+    const address = await getCcdAccountAddress(account);
+    account.address = address;
+    return address;
   }
 
   const { address } = await runCliGetAddress({

--- a/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
+++ b/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
@@ -171,7 +171,6 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
     sendVerify: {
       [AppInfos.SOLANA.name]: DeviceLabels.REVIEW_TRANSACTION_TO,
       [AppInfos.RIPPLE.name]: DeviceLabels.TRANSACTION_TYPE,
-      [AppInfos.CONCORDIUM.name]: DeviceLabels.TRANSACTION_TYPE,
       default: DeviceLabels.REVIEW_OPERATION,
     },
     sendConfirm: {

--- a/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
+++ b/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
@@ -71,6 +71,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.ETHEREUM.name]: DeviceLabels.VERIFY_ADDRESS,
       [AppInfos.SOLANA.name]: DeviceLabels.PUBKEY,
       [AppInfos.ZCASH.name]: DeviceLabels.VERIFY_ADDRESS,
+      [AppInfos.CONCORDIUM.name]: DeviceLabels.ADDRESS,
       default: DeviceLabels.ADDRESS,
     },
     receiveConfirm: {
@@ -102,6 +103,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.RIPPLE.name]: DeviceLabels.TRANSACTION_TYPE,
       [AppInfos.COSMOS.name]: DeviceLabels.TYPE_SEND,
       [AppInfos.POLKADOT.name]: DeviceLabels.CHAIN_STATEMINT,
+      [AppInfos.CONCORDIUM.name]: DeviceLabels.TRANSACTION_TYPE,
       default: DeviceLabels.REVIEW_OPERATION,
     },
     sendConfirm: {
@@ -116,6 +118,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.BITCOIN_CASH.name]: DeviceLabels.ACCEPT,
       [AppInfos.DOGECOIN.name]: DeviceLabels.ACCEPT,
       [AppInfos.BITCOIN.name]: DeviceLabels.CONTINUE,
+      [AppInfos.CONCORDIUM.name]: DeviceLabels.SIGN_TRANSACTION,
       default: DeviceLabels.CAPS_APPROVE,
     },
   },
@@ -168,6 +171,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
     sendVerify: {
       [AppInfos.SOLANA.name]: DeviceLabels.REVIEW_TRANSACTION_TO,
       [AppInfos.RIPPLE.name]: DeviceLabels.TRANSACTION_TYPE,
+      [AppInfos.CONCORDIUM.name]: DeviceLabels.TRANSACTION_TYPE,
       default: DeviceLabels.REVIEW_OPERATION,
     },
     sendConfirm: {
@@ -183,6 +187,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.KASPA.name]: DeviceLabels.APPROVE,
       [AppInfos.DOGECOIN.name]: DeviceLabels.ACCEPT,
       [AppInfos.BITCOIN_CASH.name]: DeviceLabels.ACCEPT,
+      [AppInfos.CONCORDIUM.name]: DeviceLabels.SIGN_TRANSACTION,
       default: DeviceLabels.CAPS_APPROVE,
     },
   },

--- a/libs/ledger-live-common/src/e2e/enum/Account.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Account.ts
@@ -124,6 +124,19 @@ export class Account {
     "taproot",
   );
 
+  static readonly CCD_TESTNET_1 = new Account(
+    Currency.CCD_TESTNET,
+    "Concordium (Testnet) 1",
+    0,
+    "44'/919'/404'/404'/0'",
+  );
+  static readonly CCD_TESTNET_2 = new Account(
+    Currency.CCD_TESTNET,
+    "Concordium (Testnet) 2",
+    1,
+    "44'/919'/404'/404'/1'",
+  );
+
   static readonly CELO_1 = new Account(Currency.CELO, "Celo 1", 0, "44'/52752'/0'/0/0");
 
   static readonly DOGE_1 = new Account(Currency.DOGE, "Dogecoin 1", 0, "44'/3'/0'/0/1");

--- a/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
+++ b/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
@@ -80,4 +80,6 @@ export class AppInfos {
   static readonly ONE_INCH = new AppInfos("One Inch");
 
   static readonly MINA = new AppInfos("Mina");
+
+  static readonly CONCORDIUM = new AppInfos("Concordium");
 }

--- a/libs/ledger-live-common/src/e2e/enum/Currency.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Currency.ts
@@ -220,4 +220,12 @@ export class Currency {
     AppInfos.INTERNET_COMPUTER,
     [Network.INTERNET_COMPUTER],
   );
+
+  static readonly CCD_TESTNET = new Currency(
+    "Concordium Testnet",
+    "CCD",
+    "concordium_testnet",
+    AppInfos.CONCORDIUM,
+    [Network.CONCORDIUM],
+  );
 }

--- a/libs/ledger-live-common/src/e2e/enum/Currency.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Currency.ts
@@ -222,7 +222,7 @@ export class Currency {
   );
 
   static readonly CCD_TESTNET = new Currency(
-    "Concordium Testnet",
+    "Concordium (Testnet)",
     "CCD",
     "concordium_testnet",
     AppInfos.CONCORDIUM,

--- a/libs/ledger-live-common/src/e2e/enum/Network.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Network.ts
@@ -38,4 +38,5 @@ export enum Network {
   ALEO = "Aleo",
   INTERNET_COMPUTER = "Internet Computer",
   MINA = "Mina",
+  CONCORDIUM = "Concordium",
 }

--- a/libs/ledger-live-common/src/e2e/families/concordium.ts
+++ b/libs/ledger-live-common/src/e2e/families/concordium.ts
@@ -1,0 +1,18 @@
+import { DeviceLabels } from "../enum/DeviceLabels";
+import { pressUntilTextFound } from "../speculos";
+import { isTouchDevice } from "../speculosAppVersion";
+import { withDeviceController } from "../deviceInteraction/DeviceController";
+import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
+
+export const sendConcordium = withDeviceController(({ getButtonsController }) => async () => {
+  const buttons = getButtonsController();
+
+  if (isTouchDevice()) {
+    await pressUntilTextFound(DeviceLabels.SIGN_TRANSACTION);
+    await longPressAndRelease(DeviceLabels.SIGN_TRANSACTION, 3);
+  } else {
+    // Concordium screen flow: Transaction Type → Amount → Fee → Destination → Account → Accept → Sign transaction
+    await pressUntilTextFound(DeviceLabels.SIGN_TRANSACTION);
+    await buttons.both();
+  }
+});

--- a/libs/ledger-live-common/src/e2e/families/concordium.ts
+++ b/libs/ledger-live-common/src/e2e/families/concordium.ts
@@ -1,23 +1,26 @@
 import { Account, TokenAccount } from "../enum/Account";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { runCliGetAddress } from "../runCli";
-import { pressUntilTextFound } from "../speculos";
+import { getSendEvents } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
+import { Transaction } from "../models/Transaction";
 import { withDeviceController } from "../deviceInteraction/DeviceController";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
 
-export const sendConcordium = withDeviceController(({ getButtonsController }) => async () => {
-  const buttons = getButtonsController();
+export const sendConcordium = withDeviceController(
+  ({ getButtonsController }) =>
+    async (tx: Transaction) => {
+      const buttons = getButtonsController();
 
-  if (isTouchDevice()) {
-    await pressUntilTextFound(DeviceLabels.SIGN_TRANSACTION);
-    await longPressAndRelease(DeviceLabels.SIGN_TRANSACTION, 3);
-  } else {
-    // Concordium screen flow: Transaction Type → Amount → Fee → Destination → Account → Accept → Sign transaction
-    await pressUntilTextFound(DeviceLabels.SIGN_TRANSACTION);
-    await buttons.both();
-  }
-});
+      await getSendEvents(tx);
+
+      if (isTouchDevice()) {
+        await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
+      } else {
+        await buttons.both();
+      }
+    },
+);
 
 const CCD_TESTNET_WALLET_PROXY_URL = "https://ccd-wallet-proxy-testnet.coin.ledger-test.com";
 const CCD_WALLET_PROXY_TIMEOUT_MS = 10_000;

--- a/libs/ledger-live-common/src/e2e/families/concordium.ts
+++ b/libs/ledger-live-common/src/e2e/families/concordium.ts
@@ -1,4 +1,6 @@
+import { Account, TokenAccount } from "../enum/Account";
 import { DeviceLabels } from "../enum/DeviceLabels";
+import { runCliGetAddress } from "../runCli";
 import { pressUntilTextFound } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { withDeviceController } from "../deviceInteraction/DeviceController";
@@ -16,3 +18,32 @@ export const sendConcordium = withDeviceController(({ getButtonsController }) =>
     await buttons.both();
   }
 });
+
+const CCD_TESTNET_WALLET_PROXY_URL = "https://ccd-wallet-proxy-testnet.coin.ledger-test.com";
+const CCD_WALLET_PROXY_TIMEOUT_MS = 10_000;
+
+// Concordium addresses are not derived from BIP32 paths — they come from on-chain
+// credential deployment. Resolve via wallet-proxy from the device-exported public key.
+async function resolveCcdAddressFromPublicKey(publicKey: string): Promise<string> {
+  const res = await fetch(`${CCD_TESTNET_WALLET_PROXY_URL}/v0/keyAccounts/${publicKey}`, {
+    signal: AbortSignal.timeout(CCD_WALLET_PROXY_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `[CCD] Wallet-proxy error ${res.status} ${res.statusText} for public key ${publicKey.slice(0, 16)}...`,
+    );
+  }
+  const accounts = await res.json();
+  if (!accounts?.length) {
+    throw new Error(`No on-chain accounts found for public key ${publicKey}`);
+  }
+  return accounts[0].address;
+}
+
+export async function getCcdAccountAddress(account: Account | TokenAccount): Promise<string> {
+  const { publicKey } = await runCliGetAddress({
+    currency: account.currency.speculosApp.name,
+    path: account.accountPath,
+  });
+  return resolveCcdAddressFromPublicKey(publicKey);
+}

--- a/libs/ledger-live-common/src/e2e/runCli.ts
+++ b/libs/ledger-live-common/src/e2e/runCli.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import { spawn } from "child_process";
+import type { Result as GetAddressResult } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { sanitizeError, sleep } from "./index";
 
 export const LEDGER_LIVE_CLI_BIN = path.resolve(__dirname, "../../../../apps/cli/bin/index.js");
@@ -208,7 +209,7 @@ export function runCliLiveData(opts: LiveDataOpts): Promise<string> {
   return runCliCommandWithRetry(cliOpts.join("+"));
 }
 
-export async function runCliGetAddress(opts: GetAddressOpts): Promise<{ address: string }> {
+export async function runCliGetAddress(opts: GetAddressOpts): Promise<GetAddressResult> {
   const cliOpts = ["getAddress"];
   if (opts.currency) cliOpts.push(`--currency+${opts.currency}`);
   if (opts.device) cliOpts.push(`--device+${opts.device}`);
@@ -216,7 +217,7 @@ export async function runCliGetAddress(opts: GetAddressOpts): Promise<{ address:
   if (opts.derivationMode) cliOpts.push(`--derivationMode+${opts.derivationMode}`);
   if (opts.verify) cliOpts.push("--verify");
   const output = await runCliCommandWithRetry(cliOpts.join("+"));
-  return parseGetAddressCliOutput(output) as { address: string };
+  return parseGetAddressCliOutput(output) as GetAddressResult;
 }
 
 export function runCliTokenApproval(opts: TokenApprovalOpts): Promise<string> {

--- a/libs/ledger-live-common/src/e2e/runCli.ts
+++ b/libs/ledger-live-common/src/e2e/runCli.ts
@@ -72,7 +72,7 @@ export type GetTokenAllowanceOpts = {
   ownerAddress: string;
 };
 
-function parseGetAddressCliOutput(output: string): unknown {
+function parseGetAddressCliOutput(output: string): GetAddressResult {
   const lines = output
     .split("\n")
     .map(line => line.trim())
@@ -89,11 +89,25 @@ function parseGetAddressCliOutput(output: string): unknown {
     throw new Error("CLI getAddress output does not contain JSON");
   }
 
+  let parsed: unknown;
   try {
-    return JSON.parse(jsonLine);
+    parsed = JSON.parse(jsonLine);
   } catch {
     throw new Error("Failed to parse CLI getAddress output");
   }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error(`CLI getAddress output is not an object. Raw output:\n${output}`);
+  }
+
+  const { address, path, publicKey } = parsed as Record<string, unknown>;
+  if (typeof address !== "string" || typeof path !== "string" || typeof publicKey !== "string") {
+    throw new Error(
+      `CLI getAddress output missing address/path/publicKey. Raw output:\n${output}`,
+    );
+  }
+
+  return parsed as GetAddressResult;
 }
 
 function parseCliFlag(command: string, flag: string): string | undefined {
@@ -217,7 +231,7 @@ export async function runCliGetAddress(opts: GetAddressOpts): Promise<GetAddress
   if (opts.derivationMode) cliOpts.push(`--derivationMode+${opts.derivationMode}`);
   if (opts.verify) cliOpts.push("--verify");
   const output = await runCliCommandWithRetry(cliOpts.join("+"));
-  return parseGetAddressCliOutput(output) as GetAddressResult;
+  return parseGetAddressCliOutput(output);
 }
 
 export function runCliTokenApproval(opts: TokenApprovalOpts): Promise<string> {

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -959,7 +959,7 @@ export async function signSendTransaction(tx: Transaction) {
       await sendInternetComputer(tx);
       break;
     case Currency.CCD_TESTNET.id:
-      await sendConcordium();
+      await sendConcordium(tx);
       break;
     default:
       throw new Error(`Unsupported currency: ${tx.accountToDebit.currency.ticker}`);

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -42,6 +42,7 @@ import { delegateOsmosis } from "./families/osmosis";
 import { AppInfos } from "./enum/AppInfos";
 import { DEVICE_LABELS_CONFIG } from "./data/deviceLabelsData";
 import { sendSui } from "./families/sui";
+import { sendConcordium } from "./families/concordium";
 import { getAppVersionFromCatalog, getSpeculosModel, isTouchDevice } from "./speculosAppVersion";
 import {
   pressAndRelease,
@@ -404,6 +405,14 @@ export const specs: Specs = {
     appQuery: {
       model: getSpeculosModel(),
       appName: "Mina",
+    },
+    dependencies: [],
+  },
+  Concordium: {
+    currency: getCryptoCurrencyById("concordium"),
+    appQuery: {
+      model: getSpeculosModel(),
+      appName: "Concordium",
     },
     dependencies: [],
   },
@@ -948,6 +957,9 @@ export async function signSendTransaction(tx: Transaction) {
       break;
     case Currency.ICP.id:
       await sendInternetComputer(tx);
+      break;
+    case Currency.CCD_TESTNET.id:
+      await sendConcordium();
       break;
     default:
       throw new Error(`Unsupported currency: ${tx.accountToDebit.currency.ticker}`);


### PR DESCRIPTION
- Resolve on-chain addresses via CLI.getAddress + wallet-proxy lookup (Concordium addresses are SHA256(credId), not BIP32-derived)
- Fix derivation paths to 44'/919'/404'/404'/N'
- Use CLI.liveData with currency ID to discover and add accounts (bypasses UI add-account flow)

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - New E2E send test for Concordium testnet (mobile)

### 📝 Description

Add end-to-end send test for Concordium testnet on mobile.

Account discovery uses `CLI.liveData` with the currency ID (`concordium_testnet`) to scan and add accounts via the existing bridge infrastructure. Addresses are then resolved from public keys via the wallet-proxy API, since Concordium addresses are derived from on-chain credential deployment, not BIP32 paths.

[CI e2e test run with broadcast](https://github.com/LedgerHQ/ledger-live/actions/runs/24858069749)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27270](https://ledgerhq.atlassian.net/browse/LIVE-27270?atlOrigin=eyJpIjoiYzVlNjExY2Q1NjU0NDZkNzk2ZWVjZDljNWY5ZTZjZWIiLCJwIjoiaiJ9)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.


[LIVE-27270]: https://ledgerhq.atlassian.net/browse/LIVE-27270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ