### PR TITLE
fix(e2e): adding wait networkidle to stabilize earn V2 test

### DIFF
--- a/e2e/desktop/tests/page/earn.v2.dashboard.page.ts
+++ b/e2e/desktop/tests/page/earn.v2.dashboard.page.ts
@@ -72,6 +72,7 @@ export class EarnV2Page extends EarnBasePage {
   @step("Click position row: $0")
   async clickPositionRow(identifier: string) {
     const webview = await this.getWebView();
+    await webview.waitForLoadState("networkidle");
     const row = webview.getByTestId(/^deposit-row-/).filter({ hasText: new RegExp(identifier) });
     await row.first().click();
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Ci runs:
https://github.com/LedgerHQ/ledger-live/actions/runs/23946196416
https://github.com/LedgerHQ/ledger-live/actions/runs/23942265082
https://github.com/LedgerHQ/ledger-live/actions/runs/23941746457
https://github.com/LedgerHQ/ledger-live/actions/runs/23941540682
https://github.com/LedgerHQ/ledger-live/actions/runs/23946184713


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
