### PR TITLE
[LWD] fix(desktop): migrate canton OnboardModal integration test to withFlagOverrides

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/__integrations__/OnboardModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/__integrations__/OnboardModal.integration.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { act, cleanup, render, screen, waitFor } from "tests/testSetup";
+import { act, cleanup, render, screen, waitFor, withFlagOverrides } from "tests/testSetup";
 import { http, HttpResponse } from "msw";
 import { server } from "tests/server";
 import cantonHandlers, {
@@ -68,9 +68,6 @@ function cantonDevnetCurrency(): CryptoCurrency {
 
 const cantonIntegSettings = {
   ...SETTINGS_INITIAL_STATE,
-  overriddenFeatureFlags: {
-    cantonSkipPreapprovalStep: { enabled: true },
-  },
 };
 
 function mergeCantonIntegInitialState(
@@ -80,15 +77,11 @@ function mergeCantonIntegInitialState(
   const { settings: extraSettings, ...rest } = extra;
   return {
     ...generateOnboardModalState(device),
+    ...withFlagOverrides({ cantonSkipPreapprovalStep: { enabled: true } }),
     ...rest,
     settings: {
       ...cantonIntegSettings,
       ...extraSettings,
-      overriddenFeatureFlags: {
-        ...cantonIntegSettings.overriddenFeatureFlags,
-        ...(extraSettings?.overriddenFeatureFlags ?? {}),
-        cantonSkipPreapprovalStep: { enabled: true },
-      },
     },
   };
 }


### PR DESCRIPTION
## Summary

- `OnboardModal.integration.test.tsx` was introduced in [8e1312b795](https://github.com/LedgerHQ/ledger-live/commit/8e1312b795) using `settings.overriddenFeatureFlags`, which was removed by [#15905](https://github.com/LedgerHQ/ledger-live/pull/15905)
- Migrated to `withFlagOverrides({ cantonSkipPreapprovalStep: { enabled: true } })` to fix the typecheck regression

## Test plan

- [x] `pnpm desktop typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)