### PR TITLE
chore(lwd): remove continue on error for lint:guardrails command on CI

### DIFF
--- a/.github/workflows/test-desktop-external-reusable.yml
+++ b/.github/workflows/test-desktop-external-reusable.yml
@@ -48,7 +48,6 @@ jobs:
         run: pnpm desktop lint:ci
       - name: lint (guardrails)
         run: pnpm desktop lint:guardrails
-        continue-on-error: true  # TODO: Remove once release branch is back-merged into develop (see JIRA)
       - name: typecheck
         run: pnpm desktop typecheck
       - name: check for dead code

--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -67,7 +67,6 @@ jobs:
         run: pnpm desktop lint:ci
       - name: lint (guardrails)
         run: pnpm desktop lint:guardrails
-        continue-on-error: true  # TODO: Remove once release branch is back-merged into develop (see JIRA)
       - name: typecheck
         run: pnpm desktop typecheck
       - name: check for dead code


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. <!-- Typically not required for CI-only workflow changes; add one if your team expects it. -->
- [ ] **Covered by automatic tests.** <!-- Enforcement is CI: `pnpm desktop lint:guardrails` must pass on the reusable desktop workflows. No new app unit tests required for this change. -->
- [x] **Impact of the changes:**
  - **User-facing:** None. Desktop app behaviour is unchanged.
  - **Technical:** The **lint (guardrails)** step (`pnpm desktop lint:guardrails`) becomes **blocking** again in `.github/workflows/test-desktop-reusable.yml` and `.github/workflows/test-desktop-external-reusable.yml`. PRs that violate the ESLint guardrails rule (`no-restricted-syntax` for `shell.openExternal()`, RCE safety) will fail CI instead of being allowed to pass with a warning.
  - **QA focus:** No product QA. Confirm on a failing branch (if needed) that the guardrails step fails the job when lint errors exist, and that green branches still pass.

### 📝 Description

**Problem**

Ledger Live Desktop still runs ESLint **guardrails** (`pnpm desktop lint:guardrails`) in CI for `no-restricted-syntax` on `shell.openExternal()` (see [LIVE-27168](https://ledgerhq.atlassian.net/browse/LIVE-27168) for the broader ESLint → oxlint move). While **release** and **develop** were out of sync, the **lint (guardrails)** step used `continue-on-error: true` so merges were not blocked. That was always meant to be temporary.

**Solution**

After the **release branch has been back-merged into develop**, this PR removes `continue-on-error: true` from the **lint (guardrails)** step and deletes the inline TODO comment that referenced removing it after the back-merge. Guardrails lint is enforced again: if `pnpm desktop lint:guardrails` fails, the workflow job fails.

**Implementation notes**

- `.github/workflows/test-desktop-reusable.yml`: remove `continue-on-error: true` (and the associated comment) from the **lint (guardrails)** step only.
- `.github/workflows/test-desktop-external-reusable.yml`: same change for the **lint (guardrails)** step.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27752](https://ledgerhq.atlassian.net/browse/LIVE-27752)
- **ADR link (if any):** N/A
- **Related:** [LIVE-27168](https://ledgerhq.atlassian.net/browse/LIVE-27168) (LWD ESLint → oxlint; guardrails remain on ESLint)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27168]: https://ledgerhq.atlassian.net/browse/LIVE-27168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ