### PR TITLE
chore(lwm): remove continue on error for lint:i18n command on CI

### DIFF
--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -70,7 +70,6 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
           TURBO_TEAM: "foo"
         run: pnpm turbo lint:i18n --filter="live-mobile"
-        continue-on-error: true  # TODO: Remove once release branch is back-merged into develop (see JIRA)
       - name: check for dead code
         run: pnpm mobile knip-check
         shell: bash


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. <!-- N/A: CI workflow only, no user-facing package change -->
- [x] **Covered by automatic tests.** <!-- Mobile code-check workflow; failing i18n lint fails the job -->
- [x] **Impact of the changes:**
  - **CI only:** the mobile **Run lint (i18n)** step is blocking again. No app behaviour change for end users.
  - **QA:** no manual QA required beyond confirming CI is green.

### 📝 Description

After the release branch was back-merged into `develop`, this PR removes `continue-on-error: true` from the **Run lint (i18n)** step in the mobile reusable workflow(s). That step runs `pnpm turbo lint:i18n --filter="live-mobile"` (ESLint i18n rules, separate from Oxlint).

Previously the step was non-blocking so `develop` could merge while release and `develop` were out of sync. Guardrails are enforced again: if i18n lint fails, the mobile code-check job fails.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27809](https://ledgerhq.atlassian.net/browse/LIVE-27809)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27809]: https://ledgerhq.atlassian.net/browse/LIVE-27809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ