### PR TITLE
[LIVE-26484] add craft transaction support for FA2 tokens

### DIFF
--- a/.changeset/shiny-mugs-battle.md
+++ b/.changeset/shiny-mugs-battle.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-tezos": minor
+"@ledgerhq/live-common": minor
+---
+
+add craft transaction support for FA2 tokens

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -389,6 +389,26 @@ describe("estimateFees", () => {
     ).rejects.toThrow("Fees estimation failed: test");
   });
 
+  it("should not throw for FA2 script_rejected errors (returns estimation)", async () => {
+    logicEstimateFees.mockResolvedValue({
+      estimatedFees: DEFAULT_ESTIMATED_FEES,
+      gasLimit: DEFAULT_GAS_LIMIT,
+      storageLimit: DEFAULT_STORAGE_LIMIT,
+      taquitoError: "proto.024-PtTALLiN.michelson_v1.script_rejected",
+    });
+    const result = await api.estimateFees({
+      intentType: "transaction",
+      type: "send",
+      sender: "tz1test",
+      recipient: "tz1recipient",
+      amount: 1000n,
+      asset: { type: "token", assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:0" },
+    } as TransactionIntent);
+    expect(result.value).toBe(DEFAULT_ESTIMATED_FEES);
+    expect(result.parameters?.gasLimit).toBe(DEFAULT_GAS_LIMIT);
+    expect(result.parameters?.storageLimit).toBe(DEFAULT_STORAGE_LIMIT);
+  });
+
   it("should not throw for delegate.unchanged errors", async () => {
     logicEstimateFees.mockResolvedValue({
       estimatedFees: DEFAULT_ESTIMATED_FEES,

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -42,6 +42,8 @@ import {
   hasEmptyBalance,
   mapIntentTypeToTezosMode,
   normalizePublicKeyForAddress,
+  parseTezosTokenAsset,
+  resolveTezosOperationMode,
 } from "../utils";
 import type { TezosFeeEstimation } from "./types";
 
@@ -105,12 +107,15 @@ async function craft(
     storageLimit: estimation.parameters?.storageLimit?.toString(),
   };
 
-  // Map generic staking intents to tezos modes
-  const mappedType = mapIntentTypeToTezosMode(transactionIntent.type);
+  const tezosMode = resolveTezosOperationMode(transactionIntent.type, transactionIntent.asset);
+  const mappedType: "send" | "delegate" | "undelegate" | "send_token" =
+    tezosMode === "send_token" ? "send_token" : mapIntentTypeToTezosMode(transactionIntent.type);
+  const tokenCraftInfo =
+    tezosMode === "send_token" ? parseTezosTokenAsset(transactionIntent.asset)! : undefined;
 
-  // Guard: send max is incompatible with delegated accounts
+  // Guard: send max is incompatible with delegated accounts (native XTZ only)
   let amountToUse = transactionIntent.amount;
-  if (mappedType === "send" && transactionIntent.useAllAmount) {
+  if (tezosMode === "send" && transactionIntent.useAllAmount) {
     const senderInfo = await api.getAccountByAddress(transactionIntent.sender);
     if (senderInfo.type === "user" && senderInfo.delegate?.address) {
       throw new RecommendUndelegation();
@@ -158,6 +163,10 @@ async function craft(
     recipient: transactionIntent.recipient,
     amount: amountToUse,
     fee: { ...fee, fees: txFee.toString() },
+    ...(tokenCraftInfo && {
+      contractAddress: tokenCraftInfo.contractAddress,
+      tokenId: tokenCraftInfo.tokenId,
+    }),
   };
   const publicKeyForCraft =
     needsReveal && transactionIntent.senderPublicKey
@@ -194,8 +203,12 @@ async function craft(
 async function estimate(transactionIntent: TransactionIntent): Promise<TezosFeeEstimation> {
   // avoid taquito error when estimating a 0-amount transfer during input
   const config = coinConfig.getCoinConfig();
+  const tezosModeForEstimate = resolveTezosOperationMode(
+    transactionIntent.type,
+    transactionIntent.asset,
+  );
   if (
-    transactionIntent.type === "send" &&
+    (tezosModeForEstimate === "send" || tezosModeForEstimate === "send_token") &&
     transactionIntent.amount === 0n &&
     !transactionIntent.useAllAmount
   ) {
@@ -229,11 +242,20 @@ async function estimate(transactionIntent: TransactionIntent): Promise<TezosFeeE
     balance: BigInt(senderAccountInfo.balance),
   };
 
+  const tokenEstimationInfo =
+    tezosModeForEstimate === "send_token"
+      ? parseTezosTokenAsset(transactionIntent.asset)!
+      : undefined;
+
   const transaction: CoreTransactionInfo = {
-    mode: mapIntentTypeToTezosMode(transactionIntent.type),
+    mode: tezosModeForEstimate,
     recipient: transactionIntent.recipient,
     amount: transactionIntent.amount,
     useAllAmount: !!transactionIntent.useAllAmount,
+    ...(tokenEstimationInfo && {
+      contractAddress: tokenEstimationInfo.contractAddress,
+      tokenId: tokenEstimationInfo.tokenId,
+    }),
   };
 
   async function logicEstimate(xpub?: string): Promise<EstimatedFees> {

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -46,6 +46,7 @@ import {
   resolveTezosOperationMode,
 } from "../utils";
 import type { TezosFeeEstimation } from "./types";
+import type { TezosOperationMode } from "../types/model";
 
 export function createApi(config: TezosConfig): AlpacaApi {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
@@ -108,7 +109,7 @@ async function craft(
   };
 
   const tezosMode = resolveTezosOperationMode(transactionIntent.type, transactionIntent.asset);
-  const mappedType: "send" | "delegate" | "undelegate" | "send_token" =
+  const mappedType: TezosOperationMode =
     tezosMode === "send_token" ? "send_token" : mapIntentTypeToTezosMode(transactionIntent.type);
   const tokenCraftInfo =
     tezosMode === "send_token" ? parseTezosTokenAsset(transactionIntent.asset)! : undefined;
@@ -285,7 +286,8 @@ async function estimate(transactionIntent: TransactionIntent): Promise<TezosFeeE
       estimation.taquitoError &&
       !estimation.taquitoError.includes("delegate.unchanged") &&
       !estimation.taquitoError.includes("subtraction_underflow") &&
-      !estimation.taquitoError.includes("balance_too_low")
+      !estimation.taquitoError.includes("balance_too_low") &&
+      !estimation.taquitoError.includes("script_rejected")
     ) {
       throw new Error(`Fees estimation failed: ${estimation.taquitoError}`);
     }

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.integ.test.ts
@@ -100,6 +100,79 @@ describe("Tezos Api", () => {
     );
   });
 
+  it("should craft a send_token (FA2) transaction", async () => {
+    const contractAddress = "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o";
+
+    const result = await craftTransaction(
+      { address },
+      {
+        type: "send_token",
+        recipient: "tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9", // spell-checker: disable-line
+        amount: BigInt(1),
+        fee: { fees: BigInt(1).toString() },
+        contractAddress,
+        tokenId: 0,
+      },
+    );
+
+    expect(result.type).toBe("OUT");
+    expect(result.contents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: OpKind.TRANSACTION,
+          source: address,
+          destination: contractAddress,
+          amount: "0",
+          counter: expect.any(String),
+          fee: "1",
+          gas_limit: "0",
+          storage_limit: "0",
+          parameters: expect.objectContaining({ entrypoint: "transfer" }),
+        }),
+      ]),
+    );
+  });
+
+  it("should craft a send_token (FA2) transaction with reveal for unrevealed tz2 address", async () => {
+    const tz2Address = "tz2F4XnSd1wjwWsthemvZQjoPER7NVSt35k3";
+    const expectedPublicKey = "sppk7but7h93Ws1XhAPvdBcttVmoBDGHxdpaU8dPy5549f3eLJFAjag";
+    const contractAddress = "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o";
+
+    const result = await craftTransaction(
+      { address: tz2Address },
+      {
+        type: "send_token",
+        recipient: "tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9", // spell-checker: disable-line
+        amount: BigInt(1),
+        fee: { fees: "500", gasLimit: "10000", storageLimit: "0" },
+        contractAddress,
+        tokenId: 0,
+      },
+      {
+        publicKey: expectedPublicKey,
+        publicKeyHash: tz2Address,
+      },
+    );
+
+    expect(result).toEqual({
+      type: "OUT",
+      contents: [
+        expect.objectContaining({
+          kind: OpKind.REVEAL,
+          public_key: expectedPublicKey,
+          source: tz2Address,
+        }),
+        expect.objectContaining({
+          kind: OpKind.TRANSACTION,
+          source: tz2Address,
+          destination: contractAddress,
+          amount: "0",
+          parameters: expect.objectContaining({ entrypoint: "transfer" }),
+        }),
+      ],
+    });
+  });
+
   it("should craft a send transaction from tz2 address with correct compressedreveal public key", async () => {
     // Given: LAMA account from production environment
     const tz2Address = "tz2F4XnSd1wjwWsthemvZQjoPER7NVSt35k3";

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.test.ts
@@ -305,7 +305,7 @@ describe("craftTransaction", () => {
     expect(transfer).toHaveBeenCalledWith([
       {
         from_: account.address,
-        txs: [{ to_: transaction.recipient, token_id: 0, amount: 5 }],
+        txs: [{ to_: transaction.recipient, token_id: 0, amount: 5n }],
       },
     ]);
     expect(result.contents).toEqual([

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.test.ts
@@ -4,12 +4,22 @@ import coinConfig from "../config";
 import { craftTransaction, rawEncode } from "./craftTransaction";
 import { getTezosToolkit } from "./tezosToolkit";
 
-type TransactionType = "send" | "delegate" | "undelegate";
+type TransactionType = "send" | "delegate" | "undelegate" | "send_token";
 
 jest.mock("./tezosToolkit");
 jest.mock("../config", () => ({
   getCoinConfig: jest.fn(),
 }));
+
+function setupFa2ContractMock(parameter: { entrypoint: string; value: unknown }) {
+  const toTransferParams = jest.fn().mockReturnValue({
+    parameter,
+    amount: 0,
+    mutez: true,
+  });
+  const transfer = jest.fn().mockReturnValue({ toTransferParams });
+  return { transfer, toTransferParams };
+}
 
 describe("craftTransaction", () => {
   const mockTezosToolkit = {
@@ -20,6 +30,9 @@ describe("craftTransaction", () => {
     },
     estimate: {
       reveal: jest.fn(),
+    },
+    contract: {
+      at: jest.fn(),
     },
     setProvider: jest.fn(),
   };
@@ -266,6 +279,120 @@ describe("craftTransaction", () => {
       expect(delegationFee).toBe(mainOpFee);
       expect(total).toBe(minFees + mainOpFee);
     });
+  });
+
+  it("should craft an FA2 send_token transaction", async () => {
+    const fa2Param = { entrypoint: "transfer", value: { prim: "Pair" as const } };
+    const { transfer } = setupFa2ContractMock(fa2Param);
+    mockTezosToolkit.contract.at.mockResolvedValue({ methods: { transfer } });
+    mockTezosToolkit.rpc.getContract.mockResolvedValue({ counter: "1" });
+
+    const contractAddress = "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU";
+    const account = { address: "tz1VSUr8wwNhLAzempoch5d6nLRSNtxK8LBr" };
+    const transaction = {
+      type: "send_token" as TransactionType,
+      recipient: "tz1VSUr8wwNhLAzempoch5d6nLRSNtxK8LBr",
+      amount: BigInt(5),
+      fee: { fees: "100", gasLimit: "200", storageLimit: "300" },
+      contractAddress,
+      tokenId: 0,
+    };
+
+    const result = await craftTransaction(account, transaction);
+
+    expect(result.type).toBe("OUT");
+    expect(mockTezosToolkit.contract.at).toHaveBeenCalledWith(contractAddress);
+    expect(transfer).toHaveBeenCalledWith([
+      {
+        from_: account.address,
+        txs: [{ to_: transaction.recipient, token_id: 0, amount: 5 }],
+      },
+    ]);
+    expect(result.contents).toEqual([
+      {
+        kind: OpKind.TRANSACTION,
+        source: account.address,
+        destination: contractAddress,
+        amount: "0",
+        counter: "2",
+        fee: "100",
+        gas_limit: "200",
+        storage_limit: "300",
+        parameters: fa2Param,
+      },
+    ]);
+  });
+
+  it("should craft FA2 send_token with reveal when publicKey is provided", async () => {
+    const fa2Param = { entrypoint: "transfer", value: [] };
+    const { transfer } = setupFa2ContractMock(fa2Param);
+    mockTezosToolkit.contract.at.mockResolvedValue({ methods: { transfer } });
+    mockTezosToolkit.rpc.getContract.mockResolvedValue({ counter: "1" });
+    mockTezosToolkit.estimate.reveal.mockResolvedValue({
+      gasLimit: 100,
+      storageLimit: 0,
+      suggestedFeeMutez: getRevealFee("tz1..."),
+    });
+    (coinConfig.getCoinConfig as jest.Mock).mockReturnValue({
+      fees: {
+        minRevealGasLimit: 100,
+        minFees: 0,
+        minStorageLimit: 0,
+      },
+    });
+
+    const contractAddress = "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU";
+    const account = { address: "tz1..." };
+    const transaction = {
+      type: "send_token" as TransactionType,
+      recipient: "tz2...",
+      amount: BigInt(1),
+      fee: { fees: "100", gasLimit: "200", storageLimit: "300" },
+      contractAddress,
+      tokenId: 7,
+    };
+    const publicKey = { publicKey: "publicKey", publicKeyHash: "publicKeyHash" };
+
+    const result = await craftTransaction(account, transaction, publicKey);
+
+    expect(result.contents).toHaveLength(2);
+    expect(result.contents[0].kind).toBe(OpKind.REVEAL);
+    expect(result.contents[1]).toMatchObject({
+      kind: OpKind.TRANSACTION,
+      destination: contractAddress,
+      amount: "0",
+      counter: "3",
+      parameters: fa2Param,
+    });
+  });
+
+  it("should throw when send_token is missing contractAddress or tokenId", async () => {
+    mockTezosToolkit.rpc.getContract.mockResolvedValue({ counter: "1" });
+
+    await expect(
+      craftTransaction(
+        { address: "tz1..." },
+        {
+          type: "send_token" as TransactionType,
+          recipient: "tz2...",
+          amount: 1n,
+          fee: {},
+        },
+      ),
+    ).rejects.toThrow("FA2 transfer requires contractAddress and tokenId");
+
+    await expect(
+      craftTransaction(
+        { address: "tz1..." },
+        {
+          type: "send_token" as TransactionType,
+          recipient: "tz2...",
+          amount: 1n,
+          fee: {},
+          contractAddress: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU",
+        },
+      ),
+    ).rejects.toThrow("FA2 transfer requires contractAddress and tokenId");
   });
 
   it("should throw an error for unsupported transaction type", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
@@ -98,7 +98,6 @@ export async function craftTransaction(
   }
 
   let type: TransactionType;
-  console.log("transaction.type", transaction.type);
   switch (transaction.type) {
     case "send": {
       type = "OUT";

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
@@ -125,7 +125,7 @@ export async function craftTransaction(
               {
                 to_: transaction.recipient,
                 token_id: transaction.tokenId,
-                amount: Number(transaction.amount),
+                amount: transaction.amount,
               },
             ],
           },

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
@@ -19,10 +19,12 @@ export async function craftTransaction(
     counter?: number;
   },
   transaction: {
-    type: "send" | "delegate" | "undelegate";
+    type: "send" | "delegate" | "undelegate" | "send_token";
     recipient: string;
     amount: bigint;
     fee: TransactionFee;
+    contractAddress?: string;
+    tokenId?: number;
   },
   publicKey?: {
     publicKey: string;
@@ -96,6 +98,7 @@ export async function craftTransaction(
   }
 
   let type: TransactionType;
+  console.log("transaction.type", transaction.type);
   switch (transaction.type) {
     case "send": {
       type = "OUT";
@@ -105,6 +108,37 @@ export async function craftTransaction(
         destination: transaction.recipient,
         source: address,
         counter: (counter + 1 + contents.length).toString(),
+        ...transactionFees,
+      });
+      break;
+    }
+    case "send_token": {
+      if (!transaction.contractAddress || transaction.tokenId === undefined) {
+        throw new Error("FA2 transfer requires contractAddress and tokenId");
+      }
+      type = "OUT";
+      const tokenContract = await tezosToolkit.contract.at(transaction.contractAddress);
+      const transferParams = tokenContract.methods
+        .transfer([
+          {
+            from_: address,
+            txs: [
+              {
+                to_: transaction.recipient,
+                token_id: transaction.tokenId,
+                amount: Number(transaction.amount),
+              },
+            ],
+          },
+        ])
+        .toTransferParams({ mutez: true });
+      contents.push({
+        kind: OpKind.TRANSACTION,
+        source: address,
+        destination: transaction.contractAddress,
+        amount: "0",
+        counter: (counter + 1 + contents.length).toString(),
+        parameters: transferParams.parameter,
         ...transactionFees,
       });
       break;

--- a/libs/coin-modules/coin-tezos/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/estimateFees.test.ts
@@ -29,11 +29,24 @@ const revealedAccount = {
   revealed: true,
 };
 
+function setupFa2ContractMock() {
+  const toTransferParams = jest.fn().mockReturnValue({
+    parameter: { entrypoint: "transfer", value: [] },
+    amount: 0,
+    mutez: true,
+  });
+  const transfer = jest.fn().mockReturnValue({ toTransferParams });
+  return { transfer, toTransferParams };
+}
+
 describe("estimateFees", () => {
   const mockTezosToolkit = {
     estimate: {
       setDelegate: jest.fn(),
       transfer: jest.fn(),
+    },
+    contract: {
+      at: jest.fn(),
     },
     setProvider: jest.fn(),
   };
@@ -315,6 +328,156 @@ describe("estimateFees", () => {
     const expectedRevealFee = getRevealFee(unrevealedAccount.address);
     expect(result.fees).toBe(BigInt(minEstimatedFees));
     expect(result.estimatedFees).toBe(BigInt(minEstimatedFees + expectedRevealFee));
+  });
+
+  it("send_token (FA2) revealed applies estimation from contract transfer", async () => {
+    const { transfer } = setupFa2ContractMock();
+    mockTezosToolkit.contract.at.mockResolvedValue({ methods: { transfer } });
+    mockTezosToolkit.estimate.transfer.mockResolvedValue({
+      suggestedFeeMutez: 600,
+      gasLimit: 5000,
+      storageLimit: 10,
+      burnFeeMutez: 0,
+      opSize: 250,
+    });
+
+    const contractAddress = "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU";
+    const result = await estimateFees({
+      account: revealedAccount,
+      transaction: {
+        mode: "send_token",
+        recipient: "tz1VSUr8wwNhLAzempoch5d6nLRSNtxK8LBr",
+        amount: BigInt(100),
+        contractAddress,
+        tokenId: 0,
+      },
+    });
+
+    expect(mockTezosToolkit.contract.at).toHaveBeenCalledWith(contractAddress);
+    expect(transfer).toHaveBeenCalledWith([
+      {
+        from_: revealedAccount.address,
+        txs: [{ to_: "tz1VSUr8wwNhLAzempoch5d6nLRSNtxK8LBr", token_id: 0, amount: 100 }],
+      },
+    ]);
+    expect(result.fees).toBe(600n);
+    expect(result.gasLimit).toBe(5000n);
+    expect(result.storageLimit).toBe(10n);
+    expect(result.estimatedFees).toBe(600n);
+    expect(result.amount).toBe(100n);
+  });
+
+  it("send_token unrevealed adds reveal fee to estimatedFees", async () => {
+    const { transfer } = setupFa2ContractMock();
+    mockTezosToolkit.contract.at.mockResolvedValue({ methods: { transfer } });
+    mockTezosToolkit.estimate.transfer.mockResolvedValue({
+      suggestedFeeMutez: 400,
+      gasLimit: 4000,
+      storageLimit: 0,
+      burnFeeMutez: 0,
+      opSize: 200,
+    });
+
+    const contractAddress = "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU";
+    const result = await estimateFees({
+      account: unrevealedAccount,
+      transaction: {
+        mode: "send_token",
+        recipient: "tz1VSUr8wwNhLAzempoch5d6nLRSNtxK8LBr",
+        amount: BigInt(50),
+        contractAddress,
+        tokenId: 3,
+      },
+    });
+
+    const expectedRevealFee = getRevealFee(unrevealedAccount.address);
+    expect(result.fees).toBe(400n);
+    expect(result.estimatedFees).toBe(BigInt(400 + expectedRevealFee));
+  });
+
+  it("send_token uses fallback when Taquito throws Public key not found", async () => {
+    const minEstimatedFees = 400;
+    (coinConfig.getCoinConfig as jest.Mock).mockReturnValue({
+      fees: {
+        ...defaultFeesConfig,
+        minEstimatedFees,
+        minGasLimit: 600,
+        minStorageLimit: 0,
+      },
+    });
+    const { transfer } = setupFa2ContractMock();
+    mockTezosToolkit.contract.at.mockResolvedValue({ methods: { transfer } });
+    mockTezosToolkit.estimate.transfer.mockRejectedValue(
+      Object.assign(new Error("Fail"), { status: 404, message: "Public key not found" }),
+    );
+
+    const contractAddress = "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU";
+    const result = await estimateFees({
+      account: unrevealedAccount,
+      transaction: {
+        mode: "send_token",
+        recipient: "tz1VSUr8wwNhLAzempoch5d6nLRSNtxK8LBr",
+        amount: BigInt(10),
+        contractAddress,
+        tokenId: 0,
+      },
+    });
+
+    const expectedRevealFee = getRevealFee(unrevealedAccount.address);
+    expect(result.fees).toBe(BigInt(minEstimatedFees));
+    expect(result.estimatedFees).toBe(BigInt(minEstimatedFees + expectedRevealFee));
+    expect(result.amount).toBe(10n);
+  });
+
+  it("send_token with empty recipient returns fallback without calling the contract", async () => {
+    const { transfer } = setupFa2ContractMock();
+    mockTezosToolkit.contract.at.mockResolvedValue({ methods: { transfer } });
+
+    const result = await estimateFees({
+      account: revealedAccount,
+      transaction: {
+        mode: "send_token",
+        recipient: "",
+        amount: BigInt(100),
+        contractAddress: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU",
+        tokenId: 0,
+      },
+    });
+
+    expect(mockTezosToolkit.contract.at).not.toHaveBeenCalled();
+    expect(result.fees).toBe(BigInt(defaultFeesConfig.minEstimatedFees));
+    expect(transfer).not.toHaveBeenCalled();
+  });
+
+  it("send_token propagates error when contract.at fails", async () => {
+    mockTezosToolkit.contract.at.mockRejectedValue(new Error("Invalid contract"));
+
+    await expect(
+      estimateFees({
+        account: revealedAccount,
+        transaction: {
+          mode: "send_token",
+          recipient: "tz1VSUr8wwNhLAzempoch5d6nLRSNtxK8LBr",
+          amount: BigInt(1),
+          contractAddress: "KT1Bad",
+          tokenId: 0,
+        },
+      }),
+    ).rejects.toThrow("Invalid contract");
+  });
+
+  it("send_token throws when contractAddress or tokenId is missing", async () => {
+    await expect(
+      estimateFees({
+        account: revealedAccount,
+        transaction: {
+          mode: "send_token",
+          recipient: "tz1VSUr8wwNhLAzempoch5d6nLRSNtxK8LBr",
+          amount: BigInt(1),
+          tokenId: 0,
+        },
+      }),
+    ).rejects.toThrow("FA2 transfer requires contractAddress and tokenId");
   });
 
   it("useAllAmount send computes max amount and applies minFees to main op", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/estimateFees.test.ts
@@ -357,7 +357,7 @@ describe("estimateFees", () => {
     expect(transfer).toHaveBeenCalledWith([
       {
         from_: revealedAccount.address,
-        txs: [{ to_: "tz1VSUr8wwNhLAzempoch5d6nLRSNtxK8LBr", token_id: 0, amount: 100 }],
+        txs: [{ to_: "tz1VSUr8wwNhLAzempoch5d6nLRSNtxK8LBr", token_id: 0, amount: 100n }],
       },
     ]);
     expect(result.fees).toBe(600n);

--- a/libs/coin-modules/coin-tezos/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/estimateFees.ts
@@ -131,7 +131,7 @@ export async function estimateFees({
                 {
                   to_: transaction.recipient,
                   token_id: transaction.tokenId,
-                  amount: Number(amount),
+                  amount: amount,
                 },
               ],
             },

--- a/libs/coin-modules/coin-tezos/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/estimateFees.ts
@@ -25,6 +25,10 @@ export type CoreTransactionInfo = {
   recipient: string;
   amount: bigint;
   useAllAmount?: boolean;
+  /** FA2 token contract; required when `mode` is `send_token` */
+  contractAddress?: string;
+  /** FA2 token id; required when `mode` is `send_token` */
+  tokenId?: number;
 };
 
 export type EstimatedFees = {
@@ -75,18 +79,25 @@ export async function estimateFees({
   }
 
   let amount = transaction.amount;
-  if (transaction.useAllAmount || amount === 0n) {
-    amount = 1n; // send max do a pre-estimation with minimum amount (taquito refuses 0)
+  const coerceMinAmountForEstimation =
+    (transaction.useAllAmount && transaction.mode === "send") ||
+    (amount === 0n && transaction.mode !== "send_token");
+  if (coerceMinAmountForEstimation) {
+    amount = 1n; // send max / zero-amount pre-estimation (taquito refuses 0); not used for FA2 send_token
   }
 
   try {
-    if (transaction.mode === "send" && !transaction.recipient) {
+    if (
+      (transaction.mode === "send" || transaction.mode === "send_token") &&
+      !transaction.recipient
+    ) {
       return {
         ...estimation,
         ...createFallbackEstimation(),
       };
     }
     let estimate: Estimate;
+    console.log("transaction.mode", transaction.mode);
     switch (transaction.mode) {
       case "send":
         estimate = await tezosToolkit.estimate.transfer({
@@ -108,6 +119,31 @@ export async function estimateFees({
           source: account.address,
         });
         break;
+      case "send_token": {
+        if (!transaction.contractAddress || transaction.tokenId === undefined) {
+          throw new Error("FA2 transfer requires contractAddress and tokenId");
+        }
+        const tokenContract = await tezosToolkit.contract.at(transaction.contractAddress);
+        const transferParams = tokenContract.methods
+          .transfer([
+            {
+              from_: account.address,
+              txs: [
+                {
+                  to_: transaction.recipient,
+                  token_id: transaction.tokenId,
+                  amount: Number(amount),
+                },
+              ],
+            },
+          ])
+          .toTransferParams({ mutez: true });
+        estimate = await tezosToolkit.estimate.transfer({
+          ...transferParams,
+          source: account.address,
+        });
+        break;
+      }
       default:
         throw new UnsupportedTransactionMode("unsupported mode", { mode: transaction.mode });
     }
@@ -115,8 +151,8 @@ export async function estimateFees({
     const minFees = coinConfig.getCoinConfig().fees.minFees ?? 0;
     const mainOpFee = Math.max(minFees, estimate.suggestedFeeMutez);
 
-    // NOTE: if useAllAmount is true, is it for sure in the send mode (ie. transfer)?
-    if (transaction.useAllAmount) {
+    // NOTE: send-max only applies to native XTZ transfer, not FA2
+    if (transaction.useAllAmount && transaction.mode === "send") {
       let totalFees: number;
       if (estimate.burnFeeMutez > 0) {
         // NOTE: from https://github.com/ecadlabs/taquito/blob/master/integration-tests/__tests__/contract/empty-implicit-account-into-new-implicit-account.spec.ts#L37
@@ -180,7 +216,7 @@ export async function estimateFees({
             estimation.estimatedFees + BigInt(getRevealFeeForEstimation(account.address));
         }
         // Handle useAllAmount also for send mode when estimation falls back
-        if (transaction.useAllAmount) {
+        if (transaction.useAllAmount && transaction.mode === "send") {
           // Approximate Taquito behavior for send-max using stable constants
           const suggestedFee =
             transaction.mode === "send"
@@ -230,7 +266,7 @@ export async function estimateFees({
           estimation.estimatedFees =
             estimation.estimatedFees + BigInt(getRevealFeeForEstimation(account.address));
         }
-        if (transaction.useAllAmount) {
+        if (transaction.useAllAmount && transaction.mode === "send") {
           const suggestedFee =
             transaction.mode === "send"
               ? MIN_SUGGESTED_FEE_SMALL_TRANSFER

--- a/libs/coin-modules/coin-tezos/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/estimateFees.ts
@@ -97,7 +97,6 @@ export async function estimateFees({
       };
     }
     let estimate: Estimate;
-    console.log("transaction.mode", transaction.mode);
     switch (transaction.mode) {
       case "send":
         estimate = await tezosToolkit.estimate.transfer({

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -4,8 +4,11 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
   NotEnoughBalance,
+  RecommendUndelegation,
+  NotEnoughBalanceToDelegate,
 } from "@ledgerhq/errors";
 import coinConfig from "../config";
+import { InvalidAddressBecauseAlreadyDelegated } from "../types/errors";
 import { validateIntent } from "./validateIntent";
 
 // Module-level mocks
@@ -15,10 +18,12 @@ jest.mock("./estimateFees", () => ({
 }));
 
 const mockGetAccountByAddress = jest.fn();
+const mockGetTokensBalances = jest.fn();
 jest.mock("../network/tzkt", () => ({
   __esModule: true,
   default: {
     getAccountByAddress: (...args: unknown[]) => mockGetAccountByAddress(...args),
+    getTokensBalances: (...args: unknown[]) => mockGetTokensBalances(...args),
   },
 }));
 
@@ -62,6 +67,8 @@ describe("validateIntent", () => {
       numTransactions: 0,
       firstActivityTime: "2021-01-01T00:00:00Z",
     });
+
+    mockGetTokensBalances.mockResolvedValue([]);
   });
 
   describe("recipient validation", () => {
@@ -134,6 +141,19 @@ describe("validateIntent", () => {
       expect(result.errors.amount).toBeUndefined();
     });
 
+    it("should return NotEnoughBalance when amount is negative", async () => {
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "native" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: -1n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
     it.each([["stake"], ["unstake"]])(
       "returns 0 as amount when the transaction intent is '%s'",
       async intentType => {
@@ -156,6 +176,64 @@ describe("validateIntent", () => {
         });
       },
     );
+  });
+
+  describe("transaction constraints", () => {
+    it("should return RecommendUndelegation when send-max native XTZ on a delegated account", async () => {
+      mockGetAccountByAddress.mockResolvedValue({
+        type: "user",
+        address: senderAddress,
+        publicKey: "edpk...",
+        balance: 5000000,
+        revealed: true,
+        counter: 0,
+        delegate: { alias: "baker", address: validRecipient, active: true },
+        delegationLevel: 1,
+        delegationTime: "2021-01-01T00:00:00Z",
+        numTransactions: 0,
+        firstActivityTime: "2021-01-01T00:00:00Z",
+      });
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "native" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 0n,
+        useAllAmount: true,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(RecommendUndelegation);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should return NotEnoughBalanceToDelegate when stake intent and balance is zero", async () => {
+      mockGetAccountByAddress.mockResolvedValue({
+        type: "user",
+        address: senderAddress,
+        publicKey: "edpk...",
+        balance: 0,
+        revealed: true,
+        counter: 0,
+        delegationLevel: 0,
+        delegationTime: "2021-01-01T00:00:00Z",
+        numTransactions: 0,
+        firstActivityTime: "2021-01-01T00:00:00Z",
+      });
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: BigInt(0),
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalanceToDelegate);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
   });
 
   describe("balance validation", () => {
@@ -270,6 +348,340 @@ describe("validateIntent", () => {
       });
 
       expect(result.errors).toEqual({});
+    });
+  });
+
+  describe("taquito error mapping", () => {
+    it("maps balance_too_low to NotEnoughBalance for send", async () => {
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 500n,
+        taquitoError: "proto.001-PtAtLas.contract.balance_too_low",
+      });
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "native" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 1000n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("maps balance_too_low to NotEnoughBalanceToDelegate for stake", async () => {
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 500n,
+        taquitoError: "proto.001-PtAtLas.contract.balance_too_low",
+      });
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 0n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalanceToDelegate);
+    });
+
+    it("maps subtraction_underflow to NotEnoughBalance for non-stake", async () => {
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 500n,
+        taquitoError: "some.path.subtraction_underflow",
+      });
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "native" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 1000n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("maps delegate.unchanged to InvalidAddressBecauseAlreadyDelegated for stake", async () => {
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 500n,
+        taquitoError: "proto.024-PtTALLiN.delegate.unchanged",
+      });
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 0n,
+      });
+
+      expect(result.errors.recipient).toBeInstanceOf(InvalidAddressBecauseAlreadyDelegated);
+    });
+
+    it("maps empty_implicit_contract to NotEnoughBalanceToDelegate", async () => {
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 500n,
+        taquitoError: "proto.empty_implicit_contract",
+      });
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "delegate",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 0n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalanceToDelegate);
+    });
+
+    it("maps unknown taquito errors to a generic Error on amount", async () => {
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 500n,
+        taquitoError: "proto.unknown_rpc_failure",
+      });
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "native" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 1000n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(Error);
+      expect(result.errors.amount?.message).toBe("proto.unknown_rpc_failure");
+    });
+  });
+
+  describe("account fetch and reveal", () => {
+    it("uses fixed estimated fees when account is not revealed and skips estimateFees", async () => {
+      mockGetAccountByAddress.mockResolvedValue({
+        type: "user",
+        address: senderAddress,
+        publicKey: "edpk...",
+        balance: 5000000,
+        revealed: false,
+        counter: 0,
+        delegationLevel: 0,
+        delegationTime: "2021-01-01T00:00:00Z",
+        numTransactions: 0,
+        firstActivityTime: "2021-01-01T00:00:00Z",
+      });
+
+      const amount = 1000000n;
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "native" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount,
+      });
+
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+      expect(result.estimatedFees).toBe(2000n);
+      expect(result.amount).toBe(amount);
+      expect(result.totalSpent).toBe(amount + 2000n);
+    });
+
+    it("sets estimation error when getAccountByAddress rejects", async () => {
+      mockGetAccountByAddress.mockRejectedValue(new Error("network failure"));
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "native" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 1000n,
+      });
+
+      expect(result.errors.estimation).toBeInstanceOf(Error);
+      expect(result.errors.estimation?.message).toBe("network failure");
+      expect(result.estimatedFees).toBe(0n);
+      expect(result.amount).toBe(1000n);
+      expect(result.totalSpent).toBe(1000n);
+    });
+
+    it("sets estimation error when account type is not user", async () => {
+      mockGetAccountByAddress.mockResolvedValue({
+        type: "empty",
+        address: senderAddress,
+        counter: 0,
+      });
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "native" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 1000n,
+      });
+
+      expect(result.errors.estimation).toBeInstanceOf(Error);
+      expect(result.estimatedFees).toBe(0n);
+    });
+  });
+
+  describe("FA2 token validation", () => {
+    it("should set amount to full FA2 token balance when useAllAmount is true", async () => {
+      const contract = "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU";
+      const tokenBalance = "1234567890";
+
+      mockGetTokensBalances.mockResolvedValue([
+        {
+          id: 1,
+          account: { address: senderAddress },
+          token: {
+            id: 1,
+            contract: { address: contract },
+            tokenId: "0",
+            standard: "fa2" as const,
+            metadata: { symbol: "TK", decimals: "6" },
+          },
+          balance: tokenBalance,
+          transfersCount: 0,
+          firstLevel: 0,
+          firstTime: "",
+          lastLevel: 0,
+          lastTime: "",
+        },
+      ]);
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "token", assetReference: `${contract}:0` },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 0n,
+        useAllAmount: true,
+      });
+
+      expect(mockGetTokensBalances).toHaveBeenCalledWith(senderAddress, {
+        contractAddress: contract,
+        tokenId: 0,
+      });
+      expect(result.errors.amount).toBeUndefined();
+      expect(result.amount).toBe(BigInt(tokenBalance));
+      expect(result.totalSpent).toBe(1000n);
+    });
+
+    it("should return NotEnoughBalance when estimation reports script_rejected (FA2_INSUFFICIENT_BALANCE)", async () => {
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 0n,
+        taquitoError: "proto.024-PtTALLiN.michelson_v1.script_rejected",
+      });
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "token", assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:0" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: BigInt(1_000_000),
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("should set amount to 0n when useAllAmount and token balance row is missing", async () => {
+      const contract = "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU";
+      mockGetTokensBalances.mockResolvedValue([]);
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "token", assetReference: `${contract}:0` },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 0n,
+        useAllAmount: true,
+      });
+
+      expect(result.amount).toBe(0n);
+      expect(result.totalSpent).toBe(1000n);
+    });
+  });
+
+  describe("native XTZ send max", () => {
+    it("should fall back to balance minus fees when estimateFees returns amount 0n", async () => {
+      mockEstimateFees.mockResolvedValue({
+        fees: BigInt(1000),
+        gasLimit: BigInt(10000),
+        storageLimit: BigInt(0),
+        estimatedFees: BigInt(1000),
+        amount: 0n,
+      });
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "native" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 0n,
+        useAllAmount: true,
+      });
+
+      expect(mockGetTokensBalances).not.toHaveBeenCalled();
+      expect(result.amount).toBe(4999000n);
+      expect(result.totalSpent).toBe(5000000n);
+    });
+
+    it("should prefer positive estimatedAmount from estimateFees over balance minus fees", async () => {
+      const estimatedFromTaquito = 3_000_000n;
+      mockEstimateFees.mockResolvedValue({
+        fees: BigInt(1000),
+        gasLimit: BigInt(10000),
+        storageLimit: BigInt(0),
+        estimatedFees: BigInt(1000),
+        amount: estimatedFromTaquito,
+      });
+
+      const result = await validateIntent({
+        intentType: "transaction",
+        asset: { type: "native" },
+        type: "send",
+        sender: senderAddress,
+        recipient: validRecipient,
+        amount: 0n,
+        useAllAmount: true,
+      });
+
+      expect(result.amount).toBe(estimatedFromTaquito);
+      expect(result.totalSpent).toBe(estimatedFromTaquito + 1000n);
     });
   });
 

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -14,7 +14,7 @@ import {
 import { validateAddress, ValidationResult } from "@taquito/utils";
 import api from "../network/tzkt";
 import { InvalidAddressBecauseAlreadyDelegated } from "../types/errors";
-import { mapIntentTypeToTezosMode } from "../utils";
+import { parseTezosTokenAsset, resolveTezosOperationMode } from "../utils";
 import { estimateFees } from "./estimateFees";
 
 /**
@@ -53,8 +53,12 @@ function validateTransactionConstraints(
 ): Record<string, Error> {
   const errors: Record<string, Error> = {};
 
-  // send max not allowed on delegated accounts (must undelegate acc first)
-  if (intent.type === "send" && intent.useAllAmount) {
+  // send max not allowed on delegated accounts (must undelegate acc first); native XTZ only
+  if (
+    intent.type === "send" &&
+    intent.useAllAmount &&
+    resolveTezosOperationMode(intent.type, intent.asset) === "send"
+  ) {
     if (senderInfo.type === "user" && senderInfo.delegate?.address) {
       errors.amount = new RecommendUndelegation();
     }
@@ -167,6 +171,9 @@ export async function validateIntent(intent: TransactionIntent): Promise<Transac
 
     // Estimate fees
     if (senderInfo.revealed) {
+      const tezosMode = resolveTezosOperationMode(intent.type, intent.asset);
+      const tokenInfo =
+        tezosMode === "send_token" ? parseTezosTokenAsset(intent.asset)! : undefined;
       const estimation = await estimateFees({
         account: {
           address: intent.sender,
@@ -175,10 +182,14 @@ export async function validateIntent(intent: TransactionIntent): Promise<Transac
           xpub: intent.senderPublicKey ?? senderInfo.publicKey,
         },
         transaction: {
-          mode: mapIntentTypeToTezosMode(intent.type),
+          mode: tezosMode,
           recipient: intent.recipient,
           amount: intent.amount,
           useAllAmount: !!intent.useAllAmount,
+          ...(tokenInfo && {
+            contractAddress: tokenInfo.contractAddress,
+            tokenId: tokenInfo.tokenId,
+          }),
         },
       });
       estimatedFees = estimation.estimatedFees;

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -13,9 +13,12 @@ import {
 } from "@ledgerhq/errors";
 import { validateAddress, ValidationResult } from "@taquito/utils";
 import api from "../network/tzkt";
+import type { APIAccount } from "../network/types";
 import { InvalidAddressBecauseAlreadyDelegated } from "../types/errors";
 import { parseTezosTokenAsset, resolveTezosOperationMode } from "../utils";
 import { estimateFees } from "./estimateFees";
+
+type APIUserAccount = Extract<APIAccount, { type: "user" }>;
 
 /**
  * Validates basic recipient and amount for send transactions
@@ -49,7 +52,7 @@ function validateBasicSendParams(intent: TransactionIntent): Record<string, Erro
  */
 function validateTransactionConstraints(
   intent: TransactionIntent,
-  senderInfo: any,
+  senderInfo: APIUserAccount,
 ): Record<string, Error> {
   const errors: Record<string, Error> = {};
 
@@ -57,11 +60,10 @@ function validateTransactionConstraints(
   if (
     intent.type === "send" &&
     intent.useAllAmount &&
-    resolveTezosOperationMode(intent.type, intent.asset) === "send"
+    resolveTezosOperationMode(intent.type, intent.asset) === "send" &&
+    senderInfo.delegate?.address
   ) {
-    if (senderInfo.type === "user" && senderInfo.delegate?.address) {
-      errors.amount = new RecommendUndelegation();
-    }
+    errors.amount = new RecommendUndelegation();
   }
 
   // stake requires non-zero balance
@@ -91,6 +93,8 @@ function mapTaquitoErrors(taquitoError: string, intentType: string): Record<stri
     errors.recipient = new InvalidAddressBecauseAlreadyDelegated();
   } else if (taquitoError.includes("empty_implicit_contract")) {
     errors.amount = new NotEnoughBalanceToDelegate();
+  } else if (taquitoError.includes("script_rejected")) {
+    errors.amount = new NotEnoughBalance();
   } else {
     errors.amount = new Error(taquitoError);
   }
@@ -98,26 +102,41 @@ function mapTaquitoErrors(taquitoError: string, intentType: string): Record<stri
   return errors;
 }
 
+function calculateNativeSendMaxAmountForUser(
+  balance: bigint,
+  estimatedFees: bigint,
+  estimatedAmount: bigint | undefined,
+): { amount: bigint; totalSpent: bigint } {
+  const amountFallback = balance > estimatedFees ? balance - estimatedFees : 0n;
+  const hasPositiveEstimatedAmount = estimatedAmount !== undefined && estimatedAmount > 0n;
+  const amount = hasPositiveEstimatedAmount ? estimatedAmount : amountFallback;
+  return { amount, totalSpent: amount + estimatedFees };
+}
+
 /**
  * Calculates final amounts based on transaction type
+ * @param tokenBalanceForSendMax When set, FA2 send-max: full token amount; fees are paid in XTZ only
  */
 function calculateAmounts(
   intent: TransactionIntent,
-  senderInfo: any,
+  senderInfo: APIUserAccount,
   estimatedFees: bigint,
   estimatedAmount: bigint | undefined,
+  tokenBalanceForSendMax?: bigint,
 ): { amount: bigint; totalSpent: bigint } {
   if (intent.type === "stake" || intent.type === "unstake") {
     return { amount: 0n, totalSpent: estimatedFees };
   }
 
   if (intent.type === "send" && intent.useAllAmount) {
-    if (senderInfo.type === "user") {
-      const balance = BigInt(senderInfo.balance);
-      const amount = estimatedAmount ?? (balance > estimatedFees ? balance - estimatedFees : 0n);
-      return { amount, totalSpent: amount + estimatedFees };
+    if (tokenBalanceForSendMax !== undefined) {
+      return { amount: tokenBalanceForSendMax, totalSpent: estimatedFees };
     }
-    return { amount: 0n, totalSpent: 0n };
+    return calculateNativeSendMaxAmountForUser(
+      BigInt(senderInfo.balance),
+      estimatedFees,
+      estimatedAmount,
+    );
   }
 
   const amount = intent.amount;
@@ -127,17 +146,88 @@ function calculateAmounts(
 /**
  * Validates balance coverage for the transaction
  */
-function validateBalanceCoverage(senderInfo: any, totalSpent: bigint): Record<string, Error> {
+function validateBalanceCoverage(
+  senderInfo: APIUserAccount,
+  totalSpent: bigint,
+): Record<string, Error> {
   const errors: Record<string, Error> = {};
+  const accountBalance = BigInt(senderInfo.balance);
+  if (totalSpent > accountBalance) {
+    errors.amount = new NotEnoughBalance();
+  }
+  return errors;
+}
 
-  if (senderInfo.type === "user") {
-    const accountBalance = BigInt(senderInfo.balance);
-    if (totalSpent > accountBalance) {
-      errors.amount = new NotEnoughBalance();
-    }
+async function estimateFeesForIntent(
+  intent: TransactionIntent,
+  senderInfo: APIUserAccount,
+): Promise<{
+  estimatedFees: bigint;
+  estimatedAmount: bigint | undefined;
+  errors: Record<string, Error>;
+}> {
+  if (!senderInfo.revealed) {
+    return { estimatedFees: 2000n, estimatedAmount: undefined, errors: {} };
   }
 
-  return errors;
+  const tezosMode = resolveTezosOperationMode(intent.type, intent.asset);
+  const tokenInfo = tezosMode === "send_token" ? parseTezosTokenAsset(intent.asset)! : undefined;
+  const estimation = await estimateFees({
+    account: {
+      address: intent.sender,
+      revealed: senderInfo.revealed,
+      balance: BigInt(senderInfo.balance),
+      xpub: intent.senderPublicKey ?? senderInfo.publicKey,
+    },
+    transaction: {
+      mode: tezosMode,
+      recipient: intent.recipient,
+      amount: intent.amount,
+      useAllAmount: !!intent.useAllAmount,
+      ...(tokenInfo && {
+        contractAddress: tokenInfo.contractAddress,
+        tokenId: tokenInfo.tokenId,
+      }),
+    },
+  });
+
+  const errors: Record<string, Error> = {};
+  if (estimation.taquitoError) {
+    Object.assign(errors, mapTaquitoErrors(estimation.taquitoError, intent.type));
+  }
+
+  return {
+    estimatedFees: estimation.estimatedFees,
+    estimatedAmount: estimation.amount,
+    errors,
+  };
+}
+
+async function fetchTokenBalanceForSendMax(intent: TransactionIntent): Promise<bigint | undefined> {
+  if (intent.type !== "send" || !intent.useAllAmount) {
+    return undefined;
+  }
+
+  const tezosMode = resolveTezosOperationMode(intent.type, intent.asset);
+  if (tezosMode !== "send_token") {
+    return undefined;
+  }
+
+  const tokenInfo = parseTezosTokenAsset(intent.asset);
+  if (!tokenInfo) {
+    return undefined;
+  }
+
+  const tokenBalances = await api.getTokensBalances(intent.sender, {
+    contractAddress: tokenInfo.contractAddress,
+    tokenId: tokenInfo.tokenId,
+  });
+  const row = tokenBalances.find(
+    b =>
+      b.token.contract.address === tokenInfo.contractAddress &&
+      Number(b.token.tokenId) === tokenInfo.tokenId,
+  );
+  return row ? BigInt(row.balance) : 0n;
 }
 
 export async function validateIntent(intent: TransactionIntent): Promise<TransactionValidation> {
@@ -148,7 +238,6 @@ export async function validateIntent(intent: TransactionIntent): Promise<Transac
   let amount: bigint;
   let totalSpent: bigint;
 
-  // Basic validation for send transactions
   const basicErrors = validateBasicSendParams(intent);
   Object.assign(errors, basicErrors);
 
@@ -157,11 +246,9 @@ export async function validateIntent(intent: TransactionIntent): Promise<Transac
   }
 
   try {
-    // Get sender account information
     const senderInfo = await api.getAccountByAddress(intent.sender);
     if (senderInfo.type !== "user") throw new Error("unexpected account type");
 
-    // Validate transaction-specific constraints
     const constraintErrors = validateTransactionConstraints(intent, senderInfo);
     Object.assign(errors, constraintErrors);
 
@@ -169,47 +256,23 @@ export async function validateIntent(intent: TransactionIntent): Promise<Transac
       return { errors, warnings, estimatedFees: 0n, amount: 0n, totalSpent: 0n };
     }
 
-    // Estimate fees
-    if (senderInfo.revealed) {
-      const tezosMode = resolveTezosOperationMode(intent.type, intent.asset);
-      const tokenInfo =
-        tezosMode === "send_token" ? parseTezosTokenAsset(intent.asset)! : undefined;
-      const estimation = await estimateFees({
-        account: {
-          address: intent.sender,
-          revealed: senderInfo.revealed,
-          balance: BigInt(senderInfo.balance),
-          xpub: intent.senderPublicKey ?? senderInfo.publicKey,
-        },
-        transaction: {
-          mode: tezosMode,
-          recipient: intent.recipient,
-          amount: intent.amount,
-          useAllAmount: !!intent.useAllAmount,
-          ...(tokenInfo && {
-            contractAddress: tokenInfo.contractAddress,
-            tokenId: tokenInfo.tokenId,
-          }),
-        },
-      });
-      estimatedFees = estimation.estimatedFees;
-      estimatedAmount = estimation.amount;
+    const feeResult = await estimateFeesForIntent(intent, senderInfo);
+    estimatedFees = feeResult.estimatedFees;
+    estimatedAmount = feeResult.estimatedAmount;
+    Object.assign(errors, feeResult.errors);
 
-      // Handle Taquito errors
-      if (estimation.taquitoError) {
-        const taquitoErrors = mapTaquitoErrors(estimation.taquitoError, intent.type);
-        Object.assign(errors, taquitoErrors);
-      }
-    } else {
-      estimatedFees = 2000n;
-    }
+    const tokenBalanceForSendMax = await fetchTokenBalanceForSendMax(intent);
 
-    // Calculate final amounts
-    const amounts = calculateAmounts(intent, senderInfo, estimatedFees, estimatedAmount);
+    const amounts = calculateAmounts(
+      intent,
+      senderInfo,
+      estimatedFees,
+      estimatedAmount,
+      tokenBalanceForSendMax,
+    );
     amount = amounts.amount;
     totalSpent = amounts.totalSpent;
 
-    // Final balance validation
     const balanceErrors = validateBalanceCoverage(senderInfo, totalSpent);
     Object.assign(errors, balanceErrors);
   } catch (e) {

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
@@ -360,6 +360,29 @@ describe("tzkt network API", () => {
         }),
       );
     });
+
+    it("requests a specific FA2 contract and token id when a filter is passed", async () => {
+      const balances = [{ id: 2 } as APITokenBalance];
+      mockedNetwork.mockReturnValue(networkResponse(balances) as ReturnType<typeof network>);
+
+      const result = await api.getTokensBalances("tz1bal", {
+        contractAddress: "KT1abc",
+        tokenId: 7,
+      });
+
+      expect(result).toEqual(balances);
+      expect(mockedNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining("/v1/tokens/balances"),
+          params: {
+            account: "tz1bal",
+            "token.standard": "fa2",
+            "token.contract": "KT1abc",
+            "token.tokenId": "7",
+          },
+        }),
+      );
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.ts
@@ -220,14 +220,24 @@ const api = {
 
   /**
    * Fetches FA token balances for a given account.
+   * When `tokenFilter` is omitted, only FA2 tokenId 0 balances are returned (legacy behaviour).
+   * Pass `tokenFilter` to query a specific FA2 contract + token id (e.g. send-max for FA2).
    * https://api.tzkt.io/#operation/Tokens_GetTokenBalances
    */
-  async getTokensBalances(address: string): Promise<APITokenBalance[]> {
+  async getTokensBalances(
+    address: string,
+    tokenFilter?: { contractAddress: string; tokenId: number },
+  ): Promise<APITokenBalance[]> {
     const params: Record<string, unknown> = {
       account: address,
       "token.standard": "fa2",
-      "token.tokenId": "0",
     };
+    if (tokenFilter) {
+      params["token.contract"] = tokenFilter.contractAddress;
+      params["token.tokenId"] = String(tokenFilter.tokenId);
+    } else {
+      params["token.tokenId"] = "0";
+    }
     const { data } = await network<APITokenBalance[]>({
       url: `${getExplorerUrl()}/v1/tokens/balances`,
       params,

--- a/libs/coin-modules/coin-tezos/src/transaction.ts
+++ b/libs/coin-modules/coin-tezos/src/transaction.ts
@@ -62,6 +62,8 @@ export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
     storageLimit: tr.storageLimit ? new BigNumber(tr.storageLimit) : undefined,
     estimatedFees: tr.estimatedFees ? new BigNumber(tr.estimatedFees) : undefined,
     taquitoError: tr.taquitoError,
+    contractAddress: tr.contractAddress,
+    tokenId: tr.tokenId,
   };
 };
 
@@ -81,6 +83,8 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
     storageLimit: t.storageLimit ? t.storageLimit.toString() : null,
     estimatedFees: t.estimatedFees ? t.estimatedFees.toString() : null,
     taquitoError: t.taquitoError,
+    contractAddress: t.contractAddress,
+    tokenId: t.tokenId,
   };
 };
 

--- a/libs/coin-modules/coin-tezos/src/types/bridge.fixture.ts
+++ b/libs/coin-modules/coin-tezos/src/types/bridge.fixture.ts
@@ -65,6 +65,8 @@ export function createFixtureTransaction(tx?: Partial<Transaction>): Transaction
     storageLimit: tx?.storageLimit || undefined,
     estimatedFees: tx?.estimatedFees || undefined,
     taquitoError: tx?.taquitoError || undefined,
+    contractAddress: tx?.contractAddress,
+    tokenId: tx?.tokenId,
   };
 }
 

--- a/libs/coin-modules/coin-tezos/src/types/bridge.ts
+++ b/libs/coin-modules/coin-tezos/src/types/bridge.ts
@@ -41,6 +41,10 @@ export type Transaction = TransactionCommon & {
   storageLimit: BigNumber | null | undefined;
   estimatedFees: BigNumber | null | undefined;
   taquitoError: string | null | undefined;
+  /** FA2 token contract (KT1…); set when `mode` is `send_token` */
+  contractAddress?: string;
+  /** FA2 token id; set when `mode` is `send_token` */
+  tokenId?: number;
 };
 
 export type TransactionRaw = TransactionCommonRaw & {
@@ -52,6 +56,8 @@ export type TransactionRaw = TransactionCommonRaw & {
   storageLimit: string | null | undefined;
   estimatedFees: string | null | undefined;
   taquitoError: string | null | undefined;
+  contractAddress?: string;
+  tokenId?: number;
 };
 
 type CapacityStatus = "normal" | "full";

--- a/libs/coin-modules/coin-tezos/src/types/model.ts
+++ b/libs/coin-modules/coin-tezos/src/types/model.ts
@@ -1,1 +1,1 @@
-export type TezosOperationMode = "send" | "delegate" | "undelegate";
+export type TezosOperationMode = "send" | "delegate" | "undelegate" | "send_token";

--- a/libs/coin-modules/coin-tezos/src/utils.test.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.test.ts
@@ -1,4 +1,64 @@
-import { normalizePublicKeyForAddress } from "./utils";
+import { normalizePublicKeyForAddress, parseTezosTokenAsset, resolveTezosOperationMode } from "./utils";
+
+describe("parseTezosTokenAsset", () => {
+  it("returns null for native asset", () => {
+    expect(parseTezosTokenAsset({ type: "native" })).toBeNull();
+  });
+
+  it("returns null when asset is undefined", () => {
+    expect(parseTezosTokenAsset(undefined)).toBeNull();
+  });
+
+  it("parses KT1-only reference as token id 0", () => {
+    expect(parseTezosTokenAsset({ type: "token", assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU" })).toEqual({
+      contractAddress: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU",
+      tokenId: 0,
+    });
+  });
+
+  it("parses contract:tokenId reference", () => {
+    expect(
+      parseTezosTokenAsset({ type: "token", assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:42" }),
+    ).toEqual({
+      contractAddress: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU",
+      tokenId: 42,
+    });
+  });
+
+  it("returns null for invalid token id suffix", () => {
+    expect(
+      parseTezosTokenAsset({ type: "token", assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:abc" }),
+    ).toBeNull();
+  });
+
+  it("returns null when reference does not start with KT1", () => {
+    expect(parseTezosTokenAsset({ type: "token", assetReference: "not-a-contract" })).toBeNull();
+  });
+});
+
+describe("resolveTezosOperationMode", () => {
+  it("returns send_token for send intent with token asset", () => {
+    expect(
+      resolveTezosOperationMode("send", {
+        type: "token",
+        assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:0",
+      }),
+    ).toBe("send_token");
+  });
+
+  it("returns send for send intent with native asset", () => {
+    expect(resolveTezosOperationMode("send", { type: "native" })).toBe("send");
+  });
+
+  it("maps stake to delegate regardless of asset", () => {
+    expect(
+      resolveTezosOperationMode("stake", {
+        type: "token",
+        assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:0",
+      }),
+    ).toBe("delegate");
+  });
+});
 
 describe("normalizePublicKeyForAddress", () => {
   it("should normalize hex public key for tz2 address (secp256k1) to base58 format", () => {

--- a/libs/coin-modules/coin-tezos/src/utils.test.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.test.ts
@@ -1,4 +1,8 @@
-import { normalizePublicKeyForAddress, parseTezosTokenAsset, resolveTezosOperationMode } from "./utils";
+import {
+  normalizePublicKeyForAddress,
+  parseTezosTokenAsset,
+  resolveTezosOperationMode,
+} from "./utils";
 
 describe("parseTezosTokenAsset", () => {
   it("returns null for native asset", () => {
@@ -10,7 +14,12 @@ describe("parseTezosTokenAsset", () => {
   });
 
   it("parses KT1-only reference as token id 0", () => {
-    expect(parseTezosTokenAsset({ type: "token", assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU" })).toEqual({
+    expect(
+      parseTezosTokenAsset({
+        type: "token",
+        assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU",
+      }),
+    ).toEqual({
       contractAddress: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU",
       tokenId: 0,
     });
@@ -18,7 +27,10 @@ describe("parseTezosTokenAsset", () => {
 
   it("parses contract:tokenId reference", () => {
     expect(
-      parseTezosTokenAsset({ type: "token", assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:42" }),
+      parseTezosTokenAsset({
+        type: "token",
+        assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:42",
+      }),
     ).toEqual({
       contractAddress: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU",
       tokenId: 42,
@@ -27,7 +39,10 @@ describe("parseTezosTokenAsset", () => {
 
   it("returns null for invalid token id suffix", () => {
     expect(
-      parseTezosTokenAsset({ type: "token", assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:abc" }),
+      parseTezosTokenAsset({
+        type: "token",
+        assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:abc",
+      }),
     ).toBeNull();
   });
 

--- a/libs/coin-modules/coin-tezos/src/utils.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.ts
@@ -3,6 +3,7 @@ import { compressPublicKey } from "@taquito/ledger-signer/dist/lib/utils";
 import { validatePublicKey, ValidationResult, b58Encode, PrefixV2 } from "@taquito/utils";
 import coinConfig from "./config";
 import type { APIAccount } from "./network/types";
+import type { TezosOperationMode } from "./types/model";
 
 /**
  * Dust margin in mutez to prevent transaction failures on send max operations
@@ -39,6 +40,48 @@ export function mapIntentTypeToTezosMode(intentType: string): "send" | "delegate
     default:
       return "send";
   }
+}
+
+/** Minimal asset shape from `TransactionIntent` for FA2 detection */
+export type TezosAssetLike = {
+  type: string;
+  assetReference?: string;
+};
+
+/**
+ * Parse FA1.2 / FA2 token contract + token id from Alpaca `assetReference`
+ * (`KT1…` or `KT1…:tokenId` as produced by getBlock / listOperations).
+ */
+export function parseTezosTokenAsset(
+  asset: TezosAssetLike | undefined,
+): { contractAddress: string; tokenId: number } | null {
+  if (!asset || asset.type === "native") return null;
+  const ref = asset.assetReference?.trim();
+  if (!ref?.startsWith("KT1")) return null;
+
+  const colonIdx = ref.lastIndexOf(":");
+  if (colonIdx > 0) {
+    const contractAddress = ref.slice(0, colonIdx);
+    const tokenId = Number(ref.slice(colonIdx + 1));
+    if (!Number.isFinite(tokenId) || tokenId < 0) return null;
+    return { contractAddress, tokenId };
+  }
+
+  return { contractAddress: ref, tokenId: 0 };
+}
+
+/**
+ * Resolves Tezos operation mode from intent type and asset (native XTZ vs token).
+ */
+export function resolveTezosOperationMode(
+  intentType: string,
+  asset: TezosAssetLike | undefined,
+): TezosOperationMode {
+  const base = mapIntentTypeToTezosMode(intentType);
+  if (base === "send" && parseTezosTokenAsset(asset) !== null) {
+    return "send_token";
+  }
+  return base;
 }
 
 /**

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/tezos/bridge.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/tezos/bridge.test.ts
@@ -1,7 +1,7 @@
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { setCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { getTokenFromAsset } from "./bridge";
+import { getAssetFromToken, getTokenFromAsset } from "./bridge";
 
 beforeAll(() => {
   const tezos = getCryptoCurrencyById("tezos");
@@ -10,7 +10,10 @@ beforeAll(() => {
       return undefined;
     },
     findTokenByAddressInCurrency: async (token: string, currencyId: string) => {
-      if (token === "USDt" && currencyId === "tezos") {
+      if (
+        (token === "USDt" || token === "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o") &&
+        currencyId === "tezos"
+      ) {
         const usdc: TokenCurrency = {
           type: "TokenCurrency",
           id: "tezos/fa2/tether_usd_kt1xntn74butxhfdtbmm2bgzaqfhpbvkwr8o",
@@ -65,6 +68,33 @@ describe("generic-alpaca Tezos token", () => {
           assetOwner: "unknown-owner",
         }),
       ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("getAssetFromToken", () => {
+    it("returns asset with contractAddress as assetReference and owner as assetOwner", () => {
+      const tezos = getCryptoCurrencyById("tezos");
+      const token: TokenCurrency = {
+        type: "TokenCurrency",
+        id: "tezos/fa2/tether_usd_kt1xntn74butxhfdtbmm2bgzaqfhpbvkwr8o",
+        contractAddress: "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o",
+        parentCurrency: tezos,
+        tokenType: "fa2",
+        name: "Tether USD",
+        ticker: "USDt",
+        delisted: false,
+        disableCountervalue: false,
+        units: [{ name: "Tether USD", code: "USDt", magnitude: 6 }],
+      };
+      const owner = "tz1VUmqS38E45KZevtphpVF4cKiK1YJ1P9eL";
+
+      expect(getAssetFromToken(token, owner)).toEqual({
+        type: "fa2",
+        assetReference: "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o",
+        assetOwner: owner,
+        name: "Tether USD",
+        unit: { name: "Tether USD", code: "USDt", magnitude: 6 },
+      });
     });
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/tezos/bridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/tezos/bridge.ts
@@ -6,12 +6,23 @@ import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 export async function getTokenFromAsset(asset: AssetInfo): Promise<TokenCurrency | undefined> {
   return "assetReference" in asset
     ? await getCryptoAssetsStore().findTokenByAddressInCurrency(
-      asset.assetReference as string,
-      "tezos",
-    )
+        asset.assetReference as string,
+        "tezos",
+      )
     : undefined;
+}
+
+export function getAssetFromToken(token: TokenCurrency, owner: string): AssetInfo {
+  return {
+    type: token.tokenType,
+    assetReference: token.contractAddress,
+    assetOwner: owner,
+    name: token.name,
+    unit: token.units[0],
+  };
 }
 
 export default {
   getTokenFromAsset,
+  getAssetFromToken,
 } satisfies BridgeApi;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Able to send FA2 tokens on the tezos network

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26484


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
