### PR TITLE
[LWDM] feat(desktop): set preferences step in analytics consent modal

### DIFF
--- a/.changeset/proud-dragons-refuse.md
+++ b/.changeset/proud-dragons-refuse.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat: set preferences screen analytics dialog

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__integrations__/AnalyticsConsentDialog.portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__integrations__/AnalyticsConsentDialog.portfolio.integration.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Route, Routes } from "react-router";
-import { render, screen, waitFor } from "tests/testSetup";
+import { render, screen, waitFor, within } from "tests/testSetup";
 import { FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
 import { CURRENT_PRIVACY_POLICY_VERSION } from "@ledgerhq/live-common/privacyConsent";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
@@ -204,7 +204,7 @@ describe("AnalyticsConsentDialog on portfolio route", () => {
     expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
   });
 
-  it("navigates to display settings when Set preferences is clicked", async () => {
+  it("shows preferences step when Set preferences is clicked", async () => {
     const { user } = render(<TestRouter />, {
       initialRoute: "/",
       initialState: {
@@ -217,10 +217,80 @@ describe("AnalyticsConsentDialog on portfolio route", () => {
     });
 
     await screen.findByRole("heading", { name: "Help us improve Ledger" });
-    await user.click(screen.getByRole("link", { name: /set preferences/i }));
+    const setPreferencesLink = screen.getByRole("link", { name: /set preferences/i });
+
+    // make sure the link is a11y compliant and does not navigate to a new page
+    expect(setPreferencesLink).toHaveAttribute("href", "#");
+    
+    await user.click(setPreferencesLink);
 
     await waitFor(() => {
-      expect(screen.getByTestId("settings-display-stub")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Set preferences" })).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
   });
+
+  it.each([
+    {
+      label: "both toggles on",
+      expectShareAnalytics: true,
+      expectSharePersonalized: true,
+    },
+    {
+      label: "only App performance on",
+      expectShareAnalytics: true,
+      expectSharePersonalized: false,
+    },
+    {
+      label: "only Personalized experience on",
+      expectShareAnalytics: false,
+      expectSharePersonalized: true,
+    },
+    {
+      label: "all toggles off",
+      expectShareAnalytics: false,
+      expectSharePersonalized: false,
+    },
+  ])(
+    "Set preferences: Confirm closes the modal and sets shareAnalytics and sharePersonalizedRecommandations ($label)",
+    async ({ expectShareAnalytics, expectSharePersonalized }) => {
+      const { user, store } = render(<TestRouter />, {
+        initialRoute: "/",
+        initialState: {
+          featureFlags: featureFlagsWithAnalyticsOptIn,
+          settings: baseSettings({
+            shareAnalytics: false,
+            sharePersonalizedRecommandations: false,
+          }),
+        },
+      });
+
+      await screen.findByRole("heading", { name: "Help us improve Ledger" });
+      await user.click(screen.getByRole("link", { name: /set preferences/i }));
+      const modal = await screen.findByTestId("analytics-consent-dialog");
+      await screen.findByRole("heading", { name: "Set preferences" });
+
+      // Set preferences opens with both switches ON (`onSetPreferences` seeds drafts to true).
+      const switches = within(modal).getAllByRole("switch");
+      expect(switches).toHaveLength(2);
+      const [appPerformanceSwitch, personalizedSwitch] = switches;
+      if (!expectShareAnalytics) {
+        await user.click(appPerformanceSwitch);
+      }
+      if (!expectSharePersonalized) {
+        await user.click(personalizedSwitch);
+      }
+
+      await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+      await waitFor(() => {
+        expect(modal).not.toBeInTheDocument();
+      });
+      const { settings: s } = store.getState();
+      expect(s.shareAnalytics).toBe(expectShareAnalytics);
+      expect(s.sharePersonalizedRecommandations).toBe(expectSharePersonalized);
+      expect(s.hasSeenAnalyticsOptInPrompt).toBe(true);
+      expect(s.analyticsConsentInfo.consentDate).not.toBeNull();
+    },
+  );
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__tests__/useAnalyticsConsentDialogViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__tests__/useAnalyticsConsentDialogViewModel.test.ts
@@ -10,14 +10,12 @@ import {
   useAnalyticsConsentDialogViewModel,
 } from "../hooks/useAnalyticsConsentDialogViewModel";
 
-const mockNavigate = jest.fn();
 const mockUseMatch = jest.fn();
 
 const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
-  useNavigate: () => mockNavigate,
   useMatch: (args: unknown) => mockUseMatch(args),
 }));
 
@@ -168,22 +166,5 @@ describe("useAnalyticsConsentDialogViewModel", () => {
 
     expect(jest.mocked(track)).toHaveBeenCalledWith("drawer_closed", dialogClosedPayload);
     expect(result.current.phase).toBe("closed");
-  });
-
-  it("navigates to settings display when Set preferences is used", async () => {
-    const { result } = renderHook(() => useAnalyticsConsentDialogViewModel(), {
-      initialState: consentReconfirmState,
-    });
-
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    act(() => {
-      result.current.onSetPreferences();
-    });
-
-    expect(jest.mocked(track)).toHaveBeenCalledWith("drawer_closed", dialogClosedPayload);
-    expect(mockNavigate).toHaveBeenCalledWith("/settings/display");
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/components/AnalyticsConsentDialogCopyBlock.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/components/AnalyticsConsentDialogCopyBlock.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { Title as DialogTitle } from "@radix-ui/react-dialog";
+import { useTranslation } from "react-i18next";
 import type { AnalyticsConsentPhase } from "@ledgerhq/live-common/analyticsConsentUtils";
 import { DescriptionWithPreferencesLink } from "./DescriptionWithPreferencesLink";
 import { PrivacyDescription } from "./PrivacyDescription";
 
 export type AnalyticsConsentDialogCopyBlockProps = Readonly<{
   phase: AnalyticsConsentPhase;
-  title: string;
   descriptionLead: string | null;
   privacyPolicyUrl: string;
   onOpenPrivacyPolicy: () => void;
@@ -15,15 +15,26 @@ export type AnalyticsConsentDialogCopyBlockProps = Readonly<{
 
 export function AnalyticsConsentDialogCopyBlock({
   phase,
-  title,
   descriptionLead,
   privacyPolicyUrl,
   onOpenPrivacyPolicy,
   onSetPreferences,
 }: AnalyticsConsentDialogCopyBlockProps) {
+  const { t } = useTranslation();
+
+  const getTitle = () => {
+    if (phase === "consentReconfirm") {
+      return t("analyticsConsentModal.reconfirm.title");
+    } else if (phase === "privacy") {
+      return t("analyticsConsentModal.privacy.title");
+    } else {
+      return t("analyticsConsentModal.fresh.title");
+    }
+  };
+
   return (
     <div className="flex w-full flex-col items-center gap-8 text-center">
-      <DialogTitle className="heading-4-semi-bold text-base w-full">{title}</DialogTitle>
+      <DialogTitle className="heading-4-semi-bold text-base w-full">{getTitle()}</DialogTitle>
       {phase === "privacy" ? (
         <PrivacyDescription
           privacyPolicyUrl={privacyPolicyUrl}

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/components/AnalyticsConsentDialogFooterActions.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/components/AnalyticsConsentDialogFooterActions.tsx
@@ -19,7 +19,8 @@ export function AnalyticsConsentDialogFooterActions({
   const { t } = useTranslation();
 
   return (
-    <DialogFooter className="flex flex-col gap-16 pt-32">
+    // replace pt-32 by mt-32 pt-0 to remove the padding and make Set preferences clickable.
+    <DialogFooter className="flex flex-col gap-16 mt-32 pt-0">
       {phase === "privacy" ? (
         <Button appearance="base" isFull size="lg" onClick={onPrivacyGotIt}>
           {t("analyticsConsentModal.privacy.ctaGotIt")}

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/components/AnalyticsConsentPreferenceRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/components/AnalyticsConsentPreferenceRow.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Switch } from "@ledgerhq/lumen-ui-react";
+
+export type AnalyticsConsentPreferenceRowProps = Readonly<{
+  title: React.ReactNode;
+  description: React.ReactNode;
+  selected: boolean;
+  onChange: (value: boolean) => void;
+}>;
+
+export function AnalyticsConsentPreferenceRow({
+  title,
+  description,
+  selected,
+  onChange,
+}: AnalyticsConsentPreferenceRowProps) {
+  return (
+    <div className="flex w-full flex-col gap-12">
+      <div className="flex w-full items-center justify-between gap-12 rounded-lg bg-muted px-10 py-16 dark:bg-surface">
+        <span className="body-2-semi-bold text-base">{title}</span>
+        <Switch selected={selected} onChange={onChange} />
+      </div>
+      <p className="body-3 text-muted px-2">{description}</p>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/components/DescriptionWithPreferencesLink.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/components/DescriptionWithPreferencesLink.tsx
@@ -2,8 +2,6 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "@ledgerhq/lumen-ui-react";
 
-const SETTINGS_DISPLAY_HASH_HREF = "#/settings/display";
-
 export type DescriptionWithPreferencesLinkProps = Readonly<{
   text: string;
   onSetPreferences: () => void;
@@ -18,13 +16,13 @@ export function DescriptionWithPreferencesLink({
     <div className="body-2 text-muted text-center">
       <span>{text}</span>
       <Link
+        onClick={onSetPreferences}
+        href="#"
         appearance="accent"
         size="sm"
         underline={false}
-        href={SETTINGS_DISPLAY_HASH_HREF}
-        onClick={e => {
-          e.preventDefault();
-          onSetPreferences();
+        style={{
+          padding: 1,
         }}
       >
         {t("analyticsConsentModal.setPreferences")}

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useMatch, useNavigate } from "react-router";
+import { useMatch } from "react-router";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import {
@@ -22,8 +22,8 @@ import {
   needsConsentRenewal,
   needsPrivacyPolicyAck,
   resolveAnalyticsConsentPhase,
-  type AnalyticsConsentPhase,
 } from "@ledgerhq/live-common/analyticsConsentUtils";
+import type { AnalyticsConsentDialogPhase } from "../types";
 
 export const ANALYTICS_CONSENT_DIALOG_PAGE = "Analytics consent dialog";
 
@@ -37,7 +37,6 @@ const dialogClosedPayload = {
 export function useAnalyticsConsentDialogViewModel() {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const navigate = useNavigate();
   const privacyPolicyUrl = useLocalizedUrl(urls.privacyPolicy);
   const portfolioRouteMatch = useMatch({ path: "/", end: true });
   const isPortfolioRouteFocused = Boolean(portfolioRouteMatch);
@@ -55,16 +54,14 @@ export function useAnalyticsConsentDialogViewModel() {
     feature?.enabled && hasCompletedOnboarding && (needsUpdatePrivacy || needsRenewal),
   );
 
-  const [phase, setPhase] = useState<AnalyticsConsentPhase>("closed");
+  const [phase, setPhase] = useState<AnalyticsConsentDialogPhase>("closed");
+  const [consentPhaseBeforePreferences, setConsentPhaseBeforePreferences] = useState<
+    "consentFresh" | "consentReconfirm"
+  >("consentFresh");
 
-  let title: string;
-  if (phase === "consentReconfirm") {
-    title = t("analyticsConsentModal.reconfirm.title");
-  } else if (phase === "privacy") {
-    title = t("analyticsConsentModal.privacy.title");
-  } else {
-    title = t("analyticsConsentModal.fresh.title");
-  }
+  /** Preferences-step form only; Redux settings update on Confirm via `applyPreferences`. */
+  const [draftShareAnalytics, setDraftShareAnalytics] = useState(true);
+  const [draftSharePersonalized, setDraftSharePersonalized] = useState(true);
 
   let descriptionLead: string | null;
   if (phase === "consentReconfirm") {
@@ -75,37 +72,41 @@ export function useAnalyticsConsentDialogViewModel() {
     descriptionLead = t("analyticsConsentModal.fresh.description");
   }
 
-  const onOpenPrivacyPolicy = useCallback(() => {
+  const onOpenPrivacyPolicy = () => {
     openURL(privacyPolicyUrl);
-  }, [privacyPolicyUrl]);
+  };
 
-  const handleCloseDialog = useCallback(() => {
+  const handleCloseDialog = () => {
     setPhase(current => {
       if (current !== "closed") {
         track("drawer_closed", dialogClosedPayload);
       }
       return "closed";
     });
-  }, []);
+  };
 
   useEffect(() => {
     if (!isPortfolioRouteFocused || !shouldOffer) {
-      handleCloseDialog();
+      setPhase(current => {
+        if (current !== "closed") {
+          track("drawer_closed", dialogClosedPayload);
+        }
+        return "closed";
+      });
       return;
     }
-    setPhase(current =>
-      resolveAnalyticsConsentPhase(current, needsRenewal, needsUpdatePrivacy, shareAnalytics),
-    );
-  }, [
-    isPortfolioRouteFocused,
-    shouldOffer,
-    needsRenewal,
-    needsUpdatePrivacy,
-    shareAnalytics,
-    handleCloseDialog,
-  ]);
+    setPhase(current => {
+      if (current === "preferences") return current;
+      return resolveAnalyticsConsentPhase(
+        current,
+        needsRenewal,
+        needsUpdatePrivacy,
+        shareAnalytics,
+      );
+    });
+  }, [isPortfolioRouteFocused, shouldOffer, needsRenewal, needsUpdatePrivacy, shareAnalytics]);
 
-  const persistAnalyticsConsentAck = useCallback(async () => {
+  const persistAnalyticsConsentAck = async () => {
     dispatch(setAnalyticsConsentInfo());
     dispatch(setHasSeenAnalyticsOptInPrompt(true));
     try {
@@ -113,9 +114,9 @@ export function useAnalyticsConsentDialogViewModel() {
     } catch (error) {
       console.error("Failed to update analytics identify after consent change", error);
     }
-  }, [dispatch]);
+  };
 
-  const applyOptIn = useCallback(async () => {
+  const applyOptIn = async () => {
     track("button_clicked", {
       button: "analytics_consent_opt_in",
       page: ANALYTICS_CONSENT_DIALOG_PAGE,
@@ -124,9 +125,9 @@ export function useAnalyticsConsentDialogViewModel() {
     dispatch(setSharePersonalizedRecommendations(true));
     await persistAnalyticsConsentAck();
     handleCloseDialog();
-  }, [dispatch, persistAnalyticsConsentAck, handleCloseDialog]);
+  };
 
-  const applyOptOut = useCallback(async () => {
+  const applyOptOut = async () => {
     track("button_clicked", {
       button: "analytics_consent_opt_out",
       page: ANALYTICS_CONSENT_DIALOG_PAGE,
@@ -135,32 +136,51 @@ export function useAnalyticsConsentDialogViewModel() {
     dispatch(setSharePersonalizedRecommendations(false));
     await persistAnalyticsConsentAck();
     handleCloseDialog();
-  }, [dispatch, persistAnalyticsConsentAck, handleCloseDialog]);
+  };
 
-  const onPrivacyGotIt = useCallback(async () => {
+  const onPrivacyGotIt = async () => {
     track("button_clicked", {
       button: "analytics_consent_privacy_got_it",
       page: ANALYTICS_CONSENT_DIALOG_PAGE,
     });
     await persistAnalyticsConsentAck();
     handleCloseDialog();
-  }, [handleCloseDialog, persistAnalyticsConsentAck]);
+  };
 
-  const onSetPreferences = useCallback(() => {
+  const onSetPreferences = () => {
     track("button_clicked", {
       button: "analytics_consent_set_preferences",
       page: ANALYTICS_CONSENT_DIALOG_PAGE,
     });
+    // Default opt-in: preferences screen opens with both toggles on; user can turn them off before confirming.
+    setDraftShareAnalytics(true);
+    setDraftSharePersonalized(true);
+    setPhase(current => {
+      if (current === "consentFresh" || current === "consentReconfirm") {
+        setConsentPhaseBeforePreferences(current);
+      }
+      return "preferences";
+    });
+  };
+
+  const onBackFromPreferences = () => setPhase(consentPhaseBeforePreferences);
+
+  const applyPreferences = async () => {
+    track("button_clicked", {
+      button: "analytics_consent_preferences_confirm",
+      page: ANALYTICS_CONSENT_DIALOG_PAGE,
+    });
+    dispatch(setShareAnalytics(draftShareAnalytics));
+    dispatch(setSharePersonalizedRecommendations(draftSharePersonalized));
+    await persistAnalyticsConsentAck();
     handleCloseDialog();
-    navigate("/settings/display");
-  }, [navigate, handleCloseDialog]);
+  };
 
   const isDialogOpen = phase !== "closed";
 
   return {
     phase,
     isDialogOpen,
-    title,
     descriptionLead,
     privacyPolicyUrl,
     onOpenPrivacyPolicy,
@@ -168,5 +188,11 @@ export function useAnalyticsConsentDialogViewModel() {
     applyOptIn,
     applyOptOut,
     onSetPreferences,
+    onBackFromPreferences,
+    draftShareAnalytics,
+    draftSharePersonalized,
+    setDraftShareAnalytics,
+    setDraftSharePersonalized,
+    applyPreferences,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/index.tsx
@@ -13,3 +13,4 @@ export {
   ANALYTICS_CONSENT_DIALOG_PAGE,
   useAnalyticsConsentDialogViewModel,
 } from "./hooks/useAnalyticsConsentDialogViewModel";
+export type { AnalyticsConsentDialogPhase } from "./types";

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/screens/AnalyticsConsentDialogView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/screens/AnalyticsConsentDialogView.tsx
@@ -1,19 +1,19 @@
 import React from "react";
 import { Dialog, DialogBody, DialogContent } from "@ledgerhq/lumen-ui-react";
 import TrackPage from "~/renderer/analytics/TrackPage";
-import type { AnalyticsConsentPhase } from "@ledgerhq/live-common/analyticsConsentUtils";
+import type { AnalyticsConsentDialogPhase } from "../types";
 import { AnalyticsConsentDialogCopyBlock } from "../components/AnalyticsConsentDialogCopyBlock";
 import { AnalyticsConsentDialogFooterActions } from "../components/AnalyticsConsentDialogFooterActions";
 import { AnalyticsConsentDialogIllustration } from "../components/AnalyticsConsentDialogIllustration";
 import { ConsentFooter } from "../components/ConsentFooter";
+import { AnalyticsConsentPreferencesView } from "./AnalyticsConsentPreferencesView";
 
 const sheetTopGlowClassName =
   "pointer-events-none absolute inset-0 bg-[radial-gradient(43.51%_33.05%_at_50.47%_0.14%,var(--color-light-grey-950-30)_0%,transparent_100%)] dark:bg-[radial-gradient(43.51%_33.05%_at_50.47%_0.14%,var(--color-dark-grey-950-30)_0%,transparent_100%)]";
 
 export type AnalyticsConsentDialogViewProps = Readonly<{
-  phase: AnalyticsConsentPhase;
+  phase: AnalyticsConsentDialogPhase;
   isDialogOpen: boolean;
-  title: string;
   descriptionLead: string | null;
   privacyPolicyUrl: string;
   onOpenPrivacyPolicy: () => void;
@@ -21,12 +21,17 @@ export type AnalyticsConsentDialogViewProps = Readonly<{
   applyOptOut: () => void;
   onPrivacyGotIt: () => void;
   onSetPreferences: () => void;
+  onBackFromPreferences: () => void;
+  draftShareAnalytics: boolean;
+  draftSharePersonalized: boolean;
+  setDraftShareAnalytics: (value: boolean) => void;
+  setDraftSharePersonalized: (value: boolean) => void;
+  applyPreferences: () => void;
 }>;
 
 export function AnalyticsConsentDialogView({
   phase,
   isDialogOpen,
-  title,
   descriptionLead,
   privacyPolicyUrl,
   onOpenPrivacyPolicy,
@@ -34,6 +39,12 @@ export function AnalyticsConsentDialogView({
   applyOptOut,
   onPrivacyGotIt,
   onSetPreferences,
+  onBackFromPreferences,
+  draftShareAnalytics,
+  draftSharePersonalized,
+  setDraftShareAnalytics,
+  setDraftSharePersonalized,
+  applyPreferences,
 }: AnalyticsConsentDialogViewProps) {
   if (!isDialogOpen) {
     return null;
@@ -59,30 +70,44 @@ export function AnalyticsConsentDialogView({
             phase={phase}
             refreshSource={false}
           />
-          <DialogBody className="items-center gap-24 pt-64 pb-16">
-            <AnalyticsConsentDialogIllustration phase={phase} />
-            <AnalyticsConsentDialogCopyBlock
-              phase={phase}
-              title={title}
-              descriptionLead={descriptionLead}
+          {phase === "preferences" ? (
+            <AnalyticsConsentPreferencesView
+              onBackFromPreferences={onBackFromPreferences}
+              draftShareAnalytics={draftShareAnalytics}
+              draftSharePersonalized={draftSharePersonalized}
+              setDraftShareAnalytics={setDraftShareAnalytics}
+              setDraftSharePersonalized={setDraftSharePersonalized}
+              applyPreferences={applyPreferences}
               privacyPolicyUrl={privacyPolicyUrl}
               onOpenPrivacyPolicy={onOpenPrivacyPolicy}
-              onSetPreferences={onSetPreferences}
             />
-          </DialogBody>
-          <AnalyticsConsentDialogFooterActions
-            phase={phase}
-            applyOptIn={applyOptIn}
-            applyOptOut={applyOptOut}
-            onPrivacyGotIt={onPrivacyGotIt}
-          />
-          {phase !== "privacy" && (
-            <div className="shrink-0 px-24 pt-16">
-              <ConsentFooter
-                privacyPolicyUrl={privacyPolicyUrl}
-                onOpenPrivacyPolicy={onOpenPrivacyPolicy}
+          ) : (
+            <>
+              <DialogBody className="items-center gap-24 pt-64 pb-16">
+                <AnalyticsConsentDialogIllustration phase={phase} />
+                <AnalyticsConsentDialogCopyBlock
+                  phase={phase}
+                  descriptionLead={descriptionLead}
+                  privacyPolicyUrl={privacyPolicyUrl}
+                  onOpenPrivacyPolicy={onOpenPrivacyPolicy}
+                  onSetPreferences={onSetPreferences}
+                />
+              </DialogBody>
+              <AnalyticsConsentDialogFooterActions
+                phase={phase}
+                applyOptIn={applyOptIn}
+                applyOptOut={applyOptOut}
+                onPrivacyGotIt={onPrivacyGotIt}
               />
-            </div>
+              {phase !== "privacy" && (
+                <div className="shrink-0 px-24 pt-16">
+                  <ConsentFooter
+                    privacyPolicyUrl={privacyPolicyUrl}
+                    onOpenPrivacyPolicy={onOpenPrivacyPolicy}
+                  />
+                </div>
+              )}
+            </>
           )}
         </div>
       </DialogContent>

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/screens/AnalyticsConsentPreferencesView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/screens/AnalyticsConsentPreferencesView.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { Title as DialogTitle } from "@radix-ui/react-dialog";
+import { useTranslation } from "react-i18next";
+import { Button, DialogBody, DialogFooter, NavBarBackButton } from "@ledgerhq/lumen-ui-react";
+import { AnalyticsConsentPreferenceRow } from "../components/AnalyticsConsentPreferenceRow";
+import { ConsentFooter } from "../components/ConsentFooter";
+
+export type AnalyticsConsentPreferencesViewProps = Readonly<{
+  onBackFromPreferences: () => void;
+  draftShareAnalytics: boolean;
+  draftSharePersonalized: boolean;
+  setDraftShareAnalytics: (value: boolean) => void;
+  setDraftSharePersonalized: (value: boolean) => void;
+  applyPreferences: () => void;
+  privacyPolicyUrl: string;
+  onOpenPrivacyPolicy: () => void;
+}>;
+
+export function AnalyticsConsentPreferencesView({
+  onBackFromPreferences,
+  draftShareAnalytics,
+  draftSharePersonalized,
+  setDraftShareAnalytics,
+  setDraftSharePersonalized,
+  applyPreferences,
+  privacyPolicyUrl,
+  onOpenPrivacyPolicy,
+}: AnalyticsConsentPreferencesViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="w-full">
+      <DialogBody className="flex flex-col items-stretch pb-16 pt-24">
+        <div className="mb-64 flex w-full flex-col items-stretch gap-24 px-8">
+          <div>
+            <NavBarBackButton onClick={onBackFromPreferences} className="-ml-12 mb-8" />
+            <DialogTitle className="heading-3-semi-bold text-base">
+              {t("analyticsConsentModal.setPreferences")}
+            </DialogTitle>
+          </div>
+          <div className="flex w-full flex-col gap-24">
+            <AnalyticsConsentPreferenceRow
+              title={t("analyticsConsentModal.preferences.appPerformance.title")}
+              description={t("analyticsConsentModal.preferences.appPerformance.description")}
+              selected={draftShareAnalytics}
+              onChange={setDraftShareAnalytics}
+            />
+            <AnalyticsConsentPreferenceRow
+              title={t("analyticsConsentModal.preferences.personalizedExperience.title")}
+              description={t(
+                "analyticsConsentModal.preferences.personalizedExperience.description",
+              )}
+              selected={draftSharePersonalized}
+              onChange={setDraftSharePersonalized}
+            />
+          </div>
+        </div>
+      </DialogBody>
+      <DialogFooter className="flex flex-col gap-16 pt-16">
+        <Button appearance="base" isFull size="lg" onClick={applyPreferences}>
+          {t("analyticsConsentModal.preferences.ctaConfirm")}
+        </Button>
+      </DialogFooter>
+      <div className="shrink-0 px-24 pt-16">
+        <ConsentFooter
+          privacyPolicyUrl={privacyPolicyUrl}
+          onOpenPrivacyPolicy={onOpenPrivacyPolicy}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/types.ts
@@ -1,0 +1,4 @@
+import type { AnalyticsConsentPhase } from "@ledgerhq/live-common/analyticsConsentUtils";
+
+/** Desktop-only step: granular toggles after "Set preferences" (not used on mobile). */
+export type AnalyticsConsentDialogPhase = AnalyticsConsentPhase | "preferences";

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7787,6 +7787,17 @@
       "ctaGotIt": "Got it"
     },
     "setPreferences": "Set preferences",
+    "preferences": {
+      "appPerformance": {
+        "title": "App performance",
+        "description": "Enable Ledger to collect app usage to enhance the experience"
+      },
+      "personalizedExperience": {
+        "title": "Personalized experience",
+        "description": "Enable Ledger to collect app usage to provide personalized contents"
+      },
+      "ctaConfirm": "Confirm"
+    },
     "footer": {
       "lead": "You can revoke your consent anytime in settings.",
       "privacyLink": "Privacy policy"

--- a/libs/ledger-live-common/src/analyticsConsentUtils.ts
+++ b/libs/ledger-live-common/src/analyticsConsentUtils.ts
@@ -3,11 +3,7 @@ import { CURRENT_PRIVACY_POLICY_VERSION } from "./privacyConsent";
 /** Ms after `consentDate` to re-prompt; `null`/`Infinity` = never by time. E.g. yearly: `CONSENT_RENEWAL_INTERVAL_MS = 365 * 24 * 60 * 60 * 1000`. */
 export const CONSENT_RENEWAL_INTERVAL_MS: number | null = null;
 
-export type AnalyticsConsentPhase =
-  | "closed"
-  | "privacy"
-  | "consentFresh"
-  | "consentReconfirm";
+export type AnalyticsConsentPhase = "closed" | "privacy" | "consentFresh" | "consentReconfirm";
 
 export function resolveAnalyticsConsentPhase(
   currentPhase: AnalyticsConsentPhase,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Desktop analytics consent modal: **Set preferences** flow (toggles, back, Confirm).
      - Redux `shareAnalytics` / `sharePersonalizedRecommandations` after Confirm.
      - Portfolio integration tests for all four toggle combinations; desktop view-model unit tests updated.

### 📝 Description

**Latest commit** adds an inline **Set preferences** step to the analytics consent modal (instead of only coarse Accept all / Refuse all):

- New modal phase `preferences` (`@ledgerhq/live-common` `AnalyticsConsentModalPhase`).
- Draft toggle state synced from settings when entering the step; **Confirm** dispatches both flags and completes consent metadata like other exits.
- Split **preferences** vs main consent `Dialog` trees; copy and layout aligned with design (Lumen typography / semantic `text-base`).
- English copy under `analyticsConsentModal.preferences.*`; integration coverage for **both on**, **analytics only**, **personalization only**, and **both off**.

**Note:** This branch also contains earlier commits that introduced the analytics opt-in modal MVVM refactor; the tip commit is the Set preferences / granular choices work above.


https://github.com/user-attachments/assets/556d374b-371a-4c1e-a10e-dc615b623f4f

<img width="428" height="576" alt="image" src="https://github.com/user-attachments/assets/37210301-cece-471e-b7b3-f245daf48035" />




### ❓ Context

- **JIRA or GitHub link**: [LIVE-25921](https://ledgerhq.atlassian.net/browse/LIVE-25921)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-25921]: https://ledgerhq.atlassian.net/browse/LIVE-25921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ