### PR TITLE
[LWDM] feat(coin-celo): update mobile UI to support fee currency field

### DIFF
--- a/.changeset/yellow-shirts-teach.md
+++ b/.changeset/yellow-shirts-teach.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-celo": minor
+"live-mobile": minor
+---
+
+Adds support for paying transaction fees in non-native Celo tokens (e.g. USDC, USDT) on the Mobile send flow. Users can now select which token to use for transaction fees, mirroring Celo's native fee abstraction feature.

--- a/apps/ledger-live-mobile/src/components/ValidateOnDevice.test.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateOnDevice.test.tsx
@@ -160,4 +160,122 @@ describe("ValidateOnDevice", () => {
 
     expect(getByTestId("device-validation-scroll-view")).toBeTruthy();
   });
+
+  it("uses fee currency sub-account unit when feeCurrencyAccountId is set", () => {
+    const feeSubAccount = {
+      type: "TokenAccount",
+      id: "fee-sub-account",
+      token: { contractAddress: "0xabc" },
+      currency: { units: [{ code: "USDT", magnitude: 6 }] },
+      balance: new BigNumber(1000),
+      spendableBalance: new BigNumber(1000),
+    } as any;
+
+    const accountWithSub = {
+      ...mockAccount,
+      subAccounts: [feeSubAccount],
+    } as any;
+
+    const statusWithFeeAccount = {
+      ...mockStatus,
+      feeCurrencyAccountId: "fee-sub-account",
+    } as any;
+
+    mockUseDeviceTransactionConfig.mockReturnValue({
+      fields: [{ type: "fees", label: "Fees" }],
+      loading: false,
+    });
+
+    render(
+      <ValidateOnDevice
+        device={mockDevice}
+        account={accountWithSub}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={statusWithFeeAccount}
+      />,
+    );
+
+    expect(mockUseAccountUnit).toHaveBeenCalledWith(feeSubAccount);
+  });
+
+  it("falls back to feesCurrency unit when status does not include feeCurrencyAccountId", () => {
+    // feeCurrencyAccountId is on the transaction but NOT on status — the code
+    // reads from status, so this exercises the default (feesCurrency) path.
+    const feeSubAccount = {
+      type: "TokenAccount",
+      id: "fee-sub-account",
+      token: { contractAddress: "0xabc" },
+      currency: { units: [{ code: "USDT", magnitude: 6 }] },
+      balance: new BigNumber(1000),
+      spendableBalance: new BigNumber(1000),
+    } as any;
+
+    const accountWithSub = {
+      ...mockAccount,
+      subAccounts: [feeSubAccount],
+    } as any;
+
+    const txWithFeeAccount = {
+      ...mockTransaction,
+      feeCurrencyAccountId: "fee-sub-account",
+    } as any;
+
+    mockUseDeviceTransactionConfig.mockReturnValue({
+      fields: [{ type: "fees", label: "Fees" }],
+      loading: false,
+    });
+
+    render(
+      <ValidateOnDevice
+        device={mockDevice}
+        account={accountWithSub}
+        parentAccount={null}
+        transaction={txWithFeeAccount}
+        status={mockStatus}
+      />,
+    );
+
+    // The hook is still called unconditionally, but with mainAccount since
+    // feeCurrencyAccount is null when status.feeCurrencyAccountId is absent.
+    expect(mockUseAccountUnit).toHaveBeenCalledWith(accountWithSub);
+  });
+
+  it("uses feesCurrency unit for accounts with a native feesCurrency (e.g. VeChain → VTHO)", () => {
+    const vthoToken = {
+      id: "vechain/token/vtho",
+      units: [{ code: "VTHO", magnitude: 18 }],
+    } as any;
+
+    const vechainAccount = {
+      ...mockAccount,
+      currency: {
+        family: "vechain",
+        units: [{ code: "VET", magnitude: 18 }],
+      },
+      feesCurrency: vthoToken,
+    } as any;
+
+    mockUseDeviceTransactionConfig.mockReturnValue({
+      fields: [{ type: "fees", label: "Fees" }],
+      loading: false,
+    });
+
+    // No feeCurrencyAccountId on status → should use feesCurrency (VTHO), not VET.
+    const { getByTestId } = render(
+      <ValidateOnDevice
+        device={mockDevice}
+        account={vechainAccount}
+        parentAccount={null}
+        transaction={mockTransaction}
+        status={mockStatus}
+      />,
+    );
+
+    expect(getByTestId("device-validation-scroll-view")).toBeTruthy();
+    // useAccountUnit is called with mainAccount (hook must run unconditionally),
+    // but the displayed unit comes from getFeesUnit(getFeesCurrency(mainAccount))
+    // which resolves to VTHO — not from useAccountUnit's return value.
+    expect(mockUseAccountUnit).toHaveBeenCalledWith(vechainAccount);
+  });
 });

--- a/apps/ledger-live-mobile/src/components/ValidateOnDevice.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateOnDevice.tsx
@@ -4,7 +4,12 @@ import { ScrollView } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import { getMainAccount, getFeesCurrency, getFeesUnit } from "@ledgerhq/live-common/account/index";
+import {
+  findSubAccountById,
+  getFeesCurrency,
+  getFeesUnit,
+  getMainAccount,
+} from "@ledgerhq/live-common/account/index";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 
 import { DeviceTransactionField } from "@ledgerhq/live-common/transaction/index";
@@ -55,8 +60,21 @@ function AmountField({ account, status, field }: FieldComponentProps) {
 function FeesField({ account, parentAccount, status, field }: FieldComponentProps) {
   const mainAccount = getMainAccount(account, parentAccount);
   const { estimatedFees } = status;
-  const currency = getFeesCurrency(mainAccount);
-  const feesUnit = getFeesUnit(currency);
+  const feeCurrencyAccountId = status.feeCurrencyAccountId;
+  const feeCurrencyAccount = feeCurrencyAccountId
+    ? findSubAccountById(mainAccount, feeCurrencyAccountId)
+    : null;
+  // useAccountUnit must be called unconditionally (Rules of Hooks).
+  // Its result is only used when a specific fee sub-account is identified via
+  // feeCurrencyAccountId (e.g. Celo custom fee currencies).
+  const feeCurrencyAccountUnit = useAccountUnit(feeCurrencyAccount ?? mainAccount);
+  // Default: derive the unit from account.feesCurrency so that chains like
+  // VeChain (fees paid in VTHO) are displayed correctly. Only override with
+  // the sub-account unit when status.feeCurrencyAccountId points to one.
+  const feesUnit =
+    feeCurrencyAccount
+      ? feeCurrencyAccountUnit
+      : getFeesUnit(getFeesCurrency(mainAccount));
   return <DataRowUnitValue label={field.label} unit={feesUnit} value={estimatedFees} />;
 }
 

--- a/apps/ledger-live-mobile/src/families/celo/SendRowsFee.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/SendRowsFee.tsx
@@ -1,10 +1,14 @@
 import React, { useCallback } from "react";
 import { View, StyleSheet, Linking } from "react-native";
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountLike, TransactionStatusCommon } from "@ledgerhq/types-live";
 import { Trans } from "~/context/Locale";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import {
+  getAccountCurrency,
+  findSubAccountById,
+  getMainAccount,
+} from "@ledgerhq/live-common/account/index";
 import type { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
-import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import SummaryRow from "~/screens/SendFunds/SummaryRow";
 import LText from "~/components/LText";
@@ -29,6 +33,7 @@ type Props = {
   account: AccountLike;
   parentAccount?: Account | null;
   transaction: Transaction;
+  status?: TransactionStatusCommon;
 } & CompositeScreenProps<
   | StackNavigatorProps<SendFundsNavigatorStackParamList, ScreenName.SendSummary>
   | StackNavigatorProps<SignTransactionNavigatorParamList, ScreenName.SignTransactionSummary>
@@ -41,16 +46,21 @@ type Props = {
   StackNavigatorProps<BaseNavigatorStackParamList>
 >;
 
-export default function CeloFeeRow({ account, parentAccount, transaction }: Props) {
+export default function CeloFeeRow({ account, parentAccount, transaction, status }: Props) {
   const { colors } = useTheme();
   const extraInfoFees = useCallback(() => {
     Linking.openURL(urls.feesMoreInfo);
   }, []);
 
-  const mainAccount = parentAccount ?? account;
-  const fees = (transaction as CeloTransaction).fees;
-  const unit = useAccountUnit(mainAccount);
-  const currency = getAccountCurrency(mainAccount);
+  transaction = transaction as CeloTransaction;
+  const mainAccount = getMainAccount(account, parentAccount);
+  const feeCurrencyAccountId = transaction.feeCurrencyAccountId;
+  const feeCurrencyAccount = feeCurrencyAccountId
+    ? findSubAccountById(mainAccount, feeCurrencyAccountId)
+    : null;
+  const unit = useAccountUnit(feeCurrencyAccount ?? mainAccount);
+  const currency = getAccountCurrency(feeCurrencyAccount ?? mainAccount);
+  const fees = status?.estimatedFees ?? transaction.fees;
 
   return (
     <SummaryRow

--- a/apps/ledger-live-mobile/src/families/celo/SendSelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/SendSelectRecipient.tsx
@@ -1,0 +1,205 @@
+import React, { useCallback, useState } from "react";
+import { TouchableOpacity, StyleSheet, View } from "react-native";
+import BigNumber from "bignumber.js";
+import { useTranslation } from "~/context/Locale";
+import { useTheme } from "@react-navigation/native";
+import { Icons, Text } from "@ledgerhq/native-ui";
+import Circle from "~/components/Circle";
+import QueuedDrawer from "~/components/QueuedDrawer";
+import LText from "~/components/LText";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { findSubAccountById, getMainAccount } from "@ledgerhq/live-common/account/index";
+import {
+  FEE_CURRENCY_BY_CONTRACT,
+  FEE_CURRENCY_OPTIONS,
+} from "@ledgerhq/live-common/families/celo/logic";
+import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
+import type {
+  CeloAccount,
+  Transaction as CeloTransaction,
+} from "@ledgerhq/live-common/families/celo/types";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+
+type Props = {
+  readonly account: Account;
+  readonly parentAccount?: Account | null;
+  readonly transaction: Transaction;
+  readonly setTransaction: (transaction: Transaction) => void;
+};
+
+export function SendRecipientFields({
+  account,
+  parentAccount,
+  transaction,
+  setTransaction,
+}: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const celoTransaction = transaction as CeloTransaction;
+  const mainAccount = getMainAccount(account, parentAccount) as CeloAccount;
+
+  const feeCurrencyAccount = celoTransaction.feeCurrencyAccountId
+    ? findSubAccountById(mainAccount, celoTransaction.feeCurrencyAccountId)
+    : null;
+
+  const selectedName = feeCurrencyAccount
+    ? FEE_CURRENCY_BY_CONTRACT.get(feeCurrencyAccount.token.contractAddress.toLowerCase())?.name ??
+      FEE_CURRENCY_OPTIONS[0].name
+    : FEE_CURRENCY_OPTIONS[0].name;
+
+  // Only supported token sub-accounts
+  const tokenOptions: (TokenAccount & { feeCurrencyName: string })[] = (
+    mainAccount.subAccounts ?? []
+  )
+    .filter((sub): sub is TokenAccount => sub.type === "TokenAccount")
+    .filter(sub => new BigNumber(sub.balance).gt(0))
+    .filter(sub => FEE_CURRENCY_BY_CONTRACT.has(sub.token.contractAddress.toLowerCase()))
+    .map(sub => ({
+      ...sub,
+      feeCurrencyName:
+        FEE_CURRENCY_BY_CONTRACT.get(sub.token.contractAddress.toLowerCase())?.name ??
+        sub.token.name,
+    }));
+
+  const onSelectNative = useCallback(() => {
+    const bridge = getAccountBridge(account, parentAccount);
+    setTransaction(
+      bridge.updateTransaction(transaction, {
+        feeCurrency: null,
+        feeCurrencyUnwrapped: null,
+        feeCurrencyAccountId: null,
+      }),
+    );
+    setDrawerOpen(false);
+  }, [account, parentAccount, transaction, setTransaction]);
+
+  const onSelectToken = useCallback(
+    (tokenAccount: AccountLike) => {
+      if (tokenAccount.type !== "TokenAccount") return;
+      const bridge = getAccountBridge(account, parentAccount);
+      const contractAddress = tokenAccount.token.contractAddress;
+      const matchedOption = FEE_CURRENCY_BY_CONTRACT.get(contractAddress.toLowerCase());
+      if (!matchedOption) {
+        setTransaction(
+          bridge.updateTransaction(transaction, {
+            feeCurrency: null,
+            feeCurrencyUnwrapped: null,
+            feeCurrencyAccountId: null,
+          }),
+        );
+        setDrawerOpen(false);
+        return;
+      }
+
+      const feeCurrency = matchedOption?.adapterAddress ?? matchedOption?.contractAddress ?? null;
+      const feeCurrencyUnwrapped = matchedOption?.contractAddress ?? null;
+
+      setTransaction(
+        bridge.updateTransaction(transaction, {
+          feeCurrency,
+          feeCurrencyUnwrapped,
+          feeCurrencyAccountId: tokenAccount.id,
+        }),
+      );
+      setDrawerOpen(false);
+    },
+    [account, parentAccount, transaction, setTransaction],
+  );
+
+  return (
+    <View style={styles.container}>
+      <LText style={styles.label} color="grey">
+        {t("celo.send.feeCurrency")}
+      </LText>
+      <TouchableOpacity
+        style={[styles.selector, { borderColor: colors.lightGrey }]}
+        onPress={() => setDrawerOpen(true)}
+      >
+        <LText semiBold style={styles.selectorText}>
+          {selectedName}
+        </LText>
+        <Icons.ChevronDown size="S" color="neutral.c70" />
+      </TouchableOpacity>
+
+      <QueuedDrawer
+        title={
+          <Text variant="h4" textTransform="none">
+            {t("celo.send.feeCurrency")}
+          </Text>
+        }
+        isRequestingToBeOpened={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+      >
+        <FeeCurrencyOption
+          label={FEE_CURRENCY_OPTIONS[0].name}
+          selected={!celoTransaction.feeCurrencyAccountId}
+          onPress={onSelectNative}
+        />
+        {tokenOptions.map(tokenAccount => (
+          <FeeCurrencyOption
+            key={tokenAccount.id}
+            label={tokenAccount.feeCurrencyName}
+            selected={celoTransaction.feeCurrencyAccountId === tokenAccount.id}
+            onPress={() => onSelectToken(tokenAccount)}
+          />
+        ))}
+      </QueuedDrawer>
+    </View>
+  );
+}
+
+type OptionProps = {
+  readonly label: string;
+  readonly selected: boolean;
+  readonly onPress: () => void;
+};
+
+function FeeCurrencyOption({ label, selected, onPress }: OptionProps) {
+  return (
+    <TouchableOpacity style={styles.option} onPress={onPress}>
+      <Text fontSize="body" fontWeight="semiBold" color={selected ? "primary.c80" : "neutral.c100"}>
+        {label}
+      </Text>
+      {selected && (
+        <Circle size={24} style={styles.checkIcon}>
+          <Icons.CheckmarkCircleFill size="M" color="primary.c80" />
+        </Circle>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+export default { SendRecipientFields };
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 24,
+  },
+  label: {
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  selector: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  selectorText: {
+    fontSize: 16,
+  },
+  option: {
+    padding: 16,
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  checkIcon: {
+    position: "absolute",
+    right: 0,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/celo/__tests__/SendRowsFee.test.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/__tests__/SendRowsFee.test.tsx
@@ -1,0 +1,245 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import CeloFeeRow from "../SendRowsFee";
+import type { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
+import type { TokenAccount } from "@ledgerhq/types-live";
+
+jest.mock("~/icons/ExternalLink", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { View } = require("react-native");
+  return () => <View testID="external-link-icon" />;
+});
+
+jest.mock("~/components/CurrencyUnitValue", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Text } = require("react-native");
+  return ({ value, unit }: { value: { toNumber: () => number }; unit: { code: string } }) => (
+    <Text>
+      {value.toNumber()} {unit?.code}
+    </Text>
+  );
+});
+
+jest.mock("~/components/CounterValue", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Text } = require("react-native");
+  return ({ value }: { value: { toNumber: () => number } }) => <Text>≈ ${value.toNumber()}</Text>;
+});
+
+jest.mock("LLM/hooks/useAccountUnit", () => ({
+  useAccountUnit: jest.fn().mockReturnValue({
+    name: "CELO",
+    code: "CELO",
+    magnitude: 18,
+  }),
+}));
+
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: (_account: unknown) => _account,
+  getAccountCurrency: jest.fn().mockReturnValue({ id: "celo", name: "Celo", units: [] }),
+  findSubAccountById: (_account: unknown, id: string | null) =>
+    id === "usdc-sub-account-id"
+      ? {
+          type: "TokenAccount",
+          id: "usdc-sub-account-id",
+          token: {
+            contractAddress: "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+            units: [{ name: "USDC", code: "USDC", magnitude: 6 }],
+          },
+        }
+      : null,
+}));
+
+const mockCeloAccount: CeloAccount = {
+  type: "Account",
+  id: "celo-account-id",
+  seedIdentifier: "seed",
+  derivationMode: "",
+  index: 0,
+  freshAddress: "0xabc",
+  freshAddressPath: "44'/52752'/0'/0/0",
+  used: true,
+  balance: { toNumber: () => 1000 } as never,
+  spendableBalance: { toNumber: () => 1000 } as never,
+  creationDate: new Date(),
+  blockHeight: 100000,
+  currency: { id: "celo", family: "celo" } as never,
+  operationsCount: 0,
+  operations: [],
+  pendingOperations: [],
+  lastSyncDate: new Date(),
+  balanceHistoryCache: {
+    HOUR: { latestDate: null, balances: [] },
+    DAY: { latestDate: null, balances: [] },
+    WEEK: { latestDate: null, balances: [] },
+  },
+  swapHistory: [],
+  subAccounts: [],
+  celoResources: {
+    registrationStatus: false,
+    lockedBalance: { toNumber: () => 0 } as never,
+    nonvotingLockedBalance: { toNumber: () => 0 } as never,
+    pendingWithdrawals: null,
+    votes: null,
+    electionAddress: null,
+    lockedGoldAddress: null,
+    maxNumGroupsVotedFor: { toNumber: () => 0 } as never,
+  },
+};
+
+const usdcSubAccount: TokenAccount = {
+  type: "TokenAccount",
+  id: "usdc-sub-account-id",
+  parentId: "celo-account-id",
+  token: {
+    type: "TokenCurrency",
+    id: "celo/erc20/usdc",
+    contractAddress: "0xceba9300f2b948710d2653dd7b07f33a8b32118c",
+    parentCurrency: { id: "celo" } as never,
+    name: "USD Coin",
+    ticker: "USDC",
+    units: [{ name: "USDC", code: "USDC", magnitude: 6 }],
+  } as never,
+  balance: { toNumber: () => 100 } as never,
+  spendableBalance: { toNumber: () => 100 } as never,
+  creationDate: new Date(),
+  operationsCount: 0,
+  operations: [],
+  pendingOperations: [],
+  balanceHistoryCache: {
+    HOUR: { latestDate: null, balances: [] },
+    DAY: { latestDate: null, balances: [] },
+    WEEK: { latestDate: null, balances: [] },
+  },
+  swapHistory: [],
+};
+
+const accountWithSubAccounts: CeloAccount = {
+  ...mockCeloAccount,
+  subAccounts: [usdcSubAccount],
+};
+
+const baseTransaction = {
+  family: "celo" as const,
+  amount: { toNumber: () => 0 } as never,
+  recipient: "",
+  useAllAmount: false,
+  mode: "send" as const,
+  index: null,
+  fees: null,
+  feeCurrency: null,
+  feeCurrencyUnwrapped: null,
+  feeCurrencyAccountId: null,
+};
+
+describe("CeloFeeRow", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders without fees when fees is null", () => {
+    const status = {
+      estimatedFees: { toNumber: () => 0 } as never,
+      errors: {},
+      warnings: {},
+      amount: { toNumber: () => 0 } as never,
+      totalSpent: { toNumber: () => 0 } as never,
+    };
+
+    render(
+      <CeloFeeRow
+        account={mockCeloAccount as never}
+        transaction={baseTransaction as never}
+        status={status as never}
+        navigation={{} as never}
+        route={{} as never}
+      />,
+    );
+
+    // Fee row should render with the fee title
+    expect(screen.getByText("Network fees")).toBeDefined();
+  });
+
+  it("renders the fee amount when fees are present", () => {
+    const transaction = {
+      ...baseTransaction,
+      fees: { toNumber: () => 1000 } as never,
+    };
+    const status = {
+      estimatedFees: { toNumber: () => 1000 } as never,
+      errors: {},
+      warnings: {},
+      amount: { toNumber: () => 0 } as never,
+      totalSpent: { toNumber: () => 1000 } as never,
+    };
+
+    render(
+      <CeloFeeRow
+        account={mockCeloAccount as never}
+        transaction={transaction as never}
+        status={status as never}
+        navigation={{} as never}
+        route={{} as never}
+      />,
+    );
+
+    expect(screen.getByText("Network fees")).toBeDefined();
+    expect(screen.getByText("1000 CELO")).toBeDefined();
+  });
+
+  it("renders fee in the selected fee currency when feeCurrencyAccountId is set", () => {
+    const { useAccountUnit } = jest.requireMock("LLM/hooks/useAccountUnit");
+    useAccountUnit.mockReturnValue({ name: "USDC", code: "USDC", magnitude: 6 });
+
+    const transaction = {
+      ...baseTransaction,
+      fees: { toNumber: () => 500000000000000 } as never,
+      feeCurrencyAccountId: "usdc-sub-account-id",
+    };
+    // status.estimatedFees is already converted to 6 decimals by getTransactionStatus
+    const status = {
+      estimatedFees: { toNumber: () => 500 } as never,
+      errors: {},
+      warnings: {},
+      amount: { toNumber: () => 0 } as never,
+      totalSpent: { toNumber: () => 500 } as never,
+    };
+
+    render(
+      <CeloFeeRow
+        account={accountWithSubAccounts as never}
+        transaction={transaction as never}
+        status={status as never}
+        navigation={{} as never}
+        route={{} as never}
+      />,
+    );
+
+    expect(screen.getByText("Network fees")).toBeDefined();
+    expect(screen.getByText("500 USDC")).toBeDefined();
+  });
+
+  it("renders with parentAccount when provided", () => {
+    const status = {
+      estimatedFees: { toNumber: () => 0 } as never,
+      errors: {},
+      warnings: {},
+      amount: { toNumber: () => 0 } as never,
+      totalSpent: { toNumber: () => 0 } as never,
+    };
+
+    render(
+      <CeloFeeRow
+        account={usdcSubAccount as never}
+        parentAccount={mockCeloAccount as never}
+        transaction={baseTransaction as never}
+        status={status as never}
+        navigation={{} as never}
+        route={{} as never}
+      />,
+    );
+
+    expect(screen.getByText("Network fees")).toBeDefined();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/celo/__tests__/SendSelectRecipient.test.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/__tests__/SendSelectRecipient.test.tsx
@@ -1,0 +1,336 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen } from "@tests/test-renderer";
+import { SendRecipientFields } from "../SendSelectRecipient";
+import type { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
+import type { TokenAccount } from "@ledgerhq/types-live";
+
+const mockSetTransaction = jest.fn();
+const mockUpdateTransaction = jest.fn((_tx: unknown, patch: unknown) => ({
+  ...(_tx as object),
+  ...(patch as object),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  getAccountBridge: jest.fn().mockReturnValue({
+    updateTransaction: (tx: unknown, patch: unknown) => mockUpdateTransaction(tx, patch),
+  }),
+}));
+
+jest.mock("@ledgerhq/live-common/account/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/account/index"),
+  getMainAccount: (_account: unknown, parentAccount: unknown) => parentAccount ?? _account,
+  findSubAccountById: (account: { subAccounts?: { id: string }[] }, id: string | null) =>
+    account.subAccounts?.find(sub => sub.id === id) ?? null,
+}));
+
+const usdcContractAddress = "0xceba9300f2b948710d2653dd7b07f33a8b32118c";
+const unknownContractAddress = "0x0000000000000000000000000000000000000001";
+
+const usdcSubAccount: TokenAccount = {
+  type: "TokenAccount",
+  id: "usdc-sub-account-id",
+  parentId: "celo-account-id",
+  token: {
+    type: "TokenCurrency",
+    id: "celo/erc20/usdc",
+    contractAddress: usdcContractAddress,
+    parentCurrency: { id: "celo" } as never,
+    name: "USD Coin",
+    ticker: "USDC",
+    units: [{ name: "USDC", code: "USDC", magnitude: 6 }],
+  } as never,
+  balance: { toNumber: () => 100 } as never,
+  spendableBalance: { toNumber: () => 100 } as never,
+  creationDate: new Date(),
+  operationsCount: 0,
+  operations: [],
+  pendingOperations: [],
+  balanceHistoryCache: {
+    HOUR: { latestDate: null, balances: [] },
+    DAY: { latestDate: null, balances: [] },
+    WEEK: { latestDate: null, balances: [] },
+  },
+  swapHistory: [],
+};
+
+// Sub-account with a real BigNumber balance so it passes the `new BigNumber(balance).gt(0)` filter
+const usdcSubAccountWithBalance: TokenAccount = {
+  ...usdcSubAccount,
+  balance: new BigNumber(100) as never,
+  spendableBalance: new BigNumber(100) as never,
+};
+
+// Sub-account whose contract address is NOT in FEE_CURRENCY_BY_CONTRACT
+const unknownTokenSubAccount: TokenAccount = {
+  ...usdcSubAccount,
+  id: "unknown-sub-account-id",
+  token: {
+    ...usdcSubAccount.token,
+    contractAddress: unknownContractAddress,
+    name: "Unknown Token",
+    ticker: "UNK",
+  } as never,
+  balance: new BigNumber(100) as never,
+  spendableBalance: new BigNumber(100) as never,
+};
+
+const mockCeloAccount: CeloAccount = {
+  type: "Account",
+  id: "celo-account-id",
+  seedIdentifier: "seed",
+  derivationMode: "",
+  index: 0,
+  freshAddress: "0xabc",
+  freshAddressPath: "44'/52752'/0'/0/0",
+  used: true,
+  balance: { toNumber: () => 1000 } as never,
+  spendableBalance: { toNumber: () => 1000 } as never,
+  creationDate: new Date(),
+  blockHeight: 100000,
+  currency: { id: "celo", family: "celo" } as never,
+  operationsCount: 0,
+  operations: [],
+  pendingOperations: [],
+  lastSyncDate: new Date(),
+  balanceHistoryCache: {
+    HOUR: { latestDate: null, balances: [] },
+    DAY: { latestDate: null, balances: [] },
+    WEEK: { latestDate: null, balances: [] },
+  },
+  swapHistory: [],
+  subAccounts: [usdcSubAccount],
+  celoResources: {
+    registrationStatus: false,
+    lockedBalance: { toNumber: () => 0 } as never,
+    nonvotingLockedBalance: { toNumber: () => 0 } as never,
+    pendingWithdrawals: null,
+    votes: null,
+    electionAddress: null,
+    lockedGoldAddress: null,
+    maxNumGroupsVotedFor: { toNumber: () => 0 } as never,
+  },
+};
+
+const baseTransaction = {
+  family: "celo" as const,
+  amount: { toNumber: () => 0 } as never,
+  recipient: "",
+  useAllAmount: false,
+  mode: "send" as const,
+  index: null,
+  fees: null,
+  feeCurrency: null,
+  feeCurrencyUnwrapped: null,
+  feeCurrencyAccountId: null,
+};
+
+describe("SendRecipientFields", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the fee currency selector with CELO selected by default", () => {
+    render(
+      <SendRecipientFields
+        account={mockCeloAccount as never}
+        transaction={baseTransaction as never}
+        setTransaction={mockSetTransaction}
+      />,
+    );
+
+    expect(screen.getByText("CELO")).toBeDefined();
+  });
+
+  it("shows USDC as selected fee currency when feeCurrencyAccountId matches USDC sub-account", () => {
+    const transaction = {
+      ...baseTransaction,
+      feeCurrencyAccountId: "usdc-sub-account-id",
+    };
+
+    render(
+      <SendRecipientFields
+        account={mockCeloAccount as never}
+        transaction={transaction as never}
+        setTransaction={mockSetTransaction}
+      />,
+    );
+
+    expect(screen.getByText("USDC")).toBeDefined();
+  });
+
+  it("opens the drawer when the fee currency selector is pressed", async () => {
+    const { user } = render(
+      <SendRecipientFields
+        account={mockCeloAccount as never}
+        transaction={baseTransaction as never}
+        setTransaction={mockSetTransaction}
+      />,
+    );
+
+    // Press the selector to open the drawer
+    await user.press(screen.getByText("CELO"));
+
+    // After opening the drawer, CELO should appear as an option in the list
+    const celoTexts = screen.getAllByText("CELO");
+    expect(celoTexts.length).toBeGreaterThan(0);
+  });
+
+  it("calls setTransaction with null fee currency when native CELO is selected from drawer", async () => {
+    const transactionWithUsdc = {
+      ...baseTransaction,
+      feeCurrencyAccountId: "usdc-sub-account-id",
+    };
+
+    const { user } = render(
+      <SendRecipientFields
+        account={mockCeloAccount as never}
+        transaction={transactionWithUsdc as never}
+        setTransaction={mockSetTransaction}
+      />,
+    );
+
+    // Open the drawer
+    await user.press(screen.getByText("USDC"));
+
+    // Select native CELO (first CELO in the list is the selector, second is in the drawer)
+    const celoOptions = screen.getAllByText("CELO");
+    await user.press(celoOptions[celoOptions.length - 1]);
+
+    expect(mockSetTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feeCurrency: null,
+        feeCurrencyUnwrapped: null,
+        feeCurrencyAccountId: null,
+      }),
+    );
+  });
+
+  it("renders without sub-accounts when account has no token sub-accounts", () => {
+    const accountWithoutTokens: CeloAccount = {
+      ...mockCeloAccount,
+      subAccounts: [],
+    };
+
+    render(
+      <SendRecipientFields
+        account={accountWithoutTokens as never}
+        transaction={baseTransaction as never}
+        setTransaction={mockSetTransaction}
+      />,
+    );
+
+    expect(screen.getByText("CELO")).toBeDefined();
+  });
+
+  it("renders USDC as an option in the drawer when sub-account has positive balance", async () => {
+    const accountWithBalance: CeloAccount = {
+      ...mockCeloAccount,
+      subAccounts: [usdcSubAccountWithBalance],
+    };
+
+    const { user } = render(
+      <SendRecipientFields
+        account={accountWithBalance as never}
+        transaction={baseTransaction as never}
+        setTransaction={mockSetTransaction}
+      />,
+    );
+
+    await user.press(screen.getByText("CELO"));
+
+    const usdcOptions = screen.getAllByText("USDC");
+    expect(usdcOptions.length).toBeGreaterThan(0);
+  });
+
+  it("calls setTransaction with USDC fee currency when USDC is selected from drawer", async () => {
+    const accountWithBalance: CeloAccount = {
+      ...mockCeloAccount,
+      subAccounts: [usdcSubAccountWithBalance],
+    };
+
+    const { user } = render(
+      <SendRecipientFields
+        account={accountWithBalance as never}
+        transaction={baseTransaction as never}
+        setTransaction={mockSetTransaction}
+      />,
+    );
+
+    await user.press(screen.getByText("CELO"));
+    await user.press(screen.getAllByText("USDC")[0]);
+
+    expect(mockSetTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feeCurrencyAccountId: "usdc-sub-account-id",
+        feeCurrency: expect.any(String),
+        feeCurrencyUnwrapped: expect.any(String),
+      }),
+    );
+  });
+
+  it("filters out sub-accounts with zero balance from token options in drawer", async () => {
+    const zeroBalanceSubAccount: TokenAccount = {
+      ...usdcSubAccount,
+      balance: new BigNumber(0) as never,
+      spendableBalance: new BigNumber(0) as never,
+    };
+    const accountWithZeroBalance: CeloAccount = {
+      ...mockCeloAccount,
+      subAccounts: [zeroBalanceSubAccount],
+    };
+
+    const { user } = render(
+      <SendRecipientFields
+        account={accountWithZeroBalance as never}
+        transaction={baseTransaction as never}
+        setTransaction={mockSetTransaction}
+      />,
+    );
+
+    await user.press(screen.getByText("CELO"));
+
+    // USDC should not appear as a selectable option since balance is 0
+    expect(screen.queryAllByText("USDC").length).toBe(0);
+  });
+
+  it("falls back to CELO name when feeCurrencyAccountId points to sub-account with unknown contract", () => {
+    const accountWithUnknown: CeloAccount = {
+      ...mockCeloAccount,
+      subAccounts: [unknownTokenSubAccount],
+    };
+    const transaction = {
+      ...baseTransaction,
+      feeCurrencyAccountId: "unknown-sub-account-id",
+    };
+
+    render(
+      <SendRecipientFields
+        account={accountWithUnknown as never}
+        transaction={transaction as never}
+        setTransaction={mockSetTransaction}
+      />,
+    );
+
+    // selectedName falls back to FEE_CURRENCY_OPTIONS[0].name which is "CELO"
+    expect(screen.getByText("CELO")).toBeDefined();
+  });
+
+  it("renders with parentAccount provided", () => {
+    const parentAccount: CeloAccount = {
+      ...mockCeloAccount,
+      id: "parent-account-id",
+    };
+
+    render(
+      <SendRecipientFields
+        account={mockCeloAccount as never}
+        parentAccount={parentAccount as never}
+        transaction={baseTransaction as never}
+        setTransaction={mockSetTransaction}
+      />,
+    );
+
+    expect(screen.getByText("CELO")).toBeDefined();
+  });
+});

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -5812,6 +5812,9 @@
     "alerts": {
       "withdrawableAssets": "You have a withdrawable balance.",
       "activatableVotes": "You have votes that can now be activated."
+    },
+    "send": {
+      "feeCurrency": "Fee currency"
     }
   },
   "cosmos": {

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -242,6 +242,8 @@ export default function SendSelectRecipient({ route }: Props) {
     specific && "StepRecipientCustomAlert" in specific ? specific.StepRecipientCustomAlert : null;
   const customSendRecipientCanNext =
     specific && "sendRecipientCanNext" in specific ? specific.sendRecipientCanNext : null;
+  const SendRecipientFields =
+    specific && "SendRecipientFields" in specific ? specific.SendRecipientFields : null;
 
   const customValidationSuccess = customSendRecipientCanNext?.(status) ?? true;
   const isContinueDisabled =
@@ -362,6 +364,15 @@ export default function SendSelectRecipient({ route }: Props) {
                 transaction={transaction}
                 warning={warning}
                 error={error}
+              />
+            )}
+
+            {SendRecipientFields && (
+              <SendRecipientFields
+                transaction={transaction}
+                account={mainAccount}
+                parentAccount={parentAccount}
+                setTransaction={setTransaction}
               />
             )}
 

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/getTransactionStatus.test.ts
@@ -458,6 +458,7 @@ describe("getTransactionStatus", () => {
     // When sending USDT and paying with USDC, totalSpent should be just the USDT amount
     expect(transactionStatus.totalSpent).toEqual(amount);
     expect(transactionStatus.estimatedFees).toEqual(feeInUsdc);
+    expect(transactionStatus.feeCurrencyAccountId).toEqual(usdcTokenAccount.id);
   });
 
   it("should return NotEnoughBalance error when fee token balance is insufficient", async () => {

--- a/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
@@ -171,6 +171,7 @@ export const getTransactionStatus: AccountBridge<
         estimatedFees: feesForTotalSpent,
         amount,
         totalSpent,
+        feeCurrencyAccountId: transaction.feeCurrencyAccountId,
       };
     }
   }
@@ -181,6 +182,7 @@ export const getTransactionStatus: AccountBridge<
     estimatedFees: feesForTotalSpent,
     amount,
     totalSpent,
+    feeCurrencyAccountId: transaction.feeCurrencyAccountId,
   };
 };
 

--- a/libs/coin-modules/coin-celo/src/constants.ts
+++ b/libs/coin-modules/coin-celo/src/constants.ts
@@ -15,3 +15,50 @@ export const getStableTokenEnum = (tokenTicker: string): StableToken =>
 export const MIN_GAS_FOR_NATIVE_TRANSFER = 21000;
 
 export const MAX_FEES_THRESHOLD_MULTIPLIER = 4;
+
+/**
+ * Celo Fee Abstraction — allowlisted fee currencies.
+ *
+ * Celo's protocol allows users to pay gas in tokens other than the native CELO.
+ * The on-chain allowlist is managed by `FeeCurrencyDirectory.sol`.
+ *
+ * Tokens with fewer than 18 decimals (USDC, USDT) use an **adapter** contract
+ * instead of the token address for `feeCurrency`. The adapter normalizes values
+ * to 18 decimals so the protocol can price gas consistently. For these tokens:
+ *   - `feeCurrency` on the transaction → adapter address
+ *   - `contractAddress` (ERC-20 transfer target) → token address
+ *
+ * Tokens that are natively 18-decimal (cUSD, cEUR, …) do not need an adapter
+ * and use their own token address for both purposes.
+ * This list contains the fee currencies currently supported by the allowlist.
+ *
+ * Reference: https://docs.celo.org/protocol/transaction/eip1559
+ */
+export const FEE_CURRENCY_OPTIONS: {
+  name: string;
+  contractAddress: `0x${string}` | null;
+  adapterAddress: `0x${string}` | null;
+}[] = [
+  {
+    name: "CELO",
+    contractAddress: null,
+    adapterAddress: null,
+  },
+  {
+    name: "USDT",
+    adapterAddress: "0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72",
+    contractAddress: "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e",
+  },
+  {
+    name: "USDC",
+    adapterAddress: "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
+    contractAddress: "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+  },
+] as const;
+
+/** O(1) lookup of fee currency options by contract address. `null` key → native CELO.
+ *  Keys are lowercased for case-insensitive matching against token contract addresses. */
+export const FEE_CURRENCY_BY_CONTRACT: Map<string | null, (typeof FEE_CURRENCY_OPTIONS)[number]> =
+  new Map(
+    FEE_CURRENCY_OPTIONS.map(option => [option.contractAddress?.toLowerCase() ?? null, option]),
+  );

--- a/libs/coin-modules/coin-celo/src/logic.ts
+++ b/libs/coin-modules/coin-celo/src/logic.ts
@@ -12,6 +12,8 @@ import {
 export const PRELOAD_MAX_AGE = 10 * 60 * 1000; // 10 minutes, used for max age in preload strategy
 const LEDGER_BY_FIGMENT_VALIDATOR_GROUP_ADDRESS = "0x0861a61Bf679A30680510EcC238ee43B82C5e843";
 
+export { FEE_CURRENCY_OPTIONS, FEE_CURRENCY_BY_CONTRACT } from "./constants";
+
 export const availablePendingWithdrawals = (account: CeloAccount): CeloPendingWithdrawal[] => {
   const { pendingWithdrawals } = account.celoResources || {};
 

--- a/libs/ledger-wallet-framework/src/serialization/transaction.ts
+++ b/libs/ledger-wallet-framework/src/serialization/transaction.ts
@@ -65,6 +65,7 @@ export const fromTransactionStatusRawCommon = (
   amount: new BigNumber(ts.amount),
   totalSpent: new BigNumber(ts.totalSpent),
   recipientIsReadOnly: ts.recipientIsReadOnly,
+  feeCurrencyAccountId: ts.feeCurrencyAccountId,
 });
 
 export const toTransactionStatusRawCommon = (
@@ -76,4 +77,5 @@ export const toTransactionStatusRawCommon = (
   amount: ts.amount.toString(),
   totalSpent: ts.totalSpent.toString(),
   recipientIsReadOnly: ts.recipientIsReadOnly,
+  feeCurrencyAccountId: ts.feeCurrencyAccountId,
 });

--- a/libs/ledgerjs/packages/types-live/src/transaction.ts
+++ b/libs/ledgerjs/packages/types-live/src/transaction.ts
@@ -162,6 +162,8 @@ export type TransactionStatusCommon = {
   totalSpent: BigNumber;
   // should the recipient be non editable
   recipientIsReadOnly?: boolean | undefined;
+  // Account (sub-account) responsible for paying fees
+  feeCurrencyAccountId?: string | null | undefined;
 };
 /**
  *
@@ -174,6 +176,8 @@ export type TransactionStatusCommonRaw = {
   totalSpent: string;
   useAllAmount?: boolean;
   recipientIsReadOnly?: boolean | undefined;
+  // Account (sub-account) responsible for paying fees
+  feeCurrencyAccountId?: string | null | undefined;
 };
 
 export type TransactionEditType = "cancel" | "speedup";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- UI flows are not yet covered by automated tests; manual QA required. -->
- [x] **Impact of the changes:**
  - Celo transactions now expose a **Fee Currency** selector in the Send flow (recipient step and summary screen).
  - Users with USDC or USDT sub-accounts on Celo will see those tokens as selectable fee currencies; all other users see only native CELO.
  - The transaction summary row for Celo shows the currently selected fee currency and allows editing.
  - QA should focus on: selecting each fee currency option (CELO, USDC, USDT), verifying the correct contract/adapter address is set on the transaction, and confirming the UI reflects the selection properly across the Send, Sign Transaction, and Swap flows.

| Header | Header | Header |
|--------|--------|--------|
| <img width="404" height="865" alt="image" src="https://github.com/user-attachments/assets/8bea0491-6acb-4e0f-8a3f-f52a565c56db" /> | <img width="384" height="848" alt="image" src="https://github.com/user-attachments/assets/722a1ab5-83f0-459e-896d-c0a1c4a21745" /> | <img width="388" height="845" alt="image" src="https://github.com/user-attachments/assets/721c35ed-78a5-4169-af1c-71479853ed08" /> |
| <img width="382" height="853" alt="image" src="https://github.com/user-attachments/assets/80beddf6-0cc6-42c5-81be-b0b441c0486d" /> | <img width="375" height="854" alt="image" src="https://github.com/user-attachments/assets/cc498f3f-88ce-4802-b700-b2c187f900db" /> | Cell | 

### 📝 Description

This PR adds the **fee currency selection UI** for Celo transactions in Ledger Live Mobile, implementing support for [CIP-64 / Celo Fee Abstraction](https://docs.celo.org/protocol/transaction/eip1559).

Celo's protocol allows users to pay gas fees in tokens other than native CELO (currently USDC and USDT via adapter contracts). This PR surfaces that capability in the mobile app UI.

**What was added:**

- **`EditFeeCurrency` screen** (`families/celo/EditFeeCurrency.tsx`): A dedicated screen listing all available fee currency options (native CELO + supported token sub-accounts). Selecting an option updates the transaction's `feeCurrency`, `feeCurrencyUnwrapped`, and `feeCurrencyAccountId` fields and navigates back to the summary.

- **`SendRowsCustom` component** (`families/celo/SendRowsCustom.tsx`): Adds a tappable "Fee currency" row to the Send summary screen, showing the currently selected fee currency and linking to the `EditFeeCurrency` screen.

- **`SendSelectRecipient` fields** (`families/celo/SendSelectRecipient.tsx`): Adds an inline fee currency picker (with a bottom drawer) on the recipient-entry step, so users can select a fee currency before proceeding to summary.

- **`FEE_CURRENCY_OPTIONS` / `FEE_CURRENCY_BY_CONTRACT` constants** (`coin-celo/src/constants.ts`): Defines the on-chain allowlist of supported fee currencies (CELO, USDC, USDT) with their token contract addresses and adapter addresses (needed for tokens with fewer than 18 decimals).

- **Navigator types** updated for `SendFundsNavigator`, `SignTransactionNavigator`, and `SwapNavigator` to include the new `CeloEditFeeCurrency` screen.

- **i18n strings** added for `celo.send.feeCurrency` 

| Fee currency row on summary | Fee currency drawer on recipient step |
| --- | --- |
| _(attach screenshot)_ | _(attach screenshot)_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26967]
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)



[LIVE-26967]: https://ledgerhq.atlassian.net/browse/LIVE-26967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ