### PR TITLE
[LWDM] fix(coin-cosmos): make cryptoFactory resilient to uninitialized coinConfig

### DIFF
--- a/.changeset/fix-coin-cosmos-cryptofactory-coinconfig.md
+++ b/.changeset/fix-coin-cosmos-cryptofactory-coinconfig.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cosmos": minor
+---
+
+fix cryptoFactory crashing when coinConfig is not yet initialized

--- a/libs/coin-modules/coin-cosmos/src/chain/chain.ts
+++ b/libs/coin-modules/coin-cosmos/src/chain/chain.ts
@@ -25,74 +25,79 @@ const cosmosChainParams: { [key: string]: CosmosBase } = {};
 export default function cryptoFactory(currencyId: string): CosmosBase {
   currencyId = currencyId === "osmosis" ? "osmo" : currencyId;
   if (!cosmosChainParams[currencyId]) {
+    let chain: CosmosBase;
     switch (currencyId) {
       case "osmo":
-        cosmosChainParams[currencyId] = new Osmosis();
+        chain = new Osmosis();
         break;
       case "cosmos":
-        cosmosChainParams[currencyId] = new Cosmos();
+        chain = new Cosmos();
         break;
       case "axelar":
-        cosmosChainParams[currencyId] = new Axelar();
+        chain = new Axelar();
         break;
       case "binance_beacon_chain":
-        cosmosChainParams[currencyId] = new BinanceBeaconChain();
+        chain = new BinanceBeaconChain();
         break;
       case "desmos":
-        cosmosChainParams[currencyId] = new Desmos();
+        chain = new Desmos();
         break;
       case "dydx":
-        cosmosChainParams[currencyId] = new Dydx();
+        chain = new Dydx();
         break;
       case "nyx":
-        cosmosChainParams[currencyId] = new Nyx();
+        chain = new Nyx();
         break;
       case "persistence":
-        cosmosChainParams[currencyId] = new Persistence();
+        chain = new Persistence();
         break;
       case "quicksilver":
-        cosmosChainParams[currencyId] = new Quicksilver();
+        chain = new Quicksilver();
         break;
       case "secret_network":
-        cosmosChainParams[currencyId] = new SecretNetwork();
+        chain = new SecretNetwork();
         break;
       case "stargaze":
-        cosmosChainParams[currencyId] = new Stargaze();
+        chain = new Stargaze();
         break;
       case "stride":
-        cosmosChainParams[currencyId] = new Stride();
+        chain = new Stride();
         break;
       case "umee":
-        cosmosChainParams[currencyId] = new Umee();
+        chain = new Umee();
         break;
       case "coreum":
-        cosmosChainParams[currencyId] = new Coreum();
+        chain = new Coreum();
         break;
       case "injective":
-        cosmosChainParams[currencyId] = new Injective();
+        chain = new Injective();
         break;
       case "mantra":
-        cosmosChainParams[currencyId] = new Mantra();
+        chain = new Mantra();
         break;
       case "crypto_org":
-        cosmosChainParams[currencyId] = new CryptoOrg();
+        chain = new CryptoOrg();
         break;
       case "xion":
-        cosmosChainParams[currencyId] = new Xion();
+        chain = new Xion();
         break;
       case "zenrock":
-        cosmosChainParams[currencyId] = new Zenrock();
+        chain = new Zenrock();
         break;
       case "babylon":
-        cosmosChainParams[currencyId] = new Babylon();
+        chain = new Babylon();
         break;
       default:
         throw new Error(`${currencyId} is not supported`);
     }
 
-    const coinConfig = cosmosCoinConfig.getCoinConfig(currencyId);
-    if (coinConfig) {
-      cosmosChainParams[currencyId] = { ...cosmosChainParams[currencyId], ...coinConfig };
+    try {
+      const coinConfig = cosmosCoinConfig.getCoinConfig(currencyId);
+      cosmosChainParams[currencyId] = coinConfig ? ({ ...chain, ...coinConfig } as CosmosBase) : chain;
+    } catch {
+      // coinConfig not yet initialized (bridges not loaded) — return defaults without caching
+      // so enrichment is retried on the next call once bridges are set up
+      return chain;
     }
   }
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The existing `Delegations.test.tsx` desktop unit tests cover the fixed code path.
- [x] **Impact of the changes:**
  - `coin-cosmos` only — `cryptoFactory` no longer throws when called before bridge setup is complete
  - No behaviour change when coinConfig is initialized normally (production hot path unchanged)

### 📝 Description

**Context:** this fix is a prerequisite for #16031 (lazy require() registry — deferred bridge loading). That PR moves family `setup.ts` loading from eager (barrel-file import time) to lazy (first `getCurrencyBridge()` call). This change is needed to unblock it and more broadly to prepare for deferred bridge loading.

**The bug:** `cryptoFactory()` in `chain/chain.ts` is imported directly by the `Delegation` UI component and called on every render. It calls `cosmosCoinConfig.getCoinConfig()`, which throws `MissingCoinConfig` if `setCoinConfig()` has not been called yet. `setCoinConfig()` is only called inside `createBridges()`, which runs when `setup.ts` loads lazily — i.e. on first `getCurrencyBridge("cosmos")`. If the Delegation component renders before any bridge operation (e.g. from persisted store at app start), it crashes.

There is also a secondary caching bug: the previous code wrote to the cache *before* calling `getCoinConfig()`, so after a throw the cache entry was permanently stale and coinConfig enrichment was silently skipped on all subsequent calls.

**Fix:** use a local variable in the `switch` block, wrap `getCoinConfig()` in a try/catch. On success: cache the enriched result as before. On `MissingCoinConfig`: return base chain defaults without caching, so the next call retries enrichment once bridges are loaded.

### ❓ Context

- **JIRA or GitHub link**: #16031