### PR TITLE
[LWD] fix(canton): OnboardModal integration test fix

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/__integrations__/OnboardModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/__integrations__/OnboardModal.integration.test.tsx
@@ -24,7 +24,9 @@ import {
 } from "../__tests__/testUtils";
 
 jest.mock("@ledgerhq/live-common/hw/deviceAccess", () => ({
-  withDevice: jest.fn(() => (job: (transport: unknown) => unknown) => job({})),
+  withDevice: jest.fn(() => (job: (transport: unknown) => unknown) =>
+    job({ decorateAppAPIMethods: jest.fn() }),
+  ),
 }));
 
 jest.mock("~/renderer/extra/Snow", () => ({
@@ -33,26 +35,44 @@ jest.mock("~/renderer/extra/Snow", () => ({
   isSnowTime: () => false,
 }));
 
+jest.mock("@ledgerhq/coin-canton/signer", () => ({
+  __esModule: true,
+  default: jest.fn(
+    () =>
+      (_deviceId: string, { path }: { path: string }) =>
+        Promise.resolve({
+          publicKey: MOCK_CANTON_PUBLIC_KEY_HEX,
+          address: "canton_mock_address_integ",
+          path,
+        }),
+  ),
+}));
+
+jest.mock("@ledgerhq/coin-canton/common-logic/transaction/sign", () => ({
+  __esModule: true,
+  signTransaction: jest.fn().mockResolvedValue({
+    signature: "cc".repeat(66),
+  }),
+}));
+
 jest.mock(
   "@ledgerhq/hw-app-canton",
-  () => {
-    return {
-      __esModule: true,
-      default: jest.fn(() => ({
-        getAppConfiguration: jest.fn().mockResolvedValue({ version: "3.0.0" }),
-        getAddress: jest.fn().mockImplementation((path: string) =>
-          Promise.resolve({
-            publicKey: MOCK_CANTON_PUBLIC_KEY_HEX,
-            address: "canton_mock_address_integ",
-            path,
-          }),
-        ),
-        signTransaction: jest.fn().mockResolvedValue({
-          signature: "cc".repeat(66),
+  () => ({
+    __esModule: true,
+    default: jest.fn(() => ({
+      getAppConfiguration: jest.fn().mockResolvedValue({ version: "3.0.0" }),
+      getAddress: jest.fn().mockImplementation((path: string) =>
+        Promise.resolve({
+          publicKey: MOCK_CANTON_PUBLIC_KEY_HEX,
+          address: "canton_mock_address_integ",
+          path,
         }),
-      })),
-    };
-  },
+      ),
+      signTransaction: jest.fn().mockResolvedValue({
+        signature: "cc".repeat(66),
+      }),
+    })),
+  }),
   { virtual: true },
 );
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** none. fix for the existing integration test

### 📝 Description

The hw-app-canton mock with { virtual: true } never reached LegacySignerCanton, so the real Canton class was used with an empty transport, crashing on transport.decorateAppAPIMethods().

Fix follows the Concordium integration test pattern:
  - Mock coin-canton/signer to intercept getAddress before signerContext
  - Mock coin-canton/common-logic/transaction/sign to intercept signTransaction
  - Provide decorateAppAPIMethods on the mock transport so Canton constructs
  - Keep { virtual: true } hw-app-canton mock for consistency

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
