### PR TITLE
[LWDM] refactor(live-common): lazy-load alpaca coin API and signer modules via require()

### DIFF
--- a/.changeset/alpaca-lazy-require.md
+++ b/.changeset/alpaca-lazy-require.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Lazy-load Alpaca coin API and signer modules on demand via `require()` instead of static imports to avoid evaluating unrelated coin stacks at startup

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/index.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/index.ts
@@ -1,48 +1,32 @@
-import { createApi as createXrpApi } from "@ledgerhq/coin-xrp/api/index";
-import { createApi as createStellarApi } from "@ledgerhq/coin-stellar/api/index";
-import { createApi as createCantonApi } from "@ledgerhq/coin-canton/api/index";
-import { createApi as createTronApi } from "@ledgerhq/coin-tron/api/index";
-import { createApi as createEvmApi } from "@ledgerhq/coin-evm/api/index";
-import { createApi as createTezosApi } from "@ledgerhq/coin-tezos/api/index";
-import { getCurrencyConfiguration } from "../../../config";
-import { getNetworkAlpacaApi } from "./network/network-alpaca";
 import type { AlpacaApi } from "@ledgerhq/coin-module-framework/api/types";
 import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
-import { XrpCoinConfig } from "@ledgerhq/coin-xrp/config";
-import { StellarCoinConfig } from "@ledgerhq/coin-stellar/config";
-import { CantonCoinConfig } from "@ledgerhq/coin-canton/config";
-import { TronCoinConfig } from "@ledgerhq/coin-tron/config";
-import { EvmConfigInfo } from "@ledgerhq/coin-evm/config";
-import { TezosCoinConfig } from "@ledgerhq/coin-tezos/config";
 import { findCryptoCurrencyByNetwork } from "../utils";
+import { getNetworkAlpacaApi } from "./network/network-alpaca";
 
+/**
+ * Lazy-load coin Alpaca API modules so consumers (e.g. wallet-cli EVM-only) do not evaluate
+ * unrelated coin stacks (Tron pulls tronweb/protobuf, which breaks under some Bun runtimes).
+ *
+ * Uses `require()` so the first `lib/` (CJS) build only loads the module for the matched family.
+ * The `lib-es/` build reuses the same source; bundlers / Bun resolve these subpaths on demand.
+ */
+// TODO: we could also use dynamic import here but we need to update everything to async/await where getAlpacaApi is used
 export function getAlpacaApi(network: string, kind: string): AlpacaApi<any> & BridgeApi {
   if (kind === "local") {
     const currency = findCryptoCurrencyByNetwork(network);
     switch (currency?.family) {
       case "xrp":
-        return createXrpApi(getCurrencyConfiguration<XrpCoinConfig>(currency.id)) as AlpacaApi<any> &
-          BridgeApi; // FIXME: createXrpApi returns a strongly typed Api<XrpSender>, fix AlpacaApi<any> & BridgeApi to allow it
+        return require("./local/xrp").createLocalXrpApi(currency.id);
       case "stellar":
-        return createStellarApi(
-          getCurrencyConfiguration<StellarCoinConfig>(currency.id),
-        ) as AlpacaApi<any> & BridgeApi;
+        return require("./local/stellar").createLocalStellarApi(currency.id);
       case "canton":
-        return createCantonApi(
-          getCurrencyConfiguration<CantonCoinConfig>(currency.id),
-        ) as AlpacaApi<any> & BridgeApi;
+        return require("./local/canton").createLocalCantonApi(currency.id);
       case "tron":
-        return createTronApi(getCurrencyConfiguration<TronCoinConfig>(currency.id)) as AlpacaApi<any> &
-          BridgeApi;
+        return require("./local/tron").createLocalTronApi(currency.id);
       case "evm":
-        return createEvmApi(
-          getCurrencyConfiguration<EvmConfigInfo>(currency.id),
-          currency.id,
-        ) as AlpacaApi<any> & BridgeApi;
+        return require("./local/evm").createLocalEvmApi(currency.id);
       case "tezos":
-        return createTezosApi(
-          getCurrencyConfiguration<TezosCoinConfig>(currency.id),
-        ) as AlpacaApi<any> & BridgeApi;
+        return require("./local/tezos").createLocalTezosApi(currency.id);
     }
   }
   return getNetworkAlpacaApi(network) satisfies Partial<AlpacaApi<any> & BridgeApi>;

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/canton.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/canton.ts
@@ -1,0 +1,10 @@
+import { createApi as createCantonApi } from "@ledgerhq/coin-canton/api/index";
+import { CantonCoinConfig } from "@ledgerhq/coin-canton/config";
+import type { AlpacaApi } from "@ledgerhq/coin-module-framework/api/types";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+import { getCurrencyConfiguration } from "../../../../config";
+
+export function createLocalCantonApi(currencyId: string): AlpacaApi<any> & BridgeApi {
+  return createCantonApi(getCurrencyConfiguration<CantonCoinConfig>(currencyId)) as AlpacaApi<any> &
+    BridgeApi;
+}

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/evm.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/evm.ts
@@ -1,0 +1,12 @@
+import { createApi as createEvmApi } from "@ledgerhq/coin-evm/api/index";
+import { EvmConfigInfo } from "@ledgerhq/coin-evm/config";
+import type { AlpacaApi } from "@ledgerhq/coin-module-framework/api/types";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+import { getCurrencyConfiguration } from "../../../../config";
+
+export function createLocalEvmApi(currencyId: string): AlpacaApi<any> & BridgeApi {
+  return createEvmApi(
+    getCurrencyConfiguration<EvmConfigInfo>(currencyId),
+    currencyId,
+  ) as AlpacaApi<any> & BridgeApi;
+}

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/stellar.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/stellar.ts
@@ -1,0 +1,11 @@
+import { createApi as createStellarApi } from "@ledgerhq/coin-stellar/api/index";
+import { StellarCoinConfig } from "@ledgerhq/coin-stellar/config";
+import type { AlpacaApi } from "@ledgerhq/coin-module-framework/api/types";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+import { getCurrencyConfiguration } from "../../../../config";
+
+export function createLocalStellarApi(currencyId: string): AlpacaApi<any> & BridgeApi {
+  return createStellarApi(
+    getCurrencyConfiguration<StellarCoinConfig>(currencyId),
+  ) as AlpacaApi<any> & BridgeApi;
+}

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/tezos.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/tezos.ts
@@ -1,0 +1,10 @@
+import { createApi as createTezosApi } from "@ledgerhq/coin-tezos/api/index";
+import { TezosCoinConfig } from "@ledgerhq/coin-tezos/config";
+import type { AlpacaApi } from "@ledgerhq/coin-module-framework/api/types";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+import { getCurrencyConfiguration } from "../../../../config";
+
+export function createLocalTezosApi(currencyId: string): AlpacaApi<any> & BridgeApi {
+  return createTezosApi(getCurrencyConfiguration<TezosCoinConfig>(currencyId)) as AlpacaApi<any> &
+    BridgeApi;
+}

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/tron.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/tron.ts
@@ -1,0 +1,10 @@
+import { createApi as createTronApi } from "@ledgerhq/coin-tron/api/index";
+import { TronCoinConfig } from "@ledgerhq/coin-tron/config";
+import type { AlpacaApi } from "@ledgerhq/coin-module-framework/api/types";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+import { getCurrencyConfiguration } from "../../../../config";
+
+export function createLocalTronApi(currencyId: string): AlpacaApi<any> & BridgeApi {
+  return createTronApi(getCurrencyConfiguration<TronCoinConfig>(currencyId)) as AlpacaApi<any> &
+    BridgeApi;
+}

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/xrp.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/local/xrp.ts
@@ -1,0 +1,10 @@
+import { createApi as createXrpApi } from "@ledgerhq/coin-xrp/api/index";
+import { XrpCoinConfig } from "@ledgerhq/coin-xrp/config";
+import type { AlpacaApi } from "@ledgerhq/coin-module-framework/api/types";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+import { getCurrencyConfiguration } from "../../../../config";
+
+export function createLocalXrpApi(currencyId: string): AlpacaApi<any> & BridgeApi {
+  return createXrpApi(getCurrencyConfiguration<XrpCoinConfig>(currencyId)) as AlpacaApi<any> &
+    BridgeApi;
+}

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/signer.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/signer.ts
@@ -1,23 +1,23 @@
 import type { AlpacaSigner } from "./types";
-import evmSigner from "./families/evm/signer";
-import xrpSigner from "./families/xrp/signer";
-import stellarSigner from "./families/stellar/signer";
-import tezosSigner from "./families/tezos/signer";
 
+/**
+ * Lazy-load Alpaca signer modules so wallet-cli (EVM-only flows) does not bundle XRP/Stellar/Tezos HW stacks.
+ */
+// TODO: we could also use dynamic import here but we need to update everything to async/await where getSigner is used
 export function getSigner(network: string): AlpacaSigner {
   switch (network) {
     case "ripple":
     case "xrp": {
-      return xrpSigner;
+      return require("./families/xrp/signer").default;
     }
     case "stellar": {
-      return stellarSigner;
+      return require("./families/stellar/signer").default;
     }
     case "tezos": {
-      return tezosSigner;
+      return require("./families/tezos/signer").default;
     }
     case "evm": {
-      return evmSigner;
+      return require("./families/evm/signer").default;
     }
   }
   throw new Error(`signer for ${network} not implemented`);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- Existing unit tests for getAlpacaApi cover all family branches; lazy-loading does not change observable behaviour. -->
- [x] **Impact of the changes:**
  - `live-common` only: no change to public API or runtime behaviour.
  - Each coin module (xrp, stellar, canton, tron, evm, tezos) is now loaded only when the matching family is actually requested, instead of at module evaluation time.
  - No impact on LLD / LLM runtime — bundlers tree-shake these imports already. The fix primarily benefits headless CJS consumers (e.g. `wallet-cli`) where all `require()` calls are evaluated eagerly at startup.

### 📝 Description

`generic-alpaca/alpaca/index.ts` and `generic-alpaca/signer.ts` used to statically import every coin's API factory and hardware signer at the top of the file. This means that simply importing **any** alpaca bridge pulled in the full dependency trees of xrp, stellar, canton, tron, evm and tezos coin packages — including heavy optional deps like `tronweb` / protobuf — even if only one family is ever used at runtime.

This PR replaces those static imports with inline `require()` calls inside each `switch` branch, so a coin module is only evaluated when that family is actually matched. Each factory is extracted to a thin `local/<family>.ts` shim to keep the callsite readable.

```
// before
import { createApi as createTronApi } from "@ledgerhq/coin-tron/api/index";
...
case "tron":
  return createTronApi(getCurrencyConfiguration<TronCoinConfig>(currency.id));

// after
case "tron":
  return require("./local/tron").createLocalTronApi(currency.id);
```

A `TODO` comment is left on both files noting that `dynamic import` would be the cleaner long-term solution once the callers are made async.

### ❓ Context

- **JIRA or GitHub link**: Part of the `feat/wallet-cli` work — prerequisite to land before the wallet-cli bridge PR.
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)