### PR TITLE
[LWDM] feat(common): add myWallet feature flag param to Wallet40 flags

### DIFF
--- a/.changeset/silver-clocks-breathe.md
+++ b/.changeset/silver-clocks-breathe.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/live-common": minor
+"@shared/feature-flags": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add myWallet feature flag param to lwdWallet40 and lwmWallet40 for targeted rollout control of the My Wallet navigation component

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/constants.ts
@@ -14,6 +14,7 @@ export const WALLET_FEATURES_PARAMS = [
   { key: "brazePlacement", label: "Braze Placement (Lumen content banner)" },
   { key: "operationsList", label: "TX History" },
   { key: "aggregatedAssets", label: "Aggregated Assets" },
+  { key: "myWallet", label: "My Wallet" },
 ] as const;
 
 export type WalletFeatureParamKey = (typeof WALLET_FEATURES_PARAMS)[number]["key"];

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Wallet40/useWallet40ViewModel.ts
@@ -17,6 +17,7 @@ export const WALLET_40_PARAMS = [
   { key: "brazePlacement", label: "Braze Placement (ContentBanner)" },
   { key: "operationsList", label: "TX History" },
   { key: "aggregatedAssets", label: "Aggregated Assets" },
+  { key: "myWallet", label: "My Wallet" },
 ] as const;
 
 type WalletFeatureParamKey = (typeof WALLET_40_PARAMS)[number]["key"];

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -824,6 +824,7 @@ export const DEFAULT_FEATURES: Features = {
       brazePlacement: true,
       operationsList: true,
       aggregatedAssets: true,
+      myWallet: true,
     },
   },
   lwdWallet40: {
@@ -842,6 +843,7 @@ export const DEFAULT_FEATURES: Features = {
       operationsList: true,
       brazePlacement: true,
       aggregatedAssets: true,
+      myWallet: true,
     },
   },
   addressPoisoningOperationsFilter: {

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/types.ts
@@ -15,6 +15,7 @@ export type Wallet40Params = {
   readonly brazePlacement?: boolean;
   readonly operationsList?: boolean;
   readonly aggregatedAssets?: boolean;
+  readonly myWallet?: boolean;
 };
 
 export const FEATURE_FLAG_KEYS = {
@@ -54,4 +55,6 @@ export interface WalletFeaturesConfig {
   readonly shouldDisplayOperationsList: boolean;
   /** Whether to show the aggregated assets */
   readonly shouldDisplayAggregatedAssets: boolean;
+  /** Whether to show the My Wallet component */
+  readonly shouldDisplayMyWallet: boolean;
 }

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.test.ts
@@ -49,6 +49,7 @@ const makeConfig = (
   shouldDisplayOnboardingWidget: value,
   shouldDisplayBrazePlacement: value,
   shouldDisplayOperationsList: value,
+  shouldDisplayMyWallet: value,
   shouldDisplayAggregatedAssets: value,
   ...overrides,
 });
@@ -68,6 +69,7 @@ const makeParams = (value: boolean): Wallet40Params => ({
   brazePlacement: value,
   operationsList: value,
   aggregatedAssets: value,
+  myWallet: value,
 });
 
 const DISABLED_CONFIG = makeConfig(false);
@@ -134,6 +136,7 @@ describe("useWalletFeaturesConfig hook", () => {
         ["brazePlacement", { brazePlacement: true }, { shouldDisplayBrazePlacement: true }],
         ["operationsList", { operationsList: true }, { shouldDisplayOperationsList: true }],
         ["aggregatedAssets", { aggregatedAssets: true }, { shouldDisplayAggregatedAssets: true }],
+        ["myWallet", { myWallet: true }, { shouldDisplayMyWallet: true }],
       ])("should return correct config when only %s is enabled", (_, params, expectedOverrides) => {
         const { result } = renderWalletFeaturesConfig(platform, {
           [flagKey]: createFeatureFlag(true, params),

--- a/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
+++ b/libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig.ts
@@ -47,6 +47,7 @@ export const useWalletFeaturesConfig = (platform: WalletPlatform): WalletFeature
       shouldDisplayBrazePlacement: isEnabled && Boolean(params?.brazePlacement),
       shouldDisplayOperationsList: isEnabled && Boolean(params?.operationsList),
       shouldDisplayAggregatedAssets: isEnabled && Boolean(params?.aggregatedAssets),
+      shouldDisplayMyWallet: isEnabled && Boolean(params?.myWallet),
     };
   }, [walletFeatureFlag]);
 };

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -846,6 +846,7 @@ type Feature_Wallet40_Params = {
   assetSection: boolean;
   operationsList: boolean;
   aggregatedAssets: boolean;
+  myWallet: boolean;
   // Specifics
   brazePlacement?: boolean;
   newReceiveDialog?: boolean;

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwdWallet40.ts
@@ -15,6 +15,7 @@ export const lwdWallet40 = flagWith(
     operationsList: z.boolean(),
     brazePlacement: z.boolean().optional(),
     aggregatedAssets: z.boolean(),
+    myWallet: z.boolean(),
   },
   {
     enabled: false,
@@ -31,6 +32,7 @@ export const lwdWallet40 = flagWith(
       operationsList: true,
       brazePlacement: true,
       aggregatedAssets: true,
+      myWallet: true,
     },
   },
 );

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmWallet40.ts
@@ -15,6 +15,7 @@ export const lwmWallet40 = flagWith(
     newReceiveDialog: z.boolean().optional(),
     operationsList: z.boolean(),
     aggregatedAssets: z.boolean(),
+    myWallet: z.boolean(),
     quickActionsCtasVariant: z.boolean().optional(),
     brazePlacement: z.boolean().optional(),
   },
@@ -32,6 +33,7 @@ export const lwmWallet40 = flagWith(
       onboardingWidget: true,
       operationsList: true,
       aggregatedAssets: true,
+      myWallet: true,
     },
   },
 );


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _This change is purely additive (new feature flag param with boolean getter) and does not alter any existing behavior — no test update required at this stage._
- [x] **Impact of the changes:**
  - Feature flag param `myWallet` is available in both `lwdWallet40` (desktop) and `lwmWallet40` (mobile) flags
  - The `shouldDisplayMyWallet` boolean getter is exposed via `useWalletFeaturesConfig` hook (shared between desktop and mobile)
  - Debug toggle visible in the mobile Wallet40 debug screen and the desktop WalletFeatures dev tool

### 📝 Description

As a PM, we need to control the rollout of the new navigation system via Feature Flags, specifically the ability to toggle the "My Wallet" component within that navigation for targeted user segments.

This PR adds the `myWallet: boolean` parameter to both the `lwdWallet40` (desktop) and `lwmWallet40` (mobile) Wallet 4.0 feature flags, following the same pattern established by other Wallet40 params (`assetSection`, `operationsList`, etc.).

The new param is exposed as `shouldDisplayMyWallet` through the shared `useWalletFeaturesConfig` hook, making it immediately usable from any screen on both platforms without further plumbing.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25829](https://ledgerhq.atlassian.net/browse/LIVE-25829)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25829]: https://ledgerhq.atlassian.net/browse/LIVE-25829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ