### PR TITLE
[LWD] fix(desktop): remove extra vertical spacing on portfolio when no banner cards render

### DIFF
--- a/.changeset/cyan-coats-whisper.md
+++ b/.changeset/cyan-coats-whisper.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+remove extra spacing when no content cards

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/index.tsx
@@ -1,5 +1,4 @@
 import React, { memo } from "react";
-import { Box } from "@ledgerhq/react-ui/components/layout/index";
 import RecoverBanner from "~/renderer/components/RecoverBanner/RecoverBanner";
 import PostOnboardingHubBanner from "~/renderer/components/PostOnboardingHub/PostOnboardingHubBanner";
 import ActionContentCards from "~/renderer/screens/dashboard/ActionContentCards";
@@ -17,21 +16,19 @@ export const PortfolioBannerContent = memo(function PortfolioBannerContent() {
   const { isPostOnboardingBannerVisible, isActionCardsVisible, isLNSUpsellBannerVisible } =
     useBannersVisibility();
 
+  if (isPostOnboardingBannerVisible) {
+    return <PostOnboardingHubBanner />;
+  }
+
   return (
-    <Box>
-      {isPostOnboardingBannerVisible ? (
-        <PostOnboardingHubBanner />
+    <RecoverBanner>
+      {isActionCardsVisible ? (
+        <ActionContentCards variant={ABTestingVariants.variantA} />
+      ) : isLNSUpsellBannerVisible ? (
+        <LNSUpsellBanner location="portfolio" />
       ) : (
-        <RecoverBanner>
-          {isActionCardsVisible ? (
-            <ActionContentCards variant={ABTestingVariants.variantA} />
-          ) : isLNSUpsellBannerVisible ? (
-            <LNSUpsellBanner location="portfolio" />
-          ) : (
-            <PortfolioContentCards />
-          )}
-        </RecoverBanner>
+        <PortfolioContentCards />
       )}
-    </Box>
+    </RecoverBanner>
   );
 });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new tests; layout-only change._
- [x] **Impact of the changes:**
      - Portfolio page vertical spacing when no post-onboarding banner, action cards, LNS upsell, or portfolio content cards are shown
      - Banner section that embeds `PortfolioBannerContent` (legacy dashboard)
      - Recover banner and post-onboarding flows when those banners are visible (unchanged)

### 📝 Description

**Problem:** The portfolio column used `gap-32` between flex children. `PortfolioBannerContent` always wrapped its subtree in a `Box`, which stayed a flex item even when inner content (`RecoverBanner` / `PortfolioContentCards`) rendered nothing. That produced an extra gap between the header block and content below (e.g. Market banner).

**Solution:** Remove the `Box` wrapper and return `PostOnboardingHubBanner` directly when the post-onboarding path is active. When the banner area is empty, the subtree no longer reserves a flex slot, so the duplicate vertical gap disappears.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28695](https://ledgerhq.atlassian.net/browse/LIVE-28695)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28695]: https://ledgerhq.atlassian.net/browse/LIVE-28695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ