### PR TITLE
[LWDM] chore(ui): upgrade lumen-ui packages and migrate breaking changes

### DIFF
--- a/.changeset/shaggy-goats-vanish.md
+++ b/.changeset/shaggy-goats-vanish.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Upgrade lumen-ui packages and migrate breaking changes (Spot, fit height)

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/index.tsx
@@ -5,14 +5,14 @@ import { HistoryExportDialogView } from "./HistoryExportDialogView";
 
 function HistoryExportDialogContent({
   setDialogHeight,
-}: Readonly<{ setDialogHeight: (h: "fixed" | "hug") => void }>) {
+}: Readonly<{ setDialogHeight: (h: "fixed" | "fit") => void }>) {
   const vm = useHistoryExportDialogViewModel({ setDialogHeight });
   return <HistoryExportDialogView {...vm} />;
 }
 
 export function HistoryExportDialog({ children }: Readonly<{ children: React.ReactNode }>) {
   const [open, setOpen] = useState(false);
-  const [dialogHeight, setDialogHeight] = useState<"fixed" | "hug">("fixed");
+  const [dialogHeight, setDialogHeight] = useState<"fixed" | "fit">("fixed");
 
   const handleOpenChange = useCallback((next: boolean) => {
     setOpen(next);

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/useHistoryExportDialogViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/useHistoryExportDialogViewModel.ts
@@ -27,7 +27,7 @@ export type HistoryExportDialogViewModel = {
 };
 
 type UseHistoryExportDialogViewModelArgs = {
-  setDialogHeight?: (h: "fixed" | "hug") => void;
+  setDialogHeight?: (h: "fixed" | "fit") => void;
 };
 
 export function useHistoryExportDialogViewModel({
@@ -37,7 +37,7 @@ export function useHistoryExportDialogViewModel({
   const names = useBatchMaybeAccountName(rawAccounts);
   const [checkedIds, setCheckedIds] = useState<string[]>([]);
 
-  const handleResult = useCallback(() => setDialogHeight?.("hug"), [setDialogHeight]);
+  const handleResult = useCallback(() => setDialogHeight?.("fit"), [setDialogHeight]);
 
   const {
     success,

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/PerpsEntryPoint/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/PerpsEntryPoint/index.tsx
@@ -6,7 +6,6 @@ import FeatureToggle from "@ledgerhq/live-common/featureFlags/FeatureToggle";
 import {
   ListItem,
   ListItemLeading,
-  ListItemSpot,
   ListItemContent,
   ListItemTitle,
   ListItemTrailing,
@@ -14,6 +13,7 @@ import {
   Subheader,
   SubheaderRow,
   SubheaderTitle,
+  Spot,
 } from "@ledgerhq/lumen-ui-react";
 import { track } from "~/renderer/analytics/segment";
 import { PORTFOLIO_TRACKING_PAGE_NAME } from "LLD/utils/constants";
@@ -40,7 +40,7 @@ export const PerpsEntryPoint = () => {
         </Subheader>
         <ListItem onClick={handleClick} className="rounded-md bg-surface">
           <ListItemLeading>
-            <ListItemSpot appearance="icon" icon={Infinite} />
+            <Spot appearance="icon" icon={Infinite} />
             <ListItemContent>
               <ListItemTitle>{t("portfolio.perpsEntry.description")}</ListItemTitle>
             </ListItemContent>

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
@@ -34,7 +34,7 @@ export function SendFlowLayout({ isOpen, onClose }: SendFlowLayoutProps) {
 
   const shouldShowStatusGradient =
     state.flowStatus === FLOW_STATUS.ERROR || state.flowStatus === FLOW_STATUS.SUCCESS;
-  const shouldAnimateHeight = dialogHeight === "hug";
+  const shouldAnimateHeight = dialogHeight === "fit";
 
   return (
     <Dialog height={dialogHeight} open={isOpen} onOpenChange={handleDialogOpenChange}>

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/constants.ts
@@ -16,7 +16,7 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
     id: SEND_FLOW_STEP.RECIPIENT,
     canGoBack: true,
     addressInput: true,
-    height: "hug",
+    height: "fit",
   },
   [SEND_FLOW_STEP.RECENT_HISTORY]: {
     id: SEND_FLOW_STEP.RECENT_HISTORY,
@@ -25,13 +25,13 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
     showTitle: false,
     showAvailable: false,
     backTarget: SEND_FLOW_STEP.RECIPIENT,
-    height: "hug",
+    height: "fit",
   },
   [SEND_FLOW_STEP.AMOUNT]: {
     id: SEND_FLOW_STEP.AMOUNT,
     canGoBack: true,
     addressInput: true,
-    height: "hug",
+    height: "fit",
   },
   [SEND_FLOW_STEP.CUSTOM_FEES]: {
     id: SEND_FLOW_STEP.CUSTOM_FEES,
@@ -52,13 +52,13 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
     id: SEND_FLOW_STEP.SIGNATURE,
     canGoBack: false,
     showTitle: false,
-    height: "hug",
+    height: "fit",
   },
   [SEND_FLOW_STEP.CONFIRMATION]: {
     id: SEND_FLOW_STEP.CONFIRMATION,
     canGoBack: false,
     showTitle: false,
-    height: "hug",
+    height: "fit",
   },
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressListItem.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressListItem.tsx
@@ -4,7 +4,7 @@ import {
   ListItemContent,
   ListItemDescription,
   ListItemLeading,
-  ListItemSpot,
+  Spot,
   ListItemTitle,
   ListItemTrailing,
 } from "@ledgerhq/lumen-ui-react";
@@ -53,7 +53,7 @@ export function AddressListItem({
     ? formatRelativeDate(date)
     : formatAddress(address, { prefixLength: 5, suffixLength: 5 });
 
-  const subtitle = disabled || hideDescription ? undefined : (description ?? fallbackDescription);
+  const subtitle = disabled || hideDescription ? undefined : description ?? fallbackDescription;
   const icon = isLedgerAccount ? LedgerLogo : Wallet;
 
   const trailingContent =
@@ -76,7 +76,7 @@ export function AddressListItem({
       })}
     >
       <ListItemLeading>
-        <ListItemSpot appearance="icon" icon={icon} />
+        <Spot appearance="icon" icon={icon} />
         <ListItemContent>
           <ListItemTitle>{title}</ListItemTitle>
           <ListItemDescription>{subtitle}</ListItemDescription>

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/types.ts
@@ -6,7 +6,7 @@ export type SendStepConfig = FlowStepConfig<SendFlowStep> &
   Readonly<{
     addressInput?: boolean;
     showTitle?: boolean;
-    height?: "fixed" | "hug";
+    height?: "fixed" | "fit";
     /**
      * A step that is not in an original order of previous <-> next paradigm
      */

--- a/apps/ledger-live-mobile/src/mvvm/components/device-intent-executor/DeviceContextInitializerComponentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/device-intent-executor/DeviceContextInitializerComponentLWM.tsx
@@ -102,37 +102,44 @@ const DeviceContextInitializerComponentLWM: DeviceContextInitializerComponent = 
     };
   }, [connectionResult, requiredDeviceContext, onContextInitialized, onError]);
 
+  const installPlanLine =
+    daState.status === DeviceActionStatus.Pending && daState.intermediateValue.installPlan
+      ? (() => {
+          const plan = daState.intermediateValue.installPlan;
+          const total = plan.installPlan.length;
+          const percent = Math.round(plan.currentProgress * 100);
+          return `Install plan: ${total} app(s), progress: ${plan.currentIndex}/${total} (${percent}%)`;
+        })()
+      : null;
+
   return (
     <Flex p={4}>
       <Text variant="h5" mb={4}>
-        Initializing device context ({requiredDeviceContext.appName})
+        {"Initializing device context "} ({requiredDeviceContext.appName})
       </Text>
       <Text variant="small" color="neutral.c70" mb={2}>
-        Status: {daState.status}
+        {"Status: "} {daState.status}
       </Text>
       {daState.status === DeviceActionStatus.Pending && (
         <>
           <Text variant="small" color="neutral.c70" mb={1}>
-            User interaction: {daState.intermediateValue.requiredUserInteraction}
+            {"User interaction: "} {daState.intermediateValue.requiredUserInteraction}
           </Text>
-          {daState.intermediateValue.installPlan && (
+          {installPlanLine != null && (
             <Text variant="small" color="neutral.c70" mb={1}>
-              Install plan: {daState.intermediateValue.installPlan.installPlan.length} app(s),
-              progress: {daState.intermediateValue.installPlan.currentIndex}/
-              {daState.intermediateValue.installPlan.installPlan.length} (
-              {Math.round(daState.intermediateValue.installPlan.currentProgress * 100)}%)
+              {installPlanLine}
             </Text>
           )}
         </>
       )}
       {daState.status === DeviceActionStatus.Error && (
         <Text variant="small" color="error.c60">
-          Error: {String(daState.error)}
+          {"Error: "} {String(daState.error)}
         </Text>
       )}
       {daState.status === DeviceActionStatus.Completed && (
         <Text variant="small" color="success.c60">
-          Context initialized
+          {"Context initialized"}
         </Text>
       )}
     </Flex>

--- a/apps/ledger-live-mobile/src/mvvm/components/device-intent-executor/ErrorComponentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/device-intent-executor/ErrorComponentLWM.tsx
@@ -30,13 +30,13 @@ const ErrorComponentLWM: ErrorComponent = ({ error, onRetry }) => (
   <Flex alignItems="center" justifyContent="center" p={6}>
     <Icons.Warning color="error.c60" size="L" />
     <Text variant="h5" textAlign="center" mt={4} mb={2}>
-      Something went wrong
+      {"Something went wrong"}
     </Text>
     <Text variant="body" color="neutral.c70" textAlign="center" mb={6}>
       {formatError(error)}
     </Text>
     <Button type="main" onPress={onRetry}>
-      Retry
+      {"Retry"}
     </Button>
   </Flex>
 );

--- a/apps/ledger-live-mobile/src/mvvm/components/device-intent-executor/InvalidOperationComponentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/device-intent-executor/InvalidOperationComponentLWM.tsx
@@ -27,16 +27,16 @@ const InvalidOperationComponentLWM: InvalidOperationComponent = ({ error, onClos
   <Flex alignItems="center" justifyContent="center" p={6}>
     <Icons.Warning color="error.c60" size="L" />
     <Text variant="h5" textAlign="center" mt={4} mb={2}>
-      Executor entered an invalid state
+      {"Executor entered an invalid state"}
     </Text>
     <Text variant="body" color="neutral.c70" textAlign="center" mb={2}>
-      The flow changed while a job was still running. Close the executor and restart it.
+      {"The flow changed while a job was still running. Close the executor and restart it."}
     </Text>
     <Text variant="body" color="neutral.c70" textAlign="center" mb={6}>
       {formatError(error)}
     </Text>
     <Button type="main" onPress={onClose}>
-      Close Executor
+      {"Close Executor"}
     </Button>
   </Flex>
 );

--- a/apps/ledger-live-mobile/src/mvvm/components/device-intent-executor/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/device-intent-executor/index.tsx
@@ -44,7 +44,7 @@ export function DeviceIntentExecutorLWM<JobState, Input, ExtraProps>(
       preventBackdropClick={!props.cancellableUI}
     >
       <Text variant="h5" mb={4}>
-        Device Intent Executor
+        {"Device Intent Executor"}
       </Text>
       <DeviceIntentExecutor {...props} platformConfig={platformConfig} />
     </QueuedDrawer>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioPerpsEntryPoint/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioPerpsEntryPoint/index.tsx
@@ -9,11 +9,10 @@ import FeatureToggle from "@ledgerhq/live-common/featureFlags/FeatureToggle";
 import {
   ListItem,
   ListItemLeading,
-  ListItemSpot,
+  Spot,
   ListItemContent,
   ListItemTitle,
   ListItemTrailing,
-  ListItemIcon,
   Subheader,
   SubheaderRow,
   SubheaderTitle,
@@ -44,13 +43,13 @@ export const PortfolioPerpsEntryPoint = () => {
       <Flex mb={6} mt={2}>
         <ListItem onPress={handlePress} testID="portfolio-perps-entry-point">
           <ListItemLeading>
-            <ListItemSpot appearance="icon" icon={Infinite} />
+            <Spot appearance="icon" icon={Infinite} />
             <ListItemContent>
               <ListItemTitle>{t("portfolio.perpsEntry.description")}</ListItemTitle>
             </ListItemContent>
           </ListItemLeading>
           <ListItemTrailing>
-            <ListItemIcon icon={ChevronRight} />
+            <ChevronRight size={24} />
           </ListItemTrailing>
         </ListItem>
       </Flex>

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/TransferListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/TransferListItem.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import {
   ListItem,
   ListItemLeading,
-  ListItemSpot,
+  Spot,
   ListItemContent,
   ListItemTitle,
   ListItemDescription,
@@ -22,7 +22,7 @@ const TransferListItem = ({ action }: TransferListItemProps) => {
       accessibilityLabel={action.title}
     >
       <ListItemLeading>
-        <ListItemSpot appearance="icon" icon={action.icon} />
+        <Spot appearance="icon" icon={action.icon} />
         <ListItemContent>
           <ListItemTitle>{action.title}</ListItemTitle>
           {action.description && <ListItemDescription>{action.description}</ListItemDescription>}

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/components/OptionButton.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/components/OptionButton.tsx
@@ -5,7 +5,7 @@ import {
   ListItemContent,
   ListItemTitle,
   ListItemDescription,
-  ListItemSpot,
+  Spot,
   type IconProps,
 } from "@ledgerhq/lumen-ui-rnative";
 
@@ -20,7 +20,7 @@ type Props = {
 export const OptionButton = memo(({ onPress, title, Icon, subtitle, testID }: Props) => (
   <ListItem onPress={onPress} testID={testID} lx={{ marginHorizontal: "-s8" }}>
     <ListItemLeading>
-      <ListItemSpot appearance="icon" icon={Icon} />
+      <Spot appearance="icon" icon={Icon} />
       <ListItemContent>
         <ListItemTitle>{title}</ListItemTitle>
         {subtitle ? <ListItemDescription>{subtitle}</ListItemDescription> : null}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressListItem.tsx
@@ -4,7 +4,7 @@ import {
   ListItemContent,
   ListItemDescription,
   ListItemLeading,
-  ListItemSpot,
+  Spot,
   ListItemTitle,
   ListItemTrailing,
 } from "@ledgerhq/lumen-ui-rnative";
@@ -51,7 +51,7 @@ export function AddressListItem({
     ? formatRelativeDate(date)
     : formatAddress(address, { prefixLength: 5, suffixLength: 5 });
 
-  const subtitle = disabled || hideDescription ? undefined : (description ?? fallbackDescription);
+  const subtitle = disabled || hideDescription ? undefined : description ?? fallbackDescription;
   const icon = isLedgerAccount ? LedgerLogo : Wallet;
 
   const trailingContent =
@@ -67,7 +67,7 @@ export function AddressListItem({
   return (
     <ListItem onPress={disabled ? undefined : onSelect} disabled={disabled}>
       <ListItemLeading>
-        <ListItemSpot appearance="icon" icon={icon} lx={{ marginRight: "s4" }} />
+        <Spot appearance="icon" icon={icon} lx={{ marginRight: "s4" }} />
         <ListItemContent>
           <ListItemTitle typography="body2SemiBold">{title}</ListItemTitle>
           <ListItemDescription typography="body3" ellipsizeMode="middle">

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuBottomSheet.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuBottomSheet.tsx
@@ -5,7 +5,7 @@ import {
   ListItem,
   ListItemContent,
   ListItemLeading,
-  ListItemSpot,
+  Spot,
   ListItemTitle,
 } from "@ledgerhq/lumen-ui-rnative";
 import * as LumenSymbols from "@ledgerhq/lumen-ui-rnative/symbols";
@@ -111,7 +111,7 @@ export function EarnMenuBottomSheet({ navigation }: EarnMenuBottomSheetProps) {
               style={{ marginHorizontal: -8 }}
             >
               <ListItemLeading>
-                {IconComponent && <ListItemSpot appearance="icon" icon={IconComponent} />}
+                {IconComponent && <Spot appearance="icon" icon={IconComponent} />}
                 <ListItemContent>
                   <ListItemTitle>{label}</ListItemTitle>
                 </ListItemContent>

--- a/libs/ledger-live-common/src/flows/send/types.ts
+++ b/libs/ledger-live-common/src/flows/send/types.ts
@@ -19,7 +19,7 @@ export type BaseSendStepConfig = FlowStepConfig<SendFlowStep> &
   Readonly<{
     addressInput?: boolean;
     showTitle?: boolean;
-    height?: "fixed" | "hug";
+    height?: "fixed" | "fit";
   }>;
 
 export type BaseSendFlowConfig = FlowConfig<SendFlowStep, BaseSendStepConfig>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,14 +49,14 @@ catalogs:
       specifier: 1.2.3
       version: 1.2.3
     '@ledgerhq/lumen-design-core':
-      specifier: 0.1.6
-      version: 0.1.6
+      specifier: 0.1.8
+      version: 0.1.8
     '@ledgerhq/lumen-ui-react':
-      specifier: 0.1.14
-      version: 0.1.14
+      specifier: 0.1.16
+      version: 0.1.16
     '@ledgerhq/lumen-ui-rnative':
-      specifier: 0.1.13
-      version: 0.1.13
+      specifier: 0.1.15
+      version: 0.1.15
     '@ledgerhq/speculos-device-controller':
       specifier: 0.2.3
       version: 0.2.3
@@ -534,7 +534,7 @@ importers:
         version: link:tools/create-release-hash
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.6
+        version: 0.1.8
       '@ledgerhq/pnpm-utils':
         specifier: workspace:*
         version: link:tools/pnpm-utils
@@ -944,10 +944,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.6
+        version: 0.1.8
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.14(e3565a5b1275aee5d93efe21059eb47c)
+        version: 0.1.16(e3565a5b1275aee5d93efe21059eb47c)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -1606,10 +1606,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.6
+        version: 0.1.8
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.13(e9e8bc50f9a5e817f1213c4f86e5b15f)
+        version: 0.1.15(de610b228bb347f2f8304dd3982e24ca)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -2822,13 +2822,13 @@ importers:
         version: 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.6
+        version: 0.1.8
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.14(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.16(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.13(1def3a763ff5ee610e12b742abd9c40c)
+        version: 0.1.15(f8ce5420824e17bad25c0a5b925e932d)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -16161,12 +16161,13 @@ packages:
   '@ledgerhq/logs@6.14.0':
     resolution: {integrity: sha512-kJFu1+asWQmU9XlfR1RM3lYR76wuEoPyZvkI/CNjpft78BQr3+MMf3Nu77ABzcKFnhIcmAkOLlDQ6B8L6hDXHA==}
 
-  '@ledgerhq/lumen-design-core@0.1.6':
-    resolution: {integrity: sha512-E27yIKuZb46gURpb+fpIkbvGI0Y7tZaP4gDcwoynEYRcI5eEUhu/v7zEZURJHrz+bf0BOKHb44TFtFCuVVs3ww==}
+  '@ledgerhq/lumen-design-core@0.1.8':
+    resolution: {integrity: sha512-wpiOxnNLGXvZbdzp8pqq645Cw+V1Klew2x6CuLhz4F3MhoQC69U3CHSL2//h36UMswqRm+udGXSJxy7yLKnEqg==}
 
-  '@ledgerhq/lumen-ui-react@0.1.14':
-    resolution: {integrity: sha512-F8oiFqOVg1U8UpSwlei0vgFSEc14Y+vYSFTLl9CnJ/wgNptiJRBzaFRVsrXOJB8SpDqnt5wXDPtrezURqTS5fA==}
+  '@ledgerhq/lumen-ui-react@0.1.16':
+    resolution: {integrity: sha512-PKxtV82Yl7IYKtoPj4Zm8Kc+4Ht5hR+aCCo8lRhODT2oCd4xTjYlNUBafHv7l5jOwO71BYm51hv902hm9hlJ/Q==}
     peerDependencies:
+      '@base-ui/react': ^1.3.0
       '@radix-ui/react-checkbox': ^1.3.2
       '@radix-ui/react-dialog': ^1.1.15
       '@radix-ui/react-dropdown-menu': ^2.1.2
@@ -16181,11 +16182,11 @@ packages:
       react-dom: 19.0.0
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-rnative@0.1.13':
-    resolution: {integrity: sha512-bdaX+/SrEP4i23R8WjW1us/SuzYoJpSbbFUb+mwQYwtcOSUtWP6RzDsz54tTmlaIJQTFvYtbL3D8Pgk0ZnDThw==}
+  '@ledgerhq/lumen-ui-rnative@0.1.15':
+    resolution: {integrity: sha512-L6OOfCz8XzdoVz21kzMkCNs0bTXxMY1yfZ2dnjyNXOAUuxokcRzHj556EAqgUMxyKq77cPG6wt4R53fG6YgwWA==}
     peerDependencies:
       '@gorhom/bottom-sheet': ^5.0.0
-      '@ledgerhq/lumen-design-core': 0.1.6
+      '@ledgerhq/lumen-design-core': 0.1.8
       '@sbaiahmed1/react-native-blur': ^4.5.5
       '@types/react': ^19.0.0
       expo: '>=53.0.0'
@@ -44038,12 +44039,12 @@ snapshots:
 
   '@ledgerhq/logs@6.14.0': {}
 
-  '@ledgerhq/lumen-design-core@0.1.6':
+  '@ledgerhq/lumen-design-core@0.1.8':
     dependencies:
       tailwindcss: 4.1.18
       tslib: 2.6.2
 
-  '@ledgerhq/lumen-ui-react@0.1.14(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.16(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
       '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
       clsx: 2.1.1
@@ -44055,7 +44056,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.14(e3565a5b1275aee5d93efe21059eb47c)':
+  '@ledgerhq/lumen-ui-react@0.1.16(e3565a5b1275aee5d93efe21059eb47c)':
     dependencies:
       '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -44076,26 +44077,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-rnative@0.1.13(1def3a763ff5ee610e12b742abd9c40c)':
-    dependencies:
-      '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      '@ledgerhq/lumen-design-core': 0.1.6
-      '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
-      '@types/react': 19.0.14
-      i18next: 23.10.1
-      react: 19.0.0
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
-      react-native-reanimated: 4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@ledgerhq/lumen-ui-rnative@0.1.13(e9e8bc50f9a5e817f1213c4f86e5b15f)':
+  '@ledgerhq/lumen-ui-rnative@0.1.15(de610b228bb347f2f8304dd3982e24ca)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(beb07f7799bea5989bf46dbe8fcef3d9)
-      '@ledgerhq/lumen-design-core': 0.1.6
+      '@ledgerhq/lumen-design-core': 0.1.8
       '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
       '@sbaiahmed1/react-native-blur': 4.5.5(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@types/react': 19.0.14
@@ -44108,6 +44093,22 @@ snapshots:
       react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.15(f8ce5420824e17bad25c0a5b925e932d)':
+    dependencies:
+      '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.8
+      '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
+      '@types/react': 19.0.14
+      i18next: 23.10.1
+      react: 19.0.0
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
+      react-native-reanimated: 4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - react-dom
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,9 +30,9 @@ catalog:
   "@ledgerhq/signer-utils": 1.1.3
   "@ledgerhq/device-transport-kit-web-hid": 1.2.3
   "@ledgerhq/speculos-device-controller": 0.2.3
-  "@ledgerhq/lumen-design-core": 0.1.6
-  "@ledgerhq/lumen-ui-react": 0.1.14
-  "@ledgerhq/lumen-ui-rnative": 0.1.13
+  "@ledgerhq/lumen-design-core": 0.1.8
+  "@ledgerhq/lumen-ui-react": 0.1.16
+  "@ledgerhq/lumen-ui-rnative": 0.1.15
   # React Native
   react-native: 0.79.7
   "@react-native/assets-registry": 0.79.7


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new logic introduced — this is a dependency upgrade with component renames and prop value changes._
- [x] **Impact of the changes:**
      - Desktop: `PerpsEntryPoint`, `AddressListItem`, `SendFlowLayout`, `HistoryExportDialog`, Send constants/types
      - Mobile: `PortfolioPerpsEntryPoint`, `TransferListItem`, `OptionButton`, `AddressListItem`, `EarnMenuBottomSheet`
      - Common: `send/types.ts` height type update
      - Verify ListItem rendering across all affected screens (Send, Portfolio, Receive, QuickActions, Earn)

### 📝 Description

Upgrades the Lumen UI design system packages to their latest versions:
- `@ledgerhq/lumen-design-core`: 0.1.6 → 0.1.8
- `@ledgerhq/lumen-ui-react`: 0.1.14 → 0.1.16
- `@ledgerhq/lumen-ui-rnative`: 0.1.13 → 0.1.15

Migrates all breaking changes introduced in the new versions:
- **`ListItemSpot` → `Spot`**: component renamed across desktop and mobile
- **`ListItemIcon` removed**: unused import cleaned up in mobile
- **Dialog height `"hug"` → `"fit"`**: prop value renamed in desktop Send flow, History export dialog, and shared types

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28549](https://ledgerhq.atlassian.net/browse/LIVE-28549)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28549]: https://ledgerhq.atlassian.net/browse/LIVE-28549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ