### PR TITLE
[LWM] feat(mobile): show disabled send in quick actions variant without funds

### DIFF
--- a/.changeset/quick-actions-send-disabled.md
+++ b/.changeset/quick-actions-send-disabled.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Show Send quick action as disabled in the CTAs variant when the user has no funds, and use disabled label styling for disabled actions.

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/__integrations__/QuickActionsCtas.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/__integrations__/QuickActionsCtas.integration.test.tsx
@@ -223,12 +223,13 @@ describe("QuickActionsCtas Integration Tests", () => {
     });
 
     describe("No Funds State", () => {
-      it("should display Receive, Swap, Buy buttons (no Send) when variant is enabled without funds", async () => {
+      it("should display Receive, Swap, Buy, Send buttons when variant is enabled without funds", async () => {
         render(<TestQuickActionsWrapper />, {
           overrideInitialState: overrideStateWithoutFundsVariant,
         });
 
-        const { receiveButton, swapButton, buyButton } = await getVariantNoFundsCtaButtons();
+        const { receiveButton, swapButton, buyButton, sendButton } =
+          await getVariantNoFundsCtaButtons();
 
         expect(receiveButton).toBeVisible();
         expect(receiveButton).toHaveTextContent(/receive/i);
@@ -238,17 +239,10 @@ describe("QuickActionsCtas Integration Tests", () => {
 
         expect(buyButton).toBeVisible();
         expect(buyButton).toHaveTextContent(/buy/i);
-      });
 
-      it("should not display Send button when variant is enabled without funds", async () => {
-        render(<TestQuickActionsWrapper />, {
-          overrideInitialState: overrideStateWithoutFundsVariant,
-        });
-
-        await screen.findByTestId(QUICK_ACTIONS_TEST_IDS.ctas.container);
-
-        expect(screen.queryByTestId(QUICK_ACTIONS_TEST_IDS.ctas.send)).toBeNull();
-        expect(screen.queryByTestId(QUICK_ACTIONS_TEST_IDS.ctas.transfer)).toBeNull();
+        expect(sendButton).toBeVisible();
+        expect(sendButton).toBeDisabled();
+        expect(sendButton).toHaveTextContent(/send/i);
       });
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/__integrations__/shared.tsx
@@ -171,6 +171,7 @@ export const getVariantNoFundsCtaButtons = async () => {
     receiveButton: within(container).getByRole("button", { name: /receive/i }),
     swapButton: within(container).getByRole("button", { name: /swap/i }),
     buyButton: within(container).getByRole("button", { name: /buy/i }),
+    sendButton: within(container).getByRole("button", { name: /send/i }),
   };
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/QuickActionsCtasView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/QuickActionsCtasView.tsx
@@ -25,7 +25,11 @@ const QuickActionsCtasView = ({ quickActions, isVariant = false }: QuickActionsC
           {isVariant ? (
             <Text
               typography="body3SemiBold"
-              lx={{ textAlign: "center", color: "base", marginTop: "s2" }}
+              lx={{
+                textAlign: "center",
+                color: action.disabled ? "disabled" : "base",
+                marginTop: "s2",
+              }}
             >
               {action.label}
             </Text>

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
@@ -201,13 +201,13 @@ export const useQuickActionsCtasViewModel = ({
         onPress: handleBuyPress,
         testID: QUICK_ACTIONS_TEST_IDS.ctas.buy,
       },
-      ...(userState === "has_funds"
+      ...(shouldDisplayQuickActionsCtasVariant
         ? [
             {
               id: "send" as const,
               label: t("portfolio.quickActionsCtas.send"),
               icon: ArrowUp,
-              disabled: false,
+              disabled: userState !== "has_funds",
               onPress: handleSendPress,
               testID: QUICK_ACTIONS_TEST_IDS.ctas.send,
             },
@@ -218,6 +218,7 @@ export const useQuickActionsCtasViewModel = ({
       t,
       isExchangeEnabled,
       userState,
+      shouldDisplayQuickActionsCtasVariant,
       handleReceivePress,
       handleSwapPress,
       handleBuyPress,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio **Quick actions** row when the CTAs **variant** is enabled
      - Accounts with **no funds**: Send should appear **disabled** (not hidden); label uses **disabled** text color
      - Accounts **with funds**: Send remains enabled as before

### 📝 Description

**Problem:** With the quick actions CTAs variant enabled, users without funds saw Receive, Swap, and Buy but no Send, which was inconsistent with showing the full set of actions.

**Solution:** When the variant is active, Send is always included in the CTA list. It is **disabled** when `userState !== "has_funds"` instead of being omitted. In `QuickActionsCtasView`, variant labels use the `disabled` text color when the action is disabled.

Integration tests were updated: one scenario now asserts Send is visible and disabled for the no-funds + variant case (replacing the previous test that expected Send to be absent).

https://github.com/user-attachments/assets/8cbfe673-8c91-47b7-af45-9fa444c8277c



### ❓ Context

- **JIRA or GitHub link:** [LIVE-28702](https://ledgerhq.atlassian.net/browse/LIVE-28702)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28702]: https://ledgerhq.atlassian.net/browse/LIVE-28702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ