### PR TITLE
[LWDM] fix: restore possibility to cancel aleo view key share

### DIFF
--- a/.changeset/smart-kangaroos-retire.md
+++ b/.changeset/smart-kangaroos-retire.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix: restore possibility to cancel aleo view key share

--- a/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.test.ts
@@ -1,3 +1,4 @@
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import type Transport from "@ledgerhq/hw-transport";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
@@ -79,6 +80,31 @@ describe("getViewKey", () => {
             { viewKeys: { account1: "key1", account2: "key2" }, completed: 2, total: 2 },
           ]);
           expect(mockViewKeyResolver).toHaveBeenCalledTimes(2);
+          done();
+        },
+        error: done,
+      });
+    });
+
+    it("sets viewKey to null and continues processing when user refuses on device", done => {
+      mockViewKeyResolver
+        .mockRejectedValueOnce(new UserRefusedOnDevice())
+        .mockResolvedValueOnce({ path: mockAccount2.freshAddressPath, viewKey: "key2" });
+
+      const request: Request = {
+        currency: mockCurrency,
+        selectedAccounts: [mockAccount1, mockAccount2],
+      };
+
+      const progressUpdates: ViewKeyProgress[] = [];
+
+      getViewKeyExec(mockTransport, request).subscribe({
+        next: progress => progressUpdates.push(progress),
+        complete: () => {
+          expect(progressUpdates).toEqual([
+            { viewKeys: { account1: null }, completed: 1, total: 2 },
+            { viewKeys: { account1: null, account2: "key2" }, completed: 2, total: 2 },
+          ]);
           done();
         },
         error: done,

--- a/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.ts
+++ b/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.ts
@@ -1,6 +1,7 @@
 import invariant from "invariant";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { catchError, concatMap, defer, from, map, scan, type Observable } from "rxjs";
+import { catchError, concatMap, defer, from, map, of, scan, type Observable } from "rxjs";
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import type { Account } from "@ledgerhq/types-live";
 import type { GetViewKeyOptions } from "@ledgerhq/coin-aleo/signer/getViewKey";
@@ -59,6 +60,10 @@ export const getViewKeyExec = (
           return { accountId: account.id, viewKey };
         }),
         catchError(e => {
+          if (e instanceof UserRefusedOnDevice) {
+            return of({ accountId: account.id, viewKey: null });
+          }
+
           log("hw", `getViewKey ${currency.id} on ${path} FAILED ${String(e)}`);
           throw e;
         }),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Aleo add account flow

### 📝 Description

This PR adds handling for `UserRefusedOnDevice` error when user cancels view key sharing. After the latest device app update, the UI started to show the generic "retry" step instead of simply ignoring the account with "X" icon. Previously it worked because the device app returned empty string on cancellation.

| Before        | After         |
| ------------- | ------------- |
|  <img width="2560" height="1440" alt="aleo-vk-fix-before" src="https://github.com/user-attachments/assets/7e90732f-35b8-4b67-832a-5137439efb04" /> |  <img width="2560" height="1440" alt="aleo-vk-fix-after" src="https://github.com/user-attachments/assets/82d5c16c-bd17-400b-9a52-028348b4c436" />  |


### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-23972

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
