### PR TITLE
[LWM] fix(e2e-mobile): restore typecheck after legacy feature flags bridge removal

### DIFF
--- a/apps/ledger-live-mobile/e2e/bridge/types.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/types.ts
@@ -17,7 +17,7 @@ import { RenameDeviceEvent } from "@ledgerhq/live-common/hw/renameDevice";
 import WebSocket from "ws";
 import type { FeatureId, Feature, PartialFeatures } from "@shared/feature-flags";
 
-type OverrideFeatureFlagPayload = { id: FeatureId; value: Feature | undefined };
+export type OverrideFeatureFlagPayload = { id: FeatureId; value: Feature | undefined };
 
 export type ServerData =
   | {

--- a/e2e/mobile/bridge/server.ts
+++ b/e2e/mobile/bridge/server.ts
@@ -117,6 +117,10 @@ export async function loadConfig(fileName: string, agreed: true = true): Promise
   if (data.accounts?.length) {
     postMessage({ type: "importAccounts", id: uniqueId(), payload: data.accounts });
   }
+
+  if (data.featureFlags?.overrides) {
+    await setFeatureFlags(data.featureFlags.overrides);
+  }
 }
 
 export async function setFeatureFlags(flags: PartialFeatures) {

--- a/e2e/mobile/bridge/server.ts
+++ b/e2e/mobile/bridge/server.ts
@@ -5,12 +5,13 @@ import net from "net";
 import merge from "lodash/merge";
 
 import { NavigatorName } from "../../../apps/ledger-live-mobile/src/const";
-import { MessageData, ServerData } from "../../../apps/ledger-live-mobile/e2e/bridge/types";
 import {
-  SettingsSetOverriddenFeatureFlagsPlayload,
-  SettingsSetOverriddenFeatureFlagPlayload,
-} from "../../../apps/ledger-live-mobile/src/actions/types";
-import { FeatureId } from "@ledgerhq/types-live";
+  MessageData,
+  OverrideFeatureFlagPayload,
+  ServerData,
+} from "../../../apps/ledger-live-mobile/e2e/bridge/types";
+import type { PartialFeatures, FeatureId } from "@shared/feature-flags";
+import { FeatureIdSchema } from "@shared/feature-flags";
 import { log as detoxLog } from "detox";
 import { getSpeculosModel } from "@ledgerhq/live-common/e2e/speculosAppVersion";
 import { v4 as uuid } from "uuid";
@@ -46,11 +47,8 @@ function uniqueId(): string {
   return uuid();
 }
 
-function isFeatureId(
-  key: string,
-  flags: SettingsSetOverriddenFeatureFlagsPlayload,
-): key is FeatureId {
-  return key in flags;
+function isFeatureId(key: string): key is FeatureId {
+  return FeatureIdSchema.safeParse(key).success;
 }
 
 export function init(port = 8099, onConnection?: () => void) {
@@ -121,16 +119,16 @@ export async function loadConfig(fileName: string, agreed: true = true): Promise
   }
 }
 
-export async function setFeatureFlags(flags: SettingsSetOverriddenFeatureFlagsPlayload) {
+export async function setFeatureFlags(flags: PartialFeatures) {
   for (const id in flags) {
-    if (isFeatureId(id, flags)) {
+    if (isFeatureId(id)) {
       setFeatureFlag({ id, value: flags[id] });
     }
   }
   await getFlags();
 }
 
-export async function setFeatureFlag(flag: SettingsSetOverriddenFeatureFlagPlayload) {
+export async function setFeatureFlag(flag: OverrideFeatureFlagPayload) {
   postMessage({ type: "overrideFeatureFlag", id: uniqueId(), payload: flag });
 }
 

--- a/e2e/mobile/package.json
+++ b/e2e/mobile/package.json
@@ -29,6 +29,7 @@
     "@jest/reporters": "catalog:",
     "@jest/types": "^30.2.0",
     "@ledgerhq/devices": "workspace:*",
+    "@shared/feature-flags": "workspace:*",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/ledger-key-ring-protocol": "workspace:^",
     "@ledgerhq/live-common": "workspace:^",

--- a/e2e/mobile/specs/earn/earn.ts
+++ b/e2e/mobile/specs/earn/earn.ts
@@ -17,7 +17,7 @@ const stakeProgramOverride = {
       list: ["ethereum"],
       redirects: {
         "ethereum/erc20/usd__coin": {
-          platform: "earn",
+          platform: "earn" as const,
           name: "Earn - Deposit",
           queryParams: {
             cryptoAssetId: "ethereum/erc20/usd__coin",

--- a/e2e/mobile/tsconfig.json
+++ b/e2e/mobile/tsconfig.json
@@ -13,6 +13,7 @@
       "*": ["./*"],
       "LLM/*": ["../../apps/ledger-live-mobile/src/mvvm/*"],
       "~/*": ["../../apps/ledger-live-mobile/src/*"],
+      "@shared/feature-flags": ["../../shared/feature-flags/src"],
       "@ledgerhq/live-common/e2e/*": ["../../libs/ledger-live-common/src/e2e/*"],
       "@ledgerhq/live-common/lib/e2e/*": ["../../libs/ledger-live-common/src/e2e/*"],
       "@ledgerhq/live-common/hw/index": ["../../libs/ledger-live-common/src/hw/index"],

--- a/e2e/mobile/userdata/1AccountBTC1AccountETHReadOnlyFalse.json
+++ b/e2e/mobile/userdata/1AccountBTC1AccountETHReadOnlyFalse.json
@@ -43,15 +43,7 @@
       "swapProviders": [],
       "showClearCacheBanner": false,
       "starredAccountIds": [],
-      "hasPassword": false,
-      "overriddenFeatureFlags": {
-        "ptxServiceCtaScreens": {
-          "enabled": true
-        },
-        "ptxServiceCtaExchangeDrawer": {
-          "enabled": true
-        }
-      }
+      "hasPassword": false
     },
     "user": {
       "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
@@ -21346,6 +21338,17 @@
         "version": 1
       }
     ],
-    "countervalues": {}
+    "countervalues": {},
+    "featureFlags": {
+      "overrides": {
+        "ptxServiceCtaScreens": {
+          "enabled": true
+        },
+        "ptxServiceCtaExchangeDrawer": {
+          "enabled": true
+        }
+      },
+      "bannerVisible": false
+    }
   }
 }

--- a/e2e/mobile/userdata/EthAccountXrpAccountReadOnlyFalse.json
+++ b/e2e/mobile/userdata/EthAccountXrpAccountReadOnlyFalse.json
@@ -74,8 +74,6 @@
         "acceptedProviders": [],
         "selectableCurrencies": []
       },
-      "overriddenFeatureFlags": {},
-      "featureFlagsButtonVisible": false,
       "vaultSigner": { "enabled": false, "host": "", "token": "", "workspace": "" },
       "supportedCounterValues": [],
       "dismissedContentCards": {},
@@ -3255,6 +3253,10 @@
       "actionsCompleted": { "assetsTransfer": true },
       "lastActionCompleted": "assetsTransfer",
       "postOnboardingInProgress": false
+    },
+    "featureFlags": {
+      "overrides": {},
+      "bannerVisible": false
     }
   }
 }

--- a/e2e/mobile/userdata/speculos-tests-app.json
+++ b/e2e/mobile/userdata/speculos-tests-app.json
@@ -53,8 +53,6 @@
         "acceptedProviders": [],
         "selectableCurrencies": []
       },
-      "overriddenFeatureFlags": {},
-      "featureFlagsButtonVisible": false,
       "vaultSigner": {
         "enabled": false,
         "host": "",
@@ -4136,6 +4134,10 @@
       },
       "lastActionCompleted": "assetsTransfer",
       "postOnboardingInProgress": false
+    },
+    "featureFlags": {
+      "overrides": {},
+      "bannerVisible": false
     }
   }
 }

--- a/e2e/mobile/userdata/swap-history.json
+++ b/e2e/mobile/userdata/swap-history.json
@@ -61,8 +61,6 @@
         "acceptedProviders": [],
         "selectableCurrencies": []
       },
-      "overriddenFeatureFlags": {},
-      "featureFlagsButtonVisible": false,
       "vaultSigner": { "enabled": false, "host": "", "token": "", "workspace": "" },
       "supportedCounterValues": [],
       "dismissedContentCards": {},
@@ -47416,6 +47414,10 @@
         }
       ],
       "hashes": { "ethereum": "595335fd322dd2a4165d02c8247813fdf0161f52" }
+    },
+    "featureFlags": {
+      "overrides": {},
+      "bannerVisible": false
     }
   }
 }

--- a/e2e/mobile/utils/constants.ts
+++ b/e2e/mobile/utils/constants.ts
@@ -9,6 +9,13 @@ export const WALLET_40_FEATURE_FLAGS = {
       graphRework: true,
       quickActionCtas: true,
       mainNavigation: true,
+      tour: true,
+      lazyOnboarding: true,
+      balanceRefreshRework: true,
+      assetSection: true,
+      onboardingWidget: true,
+      operationsList: true,
+      aggregatedAssets: true,
     },
   },
 } as const;

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -11,7 +11,7 @@ import {
   removeSpeculosAndDeregisterKnownSpeculos,
 } from "./speculosUtils";
 import { waitForSpeculosReady } from "@ledgerhq/live-common/e2e/speculosCI";
-import { SettingsSetOverriddenFeatureFlagsPlayload } from "~/actions/types";
+import type { PartialFeatures } from "@shared/feature-flags";
 import { sanitizeError } from "@ledgerhq/live-common/e2e/index";
 
 function checkTestFailed(): void {
@@ -34,7 +34,7 @@ export type InitOptions = {
   }[];
   userdata?: string;
   testedCurrencies?: string[];
-  featureFlags?: SettingsSetOverriddenFeatureFlagsPlayload;
+  featureFlags?: PartialFeatures;
 };
 
 type Entry = {
@@ -316,6 +316,13 @@ export class InitializationManager {
           marketBanner: isWallet40,
           graphRework: isWallet40,
           quickActionCtas: isWallet40,
+          tour: isWallet40,
+          lazyOnboarding: isWallet40,
+          balanceRefreshRework: isWallet40,
+          assetSection: isWallet40,
+          onboardingWidget: isWallet40,
+          operationsList: isWallet40,
+          aggregatedAssets: isWallet40,
         },
       },
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2696,6 +2696,9 @@ importers:
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/types-live
+      '@shared/feature-flags':
+        specifier: workspace:*
+        version: link:../../shared/feature-flags
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The fix itself restores a broken typecheck — CI will now catch future regressions via the `e2e/mobile` typecheck job.
   - E2E Run [Android](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/707ec3c8-fde2-484e-ab22-392160a83b3e/)
- [x] **Impact of the changes:**
  - Fixes `pnpm typecheck` in `e2e/mobile` (was broken since #15904)
  - No runtime behaviour change — types only
  - QA: no manual testing needed, purely a type-level fix

### 📝 Description

PR #15904 removed `SettingsSetOverriddenFeatureFlagPlayload` and `SettingsSetOverriddenFeatureFlagsPlayload` from `apps/ledger-live-mobile/src/actions/types.ts`, but two files in `e2e/mobile` were still importing them:

- `e2e/mobile/bridge/server.ts`
- `e2e/mobile/utils/initUtil.ts`

CI didn't catch it because `e2e/mobile` was not in the turbo-affected scope of that PR (none of its own files were modified).

**Changes:**
- Migrate `apps/ledger-live-mobile/e2e/bridge/types.ts` and `e2e/mobile/bridge/server.ts` to `@shared/feature-flags` types (`PartialFeatures`, `FeatureId`, `Feature`, `FeatureIdSchema`) — matching the pattern applied to `apps/ledger-live-mobile/e2e/bridge/server.ts` in #15904
- Replace `SettingsSetOverriddenFeatureFlagsPlayload` with `PartialFeatures` in `initUtil.ts`
- Add missing `lwmWallet40` params (`tour`, `lazyOnboarding`, `balanceRefreshRework`, `assetSection`, `onboardingWidget`, `operationsList`) in `constants.ts` and `initUtil.ts` — the flag schema grew since these objects were written, making them incompatible with the now-strict `PartialFeatures` type
- Fix `platform` string literal widening in `earn.ts` (`as const`)
- Add `@shared/feature-flags` path alias to `e2e/mobile/tsconfig.json` so the standalone typecheck script resolves the source directly
- Add `@shared/feature-flags` to `e2e/mobile` devDependencies

### ❓ Context

- **JIRA or GitHub link**: Fixes regression introduced by #15904

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)