### PR TITLE
[LWM] feat(mobile): implement My Wallet screen header

### DIFF
--- a/.changeset/twenty-poets-switch.md
+++ b/.changeset/twenty-poets-switch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add new header to My Wallet screen

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/MyWalletScreen.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/MyWalletScreen.integration.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { render, screen, fireEvent } from "@tests/test-renderer";
+import { useMyWalletHeaderViewModel } from "../views/Header/useMyWalletHeaderViewModel";
+import { MyWalletScreen } from "../index";
+
+jest.mock("../views/Header/useMyWalletHeaderViewModel");
+
+const mockedViewModel = jest.mocked(useMyWalletHeaderViewModel);
+
+const mockOnBackPress = jest.fn();
+const mockOnNotificationsPress = jest.fn();
+const mockOnSettingsPress = jest.fn();
+
+function renderScreen(vmOverrides: Partial<ReturnType<typeof useMyWalletHeaderViewModel>> = {}) {
+  mockedViewModel.mockReturnValue({
+    onBackPress: mockOnBackPress,
+    onNotificationsPress: mockOnNotificationsPress,
+    onSettingsPress: mockOnSettingsPress,
+    hasUnreadNotifications: false,
+    ...vmOverrides,
+  });
+  return render(<MyWalletScreen />);
+}
+
+describe("MyWalletScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render the header and handle all button presses", () => {
+    renderScreen();
+
+    expect(screen.getByTestId("my-wallet-header-back-button")).toBeVisible();
+    expect(screen.getByTestId("my-wallet-header-notifications-button")).toBeVisible();
+    expect(screen.getByTestId("my-wallet-header-settings-button")).toBeVisible();
+
+    fireEvent.press(screen.getByTestId("my-wallet-header-back-button"));
+    expect(mockOnBackPress).toHaveBeenCalledTimes(1);
+
+    fireEvent.press(screen.getByTestId("my-wallet-header-notifications-button"));
+    expect(mockOnNotificationsPress).toHaveBeenCalledTimes(1);
+
+    fireEvent.press(screen.getByTestId("my-wallet-header-settings-button"));
+    expect(mockOnSettingsPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render the bell-notification icon when there are unread notifications", () => {
+    renderScreen({ hasUnreadNotifications: true });
+    expect(screen.getByTestId("my-wallet-header-notifications-button")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
@@ -1,11 +1,14 @@
-import { Box } from "@ledgerhq/lumen-ui-rnative";
 import React from "react";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { MyWalletHeader } from "./views/Header";
 
 export function MyWalletScreen() {
+  const { top } = useSafeAreaInsets();
+
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <Box />
-    </SafeAreaView>
+    <Box style={{ paddingTop: top, flex: 1 }}>
+      <MyWalletHeader />
+    </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/__tests__/useMyWalletHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/__tests__/useMyWalletHeaderViewModel.test.ts
@@ -1,0 +1,78 @@
+import { act } from "@testing-library/react-native";
+import { renderHook } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { track } from "~/analytics";
+import { useMyWalletHeaderViewModel } from "../useMyWalletHeaderViewModel";
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate, goBack: mockGoBack }),
+}));
+
+let mockNotificationCards: { id: string; viewed: boolean }[] = [];
+
+jest.mock("~/dynamicContent/useDynamicContent", () => ({
+  __esModule: true,
+  default: () => ({ notificationCards: mockNotificationCards }),
+}));
+
+describe("useMyWalletHeaderViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNotificationCards = [];
+  });
+
+  it("should call navigation.goBack on back press", () => {
+    const { result } = renderHook(() => useMyWalletHeaderViewModel());
+    act(() => result.current.onBackPress());
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("should navigate to NotificationCenter and track event on notifications press", () => {
+    const { result } = renderHook(() => useMyWalletHeaderViewModel());
+    act(() => result.current.onNotificationsPress());
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.NotificationCenter, {
+      screen: ScreenName.NotificationCenter,
+    });
+    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+      button: "Notifications",
+      page: ScreenName.MyWallet,
+    });
+  });
+
+  it("should navigate to Settings and track event on settings press", () => {
+    const { result } = renderHook(() => useMyWalletHeaderViewModel());
+    act(() => result.current.onSettingsPress());
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Settings);
+    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+      button: "Settings",
+      page: ScreenName.MyWallet,
+    });
+  });
+
+  describe("hasUnreadNotifications", () => {
+    it("should return false when no notifications or all are viewed", () => {
+      const { result: emptyResult } = renderHook(() => useMyWalletHeaderViewModel());
+      expect(emptyResult.current.hasUnreadNotifications).toBe(false);
+
+      mockNotificationCards = [
+        { id: "1", viewed: true },
+        { id: "2", viewed: true },
+      ];
+      const { result: allViewedResult } = renderHook(() => useMyWalletHeaderViewModel());
+      expect(allViewedResult.current.hasUnreadNotifications).toBe(false);
+    });
+
+    it("should return true when at least one notification is unread", () => {
+      mockNotificationCards = [
+        { id: "1", viewed: true },
+        { id: "2", viewed: false },
+      ];
+      const { result } = renderHook(() => useMyWalletHeaderViewModel());
+      expect(result.current.hasUnreadNotifications).toBe(true);
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/index.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { IconButton, NavBar, NavBarBackButton, NavBarTrailing } from "@ledgerhq/lumen-ui-rnative";
+import { Bell, BellNotification, Settings } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
+import { useMyWalletHeaderViewModel } from "./useMyWalletHeaderViewModel";
+
+export function MyWalletHeader() {
+  const { t } = useTranslation();
+  const { onBackPress, onNotificationsPress, onSettingsPress, hasUnreadNotifications } =
+    useMyWalletHeaderViewModel();
+
+  const NotificationIcon = hasUnreadNotifications ? BellNotification : Bell;
+
+  return (
+    <NavBar appearance="compact">
+      <NavBarBackButton
+        onPress={onBackPress}
+        accessibilityLabel={t("common.back")}
+        testID="my-wallet-header-back-button"
+      />
+      <NavBarTrailing>
+        <IconButton
+          appearance="no-background"
+          size="md"
+          icon={NotificationIcon}
+          accessibilityLabel={t("notifications.title")}
+          onPress={onNotificationsPress}
+          testID="my-wallet-header-notifications-button"
+        />
+        <IconButton
+          appearance="no-background"
+          size="md"
+          icon={Settings}
+          accessibilityLabel={t("settings.title")}
+          onPress={onSettingsPress}
+          testID="my-wallet-header-settings-button"
+        />
+      </NavBarTrailing>
+    </NavBar>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/useMyWalletHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/useMyWalletHeaderViewModel.ts
@@ -1,0 +1,40 @@
+import { useCallback, useMemo } from "react";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { NavigatorName, ScreenName } from "~/const";
+import { track } from "~/analytics";
+import useDynamicContent from "~/dynamicContent/useDynamicContent";
+
+export function useMyWalletHeaderViewModel() {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<{ [key: string]: object | undefined }>>();
+  const { notificationCards } = useDynamicContent();
+
+  const hasUnreadNotifications = useMemo(
+    () => notificationCards.some(n => !n.viewed),
+    [notificationCards],
+  );
+
+  const onBackPress = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const onNotificationsPress = useCallback(() => {
+    track("menuentry_clicked", { button: "Notifications", page: ScreenName.MyWallet });
+    navigation.navigate(NavigatorName.NotificationCenter, {
+      screen: ScreenName.NotificationCenter,
+    });
+  }, [navigation]);
+
+  const onSettingsPress = useCallback(() => {
+    track("menuentry_clicked", { button: "Settings", page: ScreenName.MyWallet });
+    navigation.navigate(NavigatorName.Settings);
+  }, [navigation]);
+
+  return {
+    onBackPress,
+    onNotificationsPress,
+    onSettingsPress,
+    hasUnreadNotifications,
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio top bar: when `myWallet` FF param is enabled, the leading icon (device icon) navigates to the new My Wallet screen instead of My Ledger
  - My Wallet screen: new NavBar with back button, "My wallet" title, notification bell (with unread indicator), and settings icon
  - Each button navigates to the correct destination (goBack, NotificationCenter, Settings)

### 📝 Description

The `myWallet` feature flag param was previously added to `lwmWallet40` to control rollout of a new navigation entry point. This PR implements the actual My Wallet screen that this entry point leads to.

**What was built:**

- `MyWalletScreen` — wraps a `MyWalletHeader` with safe area insets
- `MyWalletHeader` (in `views/Header/`) — Lumen UI `NavBar` with:
  - `NavBarBackButton` → `navigation.goBack()`
  - `NavBarTitle` → "My wallet"
  - `NavBarTrailing` → notification bell (switches between `Bell` / `BellNotification` based on unread state) + settings icon
- `useMyWalletHeaderViewModel` — navigation callbacks + `hasUnreadNotifications` derived from `useDynamicContent()`
- Unit tests for the view model (navigation, tracking, unread notifications)
- Integration test for the screen (render, button presses, real navigation redirections)

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26346](https://ledgerhq.atlassian.net/browse/LIVE-26346)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26346]: https://ledgerhq.atlassian.net/browse/LIVE-26346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ