### PR TITLE
fix(e2e-mobile): add missing myWallet param to lwmWallet40 flag overrides

### DIFF
--- a/.github/workflows/test-mobile-e2e-lint.yml
+++ b/.github/workflows/test-mobile-e2e-lint.yml
@@ -43,7 +43,7 @@ jobs:
     name: "Mobile E2E Lint & Typecheck"
     needs: determine-affected
     if: >-
-      ${{ !github.event.pull_request.head.repo.fork && contains(needs.determine-affected.outputs.paths, 'e2e/mobile') }}
+      ${{ !github.event.pull_request.head.repo.fork && (contains(needs.determine-affected.outputs.paths, 'e2e/mobile') || contains(needs.determine-affected.outputs.paths, 'apps/ledger-live-mobile')) }}
     runs-on: ubuntu-22.04
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"

--- a/e2e/mobile/utils/constants.ts
+++ b/e2e/mobile/utils/constants.ts
@@ -16,6 +16,7 @@ export const WALLET_40_FEATURE_FLAGS = {
       onboardingWidget: true,
       operationsList: true,
       aggregatedAssets: true,
+      myWallet: true,
     },
   },
 } as const;

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -323,6 +323,7 @@ export class InitializationManager {
           onboardingWidget: isWallet40,
           operationsList: isWallet40,
           aggregatedAssets: isWallet40,
+          myWallet: isWallet40,
         },
       },
     };


### PR DESCRIPTION
## Summary

- PR #16098 added `myWallet: z.boolean()` as a required param to the `lwmWallet40` flag schema in `shared/feature-flags`
- This broke `ledger-live-mobile-e2e-tests:typecheck` for anyone rebasing on `develop` after that PR, because two places in `e2e/mobile` build the full params object without `myWallet`:
  - `WALLET_40_FEATURE_FLAGS` in `e2e/mobile/utils/constants.ts`
  - `defaultFlags` in `e2e/mobile/utils/initUtil.ts`
- Adds `myWallet: true` / `myWallet: isWallet40` to both

## Test plan

- [x] `pnpm --filter ledger-live-mobile-e2e-tests typecheck` passes