### PR TITLE
[LWM] test(mobile): stabilize OperationsList day-section header count

### DIFF
--- a/.changeset/calm-operations-tests-anchor.md
+++ b/.changeset/calm-operations-tests-anchor.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Stabilize OperationsList test by fixing mock operation dates for day-based sections

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { Account } from "@ledgerhq/types-live";
 import { render } from "@tests/test-renderer";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { screen, track } from "~/analytics";
@@ -9,10 +10,24 @@ import { ScreenName } from "~/const/navigation";
 import OperationsList from "../index";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 
-const accountWithOperations = genAccount("operations-list-non-empty", {
-  currency: getCryptoCurrencyById("bitcoin"),
-  operationsSize: 5,
-});
+function withTwoCalendarDaySections(account: Account): Account {
+  const newerDayMs = new Date("2020-06-15T15:00:00.000Z").getTime();
+  const olderDayMs = newerDayMs - 24 * 60 * 60 * 1000;
+  return {
+    ...account,
+    operations: account.operations.map((op, index) => ({
+      ...op,
+      date: new Date(index < 2 ? newerDayMs - index * 60_000 : olderDayMs - (index - 2) * 60_000),
+    })),
+  };
+}
+
+const accountWithOperations = withTwoCalendarDaySections(
+  genAccount("operations-list-non-empty", {
+    currency: getCryptoCurrencyById("bitcoin"),
+    operationsSize: 5,
+  }),
+);
 
 function stateWithAccountsAndOperations(base: State): State {
   return {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Jest / CI stability for Operations History (MVVM OperationsList)
      - No user-facing behavior change

### 📝 Description

**Problem:** `OperationsList` groups transactions with `groupAccountsOperationsByDay`, which buckets by local calendar day. Mock operations from `genAccount` anchor the first operation to `Date.now()`, so the number of day sections (and thus `operations-section-header` nodes) varied with runner time, timezone, and fake timers—making `toHaveLength(2)` flaky.

**Solution:** After `genAccount`, rewrite operation `date` values to two fixed calendar days (2020-06-15 vs 2020-06-14 UTC) while preserving newest-first order, so the list always renders exactly two section headers under test.

### ❓ Context

- **JIRA or GitHub link**: _Add link if applicable_

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)