### PR TITLE
[LWD] fix(lwd): fix padding input new send flow

### DIFF
--- a/.changeset/smooth-coins-explode.md
+++ b/.changeset/smooth-coins-explode.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(lwd): fix padding input custom fees new send flow

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/CustomFeesScreenView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/components/CustomFeesScreenView.tsx
@@ -39,7 +39,7 @@ export function CustomFeesScreenView({
 }: CustomFeesScreenViewProps) {
   return (
     <>
-      <DialogBody className="gap-32 -mt-12">
+      <DialogBody className="gap-32 -mt-12 pt-2">
         {hasCustomAssets && assetOptions.length > 0 && (
           <FeeAssetSelector
             options={assetOptions}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix a small padding issue on the input of the max priority fee for the new send flow

| Before        | After         |
| ------------- | ------------- |
|<img width="822" height="1116" alt="image" src="https://github.com/user-attachments/assets/dd045eed-c8f9-4e11-9e35-7fec63ab0fa2" />|<img width="428" height="587" alt="image" src="https://github.com/user-attachments/assets/54ddf62c-6927-4217-9e7a-ee16cf0b8071" />|

### ❓ Context

- [JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-28714) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
