### PR TITLE
[LWDM] fix(lwdm): allow ens for token account new send flow

### DIFF
--- a/.changeset/rare-plants-cry.md
+++ b/.changeset/rare-plants-cry.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+fix(lwdm): allow ens for token account new send flow

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -132,7 +132,7 @@ describe("useAddressValidation", () => {
     });
   });
 
-  it("resolves ENS names for Ethereum", async () => {
+  it("resolves ENS names when recipientSupportsDomain is true", async () => {
     const ensResolution = {
       domain: "vitalik.eth",
       address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
@@ -151,6 +151,7 @@ describe("useAddressValidation", () => {
         searchValue: "vitalik.eth",
         currency: createMockCurrency({ id: "ethereum", name: "Ethereum", ticker: "ETH" }),
         account: mockEthereumAccount,
+        recipientSupportsDomain: true,
       }),
     );
 
@@ -173,6 +174,7 @@ describe("useAddressValidation", () => {
         searchValue: "test.eth",
         currency: createMockCurrency({ id: "ethereum", name: "Ethereum", ticker: "ETH" }),
         account: mockEthereumAccount,
+        recipientSupportsDomain: true,
       }),
     );
 
@@ -465,6 +467,7 @@ describe("useAddressValidation", () => {
         searchValue: "test.eth",
         currency: createMockCurrency({ id: "ethereum", name: "Ethereum", ticker: "ETH" }),
         account: mockEthereumAccount,
+        recipientSupportsDomain: true,
       }),
     );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -69,6 +69,7 @@ type UseAddressValidationProps = Readonly<{
   account?: AccountLike;
   parentAccount?: Account;
   currentAccountId?: string;
+  recipientSupportsDomain?: boolean;
 }>;
 
 type UseAddressValidationResult = {
@@ -83,6 +84,7 @@ export function useAddressValidation({
   account,
   parentAccount,
   currentAccountId,
+  recipientSupportsDomain = false,
 }: UseAddressValidationProps): UseAddressValidationResult {
   const [validationState, setValidationState] = useState<{
     status: AddressValidationStatus;
@@ -99,17 +101,16 @@ export function useAddressValidation({
 
   const allAccounts = useSelector(accountsSelector);
 
-  const isEthereum = currency.id === "ethereum";
-  const domainServiceResponse = useDomain(isEthereum ? searchValue : "", "ens");
-  const domainIsLoading = isEthereum && isDomainLoading(domainServiceResponse);
+  const domainServiceResponse = useDomain(recipientSupportsDomain ? searchValue : "", "ens");
+  const domainIsLoading = recipientSupportsDomain && isDomainLoading(domainServiceResponse);
 
   const ensResolution = useMemo(() => {
-    if (!isEthereum) return null;
+    if (!recipientSupportsDomain) return null;
     if (isLoaded(domainServiceResponse) && domainServiceResponse.resolutions.length > 0) {
       return domainServiceResponse.resolutions[0];
     }
     return null;
-  }, [domainServiceResponse, isEthereum]);
+  }, [domainServiceResponse, recipientSupportsDomain]);
 
   // Use resolved address for bridge validation (ENS resolved address or original searchValue)
   const addressForBridgeValidation = useMemo(() => {
@@ -127,7 +128,9 @@ export function useAddressValidation({
     account: account ?? null,
     parentAccount: parentAccount ?? null,
     enabled: Boolean(
-      addressForBridgeValidation && account && (!isEthereum || ensResolution || !domainIsLoading),
+      addressForBridgeValidation &&
+        account &&
+        (!recipientSupportsDomain || ensResolution || !domainIsLoading),
     ),
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
@@ -32,6 +32,7 @@ export function useRecipientAddressModalViewModel({
     account,
     parentAccount,
     currentAccountId: mainAccount.id,
+    recipientSupportsDomain,
   });
 
   const hasSearchValue = recipientSearch.value.length > 0;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -127,7 +127,7 @@ describe("useAddressValidation", () => {
     });
   });
 
-  it("resolves ENS names for Ethereum", async () => {
+  it("resolves ENS names when recipientSupportsDomain is true", async () => {
     const ensResolution = {
       domain: "vitalik.eth",
       address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
@@ -146,6 +146,7 @@ describe("useAddressValidation", () => {
         searchValue: "vitalik.eth",
         currency: createMockCurrency({ id: "ethereum", name: "Ethereum", ticker: "ETH" }),
         account: mockEthereumAccount,
+        recipientSupportsDomain: true,
       }),
     );
 
@@ -168,6 +169,7 @@ describe("useAddressValidation", () => {
         searchValue: "test.eth",
         currency: createMockCurrency({ id: "ethereum", name: "Ethereum", ticker: "ETH" }),
         account: mockEthereumAccount,
+        recipientSupportsDomain: true,
       }),
     );
 
@@ -475,6 +477,7 @@ describe("useAddressValidation", () => {
         searchValue: "test.eth",
         currency: createMockCurrency({ id: "ethereum", name: "Ethereum", ticker: "ETH" }),
         account: mockEthereumAccount,
+        recipientSupportsDomain: true,
       }),
     );
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -38,6 +38,7 @@ type UseAddressValidationProps = Readonly<{
   account?: AccountLike;
   parentAccount?: Account | null;
   currentAccountId?: string;
+  recipientSupportsDomain?: boolean;
 }>;
 
 type UseAddressValidationResult = {
@@ -52,6 +53,7 @@ export function useAddressValidation({
   account,
   parentAccount,
   currentAccountId,
+  recipientSupportsDomain = false,
 }: UseAddressValidationProps): UseAddressValidationResult {
   const [validationState, setValidationState] = useState<{
     status: AddressValidationStatus;
@@ -68,17 +70,16 @@ export function useAddressValidation({
 
   const allAccounts = useSelector(accountsSelector);
 
-  const isEthereum = currency.id === "ethereum";
-  const domainServiceResponse = useDomain(isEthereum ? searchValue : "", "ens");
-  const domainIsLoading = isEthereum && isDomainLoading(domainServiceResponse);
+  const domainServiceResponse = useDomain(recipientSupportsDomain ? searchValue : "", "ens");
+  const domainIsLoading = recipientSupportsDomain && isDomainLoading(domainServiceResponse);
 
   const ensResolution = useMemo(() => {
-    if (!isEthereum) return null;
+    if (!recipientSupportsDomain) return null;
     if (isLoaded(domainServiceResponse) && domainServiceResponse.resolutions.length > 0) {
       return domainServiceResponse.resolutions[0];
     }
     return null;
-  }, [domainServiceResponse, isEthereum]);
+  }, [domainServiceResponse, recipientSupportsDomain]);
 
   // Use resolved address for bridge validation (ENS resolved address or original searchValue)
   const addressForBridgeValidation = useMemo(() => {
@@ -96,7 +97,9 @@ export function useAddressValidation({
     account: account ?? null,
     parentAccount: parentAccount ?? null,
     enabled: Boolean(
-      addressForBridgeValidation && account && (!isEthereum || ensResolution || !domainIsLoading),
+      addressForBridgeValidation &&
+        account &&
+        (!recipientSupportsDomain || ensResolution || !domainIsLoading),
     ),
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
@@ -42,6 +42,7 @@ export function useRecipientScreenView({
     account,
     parentAccount,
     currentAccountId: mainAccount.id,
+    recipientSupportsDomain,
   });
 
   const allAccounts = useSelector(accountsSelector);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Allow input of domain (ens) also for token account
Before it was only for ethereum accounts

| Before        | After         |
| ------------- | ------------- |
|<img width="798" height="570" alt="image" src="https://github.com/user-attachments/assets/7d2e94b3-91ad-4948-859d-7568df05e726" />|<img width="445" height="461" alt="image" src="https://github.com/user-attachments/assets/a41550c7-1ba3-4104-bfa8-5f9c961e1cce" />|

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-28738)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
