### PR TITLE
[LWM] refactor(mobile): stabilize modular drawer callback registry references

### DIFF
--- a/.changeset/calm-drawers-stabilize.md
+++ b/.changeset/calm-drawers-stabilize.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix modular drawer callback stability for mobile Web3 account selection

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/index.ts
@@ -1,48 +1,8 @@
-import { AccountLike } from "@ledgerhq/types-live";
-import { callbackRegistry, resetAllRegistries } from "./registries";
-import { RegistryManager, AccountCallback } from "./types";
+import { registryActions } from "./registries";
+import { RegistryManager } from "./types";
 
 /**
- * Hook to manage a callback registry for account selection callbacks and observables.
- * This replaces storing functions and observables directly in Redux state, which is an anti-pattern.
+ * Hook that returns referentially-stable callback registry actions.
  */
-export const useCallbackRegistry = (): RegistryManager => {
-  // Callback methods
-  const registerCallback = (id: string, callback: AccountCallback) =>
-    callbackRegistry.register(id, callback);
 
-  const getCallback = (id: string): AccountCallback | undefined => callbackRegistry.get(id);
-
-  const unregisterCallback = (id: string): boolean => callbackRegistry.unregister(id);
-
-  const hasCallback = (id: string): boolean => callbackRegistry.has(id);
-
-  const executeCallback = (id: string, account: AccountLike, parentAccount?: AccountLike) => {
-    const callback = callbackRegistry.get(id);
-    if (callback) {
-      callback(account, parentAccount);
-      callbackRegistry.unregister(id);
-    }
-  };
-
-  const clearCallbacks = () => callbackRegistry.clear();
-
-  const getCallbackKeys = (): string[] => callbackRegistry.keys();
-
-  // Reset methods
-  const resetAll = () => resetAllRegistries();
-
-  return {
-    // Callback methods
-    registerCallback,
-    getCallback,
-    unregisterCallback,
-    hasCallback,
-    executeCallback,
-    clearCallbacks,
-    getCallbackKeys,
-
-    // Reset methods
-    resetAll,
-  };
-};
+export const useCallbackRegistry = (): RegistryManager => registryActions;

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/registries.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/registries.ts
@@ -1,5 +1,6 @@
+import { AccountLike } from "@ledgerhq/types-live";
 import { Registry } from "./Registry";
-import { AccountCallback } from "./types";
+import { AccountCallback, RegistryManager } from "./types";
 
 // Global registries that persist across re-renders
 export const callbackRegistry = new Registry<AccountCallback>();
@@ -9,4 +10,29 @@ export const callbackRegistry = new Registry<AccountCallback>();
  */
 export const resetAllRegistries = () => {
   callbackRegistry.clear();
+};
+
+export const registryActions: RegistryManager = {
+  registerCallback: (id: string, callback: AccountCallback) =>
+    callbackRegistry.register(id, callback),
+
+  getCallback: (id: string): AccountCallback | undefined => callbackRegistry.get(id),
+
+  unregisterCallback: (id: string): boolean => callbackRegistry.unregister(id),
+
+  hasCallback: (id: string): boolean => callbackRegistry.has(id),
+
+  executeCallback: (id: string, account: AccountLike, parentAccount?: AccountLike) => {
+    const callback = callbackRegistry.get(id);
+    if (callback) {
+      callback(account, parentAccount);
+      callbackRegistry.unregister(id);
+    }
+  },
+
+  clearCallbacks: () => callbackRegistry.clear(),
+
+  getCallbackKeys: (): string[] => callbackRegistry.keys(),
+
+  resetAll: () => resetAllRegistries(),
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -1,11 +1,9 @@
 import { useCallback } from "react";
+import { shallowEqual } from "react-redux";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { AccountLike } from "@ledgerhq/types-live";
-import {
-  openModularDrawer,
-  closeModularDrawer,
-  modularDrawerStateSelector,
-} from "~/reducers/modularDrawer";
+import { openModularDrawer, closeModularDrawer } from "~/reducers/modularDrawer";
+import type { State } from "~/reducers/types";
 import { DrawerParams, DrawerRemoteParams } from "../types";
 import { useCallbackRegistry } from "./useCallbackRegistry";
 import { generateCallbackId } from "../utils/callbackIdGenerator";
@@ -37,18 +35,28 @@ export const useModularDrawerController = () => {
     useCase,
     uiUseCase,
     areCurrenciesFiltered,
-  } = useSelector(modularDrawerStateSelector);
+  } = useSelector(
+    (state: State) => ({
+      isOpen: state.modularDrawer.isOpen,
+      preselectedCurrencies: state.modularDrawer.preselectedCurrencies,
+      callbackId: state.modularDrawer.callbackId,
+      enableAccountSelection: state.modularDrawer.enableAccountSelection,
+      assetsConfiguration: state.modularDrawer.assetsConfiguration,
+      networksConfiguration: state.modularDrawer.networksConfiguration,
+      useCase: state.modularDrawer.useCase,
+      uiUseCase: state.modularDrawer.uiUseCase,
+      areCurrenciesFiltered: state.modularDrawer.areCurrenciesFiltered,
+    }),
+    shallowEqual,
+  );
 
-  const { registerCallback, executeCallback, unregisterCallback, resetAll } = useCallbackRegistry();
+  const { registerCallback, executeCallback, resetAll } = useCallbackRegistry();
 
   const openDrawer = useCallback(
     (params?: DrawerParams) => {
       const { onAccountSelected, ...otherParams } = params || {};
 
       resetAll();
-      if (callbackId) {
-        unregisterCallback(callbackId);
-      }
 
       let callbackIdToUse: string | undefined;
       if (onAccountSelected) {
@@ -69,7 +77,7 @@ export const useModularDrawerController = () => {
 
       dispatch(openModularDrawer(paramsWithIds));
     },
-    [resetAll, callbackId, dispatch, unregisterCallback, registerCallback],
+    [resetAll, dispatch, registerCallback],
   );
 
   const closeDrawer = useCallback(() => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Modular Drawer account selection flow on all surfaces (Web3 Explorer, Receive, Buy, Swap, Stake)
      - Callback identity stability across drawer open/close cycles
      - No user-facing behavior change expected

### 📝 Description

**Problem**: `useCallbackRegistry` was recreating all callback functions on every render, making `openDrawer` from `useModularDrawerController` referentially unstable. This caused unnecessary re-renders in consumers (especially Web3 Explorer account selection), required `useRef` workarounds in callers, and could trigger React-Redux selector stability warnings in development.

**Solution**:
- Moved registry actions to a module-level singleton (`registryActions`) in `registries.ts`, so `useCallbackRegistry` now returns a stable reference instead of recreating functions each render.
- Replaced the broad `modularDrawerStateSelector` (which returns the full slice object) with a field-level inline selector using `shallowEqual`, preventing unnecessary re-renders from unrelated slice fields (`searchValue`, `step`, `flow`, `source`).
- Removed `callbackId` and `unregisterCallback` from `openDrawer`'s `useCallback` dependencies, since `resetAll()` already clears the entire registry before re-registering.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28767](https://ledgerhq.atlassian.net/browse/LIVE-28767)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28767]: https://ledgerhq.atlassian.net/browse/LIVE-28767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ