### PR TITLE
[LWM] fix(mobile): fix transfer drawer reopening when tapped while animating

### DIFF
--- a/.changeset/quick-drawers-fix.md
+++ b/.changeset/quick-drawers-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix transfer drawer reopening when tapped while still animating closed

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/hooks/useTransferDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/hooks/useTransferDrawerController.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useSelector, useDispatch } from "~/context/hooks";
 import {
   openTransferDrawer,
@@ -15,20 +15,35 @@ export const useTransferDrawerController = () => {
 
   const { isOpen, sourceScreenName } = useSelector(transferDrawerStateSelector);
 
+  // Stores a tap that arrived while the drawer was still open/animating,
+  // so it can be replayed as soon as isOpen transitions to false.
+  const pendingOpenRef = useRef<OpenDrawerParams | null>(null);
+
   const openDrawer = useCallback(
     (params: OpenDrawerParams) => {
-      dispatch(
-        openTransferDrawer({
-          sourceScreenName: params.sourceScreenName,
-        }),
-      );
+      if (isOpen) {
+        pendingOpenRef.current = params;
+        return;
+      }
+      dispatch(openTransferDrawer({ sourceScreenName: params.sourceScreenName }));
     },
-    [dispatch],
+    [dispatch, isOpen],
   );
 
   const closeDrawer = useCallback(() => {
     dispatch(closeTransferDrawer());
   }, [dispatch]);
+
+  // Replay a pending open request once the drawer has fully closed.
+  // This handles the case where the user taps Transfer while the dismiss
+  // animation is still running (backdrop disappears before JS onDismiss fires).
+  useEffect(() => {
+    if (!isOpen && pendingOpenRef.current) {
+      const params = pendingOpenRef.current;
+      pendingOpenRef.current = null;
+      dispatch(openTransferDrawer({ sourceScreenName: params.sourceScreenName }));
+    }
+  }, [isOpen, dispatch]);
 
   return {
     isOpen,

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/index.tsx
@@ -21,7 +21,7 @@ export const TransferDrawer = () => {
   if (isEnabled) {
     return (
       <QueuedDrawerBottomSheet
-        isRequestingToBeOpened={isOpen}
+        isForcingToBeOpened={isOpen}
         enableDynamicSizing
         onClose={handleClose}
       >


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _This is a UI interaction timing fix; no automated test covers the animation race condition._
- [x] **Impact of the changes:**
  - Transfer drawer open/close behavior on mobile
  - Tapping Transfer while the drawer is still dismissing (animation in progress)

### 📝 Description

**Problem**: When a user tapped the Transfer button while the Transfer drawer was still in the process of closing (dismiss animation running), the open request was silently dropped. This caused the drawer to not reopen, leaving the user having to tap again.

**Solution**: Added a `pendingOpenRef` in `useTransferDrawerController` to queue an open request that arrives while `isOpen` is still `true`. A `useEffect` watches for `isOpen` transitioning to `false` and immediately replays the queued request, ensuring the drawer opens as expected. Additionally switched to `isForcingToBeOpened` on `QueuedDrawerBottomSheet` to better express the intent.


https://github.com/user-attachments/assets/cdfc367d-1f53-499c-9176-f828d773721b



### ❓ Context

- **JIRA or GitHub link**: [LIVE-28737](https://ledgerhq.atlassian.net/browse/LIVE-28737)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28737]: https://ledgerhq.atlassian.net/browse/LIVE-28737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ