### PR TITLE
[LWD] fix(desktop): analytics consent tracking and default-off preferences

### DIFF
--- a/.changeset/long-crabs-check.md
+++ b/.changeset/long-crabs-check.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+send mandatory new analytics opt-in

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__integrations__/AnalyticsConsentDialog.portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__integrations__/AnalyticsConsentDialog.portfolio.integration.test.tsx
@@ -270,14 +270,14 @@ describe("AnalyticsConsentDialog on portfolio route", () => {
       const modal = await screen.findByTestId("analytics-consent-dialog");
       await screen.findByRole("heading", { name: "Set preferences" });
 
-      // Set preferences opens with both switches ON (`onSetPreferences` seeds drafts to true).
+      // Set preferences opens with both switches OFF (`onSetPreferences` seeds drafts to false).
       const switches = within(modal).getAllByRole("switch");
       expect(switches).toHaveLength(2);
       const [appPerformanceSwitch, personalizedSwitch] = switches;
-      if (!expectShareAnalytics) {
+      if (expectShareAnalytics) {
         await user.click(appPerformanceSwitch);
       }
-      if (!expectSharePersonalized) {
+      if (expectSharePersonalized) {
         await user.click(personalizedSwitch);
       }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
@@ -7,6 +7,7 @@ import {
   analyticsConsentInfoSelector,
   hasCompletedOnboardingSelector,
   shareAnalyticsSelector,
+  sharePersonalizedRecommendationsSelector,
 } from "~/renderer/reducers/settings";
 import {
   setAnalyticsConsentInfo,
@@ -24,6 +25,7 @@ import {
   resolveAnalyticsConsentPhase,
 } from "@ledgerhq/live-common/analyticsConsentUtils";
 import type { AnalyticsConsentDialogPhase } from "../types";
+import { CURRENT_PRIVACY_POLICY_VERSION } from "@ledgerhq/live-common/privacyConsent";
 
 export const ANALYTICS_CONSENT_DIALOG_PAGE = "Analytics consent dialog";
 
@@ -46,6 +48,7 @@ export function useAnalyticsConsentDialogViewModel() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const consentInfo = useSelector(analyticsConsentInfoSelector);
   const shareAnalytics = useSelector(shareAnalyticsSelector);
+  const sharePersonalizedRecommendations = useSelector(sharePersonalizedRecommendationsSelector);
 
   const needsUpdatePrivacy = needsPrivacyPolicyAck(consentInfo.privacyPolicyVersion);
   const needsRenewal = needsConsentRenewal(consentInfo.consentDate);
@@ -60,8 +63,8 @@ export function useAnalyticsConsentDialogViewModel() {
   >("consentFresh");
 
   /** Preferences-step form only; Redux settings update on Confirm via `applyPreferences`. */
-  const [draftShareAnalytics, setDraftShareAnalytics] = useState(true);
-  const [draftSharePersonalized, setDraftSharePersonalized] = useState(true);
+  const [draftShareAnalytics, setDraftShareAnalytics] = useState(false);
+  const [draftSharePersonalized, setDraftSharePersonalized] = useState(false);
 
   let descriptionLead: string | null;
   if (phase === "consentReconfirm") {
@@ -117,10 +120,15 @@ export function useAnalyticsConsentDialogViewModel() {
   };
 
   const applyOptIn = async () => {
-    track("button_clicked", {
-      button: "analytics_consent_opt_in",
-      page: ANALYTICS_CONSENT_DIALOG_PAGE,
-    });
+    track(
+      "button_clicked",
+      {
+        button: "analytics_consent_opt_in",
+        page: ANALYTICS_CONSENT_DIALOG_PAGE,
+        privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+      },
+      true,
+    );
     dispatch(setShareAnalytics(true));
     dispatch(setSharePersonalizedRecommendations(true));
     await persistAnalyticsConsentAck();
@@ -128,10 +136,17 @@ export function useAnalyticsConsentDialogViewModel() {
   };
 
   const applyOptOut = async () => {
-    track("button_clicked", {
-      button: "analytics_consent_opt_out",
-      page: ANALYTICS_CONSENT_DIALOG_PAGE,
-    });
+    const isPreviouslyOptedOutCompletely = !shareAnalytics && !sharePersonalizedRecommendations;
+    const trackMandatory = !isPreviouslyOptedOutCompletely;
+    track(
+      "button_clicked",
+      {
+        button: "analytics_consent_opt_out",
+        page: ANALYTICS_CONSENT_DIALOG_PAGE,
+        privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+      },
+      trackMandatory,
+    );
     dispatch(setShareAnalytics(false));
     dispatch(setSharePersonalizedRecommendations(false));
     await persistAnalyticsConsentAck();
@@ -142,6 +157,7 @@ export function useAnalyticsConsentDialogViewModel() {
     track("button_clicked", {
       button: "analytics_consent_privacy_got_it",
       page: ANALYTICS_CONSENT_DIALOG_PAGE,
+      privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
     });
     await persistAnalyticsConsentAck();
     handleCloseDialog();
@@ -152,9 +168,9 @@ export function useAnalyticsConsentDialogViewModel() {
       button: "analytics_consent_set_preferences",
       page: ANALYTICS_CONSENT_DIALOG_PAGE,
     });
-    // Default opt-in: preferences screen opens with both toggles on; user can turn them off before confirming.
-    setDraftShareAnalytics(true);
-    setDraftSharePersonalized(true);
+    // Default opt-out: preferences screen opens with both toggles off; user opts in per toggle before confirming.
+    setDraftShareAnalytics(false);
+    setDraftSharePersonalized(false);
     setPhase(current => {
       if (current === "consentFresh" || current === "consentReconfirm") {
         setConsentPhaseBeforePreferences(current);
@@ -166,10 +182,16 @@ export function useAnalyticsConsentDialogViewModel() {
   const onBackFromPreferences = () => setPhase(consentPhaseBeforePreferences);
 
   const applyPreferences = async () => {
-    track("button_clicked", {
-      button: "analytics_consent_preferences_confirm",
-      page: ANALYTICS_CONSENT_DIALOG_PAGE,
-    });
+    const trackMandatory = draftShareAnalytics || draftSharePersonalized;
+    track(
+      "button_clicked",
+      {
+        button: "analytics_consent_preferences_confirm",
+        page: ANALYTICS_CONSENT_DIALOG_PAGE,
+        privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+      },
+      trackMandatory,
+    );
     dispatch(setShareAnalytics(draftShareAnalytics));
     dispatch(setSharePersonalizedRecommendations(draftSharePersonalized));
     await persistAnalyticsConsentAck();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop analytics consent modal (fresh consent, reconfirm, privacy policy update, set preferences).
  - Segment `button_clicked` payloads and mandatory flags for consent actions.
  - Set preferences step: toggles default to off; user opts in explicitly per toggle before Confirm.

### 📝 Description

**Problem:** [LIVE-25921](https://ledgerhq.atlassian.net/browse/LIVE-25921) QA feedback on the desktop analytics consent flow required more accurate Segment tracking and clearer opt-in defaults on the granular preferences step.

**Solution:**

- Add `privacyPolicyVersion` (`CURRENT_PRIVACY_POLICY_VERSION`) to consent-related `button_clicked` payloads.
- Use mandatory tracking where required: opt-in; opt-out only when the user was not already opted out on both dimensions; preferences Confirm only when at least one draft toggle is on.
- **Privacy policy “Got it”** is **not** mandatory: it uses the default `track(...)` path, so the event is sent only when analytics tracking is enabled (user is opted in), same as other non-mandatory events.
- Seed “Set preferences” draft state with both toggles **off** so confirming without enabling anything stays a full opt-out.

Portfolio integration tests were updated for the new default-off behavior.

https://github.com/user-attachments/assets/f1db0764-1c97-44aa-9969-e8b8acd6dcff

### ❓ Context

- **JIRA or GitHub link**: [LIVE-25921](https://ledgerhq.atlassian.net/browse/LIVE-25921)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-25921]: https://ledgerhq.atlassian.net/browse/LIVE-25921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-25921]: https://ledgerhq.atlassian.net/browse/LIVE-25921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ