### PR TITLE
fix(desktop): expand hidden token list before e2e visibility assertion

### DIFF
--- a/.changeset/odd-tokens-expand.md
+++ b/.changeset/odd-tokens-expand.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix desktop account page e2e token lookup by expanding hidden tokens before visibility checks.

--- a/e2e/desktop/tests/page/account.page.ts
+++ b/e2e/desktop/tests/page/account.page.ts
@@ -173,7 +173,12 @@ export class AccountPage extends AppPage {
 
   @step("Expect token to be present")
   async expectTokenToBePresent(tokenAccount: AccountType) {
-    await expect(this.tokenRow(tokenAccount.currency.ticker)).toBeVisible();
+    const row = this.tokenRow(tokenAccount.currency.ticker);
+    await this.showAllTokensButton.or(row).first().waitFor({ state: "visible" });
+    if (await this.showAllTokensButton.isVisible()) {
+      await this.showAllTokensButton.click();
+    }
+    await expect(row).toBeVisible();
   }
 
   @step("Navigate to token in account")


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Desktop typecheck was run; Playwright e2e suite was not executed in this environment._
- [x] **Impact of the changes:**
  - Desktop Playwright account page: token row visibility when tokens are behind "show all"
  - Any specs using `expectTokenToBePresent` on accounts with collapsed token lists

### Description

**Problem:** Desktop e2e checks for a token row could fail when the token list is collapsed and the row is only visible after expanding (e.g. "show all tokens").

**Solution:** In `AccountPage.expectTokenToBePresent`, wait for either the token row or the expand control, click "show all" when present, then assert the token row is visible.

### Context

- **JIRA or GitHub link:** _No ticket — internal bugfix._

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)