### PR TITLE
[LWM] chore(mobile): drop eager prepareCurrency(ethereum) at startup [LIVE-28532]

### DIFF
--- a/.changeset/drop-startup-preparecurrency-ethereum.md
+++ b/.changeset/drop-startup-preparecurrency-ethereum.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Remove eager `prepareCurrency(ethereum)` call at app startup to improve startup performance. The call was redundant as BridgeSync and the add-account flow already call it on demand.

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -1,10 +1,7 @@
 import Config from "react-native-config";
 import { listen } from "@ledgerhq/logs";
 import { setEnv, getEnv } from "@ledgerhq/live-env";
-import {
-  getCryptoCurrencyById,
-  setSupportedCurrencies,
-} from "@ledgerhq/live-common/currencies/index";
+import { setSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
 import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { setDeviceMode } from "@ledgerhq/live-common/hw/actions/app";
@@ -13,7 +10,6 @@ import { Platform } from "react-native";
 import { setSecp256k1Instance } from "@ledgerhq/live-common/families/bitcoin/logic";
 import { setGlobalOnBridgeError } from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { setResolutionConfig } from "@shared/feature-flags";
-import { prepareCurrency } from "./bridge/cache";
 import "./experimental";
 import logger, { ConsoleLogger } from "./logger";
 import BigNumber from "bignumber.js";
@@ -184,7 +180,5 @@ process.env.LEDGER_CLIENT_VERSION = ledgerClientVersion;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 setSecp256k1Instance(require("./logic/secp256k1"));
-
-prepareCurrency(getCryptoCurrencyById("ethereum"));
 
 BigNumber.set({ DECIMAL_PLACES: getEnv("BIG_NUMBER_DECIMAL_PLACES") });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 
  - e2e mobile https://github.com/LedgerHQ/ledger-live/actions/runs/24188535426
- [x] **Impact of the changes:**
  - Removes one blocking network/bridge call from app startup path
  - No functional change: `prepareCurrency` is still called for ethereum by `BridgeSync` (per-account sync) and by `useScanDeviceAccountsViewModel` (before scanning)

### 📝 Description

Removes the unconditional `prepareCurrency(getCryptoCurrencyById("ethereum"))` call from `live-common-setup.ts`.

This call was executed eagerly at module load time (app startup), blocking the first render regardless of whether the user has any Ethereum accounts.

`prepareCurrency` is already called lazily in the right places:
- **`BridgeSyncContext`** — passes it to `BridgeSync`, which calls it per-currency during account sync
- **`useScanDeviceAccountsViewModel`** — calls it via `concat(from(prepareCurrency(...)), bridge.scanAccounts(...))` before scanning
- **`useSelectDeviceViewModel`** — calls it in a `useEffect` when the user reaches the device selection screen

The startup call is therefore redundant. Desktop had the equivalent long time removed.

Also removes the now-unused `prepareCurrency` import from `./bridge/cache` and the now-unused `getCryptoCurrencyById` from the `currencies/index` import.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28532](https://ledgerhq.atlassian.net/browse/LIVE-28532)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28532]: https://ledgerhq.atlassian.net/browse/LIVE-28532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ