### PR TITLE
[LWM] fix(mobile): add gradient to analytics consent opt-in sheet

### DIFF
--- a/.changeset/soft-sheets-glow.md
+++ b/.changeset/soft-sheets-glow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add radial background gradient to analytics consent opt-in bottom sheet

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/AnalyticsConsentSheetBackgroundGradient.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/AnalyticsConsentSheetBackgroundGradient.tsx
@@ -1,0 +1,43 @@
+import React, { useId, useMemo } from "react";
+import { StyleSheet, View } from "react-native";
+import Svg, { Defs, RadialGradient, Rect, Stop } from "react-native-svg";
+import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+
+const RADIAL_CX = "0.5047";
+const RADIAL_CY = "0.0014";
+const RADIAL_RX = "0.4356";
+const RADIAL_RY = "0.3306";
+
+const OUTER_STOP_OPACITY = 0.1;
+const GRADIENT_RECT_FILL_OPACITY = 0.3;
+
+export function AnalyticsConsentSheetBackgroundGradient() {
+  const reactId = useId();
+  const gradientId = useMemo(() => `analyticsConsentSheetRadial${reactId.replace(/:/g, "")}`, [reactId]);
+  const { theme, colorScheme } = useTheme();
+  const mutedStrong = theme.colors.bg.mutedStrong;
+  const outerStop = colorScheme === "light" ? theme.colors.bg.black : theme.colors.bg.white;
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none" collapsable={false}>
+      <Svg style={StyleSheet.absoluteFill} width="100%" height="100%" preserveAspectRatio="none">
+        <Defs>
+          <RadialGradient
+            id={gradientId}
+            gradientUnits="objectBoundingBox"
+            cx={RADIAL_CX}
+            cy={RADIAL_CY}
+            rx={RADIAL_RX}
+            ry={RADIAL_RY}
+            fx={RADIAL_CX}
+            fy={RADIAL_CY}
+          >
+            <Stop offset="0" stopColor={mutedStrong} stopOpacity={1} />
+            <Stop offset="1" stopColor={outerStop} stopOpacity={OUTER_STOP_OPACITY} />
+          </RadialGradient>
+        </Defs>
+        <Rect width="100%" height="100%" fill={`url(#${gradientId})`} fillOpacity={GRADIENT_RECT_FILL_OPACITY} />
+      </Svg>
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/screens/AnalyticsConsentDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/screens/AnalyticsConsentDrawerView.tsx
@@ -1,14 +1,17 @@
 import React from "react";
+import { View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { TrackScreen } from "~/analytics";
 import { BottomSheetView, Box } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import { urls } from "~/utils/urls";
 import type { AnalyticsConsentPhase } from "@ledgerhq/live-common/analyticsConsentUtils";
 import { DescriptionWithPreferencesLink } from "../components/DescriptionWithPreferencesLink";
 import { PrivacyUpdateSheet } from "../components/PrivacyUpdateSheet";
+import { AnalyticsConsentSheetBackgroundGradient } from "../components/AnalyticsConsentSheetBackgroundGradient";
 import { TwoCtaConsentSheet } from "../components/TwoCtaConsentSheet";
 
 export type AnalyticsConsentDrawerViewProps = Readonly<{
@@ -34,6 +37,16 @@ export function AnalyticsConsentDrawerView(props: AnalyticsConsentDrawerViewProp
   const { t } = useTranslation();
   const privacyPolicyUrl = useLocalizedUrl(urls.privacyPolicy.en);
   const { bottom: bottomInset } = useSafeAreaInsets();
+  const styles = useStyleSheet(
+    theme => ({
+      sheetSurface: {
+        position: "relative",
+        width: "100%",
+        backgroundColor: theme.colors.bg.canvasSheet,
+      },
+    }),
+    [],
+  );
 
   if (!isDrawerOpen) return null;
 
@@ -93,7 +106,8 @@ export function AnalyticsConsentDrawerView(props: AnalyticsConsentDrawerViewProp
       testID="analytics-consent-drawer"
     >
       <BottomSheetView style={{ paddingHorizontal: 0, paddingBottom }}>
-        <>
+        <View style={styles.sheetSurface}>
+          <AnalyticsConsentSheetBackgroundGradient />
           <TrackScreen
             key={phase}
             category="AnalyticsConsentDrawer"
@@ -103,7 +117,7 @@ export function AnalyticsConsentDrawerView(props: AnalyticsConsentDrawerViewProp
             refreshSource={false}
           />
           {sheetChrome}
-        </>
+        </View>
       </BottomSheetView>
     </QueuedDrawerBottomSheet>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/screens/AnalyticsConsentDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/screens/AnalyticsConsentDrawerView.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import { TrackScreen } from "~/analytics";
@@ -43,14 +42,14 @@ export function AnalyticsConsentDrawerView(props: AnalyticsConsentDrawerViewProp
         position: "relative",
         width: "100%",
         backgroundColor: theme.colors.bg.canvasSheet,
+        paddingHorizontal: 0,
+        paddingBottom: bottomInset + theme.spacings.s24,
       },
     }),
     [],
   );
 
   if (!isDrawerOpen) return null;
-
-  const paddingBottom = bottomInset + 24;
 
   let sheetBody: React.ReactNode = null;
   if (phase === "consentReconfirm") {
@@ -105,19 +104,16 @@ export function AnalyticsConsentDrawerView(props: AnalyticsConsentDrawerViewProp
       noCloseButton
       testID="analytics-consent-drawer"
     >
-      <BottomSheetView style={{ paddingHorizontal: 0, paddingBottom }}>
-        <View style={styles.sheetSurface}>
-          <AnalyticsConsentSheetBackgroundGradient />
-          <TrackScreen
-            key={phase}
-            category="AnalyticsConsentDrawer"
-            name="Analytics consent"
-            type="drawer"
-            phase={phase}
-            refreshSource={false}
-          />
-          {sheetChrome}
-        </View>
+      <BottomSheetView style={styles.sheetSurface}>
+        <TrackScreen
+          key={phase}
+          category="AnalyticsConsentDrawer"
+          name="Analytics consent"
+          type="drawer"
+          phase={phase}
+          refreshSource={false}
+        />
+        {sheetChrome}
       </BottomSheetView>
     </QueuedDrawerBottomSheet>
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new unit tests; change is presentational (SVG gradient + layout). Existing drawer flows unchanged functionally._
- [x] **Impact of the changes:**
      - Analytics consent / opt-in bottom sheet appearance
      - Light and dark theme: gradient colors and `canvasSheet` surface
      - Verify sheet still scrolls and CTAs remain tappable (gradient uses `pointerEvents="none"`)

### 📝 Description

**Problem:** The analytics consent opt-in bottom sheet did not match the intended design treatment for the sheet background (missing subtle radial gradient).

**Solution:** Introduced `AnalyticsConsentSheetBackgroundGradient`, a theme-aware radial gradient (react-native-svg) using `bg.mutedStrong` toward the center and a low-opacity outer stop from black (light) or white (dark). The drawer content is wrapped in a relative surface with `theme.colors.bg.canvasSheet` so the gradient sits behind existing chrome.

<img width="934" height="877" alt="image" src="https://github.com/user-attachments/assets/ffc3c297-2acf-4575-8875-53dad5d3c636" />

_After opening the PR: use **⋯ → Edit** on the description and drop screenshots into the table._

### ❓ Context

- **JIRA or GitHub link**: 
- https://ledgerhq.atlassian.net/browse/LIVE-28751
- https://ledgerhq.atlassian.net/browse/LIVE-25910

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
