### PR TITLE
[LWM] refactor(mobile): extract operations list section separator

### DIFF
--- a/.changeset/calm-ravens-flow.md
+++ b/.changeset/calm-ravens-flow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Extract Operations list `SectionSeparator` into a dedicated module

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/SectionSeparator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/SectionSeparator.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { DailyOperationsSection, Operation } from "@ledgerhq/types-live";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+
+type Props = {
+  leadingItem?: Operation | null;
+  trailingItem?: Operation | null;
+  trailingSection?: DailyOperationsSection;
+};
+
+const testID = "operations-list-section-separator";
+
+export function SectionSeparator({ leadingItem, trailingItem, trailingSection }: Readonly<Props>) {
+  const afterSectionHeader = leadingItem == null && trailingItem != null;
+  if (afterSectionHeader) {
+    return <Box lx={afterSectionHeaderSpacingStyle} testID={testID} />;
+  }
+  const afterLastItemInSection = leadingItem != null && trailingItem == null;
+  if (afterLastItemInSection) {
+    if (trailingSection == null) return null;
+    return <Box lx={betweenSectionsSpacingStyle} testID={testID} />;
+  }
+  return null;
+}
+
+const afterSectionHeaderSpacingStyle: LumenViewStyle = {
+  height: "s12",
+};
+
+const betweenSectionsSpacingStyle: LumenViewStyle = {
+  height: "s24",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/__tests__/SectionSeparator.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/__tests__/SectionSeparator.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Operation, DailyOperationsSection } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
+import { render, screen } from "@tests/test-renderer";
+import { SectionSeparator } from "../SectionSeparator";
+
+const operation: Operation = {
+  id: "1",
+  hash: "1",
+  type: "IN",
+  value: new BigNumber(100),
+  fee: new BigNumber(0),
+  senders: ["1"],
+  recipients: ["2"],
+  blockHeight: 1,
+  blockHash: "1",
+  date: new Date(),
+  accountId: "1",
+  extra: {},
+};
+
+const section: DailyOperationsSection = {
+  day: new Date(),
+  data: [operation],
+};
+
+describe("SectionSeparator", () => {
+  it("should render after section header", () => {
+    render(
+      <SectionSeparator leadingItem={null} trailingItem={operation} trailingSection={section} />,
+    );
+    expect(screen.getByTestId("operations-list-section-separator")).toBeVisible();
+    expect(screen.getByTestId("operations-list-section-separator")).toHaveStyle({
+      height: 12,
+    });
+  });
+
+  it("should render between sections", () => {
+    render(
+      <SectionSeparator leadingItem={operation} trailingItem={null} trailingSection={section} />,
+    );
+    expect(screen.getByTestId("operations-list-section-separator")).toBeVisible();
+    expect(screen.getByTestId("operations-list-section-separator")).toHaveStyle({
+      height: 24,
+    });
+  });
+
+  it("should not render when there is no leading item and no trailing item", () => {
+    render(<SectionSeparator leadingItem={null} trailingItem={null} trailingSection={section} />);
+    expect(screen.queryByTestId("operations-list-section-separator")).toBeNull();
+  });
+
+  it("should not render when there is no trailing section after the last item in a section", () => {
+    render(
+      <SectionSeparator leadingItem={operation} trailingItem={null} trailingSection={undefined} />,
+    );
+    expect(screen.queryByTestId("operations-list-section-separator")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -13,6 +13,7 @@ import OperationsSectionHeader from "./components/OperationsSectionHeader";
 import { OperationsEmptyState } from "./components/OperationsEmptyState";
 import { OperationsListFooter } from "./components/OperationsListFooter";
 import { BottomFadeGradient } from "./components/BottomFadeGradient";
+import { SectionSeparator } from "./components/SectionSeparator";
 import { useOperationsListViewModel } from "./useOperationsListViewModel";
 import { GRADIENT_HEIGHT } from "LLM/features/OperationsHistory/const";
 
@@ -20,10 +21,6 @@ type Props = StackNavigatorProps<OperationsHistoryNavigatorParamsList, ScreenNam
 
 function keyExtractor(item: Operation) {
   return `${item.accountId}_${item.id}`;
-}
-
-function SectionSeparator() {
-  return <Box lx={sectionSeparatorStyle} />;
 }
 
 export default function OperationsList(_: Props) {
@@ -101,10 +98,6 @@ export default function OperationsList(_: Props) {
 
 const rootStyle: LumenViewStyle = {
   flex: 1,
-};
-
-const sectionSeparatorStyle: LumenViewStyle = {
-  height: "s24",
 };
 
 const listStyle = { flex: 1 } as const;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Pure refactor: `SectionSeparator` moved to its own module with no intended behavior change; no new tests added._
- [x] **Impact of the changes:**
      - Operations history list: spacing after section (day) headers and between sections

### 📝 Description

**Problem:** The operations list screen inlined `SectionSeparator` and its spacing styles, which made `OperationsList` harder to scan and maintain.

**Solution:** Extract `SectionSeparator` (and the `s12` / `s24` spacing tokens used only there) into `components/SectionSeparator.tsx` and import it from the screen.



before:

<img width="420" height="2868" alt="image" src="https://github.com/user-attachments/assets/35e4b720-54ec-47fb-97e0-9384389f601d" />


after:

<img width="420" height="2868" alt="image" src="https://github.com/user-attachments/assets/eeb457c7-f3a2-4b00-bbc1-1c12e769f75d" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-28845](https://ledgerhq.atlassian.net/browse/LIVE-28845)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28845]: https://ledgerhq.atlassian.net/browse/LIVE-28845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ