### PR TITLE
[LWM] fix(mobile): analytics consent drawer accessibility labels

### DIFF
--- a/.changeset/kind-links-a11y.md
+++ b/.changeset/kind-links-a11y.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Improve analytics consent drawer accessibility labels for links and buttons

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/ConsentFooter.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/ConsentFooter.tsx
@@ -15,7 +15,13 @@ export function ConsentFooter({ privacyPolicyUrl }: ConsentFooterProps) {
     <Box lx={{ width: "full", alignItems: "center" }}>
       <Text typography="body4" lx={{ color: "muted", textAlign: "center" }}>
         {t("analyticsConsentDrawer.footer.lead")}{" "}
-        <Text accessibilityRole="link" onPress={onOpenPrivacyPolicy} typography="body4" lx={{ textDecorationLine: "underline" }}>
+        <Text
+          accessibilityRole="link"
+          accessibilityLabel={t("analyticsConsentDrawer.footer.privacyLink")}
+          onPress={onOpenPrivacyPolicy}
+          typography="body4"
+          lx={{ textDecorationLine: "underline" }}
+        >
           {t("analyticsConsentDrawer.footer.privacyLink")}
         </Text>
       </Text>

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/DescriptionWithPreferencesLink.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/DescriptionWithPreferencesLink.tsx
@@ -12,7 +12,13 @@ export function DescriptionWithPreferencesLink({ text, onSetPreferences }: Descr
   return (
     <Text typography="body2" lx={{ color: "muted", textAlign: "center", width: "full" }}>
       {text}{" "}
-      <Text accessibilityRole="link" onPress={onSetPreferences} typography="body2" lx={{ color: "interactive" }}>
+      <Text
+        accessibilityRole="link"
+        accessibilityLabel={t("analyticsConsentDrawer.setPreferences")}
+        onPress={onSetPreferences}
+        typography="body2"
+        lx={{ color: "interactive" }}
+      >
         {t("analyticsConsentDrawer.setPreferences")}
       </Text>
     </Text>

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/PrivacyDescription.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/PrivacyDescription.tsx
@@ -16,6 +16,7 @@ export function PrivacyDescription({ privacyPolicyUrl }: PrivacyDescriptionProps
       {t("analyticsConsentDrawer.privacy.descriptionLead")}
       <Text
         accessibilityRole="link"
+        accessibilityLabel={t("analyticsConsentDrawer.privacy.descriptionLinkLabel")}
         typography="body2"
         lx={{ textDecorationLine: "underline" }}
         onPress={onOpenPrivacyPolicy}

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/PrivacyUpdateSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/PrivacyUpdateSheet.tsx
@@ -23,7 +23,13 @@ export function PrivacyUpdateSheet({ privacyPolicyUrl, onGotIt }: PrivacyUpdateS
             <PrivacyDescription privacyPolicyUrl={privacyPolicyUrl} />
           </Box>
         </Box>
-        <Button appearance="base" size="lg" lx={{ width: "full" }} onPress={onGotIt}>
+        <Button
+          appearance="base"
+          size="lg"
+          lx={{ width: "full" }}
+          accessibilityLabel={t("analyticsConsentDrawer.privacy.ctaGotIt")}
+          onPress={onGotIt}
+        >
           {t("analyticsConsentDrawer.privacy.ctaGotIt")}
         </Button>
       </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/TwoCtaConsentSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/TwoCtaConsentSheet.tsx
@@ -35,10 +35,22 @@ export function TwoCtaConsentSheet({
           </Box>
         </Box>
         <Box lx={{ width: "full", gap: "s16" }}>
-          <Button appearance="base" size="lg" lx={{ width: "full" }} onPress={onPrimary}>
+          <Button
+            appearance="base"
+            size="lg"
+            lx={{ width: "full" }}
+            accessibilityLabel={primaryLabel}
+            onPress={onPrimary}
+          >
             {primaryLabel}
           </Button>
-          <Button appearance="gray" size="lg" lx={{ width: "full" }} onPress={onSecondary}>
+          <Button
+            appearance="gray"
+            size="lg"
+            lx={{ width: "full" }}
+            accessibilityLabel={secondaryLabel}
+            onPress={onSecondary}
+          >
             {secondaryLabel}
           </Button>
         </Box>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new unit tests; verify with VoiceOver / TalkBack on device._
- [x] **Impact of the changes:**
      - Analytics consent drawer and privacy update sheet (links and primary/secondary buttons)
      - Screen reader announcements for inline links and CTAs

### 📝 Description

**Problem:** Interactive elements in the analytics consent flow used visible text but lacked explicit `accessibilityLabel` values where helpful for assistive tech, so links and buttons could be announced unclearly.

**Solution:** Set `accessibilityLabel` on privacy/preferences links, the privacy description link, the “Got it” button, and the two CTA buttons in `TwoCtaConsentSheet`, using existing copy / label props so announcements match UI text.

### ❓ Context

- **JIRA or GitHub link:** https://ledgerhq.atlassian.net/browse/LIVE-25905

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
