### PR TITLE
feat(types-live): extend DistributionItem with asset-based fields

### DIFF
--- a/.changeset/strong-cameras-retire.md
+++ b/.changeset/strong-cameras-retire.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/types-live": minor
+---
+
+Add NetworkDistributionDetail type and extend DistributionItem with optional asset-based fields

--- a/libs/ledgerjs/packages/types-live/src/portfolio.ts
+++ b/libs/ledgerjs/packages/types-live/src/portfolio.ts
@@ -91,12 +91,23 @@ export type PortfolioRangeConfig = {
  */
 export type PortfolioRange = "all" | "year" | "month" | "week" | "day";
 
+export type NetworkDistributionDetail = {
+  currency: CryptoCurrency | TokenCurrency;
+  accounts: AccountLike[];
+  amount: number;
+  countervalue?: number;
+};
+
 export type DistributionItem = {
   currency: CryptoCurrency | TokenCurrency;
   distribution: number; // % of the total (normalized in 0-1)
   accounts: AccountLike[];
   amount: number;
   countervalue?: number; // countervalue of the amount that was calculated based of the rate provided
+  metaCurrencyId?: string;
+  networks?: NetworkDistributionDetail[];
+  marketId?: string;
+  slug?: string;
 };
 
 /**


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Type-only change, no runtime logic to test._
- [x] **Impact of the changes:**
  - No breaking changes — all new fields are optional
  - Downstream consumers (`asset-aggregation`, `ledger-live-desktop`, `ledger-live-mobile`) are unaffected
  - `@ledgerhq/types-live` build and `@ledgerhq/asset-aggregation` typecheck verified

### 📝 Description

**Problem**: The `DistributionItem` type lacks fields needed for asset-based portfolio distribution grouping (grouping assets by network/meta-currency).

**Solution**: Extended `DistributionItem` in `@ledgerhq/types-live` with four optional fields (`metaCurrencyId`, `networks`, `marketId`, `slug`) and added a new `NetworkDistributionDetail` type to support network-level distribution breakdowns.

Changes in `libs/ledgerjs/packages/types-live/src/portfolio.ts`:
- Added `NetworkDistributionDetail` type with `currency`, `accounts`, `amount`, `countervalue` fields
- Extended `DistributionItem` with optional `metaCurrencyId?: string`, `networks?: NetworkDistributionDetail[]`, `marketId?: string`, `slug?: string`

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27927](https://ledgerhq.atlassian.net/browse/LIVE-27927)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27927]: https://ledgerhq.atlassian.net/browse/LIVE-27927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ