### PR TITLE
[LWD] feat(desktop): integrate lumen button for install actions in app manager

### DIFF
--- a/.changeset/happy-lions-shine.md
+++ b/.changeset/happy-lions-shine.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Refactor install click handler into named callback in AppActions

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/AppActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/AppActions.tsx
@@ -17,8 +17,10 @@ import { colors } from "~/renderer/styles/theme";
 import AccountAdd from "~/renderer/icons/AccountAdd";
 import IconCheck from "~/renderer/icons/Check";
 import IconTrash from "~/renderer/icons/Trash";
-import IconArrowDown from "~/renderer/icons/ArrowDown";
 import IconExternalLink from "~/renderer/icons/ExternalLink";
+import { Button as LumenButton } from "@ledgerhq/lumen-ui-react";
+import { ArrowDown } from "@ledgerhq/lumen-ui-react/symbols";
+import { track } from "~/renderer/analytics/segment";
 
 const ExternalLinkIconContainer = styled.span`
   display: inline-flex;
@@ -131,6 +133,13 @@ const AppActions = React.memo(
       () => installed && installQueue.length <= 0 && uninstallQueue.length <= 0,
       [installQueue.length, installed, uninstallQueue.length],
     );
+    const onInstallClick = useCallback(() => {
+      track("Manager Install Click", {
+        appName: name,
+        appVersion: app.version,
+      });
+      onInstall();
+    }, [name, app.version, onInstall]);
 
     const isCurrencyApp = type === AppType.app || type === AppType.currency;
     const showLearnMore = type === AppType.tool || (isCurrencyApp && !isLiveSupported);
@@ -266,29 +275,16 @@ const AppActions = React.memo(
                   ) : null
                 }
               >
-                <Button
-                  style={{
-                    display: "flex",
-                  }}
-                  lighterPrimary
+                <LumenButton
+                  appearance="transparent"
+                  size="sm"
                   disabled={!canInstall || notEnoughMemoryToInstall}
-                  onClick={onInstall}
-                  event="Manager Install Click"
-                  eventProperties={{
-                    appName: name,
-                    appVersion: app.version,
-                  }}
+                  onClick={onInstallClick}
+                  icon={ArrowDown}
                   data-testid={`manager-install-${name}-app-button`}
                 >
-                  <IconArrowDown size={14} />
-                  <Text
-                    style={{
-                      marginLeft: 8,
-                    }}
-                  >
-                    <Trans i18nKey="manager.applist.item.install" />
-                  </Text>
-                </Button>
+                  <Trans i18nKey="manager.applist.item.install" />
+                </LumenButton>
               </Tooltip>
             )}
             {(((installed || !installedAvailable) && !appStoreView && !onlyUpdate) ||


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _UI component swap — visual change covered by existing E2E tests._
- [x] **Impact of the changes:**
  - Verify the install button appears correctly in the App Manager for all app types
  - Verify the install action still triggers properly (analytics + actual install)
  - Check button disabled state works (not enough memory, can't install)
  - Verify tooltip still shows correctly wrapping the button

### 📝 Description

The install button in the App Manager (`AppActions`) was using the legacy `Button` component with a custom `IconArrowDown` icon. This PR migrates it to the Lumen design system `Button` from `@ledgerhq/lumen-ui-react`, using the built-in `ArrowDown` symbol and the `transparent` appearance variant.

The analytics tracking (`Manager Install Click`) has been preserved by extracting a dedicated `onInstallClick` callback that calls `track()` before delegating to `onInstall`.

<img width="1428" height="500" alt="exdark" src="https://github.com/user-attachments/assets/78ebc6c9-3628-46ad-a61d-98d90e09a34c" />
<img width="1181" height="349" alt="exlight" src="https://github.com/user-attachments/assets/34723c59-5dcc-4b8f-bca8-280871f24f68" />

### ❓ Context
- **JIRA or GitHub link**: [LIVE-28846](https://ledgerhq.atlassian.net/browse/LIVE-28846)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28846]: https://ledgerhq.atlassian.net/browse/LIVE-28846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ