### PR TITLE
[LWM] fix(mobile): improve crypto addresses button icon stack and overflow badge

### DIFF
--- a/.changeset/neat-badges-align.md
+++ b/.changeset/neat-badges-align.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix crypto addresses card icon stack: centered overflow badge, chevron when accounts exist, and token icons without network chip

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/__tests__/useCryptoAddressesButtonViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/__tests__/useCryptoAddressesButtonViewModel.test.ts
@@ -223,6 +223,45 @@ describe("useCryptoAddressesButtonViewModel", () => {
     });
   });
 
+  describe("moreAccountsCount", () => {
+    it("should be total accounts minus displayed icon slots when above three accounts", () => {
+      mockPortfolio([makeCategorizedItem(bitcoin, 100)]);
+      const fiveAccounts = [
+        genAccount("a1", { currency: bitcoin }),
+        genAccount("a2", { currency: bitcoin }),
+        genAccount("a3", { currency: bitcoin }),
+        genAccount("a4", { currency: bitcoin }),
+        genAccount("a5", { currency: bitcoin }),
+      ];
+      const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
+        overrideInitialState: withAccounts(fiveAccounts),
+      });
+
+      expect(result.current.moreAccountsCount).toBe(2);
+    });
+
+    it("should be non-positive when at most three accounts", () => {
+      mockPortfolio([makeCategorizedItem(bitcoin, 100)]);
+      const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
+        overrideInitialState: withAccounts([btcAccount, ethAccount]),
+      });
+
+      expect(result.current.moreAccountsCount).toBeLessThanOrEqual(0);
+    });
+
+    it("should not exceed 99", () => {
+      mockPortfolio([makeCategorizedItem(bitcoin, 100)]);
+      const manyAccounts = Array.from({ length: 105 }, (_, i) =>
+        genAccount(`many${i}`, { currency: bitcoin }),
+      );
+      const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {
+        overrideInitialState: withAccounts(manyAccounts),
+      });
+
+      expect(result.current.moreAccountsCount).toBe(99);
+    });
+  });
+
   describe("hasAccounts", () => {
     it("should be true when accounts exist", () => {
       const { result } = renderHook(() => useCryptoAddressesButtonViewModel(), {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  Box,
   Button,
   Card,
   CardHeader,
@@ -10,8 +11,9 @@ import {
   CardContentRow,
   CardTrailing,
   Spot,
+  Text,
 } from "@ledgerhq/lumen-ui-rnative";
-import { Wallet } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { ChevronRight, Wallet } from "@ledgerhq/lumen-ui-rnative/symbols";
 import CurrencyIcon from "~/components/CurrencyIcon";
 import { useTranslation } from "~/context/Locale";
 import AddAccountDrawer from "LLM/features/Accounts/screens/AddAccount";
@@ -24,6 +26,7 @@ export const CryptoAddressesButton: React.FC = () => {
     accountsCount,
     hasAccounts,
     firstThreeCurrencies,
+    moreAccountsCount,
     onPress,
     isAddAccountOpen,
     onCloseAddAccount,
@@ -45,8 +48,30 @@ export const CryptoAddressesButton: React.FC = () => {
                     </CardContentDescription>
                     <IconStack size={20} borderRadius={5}>
                       {firstThreeCurrencies.map(currency => (
-                        <CurrencyIcon key={currency.id} currency={currency} size={20} squared />
+                        <CurrencyIcon
+                          key={currency.id}
+                          currency={currency}
+                          size={20}
+                          squared
+                          hideNetwork
+                        />
                       ))}
+                      {moreAccountsCount > 0 && (
+                        <Box
+                          lx={{
+                            flex: 1,
+                            width: "full",
+                            height: "full",
+                            backgroundColor: "interactive",
+                            alignItems: "center",
+                            justifyContent: "center",
+                          }}
+                        >
+                          <Text typography="body4" lx={{ color: "onInteractive" }}>
+                            +{moreAccountsCount}
+                          </Text>
+                        </Box>
+                      )}
                     </IconStack>
                   </>
                 ) : (
@@ -57,7 +82,11 @@ export const CryptoAddressesButton: React.FC = () => {
               </CardContentRow>
             </CardContent>
           </CardLeading>
-          {!hasAccounts && (
+          {hasAccounts ? (
+            <CardTrailing>
+              <ChevronRight size={24} color="muted" />
+            </CardTrailing>
+          ) : (
             <CardTrailing>
               <Button appearance="base" size="sm" onPress={onPress} testID="add-account-cta">
                 {t("portfolio.cryptoAddresses.add")}

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/useCryptoAddressesButtonViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/useCryptoAddressesButtonViewModel.ts
@@ -13,10 +13,14 @@ interface CryptoAddressesButtonViewModelResult {
   accountsCount: number;
   hasAccounts: boolean;
   firstThreeCurrencies: (CryptoCurrency | TokenCurrency)[];
+  moreAccountsCount: number;
   onPress: () => void;
   isAddAccountOpen: boolean;
   onCloseAddAccount: () => void;
 }
+
+const MAX_ACCOUNTS_TO_DISPLAY = 3;
+const MAX_MORE_ACCOUNTS_DISPLAY = 99;
 
 export function useCryptoAddressesButtonViewModel(): CryptoAddressesButtonViewModelResult {
   const accounts = useSelector(shallowAccountsSelector);
@@ -33,7 +37,7 @@ export function useCryptoAddressesButtonViewModel(): CryptoAddressesButtonViewMo
     () =>
       [...categorizedAssets.cryptos, ...categorizedAssets.stablecoins]
         .sort((a, b) => b.value - a.value)
-        .slice(0, 3)
+        .slice(0, MAX_ACCOUNTS_TO_DISPLAY)
         .map(asset => asset.currency),
     [categorizedAssets],
   );
@@ -64,10 +68,16 @@ export function useCryptoAddressesButtonViewModel(): CryptoAddressesButtonViewMo
 
   const onCloseAddAccount = useCallback(() => setIsAddAccountOpen(false), []);
 
+  const moreAccountsCount = Math.min(
+    Math.max(0, accountsCount - MAX_ACCOUNTS_TO_DISPLAY),
+    MAX_MORE_ACCOUNTS_DISPLAY,
+  );
+
   return {
     accountsCount,
     hasAccounts,
     firstThreeCurrencies,
+    moreAccountsCount,
     onPress,
     isAddAccountOpen: shouldShowAddAccount,
     onCloseAddAccount,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio **Crypto accounts** card: icon stack, overflow `+N` pill, and trailing chevron vs. add CTA
      - Navigation to crypto addresses unchanged; analytics for view/add CTA unchanged

### 📝 Description

**Problem:** The crypto addresses entry on the portfolio wallet assets row did not match the intended design: stacked token icons showed the network chip (noisy at 20px), the overflow count sat in a pill with misaligned text, and the card did not show a clear trailing affordance when the user already had accounts.

**Solution:**

- Wrap the overflow label in a Lumen `Box` with `alignItems` / `justifyContent` center so `+N` is centered in the stack cell; use `body4` typography and `onInteractive` color on the text.
- Pass `hideNetwork` on `CurrencyIcon` in the stack so only the asset mark shows at small size.
- When `hasAccounts`, show a muted `ChevronRight` in `CardTrailing` (add-account button remains when there are no accounts).
- Expose `moreAccountsCount` from the view model (`accountsCount - 3`, capped by UI when `> 0`) and cover it with unit tests.


https://github.com/user-attachments/assets/cf0fa5c6-5bd2-4b22-846e-e753093632d9



### ❓ Context

- **JIRA or GitHub link**: [LIVE-28665](https://ledgerhq.atlassian.net/browse/LIVE-28665)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28665]: https://ledgerhq.atlassian.net/browse/LIVE-28665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ