### PR TITLE
[LWD] feat: add unread transaction indicator in history

### DIFF
--- a/.changeset/six-taxis-worry.md
+++ b/.changeset/six-taxis-worry.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): add unread transaction indicator in history

--- a/apps/ledger-live-desktop/src/main/db/index.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.ts
@@ -60,6 +60,7 @@ const APP_NAMESPACE_ALLOWED_KEY_PATHS: ReadonlySet<string> = new Set([
   "featureFlags",
   "discover",
   "ptx",
+  "history",
   "PLAYWRIGHT_RUN", // e2e fixtures: localStorage seed (e.g. acceptedTermsVersion) and env overrides
 ]);
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/ActionsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/ActionsList.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { TopBarSlot } from "../types";
 import { NotificationIndicator } from "./NotificationIndicator";
+import { HistoryButton } from "./HistoryButton";
 import { TopBarActionButton } from "./TopBarActionButton";
 
 type TopBarActionsListProps = {
@@ -12,6 +13,9 @@ export const TopBarActionsList = ({ slots }: TopBarActionsListProps) => (
     {slots.map(slot => {
       if (slot.type === "notification") {
         return <NotificationIndicator key="notification" />;
+      }
+      if (slot.type === "history") {
+        return <HistoryButton key="history" />;
       }
       return <TopBarActionButton key={slot.action.label} {...slot.action} />;
     })}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/HistoryButton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/HistoryButton.tsx
@@ -1,0 +1,34 @@
+import React, { useCallback } from "react";
+import type { ComponentProps } from "react";
+import { Clock } from "@ledgerhq/lumen-ui-react/symbols";
+import { TopBarActionButton } from "./TopBarActionButton";
+import { UnreadIndicator } from "LLD/components/UnreadIndicator";
+import { useHistory } from "../hooks/useHistory";
+
+export function HistoryButton() {
+  const { handleHistory, historyIcon, hasUnread, tooltip, cta } = useHistory();
+
+  const IconWithUnread = useCallback(
+    (props: ComponentProps<typeof Clock>) => {
+      const Icon = historyIcon;
+      return (
+        <span className="relative inline-flex">
+          <Icon {...props} />
+          <UnreadIndicator className="absolute top-0 right-0 pointer-events-none" />
+        </span>
+      );
+    },
+    [historyIcon],
+  );
+
+  return (
+    <TopBarActionButton
+      label="history"
+      tooltip={tooltip}
+      icon={hasUnread ? IconWithUnread : historyIcon}
+      isInteractive={true}
+      onClick={handleHistory}
+      cta={cta}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarActionButton.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/TopBarActionButton.tsx
@@ -30,7 +30,7 @@ export function TopBarActionButton({
     [onTooltipShow],
   );
 
-  const control = cta ? (
+  const button = cta ? (
     <Button
       appearance={appearance}
       size="sm"
@@ -57,7 +57,7 @@ export function TopBarActionButton({
   return (
     <div className="flex items-center gap-12">
       <Tooltip onOpenChange={handleOpenChange}>
-        <TooltipTrigger asChild>{control}</TooltipTrigger>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
         {tooltip && (
           <TooltipContent side="bottom" className={tooltipClassName}>
             {tooltip}

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/__tests__/HistoryButton.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/__tests__/HistoryButton.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { HistoryButton } from "../HistoryButton";
+import { useHistory } from "../../hooks/useHistory";
+import { Clock } from "@ledgerhq/lumen-ui-react/symbols";
+
+jest.mock("../../hooks/useHistory");
+
+const mockHandleHistory = jest.fn();
+
+const setupMock = (hasUnread: boolean) => {
+  jest.mocked(useHistory).mockReturnValue({
+    handleHistory: mockHandleHistory,
+    historyIcon: Clock,
+    hasUnread,
+    tooltip: "History",
+    cta: "History",
+  });
+};
+
+describe("HistoryButton", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders the History button", () => {
+    setupMock(false);
+    render(<HistoryButton />);
+
+    expect(screen.getByTestId("topbar-action-button-history")).toBeInTheDocument();
+  });
+
+  it("does not show the unread indicator when hasUnread is false", () => {
+    setupMock(false);
+    render(<HistoryButton />);
+
+    expect(screen.queryByTestId("unread-indicator")).not.toBeInTheDocument();
+  });
+
+  it("shows the unread indicator when hasUnread is true", () => {
+    setupMock(true);
+    render(<HistoryButton />);
+
+    expect(screen.getByTestId("unread-indicator")).toBeInTheDocument();
+  });
+
+  it("calls handleHistory when clicked", async () => {
+    setupMock(false);
+    const { user } = render(<HistoryButton />);
+
+    await user.click(screen.getByTestId("topbar-action-button-history"));
+    expect(mockHandleHistory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useHistory.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useHistory.test.ts
@@ -1,7 +1,9 @@
 import { Clock } from "@ledgerhq/lumen-ui-react/symbols";
 import { renderHook, act } from "tests/testSetup";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { useHistory } from "../useHistory";
 import { useNavigate, useLocation } from "react-router";
+import { BTC_ACCOUNT } from "src/mvvm/features/__mocks__/accounts.mock";
 
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
@@ -57,5 +59,87 @@ describe("useHistory", () => {
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  describe("hasUnread", () => {
+    it("is false when lastSeenOperationDate is null", () => {
+      const { result } = renderHook(() => useHistory(), {
+        initialState: { history: { lastSeenOperationDate: null } },
+      });
+
+      expect(result.current.hasUnread).toBe(false);
+    });
+
+    it("is false when there are no accounts", () => {
+      const { result } = renderHook(() => useHistory(), {
+        initialState: {
+          accounts: [],
+          history: { lastSeenOperationDate: new Date("2024-01-01").toISOString() },
+        },
+      });
+
+      expect(result.current.hasUnread).toBe(false);
+    });
+
+    it("is true when an account has an operation newer than lastSeenOperationDate", () => {
+      const account = genAccount("btc-unread", {
+        currency: BTC_ACCOUNT.currency,
+        operationsSize: 3,
+      });
+      // epoch ensures all real operations are newer
+      const epoch = new Date(0).toISOString();
+
+      const { result } = renderHook(() => useHistory(), {
+        initialState: {
+          accounts: [account],
+          history: { lastSeenOperationDate: epoch },
+        },
+      });
+
+      expect(result.current.hasUnread).toBe(true);
+    });
+
+    it("is false when lastSeenOperationDate is in the future", () => {
+      const account = genAccount("btc-read", { currency: BTC_ACCOUNT.currency, operationsSize: 3 });
+      const future = new Date("2099-01-01").toISOString();
+
+      const { result } = renderHook(() => useHistory(), {
+        initialState: {
+          accounts: [account],
+          history: { lastSeenOperationDate: future },
+        },
+      });
+
+      expect(result.current.hasUnread).toBe(false);
+    });
+  });
+
+  describe("handleHistory and lastSeenOperationDate", () => {
+    it("does not update lastSeenOperationDate when navigating to history", () => {
+      mockUseLocation.mockReturnValueOnce(createLocation("/accounts"));
+
+      const { result, store } = renderHook(() => useHistory(), {
+        initialState: { history: { lastSeenOperationDate: null } },
+      });
+
+      act(() => {
+        result.current.handleHistory();
+      });
+
+      expect(store.getState().history.lastSeenOperationDate).toBeNull();
+    });
+
+    it("does not update lastSeenOperationDate when already on history", () => {
+      const original = "2020-01-01T00:00:00.000Z";
+      const { result, store } = renderHook(() => useHistory(), {
+        initialState: { history: { lastSeenOperationDate: original } },
+      });
+
+      act(() => {
+        result.current.handleHistory();
+      });
+
+      expect(store.getState().history.lastSeenOperationDate).toBe(original);
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
@@ -1,4 +1,4 @@
-import { Clock, Eye, Experiment, Refresh, Settings, Tools } from "@ledgerhq/lumen-ui-react/symbols";
+import { Eye, Experiment, Refresh, Settings, Tools } from "@ledgerhq/lumen-ui-react/symbols";
 import { createElement } from "react";
 import { MemoryRouter } from "react-router";
 import { renderHook, withFlagOverrides } from "tests/testSetup";
@@ -8,7 +8,6 @@ import { useDiscreetMode } from "../useDiscreetMode";
 import { useExperimentalFeatures } from "../useExperimentalFeatures";
 import { useFeatureFlags } from "../useFeatureFlags";
 import { useSettings } from "../useSettings";
-import { useHistory } from "../useHistory";
 import type { TopBarSlot } from "../../types";
 
 jest.mock("../useActivityIndicator");
@@ -16,7 +15,6 @@ jest.mock("../useDiscreetMode");
 jest.mock("../useExperimentalFeatures");
 jest.mock("../useFeatureFlags");
 jest.mock("../useSettings");
-jest.mock("../useHistory");
 
 const defaults = {
   discreetMode: { handleDiscreet: jest.fn(), discreetIcon: Eye, tooltip: "Discreet" },
@@ -42,7 +40,6 @@ const defaults = {
     icon: Tools,
     tooltip: "Feature flags",
   },
-  history: { handleHistory: jest.fn(), historyIcon: Clock, tooltip: "History", cta: "History" },
 };
 
 type SetupOptions = {
@@ -79,7 +76,6 @@ const setup = ({
     ...defaults.featureFlags,
     isVisible: featureFlagsVisible,
   });
-  jest.mocked(useHistory).mockReturnValue(defaults.history);
 
   const needsFlags = operationsList || myWallet;
   const initialState = needsFlags
@@ -159,13 +155,11 @@ describe("useTopBarViewModel", () => {
       expect(findSlot(result.current.topBarSlots, "synchronize")?.action.isInteractive).toBe(false);
     });
 
-    it("history slot carries cta text and Clock icon", () => {
+    it("history slot is a dedicated slot type (not an action)", () => {
       const { result } = setup({ operationsList: true });
-      const historySlot = findSlot(result.current.topBarSlots, "history");
+      const historySlot = result.current.topBarSlots.find(s => s.type === "history");
 
-      expect(historySlot?.action.cta).toBe("History");
-      expect(historySlot?.action.icon).toBe(Clock);
-      expect(historySlot?.action.onClick).toBe(defaults.history.handleHistory);
+      expect(historySlot).toBeDefined();
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useHistory.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useHistory.ts
@@ -4,16 +4,20 @@ import { useTranslation } from "react-i18next";
 import { Clock } from "@ledgerhq/lumen-ui-react/symbols";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { track } from "~/renderer/analytics/segment";
+import { useSelector } from "LLD/hooks/redux";
+import { hasUnreadOperationsSelector } from "~/renderer/reducers/history";
 
 export const useHistory = (): {
   handleHistory: () => void;
   historyIcon: typeof Clock;
+  hasUnread: boolean;
   tooltip: string;
   cta: string;
 } => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
+  const hasUnread = useSelector(hasUnreadOperationsSelector);
 
   const handleHistory = useCallback(() => {
     const url = "/history";
@@ -30,6 +34,7 @@ export const useHistory = (): {
   return {
     handleHistory,
     historyIcon: Clock,
+    hasUnread,
     tooltip: t("topBar.history.tooltip"),
     cta: t("topBar.history.cta"),
   };

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
@@ -7,7 +7,6 @@ import { useExperimentalFeatures } from "./useExperimentalFeatures";
 import { useFeatureFlags } from "./useFeatureFlags";
 import { useMyLedger } from "./useMyLedger";
 import { useSettings } from "./useSettings";
-import { useHistory } from "./useHistory";
 import { useInformationCenter } from "./useInformationCenter";
 
 const useTopBarViewModel = () => {
@@ -25,7 +24,6 @@ const useTopBarViewModel = () => {
   } = useActivityIndicator();
   const { handleSettings, settingsIcon, tooltip: settingsTooltip } = useSettings();
   const { handleMyLedger, tooltip: myLedgerTooltip, icon: myLedgerIcon } = useMyLedger();
-  const { handleHistory, historyIcon, tooltip: historyTooltip, cta: historyCta } = useHistory();
   const {
     isVisible: isExperimentalVisible,
     handleExperimental,
@@ -100,21 +98,7 @@ const useTopBarViewModel = () => {
         onClick: handleDiscreet,
       },
     },
-    ...(shouldDisplayOperationsList
-      ? [
-          {
-            type: "action" as const,
-            action: {
-              label: "history",
-              tooltip: historyTooltip,
-              icon: historyIcon,
-              isInteractive: true,
-              onClick: handleHistory,
-              cta: historyCta,
-            },
-          },
-        ]
-      : []),
+    ...(shouldDisplayOperationsList ? [{ type: "history" as const }] : []),
     ...(shouldDisplayMyWallet
       ? []
       : [

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
@@ -41,8 +41,11 @@ type TopBarAction = {
   cta?: string;
 };
 
-/** A slot is either a generic action (button) or the notification indicator (button + drawer). */
-type TopBarSlot = { type: "action"; action: TopBarAction } | { type: "notification" };
+/** A slot is either a generic action (button), the notification indicator (button + drawer), or the history button. */
+type TopBarSlot =
+  | { type: "action"; action: TopBarAction }
+  | { type: "notification" }
+  | { type: "history" };
 
 type TopBarViewProps = {
   slots: TopBarSlot[];

--- a/apps/ledger-live-desktop/src/mvvm/components/UnreadIndicator.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/UnreadIndicator.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+type UnreadIndicatorProps = {
+  readonly className?: string;
+};
+
+export function UnreadIndicator({ className = "pointer-events-none" }: UnreadIndicatorProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="8"
+      height="8"
+      viewBox="0 0 8 8"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+      data-testid="unread-indicator"
+    >
+      <circle cx="4" cy="4" r="4" fill="var(--text-active)" />
+    </svg>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/HistoryView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/HistoryView.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import HistoryPageHeader from "./components/HistoryPageHeader";
 import { HistoryList } from "./screens/HistoryList";
-import type { HistoryViewModel } from "./useHistoryViewModel";
+import type { HistoryViewModel } from "./hooks/useHistoryViewModel";
 
 export function HistoryView({
   navigateToDashboard,

--- a/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
@@ -83,6 +83,22 @@ describe("History integration", () => {
     });
   }
 
+  it("marks operations as seen when leaving the History page", () => {
+    const { unmount, store } = render(<History />, {
+      initialState: {
+        accounts: [BTC_ACCOUNT],
+        settings: AFTER_ONBOARDING_STATE,
+        history: { lastSeenOperationDate: null },
+      },
+    });
+
+    expect(store.getState().history.lastSeenOperationDate).toBeNull();
+
+    unmount();
+
+    expect(store.getState().history.lastSeenOperationDate).not.toBeNull();
+  });
+
   it("should render the table header columns", async () => {
     renderHistory();
 

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
@@ -11,6 +11,7 @@ import CounterValue from "~/renderer/components/CounterValue";
 import { getAddressDirection } from "../utils/getOperationCounterpartyAddress";
 import { OperationCounterpartyLabel } from "./OperationCounterpartyLabel";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { UnreadIndicator } from "LLD/components/UnreadIndicator";
 import type { OperationRow as OperationRowType } from "../types";
 
 type OperationRowProps = {
@@ -23,7 +24,7 @@ function OperationRow({ row, onRowClick }: OperationRowProps) {
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const handleClick = useCallback(() => onRowClick(row), [onRowClick, row]);
   const item = row.original;
-  const { operation, currency, amount, address, type } = item;
+  const { operation, currency, amount, address, type, isUnread } = item;
 
   const typeLabel = operation.hasFailed
     ? t("operationDetails.failed")
@@ -57,7 +58,12 @@ function OperationRow({ row, onRowClick }: OperationRowProps) {
               <CryptoCurrencyIcon currency={currency} size={32} />
             )
           }
-          title={typeLabel}
+          title={
+            <div className="inline-flex items-center gap-12">
+              {typeLabel}
+              {isUnread && <UnreadIndicator />}
+            </div>
+          }
         />
       </TableCell>
       <TableCell align="end" data-testid="history-operation-address">

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
@@ -45,4 +45,54 @@ describe("useHistoryOperations", () => {
     expect(items[0].currency).toBeDefined();
     expect(items[0].amount).toBeDefined();
   });
+
+  describe("isUnread flag", () => {
+    it("is false for all operations when lastSeenOperationDate is null", () => {
+      const accounts = [genAccount("btc-null", { currency: bitcoinCurrency, operationsSize: 3 })];
+
+      const { result } = renderHook(() => useHistoryOperations(), {
+        initialState: {
+          accounts,
+          settings: INITIAL_STATE,
+          history: { lastSeenOperationDate: null },
+        },
+      });
+
+      expect(result.current.length).toBeGreaterThan(0);
+      expect(result.current.every(item => item.isUnread === false)).toBe(true);
+    });
+
+    it("marks all operations as unread when lastSeenOperationDate is in the distant past", () => {
+      const accounts = [genAccount("btc-old", { currency: bitcoinCurrency, operationsSize: 3 })];
+      // epoch = older than any real operation genAccount produces
+      const epoch = new Date(0).toISOString();
+
+      const { result } = renderHook(() => useHistoryOperations(), {
+        initialState: {
+          accounts,
+          settings: INITIAL_STATE,
+          history: { lastSeenOperationDate: epoch },
+        },
+      });
+
+      expect(result.current.length).toBeGreaterThan(0);
+      expect(result.current.every(item => item.isUnread === true)).toBe(true);
+    });
+
+    it("marks no operations as unread when lastSeenOperationDate is in the future", () => {
+      const accounts = [genAccount("btc-future", { currency: bitcoinCurrency, operationsSize: 3 })];
+      const future = new Date("2099-01-01").toISOString();
+
+      const { result } = renderHook(() => useHistoryOperations(), {
+        initialState: {
+          accounts,
+          settings: INITIAL_STATE,
+          history: { lastSeenOperationDate: future },
+        },
+      });
+
+      expect(result.current.length).toBeGreaterThan(0);
+      expect(result.current.every(item => item.isUnread === false)).toBe(true);
+    });
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryOperations.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryOperations.ts
@@ -1,147 +1,52 @@
 import { useMemo, useCallback } from "react";
 import { useSelector } from "LLD/hooks/redux";
-import { AccountLike, Account, Operation } from "@ledgerhq/types-live";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import {
-  flattenAccounts,
-  getAccountCurrency,
-  getMainAccount,
-} from "@ledgerhq/live-common/account/index";
-import {
-  getOperationAmountNumber,
-  flattenOperationWithInternalsAndNfts,
-  isConfirmedOperation,
-} from "@ledgerhq/live-common/operation";
+import { selectFeature } from "@shared/feature-flags";
+import { AccountLike, Operation } from "@ledgerhq/types-live";
 import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
-import { useFilterTokenOperationsZeroAmount } from "~/renderer/actions/settings";
+import { filterTokenOperationsZeroAmountSelector } from "~/renderer/reducers/settings";
+import {
+  buildHistoryOperationItems,
+  getAddressPoisoningFamiliesForFilter,
+} from "../utils/historyOperationItems";
 import { accountsSelector } from "~/renderer/reducers/accounts";
-import { currencySettingsDefaults, type CurrencySettings } from "~/renderer/reducers/settings";
-import { getOperationCounterpartyAddress } from "../utils/getOperationCounterpartyAddress";
+import { lastSeenOperationDateSelector } from "~/renderer/reducers/history";
+import type { State } from "~/renderer/reducers";
 import type { OperationTableItem } from "../types";
-
-type AccountInfo = { account: AccountLike; parentAccount?: Account };
-type FilterFn = (operation: Operation, account: AccountLike) => boolean;
-type TaggedOperation = { operation: Operation; isPending: boolean };
-
-function buildAccountsMap(accounts: Account[]): Map<string, AccountInfo> {
-  const allAccounts = flattenAccounts(accounts);
-  const mainAccountsById = new Map(
-    accounts.filter((a): a is Account => a.type === "Account").map(a => [a.id, a]),
-  );
-  const accountsById = new Map<string, AccountInfo>();
-
-  for (const acc of allAccounts) {
-    const parentAccount = acc.type === "Account" ? undefined : mainAccountsById.get(acc.parentId);
-    accountsById.set(acc.id, { account: acc, parentAccount });
-  }
-
-  return accountsById;
-}
-
-function deduplicateAndTagOperations(
-  acc: AccountLike,
-  mainAccount: Account,
-  confirmationsNb: number,
-): TaggedOperation[] {
-  const existingHashes = new Set(acc.operations.map(op => op.hash));
-
-  const pending: TaggedOperation[] = acc.pendingOperations
-    .filter(op => !existingHashes.has(op.hash))
-    .map(operation => ({ operation, isPending: true }));
-
-  const confirmed: TaggedOperation[] = acc.operations.map(operation => ({
-    operation,
-    isPending: !isConfirmedOperation(operation, mainAccount, confirmationsNb),
-  }));
-
-  return [...pending, ...confirmed];
-}
-
-function toTableItem(
-  operation: Operation,
-  info: AccountInfo,
-  isPending: boolean,
-): OperationTableItem {
-  const { account, parentAccount } = info;
-  return {
-    id: `${account.id}_${operation.id}`,
-    operation,
-    account,
-    parentAccount,
-    date: operation.date,
-    type: operation.type,
-    address: getOperationCounterpartyAddress(operation),
-    amount: getOperationAmountNumber(operation),
-    currency: getAccountCurrency(account),
-    isPending,
-  };
-}
-
-function collectAccountOperations(
-  info: AccountInfo,
-  filterOperation: FilterFn,
-  mainAccount: Account,
-  confirmationsNb: number,
-): OperationTableItem[] {
-  const taggedOps = deduplicateAndTagOperations(info.account, mainAccount, confirmationsNb);
-  return taggedOps.flatMap(({ operation: rawOp, isPending }) => {
-    if (!filterOperation(rawOp, info.account)) return [];
-    return flattenOperationWithInternalsAndNfts(rawOp)
-      .filter(op => filterOperation(op, info.account))
-      .map(op => toTableItem(op, info, isPending));
-  });
-}
-
-function buildOperationItems(
-  accountsMap: Map<string, AccountInfo>,
-  filterOperation: FilterFn,
-  getConfirmationsNb: (mainAccount: Account) => number,
-): OperationTableItem[] {
-  return [...accountsMap.values()].flatMap(info => {
-    const mainAccount = getMainAccount(info.account, info.parentAccount);
-    const confirmationsNb = getConfirmationsNb(mainAccount);
-    return collectAccountOperations(info, filterOperation, mainAccount, confirmationsNb);
-  });
-}
-
-function getConfirmationsNbForCurrency(
-  currenciesSettings: Record<string, CurrencySettings>,
-  currency: CryptoCurrency,
-): number {
-  const obj = currenciesSettings[currency.ticker];
-  if (obj) return obj.confirmationsNb;
-  const defs = currencySettingsDefaults(currency);
-  return defs.confirmationsNb ? defs.confirmationsNb.def : 0;
-}
 
 export function useHistoryOperations(): OperationTableItem[] {
   const accounts = useSelector(accountsSelector);
-  const currenciesSettings = useSelector(state => state.settings.currenciesSettings);
+  const currenciesSettings = useSelector((state: State) => state.settings.currenciesSettings);
+  const lastSeenOperationDate = useSelector(lastSeenOperationDateSelector);
+  const shouldFilterTokenOps = useSelector(filterTokenOperationsZeroAmountSelector);
+  const poisoningFeature = useSelector((state: State) =>
+    selectFeature(state, "addressPoisoningOperationsFilter"),
+  );
 
-  const [shouldFilterTokenOpsZeroAmount] = useFilterTokenOperationsZeroAmount();
-  const addressPoisoningFamilies = useAddressPoisoningOperationsFamilies({
-    shouldFilter: shouldFilterTokenOpsZeroAmount,
-  });
+  const addressPoisoningFamilies = useMemo(
+    () => getAddressPoisoningFamiliesForFilter(shouldFilterTokenOps, poisoningFeature),
+    [shouldFilterTokenOps, poisoningFeature],
+  );
 
   const filterOperation = useCallback(
     (operation: Operation, account: AccountLike) => {
-      if (!shouldFilterTokenOpsZeroAmount) return true;
+      if (!shouldFilterTokenOps) return true;
       return !isAddressPoisoningOperation(
         operation,
         account,
         addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
       );
     },
-    [shouldFilterTokenOpsZeroAmount, addressPoisoningFamilies],
+    [shouldFilterTokenOps, addressPoisoningFamilies],
   );
 
-  return useMemo(() => {
-    const getConfirmationsNb = (mainAccount: Account) =>
-      getConfirmationsNbForCurrency(currenciesSettings, mainAccount.currency);
-
-    const accountsMap = buildAccountsMap(accounts);
-    const items = buildOperationItems(accountsMap, filterOperation, getConfirmationsNb);
-    return items.sort((a, b) => b.date.getTime() - a.date.getTime());
-  }, [accounts, filterOperation, currenciesSettings]);
+  return useMemo(
+    () =>
+      buildHistoryOperationItems(
+        accounts,
+        lastSeenOperationDate,
+        currenciesSettings,
+        filterOperation,
+      ),
+    [accounts, filterOperation, currenciesSettings, lastSeenOperationDate],
+  );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
@@ -1,12 +1,14 @@
 import { useNavigate } from "react-router";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
+import { useDispatch } from "LLD/hooks/redux";
+import { markOperationsAsSeen } from "~/renderer/reducers/history";
 import type { Virtualizer } from "@tanstack/react-virtual";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
-import { useHistoryOperations } from "./hooks/useHistoryOperations";
-import { useHistoryTable } from "./hooks/useHistoryTable";
-import { useHistoryVirtualization } from "./hooks/useHistoryVirtualization";
-import type { HistoryTable, OperationRow, VirtualItem } from "./types";
+import { useHistoryOperations } from "./useHistoryOperations";
+import { useHistoryTable } from "./useHistoryTable";
+import { useHistoryVirtualization } from "./useHistoryVirtualization";
+import type { HistoryTable, OperationRow, VirtualItem } from "../types";
 import { track } from "~/renderer/analytics/segment";
 
 export type HistoryViewModel = {
@@ -22,7 +24,14 @@ export type HistoryViewModel = {
 };
 
 export function useHistoryViewModel(): HistoryViewModel {
+  const dispatch = useDispatch();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    return () => {
+      dispatch(markOperationsAsSeen());
+    };
+  }, [dispatch]);
 
   const navigateToDashboard = useCallback(() => {
     navigate("/");

--- a/apps/ledger-live-desktop/src/mvvm/features/History/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/index.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { HistoryView } from "./HistoryView";
-import { useHistoryViewModel } from "./useHistoryViewModel";
+import { useHistoryViewModel } from "./hooks/useHistoryViewModel";
 
-const History = () => <HistoryView {...useHistoryViewModel()} />;
+const History = () => {
+  const viewModel = useHistoryViewModel();
+
+  return <HistoryView {...viewModel} />;
+};
 
 export default History;

--- a/apps/ledger-live-desktop/src/mvvm/features/History/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/types.ts
@@ -16,6 +16,7 @@ export type OperationTableItem = {
   amount: BigNumber;
   currency: Currency;
   isPending: boolean;
+  isUnread: boolean;
 };
 
 export type HistoryTable = Table<OperationTableItem>;

--- a/apps/ledger-live-desktop/src/mvvm/features/History/utils/__tests__/historyOperationItems.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/utils/__tests__/historyOperationItems.test.ts
@@ -1,0 +1,80 @@
+import type { Features } from "@ledgerhq/types-live";
+import {
+  getAddressPoisoningFamiliesForFilter,
+  getConfirmationsNbForCurrency,
+  isOperationUnread,
+  parseLastSeenMs,
+} from "../historyOperationItems";
+import { BTC_ACCOUNT } from "src/mvvm/features/__mocks__/accounts.mock";
+
+const bitcoinCurrency = BTC_ACCOUNT.currency;
+
+describe("parseLastSeenMs", () => {
+  it("maps null, empty, and valid ISO to ms or null", () => {
+    expect(parseLastSeenMs(null)).toBeNull();
+    expect(parseLastSeenMs("")).toBeNull();
+    expect(parseLastSeenMs("2024-06-01T12:00:00.000Z")).toBe(
+      new Date("2024-06-01T12:00:00.000Z").getTime(),
+    );
+  });
+});
+
+describe("isOperationUnread", () => {
+  const t = new Date("2024-12-01T00:00:00.000Z").getTime();
+
+  it("compares operation time to lastSeenTs", () => {
+    expect(isOperationUnread(new Date(), null)).toBe(false);
+    expect(isOperationUnread(new Date(t), t)).toBe(false);
+    expect(isOperationUnread(new Date(t - 1), t)).toBe(false);
+    expect(isOperationUnread(new Date(t + 1), t)).toBe(true);
+  });
+});
+
+describe("getAddressPoisoningFamiliesForFilter", () => {
+  it("returns null when shouldFilter is false", () => {
+    expect(getAddressPoisoningFamiliesForFilter(false, undefined)).toBeNull();
+  });
+
+  it("when shouldFilter is true and feature is off or missing, returns split ADDRESS_POISONING_FAMILIES from env", () => {
+    const fromEnv = getAddressPoisoningFamiliesForFilter(true, undefined);
+    expect(fromEnv).not.toBeNull();
+    expect(fromEnv!.every(f => f.length > 0)).toBe(true);
+
+    const whenDisabled = getAddressPoisoningFamiliesForFilter(true, {
+      enabled: false,
+      params: { families: ["ignored"] },
+    } satisfies Features["addressPoisoningOperationsFilter"]);
+    expect(whenDisabled).toEqual(fromEnv);
+  });
+
+  it("returns feature params families when feature is enabled", () => {
+    expect(
+      getAddressPoisoningFamiliesForFilter(true, {
+        enabled: true,
+        params: { families: ["solana", "xrp"] },
+      } satisfies Features["addressPoisoningOperationsFilter"]),
+    ).toEqual(["solana", "xrp"]);
+  });
+});
+
+describe("getConfirmationsNbForCurrency", () => {
+  it("uses settings when present for the currency ticker", () => {
+    expect(
+      getConfirmationsNbForCurrency(
+        {
+          [bitcoinCurrency.ticker]: {
+            confirmationsNb: 7,
+            unit: bitcoinCurrency.units[0],
+          },
+        },
+        bitcoinCurrency,
+      ),
+    ).toBe(7);
+  });
+
+  it("falls back to currency defaults when settings are missing", () => {
+    const n = getConfirmationsNbForCurrency({}, bitcoinCurrency);
+    expect(typeof n).toBe("number");
+    expect(Number.isFinite(n)).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/History/utils/historyOperationItems.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/utils/historyOperationItems.ts
@@ -1,0 +1,192 @@
+import type { Account, AccountLike, Features, Operation } from "@ledgerhq/types-live";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { getEnv } from "@ledgerhq/live-env";
+import {
+  flattenAccounts,
+  getAccountCurrency,
+  getMainAccount,
+} from "@ledgerhq/live-common/account/index";
+import {
+  getOperationAmountNumber,
+  flattenOperationWithInternalsAndNfts,
+  isConfirmedOperation,
+} from "@ledgerhq/live-common/operation";
+import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/operation";
+import { currencySettingsDefaults, type CurrencySettings } from "~/renderer/reducers/settings";
+import { getOperationCounterpartyAddress } from "./getOperationCounterpartyAddress";
+import type { OperationTableItem } from "../types";
+
+type AccountInfo = { account: AccountLike; parentAccount?: Account };
+type FilterFn = (operation: Operation, account: AccountLike) => boolean;
+type TaggedOperation = { operation: Operation; isPending: boolean };
+
+export function parseLastSeenMs(iso: string | null): number | null {
+  if (!iso) return null;
+  const ms = new Date(iso).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+export function isOperationUnread(operationDate: Date, lastSeenTs: number | null): boolean {
+  return lastSeenTs !== null && operationDate.getTime() > lastSeenTs;
+}
+
+/**
+ * Mirrors {@link useAddressPoisoningOperationsFamilies} using Redux-resolved flags
+ * (same inputs as {@link selectFeature} for `addressPoisoningOperationsFilter`).
+ */
+export function getAddressPoisoningFamiliesForFilter(
+  shouldFilter: boolean,
+  feature: Features["addressPoisoningOperationsFilter"] | undefined,
+): string[] | null {
+  if (!shouldFilter) return null;
+  if (!feature?.enabled) {
+    return getEnv("ADDRESS_POISONING_FAMILIES")
+      .split(",")
+      .map(s => s.trim());
+  }
+  return feature.params?.families ?? null;
+}
+
+function buildAccountsMap(accounts: Account[]): Map<string, AccountInfo> {
+  const allAccounts = flattenAccounts(accounts);
+  const mainAccountsById = new Map(
+    accounts.filter((a): a is Account => a.type === "Account").map(a => [a.id, a]),
+  );
+  const accountsById = new Map<string, AccountInfo>();
+
+  for (const acc of allAccounts) {
+    const parentAccount = acc.type === "Account" ? undefined : mainAccountsById.get(acc.parentId);
+    accountsById.set(acc.id, { account: acc, parentAccount });
+  }
+
+  return accountsById;
+}
+
+function deduplicateAndTagOperations(
+  acc: AccountLike,
+  mainAccount: Account,
+  confirmationsNb: number,
+): TaggedOperation[] {
+  const existingHashes = new Set(acc.operations.map(op => op.hash));
+
+  const pending: TaggedOperation[] = acc.pendingOperations
+    .filter(op => !existingHashes.has(op.hash))
+    .map(operation => ({ operation, isPending: true }));
+
+  const confirmed: TaggedOperation[] = acc.operations.map(operation => ({
+    operation,
+    isPending: !isConfirmedOperation(operation, mainAccount, confirmationsNb),
+  }));
+
+  return [...pending, ...confirmed];
+}
+
+function toTableItem(
+  operation: Operation,
+  info: AccountInfo,
+  isPending: boolean,
+  lastSeenTs: number | null,
+): OperationTableItem {
+  const { account, parentAccount } = info;
+  return {
+    id: `${account.id}_${operation.id}`,
+    operation,
+    account,
+    parentAccount,
+    date: operation.date,
+    type: operation.type,
+    address: getOperationCounterpartyAddress(operation),
+    amount: getOperationAmountNumber(operation),
+    currency: getAccountCurrency(account),
+    isPending,
+    isUnread: isOperationUnread(operation.date, lastSeenTs),
+  };
+}
+
+function collectAccountOperations(
+  info: AccountInfo,
+  filterOperation: FilterFn,
+  mainAccount: Account,
+  confirmationsNb: number,
+  lastSeenTs: number | null,
+): OperationTableItem[] {
+  const taggedOps = deduplicateAndTagOperations(info.account, mainAccount, confirmationsNb);
+  return taggedOps.flatMap(({ operation: rawOp, isPending }) => {
+    if (!filterOperation(rawOp, info.account)) return [];
+    return flattenOperationWithInternalsAndNfts(rawOp)
+      .filter(op => filterOperation(op, info.account))
+      .map(op => toTableItem(op, info, isPending, lastSeenTs));
+  });
+}
+
+function buildOperationItems(
+  accountsMap: Map<string, AccountInfo>,
+  filterOperation: FilterFn,
+  getConfirmationsNb: (mainAccount: Account) => number,
+  lastSeenTs: number | null,
+): OperationTableItem[] {
+  return [...accountsMap.values()].flatMap(info => {
+    const mainAccount = getMainAccount(info.account, info.parentAccount);
+    const confirmationsNb = getConfirmationsNb(mainAccount);
+    return collectAccountOperations(
+      info,
+      filterOperation,
+      mainAccount,
+      confirmationsNb,
+      lastSeenTs,
+    );
+  });
+}
+
+export function getConfirmationsNbForCurrency(
+  currenciesSettings: Record<string, CurrencySettings>,
+  currency: CryptoCurrency,
+): number {
+  const obj = currenciesSettings[currency.ticker];
+  if (obj) return obj.confirmationsNb;
+  const defs = currencySettingsDefaults(currency);
+  return defs.confirmationsNb ? defs.confirmationsNb.def : 0;
+}
+
+export function buildHistoryOperationItems(
+  accounts: Account[],
+  lastSeenOperationDate: string | null,
+  currenciesSettings: Record<string, CurrencySettings>,
+  filterOperation: FilterFn,
+): OperationTableItem[] {
+  const lastSeenTs = parseLastSeenMs(lastSeenOperationDate);
+  const getConfirmationsNb = (mainAccount: Account) =>
+    getConfirmationsNbForCurrency(currenciesSettings, mainAccount.currency);
+
+  const accountsMap = buildAccountsMap(accounts);
+  const items = buildOperationItems(accountsMap, filterOperation, getConfirmationsNb, lastSeenTs);
+  return items.sort((a, b) => b.date.getTime() - a.date.getTime());
+}
+
+/**
+ * True when any operation that would appear in the global History list is newer than `lastSeenDate`.
+ * Uses the same flattening, pending merge, and filters as {@link buildHistoryOperationItems}.
+ */
+export function historyHasUnreadOperations(
+  accounts: Account[],
+  lastSeenDate: string | null,
+  currenciesSettings: Record<string, CurrencySettings>,
+  shouldFilterTokenOps: boolean,
+  addressPoisoningFamilies: string[] | null,
+): boolean {
+  if (!lastSeenDate) return false;
+  const lastSeenTs = parseLastSeenMs(lastSeenDate);
+  const filterOperation: FilterFn = (operation, account) => {
+    if (!shouldFilterTokenOps) return true;
+    return !isAddressPoisoningOperation(
+      operation,
+      account,
+      addressPoisoningFamilies ? { families: addressPoisoningFamilies } : undefined,
+    );
+  };
+  const getConfirmationsNb = (mainAccount: Account) =>
+    getConfirmationsNbForCurrency(currenciesSettings, mainAccount.currency);
+  const accountsMap = buildAccountsMap(accounts);
+  const items = buildOperationItems(accountsMap, filterOperation, getConfirmationsNb, lastSeenTs);
+  return items.some(item => item.isUnread);
+}

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -57,6 +57,7 @@ import { setupRecentAddressesStore } from "./recentAddresses";
 import { startAnalytics } from "./analytics/segment";
 import { initIdentities } from "~/renderer/helpers/identities";
 import { setAllOverrides, setBannerVisible } from "@shared/feature-flags";
+import { initHistory } from "~/renderer/reducers/history";
 
 const rootNode = document.getElementById("react-root");
 
@@ -248,6 +249,11 @@ async function init() {
     ) {
       store.dispatch(setBannerVisible(initialSettings["featureFlagsButtonVisible"]));
     }
+  }
+
+  const historyState = await getKey("app", "history");
+  if (historyState) {
+    store.dispatch(initHistory(historyState));
   }
 
   const initialCountervalues = await getKey("app", "countervalues");

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -126,6 +126,10 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
     setKey("app", "identities", persisted);
   }
 
+  if (oldState.history !== newState.history) {
+    setKey("app", "history", newState.history);
+  }
+
   if (
     oldState.featureFlags.overrides !== newState.featureFlags.overrides ||
     oldState.featureFlags.bannerVisible !== newState.featureFlags.bannerVisible

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/history.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/history.test.ts
@@ -1,0 +1,122 @@
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import { FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
+import {
+  BTC_ACCOUNT,
+  EMPTY_BTC_ACCOUNT,
+  ETH_ACCOUNT,
+  ETH_ACCOUNT_WITH_USDC,
+} from "src/mvvm/features/__mocks__/accounts.mock";
+import historyReducer, {
+  type HistoryState,
+  markOperationsAsSeen,
+  initHistory,
+  lastSeenOperationDateSelector,
+  hasUnreadOperationsSelector,
+} from "../history";
+import type { State } from "../index";
+
+const settingsUnreadBase = {
+  currenciesSettings: {},
+  filterTokenOperationsZeroAmount: false,
+};
+
+/** Every op date matters for unread (max over flattened ops). */
+function mapAllOperationsDate<T extends AccountLike>(accountLike: T, date: Date): T {
+  return {
+    ...accountLike,
+    operations: accountLike.operations.map(op => ({ ...op, date })),
+  };
+}
+
+function makeUnreadTestState(lastSeenDate: string | null, accounts: Account[]): State {
+  // Selector input is typed as full State; tests only need the slices it reads.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return {
+    accounts,
+    history: { lastSeenOperationDate: lastSeenDate },
+    settings: settingsUnreadBase,
+    featureFlags: FEATURE_FLAGS_INITIAL_STATE,
+  } as unknown as State;
+}
+
+describe("historyReducer", () => {
+  it("initialises with null lastSeenOperationDate", () => {
+    expect(historyReducer(undefined, { type: "@@INIT" })).toEqual({ lastSeenOperationDate: null });
+  });
+
+  it("markOperationsAsSeen sets a current ISO timestamp", () => {
+    const before = new Date().toISOString();
+    const state = historyReducer(undefined, markOperationsAsSeen());
+    const after = new Date().toISOString();
+
+    expect(state.lastSeenOperationDate! >= before).toBe(true);
+    expect(state.lastSeenOperationDate! <= after).toBe(true);
+  });
+
+  it("initHistory replaces state with the payload", () => {
+    const payload: HistoryState = { lastSeenOperationDate: "2024-03-15T12:00:00.000Z" };
+    expect(historyReducer(undefined, initHistory(payload))).toEqual(payload);
+  });
+});
+
+describe("lastSeenOperationDateSelector", () => {
+  it("returns the stored date string or null", () => {
+    expect(
+      lastSeenOperationDateSelector({
+        history: { lastSeenOperationDate: "2024-06-01T00:00:00.000Z" },
+      }),
+    ).toBe("2024-06-01T00:00:00.000Z");
+    expect(lastSeenOperationDateSelector({ history: { lastSeenOperationDate: null } })).toBeNull();
+  });
+});
+
+describe("hasUnreadOperationsSelector", () => {
+  it("returns false when lastSeenOperationDate is null", () => {
+    expect(hasUnreadOperationsSelector(makeUnreadTestState(null, [BTC_ACCOUNT]))).toBe(false);
+  });
+
+  it("returns false when there are no accounts or operations", () => {
+    const seen = "2024-06-01T00:00:00.000Z";
+    expect(hasUnreadOperationsSelector(makeUnreadTestState(seen, []))).toBe(false);
+    expect(hasUnreadOperationsSelector(makeUnreadTestState(seen, [EMPTY_BTC_ACCOUNT]))).toBe(false);
+  });
+
+  it("returns false when the most recent operation is not newer than lastSeenDate", () => {
+    const seen = "2024-06-01T00:00:00.000Z";
+    const old = mapAllOperationsDate(BTC_ACCOUNT, new Date("2024-01-01"));
+    expect(hasUnreadOperationsSelector(makeUnreadTestState(seen, [old]))).toBe(false);
+    const sameDate = new Date(seen);
+    const same = mapAllOperationsDate(BTC_ACCOUNT, sameDate);
+    expect(hasUnreadOperationsSelector(makeUnreadTestState(seen, [same]))).toBe(false);
+  });
+
+  it("returns true when any account has an operation newer than lastSeenDate", () => {
+    const seen = "2024-06-01T00:00:00.000Z";
+    const newer = mapAllOperationsDate(BTC_ACCOUNT, new Date("2024-12-01"));
+    expect(hasUnreadOperationsSelector(makeUnreadTestState(seen, [newer]))).toBe(true);
+
+    const old = mapAllOperationsDate(BTC_ACCOUNT, new Date("2024-01-01"));
+    const newerOnEth = mapAllOperationsDate(ETH_ACCOUNT, new Date("2024-12-01"));
+    expect(hasUnreadOperationsSelector(makeUnreadTestState(seen, [old, newerOnEth]))).toBe(true);
+  });
+
+  it("returns true when newest activity is on a token sub-account", () => {
+    const mainOld = new Date("2020-01-01");
+    const tokenNew = new Date("2024-12-01");
+    const account: Account = {
+      ...ETH_ACCOUNT_WITH_USDC,
+      operations: ETH_ACCOUNT_WITH_USDC.operations.map(op => ({ ...op, date: mainOld })),
+      subAccounts: ETH_ACCOUNT_WITH_USDC.subAccounts!.map(sa => ({
+        ...sa,
+        operations: sa.operations.map(op => ({ ...op, date: tokenNew })),
+      })),
+    };
+    const lastSeen = "2024-06-01T00:00:00.000Z";
+    expect(hasUnreadOperationsSelector(makeUnreadTestState(lastSeen, [account]))).toBe(true);
+  });
+
+  it("returns false when lastSeenOperationDate is in the future", () => {
+    const future = new Date("2099-01-01").toISOString();
+    expect(hasUnreadOperationsSelector(makeUnreadTestState(future, [BTC_ACCOUNT]))).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/reducers/history.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/history.ts
@@ -1,0 +1,60 @@
+import { createSelector, createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { selectFeature } from "@shared/feature-flags";
+import {
+  getAddressPoisoningFamiliesForFilter,
+  historyHasUnreadOperations,
+} from "LLD/features/History/utils/historyOperationItems";
+import type { State } from ".";
+import { accountsSelector } from "./accounts";
+import { filterTokenOperationsZeroAmountSelector } from "./settings";
+
+export type HistoryState = {
+  lastSeenOperationDate: string | null;
+};
+
+const initialState: HistoryState = {
+  // null ensures existing users don't see their entire history as unread on first update
+  lastSeenOperationDate: null,
+};
+
+const historySlice = createSlice({
+  name: "history",
+  initialState,
+  reducers: {
+    markOperationsAsSeen: state => {
+      state.lastSeenOperationDate = new Date().toISOString();
+    },
+    initHistory: (_, action: PayloadAction<HistoryState>) => action.payload,
+  },
+});
+
+export const { markOperationsAsSeen, initHistory } = historySlice.actions;
+
+export default historySlice.reducer;
+
+export const lastSeenOperationDateSelector = (state: Pick<State, "history">): string | null =>
+  state.history.lastSeenOperationDate;
+
+/**
+ * Returns true when any operation shown in global History is newer than lastSeenOperationDate
+ * (same pipeline as the History list: flattened accounts, pending ops, address-poisoning filter).
+ * Returns false when lastSeenOperationDate is null (fresh install).
+ */
+export const hasUnreadOperationsSelector = createSelector(
+  accountsSelector,
+  lastSeenOperationDateSelector,
+  (state: State) => state.settings.currenciesSettings,
+  filterTokenOperationsZeroAmountSelector,
+  (state: State) => selectFeature(state, "addressPoisoningOperationsFilter"),
+  (accounts, lastSeenDate, currenciesSettings, shouldFilterTokenOps, poisoningFeature) => {
+    if (!lastSeenDate) return false;
+    const families = getAddressPoisoningFamiliesForFilter(shouldFilterTokenOps, poisoningFeature);
+    return historyHasUnreadOperations(
+      accounts,
+      lastSeenDate,
+      currenciesSettings,
+      shouldFilterTokenOps,
+      families,
+    );
+  },
+);

--- a/apps/ledger-live-desktop/src/renderer/reducers/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/index.ts
@@ -4,6 +4,7 @@ import accounts, { AccountsState } from "./accounts";
 import application, { ApplicationState } from "./application";
 import devices, { DevicesState } from "./devices";
 import dynamicContent, { DynamicContentState } from "./dynamicContent";
+import history, { HistoryState } from "./history";
 import modals, { ModalsState } from "./modals";
 import UI, { UIState } from "./UI";
 import settings, { SettingsState } from "./settings";
@@ -41,6 +42,7 @@ export type State = LLDRTKApiState & {
   devices: DevicesState;
   dynamicContent: DynamicContentState;
   featureFlags: FeatureFlagsState;
+  history: HistoryState;
   identities: IdentitiesState;
   market: MarketState;
   modals: ModalsState;
@@ -68,6 +70,7 @@ const appReducer = combineReducers({
   devices,
   dynamicContent,
   featureFlags,
+  history,
   identities: identitiesSlice.reducer,
   modals,
   modularDialog,

--- a/apps/ledger-live-desktop/src/renderer/storage.ts
+++ b/apps/ledger-live-desktop/src/renderer/storage.ts
@@ -53,6 +53,7 @@ type DatabaseValues = {
   cryptoAssets: PersistedCAL;
   featureFlags: Pick<FeatureFlagsState, "overrides" | "bannerVisible">;
   identities: PersistedIdentities;
+  history: { lastSeenOperationDate: string | null };
   PLAYWRIGHT_RUN: {
     localStorage?: Record<string, string>;
   };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request introduces a new "unread" indicator for transaction history, allowing users to easily see if there are new operations they haven't viewed yet. It adds a persistent "last seen" timestamp for the transaction history, displays unread dots both in the top bar and on individual operations, and ensures the unread state is preserved across app restarts. The implementation includes Redux state management, selectors, and integration with the application's persistence layer.



### ❓ Context

[LIVE-26232](https://ledgerhq.atlassian.net/browse/LIVE-26232)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26232]: https://ledgerhq.atlassian.net/browse/LIVE-26232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ