### PR TITLE
ci(e2e): add scheduled E2E fund monitor workflow

### DIFF
--- a/.changeset/calm-wallets-monitor.md
+++ b/.changeset/calm-wallets-monitor.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+---
+
+Add scheduled GitHub workflow and Playwright fund monitor to check E2E wallet balances and post Slack alerts

--- a/.github/workflows/test-ui-e2e-fund-monitor.yml
+++ b/.github/workflows/test-ui-e2e-fund-monitor.yml
@@ -1,0 +1,102 @@
+name: "[Desktop] - E2E Fund Monitor"
+run-name: "E2E Fund Monitor • ${{ github.ref_name }}"
+
+on:
+  schedule:
+    - cron: "0 9 * * 1-5"
+  workflow_dispatch: {}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  fund-monitor:
+    name: "Check e2e wallet balances"
+    runs-on: [ledger-live-linux-e2e-speculos-32CPU-128RAM]
+    timeout-minutes: 40
+    env:
+      NODE_OPTIONS: "--max-old-space-size=14336"
+      FORCE_COLOR: 3
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      npm_config_loglevel: warn
+      TURBO_TELEMETRY_DISABLED: 1
+      DO_NOT_TRACK: 1
+      SPECULOS_DEVICE: nanoSP
+      SPECULOS_IMAGE_TAG: ghcr.io/ledgerhq/speculos:latest
+      COINAPPS: ${{ github.workspace }}/coin-apps
+
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # 2.2.1
+        with:
+          app-id: ${{ secrets.GH_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          repositories: |
+            ledger-live
+            coin-apps
+
+      - name: Checkout ledger-live
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: LedgerHQ/ledger-live
+          token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 1
+
+      - name: Checkout coin-apps (device firmware binaries)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: LedgerHQ/coin-apps
+          ref: master
+          token: ${{ steps.generate-token.outputs.token }}
+          path: coin-apps
+          fetch-depth: 1
+
+      - name: Setup caches
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        with:
+          use-mise: true
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-turbo-cache: "false"
+          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+          region: ${{ secrets.AWS_CACHE_REGION }}
+          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+
+      - name: Pull Speculos docker image
+        run: docker pull ${{ env.SPECULOS_IMAGE_TAG }}
+
+      - name: Install dependencies and build CLI
+        run: |
+          pnpm install --frozen-lockfile
+          # Build only the CLI and its transitive dependencies — no LLD needed
+          pnpm turbo run build --filter @ledgerhq/live-cli...
+
+      - name: Run fund monitor spec
+        run: |
+          xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" \
+            -- pnpm exec playwright test \
+            --config playwright.fund-monitor.config.ts
+        working-directory: e2e/desktop
+        env:
+          SEED: ${{ secrets.SEED_QAA_B2C }}
+          CI: "true"
+
+      - name: Upload fund monitor artifacts
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: fund-monitor-artifacts
+          path: |
+            e2e/desktop/tests/artifacts/fund-monitor-report.json
+            e2e/desktop/tests/artifacts/fund-monitor-slack-payload.json
+          if-no-files-found: warn
+
+      - name: Post Slack report
+        if: always()
+        run: |
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -d @${{ github.workspace }}/e2e/desktop/tests/artifacts/fund-monitor-slack-payload.json \
+            ${{ secrets.SLACK_QAA_CHANNEL_ID }}

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -1,6 +1,5 @@
-name: "[Desktop] - E2E Only - Scheduled/Manual"
-run-name: >
-  @Desktop E2E • triggered on ${{ inputs.ref || github.ref_name }} by ${{ github.actor }}
+name: "[Desktop] - E2E Fund Monitor"
+run-name: "E2E Fund Monitor • ${{ github.ref_name }}"
 
 on:
   schedule:
@@ -127,51 +126,19 @@ permissions:
   contents: read
 
 jobs:
-  prepare-devices:
-    name: "Prepare device matrix"
-    runs-on: ubuntu-latest
-    outputs:
-      device_1: ${{ steps.parse.outputs.device_1 }}
-      device_2: ${{ steps.parse.outputs.device_2 }}
-      is_dual: ${{ steps.parse.outputs.is_dual }}
-      e2e_matrix: ${{ steps.parse.outputs.e2e_matrix }}
-    steps:
-      - name: Parse speculos device input
-        id: parse
-        run: |
-          if [ "${{ inputs.speculos_device }}" = "nanoSP and stax" ]; then
-            echo "device_1=nanoSP" >> $GITHUB_OUTPUT
-            echo "device_2=stax" >> $GITHUB_OUTPUT
-            echo "is_dual=true" >> $GITHUB_OUTPUT
-            echo 'e2e_matrix={"include":[{"device":"nanoSP","is_primary":true,"artifact_suffix":""},{"device":"stax","is_primary":false,"artifact_suffix":"-stax"}]}' >> $GITHUB_OUTPUT
-          else
-            DEVICE="${{ inputs.speculos_device || 'nanoSP' }}"
-            echo "device_1=$DEVICE" >> $GITHUB_OUTPUT
-            echo "device_2=skipped" >> $GITHUB_OUTPUT
-            echo "is_dual=false" >> $GITHUB_OUTPUT
-            printf 'e2e_matrix={"include":[{"device":"%s","is_primary":true,"artifact_suffix":""}]}\n' "$DEVICE" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-
-  e2e-tests:
-    name: "Desktop E2E (${{ matrix.device }})"
-    needs: [prepare-devices]
+  fund-monitor:
+    name: "Check e2e wallet balances"
     runs-on: [ledger-live-linux-e2e-speculos-32CPU-128RAM]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare-devices.outputs.e2e_matrix) }}
     timeout-minutes: 40
     env:
       NODE_OPTIONS: "--max-old-space-size=14336"
-      INSTRUMENT_BUILD: true
       FORCE_COLOR: 3
-      CI_OS: "ubuntu-latest"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       npm_config_loglevel: warn
       TURBO_TELEMETRY_DISABLED: 1
       DO_NOT_TRACK: 1
-      SPECULOS_IMAGE_TAG: ghcr.io/ledgerhq/speculos:${{ matrix.device == 'nanoS' && '1be65b91a8e0691866f880fd437ac05fce78af9d' || 'latest' }}
-      SPECULOS_DEVICE: ${{ matrix.device }}
+      SPECULOS_DEVICE: nanoSP
+      SPECULOS_IMAGE_TAG: ghcr.io/ledgerhq/speculos:latest
       COINAPPS: ${{ github.workspace }}/coin-apps
       E2E_FEATURE_FLAGS_JSON: ${{ inputs.feature_flags_json || '' }}
     outputs:
@@ -190,10 +157,9 @@ jobs:
             ledger-live
             coin-apps
 
-      - name: Checkout ledger-live monorepo (shallow clone)
+      - name: Checkout ledger-live
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ inputs.ref || github.sha }}
           repository: LedgerHQ/ledger-live
           token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 1
@@ -208,7 +174,6 @@ jobs:
           fetch-depth: 1
 
       - name: Setup caches
-        id: caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         with:
           use-mise: true
@@ -221,32 +186,14 @@ jobs:
 
       - name: Pull Speculos docker image
         run: docker pull ${{ env.SPECULOS_IMAGE_TAG }}
-        shell: bash
 
-      - name: Install dependencies and build LLD
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-test-desktop@develop
-        id: setup-test-desktop
-        with:
-          build_type: ${{ inputs.build_type || 'testing' }}
-
-      - name: Verify Speculos Docker image is ready
+      - name: Install dependencies and build CLI
         run: |
-          while ! docker image inspect ${{ env.SPECULOS_IMAGE_TAG }} > /dev/null 2>&1; do
-            echo "Waiting for Speculos image pull to complete..."
-            sleep 2
-          done
-          echo "Speculos image ready: ${{ env.SPECULOS_IMAGE_TAG }}"
-          docker image inspect ${{ env.SPECULOS_IMAGE_TAG }} --format '{{.Size}}' | numfmt --to=iec
-        shell: bash
+          pnpm install --frozen-lockfile
+          # Build only the CLI and its transitive dependencies — no LLD needed
+          pnpm turbo run build --filter @ledgerhq/live-cli...
 
-      - name: Configure test environment (API endpoints, broadcast settings)
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-env@develop
-        with:
-          enable_broadcast: ${{ inputs.enable_broadcast }}
-          build_type: ${{ inputs.build_type }}
-
-      - name: Build Playwright grep filter from inputs
-        id: test-filter
+      - name: Run fund monitor spec
         run: |
           BASE_FILTER="${{ inputs.test_filter }}"
           if [ -n "$BASE_FILTER" ]; then
@@ -319,273 +266,22 @@ jobs:
           enable_wallet40: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 4 * * 1,3,5') || inputs.enable_wallet40 || false }}
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
-          XRAY: ${{ matrix.is_primary && inputs.export_to_xray || false }}
-          TEST_EXECUTION: ${{ inputs.test_execution }}
-          PROJECT_KEY: B2CQA
-          SWAP_API_BASE: ${{ env.SWAP_API_BASE }}
+          CI: "true"
 
-      - name: Upload Allure test results artifact
-        if: ${{ !cancelled() }}
+      - name: Upload fund monitor artifacts
+        if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: allure-results${{ matrix.artifact_suffix }}
-          path: "e2e/desktop/allure-results"
+          name: fund-monitor-artifacts
+          path: |
+            e2e/desktop/tests/artifacts/fund-monitor-report.json
+            e2e/desktop/tests/artifacts/fund-monitor-slack-payload.json
+          if-no-files-found: warn
 
-      - name: Upload Xray test results for Jira
-        if: ${{ !cancelled() && inputs.export_to_xray && matrix.is_primary }}
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: xray-reports
-          path: e2e/desktop/tests/artifacts/xray/xray-report.json
-
-  report-to-allure:
-    name: "Create Allure Report - ${{ needs.prepare-devices.outputs.device_1 }}"
-    runs-on: [ledger-live-medium]
-    needs: [prepare-devices, e2e-tests]
-    outputs:
-      test_result: ${{ steps.summary.outputs.test_result }}
-      status_color: ${{ steps.summary.outputs.status_color }}
-      status_emoji: ${{ steps.summary.outputs.status_emoji }}
-      report-url: ${{ steps.allure-server.outputs.report-url }}
-    if: ${{ !cancelled() }}
-    env:
-      ALLURE_RESULTS: "allure-results"
-    steps:
-      - name: Download Allure results from test job
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: allure-results
-          path: ${{ env.ALLURE_RESULTS }}
-
-      - name: Publish report to Allure Server
-        id: allure-server
-        if: ${{ !cancelled() }}
-        uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report@develop
-        with:
-          platform: ${{ github.event_name == 'schedule' && 'linux-speculos-nightly' || (inputs.smoke_tests && 'linux-speculos-smoke' || 'linux-speculos') }}
-          login: ${{ vars.ALLURE_USERNAME }}
-          password: ${{ secrets.ALLURE_LEDGER_LIVE_PASSWORD }}
-          path: ${{ env.ALLURE_RESULTS }}
-
-      - name: Extract test summary for Slack notification
-        if: ${{ !cancelled() && (inputs.slack_notif || github.event_name == 'schedule' )}}
-        id: summary
-        uses: LedgerHQ/ledger-live/tools/actions/composites/get-allure-summary@develop
-        with:
-          allure-results-path: ${{ env.ALLURE_RESULTS }}
-          platform: ${{ needs.prepare-devices.outputs.is_dual == 'true' && format('linux-{0}', needs.prepare-devices.outputs.device_1) || 'linux' }}
-
-  report-to-allure-device2:
-    name: "Create Allure Report - device 2"
-    runs-on: [ledger-live-medium]
-    needs: [prepare-devices, e2e-tests]
-    if: ${{ !cancelled() && needs.prepare-devices.outputs.is_dual == 'true' }}
-    outputs:
-      test_result: ${{ steps.summary.outputs.test_result }}
-      status_color: ${{ steps.summary.outputs.status_color }}
-      status_emoji: ${{ steps.summary.outputs.status_emoji }}
-      report-url: ${{ steps.allure-server.outputs.report-url }}
-    env:
-      ALLURE_RESULTS: "allure-results-device2"
-    steps:
-      - name: Download Allure results from device2 test job
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: allure-results-${{ needs.prepare-devices.outputs.device_2 }}
-          path: ${{ env.ALLURE_RESULTS }}
-
-      - name: Publish report to Allure Server
-        id: allure-server
-        if: ${{ !cancelled() }}
-        uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report@develop
-        with:
-          platform: linux-speculos-${{ needs.prepare-devices.outputs.device_2 }}
-          login: ${{ vars.ALLURE_USERNAME }}
-          password: ${{ secrets.ALLURE_LEDGER_LIVE_PASSWORD }}
-          path: ${{ env.ALLURE_RESULTS }}
-
-      - name: Extract test summary for Slack notification
-        if: ${{ !cancelled() && (inputs.slack_notif || github.event_name == 'schedule') }}
-        id: summary
-        uses: LedgerHQ/ledger-live/tools/actions/composites/get-allure-summary@develop
-        with:
-          allure-results-path: ${{ env.ALLURE_RESULTS }}
-          platform: linux-${{ needs.prepare-devices.outputs.device_2 }}
-
-  upload-to-xray:
-    name: "Upload to Xray"
-    runs-on: [ledger-live-medium]
-    env:
-      XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
-      XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}
-      XRAY_API_URL: https://xray.cloud.getxray.app/api/v2
-      JIRA_URL: https://ledgerhq.atlassian.net/browse
-    needs: [prepare-devices, e2e-tests]
-    if: ${{ !cancelled() && inputs.export_to_xray && needs.prepare-devices.outputs.is_dual == 'false' }}
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
-      - name: Download Xray Results
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: xray-reports
-          path: "e2e/desktop/artifacts/xray"
-
-      - name: Authenticate to Xray
-        id: authenticate
+      - name: Post Slack report
+        if: always()
         run: |
-          response=$(curl -H "Content-Type: application/json" -X POST --data '{"client_id": "${{ secrets.XRAY_CLIENT_ID }}", "client_secret": "${{ secrets.XRAY_CLIENT_SECRET }}"}' ${{ env.XRAY_API_URL }}/authenticate)
-          echo "xray_token=$response" >> $GITHUB_OUTPUT
-
-      - name: Publish report on Xray
-        id: publish-xray
-        run: |
-          response=$(curl -H "Content-Type: application/json" \
-                    -H "Authorization: Bearer ${{ steps.authenticate.outputs.xray_token }}" \
-                    -X POST \
-                    --data @e2e/desktop/artifacts/xray/xray-report.json \
-                    ${{ env.XRAY_API_URL }}/import/execution)
-          key=$(echo $response | jq -r '.key')
-          echo "xray_key=$key" >> $GITHUB_OUTPUT
-
-      - name: Write Xray report in summary
-        shell: bash
-        run: echo "::notice title=Xray report URL::${{ env.JIRA_URL }}/${{ steps.publish-xray.outputs.xray_key }}"
-
-  notify-to-slack:
-    name: "Notify to Slack"
-    runs-on: [ledger-live-medium]
-    needs: [prepare-devices, report-to-allure, report-to-allure-device2]
-    if: ${{ always() && (inputs.slack_notif || github.event_name == 'schedule') }}
-    steps:
-      - uses: actions/github-script@v7
-        name: Prepare Slack payload
-        id: status
-        env:
-          IS_DUAL: ${{ needs.prepare-devices.outputs.is_dual }}
-          DEVICE_1: ${{ needs.prepare-devices.outputs.device_1 }}
-          DEVICE_2: ${{ needs.prepare-devices.outputs.device_2 }}
-          STATUS_EMOJI: ${{ needs.report-to-allure.outputs.status_emoji }}
-          STATUS_EMOJI_D2: ${{ needs.report-to-allure-device2.outputs.status_emoji }}
-          EXPORT_TO_XRAY: ${{ inputs.export_to_xray }}
-          TEST_EXECUTION: ${{ github.event.inputs.test_execution }}
-        with:
-          script: |
-            const fs = require("fs");
-            const isDual = process.env.IS_DUAL === "true";
-            const device1 = process.env.DEVICE_1 || "nanoSP";
-            const device2 = process.env.DEVICE_2;
-            let blocks;
-            if (isDual) {
-              blocks = [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": `:ledger-logo: Ledger Live Desktop E2E tests results on ${{ inputs.ref || github.ref_name }} - ${device1} + ${device2}${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}`,
-                    "emoji": true
-                  }
-                },
-                { "type": "divider" },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": `- 🐧 linux (${device1}) : ${process.env.STATUS_EMOJI} ${{ needs.report-to-allure.outputs.test_result || 'No test results' }}`
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": `- 🐧 linux (${device2}) : ${process.env.STATUS_EMOJI_D2} ${{ needs.report-to-allure-device2.outputs.test_result || 'No test results' }}`
-                  }
-                },
-                { "type": "divider" },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": `*Allure Report (${device1})*\n<${{ needs.report-to-allure.outputs.report-url }}|allure-results-${device1}>`
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": `*Allure Report (${device2})*\n<${{ needs.report-to-allure-device2.outputs.report-url }}|allure-results-${device2}>`
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>"
-                    }
-                  ]
-                }
-              ];
-            } else {
-              const statusEmoji = process.env.STATUS_EMOJI;
-              blocks = [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": `:ledger-logo: Ledger Live Desktop E2E tests results on ${{ inputs.ref || github.ref_name }} - ${{ inputs.speculos_device || 'nanoSP' }}${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}`,
-                    "emoji": true
-                  }
-                },
-                { "type": "divider" },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": `- 🐧 linux : ${statusEmoji} ${{ needs.report-to-allure.outputs.test_result || 'No test results' }}`
-                  }
-                },
-                { "type": "divider" },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Allure Report*\n<${{ needs.report-to-allure.outputs.report-url }}|allure-results-linux>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>"
-                    }
-                  ]
-                }
-              ];
-              if (process.env.EXPORT_TO_XRAY === 'true') {
-                blocks.push({
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": `*Xray Link*\n<https://ledgerhq.atlassian.net/browse/${process.env.TEST_EXECUTION}|Test Execution>`
-                    }
-                  ]
-                });
-              }
-            }
-            const d1Color = "${{ needs.report-to-allure.outputs.status_color }}";
-            const d2Color = "${{ needs.report-to-allure-device2.outputs.status_color }}";
-            const color = isDual
-              ? (d1Color === "#33FF39" && d2Color === "#33FF39" ? "#33FF39" : "#FF333C")
-              : (d1Color || "#808080");
-            const slackPayload = {
-              "attachments": [
-                {
-                  "color": color,
-                  blocks
-                }
-              ]
-            };
-            fs.writeFileSync("payload-slack-content.json", JSON.stringify(slackPayload), "utf-8");
-
-      - name: Post to Slack channel
-        id: slack
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: "C05FKJ7DFAP"
-          payload-file-path: ${{ github.workspace }}/payload-slack-content.json
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -d @${{ github.workspace }}/e2e/desktop/tests/artifacts/fund-monitor-slack-payload.json \
+            ${{ secrets.SLACK_QAA_CHANNEL_ID }}

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -1,5 +1,6 @@
-name: "[Desktop] - E2E Fund Monitor"
-run-name: "E2E Fund Monitor • ${{ github.ref_name }}"
+name: "[Desktop] - E2E Only - Scheduled/Manual"
+run-name: >
+  @Desktop E2E • triggered on ${{ inputs.ref || github.ref_name }} by ${{ github.actor }}
 
 on:
   schedule:
@@ -126,19 +127,51 @@ permissions:
   contents: read
 
 jobs:
-  fund-monitor:
-    name: "Check e2e wallet balances"
+  prepare-devices:
+    name: "Prepare device matrix"
+    runs-on: ubuntu-latest
+    outputs:
+      device_1: ${{ steps.parse.outputs.device_1 }}
+      device_2: ${{ steps.parse.outputs.device_2 }}
+      is_dual: ${{ steps.parse.outputs.is_dual }}
+      e2e_matrix: ${{ steps.parse.outputs.e2e_matrix }}
+    steps:
+      - name: Parse speculos device input
+        id: parse
+        run: |
+          if [ "${{ inputs.speculos_device }}" = "nanoSP and stax" ]; then
+            echo "device_1=nanoSP" >> $GITHUB_OUTPUT
+            echo "device_2=stax" >> $GITHUB_OUTPUT
+            echo "is_dual=true" >> $GITHUB_OUTPUT
+            echo 'e2e_matrix={"include":[{"device":"nanoSP","is_primary":true,"artifact_suffix":""},{"device":"stax","is_primary":false,"artifact_suffix":"-stax"}]}' >> $GITHUB_OUTPUT
+          else
+            DEVICE="${{ inputs.speculos_device || 'nanoSP' }}"
+            echo "device_1=$DEVICE" >> $GITHUB_OUTPUT
+            echo "device_2=skipped" >> $GITHUB_OUTPUT
+            echo "is_dual=false" >> $GITHUB_OUTPUT
+            printf 'e2e_matrix={"include":[{"device":"%s","is_primary":true,"artifact_suffix":""}]}\n' "$DEVICE" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+  e2e-tests:
+    name: "Desktop E2E (${{ matrix.device }})"
+    needs: [prepare-devices]
     runs-on: [ledger-live-linux-e2e-speculos-32CPU-128RAM]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-devices.outputs.e2e_matrix) }}
     timeout-minutes: 40
     env:
       NODE_OPTIONS: "--max-old-space-size=14336"
+      INSTRUMENT_BUILD: true
       FORCE_COLOR: 3
+      CI_OS: "ubuntu-latest"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       npm_config_loglevel: warn
       TURBO_TELEMETRY_DISABLED: 1
       DO_NOT_TRACK: 1
-      SPECULOS_DEVICE: nanoSP
-      SPECULOS_IMAGE_TAG: ghcr.io/ledgerhq/speculos:latest
+      SPECULOS_IMAGE_TAG: ghcr.io/ledgerhq/speculos:${{ matrix.device == 'nanoS' && '1be65b91a8e0691866f880fd437ac05fce78af9d' || 'latest' }}
+      SPECULOS_DEVICE: ${{ matrix.device }}
       COINAPPS: ${{ github.workspace }}/coin-apps
       E2E_FEATURE_FLAGS_JSON: ${{ inputs.feature_flags_json || '' }}
     outputs:
@@ -157,9 +190,10 @@ jobs:
             ledger-live
             coin-apps
 
-      - name: Checkout ledger-live
+      - name: Checkout ledger-live monorepo (shallow clone)
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          ref: ${{ inputs.ref || github.sha }}
           repository: LedgerHQ/ledger-live
           token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 1
@@ -174,6 +208,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup caches
+        id: caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         with:
           use-mise: true
@@ -186,14 +221,32 @@ jobs:
 
       - name: Pull Speculos docker image
         run: docker pull ${{ env.SPECULOS_IMAGE_TAG }}
+        shell: bash
 
-      - name: Install dependencies and build CLI
+      - name: Install dependencies and build LLD
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-test-desktop@develop
+        id: setup-test-desktop
+        with:
+          build_type: ${{ inputs.build_type || 'testing' }}
+
+      - name: Verify Speculos Docker image is ready
         run: |
-          pnpm install --frozen-lockfile
-          # Build only the CLI and its transitive dependencies — no LLD needed
-          pnpm turbo run build --filter @ledgerhq/live-cli...
+          while ! docker image inspect ${{ env.SPECULOS_IMAGE_TAG }} > /dev/null 2>&1; do
+            echo "Waiting for Speculos image pull to complete..."
+            sleep 2
+          done
+          echo "Speculos image ready: ${{ env.SPECULOS_IMAGE_TAG }}"
+          docker image inspect ${{ env.SPECULOS_IMAGE_TAG }} --format '{{.Size}}' | numfmt --to=iec
+        shell: bash
 
-      - name: Run fund monitor spec
+      - name: Configure test environment (API endpoints, broadcast settings)
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-env@develop
+        with:
+          enable_broadcast: ${{ inputs.enable_broadcast }}
+          build_type: ${{ inputs.build_type }}
+
+      - name: Build Playwright grep filter from inputs
+        id: test-filter
         run: |
           BASE_FILTER="${{ inputs.test_filter }}"
           if [ -n "$BASE_FILTER" ]; then
@@ -266,22 +319,273 @@ jobs:
           enable_wallet40: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 4 * * 1,3,5') || inputs.enable_wallet40 || false }}
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
-          CI: "true"
+          XRAY: ${{ matrix.is_primary && inputs.export_to_xray || false }}
+          TEST_EXECUTION: ${{ inputs.test_execution }}
+          PROJECT_KEY: B2CQA
+          SWAP_API_BASE: ${{ env.SWAP_API_BASE }}
 
-      - name: Upload fund monitor artifacts
-        if: always()
+      - name: Upload Allure test results artifact
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: fund-monitor-artifacts
-          path: |
-            e2e/desktop/tests/artifacts/fund-monitor-report.json
-            e2e/desktop/tests/artifacts/fund-monitor-slack-payload.json
-          if-no-files-found: warn
+          name: allure-results${{ matrix.artifact_suffix }}
+          path: "e2e/desktop/allure-results"
 
-      - name: Post Slack report
-        if: always()
+      - name: Upload Xray test results for Jira
+        if: ${{ !cancelled() && inputs.export_to_xray && matrix.is_primary }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: xray-reports
+          path: e2e/desktop/tests/artifacts/xray/xray-report.json
+
+  report-to-allure:
+    name: "Create Allure Report - ${{ needs.prepare-devices.outputs.device_1 }}"
+    runs-on: [ledger-live-medium]
+    needs: [prepare-devices, e2e-tests]
+    outputs:
+      test_result: ${{ steps.summary.outputs.test_result }}
+      status_color: ${{ steps.summary.outputs.status_color }}
+      status_emoji: ${{ steps.summary.outputs.status_emoji }}
+      report-url: ${{ steps.allure-server.outputs.report-url }}
+    if: ${{ !cancelled() }}
+    env:
+      ALLURE_RESULTS: "allure-results"
+    steps:
+      - name: Download Allure results from test job
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: allure-results
+          path: ${{ env.ALLURE_RESULTS }}
+
+      - name: Publish report to Allure Server
+        id: allure-server
+        if: ${{ !cancelled() }}
+        uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report@develop
+        with:
+          platform: ${{ github.event_name == 'schedule' && 'linux-speculos-nightly' || (inputs.smoke_tests && 'linux-speculos-smoke' || 'linux-speculos') }}
+          login: ${{ vars.ALLURE_USERNAME }}
+          password: ${{ secrets.ALLURE_LEDGER_LIVE_PASSWORD }}
+          path: ${{ env.ALLURE_RESULTS }}
+
+      - name: Extract test summary for Slack notification
+        if: ${{ !cancelled() && (inputs.slack_notif || github.event_name == 'schedule' )}}
+        id: summary
+        uses: LedgerHQ/ledger-live/tools/actions/composites/get-allure-summary@develop
+        with:
+          allure-results-path: ${{ env.ALLURE_RESULTS }}
+          platform: ${{ needs.prepare-devices.outputs.is_dual == 'true' && format('linux-{0}', needs.prepare-devices.outputs.device_1) || 'linux' }}
+
+  report-to-allure-device2:
+    name: "Create Allure Report - device 2"
+    runs-on: [ledger-live-medium]
+    needs: [prepare-devices, e2e-tests]
+    if: ${{ !cancelled() && needs.prepare-devices.outputs.is_dual == 'true' }}
+    outputs:
+      test_result: ${{ steps.summary.outputs.test_result }}
+      status_color: ${{ steps.summary.outputs.status_color }}
+      status_emoji: ${{ steps.summary.outputs.status_emoji }}
+      report-url: ${{ steps.allure-server.outputs.report-url }}
+    env:
+      ALLURE_RESULTS: "allure-results-device2"
+    steps:
+      - name: Download Allure results from device2 test job
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: allure-results-${{ needs.prepare-devices.outputs.device_2 }}
+          path: ${{ env.ALLURE_RESULTS }}
+
+      - name: Publish report to Allure Server
+        id: allure-server
+        if: ${{ !cancelled() }}
+        uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report@develop
+        with:
+          platform: linux-speculos-${{ needs.prepare-devices.outputs.device_2 }}
+          login: ${{ vars.ALLURE_USERNAME }}
+          password: ${{ secrets.ALLURE_LEDGER_LIVE_PASSWORD }}
+          path: ${{ env.ALLURE_RESULTS }}
+
+      - name: Extract test summary for Slack notification
+        if: ${{ !cancelled() && (inputs.slack_notif || github.event_name == 'schedule') }}
+        id: summary
+        uses: LedgerHQ/ledger-live/tools/actions/composites/get-allure-summary@develop
+        with:
+          allure-results-path: ${{ env.ALLURE_RESULTS }}
+          platform: linux-${{ needs.prepare-devices.outputs.device_2 }}
+
+  upload-to-xray:
+    name: "Upload to Xray"
+    runs-on: [ledger-live-medium]
+    env:
+      XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
+      XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}
+      XRAY_API_URL: https://xray.cloud.getxray.app/api/v2
+      JIRA_URL: https://ledgerhq.atlassian.net/browse
+    needs: [prepare-devices, e2e-tests]
+    if: ${{ !cancelled() && inputs.export_to_xray && needs.prepare-devices.outputs.is_dual == 'false' }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Download Xray Results
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: xray-reports
+          path: "e2e/desktop/artifacts/xray"
+
+      - name: Authenticate to Xray
+        id: authenticate
         run: |
-          curl -X POST \
-            -H "Content-Type: application/json" \
-            -d @${{ github.workspace }}/e2e/desktop/tests/artifacts/fund-monitor-slack-payload.json \
-            ${{ secrets.SLACK_QAA_CHANNEL_ID }}
+          response=$(curl -H "Content-Type: application/json" -X POST --data '{"client_id": "${{ secrets.XRAY_CLIENT_ID }}", "client_secret": "${{ secrets.XRAY_CLIENT_SECRET }}"}' ${{ env.XRAY_API_URL }}/authenticate)
+          echo "xray_token=$response" >> $GITHUB_OUTPUT
+
+      - name: Publish report on Xray
+        id: publish-xray
+        run: |
+          response=$(curl -H "Content-Type: application/json" \
+                    -H "Authorization: Bearer ${{ steps.authenticate.outputs.xray_token }}" \
+                    -X POST \
+                    --data @e2e/desktop/artifacts/xray/xray-report.json \
+                    ${{ env.XRAY_API_URL }}/import/execution)
+          key=$(echo $response | jq -r '.key')
+          echo "xray_key=$key" >> $GITHUB_OUTPUT
+
+      - name: Write Xray report in summary
+        shell: bash
+        run: echo "::notice title=Xray report URL::${{ env.JIRA_URL }}/${{ steps.publish-xray.outputs.xray_key }}"
+
+  notify-to-slack:
+    name: "Notify to Slack"
+    runs-on: [ledger-live-medium]
+    needs: [prepare-devices, report-to-allure, report-to-allure-device2]
+    if: ${{ always() && (inputs.slack_notif || github.event_name == 'schedule') }}
+    steps:
+      - uses: actions/github-script@v7
+        name: Prepare Slack payload
+        id: status
+        env:
+          IS_DUAL: ${{ needs.prepare-devices.outputs.is_dual }}
+          DEVICE_1: ${{ needs.prepare-devices.outputs.device_1 }}
+          DEVICE_2: ${{ needs.prepare-devices.outputs.device_2 }}
+          STATUS_EMOJI: ${{ needs.report-to-allure.outputs.status_emoji }}
+          STATUS_EMOJI_D2: ${{ needs.report-to-allure-device2.outputs.status_emoji }}
+          EXPORT_TO_XRAY: ${{ inputs.export_to_xray }}
+          TEST_EXECUTION: ${{ github.event.inputs.test_execution }}
+        with:
+          script: |
+            const fs = require("fs");
+            const isDual = process.env.IS_DUAL === "true";
+            const device1 = process.env.DEVICE_1 || "nanoSP";
+            const device2 = process.env.DEVICE_2;
+            let blocks;
+            if (isDual) {
+              blocks = [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": `:ledger-logo: Ledger Live Desktop E2E tests results on ${{ inputs.ref || github.ref_name }} - ${device1} + ${device2}${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}`,
+                    "emoji": true
+                  }
+                },
+                { "type": "divider" },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": `- 🐧 linux (${device1}) : ${process.env.STATUS_EMOJI} ${{ needs.report-to-allure.outputs.test_result || 'No test results' }}`
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": `- 🐧 linux (${device2}) : ${process.env.STATUS_EMOJI_D2} ${{ needs.report-to-allure-device2.outputs.test_result || 'No test results' }}`
+                  }
+                },
+                { "type": "divider" },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": `*Allure Report (${device1})*\n<${{ needs.report-to-allure.outputs.report-url }}|allure-results-${device1}>`
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": `*Allure Report (${device2})*\n<${{ needs.report-to-allure-device2.outputs.report-url }}|allure-results-${device2}>`
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>"
+                    }
+                  ]
+                }
+              ];
+            } else {
+              const statusEmoji = process.env.STATUS_EMOJI;
+              blocks = [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": `:ledger-logo: Ledger Live Desktop E2E tests results on ${{ inputs.ref || github.ref_name }} - ${{ inputs.speculos_device || 'nanoSP' }}${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}`,
+                    "emoji": true
+                  }
+                },
+                { "type": "divider" },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": `- 🐧 linux : ${statusEmoji} ${{ needs.report-to-allure.outputs.test_result || 'No test results' }}`
+                  }
+                },
+                { "type": "divider" },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Allure Report*\n<${{ needs.report-to-allure.outputs.report-url }}|allure-results-linux>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>"
+                    }
+                  ]
+                }
+              ];
+              if (process.env.EXPORT_TO_XRAY === 'true') {
+                blocks.push({
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": `*Xray Link*\n<https://ledgerhq.atlassian.net/browse/${process.env.TEST_EXECUTION}|Test Execution>`
+                    }
+                  ]
+                });
+              }
+            }
+            const d1Color = "${{ needs.report-to-allure.outputs.status_color }}";
+            const d2Color = "${{ needs.report-to-allure-device2.outputs.status_color }}";
+            const color = isDual
+              ? (d1Color === "#33FF39" && d2Color === "#33FF39" ? "#33FF39" : "#FF333C")
+              : (d1Color || "#808080");
+            const slackPayload = {
+              "attachments": [
+                {
+                  "color": color,
+                  blocks
+                }
+              ]
+            };
+            fs.writeFileSync("payload-slack-content.json", JSON.stringify(slackPayload), "utf-8");
+
+      - name: Post to Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: "C05FKJ7DFAP"
+          payload-file-path: ${{ github.workspace }}/payload-slack-content.json
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}

--- a/e2e/desktop/package.json
+++ b/e2e/desktop/package.json
@@ -7,6 +7,7 @@
     "lint:fix": "oxfmt . && oxlint . --fix",
     "typecheck": "tsc --noEmit --project tsconfig.json --customConditions node",
     "test:playwright": "playwright test --config=playwright.config.ts",
+    "test:fund-monitor": "playwright test --config=playwright.fund-monitor.config.ts",
     "test:playwright:setup": "playwright install chromium",
     "allure:generate": "allure generate ./allure-results --clean -o ./allure-report",
     "allure:open": "allure open ./allure-report",

--- a/e2e/desktop/playwright.fund-monitor.config.ts
+++ b/e2e/desktop/playwright.fund-monitor.config.ts
@@ -1,0 +1,21 @@
+// Playwright config for the fund monitor.
+// Runs ONLY checkBalance.spec.ts — no global setup, no LLD needed.
+// Used by .github/workflows/test-ui-e2e-fund-monitor.yml
+
+import { PlaywrightTestConfig } from "@playwright/test";
+
+const config: PlaywrightTestConfig = {
+  testDir: "./tests",
+  testMatch: "**/utils/checkBalance/checkBalance.spec.ts",
+  fullyParallel: true,
+  workers: "100%",
+  retries: 1,
+  timeout: 120_000,
+  outputDir: "./tests/artifacts/test-results",
+  globalTeardown: require.resolve("./tests/utils/checkBalance/teardown"),
+  reporter: process.env.CI
+    ? [["list"], ["json", { outputFile: "tests/artifacts/fund-monitor-results.json" }]]
+    : [["list"]],
+};
+
+export default config;

--- a/e2e/desktop/playwright.fund-monitor.config.ts
+++ b/e2e/desktop/playwright.fund-monitor.config.ts
@@ -1,6 +1,5 @@
 // Playwright config for the fund monitor.
 // Runs ONLY checkBalance.spec.ts — no global setup, no LLD needed.
-// Used by .github/workflows/test-ui-e2e-fund-monitor.yml
 
 import { PlaywrightTestConfig } from "@playwright/test";
 

--- a/e2e/desktop/tests/utils/checkBalance/checkBalance.spec.ts
+++ b/e2e/desktop/tests/utils/checkBalance/checkBalance.spec.ts
@@ -1,0 +1,167 @@
+import { mkdirSync, writeFileSync } from "fs";
+import { resolve } from "path";
+import { test } from "tests/fixtures/common";
+import { runCliCommandWithRetry } from "tests/utils/runCli";
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { type MonitorEntry, unit, groupByApp } from "./config";
+import { buildCliCmd, parseCliOutput } from "./cli";
+import type { AccountResult } from "./types";
+
+const monitored: MonitorEntry[] = [
+  { account: Account.BTC_LEGACY_1, threshold: "5000", ...unit("bitcoin") }, // 0.00005 BTC
+  { account: Account.BTC_NATIVE_SEGWIT_1, threshold: "70300", ...unit("bitcoin") }, // 0.000703 BTC
+  { account: Account.BTC_SEGWIT_1, threshold: "1000", ...unit("bitcoin") }, // 0.00001 BTC
+  { account: Account.BTC_TAPROOT_1, threshold: "1000", ...unit("bitcoin") }, // 0.00001 BTC
+  { account: Account.ETH_1, threshold: "25000000000000000", ...unit("ethereum") }, // 0.025 ETH
+  { account: Account.ETH_3, threshold: "5000000000000000", ...unit("ethereum") }, // 0.005 ETH
+  {
+    account: Account.ETH_1,
+    threshold: "56000000",
+    tokenId: "ethereum/erc20/usd__coin",
+    name: "USDC (Ethereum 1)",
+    decimals: 6,
+    ticker: "USDC",
+  }, // 56 USDC
+  {
+    account: Account.ETH_1,
+    threshold: "56000000",
+    tokenId: "ethereum/erc20/usd_tether__erc20_",
+    name: "USDT (Ethereum 1)",
+    decimals: 6,
+    ticker: "USDT",
+  }, // 56 USDT
+  {
+    account: Account.ETH_2,
+    threshold: "50000000",
+    tokenId: "ethereum/erc20/usd_tether__erc20_",
+    name: "USDT (Ethereum 2)",
+    decimals: 6,
+    ticker: "USDT",
+  }, // 50 USDT
+  { account: Account.SOL_1, threshold: "700000000", ...unit("solana") }, // 0.7 SOL
+  { account: Account.SOL_2, threshold: "100000000", ...unit("solana") }, // 0.1 SOL
+  {
+    account: Account.SOL_1,
+    threshold: "500000",
+    tokenId: "solana/spl/gigachad_63lfdmnb3mq8mw9mtz2to9bea2m71kzuugq5tijxcqj9",
+    name: "GIGA (Solana 1)",
+    decimals: 5,
+    ticker: "GIGA",
+  }, // 5 GIGA
+  {
+    account: Account.SOL_1,
+    threshold: "1000000",
+    tokenId: "solana/spl/ekpqgsjtjmfqkz9kqansqyxrcf8fbopzlhyxdm65zcjm",
+    name: "WIF (Solana 1)",
+    decimals: 6,
+    ticker: "WIF",
+  }, // 1 WIF
+  { account: Account.XRP_1, threshold: "40000000", ...unit("ripple") }, // 40 XRP
+  { account: Account.DOGE_1, threshold: "10000000", ...unit("dogecoin") }, // 0.1 DOGE
+  { account: Account.TRX_1, threshold: "1100000", ...unit("tron") }, // 1.1 TRX
+  { account: Account.BASE_1, threshold: "100000000000000", ...unit("base") }, // 0.0001 ETH
+  { account: Account.ADA_1, threshold: "4000000", ...unit("cardano") }, // 4 ADA
+  { account: Account.ALGO_1, threshold: "5000000", ...unit("algorand") }, // 5 ALGO
+  {
+    account: Account.ALGO_1,
+    threshold: "50000",
+    tokenId: "algorand/asa/312769",
+    name: "USDT (Algorand 1)",
+    decimals: 6,
+    ticker: "USDT",
+  }, // 0.05 USDT
+  { account: Account.APTOS_1, threshold: "200000000", ...unit("aptos") }, // 2 APT
+  { account: Account.BCH_1, threshold: "100000", ...unit("bitcoin_cash") }, // 0.001 BCH
+  { account: Account.CELO_1, threshold: "630000000000000000000", ...unit("celo") }, // 630 CELO
+  { account: Account.ATOM_1, threshold: "50000", ...unit("cosmos") }, // 0.05 ATOM
+  { account: Account.ATOM_2, threshold: "50000", ...unit("cosmos") }, // 0.05 ATOM
+  { account: Account.DOT_1, threshold: "30000000000", ...unit("assethub_polkadot") }, // 3 DOT
+  { account: Account.HEDERA_1, threshold: "58000000000", ...unit("hedera") }, // 580 HBAR
+  { account: Account.ICP_1, threshold: "50000000", ...unit("internet_computer") }, // 0.5 ICP
+  { account: Account.INJ_1, threshold: "200000000000000000", ...unit("injective") }, // 0.2 INJ
+  { account: Account.KASPA_1, threshold: "200000000", ...unit("kaspa") }, // 2 KASPA
+  { account: Account.MULTIVERS_X_1, threshold: "1200000000000000000", ...unit("elrond") }, // 1.2 EGLD
+  { account: Account.NEAR_1, threshold: "1000000000000000000000000", ...unit("near") }, // 1 NEAR
+  { account: Account.NEAR_2, threshold: "500000000000000000000000", ...unit("near") }, // 0.5 NEAR
+  { account: Account.OSMO_1, threshold: "1000000", ...unit("osmo") }, // 1 OSMO
+  { account: Account.POL_1, threshold: "5000000000000000000", ...unit("polygon") }, // 5 POL
+  {
+    account: Account.POL_1,
+    threshold: "3000000000000000000",
+    tokenId: "polygon/erc20/(pos)_dai_stablecoin",
+    name: "DAI (Polygon 1)",
+    decimals: 18,
+    ticker: "DAI",
+  }, // 3 DAI
+  { account: Account.SUI_1, threshold: "2000000000", ...unit("sui") }, // 2 SUI
+  {
+    account: Account.SUI_1,
+    threshold: "10000000",
+    tokenId:
+      "sui/coin/usdc_0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::usdc",
+    name: "USDC (Sui 1)",
+    decimals: 6,
+    ticker: "USDC",
+  }, // 10 USDC
+  { account: Account.VET_1, threshold: "50000000000", ...unit("vechain") }, // 500 VET
+  { account: Account.XLM_1, threshold: "1000000000", ...unit("stellar") }, // 100 XLM
+  { account: Account.XTZ_1, threshold: "5000000", ...unit("tezos") }, // 5 XTZ
+  { account: Account.ZEC_1, threshold: "1500000", ...unit("zcash") }, // 0.015 ZEC
+];
+
+const artifactsDir = resolve(__dirname, "../../artifacts");
+
+for (const [appName, entries] of groupByApp(monitored)) {
+  test.describe(`Fund Monitor — ${appName}`, () => {
+    test.use({ speculosApp: entries[0].account.currency.speculosApp });
+
+    test(
+      `Check balances [${appName}]`,
+      { tag: ["@fund-monitor"] },
+      async ({ speculos: _speculos }) => {
+        const results: AccountResult[] = [];
+
+        for (const { account, threshold, tokenId, name, decimals, ticker } of entries) {
+          let balance = "0";
+          let freshAddress = "";
+          let error: string | undefined;
+
+          try {
+            const output = await runCliCommandWithRetry(buildCliCmd(account));
+            const parsed = parseCliOutput(output, tokenId);
+            if (parsed) {
+              balance = parsed.balance;
+              freshAddress = parsed.freshAddress;
+            } else {
+              error = "Could not parse CLI output";
+            }
+          } catch (e) {
+            error = (e as Error).message.slice(0, 200);
+          }
+
+          results.push({
+            name: name ?? account.accountName,
+            currency: tokenId ?? account.currency.id,
+            balance,
+            threshold,
+            freshAddress,
+            isLow: !error && BigInt(balance) < BigInt(threshold),
+            decimals,
+            ticker,
+            ...(error ? { error } : {}),
+          });
+        }
+
+        mkdirSync(artifactsDir, { recursive: true });
+        const safeAppName = appName
+          .toLowerCase()
+          .replace(/\s+/g, "-")
+          .replace(/[^a-z0-9-]/g, "");
+        writeFileSync(
+          resolve(artifactsDir, `fund-monitor-partial-${safeAppName}.json`),
+          JSON.stringify(results, null, 2),
+        );
+      },
+    );
+  });
+}

--- a/e2e/desktop/tests/utils/checkBalance/checkBalance.spec.ts
+++ b/e2e/desktop/tests/utils/checkBalance/checkBalance.spec.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, writeFileSync } from "fs";
-import { resolve } from "path";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { test } from "tests/fixtures/common";
 import { runCliCommandWithRetry } from "tests/utils/runCli";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
@@ -155,8 +155,8 @@ for (const [appName, entries] of groupByApp(monitored)) {
         mkdirSync(artifactsDir, { recursive: true });
         const safeAppName = appName
           .toLowerCase()
-          .replace(/\s+/g, "-")
-          .replace(/[^a-z0-9-]/g, "");
+          .replaceAll(/\s+/g, "-")
+          .replaceAll(/[^a-z0-9-]/g, "");
         writeFileSync(
           resolve(artifactsDir, `fund-monitor-partial-${safeAppName}.json`),
           JSON.stringify(results, null, 2),

--- a/e2e/desktop/tests/utils/checkBalance/cli.ts
+++ b/e2e/desktop/tests/utils/checkBalance/cli.ts
@@ -1,0 +1,46 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+
+export function buildCliCmd(account: Account): string {
+  const parts = [
+    "sync",
+    "--currency",
+    account.currency.id,
+    "--index",
+    String(account.index),
+    "--length",
+    "1",
+    "--format",
+    "json",
+  ];
+  if (account.derivationMode) {
+    parts.push("--scheme", account.derivationMode);
+  }
+  return parts.join("+");
+}
+
+export function parseCliOutput(
+  output: string,
+  tokenId?: string,
+): { balance: string; freshAddress: string } | null {
+  const lines = output.trim().split("\n").filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const parsed = JSON.parse(lines[i]) as Record<string, unknown>;
+      if (parsed.balance === undefined) continue;
+
+      if (tokenId) {
+        const subAccounts = parsed.subAccounts as Array<Record<string, unknown>> | undefined;
+        const sub = subAccounts?.find(sa => sa.tokenId === tokenId);
+        if (sub?.balance !== undefined) {
+          return { balance: String(sub.balance), freshAddress: String(parsed.freshAddress ?? "") };
+        }
+        continue;
+      }
+
+      return { balance: String(parsed.balance), freshAddress: String(parsed.freshAddress ?? "") };
+    } catch {
+      // not valid JSON — keep scanning
+    }
+  }
+  return null;
+}

--- a/e2e/desktop/tests/utils/checkBalance/cli.ts
+++ b/e2e/desktop/tests/utils/checkBalance/cli.ts
@@ -18,6 +18,10 @@ export function buildCliCmd(account: Account): string {
   return parts.join("+");
 }
 
+function toStr(val: unknown, fallback = ""): string {
+  return typeof val === "string" || typeof val === "number" ? String(val) : fallback;
+}
+
 export function parseCliOutput(
   output: string,
   tokenId?: string,
@@ -32,12 +36,18 @@ export function parseCliOutput(
         const subAccounts = parsed.subAccounts as Array<Record<string, unknown>> | undefined;
         const sub = subAccounts?.find(sa => sa.tokenId === tokenId);
         if (sub?.balance !== undefined) {
-          return { balance: String(sub.balance), freshAddress: String(parsed.freshAddress ?? "") };
+          return {
+            balance: toStr(sub.balance, "0"),
+            freshAddress: toStr(parsed.freshAddress),
+          };
         }
         continue;
       }
 
-      return { balance: String(parsed.balance), freshAddress: String(parsed.freshAddress ?? "") };
+      return {
+        balance: toStr(parsed.balance, "0"),
+        freshAddress: toStr(parsed.freshAddress),
+      };
     } catch {
       // not valid JSON — keep scanning
     }

--- a/e2e/desktop/tests/utils/checkBalance/config.ts
+++ b/e2e/desktop/tests/utils/checkBalance/config.ts
@@ -1,0 +1,27 @@
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+
+export interface MonitorEntry {
+  account: Account;
+  threshold: string;
+  tokenId?: string; // If set, extract balance from this token subAccount instead of the parent account balance
+  name?: string; // Display name — defaults to account.accountName, required for token entries
+  decimals: number; // Decimal magnitude for display (e.g. 8 for BTC, 18 for ETH, 6 for USDT)
+  ticker: string;
+}
+
+export function unit(currencyId: string): Pick<MonitorEntry, "decimals" | "ticker"> {
+  const { units } = getCryptoCurrencyById(currencyId);
+  return { decimals: units[0].magnitude, ticker: units[0].code };
+}
+
+/** Groups entries by speculosApp name — one group per parallel worker. */
+export function groupByApp(entries: MonitorEntry[]): Map<string, MonitorEntry[]> {
+  const map = new Map<string, MonitorEntry[]>();
+  for (const entry of entries) {
+    const key = entry.account.currency.speculosApp.name;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(entry);
+  }
+  return map;
+}

--- a/e2e/desktop/tests/utils/checkBalance/config.ts
+++ b/e2e/desktop/tests/utils/checkBalance/config.ts
@@ -4,9 +4,9 @@ import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 export interface MonitorEntry {
   account: Account;
   threshold: string;
-  tokenId?: string; // If set, extract balance from this token subAccount instead of the parent account balance
-  name?: string; // Display name — defaults to account.accountName, required for token entries
-  decimals: number; // Decimal magnitude for display (e.g. 8 for BTC, 18 for ETH, 6 for USDT)
+  tokenId?: string;
+  name?: string;
+  decimals: number;
   ticker: string;
 }
 

--- a/e2e/desktop/tests/utils/checkBalance/slack.ts
+++ b/e2e/desktop/tests/utils/checkBalance/slack.ts
@@ -4,11 +4,10 @@ function formatAmount(raw: string, decimals: number, ticker: string): string {
   const value = BigInt(raw);
   const divisor = BigInt(10 ** decimals);
   const whole = value / divisor;
-  const fraction = (value % divisor)
-    .toString()
-    .padStart(decimals, "0")
-    .replace(/0+$/, "")
-    .slice(0, 6);
+  const fractionFull = (value % divisor).toString().padStart(decimals, "0");
+  let end = Math.min(fractionFull.length, 6);
+  while (end > 0 && fractionFull[end - 1] === "0") end--;
+  const fraction = fractionFull.slice(0, end);
   return fraction ? `${whole}.${fraction} ${ticker}` : `${whole} ${ticker}`;
 }
 

--- a/e2e/desktop/tests/utils/checkBalance/slack.ts
+++ b/e2e/desktop/tests/utils/checkBalance/slack.ts
@@ -1,0 +1,49 @@
+import type { FundReport } from "./types";
+
+function formatAmount(raw: string, decimals: number, ticker: string): string {
+  const value = BigInt(raw);
+  const divisor = BigInt(10 ** decimals);
+  const whole = value / divisor;
+  const fraction = (value % divisor)
+    .toString()
+    .padStart(decimals, "0")
+    .replace(/0+$/, "")
+    .slice(0, 6);
+  return fraction ? `${whole}.${fraction} ${ticker}` : `${whole} ${ticker}`;
+}
+
+export function buildSlackPayload(report: FundReport): Record<string, unknown> {
+  const low = report.accounts.filter(a => a.isLow);
+  const errored = report.accounts.filter(a => a.error);
+  const ok = report.accounts.length - low.length - errored.length;
+
+  const header = report.hasAlerts
+    ? "⚠️ E2E Fund Monitor — Action Required"
+    : "✅ E2E Fund Monitor — All Wallets Healthy";
+
+  const summary = [
+    `Checked *${report.accounts.length}* account(s) on ${new Date(report.date).toUTCString()}`,
+    `*${low.length}* below threshold  •  *${ok}* OK  •  *${errored.length}* error(s)`,
+  ].join("\n");
+
+  const alertLines = report.accounts
+    .filter(a => a.isLow || a.error)
+    .map(a => {
+      const lines = [
+        `*${a.name}* — Balance: \`${formatAmount(a.balance, a.decimals, a.ticker)}\` | Min: \`${formatAmount(a.threshold, a.decimals, a.ticker)}\``,
+      ];
+      if (a.freshAddress) lines.push(`Top-up: \`${a.freshAddress}\``);
+      if (a.error) lines.push(`Error: \`${a.error.slice(0, 120)}\``);
+      return lines.join("\n");
+    });
+
+  const body = [summary, ...alertLines].join("\n\n");
+
+  return {
+    text: header,
+    blocks: [
+      { type: "header", text: { type: "plain_text", text: header, emoji: true } },
+      { type: "section", text: { type: "mrkdwn", text: body } },
+    ],
+  };
+}

--- a/e2e/desktop/tests/utils/checkBalance/teardown.ts
+++ b/e2e/desktop/tests/utils/checkBalance/teardown.ts
@@ -1,5 +1,5 @@
-import { readFileSync, readdirSync, unlinkSync, writeFileSync } from "fs";
-import { resolve } from "path";
+import { readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { buildSlackPayload } from "./slack";
 import type { AccountResult, FundReport } from "./types";
 

--- a/e2e/desktop/tests/utils/checkBalance/teardown.ts
+++ b/e2e/desktop/tests/utils/checkBalance/teardown.ts
@@ -1,0 +1,32 @@
+import { readFileSync, readdirSync, unlinkSync, writeFileSync } from "fs";
+import { resolve } from "path";
+import { buildSlackPayload } from "./slack";
+import type { AccountResult, FundReport } from "./types";
+
+export default async function globalTeardown() {
+  const artifactsDir = resolve(__dirname, "../../artifacts");
+
+  const partialFiles = readdirSync(artifactsDir).filter(
+    f => f.startsWith("fund-monitor-partial-") && f.endsWith(".json"),
+  );
+
+  const allResults: AccountResult[] = partialFiles.flatMap(
+    f => JSON.parse(readFileSync(resolve(artifactsDir, f), "utf-8")) as AccountResult[],
+  );
+
+  const report: FundReport = {
+    date: new Date().toISOString(),
+    hasAlerts: allResults.some(r => r.isLow),
+    accounts: allResults,
+  };
+
+  writeFileSync(resolve(artifactsDir, "fund-monitor-report.json"), JSON.stringify(report, null, 2));
+  writeFileSync(
+    resolve(artifactsDir, "fund-monitor-slack-payload.json"),
+    JSON.stringify(buildSlackPayload(report), null, 2),
+  );
+
+  for (const f of partialFiles) {
+    unlinkSync(resolve(artifactsDir, f));
+  }
+}

--- a/e2e/desktop/tests/utils/checkBalance/types.ts
+++ b/e2e/desktop/tests/utils/checkBalance/types.ts
@@ -1,0 +1,17 @@
+export interface AccountResult {
+  name: string;
+  currency: string;
+  balance: string;
+  threshold: string;
+  freshAddress: string;
+  isLow: boolean;
+  decimals: number;
+  ticker: string;
+  error?: string;
+}
+
+export interface FundReport {
+  date: string;
+  hasAlerts: boolean;
+  accounts: AccountResult[];
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - New GitHub Actions workflow `[Desktop] - E2E Fund Monitor` (weekday schedule + manual dispatch)
  - Playwright `checkBalance` spec, CLI sync parsing, Slack payload generation, artifact upload
  - `pnpm test:fund-monitor` script in `e2e/desktop` for local or CI runs

### 📝 Description

**Problem**: Shared E2E wallets can run low on funds without visibility until tests fail or someone notices manually, which slows down QA and E2E reliability.

**Solution**: This change adds a dedicated fund monitor that runs on a schedule (weekdays 09:00 UTC) and on demand. It builds `@ledgerhq/live-cli`, runs Playwright with a slim config (no LLD build), checks configured accounts and token thresholds via CLI `sync` JSON output, merges partial results in a global teardown, writes a Slack-ready payload, uploads artifacts, and posts to the QAA Slack webhook. Low balances and parse errors are surfaced in the report.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1032](https://ledgerhq.atlassian.net/browse/QAA-1032)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1032]: https://ledgerhq.atlassian.net/browse/QAA-1032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ