### PR TITLE
[LWD] fix(desktop): compute trend for portfolio asset tables

### DIFF
--- a/.changeset/little-wombats-grab.md
+++ b/.changeset/little-wombats-grab.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix 1-day trend column showing "-" instead of percentage in Portfolio asset tables

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAssetsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAssetsViewModel.ts
@@ -6,7 +6,12 @@ import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssets
 import { AssetsViewProps, AssetTableItem } from "../types";
 import { buildPlaceholderAssetItemsFromAssetsData } from "../utils/buildPlaceholderAssetItemsFromAssetsData";
 import { useSelector } from "LLD/hooks/redux";
-import { hasOnboardedDeviceSelector } from "~/renderer/reducers/settings";
+import {
+  hasOnboardedDeviceSelector,
+  counterValueCurrencySelector,
+} from "~/renderer/reducers/settings";
+import { useAllCurrencyTrends } from "./useAllCurrencyTrends";
+import { useOnDemandCurrenciesCountervalues } from "~/renderer/hooks/useOnDemandCountervalues";
 import { useAccountStatus } from "LLD/hooks/useAccountStatus";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import {
@@ -85,27 +90,56 @@ export function useAssetsViewModel(): AssetsViewProps {
     [assetsData, stablecoinTickers],
   );
 
-  const sections = useMemo(() => {
+  const { paddedCryptos, paddedStablecoins } = useMemo(() => {
     const toRealItems = (items: typeof categorizedAssets.cryptos): AssetTableItem[] =>
       isEmptyState
         ? []
         : items.slice(0, MAX_ITEM_DISPLAYED).map(item => ({ ...item, isPlaceholder: false }));
 
-    const realCryptos = toRealItems(categorizedAssets.cryptos);
-    const realStablecoins = toRealItems(categorizedAssets.stablecoins);
+    return {
+      paddedCryptos: padItems(
+        toRealItems(categorizedAssets.cryptos),
+        resolvedDefaults.cryptos,
+        EMPTY_STATE_CRYPTOS,
+      ),
+      paddedStablecoins: padItems(
+        toRealItems(categorizedAssets.stablecoins),
+        resolvedDefaults.stablecoins,
+        EMPTY_STATE_STABLECOINS,
+      ),
+    };
+  }, [isEmptyState, categorizedAssets, resolvedDefaults]);
 
-    const paddedCryptos = padItems(realCryptos, resolvedDefaults.cryptos, EMPTY_STATE_CRYPTOS);
-    const paddedStablecoins = padItems(
-      realStablecoins,
-      resolvedDefaults.stablecoins,
-      EMPTY_STATE_STABLECOINS,
-    );
+  const allItems = useMemo(
+    () => [...paddedCryptos, ...paddedStablecoins],
+    [paddedCryptos, paddedStablecoins],
+  );
 
-    return [
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const nonPlaceholderCurrencies = useMemo(
+    () => allItems.filter(i => !i.isPlaceholder).map(i => i.currency),
+    [allItems],
+  );
+  useOnDemandCurrenciesCountervalues(nonPlaceholderCurrencies, counterValueCurrency);
+
+  const trends = useAllCurrencyTrends(allItems, "day");
+
+  const cryptosWithTrend = useMemo(
+    () => paddedCryptos.map(item => ({ ...item, trend: trends.get(item.currency.id) ?? null })),
+    [paddedCryptos, trends],
+  );
+
+  const stablecoinsWithTrend = useMemo(
+    () => paddedStablecoins.map(item => ({ ...item, trend: trends.get(item.currency.id) ?? null })),
+    [paddedStablecoins, trends],
+  );
+
+  const sections = useMemo(
+    () => [
       {
         sectionId: "cryptos",
         title: t("assets.cryptos"),
-        items: paddedCryptos,
+        items: cryptosWithTrend,
         totalCount: isEmptyState ? paddedCryptos.length : categorizedAssets.cryptos.length,
         onNavigate: onNavigateToCryptos,
         onItemClick,
@@ -113,21 +147,25 @@ export function useAssetsViewModel(): AssetsViewProps {
       {
         sectionId: "stablecoins",
         title: t("assets.stablecoins"),
-        items: paddedStablecoins,
+        items: stablecoinsWithTrend,
         totalCount: isEmptyState ? paddedStablecoins.length : categorizedAssets.stablecoins.length,
         onNavigate: onNavigateToCryptoAssets,
         onItemClick,
       },
-    ];
-  }, [
-    isEmptyState,
-    categorizedAssets,
-    resolvedDefaults,
-    onNavigateToCryptoAssets,
-    onNavigateToCryptos,
-    onItemClick,
-    t,
-  ]);
+    ],
+    [
+      isEmptyState,
+      categorizedAssets,
+      paddedCryptos,
+      paddedStablecoins,
+      cryptosWithTrend,
+      stablecoinsWithTrend,
+      onNavigateToCryptoAssets,
+      onNavigateToCryptos,
+      onItemClick,
+      t,
+    ],
+  );
 
   return {
     isLoading: needsPadding


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing tests cover the hook behavior; trend computation is tested via `useAllCurrencyTrends.test.ts`._
- [x] **Impact of the changes:**
      - Portfolio page (`/`) asset tables: the 1-day trend column now shows the actual percentage instead of "-"
      - No impact on the `/assets` category page (already working)

### 📝 Description

**Problem**: After the perf refactor (e01a61bc558) that batched trend computation at the parent level, `useAssetsViewModel` (Portfolio page) was not updated to compute and inject trend data into asset table items. As a result, the `TrendCell` component receives `undefined` for the `trend` prop and renders "-" instead of the actual 1-day percentage.

**Solution**: Added `useAllCurrencyTrends` and `useOnDemandCurrenciesCountervalues` calls to `useAssetsViewModel`, mirroring exactly what `useCryptoAssetsViewModel` already does for the `/assets` category page. The padded items are now enriched with trend data before being passed to the table sections.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29030](https://ledgerhq.atlassian.net/browse/LIVE-29030)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29030]: https://ledgerhq.atlassian.net/browse/LIVE-29030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ