### PR TITLE
[LWD] feat(desktop): gate analytics on consent staleness, not policy version

### DIFF
--- a/.changeset/brisk-ravens-align.md
+++ b/.changeset/brisk-ravens-align.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+LWD: gate analytics tracking on last analytics consent date and one-year rolling window (opt-in); do not require privacy policy version for tracking enabled

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
@@ -355,18 +355,21 @@ describe("trackingEnabledSelector", () => {
     ).toBe(false);
   });
 
-  it("should not track if privacyPolicyVersion is not set", () => {
+  it("should track when privacyPolicyVersion is null if consent date is valid and share toggles are on", () => {
     expect(
       trackingEnabledSelector(
         mockStateWithSettings({
+          lastAnalyticsConsentDate: FIXED_NOW.toISOString(),
           privacyPolicyVersion: null,
+          shareAnalytics: true,
+          sharePersonalizedRecommandations: true,
         }),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   describe("opt-in analytics", () => {
-    it("should track if lastAnalyticsConsentDate is set and privacyPolicyVersion is set and is the current version", () => {
+    it("should track if lastAnalyticsConsentDate is set and share toggles are on", () => {
       expect(
         trackingEnabledSelector(
           mockStateWithSettings({
@@ -425,7 +428,7 @@ describe("trackingEnabledSelector", () => {
       ).toBe(true);
     });
 
-    it("should not track if lastAnalyticsConsentDate less than a year ago but privacyPolicyVersion is older than the current version", () => {
+    it("should track if lastAnalyticsConsentDate is less than a year ago even when privacyPolicyVersion is older than the current version", () => {
       const consentDate = new Date(FIXED_NOW);
       consentDate.setUTCMonth(consentDate.getUTCMonth() - 11);
       expect(
@@ -437,12 +440,12 @@ describe("trackingEnabledSelector", () => {
             privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION - 1,
           }),
         ),
-      ).toBe(false);
+      ).toBe(true);
     });
   });
 
   describe("opt-out analytics", () => {
-    it("should not track even if lastAnalyticsConsentDate is set and privacyPolicyVersion is set and is the current version", () => {
+    it("should not track even if lastAnalyticsConsentDate is set and consent metadata is complete", () => {
       expect(
         trackingEnabledSelector(
           mockStateWithSettings({

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -775,7 +775,7 @@ export const trackingEnabledSelector = (state: State) => {
   const s = state.settings;
 
   if (state.featureFlags?.resolved?.analyticsOptIn?.enabled) {
-    if (!s.lastAnalyticsConsentDate || !s.privacyPolicyVersion) {
+    if (!s.lastAnalyticsConsentDate) {
       return false;
     }
 
@@ -791,10 +791,6 @@ export const trackingEnabledSelector = (state: State) => {
     oneYearAgo.setUTCFullYear(oneYearAgo.getUTCFullYear() - 1);
 
     if (lastAnalyticsConsentDate.getTime() < oneYearAgo.getTime()) {
-      return false;
-    }
-
-    if (s.privacyPolicyVersion < CURRENT_PRIVACY_POLICY_VERSION) {
       return false;
     }
   }
@@ -836,8 +832,7 @@ export const swapSelectableCurrenciesSelector = (state: State) =>
   state.settings.swap.selectableCurrencies;
 export const showClearCacheBannerSelector = (state: State) => state.settings.showClearCacheBanner;
 export const overriddenFeatureFlagsSelector = (state: State) => state.featureFlags.overrides;
-export const featureFlagsButtonVisibleSelector = (state: State) =>
-  state.featureFlags.bannerVisible;
+export const featureFlagsButtonVisibleSelector = (state: State) => state.featureFlags.bannerVisible;
 export const vaultSignerSelector = (state: State) => state.settings.vaultSigner;
 export const supportedCounterValuesSelector = (state: State) =>
   state.settings.supportedCounterValues;


### PR DESCRIPTION
### Scope

Ledger Live **Desktop** only (`ledger-live-desktop`).

### What changed

**`trackingEnabledSelector`** (`apps/ledger-live-desktop/src/renderer/reducers/settings.ts`)

When the `analyticsOptIn` feature flag is enabled, Segment/analytics gating no longer depends on **`privacyPolicyVersion`**. It only requires:

- `lastAnalyticsConsentDate` set and parseable  
- consent not older than **one year** (existing UTC rolling-window logic)  
- then the usual **`shareAnalytics` / `sharePersonalizedRecommandations`** outcome  

Removed:

- the `!s.privacyPolicyVersion` early exit  
- the `s.privacyPolicyVersion < CURRENT_PRIVACY_POLICY_VERSION` check  

Also a trivial one-line formatting tweak on `featureFlagsButtonVisibleSelector` (no behavior change).

**Tests:** `settings.test.ts` — `trackingEnabledSelector` expectations updated for `privacyPolicyVersion: null` and for an older stored policy version when consent is still within the one-year window.

**Release note:** `.changeset/brisk-ravens-align.md` (`ledger-live-desktop` minor).


https://github.com/user-attachments/assets/5644c785-7f30-4a47-9634-d8a07d4c977c



### Context

- [LIVE-29031](https://ledgerhq.atlassian.net/browse/LIVE-29031)

[LIVE-29031]: https://ledgerhq.atlassian.net/browse/LIVE-29031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ