### PR TITLE
[LWDM] feat: enable aleo encrypted prove + remove JWT management by switching to staging reverse proxy

### DIFF
--- a/.changeset/smooth-mugs-protect.md
+++ b/.changeset/smooth-mugs-protect.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-aleo": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-env": minor
+---
+
+feat: enable aleo encrypted prove + remove jwt management

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/account.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/account.fixture.ts
@@ -17,12 +17,6 @@ const defaultMockAccountId =
 export const mockAleoResources: AleoResources = {
   transparentBalance: new BigNumber(1000),
   provableApi: {
-    apiKey: "abc",
-    consumerId: "consumer123",
-    jwt: {
-      token: "jwt_token",
-      exp: Math.floor(Date.now() / 1000) + 3600,
-    },
     uuid: "uuid-1234",
     scannerStatus: {
       percentage: 50,

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
@@ -416,7 +416,6 @@ describe("sync.ts", () => {
       expect(mockAccessProvableApi).toHaveBeenCalledWith({
         currency: mockCurrency,
         viewKey: "AViewKey123",
-        address: mockAccount.freshAddress,
         provableApi: accountWithProvableApi.aleoResources?.provableApi,
       });
     });
@@ -609,16 +608,12 @@ describe("sync.ts", () => {
       expect(mockGetAccountOwnedRecords).toHaveBeenCalledTimes(2);
       expect(mockGetAccountOwnedRecords).toHaveBeenCalledWith({
         currency: mockCurrency,
-        jwtToken: configuredProvableApi.jwt!.token,
         uuid: configuredProvableApi.uuid,
-        apiKey: configuredProvableApi.apiKey,
         start: 0,
       });
       expect(mockGetAccountOwnedRecords).toHaveBeenCalledWith({
         currency: mockCurrency,
-        jwtToken: configuredProvableApi.jwt!.token,
         uuid: configuredProvableApi.uuid,
-        apiKey: configuredProvableApi.apiKey,
         unspent: true,
       });
       expect(mockListPrivateOperations).toHaveBeenCalledTimes(1);

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -168,7 +168,6 @@ export async function performPrivateSync(
   const provableApi = await accessProvableApi({
     currency,
     viewKey,
-    address,
     provableApi: initialAccount.aleoResources?.provableApi ?? null,
   }).catch(err => {
     // private sync logic will be probably handled separately with https://ledgerhq.atlassian.net/browse/LIVE-26440
@@ -214,16 +213,12 @@ export async function performPrivateSync(
   const [rawNewPrivateRecords, rawUnspentPrivateRecords] = await Promise.all([
     apiClient.getAccountOwnedRecords({
       currency,
-      jwtToken: provableApi.jwt.token,
       uuid: provableApi.uuid,
-      apiKey: provableApi.apiKey,
       start: lastPrivateBlockHeight,
     }),
     apiClient.getAccountOwnedRecords({
       currency,
-      jwtToken: provableApi.jwt.token,
       uuid: provableApi.uuid,
-      apiKey: provableApi.apiKey,
       unspent: true,
     }),
   ]);

--- a/libs/coin-modules/coin-aleo/src/logic/broadcast.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/broadcast.test.ts
@@ -1,4 +1,4 @@
-import { getMockedAccount, mockAleoResources } from "../__tests__/fixtures/account.fixture";
+import { getMockedAccount } from "../__tests__/fixtures/account.fixture";
 import { apiClient } from "../network/api";
 import { sdkClient } from "../network/sdk";
 import {
@@ -50,7 +50,6 @@ describe("broadcast", () => {
       currency: mockAccount.currency,
       authorization: mockAuthorization,
       feeAuthorization: mockFeeAuthorization,
-      jwt: mockAleoResources.provableApi?.jwt?.token,
       broadcast: true,
     });
     expect(result).toBe(mockResponse.transaction.id);
@@ -71,23 +70,8 @@ describe("broadcast", () => {
     expect(apiClient.submitDelegatedProvingRequest).toHaveBeenCalledWith({
       currency: mockAccount.currency,
       authorization: mockAuthorization,
-      jwt: mockAleoResources.provableApi?.jwt?.token,
       broadcast: true,
     });
-  });
-
-  it("should throw when JWT is missing", async () => {
-    const accountWithoutJwt = getMockedAccount({
-      aleoResources: { ...mockAleoResources, provableApi: {} },
-    });
-
-    await expect(
-      broadcast({
-        configOrCurrencyId: mockConfig,
-        account: accountWithoutJwt,
-        signedTx: mockSignedTx,
-      }),
-    ).rejects.toThrow(/aleo: jwt token is missing/);
   });
 
   it("should propagate network errors from the API client", async () => {
@@ -121,13 +105,11 @@ describe("broadcast", () => {
       expect(apiClient.getProvePublicKey).toHaveBeenCalledTimes(1);
       expect(apiClient.getProvePublicKey).toHaveBeenCalledWith({
         currency: mockAccount.currency,
-        jwt: mockAleoResources.provableApi?.jwt?.token,
       });
       expect(sdkClient.encryptProvingRequest).toHaveBeenCalledTimes(1);
       expect(sdkClient.encryptProvingRequest).toHaveBeenCalledWith({
         publicKey: mockPublicKeyResponse.public_key,
         currency: mockAccount.currency,
-        jwt: mockAleoResources.provableApi?.jwt?.token,
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: true,
@@ -135,7 +117,6 @@ describe("broadcast", () => {
       expect(apiClient.submitEncryptedDelegatedProvingRequest).toHaveBeenCalledTimes(1);
       expect(apiClient.submitEncryptedDelegatedProvingRequest).toHaveBeenCalledWith({
         currency: mockAccount.currency,
-        jwt: mockAleoResources.provableApi?.jwt?.token,
         keyId: mockPublicKeyResponse.key_id,
         encryptedData: mockEncryptedData,
       });
@@ -156,7 +137,6 @@ describe("broadcast", () => {
       expect(sdkClient.encryptProvingRequest).toHaveBeenCalledWith({
         publicKey: mockPublicKeyResponse.public_key,
         currency: mockAccount.currency,
-        jwt: mockAleoResources.provableApi?.jwt?.token,
         authorization: mockAuthorization,
         broadcast: true,
       });

--- a/libs/coin-modules/coin-aleo/src/logic/broadcast.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/broadcast.ts
@@ -1,4 +1,3 @@
-import invariant from "invariant";
 import { apiClient } from "../network/api";
 import type { AleoAccount, AleoCoinConfig } from "../types";
 import { sdkClient } from "../network/sdk";
@@ -14,8 +13,6 @@ export async function broadcast({
   signedTx: string;
 }): Promise<string> {
   const config = resolveConfig(configOrCurrencyId);
-  const jwt = account.aleoResources?.provableApi?.jwt?.token;
-  invariant(jwt, `aleo: jwt token is missing for ${account.freshAddress}`);
 
   // get authorization and feeAuthorization from signed transaction
   const { authorization, feeAuthorization } = fromHex<{
@@ -28,7 +25,6 @@ export async function broadcast({
       currency: account.currency,
       authorization,
       ...(feeAuthorization && { feeAuthorization }),
-      jwt,
       broadcast: true,
     });
 
@@ -37,13 +33,11 @@ export async function broadcast({
 
   const publicKeyResponse = await apiClient.getProvePublicKey({
     currency: account.currency,
-    jwt,
   });
 
   const encryptedData = await sdkClient.encryptProvingRequest({
     publicKey: publicKeyResponse.public_key,
     currency: account.currency,
-    jwt,
     authorization,
     ...(feeAuthorization && { feeAuthorization }),
     broadcast: true,
@@ -51,7 +45,6 @@ export async function broadcast({
 
   const res = await apiClient.submitEncryptedDelegatedProvingRequest({
     currency: account.currency,
-    jwt,
     keyId: publicKeyResponse.key_id,
     encryptedData,
   });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -35,7 +35,6 @@ import {
   toAlpacaOperation,
   toBridgeOperation,
   toPrivateBridgeOperation,
-  generateUniqueUsername,
   resolveConfig,
   getTransactionType,
   calculateAmount,
@@ -381,27 +380,6 @@ describe("toBridgeOperation", () => {
   });
 });
 
-describe("generateUniqueUsername", () => {
-  it("should generate a SHA-256 hash from timestamp and address", () => {
-    const mockAddress = "aleo1test123";
-    const result = generateUniqueUsername(mockAddress);
-
-    expect(result).toMatch(/^[a-f0-9]{64}$/);
-  });
-
-  it("should generate unique hashes for different addresses", () => {
-    const address1 = "aleo1address1";
-    const address2 = "aleo1address2";
-
-    const result1 = generateUniqueUsername(address1);
-    const result2 = generateUniqueUsername(address2);
-
-    expect(result1).toMatch(/^[a-f0-9]{64}$/);
-    expect(result2).toMatch(/^[a-f0-9]{64}$/);
-    expect(result1).not.toBe(result2);
-  });
-});
-
 describe("resolveConfig", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -582,13 +560,7 @@ describe("calculateAmount", () => {
 
 describe("isProvableApiConfigured", () => {
   const validProvableApi: Required<ProvableApi> = {
-    apiKey: "test-api-key",
-    consumerId: "test-consumer-id",
     uuid: "test-uuid",
-    jwt: {
-      token: "test-token",
-      exp: 123456789,
-    },
     scannerStatus: {
       synced: true,
       percentage: 100,
@@ -608,32 +580,11 @@ describe("isProvableApiConfigured", () => {
 
     expect(isProvableApiConfigured(rest)).toBe(false);
   });
-
-  it("returns false when apiKey is missing", () => {
-    const { apiKey: _, ...rest } = validProvableApi;
-
-    expect(isProvableApiConfigured(rest)).toBe(false);
-  });
-
-  it("returns false when jwt is missing", () => {
-    const { jwt: _, ...rest } = validProvableApi;
-
-    expect(isProvableApiConfigured(rest)).toBe(false);
-  });
-
-  it("returns false when jwt.token is missing", () => {
-    const api: ProvableApi = { ...validProvableApi, jwt: { token: "", exp: 123456789 } };
-
-    expect(isProvableApiConfigured(api)).toBe(false);
-  });
 });
 
 describe("isRecordScannerReady", () => {
   const baseProvableApi: ProvableApi = {
-    apiKey: "test-api-key",
-    consumerId: "test-consumer-id",
     uuid: "test-uuid",
-    jwt: { token: "test-token", exp: 123456789 },
     scannerStatus: { synced: true, percentage: 100 },
   };
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -1,4 +1,3 @@
-import { createHash } from "crypto";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
@@ -211,13 +210,6 @@ export const toPrivateBridgeOperation = (
   };
 };
 
-export const generateUniqueUsername = (address: string): string => {
-  const timestamp = Date.now().toString();
-  const combined = `${timestamp}_${address}`;
-  const hash = createHash("sha256").update(combined).digest("hex");
-  return hash;
-};
-
 export function resolveConfig(configOrCurrencyId: AleoCoinConfig | string): AleoCoinConfig {
   if (typeof configOrCurrencyId === "string") {
     const config = aleoConfig.getCoinConfig(configOrCurrencyId);
@@ -281,8 +273,8 @@ export function calculateAmount({
 
 export const isProvableApiConfigured = (
   provableApi: ProvableApi | null,
-): provableApi is Required<Pick<ProvableApi, "jwt" | "uuid" | "apiKey">> => {
-  return !!provableApi?.uuid && !!provableApi?.apiKey && !!provableApi?.jwt?.token;
+): provableApi is Required<Pick<ProvableApi, "uuid">> => {
+  return !!provableApi?.uuid;
 };
 
 export const isRecordScannerReady = (provableApi: ProvableApi): boolean => {

--- a/libs/coin-modules/coin-aleo/src/network/api.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.test.ts
@@ -401,102 +401,7 @@ describe("apiClient", () => {
     });
   });
 
-  describe("registerNewAccount", () => {
-    const mockUsername = "test-consumer";
-
-    it("should register a new account successfully", async () => {
-      const mockResponse = {
-        consumer: { id: "consumer-uuid-123" },
-        created_at: 1700000000,
-        id: "account-uuid-456",
-        key: "api-key-789",
-      };
-      jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
-
-      const result = await apiClient.registerNewAccount(mockCurrency, mockUsername);
-
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
-      expect(network).toHaveBeenCalledTimes(1);
-      expect(network).toHaveBeenCalledWith({
-        method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/consumers`,
-        data: { username: mockUsername },
-      });
-      expect(result).toEqual(mockResponse);
-    });
-
-    it("should throw an error when registration fails", async () => {
-      const mockError = new Error("Registration failed");
-      jest.mocked(network).mockRejectedValue(mockError);
-
-      await expect(apiClient.registerNewAccount(mockCurrency, mockUsername)).rejects.toThrow(
-        "Registration failed",
-      );
-    });
-  });
-
-  describe("getAccountJWT", () => {
-    const mockApiKey = "test-api-key";
-    const mockConsumerId = "consumer-uuid-123";
-
-    it("should fetch a JWT successfully", async () => {
-      const mockExp = 1700100000;
-      const mockToken = "Bearer eyJhbGciOiJIUzI1NiJ9.test";
-
-      jest.mocked(network).mockResolvedValue({
-        data: { exp: mockExp },
-        headers: { authorization: mockToken },
-        status: 200,
-      });
-
-      const result = await apiClient.getAccountJWT(mockCurrency, mockApiKey, mockConsumerId);
-
-      expect(network).toHaveBeenCalledTimes(1);
-      expect(network).toHaveBeenCalledWith({
-        method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/jwts/${mockConsumerId}`,
-        headers: { "X-Provable-API-Key": mockApiKey },
-      });
-      expect(result).toEqual({ token: mockToken, exp: mockExp });
-    });
-
-    it("should return empty token when authorization header is missing", async () => {
-      jest.mocked(network).mockResolvedValue({
-        data: { exp: 1700100000 },
-        headers: {},
-        status: 200,
-      });
-
-      const result = await apiClient.getAccountJWT(mockCurrency, mockApiKey, mockConsumerId);
-
-      expect(result.token).toBe("");
-    });
-
-    it("should return empty token when headers are absent", async () => {
-      jest.mocked(network).mockResolvedValue({
-        data: { exp: 1700100000 },
-        status: 200,
-      });
-
-      const result = await apiClient.getAccountJWT(mockCurrency, mockApiKey, mockConsumerId);
-
-      expect(result.token).toBe("");
-    });
-
-    it("should throw an error when network request fails", async () => {
-      const mockError = new Error("Unauthorized");
-      jest.mocked(network).mockRejectedValue(mockError);
-
-      await expect(
-        apiClient.getAccountJWT(mockCurrency, mockApiKey, mockConsumerId),
-      ).rejects.toThrow("Unauthorized");
-    });
-  });
-
   describe("getScannerPublicKey", () => {
-    const mockJwt = "Bearer eyJhbGciOiJIUzI1NiJ9.test";
-
     it("should fetch the scanner public key successfully", async () => {
       const mockResponse = {
         key_id: "key-id-123",
@@ -504,7 +409,7 @@ describe("apiClient", () => {
       };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getScannerPublicKey(mockCurrency, mockJwt);
+      const result = await apiClient.getScannerPublicKey(mockCurrency);
 
       expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
@@ -512,7 +417,6 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith({
         method: "GET",
         url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/pubkey`,
-        headers: { Authorization: mockJwt },
       });
       expect(result).toEqual(mockResponse);
     });
@@ -523,12 +427,11 @@ describe("apiClient", () => {
         .mocked(network)
         .mockResolvedValue({ data: { key_id: "k1", public_key: "pk1" }, status: 200 });
 
-      await apiClient.getScannerPublicKey(mockCurrency, mockJwt);
+      await apiClient.getScannerPublicKey(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
         url: `${testnetConfig.nodeUrl}/scanner/testnet/pubkey`,
-        headers: { Authorization: mockJwt },
       });
     });
 
@@ -536,14 +439,11 @@ describe("apiClient", () => {
       const mockError = new Error("Forbidden");
       jest.mocked(network).mockRejectedValue(mockError);
 
-      await expect(apiClient.getScannerPublicKey(mockCurrency, mockJwt)).rejects.toThrow(
-        "Forbidden",
-      );
+      await expect(apiClient.getScannerPublicKey(mockCurrency)).rejects.toThrow("Forbidden");
     });
   });
 
   describe("registerForScanningAccountRecordsEncrypted", () => {
-    const mockJwt = "Bearer eyJhbGciOiJIUzI1NiJ9.test";
     const mockEncryptedData = "encrypted-ciphertext-xyz";
     const mockKeyId = "key-id-123";
 
@@ -553,7 +453,6 @@ describe("apiClient", () => {
 
       const result = await apiClient.registerForScanningAccountRecordsEncrypted({
         currency: mockCurrency,
-        jwt: mockJwt,
         encryptedData: mockEncryptedData,
         keyId: mockKeyId,
       });
@@ -564,7 +463,6 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith({
         method: "POST",
         url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/register/encrypted`,
-        headers: { Authorization: mockJwt },
         data: { key_id: mockKeyId, ciphertext: mockEncryptedData },
       });
       expect(result).toEqual(mockResponse);
@@ -576,7 +474,6 @@ describe("apiClient", () => {
 
       await apiClient.registerForScanningAccountRecordsEncrypted({
         currency: mockCurrency,
-        jwt: mockJwt,
         encryptedData: mockEncryptedData,
         keyId: mockKeyId,
       });
@@ -585,7 +482,6 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith({
         method: "POST",
         url: `${testnetConfig.nodeUrl}/scanner/${testnetConfig.networkType}/register/encrypted`,
-        headers: { Authorization: mockJwt },
         data: { key_id: mockKeyId, ciphertext: mockEncryptedData },
       });
     });
@@ -597,7 +493,6 @@ describe("apiClient", () => {
       await expect(
         apiClient.registerForScanningAccountRecordsEncrypted({
           currency: mockCurrency,
-          jwt: mockJwt,
           encryptedData: mockEncryptedData,
           keyId: mockKeyId,
         }),
@@ -606,18 +501,13 @@ describe("apiClient", () => {
   });
 
   describe("getRecordScannerStatus", () => {
-    const mockAccessToken = "Bearer eyJhbGciOiJIUzI1NiJ9.test";
     const mockUuid = "scan-uuid-789";
 
     it("should fetch the record scanner status successfully", async () => {
       const mockResponse = { synced: true, percentage: 100 };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getRecordScannerStatus(
-        mockCurrency,
-        mockAccessToken,
-        mockUuid,
-      );
+      const result = await apiClient.getRecordScannerStatus(mockCurrency, mockUuid);
 
       expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
@@ -625,7 +515,7 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith({
         method: "POST",
         url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/status`,
-        headers: { Authorization: mockAccessToken, "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json" },
         data: `"${mockUuid}"`,
       });
       expect(result).toEqual(mockResponse);
@@ -635,11 +525,7 @@ describe("apiClient", () => {
       const mockResponse = { synced: false, percentage: 42 };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getRecordScannerStatus(
-        mockCurrency,
-        mockAccessToken,
-        mockUuid,
-      );
+      const result = await apiClient.getRecordScannerStatus(mockCurrency, mockUuid);
 
       expect(result.synced).toBe(false);
       expect(result.percentage).toBe(42);
@@ -651,13 +537,13 @@ describe("apiClient", () => {
         .mocked(network)
         .mockResolvedValue({ data: { synced: true, percentage: 100 }, status: 200 });
 
-      await apiClient.getRecordScannerStatus(mockCurrency, mockAccessToken, mockUuid);
+      await apiClient.getRecordScannerStatus(mockCurrency, mockUuid);
 
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
         url: `${testnetConfig.nodeUrl}/scanner/${testnetConfig.networkType}/status`,
-        headers: { Authorization: mockAccessToken, "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json" },
         data: `"${mockUuid}"`,
       });
     });
@@ -666,15 +552,13 @@ describe("apiClient", () => {
       const mockError = new Error("Status fetch failed");
       jest.mocked(network).mockRejectedValue(mockError);
 
-      await expect(
-        apiClient.getRecordScannerStatus(mockCurrency, mockAccessToken, mockUuid),
-      ).rejects.toThrow("Status fetch failed");
+      await expect(apiClient.getRecordScannerStatus(mockCurrency, mockUuid)).rejects.toThrow(
+        "Status fetch failed",
+      );
     });
   });
 
   describe("getAccountOwnedRecords", () => {
-    const mockJwtToken = "Bearer eyJhbGciOiJIUzI1NiJ9.test";
-    const mockApiKey = "test-api-key-123";
     const mockUuid = "scan-uuid-abc-789";
 
     it("should fetch owned records successfully", async () => {
@@ -683,8 +567,6 @@ describe("apiClient", () => {
 
       const result = await apiClient.getAccountOwnedRecords({
         currency: mockCurrency,
-        jwtToken: mockJwtToken,
-        apiKey: mockApiKey,
         uuid: mockUuid,
       });
 
@@ -694,10 +576,6 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith({
         method: "POST",
         url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/records/owned`,
-        headers: {
-          Authorization: mockJwtToken,
-          "X-Provable-API-Key": mockApiKey,
-        },
         data: { uuid: mockUuid },
       });
       expect(result).toEqual(mockResponse);
@@ -708,8 +586,6 @@ describe("apiClient", () => {
 
       await apiClient.getAccountOwnedRecords({
         currency: mockCurrency,
-        jwtToken: mockJwtToken,
-        apiKey: mockApiKey,
         uuid: mockUuid,
         unspent: true,
       });
@@ -727,8 +603,6 @@ describe("apiClient", () => {
 
       await apiClient.getAccountOwnedRecords({
         currency: mockCurrency,
-        jwtToken: mockJwtToken,
-        apiKey: mockApiKey,
         uuid: mockUuid,
         unspent: false,
       });
@@ -746,8 +620,6 @@ describe("apiClient", () => {
 
       await apiClient.getAccountOwnedRecords({
         currency: mockCurrency,
-        jwtToken: mockJwtToken,
-        apiKey: mockApiKey,
         uuid: mockUuid,
       });
 
@@ -761,8 +633,6 @@ describe("apiClient", () => {
 
       await apiClient.getAccountOwnedRecords({
         currency: mockCurrency,
-        jwtToken: mockJwtToken,
-        apiKey: mockApiKey,
         uuid: mockUuid,
         start: mockStart,
       });
@@ -780,8 +650,6 @@ describe("apiClient", () => {
 
       await apiClient.getAccountOwnedRecords({
         currency: mockCurrency,
-        jwtToken: mockJwtToken,
-        apiKey: mockApiKey,
         uuid: mockUuid,
       });
 
@@ -795,8 +663,6 @@ describe("apiClient", () => {
 
       await apiClient.getAccountOwnedRecords({
         currency: mockCurrency,
-        jwtToken: mockJwtToken,
-        apiKey: mockApiKey,
         uuid: mockUuid,
         unspent: true,
         start: mockStart,
@@ -815,8 +681,6 @@ describe("apiClient", () => {
 
       const result = await apiClient.getAccountOwnedRecords({
         currency: mockCurrency,
-        jwtToken: mockJwtToken,
-        apiKey: mockApiKey,
         uuid: mockUuid,
       });
 
@@ -830,8 +694,6 @@ describe("apiClient", () => {
       await expect(
         apiClient.getAccountOwnedRecords({
           currency: mockCurrency,
-          jwtToken: mockJwtToken,
-          apiKey: mockApiKey,
           uuid: mockUuid,
         }),
       ).rejects.toThrow("Unauthorized");
@@ -843,8 +705,6 @@ describe("apiClient", () => {
 
       await apiClient.getAccountOwnedRecords({
         currency: mockCurrency,
-        jwtToken: mockJwtToken,
-        apiKey: mockApiKey,
         uuid: mockUuid,
       });
 
@@ -859,8 +719,6 @@ describe("apiClient", () => {
   });
 
   describe("getProvePublicKey", () => {
-    const mockJwt = "Bearer eyJhbGciOiJIUzI1NiJ9.test";
-
     it("should fetch the prove public key successfully", async () => {
       const mockResponse = {
         key_id: "key-id-123",
@@ -868,7 +726,7 @@ describe("apiClient", () => {
       };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getProvePublicKey({ currency: mockCurrency, jwt: mockJwt });
+      const result = await apiClient.getProvePublicKey({ currency: mockCurrency });
 
       expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
@@ -876,7 +734,6 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith({
         method: "GET",
         url: `${mockNetworkConfig.nodeUrl}/prove/${mockNetworkConfig.networkType}/pubkey`,
-        headers: { Authorization: mockJwt },
       });
       expect(result).toEqual(mockResponse);
     });
@@ -887,12 +744,11 @@ describe("apiClient", () => {
         .mocked(network)
         .mockResolvedValue({ data: { key_id: "k1", public_key: "pk1" }, status: 200 });
 
-      await apiClient.getProvePublicKey({ currency: mockCurrency, jwt: mockJwt });
+      await apiClient.getProvePublicKey({ currency: mockCurrency });
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
         url: `${testnetConfig.nodeUrl}/prove/${testnetConfig.networkType}/pubkey`,
-        headers: { Authorization: mockJwt },
       });
     });
 
@@ -900,9 +756,9 @@ describe("apiClient", () => {
       const mockError = new Error("Forbidden");
       jest.mocked(network).mockRejectedValue(mockError);
 
-      await expect(
-        apiClient.getProvePublicKey({ currency: mockCurrency, jwt: mockJwt }),
-      ).rejects.toThrow("Forbidden");
+      await expect(apiClient.getProvePublicKey({ currency: mockCurrency })).rejects.toThrow(
+        "Forbidden",
+      );
     });
   });
 
@@ -919,7 +775,6 @@ describe("apiClient", () => {
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: true,
-        jwt: "jwt_token",
       });
 
       expect(getNetworkConfig).toHaveBeenCalledTimes(1);
@@ -928,9 +783,6 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith({
         method: "POST",
         url: `${mockNetworkConfig.nodeUrl}/prove/${mockNetworkConfig.networkType}/prove`,
-        headers: {
-          Authorization: "jwt_token",
-        },
         data: {
           authorization: mockAuthorization,
           fee_authorization: mockFeeAuthorization,
@@ -949,7 +801,6 @@ describe("apiClient", () => {
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: true,
-        jwt: "jwt_token",
       });
 
       expect(network).toHaveBeenCalledTimes(1);
@@ -970,7 +821,6 @@ describe("apiClient", () => {
           authorization: mockAuthorization,
           feeAuthorization: mockFeeAuthorization,
           broadcast: true,
-          jwt: "jwt_token",
         }),
       ).rejects.toThrow("Proving request failed");
     });
@@ -983,7 +833,6 @@ describe("apiClient", () => {
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: false,
-        jwt: "jwt_token",
       });
 
       expect(network).toHaveBeenCalledTimes(1);
@@ -1003,7 +852,6 @@ describe("apiClient", () => {
         currency: mockCurrency,
         authorization: mockAuthorization,
         broadcast: true,
-        jwt: "jwt_token",
       });
 
       expect(network).toHaveBeenCalledTimes(1);
@@ -1019,7 +867,6 @@ describe("apiClient", () => {
   });
 
   describe("submitEncryptedDelegatedProvingRequest", () => {
-    const mockJwt = "jwt_token";
     const mockKeyId = "key-id-123";
     const mockEncryptedData = "encrypted-ciphertext-xyz";
     const mockDelegatedProvingResponse = getMockedDelegatedProvingResponse();
@@ -1029,7 +876,6 @@ describe("apiClient", () => {
 
       const result = await apiClient.submitEncryptedDelegatedProvingRequest({
         currency: mockCurrency,
-        jwt: mockJwt,
         keyId: mockKeyId,
         encryptedData: mockEncryptedData,
       });
@@ -1040,9 +886,6 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith({
         method: "POST",
         url: `${mockNetworkConfig.nodeUrl}/prove/${mockNetworkConfig.networkType}/prove/encrypted`,
-        headers: {
-          Authorization: mockJwt,
-        },
         data: {
           key_id: mockKeyId,
           ciphertext: mockEncryptedData,
@@ -1057,7 +900,6 @@ describe("apiClient", () => {
 
       await apiClient.submitEncryptedDelegatedProvingRequest({
         currency: mockCurrency,
-        jwt: mockJwt,
         keyId: mockKeyId,
         encryptedData: mockEncryptedData,
       });
@@ -1077,7 +919,6 @@ describe("apiClient", () => {
       await expect(
         apiClient.submitEncryptedDelegatedProvingRequest({
           currency: mockCurrency,
-          jwt: mockJwt,
           keyId: mockKeyId,
           encryptedData: mockEncryptedData,
         }),

--- a/libs/coin-modules/coin-aleo/src/network/api.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.ts
@@ -5,10 +5,7 @@ import type {
   AleoLatestBlockResponse,
   AleoPublicTransactionDetailsResponse,
   AleoPublicTransactionsResponse,
-  AleoAccountJWTResponse,
-  AleoJWT,
   AleoRecordScannerStatusResponse,
-  AleoRegisterAccountResponse,
   AleoRegisterForRecordsResponse,
   AleoGetScannerPublicKeyResponse,
   AleoGetProvePublicKeyResponse,
@@ -89,56 +86,14 @@ async function getAccountPublicTransactions({
   return res.data;
 }
 
-async function registerNewAccount(
-  currency: CryptoCurrency,
-  username: string,
-): Promise<AleoRegisterAccountResponse> {
-  const { nodeUrl } = getNetworkConfig(currency);
-
-  const res = await network<AleoRegisterAccountResponse>({
-    method: "POST",
-    url: `${nodeUrl}/consumers`,
-    data: { username },
-  });
-
-  return res.data;
-}
-
-async function getAccountJWT(
-  currency: CryptoCurrency,
-  apiKey: string,
-  consumerId: string,
-): Promise<AleoJWT> {
-  const { nodeUrl } = getNetworkConfig(currency);
-
-  const res = await network<AleoAccountJWTResponse>({
-    method: "POST",
-    url: `${nodeUrl}/jwts/${consumerId}`,
-    headers: {
-      "X-Provable-API-Key": apiKey,
-    },
-  });
-
-  const data = {
-    token: res.headers?.["authorization"] ?? "",
-    exp: res.data.exp,
-  };
-
-  return data;
-}
-
 async function getScannerPublicKey(
   currency: CryptoCurrency,
-  jwt: string,
 ): Promise<AleoGetScannerPublicKeyResponse> {
   const { nodeUrl, networkType } = getNetworkConfig(currency);
 
   const res = await network<AleoGetScannerPublicKeyResponse>({
     method: "GET",
     url: `${nodeUrl}/scanner/${networkType}/pubkey`,
-    headers: {
-      Authorization: jwt,
-    },
   });
 
   return res.data;
@@ -146,12 +101,10 @@ async function getScannerPublicKey(
 
 async function registerForScanningAccountRecordsEncrypted({
   currency,
-  jwt,
   encryptedData,
   keyId,
 }: {
   currency: CryptoCurrency;
-  jwt: string;
   encryptedData: string;
   keyId: string;
 }): Promise<AleoRegisterForRecordsResponse> {
@@ -160,9 +113,6 @@ async function registerForScanningAccountRecordsEncrypted({
   const res = await network<AleoRegisterForRecordsResponse>({
     method: "POST",
     url: `${nodeUrl}/scanner/${networkType}/register/encrypted`,
-    headers: {
-      Authorization: jwt,
-    },
     data: {
       key_id: keyId,
       ciphertext: encryptedData,
@@ -174,7 +124,6 @@ async function registerForScanningAccountRecordsEncrypted({
 
 const getRecordScannerStatus = async (
   currency: CryptoCurrency,
-  accessToken: string,
   uuid: string,
 ): Promise<AleoRecordScannerStatusResponse> => {
   const { nodeUrl, networkType } = getNetworkConfig(currency);
@@ -183,7 +132,6 @@ const getRecordScannerStatus = async (
     method: "POST",
     url: `${nodeUrl}/scanner/${networkType}/status`,
     headers: {
-      Authorization: accessToken,
       "Content-Type": "application/json",
     },
     data: `"${uuid.toString()}"`,
@@ -194,15 +142,11 @@ const getRecordScannerStatus = async (
 
 async function getAccountOwnedRecords({
   currency,
-  jwtToken,
-  apiKey,
   uuid,
   unspent,
   start,
 }: {
   currency: CryptoCurrency;
-  jwtToken: string;
-  apiKey: string;
   uuid: string;
   unspent?: boolean;
   start?: number;
@@ -212,10 +156,6 @@ async function getAccountOwnedRecords({
   const res = await network<AleoPrivateRecord[]>({
     method: "POST",
     url: `${nodeUrl}/scanner/${networkType}/records/owned`,
-    headers: {
-      Authorization: jwtToken,
-      "X-Provable-API-Key": apiKey,
-    },
     data: {
       ...(typeof unspent === "boolean" && { unspent }),
       ...(typeof start === "number" && { filter: { start } }),
@@ -231,21 +171,16 @@ async function submitDelegatedProvingRequest({
   authorization,
   feeAuthorization,
   broadcast,
-  jwt,
 }: {
   currency: CryptoCurrency;
   authorization: Record<string, unknown>;
   feeAuthorization?: Record<string, unknown>;
   broadcast: boolean;
-  jwt: string;
 }): Promise<DelegatedProvingResponse> {
   const { nodeUrl, networkType } = getNetworkConfig(currency);
   const res = await network<DelegatedProvingResponse>({
     method: "POST",
     url: `${nodeUrl}/prove/${networkType}/prove`,
-    headers: {
-      Authorization: jwt,
-    },
     data: {
       authorization,
       ...(feeAuthorization ? { fee_authorization: feeAuthorization } : {}),
@@ -258,19 +193,14 @@ async function submitDelegatedProvingRequest({
 
 async function getProvePublicKey({
   currency,
-  jwt,
 }: {
   currency: CryptoCurrency;
-  jwt: string;
 }): Promise<AleoGetProvePublicKeyResponse> {
   const { nodeUrl, networkType } = getNetworkConfig(currency);
 
   const res = await network<AleoGetProvePublicKeyResponse>({
     method: "GET",
     url: `${nodeUrl}/prove/${networkType}/pubkey`,
-    headers: {
-      Authorization: jwt,
-    },
   });
 
   return res.data;
@@ -278,12 +208,10 @@ async function getProvePublicKey({
 
 async function submitEncryptedDelegatedProvingRequest({
   currency,
-  jwt,
   keyId,
   encryptedData,
 }: {
   currency: CryptoCurrency;
-  jwt: string;
   keyId: string;
   encryptedData: string;
 }): Promise<DelegatedProvingResponse> {
@@ -291,9 +219,6 @@ async function submitEncryptedDelegatedProvingRequest({
   const res = await network<DelegatedProvingResponse>({
     method: "POST",
     url: `${nodeUrl}/prove/${networkType}/prove/encrypted`,
-    headers: {
-      Authorization: jwt,
-    },
     data: {
       key_id: keyId,
       ciphertext: encryptedData,
@@ -308,8 +233,6 @@ export const apiClient = {
   getAccountBalance,
   getTransactionById,
   getAccountPublicTransactions,
-  getAccountJWT,
-  registerNewAccount,
   getRecordScannerStatus,
   getScannerPublicKey,
   getProvePublicKey,

--- a/libs/coin-modules/coin-aleo/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/sdk.test.ts
@@ -462,7 +462,6 @@ describe("sdkClient", () => {
   });
 
   describe("encryptProvingRequest", () => {
-    const mockJwt = "Bearer mock_jwt_token";
     const mockPublicKey = "aleo1publickey";
     const mockAuthorization = { program_id: "credits.aleo", function_name: "transfer_public" };
     const mockEncryptedResponse = { encrypted: "mock_encrypted_proving_request" };
@@ -472,7 +471,6 @@ describe("sdkClient", () => {
 
       const result = await sdkClient.encryptProvingRequest({
         currency: mockCurrency,
-        jwt: mockJwt,
         publicKey: mockPublicKey,
         authorization: mockAuthorization,
         broadcast: true,
@@ -485,9 +483,6 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledWith({
         method: "POST",
         url: `${mockNetworkConfig.sdkUrl}/encrypt_proving_request`,
-        headers: {
-          Authorization: mockJwt,
-        },
         data: {
           public_key: mockPublicKey,
           proving_request: {
@@ -505,7 +500,6 @@ describe("sdkClient", () => {
 
       await sdkClient.encryptProvingRequest({
         currency: mockCurrency,
-        jwt: mockJwt,
         publicKey: mockPublicKey,
         authorization: mockAuthorization,
         broadcast: true,
@@ -525,7 +519,6 @@ describe("sdkClient", () => {
       await expect(
         sdkClient.encryptProvingRequest({
           currency: mockCurrency,
-          jwt: mockJwt,
           publicKey: mockPublicKey,
           authorization: mockAuthorization,
           broadcast: true,

--- a/libs/coin-modules/coin-aleo/src/network/sdk.ts
+++ b/libs/coin-modules/coin-aleo/src/network/sdk.ts
@@ -153,7 +153,6 @@ async function createAuthorization({
 
 async function encryptProvingRequest({
   currency,
-  jwt,
   publicKey,
   authorization,
   feeAuthorization,
@@ -161,7 +160,6 @@ async function encryptProvingRequest({
 }: {
   publicKey: string;
   currency: CryptoCurrency;
-  jwt: string;
   authorization: Record<string, unknown>;
   feeAuthorization?: Record<string, unknown>;
   broadcast: boolean;
@@ -171,9 +169,6 @@ async function encryptProvingRequest({
   const res = await network<EncryptProvingRequestResponse>({
     method: "POST",
     url: `${sdkUrl}/encrypt_proving_request`,
-    headers: {
-      Authorization: jwt,
-    },
     data: {
       public_key: publicKey,
       proving_request: {

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -9,7 +9,6 @@ import {
   getMockedPublicTransaction,
   getMockedTransactionDetails,
 } from "../__tests__/fixtures/api.fixture";
-import * as logicUtils from "../logic/utils";
 import { getMockedOperation } from "../__tests__/fixtures/operation.fixture";
 import { accessProvableApi } from "./utils";
 import { apiClient } from "./api";
@@ -26,12 +25,9 @@ jest.mock("../logic/utils", () => ({
   generateUniqueUsername: jest.fn(),
 }));
 
-const mockRegisterNewAccount = jest.mocked(apiClient.registerNewAccount);
-const mockGetAccountJWT = jest.mocked(apiClient.getAccountJWT);
 const mockGetRecordScannerStatus = jest.mocked(apiClient.getRecordScannerStatus);
 const mockGetScannerPublicKey = jest.mocked(apiClient.getScannerPublicKey);
 const mockEncryptRegistrationPayload = jest.mocked(sdkClient.encryptRegistrationPayload);
-const mockGenerateUniqueUsername = jest.mocked(logicUtils.generateUniqueUsername);
 const mockRegisterForScanningAccountRecords = jest.mocked(
   apiClient.registerForScanningAccountRecordsEncrypted,
 );
@@ -337,289 +333,21 @@ describe("network/utils", () => {
   });
 
   describe("accessProvableApi", () => {
-    const mockCurrency = getMockedCurrency();
     const mockViewKey = "AViewKey1mockviewkey";
-    const mockAddress = "aleo1test123";
-    const mockApiKey = "test-api-key-123";
-    const mockConsumerId = "consumer-id-456";
     const mockUUID = "uuid-abc-def";
-    const mockUsername = "1234567890_aleo1test123";
     const mockPublicKey = "aleo1publickey";
     const mockKeyId = "key-id-123";
     const mockEncryptedData = "encrypted-data-xyz";
-    const mockJWT = {
-      token: "jwt-token-789",
-      exp: Math.floor(Date.now() / 1000) + 3600, // 1 hour in the future,
-    };
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockGenerateUniqueUsername.mockReturnValue(mockUsername);
       mockGetScannerPublicKey.mockResolvedValue({ public_key: mockPublicKey, key_id: mockKeyId });
       mockEncryptRegistrationPayload.mockResolvedValue({ encrypted: mockEncryptedData });
-    });
-
-    describe("Initial registration flow", () => {
-      it("should register a new account when provableApi is null", async () => {
-        mockRegisterNewAccount.mockResolvedValue({
-          key: mockApiKey,
-          consumer: { id: mockConsumerId },
-          created_at: Date.now(),
-          id: "account-id",
-        });
-        mockGetAccountJWT.mockResolvedValue(mockJWT);
-        mockRegisterForScanningAccountRecords.mockResolvedValue({ uuid: mockUUID });
-        mockGetRecordScannerStatus.mockResolvedValue({ synced: false, percentage: 0 });
-
-        const result = await accessProvableApi({
-          currency: mockCurrency,
-          viewKey: mockViewKey,
-          address: mockAddress,
-          provableApi: null,
-        });
-
-        expect(mockGenerateUniqueUsername).toHaveBeenCalledTimes(1);
-        expect(mockRegisterNewAccount).toHaveBeenCalledTimes(1);
-        expect(mockGetAccountJWT).toHaveBeenCalledTimes(1);
-        expect(mockRegisterForScanningAccountRecords).toHaveBeenCalledTimes(1);
-        expect(mockGetRecordScannerStatus).toHaveBeenCalledTimes(1);
-
-        expect(result).toEqual({
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: mockJWT,
-          uuid: mockUUID,
-          scannerStatus: { synced: false, percentage: 0 },
-        });
-      });
-
-      it("should register a new account when apiKey is missing", async () => {
-        const partialProvableApi: ProvableApi = {
-          jwt: mockJWT,
-          uuid: mockUUID,
-          scannerStatus: { synced: true, percentage: 100 },
-        };
-
-        mockRegisterNewAccount.mockResolvedValue({
-          key: mockApiKey,
-          consumer: { id: mockConsumerId },
-          created_at: Date.now(),
-          id: "account-id",
-        });
-        mockGetRecordScannerStatus.mockResolvedValue({ synced: true, percentage: 100 });
-
-        const result = await accessProvableApi({
-          currency: mockCurrency,
-          viewKey: mockViewKey,
-          address: mockAddress,
-          provableApi: partialProvableApi,
-        });
-
-        expect(mockRegisterNewAccount).toHaveBeenCalledTimes(1);
-        expect(mockRegisterNewAccount).toHaveBeenCalledWith(mockCurrency, mockUsername);
-        expect(result?.apiKey).toBe(mockApiKey);
-        expect(result?.consumerId).toBe(mockConsumerId);
-      });
-
-      it("should register a new account when consumerId is missing", async () => {
-        const partialProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          jwt: mockJWT,
-          uuid: mockUUID,
-          scannerStatus: { synced: true, percentage: 100 },
-        };
-
-        mockRegisterNewAccount.mockResolvedValue({
-          key: mockApiKey,
-          consumer: { id: mockConsumerId },
-          created_at: Date.now(),
-          id: "account-id",
-        });
-        mockGetRecordScannerStatus.mockResolvedValue({ synced: true, percentage: 100 });
-
-        const result = await accessProvableApi({
-          currency: mockCurrency,
-          viewKey: mockViewKey,
-          address: mockAddress,
-          provableApi: partialProvableApi,
-        });
-
-        expect(mockRegisterNewAccount).toHaveBeenCalledTimes(1);
-        expect(mockRegisterNewAccount).toHaveBeenCalledWith(mockCurrency, mockUsername);
-        expect(result?.consumerId).toBe(mockConsumerId);
-      });
-    });
-
-    describe("JWT token management", () => {
-      it("should refresh JWT when it is expired", async () => {
-        const expiredJWT = {
-          token: "expired-token",
-          exp: Math.floor(Date.now() / 1000) - 3600, // 1 hour in the past
-        };
-
-        const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: expiredJWT,
-          uuid: mockUUID,
-          scannerStatus: { synced: true, percentage: 100 },
-        };
-
-        mockGetAccountJWT.mockResolvedValue(mockJWT);
-        mockGetRecordScannerStatus.mockResolvedValue({ synced: true, percentage: 100 });
-
-        const result = await accessProvableApi({
-          currency: mockCurrency,
-          viewKey: mockViewKey,
-          address: mockAddress,
-          provableApi: existingProvableApi,
-        });
-
-        expect(result?.jwt).toEqual(mockJWT);
-      });
-
-      it("should refresh JWT when it is about to expire (within 5 minutes)", async () => {
-        const soonToExpireJWT = {
-          token: "soon-to-expire-token",
-          exp: Math.floor(Date.now() / 1000) + 4 * 60, // 4 minutes in the future
-        };
-
-        const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: soonToExpireJWT,
-          uuid: mockUUID,
-          scannerStatus: { synced: true, percentage: 100 },
-        };
-
-        mockGetAccountJWT.mockResolvedValue(mockJWT);
-        mockGetRecordScannerStatus.mockResolvedValue({ synced: true, percentage: 100 });
-
-        const result = await accessProvableApi({
-          currency: mockCurrency,
-          viewKey: mockViewKey,
-          address: mockAddress,
-          provableApi: existingProvableApi,
-        });
-
-        expect(mockGetAccountJWT).toHaveBeenCalledTimes(1);
-        expect(mockGetAccountJWT).toHaveBeenCalledWith(mockCurrency, mockApiKey, mockConsumerId);
-        expect(result?.jwt).toEqual(mockJWT);
-      });
-
-      it("should not refresh JWT when it is still valid", async () => {
-        const validJWT = {
-          token: "valid-token",
-          exp: Math.floor(Date.now() / 1000) + 30 * 60, // 30 minutes in the future
-        };
-
-        const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: validJWT,
-          uuid: mockUUID,
-          scannerStatus: { synced: true, percentage: 100 },
-        };
-
-        mockGetRecordScannerStatus.mockResolvedValue({ synced: true, percentage: 100 });
-
-        const result = await accessProvableApi({
-          currency: mockCurrency,
-          viewKey: mockViewKey,
-          address: mockAddress,
-          provableApi: existingProvableApi,
-        });
-
-        expect(mockGetAccountJWT).not.toHaveBeenCalled();
-        expect(result?.jwt).toEqual(validJWT);
-      });
-
-      it("should request new JWT when jwt is undefined", async () => {
-        const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          uuid: mockUUID,
-          scannerStatus: { synced: true, percentage: 100 },
-        };
-
-        mockGetAccountJWT.mockResolvedValue(mockJWT);
-        mockGetRecordScannerStatus.mockResolvedValue({ synced: true, percentage: 100 });
-
-        const result = await accessProvableApi({
-          currency: mockCurrency,
-          viewKey: mockViewKey,
-          address: mockAddress,
-          provableApi: existingProvableApi,
-        });
-
-        expect(mockGetAccountJWT).toHaveBeenCalledTimes(1);
-        expect(mockGetAccountJWT).toHaveBeenCalledWith(mockCurrency, mockApiKey, mockConsumerId);
-        expect(result?.jwt).toEqual(mockJWT);
-      });
-
-      it("should return null when JWT retrieval fails with Unauthorized error", async () => {
-        const expiredJWT = {
-          token: "expired-token",
-          exp: Math.floor(Date.now() / 1000) - 3600,
-        };
-
-        const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: expiredJWT,
-          uuid: mockUUID,
-          scannerStatus: { synced: true, percentage: 100 },
-        };
-
-        const unauthorizedError = new Error("Unauthorized");
-        mockGetAccountJWT.mockRejectedValue(unauthorizedError);
-
-        const result = await accessProvableApi({
-          currency: mockCurrency,
-          viewKey: mockViewKey,
-          address: mockAddress,
-          provableApi: existingProvableApi,
-        });
-
-        expect(result).toBeNull();
-        expect(mockGetAccountJWT).toHaveBeenCalled();
-        expect(mockGetRecordScannerStatus).not.toHaveBeenCalled();
-      });
-
-      it("should throw error when JWT retrieval fails with non-Unauthorized error", async () => {
-        const expiredJWT = {
-          token: "expired-token",
-          exp: Math.floor(Date.now() / 1000) - 3600,
-        };
-
-        const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: expiredJWT,
-          uuid: mockUUID,
-          scannerStatus: { synced: true, percentage: 100 },
-        };
-
-        const networkError = new Error("Network error");
-        mockGetAccountJWT.mockRejectedValue(networkError);
-
-        await expect(
-          accessProvableApi({
-            currency: mockCurrency,
-            viewKey: mockViewKey,
-            address: mockAddress,
-            provableApi: existingProvableApi,
-          }),
-        ).rejects.toThrow("Network error");
-      });
     });
 
     describe("UUID and scanning registration", () => {
       it("should register for scanning when uuid is missing", async () => {
         const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: mockJWT,
           scannerStatus: { synced: false, percentage: 0 },
         };
 
@@ -629,12 +357,11 @@ describe("network/utils", () => {
         const result = await accessProvableApi({
           currency: mockCurrency,
           viewKey: mockViewKey,
-          address: mockAddress,
           provableApi: existingProvableApi,
         });
 
         expect(mockGetScannerPublicKey).toHaveBeenCalledTimes(1);
-        expect(mockGetScannerPublicKey).toHaveBeenCalledWith(mockCurrency, mockJWT.token);
+        expect(mockGetScannerPublicKey).toHaveBeenCalledWith(mockCurrency);
         expect(mockEncryptRegistrationPayload).toHaveBeenCalledTimes(1);
         expect(mockEncryptRegistrationPayload).toHaveBeenCalledWith({
           currency: mockCurrency,
@@ -645,7 +372,6 @@ describe("network/utils", () => {
         expect(mockRegisterForScanningAccountRecords).toHaveBeenCalledTimes(1);
         expect(mockRegisterForScanningAccountRecords).toHaveBeenCalledWith({
           currency: mockCurrency,
-          jwt: mockJWT.token,
           encryptedData: mockEncryptedData,
           keyId: mockKeyId,
         });
@@ -654,9 +380,6 @@ describe("network/utils", () => {
 
       it("should not register for scanning when uuid exists", async () => {
         const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: mockJWT,
           uuid: mockUUID,
           scannerStatus: { synced: false, percentage: 50 },
         };
@@ -666,7 +389,6 @@ describe("network/utils", () => {
         const result = await accessProvableApi({
           currency: mockCurrency,
           viewKey: mockViewKey,
-          address: mockAddress,
           provableApi: existingProvableApi,
         });
 
@@ -678,9 +400,6 @@ describe("network/utils", () => {
     describe("Scanner status updates", () => {
       it("should update scanner status when status is available", async () => {
         const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: mockJWT,
           uuid: mockUUID,
           scannerStatus: { synced: false, percentage: 50 },
         };
@@ -690,7 +409,6 @@ describe("network/utils", () => {
         const result = await accessProvableApi({
           currency: mockCurrency,
           viewKey: mockViewKey,
-          address: mockAddress,
           provableApi: existingProvableApi,
         });
 
@@ -699,9 +417,6 @@ describe("network/utils", () => {
 
       it("should return null when getRecordScannerStatus fails with a 422 error", async () => {
         const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: mockJWT,
           uuid: mockUUID,
           scannerStatus: { synced: false, percentage: 50 },
         };
@@ -716,7 +431,6 @@ describe("network/utils", () => {
         const result = await accessProvableApi({
           currency: mockCurrency,
           viewKey: mockViewKey,
-          address: mockAddress,
           provableApi: existingProvableApi,
         });
 
@@ -726,9 +440,6 @@ describe("network/utils", () => {
 
       it("should throw error when getRecordScannerStatus fails with a non-422 error", async () => {
         const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: mockJWT,
           uuid: mockUUID,
           scannerStatus: { synced: false, percentage: 50 },
         };
@@ -740,7 +451,6 @@ describe("network/utils", () => {
           accessProvableApi({
             currency: mockCurrency,
             viewKey: mockViewKey,
-            address: mockAddress,
             provableApi: existingProvableApi,
           }),
         ).rejects.toThrow(LedgerAPI5xx);
@@ -748,9 +458,6 @@ describe("network/utils", () => {
 
       it("should preserve previous scanner status when status call returns null", async () => {
         const existingProvableApi: ProvableApi = {
-          apiKey: mockApiKey,
-          consumerId: mockConsumerId,
-          jwt: mockJWT,
           uuid: mockUUID,
           scannerStatus: { synced: false, percentage: 75 },
         };
@@ -760,7 +467,6 @@ describe("network/utils", () => {
         const result = await accessProvableApi({
           currency: mockCurrency,
           viewKey: mockViewKey,
-          address: mockAddress,
           provableApi: existingProvableApi,
         });
 
@@ -768,20 +474,12 @@ describe("network/utils", () => {
       });
 
       it("should initialize scanner status with defaults when provableApi is null", async () => {
-        mockRegisterNewAccount.mockResolvedValue({
-          key: mockApiKey,
-          consumer: { id: mockConsumerId },
-          created_at: Date.now(),
-          id: "account-id",
-        });
-        mockGetAccountJWT.mockResolvedValue(mockJWT);
         mockRegisterForScanningAccountRecords.mockResolvedValue({ uuid: mockUUID });
         mockGetRecordScannerStatus.mockResolvedValue({ synced: false, percentage: 0 });
 
         const result = await accessProvableApi({
           currency: mockCurrency,
           viewKey: mockViewKey,
-          address: mockAddress,
           provableApi: null,
         });
 

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -17,7 +17,7 @@ import type {
   AleoPrivateRecord,
   AleoOperation,
 } from "../types";
-import { generateUniqueUsername, parseMicrocredits } from "../logic/utils";
+import { parseMicrocredits } from "../logic/utils";
 import { apiClient } from "./api";
 
 function limitTransactions(
@@ -120,75 +120,38 @@ export async function fetchAccountTransactionsFromHeight({
  *
  * This function ensures valid API credentials are available and up-to-date. It handles:
  * - Initial account registration if API key or consumer ID are missing
- * - JWT token refresh when expired or about to expire (within 5 minutes)
  * - Account registration for scanning records if UUID is not set
  * - Retrieval of current scanner status
  *
  * @param currency - The cryptocurrency being accessed
  * @param viewKey - The view key for the account
- * @param address - The account address
  * @param provableApi - Existing Provable API credentials and state, or null for initial setup
  *
  * @returns A Promise resolving to updated ProvableApi credentials, or null if access needs to be reset
  *
- * @throws {Error} Re-throws any errors except unauthorized errors during JWT retrieval
+ * @throws {Error} Re-throws any errors except 422 that should trigger uuid rotation
  *
  * @remarks
- * Edge cases that trigger Provable API access reset (returns null):
- * - Unauthorized error during JWT retrieval, typically indicating:
- *   - Revoked API key
- *   - Invalid consumer credentials
- *   - Account access has been terminated
- *
  * When null is returned, the caller should clear stored Provable API credentials
  * and allow the user to re-initialize access from scratch.
  */
 
-const JWT_EXPIRY_BUFFER_SECONDS = 5 * 60; // 5 minutes safe buffer
-
 export async function accessProvableApi({
   currency,
   viewKey,
-  address,
   provableApi,
 }: {
   currency: CryptoCurrency;
   viewKey: string;
-  address: string;
   provableApi: ProvableApi | null;
 }): Promise<ProvableApi | null> {
-  let apiKey = provableApi?.apiKey;
-  let consumerId = provableApi?.consumerId;
-  let jwt = provableApi?.jwt;
   let uuid = provableApi?.uuid;
   let synced: boolean | undefined = provableApi?.scannerStatus?.synced ?? false;
   let percentage: number | undefined = provableApi?.scannerStatus?.percentage ?? 0;
   let status;
 
-  if (!apiKey || !consumerId) {
-    const username = generateUniqueUsername(address);
-
-    const { key, consumer } = await apiClient.registerNewAccount(currency, username);
-
-    apiKey = key;
-    consumerId = consumer.id;
-  }
-
-  const currentTimestamp = Math.floor(Date.now() / 1000);
-  if (!jwt || currentTimestamp >= jwt.exp - JWT_EXPIRY_BUFFER_SECONDS) {
-    try {
-      jwt = await apiClient.getAccountJWT(currency, apiKey, consumerId);
-    } catch (error) {
-      // If unauthorized, likely due to revoked API key - return null to reset Provable API access
-      if (error instanceof Error && error.message.includes("Unauthorized")) {
-        return null;
-      }
-      throw error;
-    }
-  }
-
   if (!uuid) {
-    const { public_key, key_id } = await apiClient.getScannerPublicKey(currency, jwt.token);
+    const { public_key, key_id } = await apiClient.getScannerPublicKey(currency);
 
     const { encrypted: encryptedData } = await sdkClient.encryptRegistrationPayload({
       currency,
@@ -199,15 +162,15 @@ export async function accessProvableApi({
 
     const { uuid: accountUuid } = await apiClient.registerForScanningAccountRecordsEncrypted({
       currency,
-      jwt: jwt.token,
       encryptedData,
       keyId: key_id,
     });
+
     uuid = accountUuid;
   }
 
   try {
-    status = await apiClient.getRecordScannerStatus(currency, jwt.token, uuid);
+    status = await apiClient.getRecordScannerStatus(currency, uuid);
   } catch (error) {
     if (error instanceof LedgerAPI4xx && error.status === 422) {
       return null;
@@ -221,9 +184,6 @@ export async function accessProvableApi({
   }
 
   return {
-    apiKey,
-    consumerId,
-    jwt,
     uuid,
     scannerStatus: { synced, percentage },
   };

--- a/libs/coin-modules/coin-aleo/src/types/api.ts
+++ b/libs/coin-modules/coin-aleo/src/types/api.ts
@@ -80,22 +80,6 @@ export interface AleoPublicTransactionsResponse {
   };
 }
 
-export interface AleoRegisterAccountResponse {
-  consumer: { id: string };
-  created_at: number;
-  id: string;
-  key: string;
-}
-
-export interface AleoAccountJWTResponse {
-  exp: number;
-}
-
-export interface AleoJWT {
-  token: string;
-  exp: number;
-}
-
 export interface AleoRegisterForRecordsResponse {
   uuid: string;
 }

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -6,7 +6,6 @@ import type {
 } from "@ledgerhq/coin-module-framework/api/types";
 import type { TRANSACTION_TYPE } from "../constants";
 import type {
-  AleoJWT,
   AleoRecordScannerStatusResponse,
   AleoPublicTransactionDetailsResponse,
   AleoPrivateRecord,
@@ -27,9 +26,6 @@ export type EnrichedPrivateRecord = {
 };
 
 export interface ProvableApi {
-  apiKey?: string;
-  consumerId?: string;
-  jwt?: AleoJWT;
   uuid?: string;
   scannerStatus?: AleoRecordScannerStatusResponse;
 }

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -288,7 +288,7 @@ const envDefinitions = {
     desc: "Thorest API for VeChain",
   },
   ALEO_MAINNET_NODE_ENDPOINT: {
-    def: "https://api.provable.com",
+    def: "https://aleo.coin.ledger-test.com",
     parser: stringParser,
     desc: "Aleo mainnet node URL",
   },
@@ -298,7 +298,7 @@ const envDefinitions = {
     desc: "Aleo mainnet SDK URL",
   },
   ALEO_TESTNET_NODE_ENDPOINT: {
-    def: "https://api.provable.com",
+    def: "https://aleo.coin.ledger-test.com",
     parser: stringParser,
     desc: "Aleo testnet node URL",
   },

--- a/libs/ledger-live-common/src/families/aleo/config.ts
+++ b/libs/ledger-live-common/src/families/aleo/config.ts
@@ -26,7 +26,7 @@ const IS_FEE_SPONSORED = true;
  * This is the target solution that should be enabled once fix on API side is done.
  * @see https://ledgerhq.atlassian.net/browse/LIVE-27542
  */
-const USE_ENCRYPTED_PROVE = false;
+const USE_ENCRYPTED_PROVE = true;
 
 export const aleoConfig: Record<string, ConfigInfo> = {
   config_currency_aleo: {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - switched coin-aleo to reverse proxy (staging, prod should be updated next week)
  - removed JWT rotation from coin-aleo
  - enabled encrypted proving during Aleo tx broadcast

### 📝 Description

This PR switches `coin-aleo` module to staging reverse proxy that allows us to remove code responsible for Authorization and JWT rotation. It also enables encrypted proving thanks to the workaround with `Set-Cookie` overrite done on the reverse proxy level.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-23536
- https://ledgerhq.atlassian.net/browse/LIVE-27974

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
