### PR TITLE
[LWDM] feat(LIVE-28040): simplify private record enrichment logic

### DIFF
--- a/.changeset/lucky-terms-refuse.md
+++ b/.changeset/lucky-terms-refuse.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Refactor Aleo private record enrichment to reuse existing transition types, simplify outgoing transfer handling, and keep semi-private history sync behavior clearer and safer.

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -16,6 +16,7 @@ import type {
   EnrichedPrivateRecord,
   AleoPrivateRecord,
   AleoOperation,
+  AleoTransition,
 } from "../types";
 import { generateUniqueUsername, parseMicrocredits } from "../logic/utils";
 import { apiClient } from "./api";
@@ -229,6 +230,172 @@ export async function accessProvableApi({
   };
 }
 
+type EnrichedRecordData = Pick<EnrichedPrivateRecord, "sender" | "recipient" | "value">;
+type AleoTransitionInputWithValue = AleoTransition["inputs"][number] & { value: string };
+
+// PUBLIC_TO_PRIVATE where sender is this address is already captured as a public OUT op.
+function shouldSkipPublicToPrivateRecord(rawRecord: AleoPrivateRecord, address: string): boolean {
+  return (
+    rawRecord.function_name === EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE &&
+    rawRecord.sender === address
+  );
+}
+
+function getRecordTransition(
+  details: EnrichedPrivateRecord["details"],
+  rawRecord: AleoPrivateRecord,
+  transactionId: string,
+): AleoTransition | null {
+  const recordTransition = details.execution?.transitions[rawRecord.transition_index];
+
+  if (!recordTransition) {
+    log(
+      "aleo/sync",
+      `enrichPrivateRecord: transition at index ${rawRecord.transition_index} not found for tx ${transactionId}`,
+    );
+    return null;
+  }
+
+  return recordTransition;
+}
+
+function hasValueField(
+  input: AleoTransition["inputs"][number] | null,
+): input is AleoTransitionInputWithValue {
+  return Boolean(input && "value" in input);
+}
+
+function getTransferArguments(
+  recordTransition: AleoTransition,
+  transactionId: string,
+): {
+  recipientArgument: AleoTransitionInputWithValue;
+  amountArgument: AleoTransitionInputWithValue;
+} | null {
+  if (recordTransition.inputs.length <= AMOUNT_ARG_INDEX) {
+    log(
+      "aleo/sync",
+      `enrichPrivateRecord: transition has only ${recordTransition.inputs.length} inputs, expected at least ${AMOUNT_ARG_INDEX + 1} for tx ${transactionId}`,
+    );
+    return null;
+  }
+
+  // Recipient and amount are contract function arguments, so their inputs must have a `value` field.
+  // Other input (missing `value` field) would indicate unexpected API data.
+  // In that case we skip processing rather than crash.
+  const recipientInput = recordTransition.inputs[RECIPIENT_ARG_INDEX] ?? null;
+  const amountInput = recordTransition.inputs[AMOUNT_ARG_INDEX] ?? null;
+
+  if (!hasValueField(recipientInput) || !hasValueField(amountInput)) {
+    log("aleo/sync", `enrichPrivateRecord: invalid transition arguments for tx ${transactionId}`);
+    return null;
+  }
+
+  return {
+    recipientArgument: recipientInput,
+    amountArgument: amountInput,
+  };
+}
+
+async function enrichOutgoingRecord({
+  currency,
+  rawRecord,
+  recordTransition,
+  transactionId,
+  viewKey,
+  address,
+}: {
+  currency: CryptoCurrency;
+  rawRecord: AleoPrivateRecord;
+  recordTransition: AleoTransition;
+  transactionId: string;
+  viewKey: string;
+  address: string;
+}): Promise<EnrichedRecordData | null> {
+  const transferArguments = getTransferArguments(recordTransition, transactionId);
+  if (!transferArguments) {
+    return null;
+  }
+
+  const { recipientArgument, amountArgument } = transferArguments;
+
+  if (rawRecord.function_name === EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC) {
+    // The recipient and amount stay public for private-to-public transfers,
+    // so we can build the outgoing operation directly from the transition inputs.
+    if (recipientArgument.value === address) {
+      return null;
+    }
+
+    return {
+      sender: address,
+      recipient: recipientArgument.value,
+      value: new BigNumber(parseMicrocredits(amountArgument.value)),
+    };
+  }
+
+  const [recipientData, amountData] = await Promise.all([
+    sdkClient.decryptCiphertext({
+      currency,
+      ciphertext: recipientArgument.value,
+      tpk: recordTransition.tpk,
+      viewKey,
+      programId: rawRecord.program_name,
+      functionName: rawRecord.function_name,
+      outputIndex: RECIPIENT_ARG_INDEX,
+    }),
+    sdkClient.decryptCiphertext({
+      currency,
+      ciphertext: amountArgument.value,
+      tpk: recordTransition.tpk,
+      viewKey,
+      programId: rawRecord.program_name,
+      functionName: rawRecord.function_name,
+      outputIndex: AMOUNT_ARG_INDEX,
+    }),
+  ]);
+
+  return {
+    sender: address,
+    recipient: recipientData.plaintext,
+    value: new BigNumber(parseMicrocredits(amountData.plaintext)),
+  };
+}
+
+async function enrichIncomingRecord({
+  currency,
+  rawRecord,
+  transactionId,
+  viewKey,
+  address,
+}: {
+  currency: CryptoCurrency;
+  rawRecord: AleoPrivateRecord;
+  transactionId: string;
+  viewKey: string;
+  address: string;
+}): Promise<EnrichedRecordData | null> {
+  const outputRecord = await sdkClient.decryptRecord({
+    currency,
+    ciphertext: rawRecord.record_ciphertext,
+    viewKey,
+  });
+  const microcredits = outputRecord.data?.microcredits;
+
+  if (!microcredits) {
+    log(
+      "aleo/sync",
+      `enrichPrivateRecord: microcredits missing in decrypted record for tx ${transactionId}`,
+    );
+    return null;
+  }
+
+  return {
+    sender: rawRecord.sender,
+    recipient: address,
+    value: new BigNumber(parseMicrocredits(microcredits)),
+  };
+}
+
 export async function enrichPrivateRecord({
   currency,
   rawRecord,
@@ -243,99 +410,38 @@ export async function enrichPrivateRecord({
   const transactionId = rawRecord.transaction_id.trim();
   const details = await apiClient.getTransactionById(currency, transactionId);
 
-  // PUBLIC_TO_PRIVATE where sender is this address is already captured as a public OUT op
-  if (
-    rawRecord.function_name === EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE &&
-    rawRecord.sender === address
-  ) {
+  if (shouldSkipPublicToPrivateRecord(rawRecord, address)) {
     return null;
   }
 
-  const recordTransition = details.execution?.transitions[rawRecord.transition_index];
+  const recordTransition = getRecordTransition(details, rawRecord, transactionId);
   if (!recordTransition) {
-    log(
-      "aleo/sync",
-      `enrichPrivateRecord: transition at index ${rawRecord.transition_index} not found for tx ${transactionId}`,
-    );
     return null;
   }
 
-  let recipient = "";
-  let sender = "";
-  let value: BigNumber;
-
-  if (rawRecord.sender === address) {
-    if (recordTransition.inputs.length <= AMOUNT_ARG_INDEX) {
-      log(
-        "aleo/sync",
-        `enrichPrivateRecord: transition has only ${recordTransition.inputs.length} inputs, expected at least ${AMOUNT_ARG_INDEX + 1} for tx ${transactionId}`,
-      );
-      return null;
-    }
-
-    // Recipient and amount are contract function arguments, so their inputs must have a `value` field.
-    // Other input (missing `value` field) would indicate unexpected API data.
-    // In that case we skip processing rather than crash.
-    const recipientInput = recordTransition.inputs[RECIPIENT_ARG_INDEX] ?? null;
-    const amountInput = recordTransition.inputs[AMOUNT_ARG_INDEX] ?? null;
-    const recipientArgument = recipientInput && "value" in recipientInput ? recipientInput : null;
-    const amountArgument = amountInput && "value" in amountInput ? amountInput : null;
-
-    if (!recipientArgument || !amountArgument) {
-      log("aleo/sync", `enrichPrivateRecord: invalid transition arguments for tx ${transactionId}`);
-      return null;
-    }
-
-    if (rawRecord.function_name === EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC) {
-      if (recipientArgument.value === address) return null;
-      sender = address;
-      recipient = recipientArgument.value;
-      value = new BigNumber(parseMicrocredits(amountArgument.value));
-    } else {
-      const [recipientData, amountData] = await Promise.all([
-        sdkClient.decryptCiphertext({
+  const enrichedRecordData =
+    rawRecord.sender === address
+      ? await enrichOutgoingRecord({
           currency,
-          ciphertext: recipientArgument.value,
-          tpk: recordTransition.tpk,
+          rawRecord,
+          recordTransition,
+          transactionId,
           viewKey,
-          programId: rawRecord.program_name,
-          functionName: rawRecord.function_name,
-          outputIndex: RECIPIENT_ARG_INDEX,
-        }),
-        sdkClient.decryptCiphertext({
+          address,
+        })
+      : await enrichIncomingRecord({
           currency,
-          ciphertext: amountArgument.value,
-          tpk: recordTransition.tpk,
+          rawRecord,
+          transactionId,
           viewKey,
-          programId: rawRecord.program_name,
-          functionName: rawRecord.function_name,
-          outputIndex: AMOUNT_ARG_INDEX,
-        }),
-      ]);
-      sender = address;
-      recipient = recipientData.plaintext;
-      value = new BigNumber(parseMicrocredits(amountData.plaintext));
-    }
-  } else {
-    const outputRecord = await sdkClient.decryptRecord({
-      currency,
-      ciphertext: rawRecord.record_ciphertext,
-      viewKey,
-    });
-    const microcredits = outputRecord.data?.microcredits;
-    if (!microcredits) {
-      log(
-        "aleo/sync",
-        `enrichPrivateRecord: microcredits missing in decrypted record for tx ${transactionId}`,
-      );
-      return null;
-    }
-    sender = rawRecord.sender;
-    recipient = address;
-    value = new BigNumber(parseMicrocredits(microcredits));
+          address,
+        });
+
+  if (!enrichedRecordData) {
+    return null;
   }
 
-  return { rawRecord, details, sender, recipient, value };
+  return { rawRecord, details, ...enrichedRecordData };
 }
 
 function splitPublicAndSemiPublicOperations(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - This PR contains refactor Aleo private record enrichment to reuse existing transition types, simplify outgoing transfer handling, and keep semi-private history sync behavior clearer and safer.

### 📝 Description

Refactor Aleo private record enrichment to reuse existing transition types, simplify outgoing transfer handling, and keep semi-private history sync behavior clearer and safer.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-28040

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
