### PR TITLE
[LWMD] chore(desktop,mobile): bump Lumen catalog to 0.1.20

### DIFF
--- a/.changeset/calm-lumen-libraries-rise.md
+++ b/.changeset/calm-lumen-libraries-rise.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@features/market-banner": patch
+---
+
+Bump Lumen catalog deps (@ledgerhq/lumen-design-core 0.1.9, @ledgerhq/lumen-ui-react 0.1.19, @ledgerhq/lumen-ui-rnative 0.1.19) and adapt desktop to Select and InteractiveIcon API changes

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -104,7 +104,6 @@
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
-    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentBannerActionCard/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentBannerActionCard/index.tsx
@@ -61,12 +61,12 @@ export const ContentBannerActionCard = (props: ContentBannerActionCardProps) => 
       <InteractiveIcon
         type="button"
         iconType="stroked"
+        icon={Icons.Close}
+        size={16}
         aria-label={closeAriaLabel}
         onClick={handleClose}
         className="absolute top-8 right-8"
-      >
-        <Icons.Close size={16} />
-      </InteractiveIcon>
+      />
     </div>
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/StrategySelect.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/StrategySelect.tsx
@@ -4,6 +4,7 @@ import {
   SelectContent,
   SelectItem,
   SelectItemText,
+  SelectList,
   SelectTrigger,
   Subheader,
   SubheaderRow,
@@ -30,6 +31,11 @@ export const StrategySelect = ({
   learnMoreLabel,
   onLearnMoreClick,
 }: StrategySelectProps) => {
+  const items = options.map(option => ({
+    value: String(option.value),
+    label: option.label,
+  }));
+
   return (
     <div className="flex flex-col gap-12">
       <Subheader>
@@ -42,14 +48,22 @@ export const StrategySelect = ({
           </Link>
         </div>
       </Subheader>
-      <Select value={value} onValueChange={onValueChange}>
+      <Select
+        value={value}
+        onValueChange={v => {
+          if (v != null) onValueChange(v);
+        }}
+        items={items}
+      >
         <SelectTrigger />
         <SelectContent>
-          {options.map(option => (
-            <SelectItem key={option.value} value={String(option.value)}>
-              <SelectItemText>{option.label}</SelectItemText>
-            </SelectItem>
-          ))}
+          <SelectList
+            renderItem={item => (
+              <SelectItem key={item.value} value={item.value}>
+                <SelectItemText>{item.label}</SelectItemText>
+              </SelectItem>
+            )}
+          />
         </SelectContent>
       </Select>
     </div>

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/Memo/MemoTypeSelect.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/Memo/MemoTypeSelect.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectItemText,
+  SelectList,
   SelectTrigger,
 } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
@@ -18,19 +19,36 @@ type MemoTypeSelectProps = Readonly<{
 function MemoTypeSelectComponent({ currencyId, options, value, onChange }: MemoTypeSelectProps) {
   const { t } = useTranslation();
 
+  const items = useMemo(
+    () =>
+      options.map(optionValue => ({
+        value: optionValue,
+        label: t(`families.${currencyId}.memoType.${optionValue}`),
+      })),
+    [currencyId, options, t],
+  );
+
   return (
-    <Select onValueChange={onChange} value={value}>
+    <Select
+      items={items}
+      onValueChange={v => {
+        if (v != null) onChange(v);
+      }}
+      value={value ?? null}
+    >
       <SelectTrigger data-testid="send-memo-options-select" />
       <SelectContent>
-        {options.map(optionValue => (
-          <SelectItem
-            key={optionValue}
-            value={optionValue}
-            data-testid={`send-memo-select-option-${optionValue}`}
-          >
-            <SelectItemText>{t(`families.${currencyId}.memoType.${optionValue}`)}</SelectItemText>
-          </SelectItem>
-        ))}
+        <SelectList
+          renderItem={item => (
+            <SelectItem
+              key={item.value}
+              value={item.value}
+              data-testid={`send-memo-select-option-${item.value}`}
+            >
+              <SelectItemText>{item.label}</SelectItemText>
+            </SelectItem>
+          )}
+        />
       </SelectContent>
     </Select>
   );

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ModularDrawer/LabeledSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ModularDrawer/LabeledSelect.tsx
@@ -8,6 +8,7 @@ import {
   SelectContent,
   SelectItemText,
   SelectItem,
+  SelectList,
 } from "@ledgerhq/lumen-ui-react";
 
 interface LabeledSelectProps<T extends SelectOption = SelectOption> {
@@ -23,6 +24,8 @@ export const LabeledSelect = <T extends SelectOption = SelectOption>({
   options,
   onChange,
 }: LabeledSelectProps<T>) => {
+  const items = options.map(option => ({ value: option.value, label: option.label }));
+
   return (
     <div className="flex w-400 flex-row items-center">
       <Text variant="body" fontSize="14px" mr="2">
@@ -31,18 +34,22 @@ export const LabeledSelect = <T extends SelectOption = SelectOption>({
 
       <Select
         value={value.value}
+        items={items}
         onValueChange={option => {
-          const found = option && options.find(o => o.value === option);
+          if (option == null) return;
+          const found = options.find(o => o.value === option);
           if (found) onChange(found);
         }}
       >
         <SelectTrigger label={label} />
         <SelectContent>
-          {options.map(option => (
-            <SelectItem key={option.value} value={option.value}>
-              <SelectItemText>{option.label}</SelectItemText>
-            </SelectItem>
-          ))}
+          <SelectList
+            renderItem={item => (
+              <SelectItem key={item.value} value={item.value}>
+                <SelectItemText>{item.label}</SelectItemText>
+              </SelectItem>
+            )}
+          />
         </SelectContent>
       </Select>
     </div>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ModularDrawer/VerticalLabeledSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ModularDrawer/VerticalLabeledSelect.tsx
@@ -6,6 +6,7 @@ import {
   SelectContent,
   SelectItem,
   SelectItemText,
+  SelectList,
   SelectTrigger,
 } from "@ledgerhq/lumen-ui-react";
 interface VerticalLabeledSelectProps<T = SelectOption> {
@@ -23,6 +24,8 @@ export const VerticalLabeledSelect = <T extends SelectOption>({
   onChange,
   width = "250px",
 }: VerticalLabeledSelectProps<T>) => {
+  const items = options.map(option => ({ value: option.value, label: option.label }));
+
   return (
     <Flex flexDirection="column" justifyContent="center" width={width}>
       <Text variant="body" fontSize="14px" mb="2">
@@ -30,18 +33,22 @@ export const VerticalLabeledSelect = <T extends SelectOption>({
       </Text>
       <Select
         value={value.value}
+        items={items}
         onValueChange={option => {
-          const found = option && options.find(o => o.value === option);
+          if (option == null) return;
+          const found = options.find(o => o.value === option);
           if (found) onChange(found);
         }}
       >
         <SelectTrigger label={label} />
         <SelectContent>
-          {options.map(option => (
-            <SelectItem key={option.value} value={option.value}>
-              <SelectItemText>{option.label}</SelectItemText>
-            </SelectItem>
-          ))}
+          <SelectList
+            renderItem={item => (
+              <SelectItem key={item.value} value={item.value}>
+                <SelectItemText>{item.label}</SelectItemText>
+              </SelectItem>
+            )}
+          />
         </SelectContent>
       </Select>
     </Flex>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,11 +52,11 @@ catalogs:
       specifier: 0.1.9
       version: 0.1.9
     '@ledgerhq/lumen-ui-react':
-      specifier: 0.1.19
-      version: 0.1.19
+      specifier: 0.1.20
+      version: 0.1.20
     '@ledgerhq/lumen-ui-rnative':
-      specifier: 0.1.19
-      version: 0.1.19
+      specifier: 0.1.20
+      version: 0.1.20
     '@ledgerhq/speculos-device-controller':
       specifier: 0.2.3
       version: 0.2.3
@@ -953,7 +953,7 @@ importers:
         version: 0.1.9
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.19(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.20(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -1612,7 +1612,7 @@ importers:
         version: 0.1.9
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.19(86429e051cab61f3619270fef622fc08)
+        version: 0.1.20(86429e051cab61f3619270fef622fc08)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -2851,10 +2851,10 @@ importers:
         version: 0.1.9
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.19(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.20(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.19(c93f8ced60089c42caa4a9162fe9ed8c)
+        version: 0.1.20(c93f8ced60089c42caa4a9162fe9ed8c)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -16334,8 +16334,8 @@ packages:
   '@ledgerhq/lumen-design-core@0.1.9':
     resolution: {integrity: sha512-vFhej/eWrfbrhB/Jd7/8yMBMcSU95vYcrTnR0e0PtEbX4H4fyEPCOcfiFPMyNGNlqnynzMyLjQVpmLqXF08rdA==}
 
-  '@ledgerhq/lumen-ui-react@0.1.19':
-    resolution: {integrity: sha512-QQJ8P97y+Cjb9F/7I5AapyvmKfdMwxGJ0Qv9CKJrwSSZWBWgBjBB/4DGBMRxr1n+my/PCJxt0DOKtsOOivEEzQ==}
+  '@ledgerhq/lumen-ui-react@0.1.20':
+    resolution: {integrity: sha512-YO5eTV9alSATkVE9qDIZgnlZhLU6/9qZjHyL6pEvOhWhUPRr5BpeLQJ15agxm7h7GZPn+fXay0p3yejpPSSSFQ==}
     peerDependencies:
       '@base-ui/react': ^1.3.0
       '@radix-ui/react-checkbox': ^1.3.2
@@ -16351,8 +16351,8 @@ packages:
       react-dom: 19.0.0
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-rnative@0.1.19':
-    resolution: {integrity: sha512-0LGY6CoG5i1Ya6+dQpXTC4SP6BYI1wInMLmJnA5wt7uWircbw51vrNyr5noqfnqQKZRoePlaAUxQi2m+uQ9eqA==}
+  '@ledgerhq/lumen-ui-rnative@0.1.20':
+    resolution: {integrity: sha512-p3taJHEIUdvJW719UaE44ErNfakLip3cOge5Q5NsEw9WcDxeaIe2sIcr4qu6X2QNgidTfjbgRXyqqftLLoTeOg==}
     peerDependencies:
       '@gorhom/bottom-sheet': ^5.0.0
       '@ledgerhq/lumen-design-core': 0.1.10
@@ -44206,7 +44206,7 @@ snapshots:
       tailwindcss: 4.1.18
       tslib: 2.6.2
 
-  '@ledgerhq/lumen-ui-react@0.1.19(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.20(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -44226,7 +44226,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.19(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.20(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       clsx: 2.1.1
@@ -44238,7 +44238,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-rnative@0.1.19(86429e051cab61f3619270fef622fc08)':
+  '@ledgerhq/lumen-ui-rnative@0.1.20(86429e051cab61f3619270fef622fc08)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(beb07f7799bea5989bf46dbe8fcef3d9)
       '@ledgerhq/lumen-design-core': 0.1.9
@@ -44257,7 +44257,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.19(c93f8ced60089c42caa4a9162fe9ed8c)':
+  '@ledgerhq/lumen-ui-rnative@0.1.20(c93f8ced60089c42caa4a9162fe9ed8c)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/lumen-design-core': 0.1.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,14 +49,14 @@ catalogs:
       specifier: 1.2.3
       version: 1.2.3
     '@ledgerhq/lumen-design-core':
-      specifier: 0.1.8
-      version: 0.1.8
+      specifier: 0.1.9
+      version: 0.1.9
     '@ledgerhq/lumen-ui-react':
-      specifier: 0.1.16
-      version: 0.1.16
+      specifier: 0.1.19
+      version: 0.1.19
     '@ledgerhq/lumen-ui-rnative':
-      specifier: 0.1.15
-      version: 0.1.15
+      specifier: 0.1.19
+      version: 0.1.19
     '@ledgerhq/speculos-device-controller':
       specifier: 0.2.3
       version: 0.2.3
@@ -537,7 +537,7 @@ importers:
         version: link:tools/create-release-hash
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.8
+        version: 0.1.9
       '@ledgerhq/pnpm-utils':
         specifier: workspace:*
         version: link:tools/pnpm-utils
@@ -950,10 +950,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.8
+        version: 0.1.9
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.16(e3565a5b1275aee5d93efe21059eb47c)
+        version: 0.1.19(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -984,9 +984,6 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-select':
-        specifier: ^2.2.6
-        version: 2.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.4(@types/react@19.0.14)(react@19.0.0)
@@ -1612,10 +1609,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.8
+        version: 0.1.9
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.15(de610b228bb347f2f8304dd3982e24ca)
+        version: 0.1.19(86429e051cab61f3619270fef622fc08)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -2851,13 +2848,13 @@ importers:
         version: 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.8
+        version: 0.1.9
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.16(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.19(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.15(f8ce5420824e17bad25c0a5b925e932d)
+        version: 0.1.19(c93f8ced60089c42caa4a9162fe9ed8c)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -16334,17 +16331,16 @@ packages:
   '@ledgerhq/logs@6.14.0':
     resolution: {integrity: sha512-kJFu1+asWQmU9XlfR1RM3lYR76wuEoPyZvkI/CNjpft78BQr3+MMf3Nu77ABzcKFnhIcmAkOLlDQ6B8L6hDXHA==}
 
-  '@ledgerhq/lumen-design-core@0.1.8':
-    resolution: {integrity: sha512-wpiOxnNLGXvZbdzp8pqq645Cw+V1Klew2x6CuLhz4F3MhoQC69U3CHSL2//h36UMswqRm+udGXSJxy7yLKnEqg==}
+  '@ledgerhq/lumen-design-core@0.1.9':
+    resolution: {integrity: sha512-vFhej/eWrfbrhB/Jd7/8yMBMcSU95vYcrTnR0e0PtEbX4H4fyEPCOcfiFPMyNGNlqnynzMyLjQVpmLqXF08rdA==}
 
-  '@ledgerhq/lumen-ui-react@0.1.16':
-    resolution: {integrity: sha512-PKxtV82Yl7IYKtoPj4Zm8Kc+4Ht5hR+aCCo8lRhODT2oCd4xTjYlNUBafHv7l5jOwO71BYm51hv902hm9hlJ/Q==}
+  '@ledgerhq/lumen-ui-react@0.1.19':
+    resolution: {integrity: sha512-QQJ8P97y+Cjb9F/7I5AapyvmKfdMwxGJ0Qv9CKJrwSSZWBWgBjBB/4DGBMRxr1n+my/PCJxt0DOKtsOOivEEzQ==}
     peerDependencies:
       '@base-ui/react': ^1.3.0
       '@radix-ui/react-checkbox': ^1.3.2
       '@radix-ui/react-dialog': ^1.1.15
       '@radix-ui/react-dropdown-menu': ^2.1.2
-      '@radix-ui/react-select': ^2.2.6
       '@radix-ui/react-slot': ^1.2.3
       '@radix-ui/react-switch': ^1.2.6
       '@radix-ui/react-tooltip': ^1.2.8
@@ -16355,11 +16351,11 @@ packages:
       react-dom: 19.0.0
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-rnative@0.1.15':
-    resolution: {integrity: sha512-L6OOfCz8XzdoVz21kzMkCNs0bTXxMY1yfZ2dnjyNXOAUuxokcRzHj556EAqgUMxyKq77cPG6wt4R53fG6YgwWA==}
+  '@ledgerhq/lumen-ui-rnative@0.1.19':
+    resolution: {integrity: sha512-0LGY6CoG5i1Ya6+dQpXTC4SP6BYI1wInMLmJnA5wt7uWircbw51vrNyr5noqfnqQKZRoePlaAUxQi2m+uQ9eqA==}
     peerDependencies:
       '@gorhom/bottom-sheet': ^5.0.0
-      '@ledgerhq/lumen-design-core': 0.1.8
+      '@ledgerhq/lumen-design-core': 0.1.10
       '@sbaiahmed1/react-native-blur': ^4.5.5
       '@types/react': ^19.0.0
       expo: '>=53.0.0'
@@ -16370,8 +16366,8 @@ packages:
       react-native-safe-area-context: ^4.0.0 || ^5.0.0
       react-native-svg: ^15.0.0
 
-  '@ledgerhq/lumen-utils-shared@0.1.2':
-    resolution: {integrity: sha512-ct6OSX5ExBn69pJ3cSBygBJ3SE4DJXV+TCLerqyI+iyO/0L1Mgf0LRmNeSXlFrHXQmmuPw18BISvQA+5J2Cp0w==}
+  '@ledgerhq/lumen-utils-shared@0.1.3':
+    resolution: {integrity: sha512-vnYl8joMbicAgcRZs+rnUiwHi6o+LpwmBtjXywWcpVobwxHrgKgTF9Idy3+0mJLGyYYgInIcwKnx2p5ZtG75Yg==}
     peerDependencies:
       react: 19.0.0
 
@@ -17572,9 +17568,6 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
-  '@radix-ui/number@1.1.1':
-    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
-
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
@@ -17781,19 +17774,6 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: 19.0.0
-      react-dom: 19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-select@2.2.6':
-    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -44221,30 +44201,17 @@ snapshots:
 
   '@ledgerhq/logs@6.14.0': {}
 
-  '@ledgerhq/lumen-design-core@0.1.8':
+  '@ledgerhq/lumen-design-core@0.1.9':
     dependencies:
       tailwindcss: 4.1.18
       tslib: 2.6.2
 
-  '@ledgerhq/lumen-ui-react@0.1.16(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.19(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
-      '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
-      clsx: 2.1.1
-      i18next: 23.10.1
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      tailwind-merge: 3.4.0
-    transitivePeerDependencies:
-      - react-native
-
-  '@ledgerhq/lumen-ui-react@0.1.16(e3565a5b1275aee5d93efe21059eb47c)':
-    dependencies:
-      '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
+      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.0.14)(react@19.0.0)
       '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -44259,11 +44226,23 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-rnative@0.1.15(de610b228bb347f2f8304dd3982e24ca)':
+  '@ledgerhq/lumen-ui-react@0.1.19(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+    dependencies:
+      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
+      clsx: 2.1.1
+      i18next: 23.10.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      tailwind-merge: 3.4.0
+    transitivePeerDependencies:
+      - react-native
+
+  '@ledgerhq/lumen-ui-rnative@0.1.19(86429e051cab61f3619270fef622fc08)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(beb07f7799bea5989bf46dbe8fcef3d9)
-      '@ledgerhq/lumen-design-core': 0.1.8
-      '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.9
+      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       '@sbaiahmed1/react-native-blur': 4.5.5(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@types/react': 19.0.14
       expo: 53.0.25(4b2c01f5a47d338b1c9e7803e0aed015)
@@ -44278,11 +44257,11 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.15(f8ce5420824e17bad25c0a5b925e932d)':
+  '@ledgerhq/lumen-ui-rnative@0.1.19(c93f8ced60089c42caa4a9162fe9ed8c)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      '@ledgerhq/lumen-design-core': 0.1.8
-      '@ledgerhq/lumen-utils-shared': 0.1.2(react@19.0.0)
+      '@ledgerhq/lumen-design-core': 0.1.9
+      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       '@types/react': 19.0.14
       i18next: 23.10.1
       react: 19.0.0
@@ -44294,7 +44273,7 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-utils-shared@0.1.2(react@19.0.0)':
+  '@ledgerhq/lumen-utils-shared@0.1.3(react@19.0.0)':
     dependencies:
       clsx: 2.1.1
       react: 19.0.0
@@ -45783,8 +45762,6 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@radix-ui/number@1.1.1': {}
-
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
@@ -46002,35 +45979,6 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.14)(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-    optionalDependencies:
-      '@types/react': 19.0.14
-      '@types/react-dom': 19.0.0(@types/react@19.0.14)
-
-  '@radix-ui/react-select@2.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@radix-ui/number': 1.1.1
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.14)(react@19.0.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.14)(react@19.0.0)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.14)(react@19.0.0)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.0.14)(react@19.0.0)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.0.14)(react@19.0.0)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.0.14)(react@19.0.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.14)(react@19.0.0)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.14)(react@19.0.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.14)(react@19.0.0)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.0.14)(react@19.0.0)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      aria-hidden: 1.2.4
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      react-remove-scroll: 2.7.1(@types/react@19.0.14)(react@19.0.0)
     optionalDependencies:
       '@types/react': 19.0.14
       '@types/react-dom': 19.0.0(@types/react@19.0.14)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,8 +31,8 @@ catalog:
   "@ledgerhq/device-transport-kit-web-hid": 1.2.3
   "@ledgerhq/speculos-device-controller": 0.2.3
   "@ledgerhq/lumen-design-core": 0.1.9
-  "@ledgerhq/lumen-ui-react": 0.1.19
-  "@ledgerhq/lumen-ui-rnative": 0.1.19
+  "@ledgerhq/lumen-ui-react": 0.1.20
+  "@ledgerhq/lumen-ui-rnative": 0.1.20
   # React Native
   react-native: 0.79.7
   "@react-native/assets-registry": 0.79.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,9 +30,9 @@ catalog:
   "@ledgerhq/signer-utils": 1.1.3
   "@ledgerhq/device-transport-kit-web-hid": 1.2.3
   "@ledgerhq/speculos-device-controller": 0.2.3
-  "@ledgerhq/lumen-design-core": 0.1.8
-  "@ledgerhq/lumen-ui-react": 0.1.16
-  "@ledgerhq/lumen-ui-rnative": 0.1.15
+  "@ledgerhq/lumen-design-core": 0.1.9
+  "@ledgerhq/lumen-ui-react": 0.1.19
+  "@ledgerhq/lumen-ui-rnative": 0.1.19
   # React Native
   react-native: 0.79.7
   "@react-native/assets-registry": 0.79.7


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Typecheck passes for desktop and mobile; no new tests added for the Select / InteractiveIcon migrations._
- [x] **Impact of the changes:**
      - Desktop: send flow memo type select, coin control strategy select, content banner action card close control, developer Modular Drawer labeled selects
      - Mobile: consumes `@ledgerhq/lumen-ui-rnative@0.1.19` from catalog (layout/ListItem token sync; verify key wallet surfaces)
      - `@features/market-banner`: catalog-aligned Lumen packages

### 📝 Description

**Problem:** Ledger Wallet depends on pinned Lumen packages via the pnpm catalog. `@ledgerhq/lumen-ui-react` and `@ledgerhq/lumen-ui-rnative` **0.1.19** (with `@ledgerhq/lumen-design-core` **0.1.9**) introduce breaking API changes that must be adopted before the catalog can move forward.

**Solution:**
- Raised catalog versions: `lumen-design-core` 0.1.9, `lumen-ui-react` / `lumen-ui-rnative` 0.1.19 and refreshed `pnpm-lock.yaml`.
- **Desktop:** `InteractiveIcon` now uses `icon` + `size` instead of icon children (content banner action card). `Select` usages migrated to the data-driven API (`items` + `SelectList` / `renderItem`) for strategy select, memo type select, and developer Modular Drawer selects.
- **Changeset:** patch bumps for `ledger-live-desktop`, `live-mobile`, and `@features/market-banner`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29042](https://ledgerhq.atlassian.net/browse/LIVE-29042)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29042]: https://ledgerhq.atlassian.net/browse/LIVE-29042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ