### PR TITLE
[LWM] feat(mobile): add avatar and profile section to my wallet screen

### DIFF
--- a/.changeset/flat-trainers-fail.md
+++ b/.changeset/flat-trainers-fail.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add avatar and title for my wallet

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2688,6 +2688,7 @@
     "accounts": "Accounts",
     "transfer": "Transfer",
     "manager": "My Ledger",
+    "myWallet": "My wallet",
     "settings": "Settings",
     "platform": "Live Apps",
     "discover": "Discover",

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/MyWalletScreen.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/MyWalletScreen.integration.test.tsx
@@ -48,4 +48,10 @@ describe("MyWalletScreen", () => {
     renderScreen({ hasUnreadNotifications: true });
     expect(screen.getByTestId("my-wallet-header-notifications-button")).toBeVisible();
   });
+
+  it("should render the profile section with avatar and title", () => {
+    renderScreen();
+    expect(screen.getByTestId("my-wallet-avatar")).toBeVisible();
+    expect(screen.getByTestId("my-wallet-profile-title")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/components/UserAvatar/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/components/UserAvatar/index.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { Avatar } from "@ledgerhq/lumen-ui-rnative";
+
+export function UserAvatar() {
+  return <Avatar size="lg" alt="My wallet avatar" testID="my-wallet-avatar" />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { MyWalletHeader } from "./views/Header";
+import { ProfileSection } from "./views/ProfileSection";
 
 export function MyWalletScreen() {
   const { top } = useSafeAreaInsets();
@@ -9,6 +10,7 @@ export function MyWalletScreen() {
   return (
     <Box style={{ paddingTop: top, flex: 1 }}>
       <MyWalletHeader />
+      <ProfileSection />
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/ProfileSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/ProfileSection/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+import { UserAvatar } from "../../components/UserAvatar";
+
+export function ProfileSection() {
+  const { t } = useTranslation();
+
+  return (
+    <Box lx={{ alignItems: "center", gap: "s12" }}>
+      <UserAvatar />
+      <Text typography="heading5SemiBold" lx={{ color: "base" }} testID="my-wallet-profile-title">
+        {t("tabs.myWallet")}
+      </Text>
+    </Box>
+  );
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - My Wallet screen: avatar rendering, title display, header navigation buttons
      - Verify the `UserAvatar` component renders correctly with the Lumen UI `Avatar`
      - Verify the "My wallet" title is displayed below the avatar
      - Ensure header buttons (back, notifications badge, settings) still function correctly

### 📝 Description

The My Wallet screen needed a profile section displaying the user's avatar and a localized title, as part of the Wallet 4.0 redesign.

This PR adds a `ProfileSection` view composed of a `UserAvatar` component (using Lumen UI's `Avatar`) and a "My wallet" title. Integration tests verify the avatar and title render on the screen, and the header view model is fully covered by unit tests.

<img width="1206" height="2622" alt="Simulator Screenshot - Test Ios - 2026-04-09 at 08 37 02" src="https://github.com/user-attachments/assets/7071f193-a6bd-4ad9-a611-6742af65e848" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-26347](https://ledgerhq.atlassian.net/browse/LIVE-26347)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26347]: https://ledgerhq.atlassian.net/browse/LIVE-26347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ