### PR TITLE
[LWDM] feat(asset-aggregation): add buildAssetDistribution with DADA grouping

### DIFF
--- a/.changeset/fast-sloths-cross.md
+++ b/.changeset/fast-sloths-cross.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/asset-aggregation": minor
+---
+
+Add buildAssetDistribution with DADA meta-currency grouping and bySlug lookup

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -56,6 +56,7 @@ libs/live-countervalues/                                 @ledgerhq/wallet-xp
 libs/live-currency-format/                               @ledgerhq/wallet-xp
 libs/live-hooks/                                         @ledgerhq/wallet-xp
 libs/ui/                                                 @ledgerhq/wallet-xp
+libs/asset-aggregation/                                  @ledgerhq/wallet-xp
 libs/live-wallet/                                        @ledgerhq/wallet-xp
 libs/ledger-live-common/src/featureFlags/walletFeaturesConfig/ @ledgerhq/wallet-xp
 libs/ledger-live-common/src/modularDrawer/               @ledgerhq/wallet-xp

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
@@ -1,0 +1,166 @@
+import { buildAssetDistribution } from "../buildAssetDistribution";
+import type { AssetsDataLike, BuildAssetDistributionOpts } from "../types";
+import type { Account } from "@ledgerhq/types-live";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import BigNumber from "bignumber.js";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+
+jest.mock("@ledgerhq/live-countervalues/logic", () => ({
+  calculate: jest.fn((_state, { value }: { value: number }) => value * 2),
+}));
+
+function makeCurrency(id: string, name = id): CryptoCurrency {
+  return {
+    type: "CryptoCurrency",
+    id,
+    name,
+    ticker: id.toUpperCase(),
+    units: [{ name: id, code: id.toUpperCase(), magnitude: 8 }],
+  } as unknown as CryptoCurrency;
+}
+
+function makeAccount(id: string, currency: CryptoCurrency, balance: number): Account {
+  return {
+    type: "Account",
+    id,
+    currency,
+    balance: new BigNumber(balance),
+    subAccounts: [],
+  } as unknown as Account;
+}
+
+const cvState = {} as CounterValuesState;
+const usd = { type: "FiatCurrency", id: "usd", ticker: "USD" } as any;
+
+describe("buildAssetDistribution", () => {
+  const ethMainnet = makeCurrency("ethereum", "Ethereum");
+  const ethArbitrum = makeCurrency("arbitrum", "Arbitrum");
+  const ethBase = makeCurrency("base", "Base");
+  const btcCurrency = makeCurrency("bitcoin", "Bitcoin");
+
+  const assetsData: AssetsDataLike = {
+    cryptoAssets: {
+      "urn:crypto:meta-currency:ethereum": {
+        id: "urn:crypto:meta-currency:ethereum",
+        assetsIds: { ethereum: "ethereum", arbitrum: "arbitrum", base: "base" },
+      },
+      "urn:crypto:meta-currency:bitcoin": {
+        id: "urn:crypto:meta-currency:bitcoin",
+        assetsIds: { bitcoin: "bitcoin" },
+      },
+    },
+    markets: {
+      ethereum: { id: "ethereum" },
+      bitcoin: { id: "bitcoin" },
+    },
+  };
+
+  const distribute = (accounts: Account[], opts?: BuildAssetDistributionOpts) =>
+    buildAssetDistribution(accounts, cvState, usd, assetsData, opts);
+
+  it("should group ETH across multiple networks into a single item", () => {
+    const result = distribute([
+      makeAccount("eth-1", ethMainnet, 1000),
+      makeAccount("arb-1", ethArbitrum, 500),
+      makeAccount("base-1", ethBase, 300),
+    ]);
+
+    expect(result.isAvailable).toBe(true);
+    expect(result.list).toHaveLength(1);
+    expect(result.list[0].metaCurrencyId).toBe("urn:crypto:meta-currency:ethereum");
+    expect(result.list[0].amount).toBe(1800);
+    expect(result.list[0].accounts).toHaveLength(3);
+  });
+
+  it("should populate networks[] with per-network breakdown", () => {
+    const result = distribute([
+      makeAccount("eth-1", ethMainnet, 1000),
+      makeAccount("arb-1", ethArbitrum, 500),
+    ]);
+
+    expect(result.list[0].networks).toHaveLength(2);
+    const ethNetwork = result.list[0].networks!.find(n => n.currency.id === "ethereum");
+    const arbNetwork = result.list[0].networks!.find(n => n.currency.id === "arbitrum");
+    expect(ethNetwork?.amount).toBe(1000);
+    expect(arbNetwork?.amount).toBe(500);
+  });
+
+  it("should resolve marketId and slug from metaCurrencyId", () => {
+    const result = distribute([makeAccount("eth-1", ethMainnet, 1000)]);
+
+    expect(result.list[0].marketId).toBe("ethereum");
+    expect(result.list[0].slug).toBe("ethereum");
+  });
+
+  it("should resolve marketId via primary asset when only secondary network accounts exist", () => {
+    const result = distribute([makeAccount("arb-1", ethArbitrum, 500)]);
+
+    expect(result.list[0].metaCurrencyId).toBe("urn:crypto:meta-currency:ethereum");
+    expect(result.list[0].marketId).toBe("ethereum");
+  });
+
+  it("should build bySlug lookup", () => {
+    const result = distribute([
+      makeAccount("eth-1", ethMainnet, 1000),
+      makeAccount("btc-1", btcCurrency, 2000),
+    ]);
+
+    expect(result.bySlug!["ethereum"]).toBe(result.list.find(i => i.slug === "ethereum"));
+    expect(result.bySlug!["bitcoin"]).toBe(result.list.find(i => i.slug === "bitcoin"));
+  });
+
+  it("should fallback to currency.id when no DADA mapping exists", () => {
+    const solana = makeCurrency("solana", "Solana");
+    const result = distribute([makeAccount("sol-1", solana, 500)]);
+
+    expect(result.list).toHaveLength(1);
+    expect(result.list[0].metaCurrencyId).toBe("solana");
+    expect(result.list[0].slug).toBe("solana");
+  });
+
+  it("should return not available for empty accounts", () => {
+    const result = distribute([]);
+
+    expect(result.isAvailable).toBe(false);
+    expect(result.list).toHaveLength(0);
+  });
+
+  it("should sort by countervalue descending", () => {
+    const result = distribute([
+      makeAccount("eth-1", ethMainnet, 500),
+      makeAccount("btc-1", btcCurrency, 2000),
+    ]);
+
+    expect(result.list[0].currency.id).toBe("bitcoin");
+    expect(result.list[1].metaCurrencyId).toBe("urn:crypto:meta-currency:ethereum");
+  });
+
+  it("should compute distribution ratios summing to 1", () => {
+    const result = distribute([
+      makeAccount("eth-1", ethMainnet, 1000),
+      makeAccount("btc-1", btcCurrency, 3000),
+    ]);
+
+    const total = result.list.reduce((sum, item) => sum + item.distribution, 0);
+    expect(total).toBeCloseTo(1, 10);
+  });
+
+  it("should skip zero-balance accounts when showEmptyAccounts is false", () => {
+    const result = distribute(
+      [makeAccount("eth-1", ethMainnet, 0), makeAccount("btc-1", btcCurrency, 1000)],
+      { showEmptyAccounts: false },
+    );
+
+    expect(result.list).toHaveLength(1);
+    expect(result.list[0].currency.id).toBe("bitcoin");
+  });
+
+  it("should include zero-balance accounts when showEmptyAccounts is true", () => {
+    const result = distribute(
+      [makeAccount("eth-1", ethMainnet, 0), makeAccount("btc-1", btcCurrency, 1000)],
+      { showEmptyAccounts: true },
+    );
+
+    expect(result.list).toHaveLength(2);
+  });
+});

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/toSlug.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/toSlug.test.ts
@@ -1,0 +1,14 @@
+import { toSlug } from "../toSlug";
+
+describe("toSlug", () => {
+  it.each([
+    ["urn:crypto:meta-currency:usd_coin", "usd-coin"],
+    ["urn:crypto:meta-currency:ethereum", "ethereum"],
+    ["urn:crypto:meta-currency:bitcoin", "bitcoin"],
+    ["urn:crypto:meta-currency:injective_protocol_v2", "injective-protocol-v2"],
+    ["solana", "solana"],
+    ["", ""],
+  ])("toSlug(%j) → %j", (input, expected) => {
+    expect(toSlug(input)).toBe(expected);
+  });
+});

--- a/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
+++ b/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
@@ -1,0 +1,155 @@
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
+import { toSlug } from "./toSlug";
+import type {
+  AssetsDataLike,
+  BuildAssetDistributionOpts,
+  AssetsDistribution,
+  DistributionItem,
+  CurrencyLookups,
+  MetaGroup,
+} from "./types";
+
+function getAccountCurrency(account: AccountLike): CryptoCurrency | TokenCurrency {
+  return account.type === "Account" ? account.currency : account.token;
+}
+
+function shouldSkipAccount(
+  account: AccountLike,
+  showEmptyAccounts: boolean,
+  hideEmptyTokenAccount: boolean,
+): boolean {
+  if (account.balance.isGreaterThan(0)) return false;
+  return account.type === "TokenAccount" ? hideEmptyTokenAccount : !showEmptyAccounts;
+}
+
+function buildCurrencyLookups(cryptoAssets: AssetsDataLike["cryptoAssets"]): CurrencyLookups {
+  const currencyToMetaId: Record<string, string> = {};
+  const primaryAssets: Record<string, string> = {};
+  for (const [metaId, meta] of Object.entries(cryptoAssets)) {
+    const assetIds = Object.values(meta.assetsIds);
+    if (assetIds[0]) primaryAssets[metaId] = assetIds[0];
+    for (const assetId of assetIds) currencyToMetaId[assetId] = metaId;
+  }
+  return { currencyToMetaId, primaryAssets };
+}
+
+function computeDistribution(countervalue: number, sum: number, fallback: number): number {
+  if (sum !== 0) return countervalue / sum;
+  return fallback;
+}
+
+function buildSlugIndex(list: DistributionItem[]): Record<string, DistributionItem> {
+  const index: Record<string, DistributionItem> = {};
+  for (const item of list) {
+    if (item.slug) index[item.slug] = item;
+  }
+  return index;
+}
+
+const EMPTY_DISTRIBUTION: AssetsDistribution = Object.freeze({
+  isAvailable: false,
+  list: [],
+  showFirst: 0,
+  sum: 0,
+});
+
+/**
+ * Groups accounts by DADA meta-currency (cross-network), computes
+ * countervalues per unique currency (aggregated), and produces the
+ * full AssetsDistribution with slug, marketId, and per-network breakdown.
+ */
+export function buildAssetDistribution(
+  topAccounts: Account[],
+  cvState: CounterValuesState,
+  to: Currency,
+  assetsData: AssetsDataLike,
+  opts?: BuildAssetDistributionOpts,
+): AssetsDistribution {
+  const showEmptyAccounts = opts?.showEmptyAccounts ?? false;
+  const hideEmptyTokenAccount = opts?.hideEmptyTokenAccount ?? false;
+
+  const { currencyToMetaId, primaryAssets } = buildCurrencyLookups(assetsData.cryptoAssets);
+  const allAccounts: AccountLike[] = topAccounts.flatMap(a => [a, ...(a.subAccounts ?? [])]);
+
+  const currencyById = new Map<string, CryptoCurrency | TokenCurrency>();
+  const groups = new Map<string, MetaGroup>();
+
+  for (const account of allAccounts) {
+    const currency = getAccountCurrency(account);
+    currencyById.set(currency.id, currency);
+
+    if (shouldSkipAccount(account, showEmptyAccounts, hideEmptyTokenAccount)) continue;
+
+    const metaCurrencyId = currencyToMetaId[currency.id] ?? currency.id;
+    const balance = account.balance.toNumber();
+
+    let group = groups.get(metaCurrencyId);
+    if (!group) {
+      group = {
+        metaCurrencyId,
+        currency,
+        accounts: [],
+        countervalue: 0,
+        amount: 0,
+        networks: new Map(),
+      };
+      groups.set(metaCurrencyId, group);
+    }
+
+    group.accounts.push(account);
+    group.amount += balance;
+    group.marketId ??= assetsData.markets[currency.id]?.id;
+
+    let network = group.networks.get(currency.id);
+    if (!network) {
+      network = { currency, accounts: [], amount: 0, countervalue: 0 };
+      group.networks.set(currency.id, network);
+    }
+    network.accounts.push(account);
+    network.amount += balance;
+  }
+
+  if (groups.size === 0) return EMPTY_DISTRIBUTION;
+
+  let sum = 0;
+  for (const group of groups.values()) {
+    const primaryAssetId = primaryAssets[group.metaCurrencyId];
+    const primaryCurrency = currencyById.get(primaryAssetId);
+    if (primaryCurrency) group.currency = primaryCurrency;
+    group.marketId ??= assetsData.markets[primaryAssetId]?.id;
+
+    let groupCountervalue = 0;
+    for (const network of group.networks.values()) {
+      const countervalue =
+        calculate(cvState, { value: network.amount, from: network.currency, to }) ?? 0;
+      network.countervalue = countervalue;
+      groupCountervalue += countervalue;
+    }
+    group.countervalue = groupCountervalue;
+    sum += groupCountervalue;
+  }
+
+  const isAvailable = sum !== 0 || showEmptyAccounts;
+  const uniformDistribution = isAvailable ? 1 / groups.size : 0;
+
+  const list: DistributionItem[] = Array.from(groups.values())
+    .map(group => ({
+      currency: group.currency,
+      countervalue: group.countervalue,
+      amount: group.amount,
+      distribution: computeDistribution(group.countervalue, sum, uniformDistribution),
+      accounts: group.accounts,
+      metaCurrencyId: group.metaCurrencyId,
+      networks: Array.from(group.networks.values()),
+      marketId: group.marketId,
+      slug: toSlug(group.metaCurrencyId),
+    }))
+    .sort(
+      (a, b) => b.countervalue - a.countervalue || a.currency.name.localeCompare(b.currency.name),
+    );
+
+  return { isAvailable, list, showFirst: list.length, sum, bySlug: buildSlugIndex(list) };
+}

--- a/libs/asset-aggregation/src/assetDistribution/index.ts
+++ b/libs/asset-aggregation/src/assetDistribution/index.ts
@@ -1,0 +1,10 @@
+export { buildAssetDistribution } from "./buildAssetDistribution";
+export { toSlug } from "./toSlug";
+export type {
+  AssetsDataLike,
+  BuildAssetDistributionOpts,
+  CryptoAssetMetaLike,
+  CurrencyLookups,
+  MarketEntryLike,
+  MetaGroup,
+} from "./types";

--- a/libs/asset-aggregation/src/assetDistribution/toSlug.ts
+++ b/libs/asset-aggregation/src/assetDistribution/toSlug.ts
@@ -1,0 +1,10 @@
+/**
+ * Derives a URL-safe slug from a DADA metaCurrencyId.
+ *
+ * @example toSlug("urn:crypto:meta-currency:usd_coin") // "usd-coin"
+ * @example toSlug("urn:crypto:meta-currency:ethereum")  // "ethereum"
+ */
+export function toSlug(metaCurrencyId: string): string {
+  const lastSegment = metaCurrencyId.split(":").pop() ?? metaCurrencyId;
+  return lastSegment.replace(/_/g, "-");
+}

--- a/libs/asset-aggregation/src/assetDistribution/types.ts
+++ b/libs/asset-aggregation/src/assetDistribution/types.ts
@@ -1,0 +1,48 @@
+import type {
+  AccountLike,
+  AssetsDistribution,
+  DistributionItem,
+  NetworkDistributionDetail,
+} from "@ledgerhq/types-live";
+import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+
+/** Minimal shape of DADA's CryptoAssetMeta needed by buildAssetDistribution. */
+export interface CryptoAssetMetaLike {
+  id: string;
+  assetsIds: Record<string, string>;
+}
+
+/** Minimal shape of the DADA market entry needed for marketId resolution. */
+export interface MarketEntryLike {
+  id?: string;
+}
+
+/** Minimal shape of the DADA AssetsData needed by buildAssetDistribution. */
+export interface AssetsDataLike {
+  cryptoAssets: Record<string, CryptoAssetMetaLike>;
+  markets: Record<string, MarketEntryLike>;
+}
+
+export interface BuildAssetDistributionOpts {
+  showEmptyAccounts?: boolean;
+  hideEmptyTokenAccount?: boolean;
+}
+
+export type MetaGroup = {
+  metaCurrencyId: string;
+  currency: CryptoCurrency | TokenCurrency;
+  accounts: AccountLike[];
+  countervalue: number;
+  amount: number;
+  networks: Map<string, NetworkDistributionDetail>;
+  marketId?: string;
+};
+
+export type CurrencyLookups = {
+  /** currency.id -> metaCurrencyId */
+  currencyToMetaId: Record<string, string>;
+  /** metaCurrencyId -> primary asset ID (first entry in assetsIds) */
+  primaryAssets: Record<string, string>;
+};
+
+export type { AccountLike, AssetsDistribution, DistributionItem };

--- a/libs/asset-aggregation/src/index.ts
+++ b/libs/asset-aggregation/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./assetAggregation";
 export * from "./assetCategorization";
+export * from "./assetDistribution";

--- a/libs/ledgerjs/packages/types-live/src/portfolio.ts
+++ b/libs/ledgerjs/packages/types-live/src/portfolio.ts
@@ -122,4 +122,5 @@ export type AssetsDistribution = {
   showFirst: number;
   // sum of all countervalues
   sum: number;
+  bySlug?: Record<string, DistributionItem>;
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Asset distribution computation in `@ledgerhq/asset-aggregation`
      - `AssetsDistribution` type in `@ledgerhq/types-live` (new optional `bySlug` field)
      - No UI changes — library-only

### 📝 Description

**Problem**: Asset distribution logic was previously tightly coupled to UI layers and did not support DADA meta-currency grouping across networks (e.g. ETH on Mainnet + Arbitrum + Base should be a single distribution item).

**Solution**: Introduces `buildAssetDistribution` in `@ledgerhq/asset-aggregation` that:
- Groups accounts by DADA meta-currency across all networks
- Computes per-network breakdown (`networks[]` on each `DistributionItem`)
- Resolves `marketId` and `slug` from DADA metadata
- Adds `bySlug` lookup map on `AssetsDistribution` for O(1) access
- Includes `toSlug` utility to convert `urn:crypto:meta-currency:*` IDs to URL-safe slugs
- Full unit test coverage for both `buildAssetDistribution` and `toSlug`

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27931](https://ledgerhq.atlassian.net/browse/LIVE-27931)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27931]: https://ledgerhq.atlassian.net/browse/LIVE-27931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ