### PR TITLE
refactor(cryptoassets): use globalThis as store reference to fix lazy-loaded coin-modules

### DIFF
--- a/.changeset/beige-starfishes-cheer.md
+++ b/.changeset/beige-starfishes-cheer.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/cryptoassets": minor
+---
+
+refactor(cryptoassets): use globalThis as sole store reference to fix lazy-loaded coin-modules
+
+Replace the module-scoped `let` variable with `globalThis.__ledgerCryptoAssetsStore`
+as the single source of truth for CryptoAssetsStore. When coin-modules are
+lazy-loaded, bundlers may resolve separate module copies, causing the module-level
+variable to be undefined even after the store was set. Using globalThis exclusively
+avoids this duplicate-reference issue.
+
+Also removes unused `getReduxStore`/`setReduxStore` (no external consumers).

--- a/libs/ledgerjs/packages/cryptoassets/.unimportedrc.json
+++ b/libs/ledgerjs/packages/cryptoassets/.unimportedrc.json
@@ -14,6 +14,7 @@
   ],
   "ignoreUnused": [
     "zod",
+    "lodash",
     "@reduxjs/toolkit",
     "@ledgerhq/logs",
     "@ledgerhq/errors",

--- a/libs/ledgerjs/packages/cryptoassets/src/state.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/state.ts
@@ -1,26 +1,21 @@
 import type { CryptoAssetsStore } from "@ledgerhq/types-live";
-import type { Store } from "@reduxjs/toolkit";
-import type { StateWithCryptoAssets } from "./cal-client/persistence";
 
-/**
- * Global CryptoAssetsStore instance.
- * This is the single source of truth for the cryptoassets store.
- * All modules should use this store directly.
- */
-let globalCryptoAssetsStore: CryptoAssetsStore | undefined = undefined;
-
-/**
- * Global Redux store instance (for accessing RTK Query state).
- * This is set when setupCalClientStore() is called.
- */
-let globalReduxStore: Store<StateWithCryptoAssets> | undefined = undefined;
+declare global {
+  interface GlobalThis {
+    __ledgerCryptoAssetsStore?: CryptoAssetsStore;
+  }
+}
 
 /**
  * Sets the global CryptoAssetsStore instance.
  * This should be called once during application initialization.
+ *
+ * Uses globalThis to ensure a single shared reference across all module instances,
+ * which is critical when coin-modules are lazy-loaded and may resolve to separate
+ * module copies.
  */
 export function setCryptoAssetsStore(store: CryptoAssetsStore): void {
-  globalCryptoAssetsStore = store;
+  globalThis.__ledgerCryptoAssetsStore = store;
 }
 
 /**
@@ -28,29 +23,8 @@ export function setCryptoAssetsStore(store: CryptoAssetsStore): void {
  * @throws {Error} If the store has not been set yet.
  */
 export function getCryptoAssetsStore(): CryptoAssetsStore {
-  if (!globalCryptoAssetsStore) {
+  if (!globalThis.__ledgerCryptoAssetsStore) {
     throw new Error("CryptoAssetsStore is not set. Please call setCryptoAssetsStore first.");
   }
-  return globalCryptoAssetsStore;
-}
-
-/**
- * Sets the global Redux store instance.
- * This should be called when setting up the CAL client store.
- * @internal
- */
-export function setReduxStore(store: Store<StateWithCryptoAssets>): void {
-  globalReduxStore = store;
-}
-
-/**
- * Gets the global Redux store instance.
- * This allows access to the RTK Query state for persistence operations.
- * @throws {Error} If the store has not been set yet.
- */
-export function getReduxStore(): Store<StateWithCryptoAssets> {
-  if (!globalReduxStore) {
-    throw new Error("Redux store is not set. Please call setupCalClientStore first.");
-  }
-  return globalReduxStore;
+  return globalThis.__ledgerCryptoAssetsStore;
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Shouldn't impact much more than the tests as we just move the global in a better place

### 📝 Description

Replace the module-scoped `let` variable with `globalThis.__ledgerCryptoAssetsStore` as the single source of truth for CryptoAssetsStore. When coin-modules are lazy-loaded, bundlers may resolve separate module copies, causing the module-level variable to be undefined even after the store was set. Using globalThis exclusively avoids this duplicate-reference issue.

It fixes the failing test on confirmTransaction.spec.ts and might help for other issues related to the lazy-loading of coin-modules.

Also removes unused `getReduxStore`/`setReduxStore` (no external consumers).

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
