### PR TITLE
[LWDM] feat(common): add useAssetDistribution hook and integrate into useDistribution

### DIFF
--- a/.changeset/fuzzy-windows-heal.md
+++ b/.changeset/fuzzy-windows-heal.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Adapt Assets components to use CryptoIcon and conditional market routing when aggregated assets FF is ON

--- a/.changeset/lovely-plants-clap.md
+++ b/.changeset/lovely-plants-clap.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-countervalues-react": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+useDistribution to be usable in legacy and in v4 mode. introduce also useAssetDistribution hook

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/useAllocationData.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/useAllocationData.ts
@@ -6,6 +6,7 @@ import {
   blacklistedTokenIdsSelector,
 } from "~/renderer/reducers/settings";
 import { useDistribution } from "~/renderer/actions/general";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/index";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import type { AllocationTableItem, AllocationViewProps } from "../types";
 
@@ -13,10 +14,14 @@ const PAGE_SIZE = 6;
 
 export function useAllocationData(): AllocationViewProps {
   const navigate = useNavigate();
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const hideEmptyTokenAccount = useSelector(hideEmptyTokenAccountsSelector);
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
 
-  const distribution = useDistribution({ hideEmptyTokenAccount });
+  const distribution = useDistribution({
+    hideEmptyTokenAccount,
+    groupBy: shouldDisplayAggregatedAssets ? "asset" : undefined,
+  });
 
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/useAllocationTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/useAllocationTable.tsx
@@ -1,6 +1,9 @@
 import React, { useMemo } from "react";
 import { TableCellContent, useLumenDataTable } from "@ledgerhq/lumen-ui-react";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/index";
 import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { getValidCryptoIconSize } from "~/renderer/utils/cryptoIconSize";
 import { useTranslation } from "react-i18next";
 import { ColumnDef } from "@tanstack/react-table";
 import { BalanceCell } from "../../Assets/components/Cells/BalanceCell";
@@ -10,6 +13,7 @@ import { localeSelector } from "~/renderer/reducers/settings";
 import type { AllocationTableItem } from "../types";
 
 export const useAllocationTable = (items: AllocationTableItem[]) => {
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const { t } = useTranslation();
   const locale = useSelector(localeSelector);
 
@@ -21,7 +25,17 @@ export const useAllocationTable = (items: AllocationTableItem[]) => {
         enableSorting: false,
         cell: ({ row }) => (
           <TableCellContent
-            leadingContent={<CryptoCurrencyIcon currency={row.original.currency} size={32} />}
+            leadingContent={
+              shouldDisplayAggregatedAssets ? (
+                <CryptoIcon
+                  ledgerId={row.original.currency.id}
+                  ticker={row.original.currency.ticker}
+                  size={getValidCryptoIconSize(32)}
+                />
+              ) : (
+                <CryptoCurrencyIcon currency={row.original.currency} size={32} />
+              )
+            }
             title={row.original.currency.name}
             description={row.original.currency.ticker}
           />
@@ -64,7 +78,7 @@ export const useAllocationTable = (items: AllocationTableItem[]) => {
         meta: { align: "end" },
       },
     ],
-    [t, locale],
+    [t, locale, shouldDisplayAggregatedAssets],
   );
 
   return useLumenDataTable({

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAssetsViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAssetsViewModel.test.ts
@@ -1,7 +1,8 @@
 import { renderHook, act } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { useAssetsViewModel } from "../useAssetsViewModel";
-import { padItems, dadaIdToMarketId } from "../../utils/assetTableHelpers";
+import { padItems } from "../../utils/assetTableHelpers";
+import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
 import {
   createMockCategorizedAssets,
   BITCOIN_ASSET,
@@ -168,24 +169,6 @@ describe("padItems", () => {
 
   it("should return empty array when both inputs are empty", () => {
     expect(padItems([], [], 3)).toEqual([]);
-  });
-});
-
-describe("dadaIdToMarketId", () => {
-  it("should return the last segment of a URN", () => {
-    expect(dadaIdToMarketId("urn:crypto:meta-currency:ethereum")).toBe("ethereum");
-  });
-
-  it("should return the id as-is when it has no colons", () => {
-    expect(dadaIdToMarketId("bitcoin")).toBe("bitcoin");
-  });
-
-  it("should replace underscores with hyphens in URN last segment", () => {
-    expect(dadaIdToMarketId("urn:crypto:meta-currency:usd_coin")).toBe("usd-coin");
-  });
-
-  it("should not replace underscores in plain ids", () => {
-    expect(dadaIdToMarketId("usd_coin")).toBe("usd_coin");
   });
 });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAssetsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAssetsViewModel.ts
@@ -23,14 +23,16 @@ import {
 } from "../constants";
 import { buildAssetsPagePath } from "../utils/buildAssetsPagePath";
 import { padItems } from "../utils/assetTableHelpers";
+import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/index";
 import { track } from "~/renderer/analytics/segment";
 import {
   ASSETS_TRACKING_PAGE_NAME,
   CRYPTO_TRACKING_PAGE_NAME,
 } from "../../CryptoAddresses/constants";
-import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
 
 export function useAssetsViewModel(): AssetsViewProps {
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const hasOnboardedDevice = useSelector(hasOnboardedDeviceSelector);
   const { hasAccount } = useAccountStatus();
   const isEmptyState = !hasOnboardedDevice || !hasAccount;
@@ -73,13 +75,14 @@ export function useAssetsViewModel(): AssetsViewProps {
   const onItemClick = useCallback(
     (item: AssetTableItem) => {
       setTrackingSource("asset allocation");
+      const rawId = item.marketId ?? item.currency.id;
       navigate(
         item.isPlaceholder
-          ? `/market/${encodeURIComponent(dadaIdToMarketId(item.marketId ?? item.currency.id))}`
+          ? `/market/${encodeURIComponent(shouldDisplayAggregatedAssets ? rawId : dadaIdToMarketId(rawId))}`
           : `/asset/${item.currency.id}`,
       );
     },
-    [navigate],
+    [navigate, shouldDisplayAggregatedAssets],
   );
 
   const resolvedDefaults = useMemo(

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
@@ -9,6 +9,7 @@ import {
 } from "@ledgerhq/lumen-ui-react";
 import { BigNumber } from "bignumber.js";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/index";
 import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { getValidCryptoIconSize } from "~/renderer/utils/cryptoIconSize";
@@ -29,6 +30,7 @@ export type UseAssetTableOptions = {
 
 export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOptions) => {
   const showTrendColumnTooltip = options?.showTrendColumnTooltip ?? true;
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const { t } = useTranslation();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
 
@@ -46,7 +48,7 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
         cell: ({ row }) => (
           <TableCellContent
             leadingContent={
-              row.original.isPlaceholder ? (
+              row.original.isPlaceholder || shouldDisplayAggregatedAssets ? (
                 <CryptoIcon
                   ledgerId={row.original.currency.id}
                   ticker={row.original.currency.ticker}
@@ -121,7 +123,7 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
         },
       },
     ],
-    [t, emptyFiatValue, showTrendColumnTooltip],
+    [t, emptyFiatValue, showTrendColumnTooltip, shouldDisplayAggregatedAssets],
   );
 
   const table = useLumenDataTable({

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/utils/assetTableHelpers.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/utils/assetTableHelpers.ts
@@ -1,5 +1,4 @@
 import type { AssetTableItem } from "../types";
-export { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
 
 export function padItems(
   realItems: AssetTableItem[],

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAssetsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/hooks/useCryptoAssetsViewModel.ts
@@ -14,7 +14,9 @@ import { useOnDemandCurrenciesCountervalues } from "~/renderer/hooks/useOnDemand
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { buildPlaceholderAssetItemsFromAssetsData } from "LLD/features/Assets/utils/buildPlaceholderAssetItemsFromAssetsData";
 import { parseAssetsPageCategory } from "LLD/features/Assets/utils/buildAssetsPagePath";
-import { padItems, dadaIdToMarketId } from "LLD/features/Assets/utils/assetTableHelpers";
+import { padItems } from "LLD/features/Assets/utils/assetTableHelpers";
+import { dadaIdToMarketId } from "@ledgerhq/live-common/market/utils/index";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/index";
 import {
   ASSETS_PAGE_CATEGORY_CRYPTOS,
   ASSETS_PAGE_CATEGORY_STABLECOINS,
@@ -27,6 +29,7 @@ import { track } from "~/renderer/analytics/segment";
 import { ASSETS_TRACKING_PAGE_NAME } from "../constants";
 
 export default function useCryptoAssetsViewModel(): CryptoAssetsViewModel {
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -119,13 +122,14 @@ export default function useCryptoAssetsViewModel(): CryptoAssetsViewModel {
         asset: item.currency.name,
         page: ASSETS_TRACKING_PAGE_NAME,
       });
+      const rawId = item.marketId ?? item.currency.id;
       navigate(
         item.isPlaceholder
-          ? `/market/${encodeURIComponent(dadaIdToMarketId(item.marketId ?? item.currency.id))}`
+          ? `/market/${encodeURIComponent(shouldDisplayAggregatedAssets ? rawId : dadaIdToMarketId(rawId))}`
           : `/asset/${item.currency.id}`,
       );
     },
-    [navigate],
+    [navigate, shouldDisplayAggregatedAssets],
   );
 
   return {

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useCategorizedAssets.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useCategorizedAssets.ts
@@ -3,16 +3,24 @@ import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/us
 import { useCategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/index";
 import { useSelector } from "LLD/hooks/redux";
 import { hideEmptyTokenAccountsSelector } from "~/renderer/reducers/settings";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/index";
 
 export function useCategorizedAssetsFromPortfolio() {
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const hideEmptyTokenAccount = useSelector(hideEmptyTokenAccountsSelector);
-  const distribution = useDistribution({ showEmptyAccounts: true, hideEmptyTokenAccount });
+
+  const distribution = useDistribution({
+    showEmptyAccounts: true,
+    hideEmptyTokenAccount,
+    groupBy: shouldDisplayAggregatedAssets ? "asset" : undefined,
+  });
+
   const { tickers: stablecoinTickers, isLoading: isLoadingStablecoinTickers } =
     useStablecoinTickers("lld", __APP_VERSION__);
   const categorizedAssets = useCategorizedAssets(distribution, stablecoinTickers);
   return {
     categorizedAssets,
-    isLoadingStablecoinTickers,
+    isLoadingStablecoinTickers: isLoadingStablecoinTickers || distribution.isLoading,
     stablecoinTickers,
   };
 }

--- a/apps/ledger-live-desktop/src/renderer/actions/general.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/general.ts
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { createSelector } from "reselect";
-// TODO make a generic way to implement this for each family
-import { FlattenAccountsOptions } from "@ledgerhq/live-common/account/index";
+import type { FlattenAccountsOptions } from "@ledgerhq/live-common/account/index";
 import { isAccountDelegating } from "@ledgerhq/live-common/families/tezos/staking";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
@@ -10,12 +9,17 @@ import {
   useCalculateCountervalueCallback as useCalculateCountervalueCallbackCommon,
   useTrackingPairForAccounts,
 } from "@ledgerhq/live-countervalues-react";
-import { useDistribution as useDistributionRaw } from "@ledgerhq/live-countervalues-react/portfolio";
 import { resolveTrackingPairs } from "@ledgerhq/live-countervalues/logic";
 import {
   flattenSortAccounts,
   sortAccountsComparatorFromOrder,
 } from "@ledgerhq/live-wallet/ordering";
+import { useDistribution as useLegacyDistribution } from "@ledgerhq/live-countervalues-react/portfolio";
+import {
+  useAssetDistribution,
+  type DistributionOpts,
+  type DistributionResult,
+} from "@ledgerhq/live-common/portfolio/useAssetDistribution";
 import { reorderAccounts } from "~/renderer/actions/accounts";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { osDarkModeSelector } from "~/renderer/reducers/application";
@@ -28,16 +32,26 @@ import { walletSelector } from "../reducers/wallet";
 import { countervaluesActions } from "./countervalues";
 import { selectExtraTrackingPairs } from "~/renderer/reducers/countervaluesExtraTracking";
 
-export function useDistribution(
-  opts: Omit<Parameters<typeof useDistributionRaw>[0], "accounts" | "to">,
-) {
+export function useDistribution(opts: DistributionOpts = {}): DistributionResult {
   const accounts = useSelector(accountsSelector);
   const to = useSelector(counterValueCurrencySelector);
-  return useDistributionRaw({
+  const { groupBy, ...displayOpts } = opts;
+  const isAssetMode = groupBy === "asset";
+
+  const legacy = useLegacyDistribution({ accounts, to, skip: isAssetMode, ...displayOpts });
+  const asset = useAssetDistribution({
     accounts,
     to,
-    ...opts,
+    product: "lld",
+    version: __APP_VERSION__,
+    skip: !isAssetMode,
+    ...displayOpts,
   });
+
+  if (isAssetMode) {
+    return { ...asset.distribution, isLoading: asset.isLoading };
+  }
+  return { ...legacy, isLoading: false };
 }
 export function useCalculateCountervalueCallback() {
   const to = useSelector(counterValueCurrencySelector);

--- a/apps/ledger-live-mobile/src/actions/general.ts
+++ b/apps/ledger-live-mobile/src/actions/general.ts
@@ -11,15 +11,17 @@ import {
   useCountervaluesPolling,
   useTrackingPairForAccounts,
 } from "@ledgerhq/live-countervalues-react";
-import { useDistribution as useDistributionCommon } from "@ledgerhq/live-countervalues-react/portfolio";
+import { useDistribution as useLegacyDistribution } from "@ledgerhq/live-countervalues-react/portfolio";
+import {
+  useAssetDistribution,
+  type DistributionOpts,
+  type DistributionResult,
+} from "@ledgerhq/live-common/portfolio/useAssetDistribution";
+import VersionNumber from "react-native-version-number";
 import { BehaviorSubject } from "rxjs";
 import { cleanCache, reorderAccounts } from "./accounts";
 import { accountsSelector } from "../reducers/accounts";
-import {
-  blacklistedTokenIdsSelector,
-  counterValueCurrencySelector,
-  orderAccountsSelector,
-} from "../reducers/settings";
+import { counterValueCurrencySelector, orderAccountsSelector } from "../reducers/settings";
 import { clearBridgeCache } from "../bridge/cache";
 import { flushAll } from "../components/DBSave";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
@@ -29,12 +31,27 @@ import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 const extraSessionTrackingPairsChanges: BehaviorSubject<TrackingPair[]> = new BehaviorSubject<
   TrackingPair[]
 >([]);
-export function useDistribution(
-  opts: Omit<Parameters<typeof useDistributionCommon>[0], "accounts" | "to">,
-) {
+
+export function useDistribution(opts: DistributionOpts = {}): DistributionResult {
   const accounts = useSelector(accountsSelector);
   const to = useSelector(counterValueCurrencySelector);
-  return useDistributionCommon({ accounts, to, ...opts });
+  const { groupBy, ...displayOpts } = opts;
+  const isAssetMode = groupBy === "asset";
+
+  const legacy = useLegacyDistribution({ accounts, to, skip: isAssetMode, ...displayOpts });
+  const asset = useAssetDistribution({
+    accounts,
+    to,
+    product: "llm",
+    version: VersionNumber.appVersion ?? "",
+    skip: !isAssetMode,
+    ...displayOpts,
+  });
+
+  if (isAssetMode) {
+    return { ...asset.distribution, isLoading: asset.isLoading };
+  }
+  return { ...legacy, isLoading: false };
 }
 export function useCalculateCountervalueCallback() {
   const to = useSelector(counterValueCurrencySelector);

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useCategorizedAssetsFromPortfolio.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useCategorizedAssetsFromPortfolio.ts
@@ -1,12 +1,19 @@
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useStablecoinTickers } from "@ledgerhq/live-common/dada-client/hooks/useStablecoinTickers";
 import { useCategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/index";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/index";
 import VersionNumber from "react-native-version-number";
 import { useDistribution } from "~/actions/general";
 
 export function useCategorizedAssetsFromPortfolio() {
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("mobile");
   const hideEmptyTokenAccount = useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
-  const distribution = useDistribution({ showEmptyAccounts: true, hideEmptyTokenAccount });
+
+  const distribution = useDistribution({
+    showEmptyAccounts: true,
+    hideEmptyTokenAccount,
+    groupBy: shouldDisplayAggregatedAssets ? "asset" : undefined,
+  });
 
   const {
     tickers: stablecoinTickers,
@@ -18,7 +25,7 @@ export function useCategorizedAssetsFromPortfolio() {
 
   return {
     categorizedAssets,
-    isLoadingStablecoinTickers,
+    isLoadingStablecoinTickers: isLoadingStablecoinTickers || distribution.isLoading,
     isStablecoinTickersError,
     stablecoinTickers,
   };

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -275,6 +275,8 @@
     "src/platform/serializers.ts",
     "src/platform/tracking.ts",
     "src/platform/types.ts",
+    "src/portfolio/index.ts",
+    "src/portfolio/useAssetDistribution.ts",
     "src/postOnboarding/actions.ts",
     "src/postOnboarding/hooks/index.ts",
     "src/postOnboarding/hooks/usePostOnboardingEntryPointVisibleOnWallet.ts",

--- a/libs/ledger-live-common/src/portfolio/__tests__/useAssetDistribution.test.ts
+++ b/libs/ledger-live-common/src/portfolio/__tests__/useAssetDistribution.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { useAssetDistribution } from "../useAssetDistribution";
+import type { Account, AssetsDistribution } from "@ledgerhq/types-live";
+import type { CryptoCurrency, Currency } from "@ledgerhq/types-cryptoassets";
+import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+
+const mockCvState = {} as CounterValuesState;
+jest.mock("@ledgerhq/live-countervalues-react", () => ({
+  useCountervaluesState: () => mockCvState,
+}));
+
+const mockBuildAssetDistribution = jest.fn<AssetsDistribution, unknown[]>();
+jest.mock("@ledgerhq/asset-aggregation/assetDistribution/index", () => ({
+  buildAssetDistribution: (...args: unknown[]) => mockBuildAssetDistribution(...args),
+}));
+
+const mockUseChunkedAssetsData = jest.fn();
+jest.mock("../../dada-client/hooks/useChunkedAssetsData", () => ({
+  useChunkedAssetsData: (...args: unknown[]) => mockUseChunkedAssetsData(...args),
+}));
+
+const makeCryptoCurrency = (id: string, ticker: string) =>
+  ({ type: "CryptoCurrency", id, ticker }) as unknown as CryptoCurrency;
+
+const makeFiatCurrency = (id: string, ticker: string) =>
+  ({ type: "FiatCurrency", id, ticker }) as unknown as Currency;
+
+const makeAccount = (id: string, currency: CryptoCurrency) =>
+  ({
+    type: "Account",
+    id,
+    currency,
+    balance: { toNumber: () => 100, isGreaterThan: () => true },
+    subAccounts: [],
+  }) as unknown as Account;
+
+const btc = makeCryptoCurrency("bitcoin", "BTC");
+const eth = makeCryptoCurrency("ethereum", "ETH");
+const usd = makeFiatCurrency("usd", "USD");
+
+const accounts = [makeAccount("acc-btc", btc), makeAccount("acc-eth", eth)];
+const baseOpts = { accounts, to: usd, product: "lld" as const, version: "1.0.0" };
+
+const assetResult: AssetsDistribution = {
+  isAvailable: true,
+  list: [
+    {
+      currency: btc,
+      distribution: 0.7,
+      accounts: [],
+      amount: 100,
+      countervalue: 7000,
+      metaCurrencyId: "bitcoin",
+      slug: "bitcoin",
+    },
+  ],
+  showFirst: 1,
+  sum: 10000,
+};
+
+describe("useAssetDistribution", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseChunkedAssetsData.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isSuccess: false,
+    });
+  });
+
+  it("returns loading state while chunked data is pending", () => {
+    mockUseChunkedAssetsData.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isSuccess: false,
+    });
+
+    const { result } = renderHook(() => useAssetDistribution(baseOpts));
+
+    expect(result.current.distribution).toMatchObject({ isAvailable: false, list: [] });
+    expect(result.current.isLoading).toBe(true);
+    expect(mockUseChunkedAssetsData).toHaveBeenCalledWith(
+      expect.objectContaining({ product: "lld", version: "1.0.0", skip: false }),
+    );
+  });
+
+  it("returns built distribution once chunked data resolves", () => {
+    const assetsData = {
+      cryptoAssets: { bitcoin: { id: "bitcoin", assetsIds: { bitcoin: "bitcoin" } } },
+      markets: { bitcoin: { id: "bitcoin" } },
+    };
+    mockUseChunkedAssetsData.mockReturnValue({
+      data: assetsData,
+      isLoading: false,
+      isSuccess: true,
+    });
+    mockBuildAssetDistribution.mockReturnValue(assetResult);
+
+    const { result } = renderHook(() => useAssetDistribution(baseOpts));
+
+    expect(result.current.distribution).toMatchObject({ isAvailable: true });
+    expect(result.current.distribution.list[0].metaCurrencyId).toBe("bitcoin");
+    expect(result.current.isLoading).toBe(false);
+    expect(mockBuildAssetDistribution).toHaveBeenCalledWith(
+      accounts,
+      mockCvState,
+      usd,
+      assetsData,
+      expect.objectContaining({ showEmptyAccounts: false, hideEmptyTokenAccount: false }),
+    );
+  });
+
+  it("skips fetch when skip is true", () => {
+    renderHook(() => useAssetDistribution({ ...baseOpts, skip: true }));
+
+    expect(mockUseChunkedAssetsData).toHaveBeenCalledWith(expect.objectContaining({ skip: true }));
+  });
+
+  it("skips fetch when no accounts", () => {
+    renderHook(() => useAssetDistribution({ ...baseOpts, accounts: [] }));
+
+    expect(mockUseChunkedAssetsData).toHaveBeenCalledWith(expect.objectContaining({ skip: true }));
+  });
+});

--- a/libs/ledger-live-common/src/portfolio/index.ts
+++ b/libs/ledger-live-common/src/portfolio/index.ts
@@ -1,0 +1,7 @@
+export { useAssetDistribution } from "./useAssetDistribution";
+export type {
+  AssetDistributionResult,
+  DistributionOpts,
+  DistributionResult,
+  UseAssetDistributionOpts,
+} from "./useAssetDistribution";

--- a/libs/ledger-live-common/src/portfolio/useAssetDistribution.ts
+++ b/libs/ledger-live-common/src/portfolio/useAssetDistribution.ts
@@ -65,7 +65,7 @@ export function useAssetDistribution(opts: UseAssetDistributionOpts): AssetDistr
   });
 
   const distribution = useMemo<AssetsDistribution>(() => {
-    if (!isChunkedSuccess || !assetsData) {
+    if (skip || !isChunkedSuccess || !assetsData) {
       return emptyDistribution;
     }
 
@@ -74,6 +74,7 @@ export function useAssetDistribution(opts: UseAssetDistributionOpts): AssetDistr
       hideEmptyTokenAccount: !!displayOpts.hideEmptyTokenAccount,
     });
   }, [
+    skip,
     isChunkedSuccess,
     assetsData,
     accounts,

--- a/libs/ledger-live-common/src/portfolio/useAssetDistribution.ts
+++ b/libs/ledger-live-common/src/portfolio/useAssetDistribution.ts
@@ -1,0 +1,87 @@
+import { useMemo } from "react";
+import type { Account, AssetsDistribution } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import { useCountervaluesState } from "@ledgerhq/live-countervalues-react";
+import { buildAssetDistribution } from "@ledgerhq/asset-aggregation/assetDistribution/index";
+import { flattenAccounts, getAccountCurrency } from "../account/helpers";
+import { useChunkedAssetsData } from "../dada-client/hooks/useChunkedAssetsData";
+
+export type DistributionResult = AssetsDistribution & { isLoading: boolean };
+
+export type DistributionOpts = {
+  groupBy?: "currency" | "asset";
+  showEmptyAccounts?: boolean;
+  hideEmptyTokenAccount?: boolean;
+};
+
+export type AssetDistributionResult = {
+  distribution: AssetsDistribution;
+  isLoading: boolean;
+};
+
+export type UseAssetDistributionOpts = {
+  accounts: Account[];
+  to: Currency;
+  product: "lld" | "llm";
+  version: string;
+  showEmptyAccounts?: boolean;
+  hideEmptyTokenAccount?: boolean;
+  skip?: boolean;
+};
+
+const emptyDistribution: AssetsDistribution = {
+  isAvailable: false,
+  list: [],
+  showFirst: 0,
+  sum: 0,
+};
+
+/**
+ * Fetches DADA-powered asset data and builds a cross-network asset distribution.
+ *
+ * Designed to be composed with `useDistribution` from `live-countervalues-react`
+ * by passing the result as the `assetDistribution` parameter.
+ */
+export function useAssetDistribution(opts: UseAssetDistributionOpts): AssetDistributionResult {
+  const { accounts, to, product, version, skip = false, ...displayOpts } = opts;
+
+  const cvState = useCountervaluesState();
+
+  const accountCurrencyIds = useMemo(() => {
+    if (skip) return [];
+    const ids = new Set(flattenAccounts(accounts).map(a => getAccountCurrency(a).id));
+    return Array.from(ids);
+  }, [accounts, skip]);
+
+  const {
+    data: assetsData,
+    isLoading: isChunkedLoading,
+    isSuccess: isChunkedSuccess,
+  } = useChunkedAssetsData({
+    currencyIds: accountCurrencyIds,
+    product,
+    version,
+    skip: skip || accountCurrencyIds.length === 0,
+  });
+
+  const distribution = useMemo<AssetsDistribution>(() => {
+    if (!isChunkedSuccess || !assetsData) {
+      return emptyDistribution;
+    }
+
+    return buildAssetDistribution(accounts, cvState, to, assetsData, {
+      showEmptyAccounts: !!displayOpts.showEmptyAccounts,
+      hideEmptyTokenAccount: !!displayOpts.hideEmptyTokenAccount,
+    });
+  }, [
+    isChunkedSuccess,
+    assetsData,
+    accounts,
+    cvState,
+    to,
+    displayOpts.showEmptyAccounts,
+    displayOpts.hideEmptyTokenAccount,
+  ]);
+
+  return { distribution, isLoading: isChunkedLoading };
+}

--- a/libs/live-countervalues-react/src/portfolio.tsx
+++ b/libs/live-countervalues-react/src/portfolio.tsx
@@ -144,18 +144,28 @@ export function useCurrencyPortfolio({
   return getCurrencyPortfolio(accounts, range, state, to);
 }
 
+const emptyDistribution: AssetsDistribution = {
+  isAvailable: false,
+  list: [],
+  showFirst: 0,
+  sum: 0,
+};
+
 export function useDistribution({
   accounts,
   to,
+  skip,
   showEmptyAccounts,
   hideEmptyTokenAccount,
 }: {
   accounts: Account[];
   to: Currency;
+  skip?: boolean;
   showEmptyAccounts?: boolean;
   hideEmptyTokenAccount?: boolean;
 }): AssetsDistribution {
   const state = useCountervaluesState();
+  if (skip) return emptyDistribution;
   return getAssetsDistribution(accounts, state, to, {
     minShowFirst: 6,
     maxShowFirst: 6,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - `useDistribution` hook behavior in both LLD and LLM (now supports `groupBy: "asset"` mode)
      - `useCategorizedAssetsFromPortfolio` in both apps (now passes `groupBy` based on feature flag)
      - `useDistribution` in `live-countervalues-react` (new `skip` parameter)
      - No UI changes — hook/logic only

### 📝 Description

**Problem**: The `useDistribution` hooks in LLD and LLM had no way to switch between the legacy per-currency distribution and the new DADA-powered cross-network asset distribution. The `LocalDistributionOpts` type was also duplicated across both apps.

**Solution**:
- Introduces `useAssetDistribution` hook in `@ledgerhq/live-common/portfolio` that fetches DADA chunked data and calls `buildAssetDistribution`
- Refactors `useDistribution` in both apps to support a `groupBy: "currency" | "asset"` option, delegating to the legacy or DADA path accordingly
- Centralizes the shared `DistributionOpts` type in `@ledgerhq/live-common/portfolio`
- Adds `skip` support to `useDistribution` in `live-countervalues-react` to avoid unnecessary computation
- Updates `useCategorizedAssetsFromPortfolio` in both LLD and LLM to pass `groupBy` based on `shouldDisplayAggregatedAssets` feature flag
- Includes full test coverage for the new `useAssetDistribution` hook

### ❓ Context

- **JIRA or GitHub link**: [LIVE-27936](https://ledgerhq.atlassian.net/browse/LIVE-27936), [LIVE-27934](https://ledgerhq.atlassian.net/browse/LIVE-27934)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-27936]: https://ledgerhq.atlassian.net/browse/LIVE-27936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ