### PR TITLE
[LWDM] feat(portfolio): move Perpetuals entry point below Asset Allocation

### DIFF
--- a/.changeset/smooth-perps-slide.md
+++ b/.changeset/smooth-perps-slide.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Move Perpetuals entry point below Asset Allocation on portfolio screen

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
@@ -66,9 +66,9 @@ export const PortfolioView = memo(function PortfolioView({
           <PortfolioBannerContent />
           {shouldDisplayMarketBanner && <MarketBanner />}
 
-          <PerpsEntryPoint />
-
           {shouldDisplayAssetSection ? <Assets /> : <AssetDistribution />}
+
+          <PerpsEntryPoint />
           {shouldDisplayAddAccountCta && <AddAccount />}
           {shouldDisplayAssetSection && <CryptoAddressesBanner />}
           {shouldDisplayBrazePlacement && <BottomCarouselContentCards />}

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
@@ -67,10 +67,10 @@ export const PortfolioView = memo(function PortfolioView({
           {shouldDisplayMarketBanner && <MarketBanner />}
 
           {shouldDisplayAssetSection ? <Assets /> : <AssetDistribution />}
-
-          <PerpsEntryPoint />
           {shouldDisplayAddAccountCta && <AddAccount />}
           {shouldDisplayAssetSection && <CryptoAddressesBanner />}
+
+          <PerpsEntryPoint />
           {shouldDisplayBrazePlacement && <BottomCarouselContentCards />}
           {shouldRenderLegacyOperationsList && (
             <OperationsList

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -485,6 +485,34 @@ describe("PortfolioView", () => {
       expect(screen.queryByTestId("portfolio-perps-entry-point")).toBeNull();
     });
 
+    it("should render perps entry point after asset section", () => {
+      render(<PortfolioView {...defaultProps} shouldDisplayAssetSection={true} />, {
+        initialState: {
+          settings: {
+            ...AFTER_ONBOARDING_STATE,
+          },
+          ...withFlagOverrides({
+            ptxPerpsLiveApp: {
+              enabled: true,
+            },
+          }),
+        },
+      });
+
+      const container = screen.getByTestId("portfolio-container");
+      const perps = screen.getByTestId("portfolio-perps-entry-point");
+      const allElements = Array.from(container.querySelectorAll("[data-testid]"));
+      const assetIndex = allElements.findIndex(
+        el =>
+          el.getAttribute("data-testid") === "categorized-assets" ||
+          el.getAttribute("data-testid") === "asset-distribution",
+      );
+      const perpsIndex = allElements.indexOf(perps);
+
+      expect(assetIndex).toBeGreaterThanOrEqual(0);
+      expect(perpsIndex).toBeGreaterThan(assetIndex);
+    });
+
     it("should track and navigate when clicking perps entry point", async () => {
       const { user } = render(<PortfolioView {...defaultProps} />, {
         initialState: {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/portfolio.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/portfolio.integration.test.tsx
@@ -118,6 +118,17 @@ describe("Portfolio Screen", () => {
 
       expect(await screen.findByTestId("portfolio-perps-entry-point")).toBeVisible();
     });
+
+    it("should not render perps section wrapper when feature flag is disabled", async () => {
+      renderWithReactQuery(<PortfolioTest />, {
+        overrideInitialState: overrideInitialStateWithPerpsEntryPoint(false),
+      });
+
+      await screen.findByTestId("PortfolioAccountsList");
+
+      expect(screen.queryByTestId("portfolio-perps-entry-point")).toBeNull();
+      expect(screen.queryByTestId("portfolio-perps-subheader-row")).toBeNull();
+    });
   });
 
   describe("Asset Section Feature", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioPerpsEntryPoint/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioPerpsEntryPoint/index.tsx
@@ -40,7 +40,7 @@ export const PortfolioPerpsEntryPoint = () => {
           <SubheaderTitle>{t("portfolio.perpsEntry.title")}</SubheaderTitle>
         </SubheaderRow>
       </Subheader>
-      <Flex mb={6} mt={2}>
+      <Flex mb={6} mt={3}>
         <ListItem onPress={handlePress} testID="portfolio-perps-entry-point">
           <ListItemLeading>
             <Spot appearance="icon" icon={Infinite} />

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { Platform } from "react-native";
 import Animated from "react-native-reanimated";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import CheckLanguageAvailability from "~/components/CheckLanguageAvailability";
 import CheckTermOfUseUpdate from "~/components/CheckTermOfUseUpdate";
 import CollapsibleHeaderFlatList from "~/components/WalletTab/CollapsibleHeaderFlatList";
@@ -70,6 +71,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     shouldAddBottomPaddingForLegacyAssets,
   } = usePortfolioViewModel(navigation);
 
+  const ptxPerpsLiveAppMobile = useFeature("ptxPerpsLiveAppMobile");
   const progressViewOffset = getProgressViewOffset(Platform.OS, shouldDisplayWallet40MainNav);
 
   const { handleFlatListRef } = useScrollToTop();
@@ -131,12 +133,6 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
       );
     }
 
-    sections.push(
-      <Box key="perps" px={6}>
-        <PortfolioPerpsEntryPoint key="perpsEntryPoint" />
-      </Box>,
-    );
-
     if (shouldDisplayAssetSection) {
       sections.push(<WalletAssetsView key="categorizedAssets" />);
     } else {
@@ -149,6 +145,14 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
           onHeightChange={handleHeightChange}
           shouldAddBottomPadding={shouldAddBottomPaddingForLegacyAssets}
         />,
+      );
+    }
+
+    if (ptxPerpsLiveAppMobile?.enabled) {
+      sections.push(
+        <Box key="perps" px={6}>
+          <PortfolioPerpsEntryPoint />
+        </Box>,
       );
     }
 
@@ -188,6 +192,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     goToAnalyticsAllocations,
     shouldDisplayOperationsList,
     shouldAddBottomPaddingForLegacyAssets,
+    ptxPerpsLiveAppMobile?.enabled,
   ]);
 
   return (
@@ -199,7 +204,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
           onFlatListRef={handleFlatListRef}
           data={data}
           renderItem={renderItem<React.JSX.Element>}
-          keyExtractor={(_: unknown, index: number) => String(index)}
+          keyExtractor={(item: React.JSX.Element, index: number) => String(item.key ?? index)}
           showsVerticalScrollIndicator={false}
           testID={showAssets ? "PortfolioAccountsList" : "PortfolioEmptyList"}
           useSafeArea={!shouldDisplayWallet40MainNav}


### PR DESCRIPTION


<img width="1434" height="916" alt="image" src="https://github.com/user-attachments/assets/e7437b7d-4454-4af0-a936-625469ef4b2f" />




### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio home screen layout ordering on both Desktop and Mobile (Wallet 4.0)
      - Perpetuals entry point visibility when feature flag is off (mobile: empty row removed)
      - FlatList section reconciliation on mobile (stable keys)

### 📝 Description

**Problem**: The Perpetuals entry point was positioned between "Explore the market" and "Asset allocation" on the portfolio home screen. Product/design wants it moved below Asset Allocation to better match the information hierarchy.

**Solution**:
- **Desktop (LLD)**: Moved `<PerpsEntryPoint />` after `<Assets />` / `<AssetDistribution />` in `PortfolioView.tsx`
- **Mobile (LLM)**: Moved perps section push after the assets block in `PortfolioScreen`. Additionally:
  - Gated the section push on `ptxPerpsLiveAppMobile` flag to avoid rendering an empty padded row when the feature is off
  - Improved `keyExtractor` to use stable React element keys instead of index-only (prevents unnecessary remounts on reorder)
  - Fixed internal spacing from `mt={2}` (8px) to `mt={3}` (12px) to match Figma's `spacing/12` token

**Scope**: Wallet 4.0 paths only — legacy portfolio layouts are intentionally unchanged.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **Figma**: [Perps Production • Wallet](https://www.figma.com/design/MvRovJZb3026njxHWgjR8L/Perps-Production-%E2%80%A2-Wallet?node-id=8452-207483)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)