### PR TITLE
[LWDM] Serialize DMK APDU exchanges per Speculos base URL

### DIFF
--- a/e2e/mobile/page/trade/deviceValidation.page.ts
+++ b/e2e/mobile/page/trade/deviceValidation.page.ts
@@ -34,24 +34,4 @@ export default class DeviceValidationPage extends CommonPage {
   async expectFees(fees: string) {
     await detoxExpect(this.validationFees()).toHaveText(fees);
   }
-
-  @Step("Wait for swap device validation and retry")
-  async waitDeviceValidationAndRetry() {
-    const WAIT_TIMEOUT = 30000;
-    const CHECK_INTERVAL = 1000;
-    const startTime = Date.now();
-
-    while (Date.now() - startTime < WAIT_TIMEOUT) {
-      if (await IsIdVisible(this.validationAmountId, 100)) {
-        return;
-      }
-      if (await IsIdVisible(this.proceedButtonId, 100)) {
-        await tapById(this.proceedButtonId);
-        return;
-      }
-      await delay(CHECK_INTERVAL);
-    }
-
-    throw new Error(`Device validation timed out after ${WAIT_TIMEOUT / 1000} seconds.`);
-  }
 }

--- a/e2e/mobile/specs/swap/otherTestCases/swapDexNativeFlow.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDexNativeFlow.ts
@@ -55,7 +55,6 @@ export function runSwapDexNativeFlow(
       await app.swapLiveApp.tapExecuteSwapOnStepApproval();
       await app.send.summaryContinue();
 
-      await app.deviceValidation.waitDeviceValidationAndRetry();
       await app.swap.verifyAmountsAndAcceptSwap(swap, Number(amountToSwap).toFixed(8));
       await app.swap.waitForSwapHeaderCompleted();
     });

--- a/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.test.ts
+++ b/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.test.ts
@@ -105,8 +105,14 @@ afterEach(() => {
   jest.clearAllMocks();
   listenSubject = new Subject<DiscoveredDevice[]>();
   fakeDmk.listenToAvailableDevices.mockImplementation(() => listenSubject.asObservable());
+  fakeDmk.sendApdu = jest.fn();
   // Clear the static cache between tests
   DeviceManagementKitTransportSpeculos["byBase"].clear();
+  (
+    DeviceManagementKitTransportSpeculos as unknown as {
+      exchangeTailByBase: Map<string, Promise<unknown>>;
+    }
+  ).exchangeTailByBase.clear();
 });
 
 describe("DeviceManagementKitTransportSpeculos", () => {
@@ -161,11 +167,12 @@ describe("DeviceManagementKitTransportSpeculos", () => {
   });
 
   it("exchange() sends an APDU and returns the full response buffer", async () => {
-    // given
-    fakeDmk.sendApdu.mockResolvedValue({
+    // given — capture impl before open() wraps dmk.sendApdu with the per-base queue
+    const sendImpl = jest.fn().mockResolvedValue({
       data: Uint8Array.from([0x90]),
       statusCode: new Uint8Array([0x00]),
     });
+    fakeDmk.sendApdu = sendImpl;
 
     const transport = await openTransport();
     const apdu = Buffer.from([0x00, 0x01]);
@@ -174,7 +181,7 @@ describe("DeviceManagementKitTransportSpeculos", () => {
     const resp = await transport.exchange(apdu);
 
     // then
-    expect(fakeDmk.sendApdu).toHaveBeenCalledWith({
+    expect(sendImpl).toHaveBeenCalledWith({
       sessionId: "session-1",
       apdu: new Uint8Array(apdu.buffer, apdu.byteOffset, apdu.byteLength),
     });
@@ -183,8 +190,9 @@ describe("DeviceManagementKitTransportSpeculos", () => {
 
   it("propagates errors from exchange() when sendApdu fails after retry", async () => {
     // given
+    const sendImpl = jest.fn().mockRejectedValue(new Error("apdu-failed"));
+    fakeDmk.sendApdu = sendImpl;
     const transport = await openTransport();
-    fakeDmk.sendApdu.mockRejectedValue(new Error("apdu-failed"));
 
     // when - exchange fails, triggers session reset and retry
     const exchangePromise = transport.exchange(Buffer.from([0x00]));

--- a/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
+++ b/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
@@ -45,6 +45,7 @@ type ButtonsController = {
 
 export default class SpeculosHttpTransport extends Transport {
   static readonly byBase = new Map<string, DmkEntry>();
+  private static readonly exchangeTailByBase = new Map<string, Promise<unknown>>();
   private readonly options: SpeculosHttpTransportOpts;
   private readonly baseUrl: string;
   private readonly buttonEnumToControllerInput: Record<SpeculosButton, ControllerButton> = {
@@ -154,6 +155,7 @@ export default class SpeculosHttpTransport extends Transport {
       }
     }
     this.byBase.clear();
+    this.exchangeTailByBase.clear();
   }
 
   static isSupported = async () => true;
@@ -193,14 +195,27 @@ export default class SpeculosHttpTransport extends Transport {
     return await this.getButtonClient().press(resolved);
   }
 
-  async exchange(apduCommand: Buffer): Promise<Buffer> {
+  private enqueueSerializedExchange<T>(run: () => Promise<T>): Promise<T> {
+    const key = this.baseUrl;
+    const previous = SpeculosHttpTransport.exchangeTailByBase.get(key) ?? Promise.resolve();
+    const current = previous.then(run);
+    SpeculosHttpTransport.exchangeTailByBase.set(
+      key,
+      current.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    return current;
+  }
+
+  private async exchangeOnce(apduCommand: Buffer): Promise<Buffer> {
     try {
       const { data, statusCode } = await this.dmk.sendApdu({
         sessionId: this.sessionId,
         apdu: new Uint8Array(apduCommand.buffer, apduCommand.byteOffset, apduCommand.byteLength),
       });
-      const responseBuffer = Buffer.from([...data, ...statusCode]);
-      return responseBuffer;
+      return Buffer.from([...data, ...statusCode]);
     } catch {
       const deviceManagementEntry = SpeculosHttpTransport.ensureEntry(
         this.baseUrl,
@@ -217,9 +232,12 @@ export default class SpeculosHttpTransport extends Transport {
         sessionId: this.sessionId,
         apdu: new Uint8Array(apduCommand.buffer, apduCommand.byteOffset, apduCommand.byteLength),
       });
-      const responseBuffer = Buffer.from([...data, ...statusCode]);
-      return responseBuffer;
+      return Buffer.from([...data, ...statusCode]);
     }
+  }
+
+  async exchange(apduCommand: Buffer): Promise<Buffer> {
+    return this.enqueueSerializedExchange(() => this.exchangeOnce(apduCommand));
   }
 
   async close() {

--- a/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
+++ b/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
@@ -6,10 +6,12 @@ import {
   DeviceManagementKitBuilder,
   DeviceManagementKit,
   type DiscoveredDevice,
+  LogLevel,
 } from "@ledgerhq/device-management-kit";
 import { speculosTransportFactory } from "@ledgerhq/device-transport-kit-speculos";
 import { getEnv } from "@ledgerhq/live-env";
 import { ButtonKey, deviceControllerClientFactory } from "@ledgerhq/speculos-device-controller";
+import { LedgerLiveLogger } from "./LedgerLiveLogger";
 
 export type SpeculosHttpTransportOpts = {
   apiPort?: string;
@@ -105,6 +107,7 @@ export default class SpeculosHttpTransport extends Transport {
     if (!deviceManagementEntry) {
       const deviceManagementKit = new DeviceManagementKitBuilder()
         .addTransport(speculosTransportFactory(baseUrl, true))
+        .addLogger(new LedgerLiveLogger(LogLevel.Debug))
         .build();
 
       deviceManagementEntry = {

--- a/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
+++ b/libs/live-dmk-speculos/src/transport/DeviceManagementKitTransportSpeculos.ts
@@ -30,6 +30,7 @@ type DmkEntry = {
   sessionId?: string;
   connectPromise?: Promise<void>;
   timeout: number;
+  unqueuedSendApdu?: DeviceManagementKit["sendApdu"];
 };
 
 type ControllerButton = "left" | "right" | "both";
@@ -103,6 +104,33 @@ export default class SpeculosHttpTransport extends Transport {
     return resolvedBaseUrl;
   }
 
+  private static wrapDmkSendApduWithPerBaseQueue(dmk: DeviceManagementKit, baseUrl: string) {
+    const rawSendApdu = dmk.sendApdu.bind(dmk);
+    dmk.sendApdu = async params =>
+      SpeculosHttpTransport.enqueueByBase(baseUrl, () => rawSendApdu(params));
+    return rawSendApdu;
+  }
+
+  private static enqueueByBase<T>(baseUrl: string, run: () => Promise<T>): Promise<T> {
+    const previous = SpeculosHttpTransport.exchangeTailByBase.get(baseUrl) ?? Promise.resolve();
+    const current = previous.then(run);
+    SpeculosHttpTransport.exchangeTailByBase.set(
+      baseUrl,
+      current.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    return current;
+  }
+
+  private static async awaitExchangeTail(baseUrl: string): Promise<void> {
+    const tail = SpeculosHttpTransport.exchangeTailByBase.get(baseUrl);
+    if (tail) {
+      await tail.catch(() => {});
+    }
+  }
+
   private static ensureEntry(baseUrl: string, connectionTimeoutMs: number): DmkEntry {
     let deviceManagementEntry = this.byBase.get(baseUrl);
     if (!deviceManagementEntry) {
@@ -111,9 +139,15 @@ export default class SpeculosHttpTransport extends Transport {
         .addLogger(new LedgerLiveLogger(LogLevel.Debug))
         .build();
 
+      const unqueuedSendApdu = SpeculosHttpTransport.wrapDmkSendApduWithPerBaseQueue(
+        deviceManagementKit,
+        baseUrl,
+      );
+
       deviceManagementEntry = {
         dmk: deviceManagementKit,
         timeout: connectionTimeoutMs,
+        unqueuedSendApdu,
       };
 
       this.byBase.set(baseUrl, deviceManagementEntry);
@@ -149,7 +183,11 @@ export default class SpeculosHttpTransport extends Transport {
   }
 
   static async disconnectAll(): Promise<void> {
-    for (const [, entry] of this.byBase) {
+    for (const [baseUrl, entry] of this.byBase) {
+      await SpeculosHttpTransport.awaitExchangeTail(baseUrl);
+      if (entry.unqueuedSendApdu) {
+        entry.dmk.sendApdu = entry.unqueuedSendApdu;
+      }
       if (entry.sessionId) {
         await entry.dmk.disconnect({ sessionId: entry.sessionId }).catch(() => {});
       }
@@ -165,6 +203,9 @@ export default class SpeculosHttpTransport extends Transport {
   static async open(options: SpeculosHttpTransportOpts = {}): Promise<SpeculosHttpTransport> {
     const baseUrl = this.resolveBaseFromEnv(options);
     const connectTimeoutMs = options.timeout ?? 10_000;
+
+    await SpeculosHttpTransport.awaitExchangeTail(baseUrl);
+
     const entry = this.ensureEntry(baseUrl, connectTimeoutMs);
 
     await this.ensureSession(entry);
@@ -195,20 +236,6 @@ export default class SpeculosHttpTransport extends Transport {
     return await this.getButtonClient().press(resolved);
   }
 
-  private enqueueSerializedExchange<T>(run: () => Promise<T>): Promise<T> {
-    const key = this.baseUrl;
-    const previous = SpeculosHttpTransport.exchangeTailByBase.get(key) ?? Promise.resolve();
-    const current = previous.then(run);
-    SpeculosHttpTransport.exchangeTailByBase.set(
-      key,
-      current.then(
-        () => undefined,
-        () => undefined,
-      ),
-    );
-    return current;
-  }
-
   private async exchangeOnce(apduCommand: Buffer): Promise<Buffer> {
     try {
       const { data, statusCode } = await this.dmk.sendApdu({
@@ -237,10 +264,11 @@ export default class SpeculosHttpTransport extends Transport {
   }
 
   async exchange(apduCommand: Buffer): Promise<Buffer> {
-    return this.enqueueSerializedExchange(() => this.exchangeOnce(apduCommand));
+    return this.exchangeOnce(apduCommand);
   }
 
   async close() {
+    await SpeculosHttpTransport.awaitExchangeTail(this.baseUrl);
     try {
       const s = this.eventStream;
       if (!s) return;

--- a/libs/live-dmk-speculos/src/transport/LedgerLiveLogger.ts
+++ b/libs/live-dmk-speculos/src/transport/LedgerLiveLogger.ts
@@ -1,0 +1,21 @@
+import { log } from "@ledgerhq/logs";
+import {
+  LoggerSubscriberService,
+  LogLevel,
+  LogSubscriberOptions,
+} from "@ledgerhq/device-management-kit";
+
+export class LedgerLiveLogger implements LoggerSubscriberService {
+  private readonly maxLevel: LogLevel;
+
+  constructor(level: LogLevel = LogLevel.Debug) {
+    this.maxLevel = level;
+  }
+
+  log(level: LogLevel | null, message: string, options: LogSubscriberOptions): void {
+    if (level !== null && level > this.maxLevel) {
+      return;
+    }
+    log("live-dmk-logger", message, { level, ...options });
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LW E2E tests

### 📝 Description

Fix for https://ledgerhq.atlassian.net/browse/LIVE-29047

Speculos HTTP transport reuses a single DMK session for a given base URL. Overlapping withDevice jobs could issue concurrent sendApdu calls, which led to responses being matched to the wrong request (InvalidResponseFormatError, flaky swap / DEX-native E2E).

This change adds a per–base-URL promise queue so exchange() runs strictly one APDU at a time. Button handling is unchanged (separate HTTP API). disconnectAll() clears the queue together with existing session cleanup.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- Desktop [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/24246074956)
- Mobile [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/24246088486)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
