### PR TITLE
[LWDM] refactor: migrate module-level singletons to globalThis to prevent duplication

### DIFF
--- a/libs/coin-modules/coin-bitcoin/src/config.ts
+++ b/libs/coin-modules/coin-bitcoin/src/config.ts
@@ -9,20 +9,22 @@ type BitcoinCoinConfig = {
 
 export type CoinConfig = (currencyId: string) => BitcoinCoinConfig;
 
-let coinConfig: CoinConfig | undefined;
+declare global {
+  var __ledgerCoinConfig_bitcoin: CoinConfig | undefined;
+}
 
 export const setCoinConfig = (config: CoinConfig): void => {
-  coinConfig = config;
+  globalThis.__ledgerCoinConfig_bitcoin = config;
 };
 
 export const getCoinConfig = (
   currencyId: string,
 ): BitcoinCoinConfig & { family: FamilyConfig | undefined } => {
-  if (!coinConfig) {
+  if (!globalThis.__ledgerCoinConfig_bitcoin) {
     throw new Error("Bitcoin module config not set");
   }
 
-  const coin = coinConfig(currencyId);
+  const coin = globalThis.__ledgerCoinConfig_bitcoin(currencyId);
   const family = findFamilyConfigById(currencyId);
 
   return {

--- a/libs/coin-modules/coin-casper/src/config.ts
+++ b/libs/coin-modules/coin-casper/src/config.ts
@@ -7,16 +7,18 @@ export type CasperCoinConfig = () => CurrencyConfig & {
   };
 };
 
-let coinConfig: CasperCoinConfig | undefined;
+declare global {
+  var __ledgerCoinConfig_casper: CasperCoinConfig | undefined;
+}
 
 export const setCoinConfig = (config: CasperCoinConfig): void => {
-  coinConfig = config;
+  globalThis.__ledgerCoinConfig_casper = config;
 };
 
 export const getCoinConfig = (): ReturnType<CasperCoinConfig> => {
-  if (!coinConfig?.()) {
+  if (!globalThis.__ledgerCoinConfig_casper?.()) {
     throw new Error("Casper module config not set");
   }
 
-  return coinConfig();
+  return globalThis.__ledgerCoinConfig_casper();
 };

--- a/libs/coin-modules/coin-evm/src/config.ts
+++ b/libs/coin-modules/coin-evm/src/config.ts
@@ -57,16 +57,18 @@ export type EvmCoinConfig = {
 
 export type CoinConfig = (currencyId: string) => EvmCoinConfig;
 
-let coinConfig: CoinConfig | undefined;
+declare global {
+  var __ledgerCoinConfig_evm: CoinConfig | undefined;
+}
 
 export const setCoinConfig = (config: CoinConfig): void => {
-  coinConfig = config;
+  globalThis.__ledgerCoinConfig_evm = config;
 };
 
 export const getCoinConfig = (currencyId: string): EvmCoinConfig => {
-  if (!coinConfig) {
+  if (!globalThis.__ledgerCoinConfig_evm) {
     throw new Error("EVM module config not set");
   }
 
-  return coinConfig(currencyId);
+  return globalThis.__ledgerCoinConfig_evm(currencyId);
 };

--- a/libs/coin-modules/coin-icon/src/config.ts
+++ b/libs/coin-modules/coin-icon/src/config.ts
@@ -14,16 +14,18 @@ export type IconConfig = {
 
 export type IconCoinConfig = CurrencyConfig & IconConfig;
 
-let coinConfig: CoinConfig<IconCoinConfig> | undefined;
+declare global {
+  var __ledgerCoinConfig_icon: CoinConfig<IconCoinConfig> | undefined;
+}
 
 export const setCoinConfig = (config: CoinConfig<IconCoinConfig>): void => {
-  coinConfig = config;
+  globalThis.__ledgerCoinConfig_icon = config;
 };
 
 export const getCoinConfig = (): IconCoinConfig => {
-  if (!coinConfig) {
+  if (!globalThis.__ledgerCoinConfig_icon) {
     throw new MissingCoinConfig();
   }
 
-  return coinConfig();
+  return globalThis.__ledgerCoinConfig_icon();
 };

--- a/libs/coin-modules/coin-mina/src/config.ts
+++ b/libs/coin-modules/coin-mina/src/config.ts
@@ -6,16 +6,18 @@ export type MinaCoinConfig = () => CurrencyConfig & {
   };
 };
 
-let coinConfig: MinaCoinConfig | undefined;
+declare global {
+  var __ledgerCoinConfig_mina: MinaCoinConfig | undefined;
+}
 
 export const setCoinConfig = (config: MinaCoinConfig): void => {
-  coinConfig = config;
+  globalThis.__ledgerCoinConfig_mina = config;
 };
 
 export const getCoinConfig = (): ReturnType<MinaCoinConfig> => {
-  if (!coinConfig?.()) {
+  if (!globalThis.__ledgerCoinConfig_mina?.()) {
     throw new Error("Mina module config not set");
   }
 
-  return coinConfig();
+  return globalThis.__ledgerCoinConfig_mina();
 };

--- a/libs/coin-modules/coin-multiversx/src/config.ts
+++ b/libs/coin-modules/coin-multiversx/src/config.ts
@@ -11,16 +11,18 @@ export type MultiversXCoinConfig = () => CurrencyConfig & {
   };
 };
 
-let coinConfig: MultiversXCoinConfig | undefined;
+declare global {
+  var __ledgerCoinConfig_multiversx: MultiversXCoinConfig | undefined;
+}
 
 export const setCoinConfig = (config: MultiversXCoinConfig): void => {
-  coinConfig = config;
+  globalThis.__ledgerCoinConfig_multiversx = config;
 };
 
 export const getCoinConfig = (): ReturnType<MultiversXCoinConfig> => {
-  if (!coinConfig?.()) {
+  if (!globalThis.__ledgerCoinConfig_multiversx?.()) {
     throw new Error("MultiversX module config not set");
   }
 
-  return coinConfig();
+  return globalThis.__ledgerCoinConfig_multiversx();
 };

--- a/libs/coin-modules/coin-near/src/config.ts
+++ b/libs/coin-modules/coin-near/src/config.ts
@@ -10,16 +10,18 @@ export type NearCoinConfig = () => CurrencyConfig & {
   };
 };
 
-let coinConfig: NearCoinConfig | undefined;
+declare global {
+  var __ledgerCoinConfig_near: NearCoinConfig | undefined;
+}
 
 export const setCoinConfig = (config: NearCoinConfig): void => {
-  coinConfig = config;
+  globalThis.__ledgerCoinConfig_near = config;
 };
 
 export const getCoinConfig = (): ReturnType<NearCoinConfig> => {
-  if (!coinConfig?.()) {
+  if (!globalThis.__ledgerCoinConfig_near?.()) {
     throw new Error("Near module config not set");
   }
 
-  return coinConfig();
+  return globalThis.__ledgerCoinConfig_near();
 };

--- a/libs/coin-modules/coin-stacks/src/config.ts
+++ b/libs/coin-modules/coin-stacks/src/config.ts
@@ -11,16 +11,18 @@ export type StacksCoinConfig = () => CurrencyConfig & {
   };
 };
 
-let coinConfig: StacksCoinConfig | undefined;
+declare global {
+  var __ledgerCoinConfig_stacks: StacksCoinConfig | undefined;
+}
 
 export const setCoinConfig = (config: StacksCoinConfig): void => {
-  coinConfig = config;
+  globalThis.__ledgerCoinConfig_stacks = config;
 };
 
 export const getCoinConfig = (): ReturnType<StacksCoinConfig> => {
-  if (!coinConfig?.()) {
+  if (!globalThis.__ledgerCoinConfig_stacks?.()) {
     throw new Error("Stacks module config not set");
   }
 
-  return coinConfig();
+  return globalThis.__ledgerCoinConfig_stacks();
 };

--- a/libs/coin-modules/coin-ton/src/config.ts
+++ b/libs/coin-modules/coin-ton/src/config.ts
@@ -8,16 +8,18 @@ export type TonCoinConfig = () => CurrencyConfig & {
   };
 };
 
-let coinConfig: TonCoinConfig | undefined;
+declare global {
+  var __ledgerCoinConfig_ton: TonCoinConfig | undefined;
+}
 
 export const setCoinConfig = (config: TonCoinConfig): void => {
-  coinConfig = config;
+  globalThis.__ledgerCoinConfig_ton = config;
 };
 
 export const getCoinConfig = (): ReturnType<TonCoinConfig> => {
-  if (!coinConfig?.()) {
+  if (!globalThis.__ledgerCoinConfig_ton?.()) {
     throw new Error("Ton module config not set");
   }
 
-  return coinConfig();
+  return globalThis.__ledgerCoinConfig_ton();
 };

--- a/libs/coin-modules/coin-vechain/src/config.ts
+++ b/libs/coin-modules/coin-vechain/src/config.ts
@@ -3,16 +3,18 @@ import { MissingCoinConfig } from "@ledgerhq/coin-module-framework/errors";
 
 export type VechainCoinConfig = () => CurrencyConfig;
 
-let coinConfig: CoinConfig<CurrencyConfig> | undefined;
+declare global {
+  var __ledgerCoinConfig_vechain: CoinConfig<CurrencyConfig> | undefined;
+}
 
 export function setCoinConfig(config: CoinConfig<CurrencyConfig>): void {
-  coinConfig = config;
+  globalThis.__ledgerCoinConfig_vechain = config;
 }
 
 export function getCoinConfig(): CurrencyConfig {
-  if (!coinConfig) {
+  if (!globalThis.__ledgerCoinConfig_vechain) {
     throw new MissingCoinConfig();
   }
 
-  return coinConfig();
+  return globalThis.__ledgerCoinConfig_vechain();
 }

--- a/libs/ledger-live-common/src/account/recentAddresses.ts
+++ b/libs/ledger-live-common/src/account/recentAddresses.ts
@@ -12,22 +12,27 @@ export interface RecentAddressesStore {
   getAddresses(currency: string): RecentAddress[];
 }
 
-let recentAddressesStore: RecentAddressesStore | null = null;
+declare global {
+  var __ledgerRecentAddressesStore: RecentAddressesStore | undefined;
+}
 
 export function getRecentAddressesStore(): RecentAddressesStore {
-  if (recentAddressesStore === null) {
+  if (!globalThis.__ledgerRecentAddressesStore) {
     throw new Error(
       "Recent addresses store instance is null, please call function setupRecentAddressesStore in application initialization",
     );
   }
-  return recentAddressesStore;
+  return globalThis.__ledgerRecentAddressesStore;
 }
 
 export function setupRecentAddressesStore(
   addressesByCurrency: RecentAddressesCache,
   onAddAddressComplete: (addressesByCurrency: RecentAddressesCache) => void,
 ): void {
-  recentAddressesStore = new RecentAddressesStoreImpl(addressesByCurrency, onAddAddressComplete);
+  globalThis.__ledgerRecentAddressesStore = new RecentAddressesStoreImpl(
+    addressesByCurrency,
+    onAddAddressComplete,
+  );
 }
 
 class RecentAddressesStoreImpl implements RecentAddressesStore {

--- a/libs/ledger-live-common/src/bridge/useBridgeTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/useBridgeTransaction.ts
@@ -392,8 +392,9 @@ const useBridgeTransaction = <T extends Transaction = Transaction>(
   const bridgeError = errorAccount || errorStatus;
 
   useEffect(() => {
-    if (bridgeError && globalOnBridgeError) {
-      globalOnBridgeError(bridgeError);
+    const onBridgeError = getGlobalOnBridgeError();
+    if (bridgeError && onBridgeError) {
+      onBridgeError(bridgeError);
     }
   }, [bridgeError]);
 
@@ -413,14 +414,16 @@ const useBridgeTransaction = <T extends Transaction = Transaction>(
 
 type GlobalBridgeErrorFn = null | ((error: any) => void);
 
-let globalOnBridgeError: GlobalBridgeErrorFn = null;
+declare global {
+  var __ledgerGlobalOnBridgeError: GlobalBridgeErrorFn | undefined;
+}
 
 // allows to globally set a bridge error catch function in order to log it / report to sentry / ...
 export function setGlobalOnBridgeError(f: GlobalBridgeErrorFn): void {
-  globalOnBridgeError = f;
+  globalThis.__ledgerGlobalOnBridgeError = f;
 }
 export function getGlobalOnBridgeError(): GlobalBridgeErrorFn {
-  return globalOnBridgeError;
+  return globalThis.__ledgerGlobalOnBridgeError ?? null;
 }
 
 export default useBridgeTransaction;

--- a/libs/ledger-live-common/src/wallet-api/version.ts
+++ b/libs/ledger-live-common/src/wallet-api/version.ts
@@ -3,11 +3,15 @@
 // it's like we do for enabling coins.
 // beware this must be set in the first import of the end project.
 import invariant from "invariant";
-let version = "";
+
+declare global {
+  var __ledgerWalletAPIVersion: string | undefined;
+}
+
 export function getWalletAPIVersion(): string {
-  invariant(version, "setWalletAPIVersion must be called before anything else.");
-  return version;
+  invariant(globalThis.__ledgerWalletAPIVersion, "setWalletAPIVersion must be called before anything else.");
+  return globalThis.__ledgerWalletAPIVersion;
 }
 export function setWalletAPIVersion(v: string): void {
-  version = v;
+  globalThis.__ledgerWalletAPIVersion = v;
 }

--- a/libs/ledgerjs/packages/errors/src/helpers.ts
+++ b/libs/ledgerjs/packages/errors/src/helpers.ts
@@ -3,15 +3,26 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-prototype-builtins */
 
-const errorClasses = {};
-const deserializers = {};
+declare global {
+  var __ledgerErrorClasses: Record<string, ErrorConstructor> | undefined;
+  var __ledgerErrorDeserializers: Record<string, (obj: any) => any> | undefined;
+}
+
+function getErrorClasses(): Record<string, ErrorConstructor> {
+  return (globalThis.__ledgerErrorClasses ??= {});
+}
+
+function getDeserializers(): Record<string, (obj: any) => any> {
+  return (globalThis.__ledgerErrorDeserializers ??= {});
+}
 
 export const addCustomErrorDeserializer = (name: string, deserializer: (obj: any) => any): void => {
-  deserializers[name] = deserializer;
+  getDeserializers()[name] = deserializer;
 };
 
-export interface LedgerErrorConstructor<F extends { [key: string]: unknown }>
-  extends ErrorConstructor {
+export interface LedgerErrorConstructor<
+  F extends { [key: string]: unknown },
+> extends ErrorConstructor {
   new (message?: string, fields?: F, options?: any): Error & F;
   (message?: string, fields?: F, options?: any): Error & F;
   readonly prototype: Error & F;
@@ -52,7 +63,7 @@ export const createCustomErrorClass = <
     }
   }
 
-  errorClasses[name] = CustomErrorClass;
+  getErrorClasses()[name] = CustomErrorClass as unknown as ErrorConstructor;
 
   return CustomErrorClass as unknown as T;
 };
@@ -78,11 +89,11 @@ export const deserializeError = (object: any): Error | undefined => {
     let error;
     if (typeof object.name === "string") {
       const { name } = object;
-      const des = deserializers[name];
+      const des = getDeserializers()[name];
       if (des) {
         error = des(object);
       } else {
-        let constructor = name === "Error" ? Error : errorClasses[name];
+        let constructor = name === "Error" ? Error : getErrorClasses()[name];
 
         if (!constructor) {
           console.warn("deserializing an unknown class '" + name + "'");

--- a/libs/ledgerjs/packages/logs/src/index.ts
+++ b/libs/ledgerjs/packages/logs/src/index.ts
@@ -32,8 +32,19 @@ export interface Log {
 export type Unsubscribe = () => void;
 export type Subscriber = (arg0: Log) => void;
 
-let id = 0;
-const subscribers: Subscriber[] = [];
+declare global {
+  var __ledgerLogsId: number | undefined;
+  var __ledgerLogsSubscribers: Subscriber[] | undefined;
+}
+
+function nextLogId(): string {
+  globalThis.__ledgerLogsId = (globalThis.__ledgerLogsId ?? 0) + 1;
+  return String(globalThis.__ledgerLogsId);
+}
+
+function getSubscribers(): Subscriber[] {
+  return (globalThis.__ledgerLogsSubscribers ??= []);
+}
 
 /**
  * Logs something
@@ -44,7 +55,7 @@ const subscribers: Subscriber[] = [];
 export const log = (type: LogType, message?: string, data?: LogData) => {
   const obj: Log = {
     type,
-    id: String(++id),
+    id: nextLogId(),
     date: new Date(),
   };
   if (message) obj.message = message;
@@ -73,7 +84,7 @@ export const trace = ({
 }) => {
   const obj: Log = {
     type,
-    id: String(++id),
+    id: nextLogId(),
     date: new Date(),
   };
 
@@ -169,22 +180,24 @@ export class LocalTracer {
  * @return a function that can be called to unsubscribe the listener
  */
 export const listen = (cb: Subscriber): Unsubscribe => {
-  subscribers.push(cb);
+  getSubscribers().push(cb);
   return () => {
-    const i = subscribers.indexOf(cb);
+    const subs = getSubscribers();
+    const i = subs.indexOf(cb);
 
     if (i !== -1) {
-      // equivalent of subscribers.splice(i, 1) // https://twitter.com/Rich_Harris/status/1125850391155965952
-      subscribers[i] = subscribers[subscribers.length - 1];
-      subscribers.pop();
+      // equivalent of subs.splice(i, 1) // https://twitter.com/Rich_Harris/status/1125850391155965952
+      subs[i] = subs[subs.length - 1];
+      subs.pop();
     }
   };
 };
 
 function dispatch(log: Log) {
-  for (let i = 0; i < subscribers.length; i++) {
+  const subs = getSubscribers();
+  for (let i = 0; i < subs.length; i++) {
     try {
-      subscribers[i](log);
+      subs[i](log);
     } catch (e) {
       console.error(e);
     }

--- a/libs/live-dmk-desktop/src/hooks/useDeviceManagementKit.tsx
+++ b/libs/live-dmk-desktop/src/hooks/useDeviceManagementKit.tsx
@@ -12,24 +12,26 @@ import { LocalTracer } from "@ledgerhq/logs";
 
 const tracer = new LocalTracer("live-dmk-tracer", { function: "useDeviceManagementKit" });
 
-let instance: DeviceManagementKit | null = null;
+declare global {
+  var __ledgerDmkDesktopInstance: DeviceManagementKit | undefined;
+}
 
 export const getDeviceManagementKit = (): DeviceManagementKit => {
-  if (!instance) {
+  if (!globalThis.__ledgerDmkDesktopInstance) {
     const userId = getEnv("USER_ID");
     const firmwareDistributionSalt = UserHashService.compute(userId).firmwareSalt;
     tracer.trace("Initialize DeviceManagementKit", {
       firmwareDistributionSalt,
     });
 
-    instance = new DeviceManagementKitBuilder()
+    globalThis.__ledgerDmkDesktopInstance = new DeviceManagementKitBuilder()
       .addTransport(webHidTransportFactory)
       .addLogger(new LedgerLiveLogger(LogLevel.Debug))
       .addConfig({ firmwareDistributionSalt })
       .build();
   }
 
-  return instance;
+  return globalThis.__ledgerDmkDesktopInstance;
 };
 
 export const DeviceManagementKitContext = createContext<DeviceManagementKit | null>(null);

--- a/libs/live-dmk-mobile/src/hooks/useDeviceManagementKit.tsx
+++ b/libs/live-dmk-mobile/src/hooks/useDeviceManagementKit.tsx
@@ -12,23 +12,25 @@ import { LocalTracer } from "@ledgerhq/logs";
 
 const tracer = new LocalTracer("live-dmk-tracer", { function: "useDeviceManagementKit" });
 
-let instance: DeviceManagementKit | null = null;
+declare global {
+  var __ledgerDmkMobileInstance: DeviceManagementKit | undefined;
+}
 
 export const getDeviceManagementKit = (): DeviceManagementKit => {
-  if (!instance) {
+  if (!globalThis.__ledgerDmkMobileInstance) {
     const userId = getEnv("USER_ID");
     const firmwareDistributionSalt = UserHashService.compute(userId).firmwareSalt;
     tracer.trace("Initialize DeviceManagementKit", {
       firmwareDistributionSalt,
     });
-    instance = new DeviceManagementKitBuilder()
+    globalThis.__ledgerDmkMobileInstance = new DeviceManagementKitBuilder()
       .addTransport(RNBleTransportFactory)
       .addTransport(RNHidTransportFactory)
       .addLogger(new LedgerLiveLogger(LogLevel.Debug))
       .addConfig({ firmwareDistributionSalt })
       .build();
   }
-  return instance;
+  return globalThis.__ledgerDmkMobileInstance;
 };
 
 const DeviceManagementKitContext = createContext<DeviceManagementKit | null>(null);


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - coin-modules
  - errors
  - logs
  - dmk singleton

### 📝 Description

Module-level `let` bindings become duplicated when a package is evaluated more than once — e.g. when ESM and CJS copies coexist in the same bundle, or when coin modules are lazy-loaded. Each evaluation gets its own binding, so app-init writes to copy A while features read from a stale copy B.

Migrate all affected singletons to `globalThis` under namespaced `__ledger*` keys, matching the pattern already used in `@ledgerhq/cryptoassets/state`.

Changed files:
- `@ledgerhq/live-common` — recentAddresses store, wallet-api version, globalOnBridgeError bridge error handler
- `coin-bitcoin`, `coin-evm` — setCoinConfig/getCoinConfig (currencyId-based)
- `coin-casper`, `coin-mina`, `coin-near`, `coin-stacks`, `coin-ton`, `coin-multiversx`, `coin-icon`, `coin-vechain` — setCoinConfig/getCoinConfig (thunk-based, manually implemented without buildCoinConfig)
- `@ledgerhq/logs` — subscribers array and id counter
- `@ledgerhq/errors` — errorClasses and deserializers registries
- `@ledgerhq/live-dmk-desktop`, `@ledgerhq/live-dmk-mobile` — DMK singleton instance

Coins using `buildCoinConfig` from `@ledgerhq/coin-module-framework` are intentionally left unchanged.

### ❓ Context

- **JIRA or GitHub link**:
- **ADR link (if any)**:

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
