### PR TITLE
[LWD] fix(desktop): show legacy analytics opt-in prompt when CMP flag is on

### DIFF
--- a/.changeset/brisk-onboarding-drawers-open.md
+++ b/.changeset/brisk-onboarding-drawers-open.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Show legacy analytics opt-in drawer on onboarding when the analytics opt-in CMP feature flag is enabled

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
@@ -29,7 +29,6 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
   const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
   const isTrackingEnabled = useSelector(trackingEnabledSelector);
   const lldAnalyticsOptInPromptFlag = useFeature("lldAnalyticsOptInPrompt");
-  const analyticsOptInCmpFlag = useFeature("analyticsOptIn");
   const shouldWeTrack = isTrackingEnabled || !hasSeenAnalyticsOptInPrompt;
 
   const dispatch = useDispatch();
@@ -63,12 +62,10 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
 
   const isFlagEnabled = useMemo(
     () =>
-      !analyticsOptInCmpFlag?.enabled &&
       isEntryPointIncludedInFlagParams &&
       lldAnalyticsOptInPromptFlag?.enabled &&
       (!hasSeenAnalyticsOptInPrompt || entryPoint === EntryPoint.onboarding),
     [
-      analyticsOptInCmpFlag?.enabled,
       lldAnalyticsOptInPromptFlag,
       hasSeenAnalyticsOptInPrompt,
       entryPoint,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new tests; hook logic change only._
- [x] **Impact of the changes:**
      - Onboarding welcome: **Get started** (and related CTAs) when `lldAnalyticsOptInPrompt` is enabled
      - Legacy analytics opt-in side drawer vs. `analyticsOptIn` CMP flag interaction

### 📝 Description

**Problem:** `useAnalyticsOptInPrompt` required the `analyticsOptIn` (CMP) feature flag to be **off** before `isFeatureFlagsAnalyticsPrefDisplayed` could be true. With CMP enabled, onboarding never showed the legacy `lldAnalyticsOptInPrompt` drawer even when that flow was intended.

**Solution:** Remove the `!analyticsOptInCmpFlag?.enabled` guard so eligibility depends on `lldAnalyticsOptInPrompt`, entry points, and `hasSeenAnalyticsOptInPrompt` / onboarding exception—matching the goal of showing the legacy drawer on onboarding while CMP can stay on.

<table>
<tr>
 <td>before
 <td>after
<tr>
 <td><video src="https://github.com/user-attachments/assets/45d311d1-5463-4614-bb8b-dab7aae72d23"/>
 <td><video src="https://github.com/user-attachments/assets/e17aa221-c49e-4d76-9e9a-9e4748f68f7c"/>
</table>

### ❓ Context

- **JIRA or GitHub link:** _Add ticket link if applicable_

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)