### PR TITLE
chore(tools): share /e2e-desktop-add-or-update skill across tools

### DIFF
--- a/.claude/skills/e2e-desktop-add-or-update/SKILL.md
+++ b/.claude/skills/e2e-desktop-add-or-update/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: e2e-desktop-add-or-update
+description: Add E2E tests for new coins or update existing Playwright tests for ledger-live-desktop. Use when the user wants to add send/receive e2e tests for a new cryptocurrency, update test configurations, or work with Speculos device simulator.
+---
+
+[Read](/e2e/desktop/skills/add-or-update-e2e.md)

--- a/.cursor/skills/e2e-desktop-add-or-update/SKILL.md
+++ b/.cursor/skills/e2e-desktop-add-or-update/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: e2e-desktop-add-or-update
+description: Add E2E tests for new coins or update existing Playwright tests for ledger-live-desktop. Use when the user wants to add send/receive e2e tests for a new cryptocurrency, update test configurations, or work with Speculos device simulator.
+---
+
+[Read](/e2e/desktop/skills/add-or-update-e2e.md)

--- a/e2e/desktop/skills/README.md
+++ b/e2e/desktop/skills/README.md
@@ -1,0 +1,1 @@
+This directory contains skills relevant to the parent directory

--- a/e2e/desktop/skills/add-or-update-e2e.md
+++ b/e2e/desktop/skills/add-or-update-e2e.md
@@ -1,8 +1,3 @@
----
-name: e2e
-description: Add E2E tests for new coins or update existing Playwright tests for ledger-live-desktop. Use when the user wants to add send/receive e2e tests for a new cryptocurrency, update test configurations, or work with Speculos device simulator.
----
-
 # E2E Desktop Testing Agent
 
 This agent guides you through adding or updating E2E tests for ledger-live-desktop using Playwright and Speculos.
@@ -46,7 +41,7 @@ When the user wants to add e2e tests for a new coin, follow these steps and **as
 
 ### Step 1: Add Network enum
 
-**File:** `libs/ledger-live-common/src/e2e/enum/Network.ts`
+[File](/libs/ledger-live-common/src/e2e/enum/Network.ts)
 
 ```typescript
 NEWCOIN = "NewCoin",
@@ -54,7 +49,7 @@ NEWCOIN = "NewCoin",
 
 ### Step 2: Add AppInfos
 
-**File:** `libs/ledger-live-common/src/e2e/enum/AppInfos.ts`
+[File](/libs/ledger-live-common/src/e2e/enum/AppInfos.ts)
 
 ```typescript
 static readonly NEWCOIN = new AppInfos("NewCoin");
@@ -62,7 +57,7 @@ static readonly NEWCOIN = new AppInfos("NewCoin");
 
 ### Step 3: Add Currency
 
-**File:** `libs/ledger-live-common/src/e2e/enum/Currency.ts`
+[File](/libs/ledger-live-common/src/e2e/enum/Currency.ts)
 
 **Ask user for:** name, ticker, currency_id
 
@@ -72,7 +67,7 @@ static readonly NEWCOIN = new Currency("NewCoin", "TICKER", "currency_id", AppIn
 
 ### Step 4: Add Accounts
 
-**File:** `libs/ledger-live-common/src/e2e/enum/Account.ts`
+[File](/libs/ledger-live-common/src/e2e/enum/Account.ts)
 
 **Ask user for:** account derivation path (BIP44)
 
@@ -83,7 +78,7 @@ static readonly NEWCOIN_2 = new Account(Currency.NEWCOIN, "NewCoin 2", 1, "44'/x
 
 ### Step 5: Add family file (if new family)
 
-**File:** `libs/ledger-live-common/src/e2e/families/newcoin.ts`
+[File](/libs/ledger-live-common/src/e2e/families/newcoin.ts)
 
 **Ask user:** "Does this coin belong to an existing family (evm, bitcoin, cosmos...)?"
 
@@ -98,7 +93,7 @@ import { getSendEvents, containsSubstringInEvent } from "../speculos";
 
 ### Step 6: Add to speculos.ts
 
-**File:** `libs/ledger-live-common/src/e2e/speculos.ts`
+[File](libs/ledger-live-common/src/e2e/speculos.ts)
 
 **6a. Add to `specs` object:**
 
@@ -123,7 +118,7 @@ case Currency.NEWCOIN.id:
 
 ### Step 7: Add test case to spec
 
-**File:** `e2e/desktop/tests/specs/send.tx.spec.ts`
+[File](e2e/desktop/tests/specs/send.tx.spec.ts)
 
 **Ask user for:** valid unique xray ticket number
 


### PR DESCRIPTION
These changes present an example for how we can 1) locate documentation (including skills) close to where it is used and 2) share skills between different agent tools.

### Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-28637
- **ADR**: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6957301977

### Details

- [x] Provide all agent tools (Claude and Cursor for now) with the `/e2e-desktop-add-or-update` skill
- [x] Avoid duplicating the body of the skill
- [x] Locate the body of the skill within the relevant directory

#### Also done

- [x] Prefer markdown links when referencing specific files
- [x] Prefer specifying "desktop" in the skill name

### Review notes

- This is a POC so please test it (does the skill still work in Cursor? does it also work in Claude?)
- Consider whether this is a pattern we'd like to see applied consistently across the repo

#### Skill in Claude ✅ 

<img width="1372" height="327" alt="Screenshot 2026-04-10 at 16 53 17" src="https://github.com/user-attachments/assets/2332a849-33a8-4022-8906-5f48f1f53666" />

#### Skill in Cursor ✅ 

<img width="359" height="389" alt="Screenshot 2026-04-10 at 16 50 32" src="https://github.com/user-attachments/assets/95772a8d-33ca-4ca3-b77d-351a37513acc" />

### Further considerations

#### Do we need to duplicate the skill directory and file across `.claude/skills` and `.cursor/skills`?

Maybe we can move all skills to `/skills` and include a line in AGENT.md to let agent tools know about this convention. This would simplify things further. 

Let's leave this experiment for the future.