### PR TITLE
test(desktop): add language change E2E tests

### DIFF
--- a/.changeset/calm-languages-e2e.md
+++ b/.changeset/calm-languages-e2e.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add Language change E2E coverage in Settings (Playwright)

--- a/e2e/desktop/tests/page/settings.page.ts
+++ b/e2e/desktop/tests/page/settings.page.ts
@@ -26,6 +26,11 @@ export class SettingsPage extends AppPage {
   readonly languageSelector = this.page.locator(
     "[data-testid='setting-language-dropDown'] .select__value-container",
   );
+  private languageOptions = this.page.locator(".select__option");
+  private generalTab = this.page.getByTestId("settings-display-tab");
+  private languageRow = this.page.getByTestId("setting-language-dropDown");
+  private counterValueRow = this.page.getByTestId("setting-countervalue-dropDown");
+  private themeRow = this.page.getByTestId("setting-theme-dropDown");
   readonly themeSelector = this.page.locator(
     "[data-testid='setting-theme-dropDown'] .select__value-container",
   );
@@ -51,6 +56,48 @@ export class SettingsPage extends AppPage {
   @step("Expect counter value to be $0")
   async expectCounterValue(currency: string) {
     await expect(this.counterValueSelector).toHaveText(currency);
+  }
+
+  @step("Change language to $0")
+  async changeLanguage(languageLabel: string) {
+    await this.languageSelector.click();
+    await this.languageOptions.filter({ hasText: languageLabel }).click();
+  }
+
+  @step("Expect language to be selected: $0")
+  async expectLanguageSelected(languageLabel: string) {
+    await expect(this.languageSelector).toHaveText(languageLabel);
+  }
+
+  @step("Expect General settings tab to show $0")
+  async expectGeneralTabLabel(text: string) {
+    await expect(this.generalTab).toContainText(text);
+  }
+
+  @step("Expect language row title to contain $0")
+  async expectLanguageRowTitle(title: string) {
+    await expect(this.languageRow).toContainText(title);
+  }
+
+  @step("Expect language row title to be $0")
+  async expectLanguageRowTranslation(text: string) {
+    await expect(this.languageRow).toContainText(text);
+  }
+
+  @step("Expect counter value row title to be $0")
+  async expectCounterValueRowTranslation(text: string) {
+    await expect(this.counterValueRow).toContainText(text);
+  }
+
+  @step("Expect theme row title to be $0")
+  async expectThemeRowTranslation(text: string) {
+    await expect(this.themeRow).toContainText(text);
+  }
+
+  @step("Expect counter value row to contain characters matching $0")
+  async expectCounterValueRowCharacterSet(regex: RegExp) {
+    const text = await this.counterValueRow.innerText();
+    expect(text).toMatch(regex);
   }
 
   @step("Click 'Hide Empty Token Accounts' toggle")

--- a/e2e/desktop/tests/page/settings.page.ts
+++ b/e2e/desktop/tests/page/settings.page.ts
@@ -26,15 +26,12 @@ export class SettingsPage extends AppPage {
   readonly languageSelector = this.page.locator(
     "[data-testid='setting-language-dropDown'] .select__value-container",
   );
-  private languageOptions = this.page.locator(".select__option");
-  private generalTab = this.page.getByTestId("settings-display-tab");
-  private languageRow = this.page.getByTestId("setting-language-dropDown");
-  private counterValueRow = this.page.getByTestId("setting-countervalue-dropDown");
-  private themeRow = this.page.getByTestId("setting-theme-dropDown");
-  readonly themeSelector = this.page.locator(
-    "[data-testid='setting-theme-dropDown'] .select__value-container",
-  );
-  private hideEmptyTokenAccountsToggle = this.page.getByTestId("hideEmptyTokenAccounts");
+  readonly languageOptions = this.page.locator("div.select__option");
+  readonly generalTab = this.page.getByTestId("settings-display-tab");
+  readonly languageRow = this.page.getByTestId("setting-language-dropDown");
+  readonly counterValueRow = this.page.getByTestId("setting-countervalue-dropDown");
+  readonly themeRow = this.page.getByTestId("setting-theme-dropDown");
+  readonly hideEmptyTokenAccountsToggle = this.page.getByTestId("hideEmptyTokenAccounts");
 
   @step("Go to Settings Accounts tab")
   async goToAccountsTab() {
@@ -74,11 +71,6 @@ export class SettingsPage extends AppPage {
     await expect(this.generalTab).toContainText(text);
   }
 
-  @step("Expect language row title to contain $0")
-  async expectLanguageRowTitle(title: string) {
-    await expect(this.languageRow).toContainText(title);
-  }
-
   @step("Expect language row title to be $0")
   async expectLanguageRowTranslation(text: string) {
     await expect(this.languageRow).toContainText(text);
@@ -96,8 +88,7 @@ export class SettingsPage extends AppPage {
 
   @step("Expect counter value row to contain characters matching $0")
   async expectCounterValueRowCharacterSet(regex: RegExp) {
-    const text = await this.counterValueRow.innerText();
-    expect(text).toMatch(regex);
+    await expect(this.counterValueRow).toContainText(regex);
   }
 
   @step("Click 'Hide Empty Token Accounts' toggle")

--- a/e2e/desktop/tests/specs/settings.spec.ts
+++ b/e2e/desktop/tests/specs/settings.spec.ts
@@ -213,3 +213,59 @@ test.describe("Settings - Help tab", () => {
     },
   );
 });
+
+const languageTestData = [
+  {
+    lang: "Français",
+    generalTabLabel: "Général",
+    characterSet: /[\u00C0-\u024F]/,
+    languageLabel: "Langue d\u2019affichage",
+    counterValueLabel: "Monnaie pr\u00e9f\u00e9r\u00e9e",
+    themeLabel: "Mode",
+  },
+  {
+    lang: "Русский",
+    generalTabLabel: "Общие",
+    characterSet: /[\u0400-\u04FF]/,
+    languageLabel: "Язык",
+    counterValueLabel: "Предпочтительная валюта",
+    themeLabel: "Тема оформления",
+  },
+  {
+    lang: "日本語",
+    generalTabLabel: "一般",
+    characterSet: /[\u4E00-\u9FFF]/,
+    languageLabel: "表示言語",
+    counterValueLabel: "優先する通貨",
+    themeLabel: "テーマ",
+  },
+];
+
+test.describe("Language change", () => {
+  test.use({
+    teamOwner: Team.WALLET_XP,
+    userdata: "skip-onboarding-with-last-seen-device",
+  });
+
+  for (const l10n of languageTestData) {
+    test(
+      `Settings — change app language to ${l10n.lang}`,
+      {
+        tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+        annotation: { type: "TMS", description: "B2CQA-2344" },
+      },
+      async ({ app }) => {
+        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+        await app.mainNavigation.openSettings();
+        await app.settings.changeLanguage(l10n.lang);
+        await app.settings.expectLanguageSelected(l10n.lang);
+        await app.settings.expectGeneralTabLabel(l10n.generalTabLabel);
+        await app.settings.expectCounterValueRowCharacterSet(l10n.characterSet);
+        await app.settings.expectLanguageRowTranslation(l10n.languageLabel);
+        await app.settings.expectCounterValueRowTranslation(l10n.counterValueLabel);
+        await app.settings.expectThemeRowTranslation(l10n.themeLabel);
+      },
+    );
+  }
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop E2E: Settings → General tab, language dropdown and localized row labels (EN, FR, RU, JA scenarios)
  - Playwright `SettingsPage` helpers for changing language and asserting translations

### 📝 Description

**Problem:** App language changes in Settings were not covered by automated Desktop E2E tests.

**Solution:** Adds a `Language change` Playwright suite that switches the display language for several locales and asserts the selector and row labels. Extends `SettingsPage` with helpers (`changeLanguage`, `expectLanguageSelected`, `expectLanguageRowTranslation`, etc.).

**CI execution:** [Desktop E2E workflow run #24253552950](https://github.com/LedgerHQ/ledger-live/actions/runs/24253552950) (run on this branch).
Wallet 40 exec: https://github.com/LedgerHQ/ledger-live/actions/runs/24253827644

### ❓ Context

- **JIRA or GitHub link**: [QAA-1142](https://ledgerhq.atlassian.net/browse/QAA-1142)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1142]: https://ledgerhq.atlassian.net/browse/QAA-1142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ