### PR TITLE
[LWDM] fix(analytics): Wallet V4 legacy opt-in gate; consent fresh vs reconfirm by hasSeenAnalyticsOptInPrompt

### DIFF
--- a/.changeset/quiet-badgers-gate.md
+++ b/.changeset/quiet-badgers-gate.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+- **Desktop:** Do not auto-open the legacy portfolio analytics opt-in when Wallet V4 is on (consent stays on `/`).
+- **Desktop (`AnalyticsConsentDialog`):** Offer the home consent flow when **`hasSeenAnalyticsOptInPrompt` is false**, or when privacy / consent renewal requires it (`analyticsOptIn` on, onboarding complete).
+- **Common + desktop + mobile:** On consent renewal, choose **fresh** vs **reconfirm** using **`hasSeenAnalyticsOptInPrompt`**, not analytics sharing state.
+- **Desktop (Developer QA screen):** Show `hasSeenAnalyticsOptInPrompt` with **Mark not seen**; remove the old full-reset control from that screen.

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__tests__/useAnalyticsConsentDialogViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/__tests__/useAnalyticsConsentDialogViewModel.test.ts
@@ -47,6 +47,7 @@ describe("useAnalyticsConsentDialogViewModel", () => {
     settings: {
       ...INITIAL_STATE,
       hasCompletedOnboarding: true,
+      hasSeenAnalyticsOptInPrompt: true,
       shareAnalytics: true,
       sharePersonalizedRecommandations: true,
       analyticsConsentInfo: {
@@ -77,7 +78,7 @@ describe("useAnalyticsConsentDialogViewModel", () => {
     expect(result.current.isDialogOpen).toBe(false);
   });
 
-  it("opens consentReconfirm when renewal is needed, policy is current, and share analytics is on", async () => {
+  it("opens consentReconfirm when renewal is needed, policy is current, and user already saw legacy opt-in", async () => {
     const { result } = renderHook(() => useAnalyticsConsentDialogViewModel(), {
       initialState: consentReconfirmState,
     });
@@ -102,6 +103,7 @@ describe("useAnalyticsConsentDialogViewModel", () => {
           settings: {
             ...INITIAL_STATE,
             hasCompletedOnboarding: true,
+            hasSeenAnalyticsOptInPrompt: true,
             shareAnalytics: false,
             sharePersonalizedRecommandations: false,
             analyticsConsentInfo: {

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/hooks/useAnalyticsConsentDialogViewModel.ts
@@ -6,6 +6,7 @@ import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import {
   analyticsConsentInfoSelector,
   hasCompletedOnboardingSelector,
+  hasSeenAnalyticsOptInPromptSelector,
   shareAnalyticsSelector,
   sharePersonalizedRecommendationsSelector,
 } from "~/renderer/reducers/settings";
@@ -49,12 +50,15 @@ export function useAnalyticsConsentDialogViewModel() {
   const consentInfo = useSelector(analyticsConsentInfoSelector);
   const shareAnalytics = useSelector(shareAnalyticsSelector);
   const sharePersonalizedRecommendations = useSelector(sharePersonalizedRecommendationsSelector);
+  const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
 
   const needsUpdatePrivacy = needsPrivacyPolicyAck(consentInfo.privacyPolicyVersion);
   const needsRenewal = needsConsentRenewal(consentInfo.consentDate);
 
   const shouldOffer = Boolean(
-    feature?.enabled && hasCompletedOnboarding && (needsUpdatePrivacy || needsRenewal),
+    feature?.enabled &&
+      hasCompletedOnboarding &&
+      (!hasSeenAnalyticsOptInPrompt || needsUpdatePrivacy || needsRenewal),
   );
 
   const [phase, setPhase] = useState<AnalyticsConsentDialogPhase>("closed");
@@ -98,16 +102,23 @@ export function useAnalyticsConsentDialogViewModel() {
       });
       return;
     }
+
     setPhase(current => {
       if (current === "preferences") return current;
       return resolveAnalyticsConsentPhase(
         current,
         needsRenewal,
         needsUpdatePrivacy,
-        shareAnalytics,
+        hasSeenAnalyticsOptInPrompt,
       );
     });
-  }, [isPortfolioRouteFocused, shouldOffer, needsRenewal, needsUpdatePrivacy, shareAnalytics]);
+  }, [
+    isPortfolioRouteFocused,
+    shouldOffer,
+    needsRenewal,
+    needsUpdatePrivacy,
+    hasSeenAnalyticsOptInPrompt,
+  ]);
 
   const persistAnalyticsConsentAck = async () => {
     dispatch(setAnalyticsConsentInfo());

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useDisplayOnPortfolio.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useDisplayOnPortfolio.tsx
@@ -1,8 +1,11 @@
 import { useEffect } from "react";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useAnalyticsOptInPrompt } from "LLD/features/AnalyticsOptInPrompt/hooks/useCommonLogic";
 import { EntryPoint } from "../types/AnalyticsOptInPromptNavigator";
 
 export const useDisplayOnPortfolioAnalytics = () => {
+  const { isEnabled: isWallet40Enabled } = useWalletFeaturesConfig("desktop");
+
   const {
     analyticsOptInPromptProps,
     setIsAnalyticsOptInPromptOpened,
@@ -15,12 +18,20 @@ export const useDisplayOnPortfolioAnalytics = () => {
     onSubmit,
   };
 
+  const shouldShowPortfolioAnalyticsOptInPrompt = isFeatureFlagsAnalyticsPrefDisplayed;
+
   useEffect(() => {
-    if (isFeatureFlagsAnalyticsPrefDisplayed) setIsAnalyticsOptInPromptOpened(true);
-  }, [isFeatureFlagsAnalyticsPrefDisplayed, setIsAnalyticsOptInPromptOpened]);
+    if (isWallet40Enabled) {
+      // Wallet V4 handles consent on the home route via AnalyticsConsentDialog; skip the legacy modal.
+      return;
+    }
+    if (shouldShowPortfolioAnalyticsOptInPrompt) {
+      setIsAnalyticsOptInPromptOpened(true);
+    }
+  }, [shouldShowPortfolioAnalyticsOptInPrompt, setIsAnalyticsOptInPromptOpened, isWallet40Enabled]);
 
   return {
     analyticsOptInPromptProps: extendedAnalyticsOptInPromptProps,
-    isFeatureFlagsAnalyticsPrefDisplayed,
+    isFeatureFlagsAnalyticsPrefDisplayed: shouldShowPortfolioAnalyticsOptInPrompt,
   };
 };

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -89,12 +89,13 @@ export const DANGEROUSLY_setAnalyticsConsentInfoForQa = (patch: Partial<Analytic
 
 /**
  * @deprecated QA / developer tools only. Do not use in production flows.
- * Clears consent metadata and turns off analytics sharing flags to simulate a pre-consent state.
+ * Clears consent metadata, resets legacy opt-in prompt seen state, and turns off analytics sharing flags to simulate a pre-consent state.
  */
 export const DANGEROUSLY_resetAnalyticsOptInStateForQa = () =>
   saveSettings({
     shareAnalytics: false,
     sharePersonalizedRecommandations: false,
+    hasSeenAnalyticsOptInPrompt: false,
     analyticsConsentInfo: {
       consentDate: null,
       privacyPolicyVersion: null,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/AnalyticsConsentOptInDevTool/AnalyticsConsentOptInDevScreen.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/AnalyticsConsentOptInDevTool/AnalyticsConsentOptInDevScreen.tsx
@@ -9,11 +9,11 @@ import Box from "~/renderer/components/Box";
 import {
   analyticsConsentInfoSelector,
   hasCompletedOnboardingSelector,
-  shareAnalyticsSelector,
+  hasSeenAnalyticsOptInPromptSelector,
 } from "~/renderer/reducers/settings";
 import {
-  DANGEROUSLY_resetAnalyticsOptInStateForQa,
   DANGEROUSLY_setAnalyticsConsentInfoForQa,
+  setHasSeenAnalyticsOptInPrompt,
 } from "~/renderer/actions/settings";
 import { CURRENT_PRIVACY_POLICY_VERSION } from "@ledgerhq/live-common/privacyConsent";
 import {
@@ -34,21 +34,23 @@ export function AnalyticsConsentOptInDevScreen() {
   const dispatch = useDispatch();
   const consentInfo = useSelector(analyticsConsentInfoSelector);
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
-  const shareAnalytics = useSelector(shareAnalyticsSelector);
+  const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
   const analyticsOptInFeature = useFeature("analyticsOptIn");
 
   const needsPrivacy = needsPrivacyPolicyAck(consentInfo.privacyPolicyVersion);
   const needsRenewal = needsConsentRenewal(consentInfo.consentDate);
 
   const shouldOfferModal = Boolean(
-    analyticsOptInFeature?.enabled && hasCompletedOnboarding && (needsPrivacy || needsRenewal),
+    analyticsOptInFeature?.enabled &&
+      hasCompletedOnboarding &&
+      (!hasSeenAnalyticsOptInPrompt || needsPrivacy || needsRenewal),
   );
 
   const modalPhaseIfOffered = resolveAnalyticsConsentPhase(
     "closed",
     needsRenewal,
     needsPrivacy,
-    shareAnalytics,
+    hasSeenAnalyticsOptInPrompt,
   );
 
   const modalPreview = (() => {
@@ -101,8 +103,8 @@ export function AnalyticsConsentOptInDevScreen() {
     dispatch(DANGEROUSLY_setAnalyticsConsentInfoForQa({ consentDate: null }));
   };
 
-  const onResetForConsentFresh = () => {
-    dispatch(DANGEROUSLY_resetAnalyticsOptInStateForQa());
+  const onResetSeenAnalyticsOptInPrompt = () => {
+    dispatch(setHasSeenAnalyticsOptInPrompt(false));
   };
 
   return (
@@ -125,11 +127,28 @@ export function AnalyticsConsentOptInDevScreen() {
             {t("settings.developer.analyticsConsentOptInQa.readSection")}
           </h2>
           <div className="flex flex-col gap-8">
-            <p className="body-2 leading-relaxed text-muted">
-              {t("settings.developer.analyticsConsentOptInQa.currentPrivacyVersion", {
-                version: String(CURRENT_PRIVACY_POLICY_VERSION),
-              })}
-            </p>
+            <div className="flex flex-row flex-wrap items-center justify-between gap-10">
+              <span
+                className={`min-w-0 flex-1 body-2 font-medium leading-relaxed ${
+                  hasSeenAnalyticsOptInPrompt ? "text-success" : "text-error"
+                }`}
+              >
+                {t("settings.developer.analyticsConsentOptInQa.seenAnalyticsOptInPrompt", {
+                  value: String(hasSeenAnalyticsOptInPrompt),
+                })}
+              </span>
+              <Button
+                className="shrink-0 self-center"
+                size="sm"
+                appearance="accent"
+                disabled={!hasSeenAnalyticsOptInPrompt}
+                onClick={onResetSeenAnalyticsOptInPrompt}
+              >
+                {t(
+                  "settings.developer.analyticsConsentOptInQa.inlineResetSeenAnalyticsOptInPrompt",
+                )}
+              </Button>
+            </div>
             <div className="flex flex-row flex-wrap items-center justify-between gap-10">
               <span
                 className={`min-w-0 flex-1 body-2 font-medium leading-relaxed ${
@@ -183,15 +202,6 @@ export function AnalyticsConsentOptInDevScreen() {
           </p>
           <p className="body-3 leading-relaxed text-muted">
             {t("settings.developer.analyticsConsentOptInQa.modalPreviewGoToHome")}
-          </p>
-        </section>
-
-        <section className="mt-32 flex flex-col gap-8">
-          <Button size="sm" appearance="red" onClick={onResetForConsentFresh}>
-            {t("settings.developer.analyticsConsentOptInQa.actionResetForConsentFresh")}
-          </Button>
-          <p className="max-w-xl leading-relaxed body-3 text-muted">
-            {t("settings.developer.analyticsConsentOptInQa.note")}
           </p>
         </section>
       </Box>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4635,12 +4635,12 @@
         "rowDesc": "Inspect stored privacy consent version and consent date; simulate outdated states for the portfolio analytics consent modal.",
         "title": "Analytics opt-in consent — QA",
         "readSection": "Current settings (read-only)",
+        "seenAnalyticsOptInPrompt": "hasSeenAnalyticsOptInPrompt: {{value}}",
+        "inlineResetSeenAnalyticsOptInPrompt": "Mark not seen",
         "storedPrivacyVersion": "Stored privacy policy version: {{version}}",
-        "currentPrivacyVersion": "App current privacy policy version: {{version}}",
         "consentDate": "Consent date (raw): {{value}}",
         "inlineOutdatePrivacyVersion": "Outdate version",
         "inlineRemoveConsentDate": "Remove date",
-        "actionResetForConsentFresh": "Reset for consent fresh (clear consent data, turn off analytics & personalization)",
         "modalPreviewSection": "Expected modal on portfolio (home)",
         "modalPreviewNoModalUserOk": "No modal. Privacy policy version and consent date are fine: nothing to renew or re-acknowledge.",
         "modalPreviewNoModalFeatureOff": "No modal. The analytics opt-in feature flag is off.",
@@ -4648,8 +4648,7 @@
         "modalPreviewFresh": "First-time consent modal (consent fresh). Consent renewal is required (missing or invalid consent date) and Share analytics is off — e.g. no stored privacy ack / no consent date with analytics disabled.",
         "modalPreviewReconfirm": "Reconfirm consent modal. Consent renewal is required and Share analytics is on — user gets the reconfirm / continue-or-stop flow instead of first-time copy.",
         "modalPreviewPrivacy": "Privacy update modal. Stored privacy policy version is outdated (lower than the app), and consent renewal is not blocking — user sees the privacy-policy update step first.",
-        "modalPreviewGoToHome": "Open the portfolio home page to see the modal when it should appear.",
-        "note": "Remove date sets consent to null. Outdate version lowers the stored privacy policy version below the app's current version. Reset clears consent metadata and turns off analytics and personalization to reproduce the consent fresh modal. Time-based renewal stays off while CONSENT_RENEWAL_INTERVAL_MS is null in live-common."
+        "modalPreviewGoToHome": "Open the portfolio home page to see the modal when it should appear."
       },
       "brazeTools": {
         "title": "Braze Tools",

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__integrations__/AnalyticsConsentDrawer.portfolio.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__integrations__/AnalyticsConsentDrawer.portfolio.integration.test.tsx
@@ -70,12 +70,13 @@ const overridePortfolioWithAnalyticsConsentDrawer = composePortfolioOverrides({
   privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
 });
 
-/** Reconfirm: renewal first, analytics on → consentReconfirm. */
+/** Reconfirm: renewal first, user already saw opt-in → consentReconfirm. */
 const overridePortfolioWithAnalyticsConsentReconfirm = composePortfolioOverrides({
   hasCompletedOnboarding: true,
   analyticsOptInEnabled: true,
   analyticsEnabled: true,
   personalizedRecommendationsEnabled: true,
+  hasSeenAnalyticsOptInPrompt: true,
   consentDate: null,
   privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
 });
@@ -217,13 +218,14 @@ describe("AnalyticsConsentDrawer on Portfolio", () => {
       needsConsentRenewalSpy.mockRestore();
     });
 
-    it("should show reconfirm when consent is older than one year and analytics are on", async () => {
+    it("should show reconfirm when consent is older than one year and user already saw opt-in", async () => {
       renderWithReactQuery(<IntegrationNavigator />, {
         overrideInitialState: composePortfolioOverrides({
           hasCompletedOnboarding: true,
           analyticsOptInEnabled: true,
           analyticsEnabled: true,
           personalizedRecommendationsEnabled: true,
+          hasSeenAnalyticsOptInPrompt: true,
           consentDate: consentIsoOlderThanOneYear(),
           privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
         }),

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__tests__/helpers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__tests__/helpers.ts
@@ -9,11 +9,12 @@ export type ConsentDrawerTestOptions = {
   privacyPolicyVersion?: number | null;
   analyticsEnabled?: boolean;
   personalizedRecommendationsEnabled?: boolean;
+  hasSeenAnalyticsOptInPrompt?: boolean;
 };
 
 /**
- * Drawer opens on **consentFresh**: consent renewal needed first, analytics off (`needsRenewal`
- * before privacy in the hook). Use for tests that tap fresh CTAs without extra boilerplate.
+ * Drawer opens on **consentFresh**: renewal needed and user has not seen the opt-in yet.
+ * Use for tests that tap fresh CTAs without extra boilerplate.
  */
 export function withConsentDrawerOpeningFresh(options: ConsentDrawerTestOptions = {}) {
   return withConsentDrawerState({
@@ -37,6 +38,7 @@ export function withConsentDrawerState(options: ConsentDrawerTestOptions = {}) {
     privacyPolicyVersion = CURRENT_PRIVACY_POLICY_VERSION,
     analyticsEnabled = true,
     personalizedRecommendationsEnabled = true,
+    hasSeenAnalyticsOptInPrompt = false,
   } = options;
 
   return (state: State): State =>
@@ -45,6 +47,7 @@ export function withConsentDrawerState(options: ConsentDrawerTestOptions = {}) {
       settings: {
         ...state.settings,
         hasCompletedOnboarding,
+        hasSeenAnalyticsOptInPrompt,
         analyticsEnabled,
         personalizedRecommendationsEnabled,
         analyticsConsentInfo: {

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__tests__/useAnalyticsConsentDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__tests__/useAnalyticsConsentDrawerViewModel.test.ts
@@ -220,11 +220,12 @@ describe("useAnalyticsConsentDrawerViewModel", () => {
   });
 
   describe("needs reconfirmation", () => {
-    it("should open consentReconfirm when renewal is needed, policy is current, and analytics is on", async () => {
+    it("should open consentReconfirm when renewal is needed, policy is current, and user already saw opt-in", async () => {
       const { result } = renderHook(() => useAnalyticsConsentDrawerViewModel(), {
         overrideInitialState: withConsentDrawerState({
           analyticsEnabled: true,
           personalizedRecommendationsEnabled: true,
+          hasSeenAnalyticsOptInPrompt: true,
           privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
           consentDate: null,
         }),
@@ -240,6 +241,7 @@ describe("useAnalyticsConsentDrawerViewModel", () => {
         overrideInitialState: withConsentDrawerState({
           analyticsEnabled: true,
           personalizedRecommendationsEnabled: true,
+          hasSeenAnalyticsOptInPrompt: true,
           privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
           consentDate: null,
         }),
@@ -275,6 +277,7 @@ describe("useAnalyticsConsentDrawerViewModel", () => {
         overrideInitialState: withConsentDrawerState({
           analyticsEnabled: true,
           personalizedRecommendationsEnabled: true,
+          hasSeenAnalyticsOptInPrompt: true,
           privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
           consentDate: null,
         }),
@@ -371,12 +374,13 @@ describe("useAnalyticsConsentDrawerViewModel", () => {
       });
     });
 
-    it("should open consentReconfirm when consent is stale by time even if both toggles are on (renewal first)", async () => {
+    it("should open consentReconfirm when consent is stale by time and user already saw opt-in (renewal first)", async () => {
       const oldIso = new Date(Date.now() - YEAR_MS - 86_400_000).toISOString();
       const { result } = renderHook(() => useAnalyticsConsentDrawerViewModel(), {
         overrideInitialState: withConsentDrawerState({
           analyticsEnabled: true,
           personalizedRecommendationsEnabled: true,
+          hasSeenAnalyticsOptInPrompt: true,
           privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
           consentDate: oldIso,
         }),

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/hooks/useAnalyticsConsentDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/hooks/useAnalyticsConsentDrawerViewModel.ts
@@ -7,6 +7,7 @@ import {
   analyticsConsentInfoSelector,
   analyticsEnabledSelector,
   hasCompletedOnboardingSelector,
+  hasSeenAnalyticsOptInPromptSelector,
   personalizedRecommendationsEnabledSelector,
 } from "~/reducers/settings";
 import {
@@ -43,6 +44,7 @@ export function useAnalyticsConsentDrawerViewModel() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const consentInfo = useSelector(analyticsConsentInfoSelector);
   const analyticsEnabled = useSelector(analyticsEnabledSelector);
+  const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
   const personalizedRecommendationsEnabled = useSelector(
     personalizedRecommendationsEnabledSelector,
   );
@@ -71,14 +73,19 @@ export function useAnalyticsConsentDrawerViewModel() {
       return;
     }
     setPhase(current =>
-      resolveAnalyticsConsentPhase(current, needsRenewal, needsUpdatePrivacy, analyticsEnabled),
+      resolveAnalyticsConsentPhase(
+        current,
+        needsRenewal,
+        needsUpdatePrivacy,
+        hasSeenAnalyticsOptInPrompt,
+      ),
     );
   }, [
     isFocused,
     shouldOffer,
     needsRenewal,
     needsUpdatePrivacy,
-    analyticsEnabled,
+    hasSeenAnalyticsOptInPrompt,
     handleCloseDrawer,
   ]);
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/AnalyticsConsentQA/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/AnalyticsConsentQA/index.tsx
@@ -12,6 +12,7 @@ import {
   analyticsConsentInfoSelector,
   analyticsEnabledSelector,
   hasCompletedOnboardingSelector,
+  hasSeenAnalyticsOptInPromptSelector,
   personalizedRecommendationsEnabledSelector,
 } from "~/reducers/settings";
 import {
@@ -35,6 +36,7 @@ export default function DebugAnalyticsConsentQA() {
   const analyticsEnabled = useSelector(analyticsEnabledSelector);
   const personalizedEnabled = useSelector(personalizedRecommendationsEnabledSelector);
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
 
   const storedVersionOk = !needsPrivacyPolicyAck(consentInfo.privacyPolicyVersion);
   const consentDateOk = !needsConsentRenewal(consentInfo.consentDate);
@@ -56,7 +58,7 @@ export default function DebugAnalyticsConsentQA() {
       "closed",
       needsRenewal,
       needsUpdatePrivacy,
-      analyticsEnabled,
+      hasSeenAnalyticsOptInPrompt,
     );
     if (phase === "closed") {
       return { shouldOffer: false as const, phase: null, reason: "nothingToRenew" as const };
@@ -66,6 +68,7 @@ export default function DebugAnalyticsConsentQA() {
     analyticsEnabled,
     feature?.enabled,
     hasCompletedOnboarding,
+    hasSeenAnalyticsOptInPrompt,
     consentInfo.consentDate,
     consentInfo.privacyPolicyVersion,
   ]);

--- a/libs/ledger-live-common/src/analyticsConsentUtils.test.ts
+++ b/libs/ledger-live-common/src/analyticsConsentUtils.test.ts
@@ -72,7 +72,7 @@ describe("analyticsConsentUtils", () => {
       expect(resolveAnalyticsConsentPhase("privacy", false, true, false)).toBe("privacy");
     });
 
-    it("when closed and renewal: reconfirm if sharing on, else fresh", () => {
+    it("when closed and renewal: reconfirm if user already saw opt-in, else fresh", () => {
       expect(resolveAnalyticsConsentPhase("closed", true, false, true)).toBe("consentReconfirm");
       expect(resolveAnalyticsConsentPhase("closed", true, false, false)).toBe("consentFresh");
     });

--- a/libs/ledger-live-common/src/analyticsConsentUtils.ts
+++ b/libs/ledger-live-common/src/analyticsConsentUtils.ts
@@ -9,11 +9,14 @@ export function resolveAnalyticsConsentPhase(
   currentPhase: AnalyticsConsentPhase,
   needsRenewal: boolean,
   needsUpdatePrivacy: boolean,
-  analyticsSharingEnabled: boolean,
+  hasSeenAnalyticsOptInPrompt: boolean,
 ): AnalyticsConsentPhase {
   if (currentPhase !== "closed") return currentPhase;
-  if (needsRenewal) return analyticsSharingEnabled ? "consentReconfirm" : "consentFresh";
+
+  if (!hasSeenAnalyticsOptInPrompt) return "consentFresh";
+  if (needsRenewal) return "consentReconfirm";
   if (needsUpdatePrivacy) return "privacy";
+
   return "consentFresh";
 }
 


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** View-model and drawer tests updated for `resolveAnalyticsConsentPhase` and consent offer rules.
- [x] **Impact of the changes:**
      - Desktop **Wallet V4:** legacy portfolio analytics opt-in modal does not auto-open; **`/`** consent dialog handles CMP.
      - Desktop **`AnalyticsConsentDialog`:** modal is offered if **`hasSeenAnalyticsOptInPrompt`** is false **or** privacy / renewal requires action.
      - **`live-common` + LWD + LWM:** **fresh** vs **reconfirm** on renewal uses **`hasSeenAnalyticsOptInPrompt`**, not share/analytics toggles.
      - **Developer → Analytics consent QA:** **`hasSeenAnalyticsOptInPrompt`** display + **Mark not seen**; bulk reset control removed from that screen.

### Description

**Goal:** Align legacy portfolio opt-in with Wallet V4, drive CMP fresh/reconfirm from **`hasSeenAnalyticsOptInPrompt`**, and surface first-time offer rules on desktop.

**Changes:** Skip legacy portfolio opt-in when Wallet V4 is on; **`resolveAnalyticsConsentPhase`** and callers use **`hasSeenAnalyticsOptInPrompt`** for the renewal branch; desktop **`shouldOffer`** includes **`!hasSeenAnalyticsOptInPrompt`** (or privacy/renewal); QA dev screen shows the flag with **Mark not seen**; **`DANGEROUSLY_resetAnalyticsOptInStateForQa`** clears **`hasSeenAnalyticsOptInPrompt`** among other QA reset fields.

### Context

- **JIRA or GitHub link:** None

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked issue (N/A).
- **The PR description documents** behavior and QA impact.
- **No undocumented trade-offs** beyond the product rules above.
- **Tests** cover dialog/drawer view models and `resolveAnalyticsConsentPhase`.
- **No new dependencies.**
