### PR TITLE
[LWM] Stabilizing connect-app dependencies

### DIFF
--- a/apps/ledger-live-mobile/src/screens/SignRawTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignRawTransaction/02-ConnectDevice.tsx
@@ -3,7 +3,9 @@ import React, { memo, useCallback, useMemo } from "react";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import type { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
 import { dependenciesToAppRequests } from "@ledgerhq/live-common/hw/actions/app";
+import { isSwapDisableAppsInstall } from "@ledgerhq/live-common/exchange/swap/utils/isIntegrationTestEnv";
 import { useTheme } from "@react-navigation/native";
 import { TransactionResult } from "@ledgerhq/live-common/hw/actions/transaction";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
@@ -25,6 +27,8 @@ export type SignRawTransactionConnectDeviceProps = StackNavigatorProps<
   SignRawTransactionNavigatorParamList,
   ScreenName.SignRawTransactionConnectDevice
 >;
+
+const NO_CONNECT_APP_DEPENDENCIES: AppRequest[] = [];
 
 function ConnectDevice({ navigation, route }: SignRawTransactionConnectDeviceProps) {
   const action = useRawTransactionDeviceAction();
@@ -59,6 +63,15 @@ function ConnectDevice({ navigation, route }: SignRawTransactionConnectDevicePro
     [onSuccess, navigation, route.params],
   );
 
+  const swapSpeculosBypass = isSwapDisableAppsInstall();
+  const connectAppDependencies = useMemo(
+    () =>
+      swapSpeculosBypass
+        ? NO_CONNECT_APP_DEPENDENCIES
+        : [{ currency: mainAccount.currency }, ...dependenciesToAppRequests(dependencies)],
+    [swapSpeculosBypass, mainAccount.currency, dependencies],
+  );
+
   const request = useMemo(
     () => ({
       account,
@@ -66,13 +79,10 @@ function ConnectDevice({ navigation, route }: SignRawTransactionConnectDevicePro
       appName,
       transaction,
       broadcast,
-      dependencies: [
-        { currency: mainAccount.currency },
-        ...dependenciesToAppRequests(dependencies),
-      ],
-      requireLatestFirmware: true,
+      dependencies: connectAppDependencies,
+      requireLatestFirmware: !swapSpeculosBypass,
     }),
-    [account, appName, broadcast, dependencies, mainAccount.currency, parentAccount, transaction],
+    [account, appName, broadcast, connectAppDependencies, parentAccount, swapSpeculosBypass, transaction],
   );
 
   const onSelectDeviceLink = useCallback(() => {

--- a/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
@@ -4,6 +4,7 @@ import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import type { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
 import { dependenciesToAppRequests } from "@ledgerhq/live-common/hw/actions/app";
 import { useTheme } from "@react-navigation/native";
 import { TransactionResult } from "@ledgerhq/live-common/hw/actions/transaction";
@@ -27,6 +28,8 @@ export type SignTransactionConnectDeviceProps = StackNavigatorProps<
   SignTransactionNavigatorParamList,
   ScreenName.SignTransactionConnectDevice
 >;
+
+const NO_CONNECT_APP_DEPENDENCIES: AppRequest[] = [];
 
 function ConnectDevice({ navigation, route }: SignTransactionConnectDeviceProps) {
   const action = useTransactionDeviceAction();
@@ -70,7 +73,7 @@ function ConnectDevice({ navigation, route }: SignTransactionConnectDeviceProps)
   const connectAppDependencies = useMemo(
     () =>
       swapSpeculosBypass
-        ? []
+        ? NO_CONNECT_APP_DEPENDENCIES
         : [{ currency: mainAccount.currency }, ...dependenciesToAppRequests(dependencies)],
     [swapSpeculosBypass, mainAccount.currency, dependencies],
   );

--- a/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
@@ -66,6 +66,15 @@ function ConnectDevice({ navigation, route }: SignTransactionConnectDeviceProps)
     [onSuccess, navigation, route.params],
   );
 
+  const swapSpeculosBypass = isSwapDisableAppsInstall();
+  const connectAppDependencies = useMemo(
+    () =>
+      swapSpeculosBypass
+        ? []
+        : [{ currency: mainAccount.currency }, ...dependenciesToAppRequests(dependencies)],
+    [swapSpeculosBypass, mainAccount.currency, dependencies],
+  );
+
   const request = useMemo(
     () => ({
       account,
@@ -77,21 +86,18 @@ function ConnectDevice({ navigation, route }: SignTransactionConnectDeviceProps)
       transaction: transaction!,
       status,
       tokenCurrency,
-      dependencies: isSwapDisableAppsInstall() ? [] : [
-        { currency: mainAccount.currency },
-        ...dependenciesToAppRequests(dependencies),
-      ],
-      requireLatestFirmware: !isSwapDisableAppsInstall(),
+      dependencies: connectAppDependencies,
+      requireLatestFirmware: !swapSpeculosBypass,
       isACRE: route.params.isACRE,
     }),
     [
       account,
       appName,
-      dependencies,
-      mainAccount.currency,
+      connectAppDependencies,
       parentAccount,
       route.params.isACRE,
       status,
+      swapSpeculosBypass,
       tokenCurrency,
       transaction,
     ],

--- a/e2e/mobile/page/trade/deviceValidation.page.ts
+++ b/e2e/mobile/page/trade/deviceValidation.page.ts
@@ -1,5 +1,4 @@
 import CommonPage from "../common.page";
-import { delay } from "../../helpers/commonHelpers";
 import { Step } from "jest-allure2-reporter/api";
 
 export default class DeviceValidationPage extends CommonPage {
@@ -33,25 +32,5 @@ export default class DeviceValidationPage extends CommonPage {
   @Step("Expect fees in device validation screen")
   async expectFees(fees: string) {
     await detoxExpect(this.validationFees()).toHaveText(fees);
-  }
-
-  @Step("Wait for swap device validation and retry")
-  async waitDeviceValidationAndRetry() {
-    const WAIT_TIMEOUT = 30000;
-    const CHECK_INTERVAL = 1000;
-    const startTime = Date.now();
-
-    while (Date.now() - startTime < WAIT_TIMEOUT) {
-      if (await IsIdVisible(this.validationAmountId, 100)) {
-        return;
-      }
-      if (await IsIdVisible(this.proceedButtonId, 100)) {
-        await tapById(this.proceedButtonId);
-        return;
-      }
-      await delay(CHECK_INTERVAL);
-    }
-
-    throw new Error(`Device validation timed out after ${WAIT_TIMEOUT / 1000} seconds.`);
   }
 }

--- a/e2e/mobile/specs/swap/otherTestCases/swapDexNativeFlow.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDexNativeFlow.ts
@@ -55,7 +55,6 @@ export function runSwapDexNativeFlow(
       await app.swapLiveApp.tapExecuteSwapOnStepApproval();
       await app.send.summaryContinue();
 
-      await app.deviceValidation.waitDeviceValidationAndRetry();
       await app.swap.verifyAmountsAndAcceptSwap(swap, Number(amountToSwap).toFixed(8));
       await app.swap.waitForSwapHeaderCompleted();
     });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Swap

### 📝 Description

Stabilizing connect-app dependencies so bridge-driven transaction updates don't restart the hook causing fail in E2E tests.
Issue : A fresh `dependencies: [...]` each time makes `appRequest.dependencies` a new reference, which restarts the connect-app useEffect (unsubscribe withDevice → new job) mid-flow.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- E2E Mobile [run](https://github.com/LedgerHQ/ledger-live/actions/runs/24333587042) OKX fail is expected


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
