### PR TITLE
[LWDM] feat(portfolio): reposition perps entry point below assets

### DIFF
--- a/.changeset/calm-badgers-move.md
+++ b/.changeset/calm-badgers-move.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Reposition portfolio Perps entry point below assets on mobile and desktop

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
@@ -66,9 +66,8 @@ export const PortfolioView = memo(function PortfolioView({
           <PortfolioBannerContent />
           {shouldDisplayMarketBanner && <MarketBanner />}
 
-          <PerpsEntryPoint />
-
           {shouldDisplayAssetSection ? <Assets /> : <AssetDistribution />}
+          <PerpsEntryPoint />
           {shouldDisplayAddAccountCta && <AddAccount />}
           {shouldDisplayAssetSection && <CryptoAddressesBanner />}
           {shouldDisplayBrazePlacement && <BottomCarouselContentCards />}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioPerpsEntryPoint/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioPerpsEntryPoint/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from "react";
-import { Flex } from "@ledgerhq/native-ui";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useTranslation } from "~/context/Locale";
@@ -16,6 +15,7 @@ import {
   Subheader,
   SubheaderRow,
   SubheaderTitle,
+  Box,
 } from "@ledgerhq/lumen-ui-rnative";
 import { ChevronRight, Infinite } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { track } from "~/analytics";
@@ -35,13 +35,17 @@ export const PortfolioPerpsEntryPoint = () => {
 
   return (
     <FeatureToggle featureId="ptxPerpsLiveAppMobile">
-      <Subheader>
-        <SubheaderRow onPress={handlePress} data-testid="portfolio-perps-subheader-row">
-          <SubheaderTitle>{t("portfolio.perpsEntry.title")}</SubheaderTitle>
-        </SubheaderRow>
-      </Subheader>
-      <Flex mb={6} mt={2}>
-        <ListItem onPress={handlePress} testID="portfolio-perps-entry-point">
+      <Box lx={{ marginTop: "s16", paddingHorizontal: "s16" }}>
+        <Subheader>
+          <SubheaderRow onPress={handlePress} data-testid="portfolio-perps-subheader-row">
+            <SubheaderTitle>{t("portfolio.perpsEntry.title")}</SubheaderTitle>
+          </SubheaderRow>
+        </Subheader>
+        <ListItem
+          onPress={handlePress}
+          testID="portfolio-perps-entry-point"
+          lx={{ marginHorizontal: "-s8", marginTop: "s4" }}
+        >
           <ListItemLeading>
             <Spot appearance="icon" icon={Infinite} />
             <ListItemContent>
@@ -52,7 +56,7 @@ export const PortfolioPerpsEntryPoint = () => {
             <ChevronRight size={24} />
           </ListItemTrailing>
         </ListItem>
-      </Flex>
+      </Box>
     </FeatureToggle>
   );
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -131,12 +131,6 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
       );
     }
 
-    sections.push(
-      <Box key="perps" px={6}>
-        <PortfolioPerpsEntryPoint key="perpsEntryPoint" />
-      </Box>,
-    );
-
     if (shouldDisplayAssetSection) {
       sections.push(<WalletAssetsView key="categorizedAssets" />);
     } else {
@@ -151,6 +145,8 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
         />,
       );
     }
+
+    sections.push(<PortfolioPerpsEntryPoint key="perpsEntryPoint" />);
 
     if (isAWalletCardDisplayed) {
       sections.push(<PortfolioCarouselSection key="carousel" backgroundColor={backgroundColor} />);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No new automated tests; layout/order change. 
- [x] **Impact of the changes:**
      - Portfolio home / dashboard layout and section order
      - Perps entry point position relative to assets (should appear below assets)
      - Mobile: spacing and horizontal padding around the Perps block

### 📝 Description

**Problem**: The Perps entry point on the portfolio needed to be shown after the assets section on both Ledger Wallet Desktop and Mobile ([LIVE-29007](https://ledgerhq.atlassian.net/browse/LIVE-29007)).

**Solution**:

- **Desktop** (`PortfolioView`): `PerpsEntryPoint` is rendered immediately after `Assets` / `AssetDistribution` and before the add-account CTA, instead of above the assets block.
- **Mobile** (`Portfolio` screen): `PortfolioPerpsEntryPoint` is pushed into the sections list after the wallet assets or distribution section. Outer layout is adjusted by wrapping the subheader and list in a `Flex` with `mt={6}` and `px={6}` inside the component, replacing the previous section-level `Box` wrapper with horizontal padding only.

### 📸 Screenshots

<img width="1389" height="872" alt="Screenshot 2026-04-13 at 08 28 39" src="https://github.com/user-attachments/assets/80fbde69-cd66-4575-b843-72fd5d74e6a8" />

<img width="395" height="796" alt="Screenshot 2026-04-13 at 11 39 56" src="https://github.com/user-attachments/assets/49bece90-9222-4975-bfbf-051a69bd115d" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29007](https://ledgerhq.atlassian.net/browse/LIVE-29007)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29007]: https://ledgerhq.atlassian.net/browse/LIVE-29007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-29007]: https://ledgerhq.atlassian.net/browse/LIVE-29007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ