### PR TITLE
[LWM] feat(mobile): add my wallet quick actions row

### DIFF
--- a/.changeset/brave-foxes-dance.md
+++ b/.changeset/brave-foxes-dance.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add my wallet quick actions row with recover, help, and referral CTAs

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8843,5 +8843,12 @@
       "title": "Failed to install {{appName}}",
       "description": "Something went wrong during installation. Please try again."
     }
+  },
+  "myWallet": {
+    "quickActions": {
+      "recover": "[L] Recover",
+      "help": "Help",
+      "referral": "Referral"
+    }
   }
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/Navigator.tsx
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { useTheme as useLumenTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+import { getStackNavigationConfigV4 } from "LLM/components/Navigation/getStackNavigationConfigV4";
 import { ScreenName } from "~/const";
 import { MyWalletScreen } from "./index";
 import { MyWalletNavigatorStackParamList } from "./types";
@@ -7,9 +9,16 @@ import { MyWalletNavigatorStackParamList } from "./types";
 const Stack = createNativeStackNavigator<MyWalletNavigatorStackParamList>();
 
 export default function MyWalletNavigator() {
+  const { theme: lumenTheme } = useLumenTheme();
+  const stackNavConfigV4 = useMemo(() => getStackNavigationConfigV4(lumenTheme), [lumenTheme]);
+
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
-      <Stack.Screen name={ScreenName.MyWallet} component={MyWalletScreen} />
+      <Stack.Screen
+        name={ScreenName.MyWallet}
+        component={MyWalletScreen}
+        options={{ headerShown: false, ...stackNavConfigV4 }}
+      />
     </Stack.Navigator>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/MyWalletScreen.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/MyWalletScreen.integration.test.tsx
@@ -54,4 +54,13 @@ describe("MyWalletScreen", () => {
     expect(screen.getByTestId("my-wallet-avatar")).toBeVisible();
     expect(screen.getByTestId("my-wallet-profile-title")).toBeVisible();
   });
+
+  it("should render the quick actions row with all action buttons", () => {
+    renderScreen();
+
+    expect(screen.getByTestId("my-wallet-quick-actions-row")).toBeVisible();
+    expect(screen.getByLabelText("[L] Recover")).toBeVisible();
+    expect(screen.getByLabelText("Help")).toBeVisible();
+    expect(screen.getByLabelText("Referral")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
@@ -3,6 +3,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { MyWalletHeader } from "./views/Header";
 import { ProfileSection } from "./views/ProfileSection";
+import { QuickActionsRow } from "./views/QuickActionsRow";
 
 export function MyWalletScreen() {
   const { top } = useSafeAreaInsets();
@@ -11,6 +12,9 @@ export function MyWalletScreen() {
     <Box style={{ paddingTop: top, flex: 1 }}>
       <MyWalletHeader />
       <ProfileSection />
+      <Box lx={{ paddingHorizontal: "s16", marginTop: "s24" }}>
+        <QuickActionsRow />
+      </Box>
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/QuickActionsRowView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/QuickActionsRowView.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Box, TileButton } from "@ledgerhq/lumen-ui-rnative";
+import { QuickActionRowItem } from "./useQuickActionsRowViewModel";
+
+interface QuickActionsRowViewProps {
+  readonly actions: readonly QuickActionRowItem[];
+}
+
+export function QuickActionsRowView({ actions }: QuickActionsRowViewProps) {
+  return (
+    <Box lx={{ flexDirection: "row", gap: "s8" }} testID="my-wallet-quick-actions-row">
+      {actions.map(action => (
+        <TileButton
+          key={action.id}
+          lx={{ flex: 1 }}
+          icon={action.icon}
+          onPress={action.onPress}
+          isFull
+          testID={action.testID}
+          accessibilityLabel={action.label}
+        >
+          {action.label}
+        </TileButton>
+      ))}
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { useQuickActionsRowViewModel } from "./useQuickActionsRowViewModel";
+import { QuickActionsRowView } from "./QuickActionsRowView";
+
+export function QuickActionsRow() {
+  const { actions } = useQuickActionsRowViewModel();
+
+  return <QuickActionsRowView actions={actions} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from "react";
+import { TileButtonProps } from "@ledgerhq/lumen-ui-rnative";
+import { ShieldCheckNotification, LifeRing, Gift } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
+
+export interface QuickActionRowItem {
+  readonly id: string;
+  readonly label: string;
+  readonly icon: TileButtonProps["icon"];
+  readonly onPress: () => void;
+  readonly testID: string;
+}
+
+interface QuickActionsRowViewModel {
+  readonly actions: readonly QuickActionRowItem[];
+}
+
+export const useQuickActionsRowViewModel = (): QuickActionsRowViewModel => {
+  const { t } = useTranslation();
+
+  const handleRecoverPress = useCallback(() => {
+    // TODO: implement recover navigation
+  }, []);
+
+  const handleHelpPress = useCallback(() => {
+    // TODO: implement help navigation
+  }, []);
+
+  const handleReferralPress = useCallback(() => {
+    // TODO: implement referral navigation
+  }, []);
+
+  const actions: readonly QuickActionRowItem[] = useMemo(
+    () => [
+      {
+        id: "recover",
+        label: t("myWallet.quickActions.recover"),
+        icon: ShieldCheckNotification,
+        onPress: handleRecoverPress,
+        testID: "my-wallet-quick-action-recover",
+      },
+      {
+        id: "help",
+        label: t("myWallet.quickActions.help"),
+        icon: LifeRing,
+        onPress: handleHelpPress,
+        testID: "my-wallet-quick-action-help",
+      },
+      {
+        id: "referral",
+        label: t("myWallet.quickActions.referral"),
+        icon: Gift,
+        onPress: handleReferralPress,
+        testID: "my-wallet-quick-action-referral",
+      },
+    ],
+    [t, handleRecoverPress, handleHelpPress, handleReferralPress],
+  );
+
+  return { actions };
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _No automated tests added for this UI component yet._
- [x] **Impact of the changes:**
  - The My Wallet screen now displays a quick actions row with three CTAs: Recover, Help, and Referral
  - Verify the quick actions row renders correctly on the My Wallet screen
  - Verify each button is tappable and accessible (accessibilityLabel is set)
  - Verify testIDs are present for automation

### 📝 Description

The My Wallet screen was missing quick action entry points to key features (Recover, Help, Referral). Users had no fast path to these actions from the wallet overview.

This PR introduces a `QuickActionsRow` component using the `TileButton` from Lumen UI, following the MVVM pattern. The view is colocated with its view model (`useQuickActionsRowViewModel`) and exposes three actions — Recover, Help, and Referral — with their respective icons and i18n labels.

<img width="1206" height="2622" alt="Simulator Screenshot - Test Ios - 2026-04-13 at 10 56 10" src="https://github.com/user-attachments/assets/f40a6569-1c6d-464e-82c4-f68bc00cd1c1" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26349](https://ledgerhq.atlassian.net/browse/LIVE-26349)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26349]: https://ledgerhq.atlassian.net/browse/LIVE-26349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ