### PR TITLE
[LWDM] fix(LIVE-29101): avoid unnecessary Aleo syncs with postSync clean up

### DIFF
--- a/.changeset/wild-radios-sin.md
+++ b/.changeset/wild-radios-sin.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+fix: avoid unnecessary aleo syncs with postSync clean up

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
@@ -18,6 +18,7 @@ import {
   performPrivateSync,
   createPrivateSyncObservable,
   createPublicSyncObservable,
+  postSync,
 } from "./sync";
 import { buildSyncObservables, makeGetAccountShape } from "./sync";
 
@@ -1211,6 +1212,42 @@ describe("sync.ts", () => {
       // The public emission arrived before the private failure
       expect(emissions).toHaveLength(1);
       expect(emissions[0].blockHeight).toBe(100);
+    });
+  });
+
+  describe("postSync", () => {
+    it("should return synced account unchanged when there are no pending operations", () => {
+      const synced: AleoAccount = {
+        ...mockInitialAccount,
+        operations: [getMockedOperation({ hash: "confirmed-hash" })],
+        pendingOperations: [],
+      };
+
+      expect(postSync(synced, synced)).toBe(synced);
+    });
+
+    it("should remove only confirmed pending operations and keep unconfirmed ones", () => {
+      const confirmedOp = getMockedOperation({ id: "confirmed", hash: "tx-confirmed" });
+      const pendingConfirmedOp = getMockedOperation({
+        id: "pending-confirmed",
+        hash: "tx-confirmed",
+      });
+      const pendingUnconfirmedOp = getMockedOperation({
+        id: "pending-unconfirmed",
+        hash: "tx-pending",
+      });
+
+      const synced: AleoAccount = {
+        ...mockInitialAccount,
+        operations: [confirmedOp],
+        pendingOperations: [pendingConfirmedOp, pendingUnconfirmedOp],
+      };
+
+      const result = postSync(synced, synced);
+
+      expect(result.pendingOperations).toEqual([
+        expect.objectContaining({ hash: pendingUnconfirmedOp.hash }),
+      ]);
     });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -420,7 +420,37 @@ export function makeGetAccountShape(): GetAccountShapeStream<AleoAccount> {
     });
 }
 
+/**
+ * Aleo doesn't have a per-account transaction nonce, so there is no natural value
+ * to assign to `transactionSequenceNumber` on confirmed operations.
+ *
+ * The framework's `shouldRetainPendingOperation` drops a pending operation when the most recent
+ * confirmed operation from the same sender has an equal or higher `transactionSequenceNumber`.
+ *
+ * Optimistic pending operations are created with increasing sequence numbers via `getNextSequenceNumber`,
+ * because without this only one pending operation could be rendered in LW.
+ * Confirmed operations lack this field, making the comparison always false and leaving pending operations stuck.
+ *
+ * Instead pending operations are removed here by matching on transaction hash:
+ * once a hash appears in the confirmed operations list, the corresponding pending operation is no longer needed.
+ */
+export function postSync(_initial: AleoAccount, synced: AleoAccount): AleoAccount {
+  const pendingOperations = synced.pendingOperations ?? [];
+
+  if (pendingOperations.length === 0) {
+    return synced;
+  }
+
+  const confirmedHashes = new Set(synced.operations.map(o => o.hash));
+
+  return {
+    ...synced,
+    pendingOperations: pendingOperations.filter(po => !confirmedHashes.has(po.hash)),
+  };
+}
+
 export const sync = makeSync<AleoTransaction, AleoAccount>({
   getAccountShape: makeGetAccountShape(),
   shouldMergeOps: false,
+  postSync,
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Aleo's pending operation should be correctly removed from the state after op is confirmed

### 📝 Description

This PR ensures that pending operations are correctly removed from Aleo account state. Previously, pending operation disappeared from the UI after confirmation, but `account.pendingOperations` array was left untouched, which resulted in unnecessary syncs that were called every ~5 seconds.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-29101

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
