### PR TITLE
[LWDM] feat(LIVE-28042): accept pre-resolved config in network layer to avoid redundant lookups

### DIFF
--- a/.changeset/bright-moose-report.md
+++ b/.changeset/bright-moose-report.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Refactor coin-aleo network layer to accept pre-resolved config objects, eliminating redundant `getCoinConfig()` lookups on the Alpaca path.

--- a/libs/coin-modules/coin-aleo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.test.ts
@@ -218,7 +218,7 @@ describe("createApi", () => {
 
       expect(mockedListOperations).toHaveBeenCalledTimes(1);
       expect(mockedListOperations).toHaveBeenCalledWith({
-        currency: expect.any(Object),
+        configOrCurrencyId: expect.objectContaining({ status: { type: "active" } }),
         address: "aleo1test",
         options,
         mode: "alpaca",

--- a/libs/coin-modules/coin-aleo/src/api/index.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.ts
@@ -17,7 +17,6 @@ import type {
 } from "@ledgerhq/coin-module-framework/api/index";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import coinConfig from "../config";
 import { estimateFees, getBalance, lastBlock, listOperations, validateAddress } from "../logic";
 import { getTransactionType } from "../logic/utils";
@@ -25,11 +24,10 @@ import type { AleoCoinConfig, AleoConfig, AleoTransactionIntentData } from "../t
 
 export function createApi(
   config: AleoConfig,
-  currencyId: string,
+  _currencyId: string,
 ): AlpacaApi<MemoNotSupported, AleoTransactionIntentData> {
   const aleoCoinConfig: AleoCoinConfig = { ...config, status: { type: "active" } };
   coinConfig.setCoinConfig(() => aleoCoinConfig);
-  const currency = getCryptoCurrencyById(currencyId);
 
   return {
     broadcast: (_signature: string): Promise<string> => {
@@ -57,14 +55,14 @@ export function createApi(
       return estimateFees({ configOrCurrencyId: aleoCoinConfig, transactionType });
     },
     getBalance: (address: string, options?: BalanceOptions): Promise<Balance[]> => {
-      return rejectBalanceOptions(() => getBalance(currency, address), options);
+      return rejectBalanceOptions(() => getBalance(aleoCoinConfig, address), options);
     },
     lastBlock: async (): Promise<BlockInfo> => {
-      return lastBlock(currency);
+      return lastBlock(aleoCoinConfig);
     },
     listOperations: async (address, options) => {
       const { operations, nextCursor } = await listOperations({
-        currency,
+        configOrCurrencyId: aleoCoinConfig,
         address,
         options,
         mode: "alpaca",

--- a/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
@@ -45,7 +45,7 @@ async function buildRootAuthorization(
   );
 
   return sdkClient.createAuthorization({
-    currency: account.currency,
+    configOrCurrencyId: account.currency.id,
     request,
     signatures: signature,
     viewKey,
@@ -79,7 +79,7 @@ async function buildFeeAuthorization(
   const { signature } = await signer.signFeeIntent(Buffer.from(feeRequest.tlv, "hex"));
 
   const result = await sdkClient.createAuthorization({
-    currency: account.currency,
+    configOrCurrencyId: account.currency.id,
     request: feeRequest,
     signatures: signature,
     viewKey,

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
@@ -198,7 +198,7 @@ describe("sync.ts", () => {
 
       expect(mockListOperations).toHaveBeenCalledTimes(1);
       expect(mockListOperations).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAccount.freshAddress,
         ledgerAccountId: expect.any(String),
         mode: "bridge",
@@ -234,7 +234,7 @@ describe("sync.ts", () => {
 
       expect(mockListOperations).toHaveBeenCalledTimes(1);
       expect(mockListOperations).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAccount.freshAddress,
         ledgerAccountId: mockInitialAccount.id,
         mode: "bridge",
@@ -414,7 +414,7 @@ describe("sync.ts", () => {
 
       expect(mockAccessProvableApi).toHaveBeenCalledTimes(1);
       expect(mockAccessProvableApi).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         viewKey: "AViewKey123",
         provableApi: accountWithProvableApi.aleoResources?.provableApi,
       });
@@ -607,12 +607,12 @@ describe("sync.ts", () => {
 
       expect(mockFetchAllOwnedRecords).toHaveBeenCalledTimes(2);
       expect(mockFetchAllOwnedRecords).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: configuredProvableApi.uuid,
         start: 0,
       });
       expect(mockFetchAllOwnedRecords).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: configuredProvableApi.uuid,
         unspent: true,
       });
@@ -904,7 +904,7 @@ describe("sync.ts", () => {
 
       expect(mockPatchPublicOperations).toHaveBeenCalledTimes(1);
       expect(mockPatchPublicOperations).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: expect.any(Array),
         privateRecords: [privateRecord],
         address: mockAccount.freshAddress,

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -52,8 +52,8 @@ export async function performPublicSync(
   });
 
   const [balances, latestBlock] = await Promise.all([
-    getBalance(currency, address),
-    lastBlock(currency),
+    getBalance(currency.id, address),
+    lastBlock(currency.id),
   ]);
 
   const blockHeight = latestBlock?.height ?? initialAccount?.blockHeight ?? 0;
@@ -61,15 +61,15 @@ export async function performPublicSync(
   const transparentBalance = new BigNumber(nativeBalance.toString());
 
   const shouldSyncFromScratch = !initialAccount;
-  const allOldOperations = shouldSyncFromScratch ? [] : (initialAccount?.operations ?? []);
+  const allOldOperations = shouldSyncFromScratch ? [] : initialAccount?.operations ?? [];
 
   // Keep public and private ops separate so each cursor is derived from the correct op type.
   // Mixing them risks using a private op's blockHeight as the public sync cursor.
   const [oldPrivateOps, oldPublicOps] = splitPrivateAndPublicOperations(allOldOperations);
-  const lastBlockHeight = shouldSyncFromScratch ? 0 : (oldPublicOps[0]?.blockHeight ?? 0);
+  const lastBlockHeight = shouldSyncFromScratch ? 0 : oldPublicOps[0]?.blockHeight ?? 0;
 
   const latestAccountPublicOperations = await listOperations({
-    currency,
+    configOrCurrencyId: currency.id,
     address,
     ledgerAccountId,
     mode: "bridge",
@@ -165,7 +165,7 @@ export async function performPrivateSync(
   const viewKey = extractViewKey(initialAccount);
 
   const provableApi = await accessProvableApi({
-    currency,
+    configOrCurrencyId: currency.id,
     viewKey,
     provableApi: initialAccount.aleoResources?.provableApi ?? null,
   }).catch(err => {
@@ -202,7 +202,7 @@ export async function performPrivateSync(
     customData: viewKey,
   });
 
-  const latestBlock = await lastBlock(currency);
+  const latestBlock = await lastBlock(currency.id);
   const blockHeight = latestBlock?.height ?? initialAccount?.blockHeight ?? 0;
 
   const allOldOperations = initialAccount.operations ?? [];
@@ -211,12 +211,12 @@ export async function performPrivateSync(
 
   const [rawNewPrivateRecords, rawUnspentPrivateRecords] = await Promise.all([
     fetchAllOwnedRecords({
-      currency,
+      configOrCurrencyId: currency.id,
       uuid: provableApi.uuid,
       start: lastPrivateBlockHeight,
     }),
     fetchAllOwnedRecords({
-      currency,
+      configOrCurrencyId: currency.id,
       uuid: provableApi.uuid,
       unspent: true,
     }),
@@ -231,7 +231,7 @@ export async function performPrivateSync(
       privateRecords: rawNewPrivateRecords,
     }),
     patchPublicOperations({
-      currency,
+      configOrCurrencyId: currency.id,
       publicOperations: currentPublicOps,
       privateRecords: rawNewPrivateRecords,
       address,

--- a/libs/coin-modules/coin-aleo/src/logic/broadcast.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/broadcast.test.ts
@@ -47,7 +47,7 @@ describe("broadcast", () => {
     expect(mockFromHex).toHaveBeenCalledWith(mockSignedTx);
     expect(apiClient.submitDelegatedProvingRequest).toHaveBeenCalledTimes(1);
     expect(apiClient.submitDelegatedProvingRequest).toHaveBeenCalledWith({
-      currency: mockAccount.currency,
+      configOrCurrencyId: mockConfig,
       authorization: mockAuthorization,
       feeAuthorization: mockFeeAuthorization,
       broadcast: true,
@@ -68,7 +68,7 @@ describe("broadcast", () => {
 
     expect(apiClient.submitDelegatedProvingRequest).toHaveBeenCalledTimes(1);
     expect(apiClient.submitDelegatedProvingRequest).toHaveBeenCalledWith({
-      currency: mockAccount.currency,
+      configOrCurrencyId: mockConfig,
       authorization: mockAuthorization,
       broadcast: true,
     });
@@ -104,19 +104,19 @@ describe("broadcast", () => {
 
       expect(apiClient.getProvePublicKey).toHaveBeenCalledTimes(1);
       expect(apiClient.getProvePublicKey).toHaveBeenCalledWith({
-        currency: mockAccount.currency,
+        configOrCurrencyId: encryptedConfig,
       });
       expect(sdkClient.encryptProvingRequest).toHaveBeenCalledTimes(1);
       expect(sdkClient.encryptProvingRequest).toHaveBeenCalledWith({
         publicKey: mockPublicKeyResponse.public_key,
-        currency: mockAccount.currency,
+        configOrCurrencyId: encryptedConfig,
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: true,
       });
       expect(apiClient.submitEncryptedDelegatedProvingRequest).toHaveBeenCalledTimes(1);
       expect(apiClient.submitEncryptedDelegatedProvingRequest).toHaveBeenCalledWith({
-        currency: mockAccount.currency,
+        configOrCurrencyId: encryptedConfig,
         keyId: mockPublicKeyResponse.key_id,
         encryptedData: mockEncryptedData,
       });
@@ -136,7 +136,7 @@ describe("broadcast", () => {
 
       expect(sdkClient.encryptProvingRequest).toHaveBeenCalledWith({
         publicKey: mockPublicKeyResponse.public_key,
-        currency: mockAccount.currency,
+        configOrCurrencyId: encryptedConfig,
         authorization: mockAuthorization,
         broadcast: true,
       });

--- a/libs/coin-modules/coin-aleo/src/logic/broadcast.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/broadcast.ts
@@ -22,7 +22,7 @@ export async function broadcast({
 
   if (!config.useEncryptedProve) {
     const res = await apiClient.submitDelegatedProvingRequest({
-      currency: account.currency,
+      configOrCurrencyId,
       authorization,
       ...(feeAuthorization && { feeAuthorization }),
       broadcast: true,
@@ -32,19 +32,19 @@ export async function broadcast({
   }
 
   const publicKeyResponse = await apiClient.getProvePublicKey({
-    currency: account.currency,
+    configOrCurrencyId,
   });
 
   const encryptedData = await sdkClient.encryptProvingRequest({
     publicKey: publicKeyResponse.public_key,
-    currency: account.currency,
+    configOrCurrencyId,
     authorization,
     ...(feeAuthorization && { feeAuthorization }),
     broadcast: true,
   });
 
   const res = await apiClient.submitEncryptedDelegatedProvingRequest({
-    currency: account.currency,
+    configOrCurrencyId,
     keyId: publicKeyResponse.key_id,
     encryptedData,
   });

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.test.ts
@@ -53,7 +53,7 @@ describe("craftTransaction", () => {
     expect(mapTransactionIntentToSdkIntent).toHaveBeenCalledWith(mockTxIntentTransferPublic);
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledTimes(1);
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      configOrCurrencyId: mockCurrency.id,
       intent: mockSdkIntent,
       feeConfiguration: mockFeeConfiguration,
       viewKey: mockViewKey,
@@ -71,7 +71,7 @@ describe("craftTransaction", () => {
 
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledTimes(1);
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      configOrCurrencyId: mockCurrency.id,
       intent: mockSdkIntent,
       feeConfiguration: null,
     });

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.ts
@@ -21,7 +21,7 @@ export async function craftTransaction({
 }): Promise<CraftedTransaction> {
   const intent = mapTransactionIntentToSdkIntent(txIntent);
   const response = await sdkClient.createRequestFromIntent({
-    currency,
+    configOrCurrencyId: currency.id,
     intent,
     feeConfiguration,
     ...(viewKey !== undefined && { viewKey }),

--- a/libs/coin-modules/coin-aleo/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getBalance.test.ts
@@ -18,7 +18,7 @@ describe("getBalance", () => {
   it("should return balance when account has funds", async () => {
     mockGetAccountBalance.mockResolvedValue("1000000u64");
 
-    const result = await getBalance(mockCurrency, mockAccount.freshAddress);
+    const result = await getBalance(mockCurrency.id, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -27,13 +27,13 @@ describe("getBalance", () => {
       },
     ]);
     expect(mockGetAccountBalance).toHaveBeenCalledTimes(1);
-    expect(mockGetAccountBalance).toHaveBeenCalledWith(mockCurrency, mockAccount.freshAddress);
+    expect(mockGetAccountBalance).toHaveBeenCalledWith(mockCurrency.id, mockAccount.freshAddress);
   });
 
   it("should handle zero balance", async () => {
     mockGetAccountBalance.mockResolvedValue("0u64");
 
-    const result = await getBalance(mockCurrency, mockAccount.freshAddress);
+    const result = await getBalance(mockCurrency.id, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -46,7 +46,7 @@ describe("getBalance", () => {
   it("should handle large balance values", async () => {
     mockGetAccountBalance.mockResolvedValue("999999999999999999u64");
 
-    const result = await getBalance(mockCurrency, mockAccount.freshAddress);
+    const result = await getBalance(mockCurrency.id, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -59,7 +59,7 @@ describe("getBalance", () => {
   it("should parse balance correctly by removing last 3 characters (u64)", async () => {
     mockGetAccountBalance.mockResolvedValue("123456789u64");
 
-    const result = await getBalance(mockCurrency, mockAccount.freshAddress);
+    const result = await getBalance(mockCurrency.id, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -72,7 +72,7 @@ describe("getBalance", () => {
   it("should return empty array when API returns null", async () => {
     mockGetAccountBalance.mockResolvedValue(null);
 
-    const result = await getBalance(mockCurrency, mockAccount.freshAddress);
+    const result = await getBalance(mockCurrency.id, mockAccount.freshAddress);
 
     expect(result).toEqual([]);
   });
@@ -80,18 +80,18 @@ describe("getBalance", () => {
   it("should throw error when balance format is invalid (missing u64)", async () => {
     mockGetAccountBalance.mockResolvedValue("1000000");
 
-    await expect(getBalance(mockCurrency, mockAccount.freshAddress)).rejects.toThrow();
+    await expect(getBalance(mockCurrency.id, mockAccount.freshAddress)).rejects.toThrow();
   });
 
   it("should throw error when balance format has wrong suffix", async () => {
     mockGetAccountBalance.mockResolvedValue("1000000u32");
 
-    await expect(getBalance(mockCurrency, mockAccount.freshAddress)).rejects.toThrow();
+    await expect(getBalance(mockCurrency.id, mockAccount.freshAddress)).rejects.toThrow();
   });
 
   it("should throw error when balance format is completely invalid", async () => {
     mockGetAccountBalance.mockResolvedValue("invalid");
 
-    await expect(getBalance(mockCurrency, mockAccount.freshAddress)).rejects.toThrow();
+    await expect(getBalance(mockCurrency.id, mockAccount.freshAddress)).rejects.toThrow();
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getBalance.ts
@@ -1,10 +1,13 @@
 import type { Balance } from "@ledgerhq/coin-module-framework/api/types";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { AleoCoinConfig } from "../types";
 import { apiClient } from "../network/api";
 import { parseMicrocredits } from "./utils";
 
-export async function getBalance(currency: CryptoCurrency, address: string): Promise<Balance[]> {
-  const microcreditsU64 = await apiClient.getAccountBalance(currency, address);
+export async function getBalance(
+  configOrCurrencyId: AleoCoinConfig | string,
+  address: string,
+): Promise<Balance[]> {
+  const microcreditsU64 = await apiClient.getAccountBalance(configOrCurrencyId, address);
 
   if (!microcreditsU64) {
     return [];

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.test.ts
@@ -49,7 +49,7 @@ describe("getPrivateBalance", () => {
 
     expect(sdkClient.decryptRecord).toHaveBeenCalledTimes(1);
     expect(sdkClient.decryptRecord).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      configOrCurrencyId: mockCurrency.id,
       viewKey: mockViewKey,
       ciphertext: record.record_ciphertext,
     });

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.ts
@@ -36,7 +36,7 @@ export async function getPrivateBalance({
     }
 
     const decryptedRecord = await sdkClient.decryptRecord({
-      currency,
+      configOrCurrencyId: currency.id,
       viewKey,
       ciphertext: record.record_ciphertext,
     });

--- a/libs/coin-modules/coin-aleo/src/logic/lastBlock.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/lastBlock.test.ts
@@ -27,10 +27,10 @@ describe("lastBlock", () => {
 
     mockGetLatestBlock.mockResolvedValue(mockBlockResponse);
 
-    const result = await lastBlock(mockCurrency);
+    const result = await lastBlock(mockCurrency.id);
 
     expect(mockGetLatestBlock).toHaveBeenCalledTimes(1);
-    expect(mockGetLatestBlock).toHaveBeenCalledWith(mockCurrency);
+    expect(mockGetLatestBlock).toHaveBeenCalledWith(mockCurrency.id);
     expect(result).toEqual({
       height: 1234567,
       hash: "ab1234567890",

--- a/libs/coin-modules/coin-aleo/src/logic/lastBlock.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/lastBlock.ts
@@ -1,9 +1,9 @@
 import type { BlockInfo } from "@ledgerhq/coin-module-framework/api/index";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { AleoCoinConfig } from "../types";
 import { apiClient } from "../network/api";
 
-export async function lastBlock(currency: CryptoCurrency): Promise<BlockInfo> {
-  const lastBlock = await apiClient.getLatestBlock(currency);
+export async function lastBlock(configOrCurrencyId: AleoCoinConfig | string): Promise<BlockInfo> {
+  const lastBlock = await apiClient.getLatestBlock(configOrCurrencyId);
 
   return {
     height: lastBlock.header.metadata.height,

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.test.ts
@@ -38,7 +38,7 @@ describe("listOperations", () => {
       mockToBridgeOperation.mockReturnValueOnce(mockOp1).mockReturnValueOnce(mockOp2);
 
       const result = await listOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         ledgerAccountId: mockLedgerAccountId,
         mode: "bridge",
@@ -47,7 +47,7 @@ describe("listOperations", () => {
 
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledTimes(1);
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         fetchAllPages: true,
         minBlockHeight: 0,
@@ -70,7 +70,7 @@ describe("listOperations", () => {
       mockToBridgeOperation.mockReturnValue(mockOp);
 
       await listOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         ledgerAccountId: mockLedgerAccountId,
         mode: "bridge",
@@ -88,7 +88,7 @@ describe("listOperations", () => {
       });
 
       const result = await listOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         ledgerAccountId: mockLedgerAccountId,
         mode: "bridge",
@@ -112,7 +112,7 @@ describe("listOperations", () => {
       mockToAlpacaOperation.mockReturnValue(mockAlpacaOp);
 
       const result = await listOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         mode: "alpaca",
         options: { minHeight: 0, order: "asc" },
@@ -120,7 +120,7 @@ describe("listOperations", () => {
 
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledTimes(1);
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         fetchAllPages: false,
         minBlockHeight: 0,
@@ -140,7 +140,7 @@ describe("listOperations", () => {
       });
 
       const result = await listOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         mode: "alpaca",
         options: { minHeight: 0 },
@@ -159,7 +159,7 @@ describe("listOperations", () => {
       });
 
       await listOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         mode: "alpaca",
         options: {
@@ -172,7 +172,7 @@ describe("listOperations", () => {
 
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledTimes(1);
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         fetchAllPages: false,
         minBlockHeight: 1000,

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
@@ -1,11 +1,11 @@
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Operation, ListOperationsOptions } from "@ledgerhq/coin-module-framework/api/types";
-import type { AleoOperation } from "../types/bridge";
 import { fetchAccountTransactionsFromHeight } from "../network/utils";
+import type { AleoCoinConfig } from "../types";
+import type { AleoOperation } from "../types/bridge";
 import { toAlpacaOperation, toBridgeOperation } from "./utils";
 
 interface Params {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   address: string;
   options: ListOperationsOptions;
 }
@@ -29,12 +29,12 @@ export async function listOperations(params: AlpacaParams): Promise<Result<Opera
 export async function listOperations(
   params: BridgeParams | AlpacaParams,
 ): Promise<Result<AleoOperation | Operation>> {
-  const { mode, currency, address, options } = params;
+  const { mode, configOrCurrencyId, address, options } = params;
   const operations: Array<AleoOperation | Operation> = [];
   const fetchAllPages = mode === "bridge";
 
   const result = await fetchAccountTransactionsFromHeight({
-    currency,
+    configOrCurrencyId,
     address,
     fetchAllPages,
     minBlockHeight: options.minHeight,

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
@@ -95,7 +95,7 @@ describe("listPrivateOperations", () => {
 
     expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(1);
     expect(mockEnrichPrivateRecord).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      configOrCurrencyId: mockCurrency.id,
       rawRecord: record,
       viewKey: mockViewKey,
       address: mockAddress,
@@ -123,7 +123,7 @@ describe("listPrivateOperations", () => {
 
     expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(1);
     expect(mockEnrichPrivateRecord).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      configOrCurrencyId: mockCurrency.id,
       rawRecord: record,
       viewKey: mockViewKey,
       address: mockAddress,
@@ -151,7 +151,7 @@ describe("listPrivateOperations", () => {
 
     expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(1);
     expect(mockEnrichPrivateRecord).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      configOrCurrencyId: mockCurrency.id,
       rawRecord: record,
       viewKey: mockViewKey,
       address: mockAddress,

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
@@ -47,7 +47,7 @@ export async function listPrivateOperations({
   const consumedRecordTags = new Set<string>();
   const nativePrivateRecords = privateRecords.filter(onlyNativeCoinOperations);
   const enrichedRecords = await promiseAllBatched(2, nativePrivateRecords, rawRecord =>
-    enrichPrivateRecord({ currency, rawRecord, address, viewKey }),
+    enrichPrivateRecord({ configOrCurrencyId: currency.id, rawRecord, address, viewKey }),
   );
 
   // Build the set of record tags consumed as inputs in outgoing transactions.

--- a/libs/coin-modules/coin-aleo/src/network/api.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.test.ts
@@ -1,6 +1,7 @@
 import network from "@ledgerhq/live-network";
-import { getNetworkConfig } from "../logic/utils";
+import { resolveConfig } from "../logic/utils";
 import type { AleoLatestBlockResponse } from "../types/api";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import {
   testnetPrivateRecord,
   getMockedTransactionDetails,
@@ -18,20 +19,15 @@ jest.mock("../logic/utils");
 
 describe("apiClient", () => {
   const mockCurrency = getMockedCurrency();
-  const mockNetworkConfig: ReturnType<typeof getNetworkConfig> = {
-    nodeUrl: "https://api.aleo.network",
-    sdkUrl: "https://sdk.aleo.network",
-    networkType: "mainnet",
-  };
-  const testnetConfig: ReturnType<typeof getNetworkConfig> = {
-    nodeUrl: "https://api.testnet.aleo.network",
-    sdkUrl: "https://sdk.testnet.aleo.network",
-    networkType: "testnet",
+  const mockResolvedConfig = getMockedConfig("testnet");
+  const customNodeConfig = {
+    ...getMockedConfig("testnet"),
+    apiUrls: { ...getMockedConfig("testnet").apiUrls, node: "https://custom-node.example.com" },
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(getNetworkConfig).mockReturnValue(mockNetworkConfig);
+    jest.mocked(resolveConfig).mockReturnValue(mockResolvedConfig);
   });
 
   describe("getLatestBlock", () => {
@@ -49,14 +45,12 @@ describe("apiClient", () => {
 
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getLatestBlock(mockCurrency);
+      const result = await apiClient.getLatestBlock(mockCurrency.id);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/blocks/latest`,
+        url: `${mockResolvedConfig.apiUrls.node}/v2/${mockResolvedConfig.networkType}/blocks/latest`,
       });
       expect(result).toEqual(mockResponse);
     });
@@ -64,11 +58,11 @@ describe("apiClient", () => {
     it("should throw an error when network request fails", async () => {
       jest.mocked(network).mockRejectedValue(new Error("Network error"));
 
-      await expect(apiClient.getLatestBlock(mockCurrency)).rejects.toThrow("Network error");
+      await expect(apiClient.getLatestBlock(mockCurrency.id)).rejects.toThrow("Network error");
     });
 
     it("should use correct network configuration", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customNodeConfig);
 
       const mockResponse: AleoLatestBlockResponse = {
         block_hash: "test123",
@@ -83,13 +77,11 @@ describe("apiClient", () => {
 
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      await apiClient.getLatestBlock(mockCurrency);
-
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
+      await apiClient.getLatestBlock(mockCurrency.id);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/v2/${testnetConfig.networkType}/blocks/latest`,
+        url: `${customNodeConfig.apiUrls.node}/v2/testnet/blocks/latest`,
       });
     });
   });
@@ -101,14 +93,12 @@ describe("apiClient", () => {
 
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getTransactionById(mockCurrency, mockTransactionId);
+      const result = await apiClient.getTransactionById(mockCurrency.id, mockTransactionId);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/${mockTransactionId}`,
+        url: `${mockResolvedConfig.apiUrls.node}/v2/${mockResolvedConfig.networkType}/transactions/${mockTransactionId}`,
       });
       expect(result).toEqual(mockResponse);
     });
@@ -116,13 +106,13 @@ describe("apiClient", () => {
     it("should throw an error when transaction is not found", async () => {
       jest.mocked(network).mockRejectedValue(new Error("Transaction not found"));
 
-      await expect(apiClient.getTransactionById(mockCurrency, "at1nonexistent")).rejects.toThrow(
+      await expect(apiClient.getTransactionById(mockCurrency.id, "at1nonexistent")).rejects.toThrow(
         "Transaction not found",
       );
     });
 
     it("should use correct network configuration for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customNodeConfig);
 
       const mockTransactionId = "at1testnet123";
       const mockResponse = getMockedSimpleTransactionDetails(mockTransactionId, {
@@ -132,13 +122,11 @@ describe("apiClient", () => {
 
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      await apiClient.getTransactionById(mockCurrency, mockTransactionId);
-
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
+      await apiClient.getTransactionById(mockCurrency.id, mockTransactionId);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/v2/${testnetConfig.networkType}/transactions/${mockTransactionId}`,
+        url: `${customNodeConfig.apiUrls.node}/v2/testnet/transactions/${mockTransactionId}`,
       });
     });
   });
@@ -152,16 +140,14 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=50&sort=asc&direction=next`,
+        url: `${mockResolvedConfig.apiUrls.node}/v2/${mockResolvedConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=50&sort=asc&direction=next`,
       });
       expect(result).toEqual(mockResponse);
       expect(result.transactions).toHaveLength(2);
@@ -176,16 +162,14 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         limit: customLimit,
       });
-
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=10&sort=asc&direction=next`,
+        url: `${mockResolvedConfig.apiUrls.node}/v2/${mockResolvedConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=10&sort=asc&direction=next`,
       });
     });
 
@@ -197,16 +181,14 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         order: "desc",
       });
-
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=50&sort=desc&direction=next`,
+        url: `${mockResolvedConfig.apiUrls.node}/v2/${mockResolvedConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=50&sort=desc&direction=next`,
       });
     });
 
@@ -227,16 +209,14 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         cursor,
       });
-
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=50&sort=asc&direction=next&cursor_block_number=${cursor}`,
+        url: `${mockResolvedConfig.apiUrls.node}/v2/${mockResolvedConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=50&sort=asc&direction=next&cursor_block_number=${cursor}`,
       });
     });
 
@@ -248,16 +228,14 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         direction: "prev",
       });
-
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=50&sort=asc&direction=prev`,
+        url: `${mockResolvedConfig.apiUrls.node}/v2/${mockResolvedConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=50&sort=asc&direction=prev`,
       });
     });
 
@@ -285,19 +263,17 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
         cursor,
         limit: 20,
         order: "desc",
         direction: "prev",
       });
-
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=20&sort=desc&direction=prev&cursor_block_number=${cursor}`,
+        url: `${mockResolvedConfig.apiUrls.node}/v2/${mockResolvedConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=20&sort=desc&direction=prev&cursor_block_number=${cursor}`,
       });
       expect(result).toEqual(mockResponse);
     });
@@ -307,7 +283,7 @@ describe("apiClient", () => {
 
       await expect(
         apiClient.getAccountPublicTransactions({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
         }),
       ).rejects.toThrow("Network error");
@@ -321,7 +297,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
       });
 
@@ -329,7 +305,7 @@ describe("apiClient", () => {
     });
 
     it("should use correct network configuration for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customNodeConfig);
 
       const mockResponse = getMockedAccountPublicTransactions(mockAddress, {
         transactions: [],
@@ -338,15 +314,13 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         address: mockAddress,
       });
-
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/v2/${testnetConfig.networkType}/transactions/address/${mockAddress}?metadata=true&limit=50&sort=asc&direction=next`,
+        url: `${customNodeConfig.apiUrls.node}/v2/testnet/transactions/address/${mockAddress}?metadata=true&limit=50&sort=asc&direction=next`,
       });
     });
   });
@@ -358,14 +332,12 @@ describe("apiClient", () => {
       const mockBalance = "1000000u64";
       jest.mocked(network).mockResolvedValue({ data: mockBalance, status: 200 });
 
-      const result = await apiClient.getAccountBalance(mockCurrency, mockAddress);
+      const result = await apiClient.getAccountBalance(mockCurrency.id, mockAddress);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/program/credits.aleo/mapping/account/${mockAddress}`,
+        url: `${mockResolvedConfig.apiUrls.node}/v2/${mockResolvedConfig.networkType}/program/credits.aleo/mapping/account/${mockAddress}`,
       });
       expect(result).toEqual(mockBalance);
     });
@@ -373,7 +345,7 @@ describe("apiClient", () => {
     it("should return null when account has no balance", async () => {
       jest.mocked(network).mockResolvedValue({ data: null, status: 200 });
 
-      const result = await apiClient.getAccountBalance(mockCurrency, mockAddress);
+      const result = await apiClient.getAccountBalance(mockCurrency.id, mockAddress);
 
       expect(result).toBeNull();
     });
@@ -382,21 +354,21 @@ describe("apiClient", () => {
       const mockError = new Error("Network error");
       jest.mocked(network).mockRejectedValue(mockError);
 
-      await expect(apiClient.getAccountBalance(mockCurrency, mockAddress)).rejects.toThrow(
+      await expect(apiClient.getAccountBalance(mockCurrency.id, mockAddress)).rejects.toThrow(
         "Network error",
       );
     });
 
     it("should use correct network configuration for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customNodeConfig);
       jest.mocked(network).mockResolvedValue({ data: "500000u64", status: 200 });
 
-      await apiClient.getAccountBalance(mockCurrency, mockAddress);
+      await apiClient.getAccountBalance(mockCurrency.id, mockAddress);
 
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/v2/${testnetConfig.networkType}/program/credits.aleo/mapping/account/${mockAddress}`,
+        url: `${customNodeConfig.apiUrls.node}/v2/testnet/program/credits.aleo/mapping/account/${mockAddress}`,
       });
     });
   });
@@ -409,29 +381,27 @@ describe("apiClient", () => {
       };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getScannerPublicKey(mockCurrency);
+      const result = await apiClient.getScannerPublicKey(mockCurrency.id);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/pubkey`,
+        url: `${mockResolvedConfig.apiUrls.node}/scanner/${mockResolvedConfig.networkType}/pubkey`,
       });
       expect(result).toEqual(mockResponse);
     });
 
     it("should use the correct network type in the URL", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customNodeConfig);
       jest
         .mocked(network)
         .mockResolvedValue({ data: { key_id: "k1", public_key: "pk1" }, status: 200 });
 
-      await apiClient.getScannerPublicKey(mockCurrency);
+      await apiClient.getScannerPublicKey(mockCurrency.id);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/scanner/testnet/pubkey`,
+        url: `${customNodeConfig.apiUrls.node}/scanner/testnet/pubkey`,
       });
     });
 
@@ -439,7 +409,7 @@ describe("apiClient", () => {
       const mockError = new Error("Forbidden");
       jest.mocked(network).mockRejectedValue(mockError);
 
-      await expect(apiClient.getScannerPublicKey(mockCurrency)).rejects.toThrow("Forbidden");
+      await expect(apiClient.getScannerPublicKey(mockCurrency.id)).rejects.toThrow("Forbidden");
     });
   });
 
@@ -452,28 +422,26 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.registerForScanningAccountRecordsEncrypted({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         encryptedData: mockEncryptedData,
         keyId: mockKeyId,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/register/encrypted`,
+        url: `${mockResolvedConfig.apiUrls.node}/scanner/${mockResolvedConfig.networkType}/register/encrypted`,
         data: { key_id: mockKeyId, ciphertext: mockEncryptedData },
       });
       expect(result).toEqual(mockResponse);
     });
 
     it("should use the correct network type in the URL", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customNodeConfig);
       jest.mocked(network).mockResolvedValue({ data: { uuid: "scan-uuid-testnet" }, status: 200 });
 
       await apiClient.registerForScanningAccountRecordsEncrypted({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         encryptedData: mockEncryptedData,
         keyId: mockKeyId,
       });
@@ -481,7 +449,7 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${testnetConfig.nodeUrl}/scanner/${testnetConfig.networkType}/register/encrypted`,
+        url: `${customNodeConfig.apiUrls.node}/scanner/testnet/register/encrypted`,
         data: { key_id: mockKeyId, ciphertext: mockEncryptedData },
       });
     });
@@ -492,7 +460,7 @@ describe("apiClient", () => {
 
       await expect(
         apiClient.registerForScanningAccountRecordsEncrypted({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           encryptedData: mockEncryptedData,
           keyId: mockKeyId,
         }),
@@ -507,14 +475,12 @@ describe("apiClient", () => {
       const mockResponse = { synced: true, percentage: 100 };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getRecordScannerStatus(mockCurrency, mockUuid);
+      const result = await apiClient.getRecordScannerStatus(mockCurrency.id, mockUuid);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/status`,
+        url: `${mockResolvedConfig.apiUrls.node}/scanner/${mockResolvedConfig.networkType}/status`,
         headers: { "Content-Type": "application/json" },
         data: `"${mockUuid}"`,
       });
@@ -525,24 +491,24 @@ describe("apiClient", () => {
       const mockResponse = { synced: false, percentage: 42 };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getRecordScannerStatus(mockCurrency, mockUuid);
+      const result = await apiClient.getRecordScannerStatus(mockCurrency.id, mockUuid);
 
       expect(result.synced).toBe(false);
       expect(result.percentage).toBe(42);
     });
 
     it("should use the correct network type in the URL", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customNodeConfig);
       jest
         .mocked(network)
         .mockResolvedValue({ data: { synced: true, percentage: 100 }, status: 200 });
 
-      await apiClient.getRecordScannerStatus(mockCurrency, mockUuid);
+      await apiClient.getRecordScannerStatus(mockCurrency.id, mockUuid);
 
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${testnetConfig.nodeUrl}/scanner/${testnetConfig.networkType}/status`,
+        url: `${customNodeConfig.apiUrls.node}/scanner/testnet/status`,
         headers: { "Content-Type": "application/json" },
         data: `"${mockUuid}"`,
       });
@@ -552,7 +518,7 @@ describe("apiClient", () => {
       const mockError = new Error("Status fetch failed");
       jest.mocked(network).mockRejectedValue(mockError);
 
-      await expect(apiClient.getRecordScannerStatus(mockCurrency, mockUuid)).rejects.toThrow(
+      await expect(apiClient.getRecordScannerStatus(mockCurrency.id, mockUuid)).rejects.toThrow(
         "Status fetch failed",
       );
     });
@@ -566,16 +532,14 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/records/owned`,
+        url: `${mockResolvedConfig.apiUrls.node}/scanner/${mockResolvedConfig.networkType}/records/owned`,
         data: { uuid: mockUuid },
       });
       expect(result).toEqual(mockResponse);
@@ -585,7 +549,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
         unspent: true,
       });
@@ -602,7 +566,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
         unspent: false,
       });
@@ -619,7 +583,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
       });
 
@@ -632,7 +596,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
         start: mockStart,
       });
@@ -649,7 +613,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
       });
 
@@ -662,7 +626,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
         unspent: true,
         start: mockStart,
@@ -680,7 +644,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       const result = await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
       });
 
@@ -693,18 +657,18 @@ describe("apiClient", () => {
 
       await expect(
         apiClient.getAccountOwnedRecords({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           uuid: mockUuid,
         }),
       ).rejects.toThrow("Unauthorized");
     });
 
     it("should use the correct network type in the URL for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customNodeConfig);
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
       });
 
@@ -712,7 +676,7 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
           method: "POST",
-          url: `${testnetConfig.nodeUrl}/scanner/${testnetConfig.networkType}/records/owned`,
+          url: `${customNodeConfig.apiUrls.node}/scanner/testnet/records/owned`,
         }),
       );
     });
@@ -721,7 +685,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
         resultsPerPage: 100,
       });
@@ -738,7 +702,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
         page: 2,
       });
@@ -756,7 +720,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
         start: mockStart,
         resultsPerPage: 500,
@@ -778,7 +742,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
         unspent: true,
         resultsPerPage: 200,
@@ -801,7 +765,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUuid,
         page: 0,
       });
@@ -823,29 +787,27 @@ describe("apiClient", () => {
       };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getProvePublicKey({ currency: mockCurrency });
+      const result = await apiClient.getProvePublicKey({ configOrCurrencyId: mockCurrency.id });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/prove/${mockNetworkConfig.networkType}/pubkey`,
+        url: `${mockResolvedConfig.apiUrls.node}/prove/${mockResolvedConfig.networkType}/pubkey`,
       });
       expect(result).toEqual(mockResponse);
     });
 
     it("should use the correct network type in the URL", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customNodeConfig);
       jest
         .mocked(network)
         .mockResolvedValue({ data: { key_id: "k1", public_key: "pk1" }, status: 200 });
 
-      await apiClient.getProvePublicKey({ currency: mockCurrency });
+      await apiClient.getProvePublicKey({ configOrCurrencyId: mockCurrency.id });
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/prove/${testnetConfig.networkType}/pubkey`,
+        url: `${customNodeConfig.apiUrls.node}/prove/testnet/pubkey`,
       });
     });
 
@@ -853,9 +815,9 @@ describe("apiClient", () => {
       const mockError = new Error("Forbidden");
       jest.mocked(network).mockRejectedValue(mockError);
 
-      await expect(apiClient.getProvePublicKey({ currency: mockCurrency })).rejects.toThrow(
-        "Forbidden",
-      );
+      await expect(
+        apiClient.getProvePublicKey({ configOrCurrencyId: mockCurrency.id }),
+      ).rejects.toThrow("Forbidden");
     });
   });
 
@@ -868,18 +830,16 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       const result = await apiClient.submitDelegatedProvingRequest({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: true,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/prove/${mockNetworkConfig.networkType}/prove`,
+        url: `${mockResolvedConfig.apiUrls.node}/prove/${mockResolvedConfig.networkType}/prove`,
         data: {
           authorization: mockAuthorization,
           fee_authorization: mockFeeAuthorization,
@@ -890,11 +850,11 @@ describe("apiClient", () => {
     });
 
     it("should use correct network URL for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customNodeConfig);
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       await apiClient.submitDelegatedProvingRequest({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: true,
@@ -903,7 +863,7 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.nodeUrl}/prove/${testnetConfig.networkType}/prove`,
+          url: `${customNodeConfig.apiUrls.node}/prove/testnet/prove`,
         }),
       );
     });
@@ -914,7 +874,7 @@ describe("apiClient", () => {
 
       await expect(
         apiClient.submitDelegatedProvingRequest({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           authorization: mockAuthorization,
           feeAuthorization: mockFeeAuthorization,
           broadcast: true,
@@ -926,7 +886,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       await apiClient.submitDelegatedProvingRequest({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: false,
@@ -946,7 +906,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       await apiClient.submitDelegatedProvingRequest({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         authorization: mockAuthorization,
         broadcast: true,
       });
@@ -972,17 +932,15 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       const result = await apiClient.submitEncryptedDelegatedProvingRequest({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         keyId: mockKeyId,
         encryptedData: mockEncryptedData,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/prove/${mockNetworkConfig.networkType}/prove/encrypted`,
+        url: `${mockResolvedConfig.apiUrls.node}/prove/${mockResolvedConfig.networkType}/prove/encrypted`,
         data: {
           key_id: mockKeyId,
           ciphertext: mockEncryptedData,
@@ -992,11 +950,11 @@ describe("apiClient", () => {
     });
 
     it("should use correct network URL for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customNodeConfig);
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       await apiClient.submitEncryptedDelegatedProvingRequest({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         keyId: mockKeyId,
         encryptedData: mockEncryptedData,
       });
@@ -1004,7 +962,7 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.nodeUrl}/prove/${testnetConfig.networkType}/prove/encrypted`,
+          url: `${customNodeConfig.apiUrls.node}/prove/testnet/prove/encrypted`,
         }),
       );
     });
@@ -1015,7 +973,7 @@ describe("apiClient", () => {
 
       await expect(
         apiClient.submitEncryptedDelegatedProvingRequest({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           keyId: mockKeyId,
           encryptedData: mockEncryptedData,
         }),

--- a/libs/coin-modules/coin-aleo/src/network/api.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.ts
@@ -1,6 +1,8 @@
 import network from "@ledgerhq/live-network";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { LiveNetworkResponse } from "@ledgerhq/live-network/network";
+import { PROGRAM_ID } from "../constants";
+import { resolveConfig } from "../logic/utils";
+import type { AleoCoinConfig } from "../types";
 import type {
   AleoLatestBlockResponse,
   AleoPublicTransactionDetailsResponse,
@@ -12,64 +14,64 @@ import type {
   AleoPrivateRecord,
   DelegatedProvingResponse,
 } from "../types/api";
-import { getNetworkConfig } from "../logic/utils";
-import { PROGRAM_ID } from "../constants";
 
-async function getLatestBlock(currency: CryptoCurrency): Promise<AleoLatestBlockResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+async function getLatestBlock(
+  configOrCurrencyId: AleoCoinConfig | string,
+): Promise<AleoLatestBlockResponse> {
+  const { apiUrls, networkType } = resolveConfig(configOrCurrencyId);
 
   const res = await network<AleoLatestBlockResponse>({
     method: "GET",
-    url: `${nodeUrl}/v2/${networkType}/blocks/latest`,
+    url: `${apiUrls.node}/v2/${networkType}/blocks/latest`,
   });
 
   return res.data;
 }
 
 async function getAccountBalance(
-  currency: CryptoCurrency,
+  configOrCurrencyId: AleoCoinConfig | string,
   address: string,
 ): Promise<string | null> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = resolveConfig(configOrCurrencyId);
 
   const res = await network<string | null>({
     method: "GET",
-    url: `${nodeUrl}/v2/${networkType}/program/${PROGRAM_ID.CREDITS}/mapping/account/${address}`,
+    url: `${apiUrls.node}/v2/${networkType}/program/${PROGRAM_ID.CREDITS}/mapping/account/${address}`,
   });
 
   return res.data;
 }
 
 async function getTransactionById(
-  currency: CryptoCurrency,
+  configOrCurrencyId: AleoCoinConfig | string,
   transactionId: string,
 ): Promise<AleoPublicTransactionDetailsResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = resolveConfig(configOrCurrencyId);
 
   const res = await network<AleoPublicTransactionDetailsResponse>({
     method: "GET",
-    url: `${nodeUrl}/v2/${networkType}/transactions/${transactionId}`,
+    url: `${apiUrls.node}/v2/${networkType}/transactions/${transactionId}`,
   });
 
   return res.data;
 }
 
 async function getAccountPublicTransactions({
-  currency,
+  configOrCurrencyId,
   address,
   cursor,
   limit = 50,
   order = "asc",
   direction = "next",
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   address: string;
   cursor?: string;
   limit?: number;
   order?: "asc" | "desc";
   direction?: "prev" | "next";
 }): Promise<AleoPublicTransactionsResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = resolveConfig(configOrCurrencyId);
   const params = new URLSearchParams({
     metadata: "true",
     limit: limit.toString(),
@@ -80,39 +82,39 @@ async function getAccountPublicTransactions({
 
   const res: LiveNetworkResponse<AleoPublicTransactionsResponse> = await network({
     method: "GET",
-    url: `${nodeUrl}/v2/${networkType}/transactions/address/${address}?${params.toString()}`,
+    url: `${apiUrls.node}/v2/${networkType}/transactions/address/${address}?${params.toString()}`,
   });
 
   return res.data;
 }
 
 async function getScannerPublicKey(
-  currency: CryptoCurrency,
+  configOrCurrencyId: AleoCoinConfig | string,
 ): Promise<AleoGetScannerPublicKeyResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = resolveConfig(configOrCurrencyId);
 
   const res = await network<AleoGetScannerPublicKeyResponse>({
     method: "GET",
-    url: `${nodeUrl}/scanner/${networkType}/pubkey`,
+    url: `${apiUrls.node}/scanner/${networkType}/pubkey`,
   });
 
   return res.data;
 }
 
 async function registerForScanningAccountRecordsEncrypted({
-  currency,
+  configOrCurrencyId,
   encryptedData,
   keyId,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   encryptedData: string;
   keyId: string;
 }): Promise<AleoRegisterForRecordsResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = resolveConfig(configOrCurrencyId);
 
   const res = await network<AleoRegisterForRecordsResponse>({
     method: "POST",
-    url: `${nodeUrl}/scanner/${networkType}/register/encrypted`,
+    url: `${apiUrls.node}/scanner/${networkType}/register/encrypted`,
     data: {
       key_id: keyId,
       ciphertext: encryptedData,
@@ -123,14 +125,14 @@ async function registerForScanningAccountRecordsEncrypted({
 }
 
 const getRecordScannerStatus = async (
-  currency: CryptoCurrency,
+  configOrCurrencyId: AleoCoinConfig | string,
   uuid: string,
 ): Promise<AleoRecordScannerStatusResponse> => {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = resolveConfig(configOrCurrencyId);
 
   const res = await network<AleoRecordScannerStatusResponse>({
     method: "POST",
-    url: `${nodeUrl}/scanner/${networkType}/status`,
+    url: `${apiUrls.node}/scanner/${networkType}/status`,
     headers: {
       "Content-Type": "application/json",
     },
@@ -141,21 +143,21 @@ const getRecordScannerStatus = async (
 };
 
 async function getAccountOwnedRecords({
-  currency,
+  configOrCurrencyId,
   uuid,
   unspent,
   start,
   resultsPerPage,
   page,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   uuid: string;
   unspent?: boolean;
   start?: number;
   resultsPerPage?: number;
   page?: number;
 }): Promise<AleoPrivateRecord[]> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = resolveConfig(configOrCurrencyId);
 
   const filter = {
     ...(typeof start === "number" && { start }),
@@ -165,7 +167,7 @@ async function getAccountOwnedRecords({
 
   const res = await network<AleoPrivateRecord[]>({
     method: "POST",
-    url: `${nodeUrl}/scanner/${networkType}/records/owned`,
+    url: `${apiUrls.node}/scanner/${networkType}/records/owned`,
     data: {
       ...(typeof unspent === "boolean" && { unspent }),
       ...(Object.keys(filter).length > 0 && { filter }),
@@ -177,20 +179,20 @@ async function getAccountOwnedRecords({
 }
 
 async function submitDelegatedProvingRequest({
-  currency,
+  configOrCurrencyId,
   authorization,
   feeAuthorization,
   broadcast,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   authorization: Record<string, unknown>;
   feeAuthorization?: Record<string, unknown>;
   broadcast: boolean;
 }): Promise<DelegatedProvingResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = resolveConfig(configOrCurrencyId);
   const res = await network<DelegatedProvingResponse>({
     method: "POST",
-    url: `${nodeUrl}/prove/${networkType}/prove`,
+    url: `${apiUrls.node}/prove/${networkType}/prove`,
     data: {
       authorization,
       ...(feeAuthorization ? { fee_authorization: feeAuthorization } : {}),
@@ -202,33 +204,33 @@ async function submitDelegatedProvingRequest({
 }
 
 async function getProvePublicKey({
-  currency,
+  configOrCurrencyId,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
 }): Promise<AleoGetProvePublicKeyResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = resolveConfig(configOrCurrencyId);
 
   const res = await network<AleoGetProvePublicKeyResponse>({
     method: "GET",
-    url: `${nodeUrl}/prove/${networkType}/pubkey`,
+    url: `${apiUrls.node}/prove/${networkType}/pubkey`,
   });
 
   return res.data;
 }
 
 async function submitEncryptedDelegatedProvingRequest({
-  currency,
+  configOrCurrencyId,
   keyId,
   encryptedData,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   keyId: string;
   encryptedData: string;
 }): Promise<DelegatedProvingResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = resolveConfig(configOrCurrencyId);
   const res = await network<DelegatedProvingResponse>({
     method: "POST",
-    url: `${nodeUrl}/prove/${networkType}/prove/encrypted`,
+    url: `${apiUrls.node}/prove/${networkType}/prove/encrypted`,
     data: {
       key_id: keyId,
       ciphertext: encryptedData,

--- a/libs/coin-modules/coin-aleo/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/sdk.test.ts
@@ -1,6 +1,7 @@
 import network from "@ledgerhq/live-network";
-import { getNetworkConfig } from "../logic/utils";
+import { resolveConfig } from "../logic/utils";
 import type { AleoEncryptedRegistrationResponse, FeeConfiguration, Intent } from "../types/sdk";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
 import { getMockedPreparedRequestResponse } from "../__tests__/fixtures/sdk.fixture";
 import { sdkClient } from "./sdk";
@@ -10,20 +11,15 @@ jest.mock("../logic/utils");
 
 describe("sdkClient", () => {
   const mockCurrency = getMockedCurrency();
-  const mockNetworkConfig: ReturnType<typeof getNetworkConfig> = {
-    nodeUrl: "https://node.aleo.network",
-    sdkUrl: "https://sdk.aleo.network",
-    networkType: "mainnet",
-  };
-  const testnetConfig: ReturnType<typeof getNetworkConfig> = {
-    nodeUrl: "https://node.testnet.aleo.network",
-    sdkUrl: "https://sdk.testnet.aleo.network",
-    networkType: "testnet",
+  const mockResolvedConfig = getMockedConfig("testnet");
+  const customSdkConfig = {
+    ...getMockedConfig("testnet"),
+    apiUrls: { ...getMockedConfig("testnet").apiUrls, sdk: "https://custom-sdk.example.com" },
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(getNetworkConfig).mockReturnValue(mockNetworkConfig);
+    jest.mocked(resolveConfig).mockReturnValue(mockResolvedConfig);
   });
 
   describe("encryptRegistrationPayload", () => {
@@ -31,25 +27,11 @@ describe("sdkClient", () => {
       encrypted: "mock_encrypted_data",
     };
 
-    it("should call getNetworkConfig with the provided currency", async () => {
-      jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
-
-      await sdkClient.encryptRegistrationPayload({
-        currency: mockCurrency,
-        publicKey: "aleo1publickey",
-        viewKey: "AViewKey1viewkey",
-        start: 0,
-      });
-
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
-    });
-
     it("should call network with correct method, url and data", async () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await sdkClient.encryptRegistrationPayload({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicKey: "aleo1publickey",
         viewKey: "AViewKey1viewkey",
         start: 0,
@@ -58,7 +40,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/encrypt_registration`,
+        url: `${mockResolvedConfig.apiUrls.sdk}/encrypt_registration`,
         data: {
           public_key: "aleo1publickey",
           view_key: "AViewKey1viewkey",
@@ -71,7 +53,7 @@ describe("sdkClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await sdkClient.encryptRegistrationPayload({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicKey: "aleo1publickey",
         viewKey: "AViewKey1viewkey",
         start: 0,
@@ -80,12 +62,12 @@ describe("sdkClient", () => {
       expect(result).toEqual(mockResponse);
     });
 
-    it("should construct the URL using sdkUrl from getNetworkConfig", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+    it("should construct the URL using sdkUrl from network config", async () => {
+      jest.mocked(resolveConfig).mockReturnValue(customSdkConfig);
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await sdkClient.encryptRegistrationPayload({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicKey: "aleo1publickey",
         viewKey: "AViewKey1viewkey",
         start: 0,
@@ -94,7 +76,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.sdkUrl}/encrypt_registration`,
+          url: `${customSdkConfig.apiUrls.sdk}/encrypt_registration`,
         }),
       );
     });
@@ -105,7 +87,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.encryptRegistrationPayload({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           publicKey: "aleo1publickey",
           viewKey: "AViewKey1viewkey",
           start: 0,
@@ -128,7 +110,7 @@ describe("sdkClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockDecryptedData, status: 200 });
 
       const result = await sdkClient.decryptRecord({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         ciphertext: mockCiphertext,
         viewKey: mockViewKey,
       });
@@ -136,7 +118,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/decrypt`,
+        url: `${mockResolvedConfig.apiUrls.sdk}/decrypt`,
         data: {
           ciphertext: mockCiphertext,
           view_key: mockViewKey,
@@ -151,7 +133,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.decryptRecord({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           ciphertext: mockCiphertext,
           viewKey: mockViewKey,
         }),
@@ -161,7 +143,7 @@ describe("sdkClient", () => {
 
   describe("decryptCiphertext", () => {
     const mockParams = {
-      currency: mockCurrency,
+      configOrCurrencyId: mockCurrency.id,
       ciphertext: "ct1mock_ciphertext_data",
       tpk: "tpk1mock_transition_public_key",
       viewKey: "AViewKey1mock_view_key_data",
@@ -181,7 +163,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/symmetric_decrypt`,
+        url: `${mockResolvedConfig.apiUrls.sdk}/symmetric_decrypt`,
         headers: {
           "Content-Type": "application/json",
         },
@@ -234,18 +216,16 @@ describe("sdkClient", () => {
 
     it("should create a transaction request from intent", async () => {
       const result = await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         intent: mockIntent,
         feeConfiguration: null,
         viewKey: mockViewKey,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/transactions/request`,
+        url: `${mockResolvedConfig.apiUrls.sdk}/transactions/request`,
         data: {
           intent: mockIntent,
           fee: null,
@@ -256,10 +236,10 @@ describe("sdkClient", () => {
     });
 
     it("should use correct SDK URL from network config", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customSdkConfig);
 
       await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         intent: mockIntent,
         feeConfiguration: null,
         viewKey: mockViewKey,
@@ -267,7 +247,7 @@ describe("sdkClient", () => {
 
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.sdkUrl}/transactions/request`,
+          url: `${customSdkConfig.apiUrls.sdk}/transactions/request`,
         }),
       );
       expect(network).toHaveBeenCalledTimes(1);
@@ -281,7 +261,7 @@ describe("sdkClient", () => {
       };
 
       await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         intent: largeAmountIntent,
         feeConfiguration: null,
         viewKey: mockViewKey,
@@ -289,7 +269,7 @@ describe("sdkClient", () => {
 
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/transactions/request`,
+        url: `${mockResolvedConfig.apiUrls.sdk}/transactions/request`,
         data: {
           intent: largeAmountIntent,
           fee: null,
@@ -305,7 +285,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.createRequestFromIntent({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           intent: mockIntent,
           feeConfiguration: null,
           viewKey: mockViewKey,
@@ -319,7 +299,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.createRequestFromIntent({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           intent: mockIntent,
           feeConfiguration: null,
           viewKey: mockViewKey,
@@ -334,7 +314,7 @@ describe("sdkClient", () => {
       jest.mocked(network).mockResolvedValue({ data: responseWithMetadata, status: 200 });
 
       const result = await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         intent: mockIntent,
         feeConfiguration: null,
         viewKey: mockViewKey,
@@ -351,7 +331,7 @@ describe("sdkClient", () => {
       };
 
       await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         intent: mockIntent,
         feeConfiguration,
         viewKey: mockViewKey,
@@ -360,7 +340,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/transactions/request`,
+        url: `${mockResolvedConfig.apiUrls.sdk}/transactions/request`,
         data: {
           intent: mockIntent,
           fee: feeConfiguration,
@@ -377,7 +357,7 @@ describe("sdkClient", () => {
       };
 
       await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         intent: mockIntent,
         feeConfiguration,
       });
@@ -385,7 +365,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/transactions/request`,
+        url: `${mockResolvedConfig.apiUrls.sdk}/transactions/request`,
         data: {
           intent: mockIntent,
           fee: feeConfiguration,
@@ -407,19 +387,18 @@ describe("sdkClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockAuthorizationResponse, status: 200 });
 
       const result = await sdkClient.createAuthorization({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         request: mockRequest,
         signatures: mockSignatures,
         viewKey: mockViewKey,
       });
 
       expect(result).toEqual(mockAuthorizationResponse);
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
+
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/transactions/authorization`,
+        url: `${mockResolvedConfig.apiUrls.sdk}/transactions/authorization`,
         data: {
           request: mockRequest,
           signatures: mockSignatures,
@@ -429,11 +408,11 @@ describe("sdkClient", () => {
     });
 
     it("should use correct SDK URL from network config", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customSdkConfig);
       jest.mocked(network).mockResolvedValue({ data: mockAuthorizationResponse, status: 200 });
 
       await sdkClient.createAuthorization({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         request: mockRequest,
         signatures: mockSignatures,
         viewKey: mockViewKey,
@@ -441,7 +420,7 @@ describe("sdkClient", () => {
 
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.sdkUrl}/transactions/authorization`,
+          url: `${customSdkConfig.apiUrls.sdk}/transactions/authorization`,
         }),
       );
     });
@@ -452,7 +431,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.createAuthorization({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           request: mockRequest,
           signatures: mockSignatures,
           viewKey: mockViewKey,
@@ -470,19 +449,18 @@ describe("sdkClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockEncryptedResponse, status: 200 });
 
       const result = await sdkClient.encryptProvingRequest({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicKey: mockPublicKey,
         authorization: mockAuthorization,
         broadcast: true,
       });
 
       expect(result).toBe(mockEncryptedResponse.encrypted);
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
+
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/encrypt_proving_request`,
+        url: `${mockResolvedConfig.apiUrls.sdk}/encrypt_proving_request`,
         data: {
           public_key: mockPublicKey,
           proving_request: {
@@ -495,11 +473,11 @@ describe("sdkClient", () => {
     });
 
     it("should use correct SDK URL from network config", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+      jest.mocked(resolveConfig).mockReturnValue(customSdkConfig);
       jest.mocked(network).mockResolvedValue({ data: mockEncryptedResponse, status: 200 });
 
       await sdkClient.encryptProvingRequest({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicKey: mockPublicKey,
         authorization: mockAuthorization,
         broadcast: true,
@@ -507,7 +485,7 @@ describe("sdkClient", () => {
 
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.sdkUrl}/encrypt_proving_request`,
+          url: `${customSdkConfig.apiUrls.sdk}/encrypt_proving_request`,
         }),
       );
     });
@@ -518,7 +496,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.encryptProvingRequest({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           publicKey: mockPublicKey,
           authorization: mockAuthorization,
           broadcast: true,

--- a/libs/coin-modules/coin-aleo/src/network/sdk.ts
+++ b/libs/coin-modules/coin-aleo/src/network/sdk.ts
@@ -1,7 +1,6 @@
 import network from "@ledgerhq/live-network";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { getNetworkConfig } from "../logic/utils";
-import type { AleoDecryptedCiphertextResponse } from "../types";
+import { resolveConfig } from "../logic/utils";
+import type { AleoCoinConfig, AleoDecryptedCiphertextResponse } from "../types";
 import type {
   AleoDecryptedRecordResponse,
   AleoEncryptedRegistrationResponse,
@@ -13,21 +12,21 @@ import type {
 } from "../types/sdk";
 
 async function encryptRegistrationPayload({
-  currency,
+  configOrCurrencyId,
   publicKey,
   viewKey,
   start,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   publicKey: string;
   viewKey: string;
   start: number;
 }): Promise<AleoEncryptedRegistrationResponse> {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = resolveConfig(configOrCurrencyId);
 
   const res = await network<AleoEncryptedRegistrationResponse>({
     method: "POST",
-    url: `${sdkUrl}/encrypt_registration`,
+    url: `${apiUrls.sdk}/encrypt_registration`,
     data: {
       public_key: publicKey,
       view_key: viewKey,
@@ -39,19 +38,19 @@ async function encryptRegistrationPayload({
 }
 
 async function decryptRecord({
-  currency,
+  configOrCurrencyId,
   ciphertext,
   viewKey,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   ciphertext: string;
   viewKey: string;
 }): Promise<AleoDecryptedRecordResponse> {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = resolveConfig(configOrCurrencyId);
 
   const res = await network<AleoDecryptedRecordResponse>({
     method: "POST",
-    url: `${sdkUrl}/decrypt`,
+    url: `${apiUrls.sdk}/decrypt`,
     data: {
       ciphertext,
       view_key: viewKey,
@@ -62,7 +61,7 @@ async function decryptRecord({
 }
 
 async function decryptCiphertext({
-  currency,
+  configOrCurrencyId,
   ciphertext,
   tpk,
   viewKey,
@@ -70,7 +69,7 @@ async function decryptCiphertext({
   functionName,
   outputIndex,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   ciphertext: string;
   tpk: string;
   viewKey: string;
@@ -78,11 +77,11 @@ async function decryptCiphertext({
   functionName: string;
   outputIndex: number;
 }): Promise<AleoDecryptedCiphertextResponse> {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = resolveConfig(configOrCurrencyId);
 
   const res = await network<AleoDecryptedCiphertextResponse>({
     method: "POST",
-    url: `${sdkUrl}/symmetric_decrypt`,
+    url: `${apiUrls.sdk}/symmetric_decrypt`,
     headers: {
       "Content-Type": "application/json",
     },
@@ -100,21 +99,21 @@ async function decryptCiphertext({
 }
 
 async function createRequestFromIntent({
-  currency,
+  configOrCurrencyId,
   intent,
   feeConfiguration,
   viewKey,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   intent: Intent;
   feeConfiguration: FeeConfiguration | null;
   viewKey?: string;
 }): Promise<PreparedRequestResponse> {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = resolveConfig(configOrCurrencyId);
 
   const res = await network<PreparedRequestResponse>({
     method: "POST",
-    url: `${sdkUrl}/transactions/request`,
+    url: `${apiUrls.sdk}/transactions/request`,
     data: {
       intent,
       fee: feeConfiguration,
@@ -126,21 +125,21 @@ async function createRequestFromIntent({
 }
 
 async function createAuthorization({
-  currency,
+  configOrCurrencyId,
   request,
   signatures,
   viewKey,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   request: PreparedRequestResponse;
   signatures: string;
   viewKey: string;
 }) {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = resolveConfig(configOrCurrencyId);
 
   const res = await network<AuthorizationResponse>({
     method: "POST",
-    url: `${sdkUrl}/transactions/authorization`,
+    url: `${apiUrls.sdk}/transactions/authorization`,
     data: {
       request,
       signatures,
@@ -152,23 +151,23 @@ async function createAuthorization({
 }
 
 async function encryptProvingRequest({
-  currency,
+  configOrCurrencyId,
   publicKey,
   authorization,
   feeAuthorization,
   broadcast,
 }: {
+  configOrCurrencyId: AleoCoinConfig | string;
   publicKey: string;
-  currency: CryptoCurrency;
   authorization: Record<string, unknown>;
   feeAuthorization?: Record<string, unknown>;
   broadcast: boolean;
 }): Promise<string> {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = resolveConfig(configOrCurrencyId);
 
   const res = await network<EncryptProvingRequestResponse>({
     method: "POST",
-    url: `${sdkUrl}/encrypt_proving_request`,
+    url: `${apiUrls.sdk}/encrypt_proving_request`,
     data: {
       public_key: publicKey,
       proving_request: {

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -70,7 +70,7 @@ describe("network/utils", () => {
           });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -78,13 +78,13 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(2);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenNthCalledWith(1, {
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           limit: 50,
           order: "asc",
         });
         expect(apiClient.getAccountPublicTransactions).toHaveBeenNthCalledWith(2, {
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           limit: 50,
           order: "asc",
@@ -109,7 +109,7 @@ describe("network/utils", () => {
         });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -117,7 +117,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           limit: 50,
           order: "asc",
@@ -143,7 +143,7 @@ describe("network/utils", () => {
         });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -152,7 +152,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           limit: 50,
           order: "desc",
@@ -179,7 +179,7 @@ describe("network/utils", () => {
         });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           fetchAllPages: false,
           minBlockHeight,
@@ -188,7 +188,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           limit,
           order: "asc",
@@ -211,7 +211,7 @@ describe("network/utils", () => {
         });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           fetchAllPages: false,
           minBlockHeight,
@@ -220,7 +220,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           limit,
           order: "asc",
@@ -240,7 +240,7 @@ describe("network/utils", () => {
         });
 
         await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           fetchAllPages: false,
           minBlockHeight,
@@ -249,7 +249,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           limit: 50,
           order: "asc",
@@ -268,7 +268,7 @@ describe("network/utils", () => {
         });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -289,7 +289,7 @@ describe("network/utils", () => {
         });
 
         await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -298,7 +298,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           limit: customLimit,
           order: "asc",
@@ -315,7 +315,7 @@ describe("network/utils", () => {
         });
 
         await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -324,7 +324,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           address: mockAddress,
           limit: 50,
           order: "desc",
@@ -356,23 +356,23 @@ describe("network/utils", () => {
         mockGetRecordScannerStatus.mockResolvedValue({ synced: false, percentage: 5 });
 
         const result = await accessProvableApi({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           viewKey: mockViewKey,
           provableApi: existingProvableApi,
         });
 
         expect(mockGetScannerPublicKey).toHaveBeenCalledTimes(1);
-        expect(mockGetScannerPublicKey).toHaveBeenCalledWith(mockCurrency);
+        expect(mockGetScannerPublicKey).toHaveBeenCalledWith(mockCurrency.id);
         expect(mockEncryptRegistrationPayload).toHaveBeenCalledTimes(1);
         expect(mockEncryptRegistrationPayload).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           publicKey: mockPublicKey,
           viewKey: mockViewKey,
           start: 0,
         });
         expect(mockRegisterForScanningAccountRecords).toHaveBeenCalledTimes(1);
         expect(mockRegisterForScanningAccountRecords).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           encryptedData: mockEncryptedData,
           keyId: mockKeyId,
         });
@@ -388,7 +388,7 @@ describe("network/utils", () => {
         mockGetRecordScannerStatus.mockResolvedValue({ synced: false, percentage: 60 });
 
         const result = await accessProvableApi({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           viewKey: mockViewKey,
           provableApi: existingProvableApi,
         });
@@ -408,7 +408,7 @@ describe("network/utils", () => {
         mockGetRecordScannerStatus.mockResolvedValue({ synced: true, percentage: 100 });
 
         const result = await accessProvableApi({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           viewKey: mockViewKey,
           provableApi: existingProvableApi,
         });
@@ -430,7 +430,7 @@ describe("network/utils", () => {
         mockGetRecordScannerStatus.mockRejectedValue(error422);
 
         const result = await accessProvableApi({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           viewKey: mockViewKey,
           provableApi: existingProvableApi,
         });
@@ -450,7 +450,7 @@ describe("network/utils", () => {
 
         await expect(
           accessProvableApi({
-            currency: mockCurrency,
+            configOrCurrencyId: mockCurrency.id,
             viewKey: mockViewKey,
             provableApi: existingProvableApi,
           }),
@@ -466,7 +466,7 @@ describe("network/utils", () => {
         mockGetRecordScannerStatus.mockResolvedValue(null as any);
 
         const result = await accessProvableApi({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           viewKey: mockViewKey,
           provableApi: existingProvableApi,
         });
@@ -479,7 +479,7 @@ describe("network/utils", () => {
         mockGetRecordScannerStatus.mockResolvedValue({ synced: false, percentage: 0 });
 
         const result = await accessProvableApi({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           viewKey: mockViewKey,
           provableApi: null,
         });
@@ -520,7 +520,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -528,7 +528,7 @@ describe("network/utils", () => {
 
       expect(result).toBeNull();
       expect(mockGetTransactionById).toHaveBeenCalledTimes(1);
-      expect(mockGetTransactionById).toHaveBeenCalledWith(mockCurrency, "tx_pub_to_priv");
+      expect(mockGetTransactionById).toHaveBeenCalledWith(mockCurrency.id, "tx_pub_to_priv");
       expect(mockDecryptCiphertext).not.toHaveBeenCalled();
       expect(mockDecryptRecord).not.toHaveBeenCalled();
     });
@@ -545,7 +545,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -583,7 +583,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -625,7 +625,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -667,7 +667,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -709,7 +709,7 @@ describe("network/utils", () => {
       mockGetTransactionById.mockResolvedValueOnce(mockDetails);
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -760,7 +760,7 @@ describe("network/utils", () => {
         .mockResolvedValueOnce({ plaintext: "750000u64" });
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -774,7 +774,7 @@ describe("network/utils", () => {
       expect(mockDecryptCiphertext).toHaveBeenCalledTimes(2);
       expect(mockDecryptRecord).not.toHaveBeenCalled();
       expect(mockDecryptCiphertext).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         ciphertext: "ciphertext_recipient",
         tpk: "tpk_private",
         viewKey: mockViewKey,
@@ -783,7 +783,7 @@ describe("network/utils", () => {
         outputIndex: 1, // RECIPIENT_ARG_INDEX
       });
       expect(mockDecryptCiphertext).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         ciphertext: "ciphertext_amount",
         tpk: "tpk_private",
         viewKey: mockViewKey,
@@ -827,7 +827,7 @@ describe("network/utils", () => {
       });
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -872,7 +872,7 @@ describe("network/utils", () => {
       });
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -885,7 +885,7 @@ describe("network/utils", () => {
       expect(mockGetTransactionById).toHaveBeenCalledTimes(1);
       expect(mockDecryptRecord).toHaveBeenCalledTimes(1);
       expect(mockDecryptRecord).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         ciphertext: "ciphertext_output_record",
         viewKey: mockViewKey,
       });
@@ -923,14 +923,14 @@ describe("network/utils", () => {
       });
 
       await enrichPrivateRecord({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
       });
 
       expect(mockGetTransactionById).toHaveBeenCalledTimes(1);
-      expect(mockGetTransactionById).toHaveBeenCalledWith(mockCurrency, "tx_with_spaces");
+      expect(mockGetTransactionById).toHaveBeenCalledWith(mockCurrency.id, "tx_with_spaces");
       expect(mockDecryptRecord).toHaveBeenCalledTimes(1);
       expect(mockDecryptCiphertext).not.toHaveBeenCalled();
     });
@@ -949,7 +949,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [publicOp],
         privateRecords: [],
         address: patchAddress,
@@ -980,7 +980,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [publicOp],
         privateRecords: [matchingRecord],
         address: patchAddress,
@@ -1026,7 +1026,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [publicOp],
         privateRecords: [matchingRecord],
         address: patchAddress,
@@ -1068,7 +1068,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [publicOp],
         privateRecords: [matchingRecord],
         address: patchAddress,
@@ -1114,7 +1114,7 @@ describe("network/utils", () => {
       mockDecryptCiphertext.mockResolvedValueOnce({ plaintext: "aleo1decrypted_recipient" });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [publicOp],
         privateRecords: [feeRecord],
         address: patchAddress,
@@ -1161,7 +1161,7 @@ describe("network/utils", () => {
 
       // no private records -> latestScannedBlockHeight = 0, which is less than tx block 100
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [publicOp],
         privateRecords: [],
         address: patchAddress,
@@ -1176,7 +1176,7 @@ describe("network/utils", () => {
         }),
       ]);
       expect(mockGetTransactionById).toHaveBeenCalledTimes(1);
-      expect(mockGetTransactionById).toHaveBeenCalledWith(mockCurrency, txHash);
+      expect(mockGetTransactionById).toHaveBeenCalledWith(mockCurrency.id, txHash);
       expect(mockDecryptCiphertext).toHaveBeenCalledTimes(1);
       expect(mockDecryptCiphertext).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1225,7 +1225,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [publicOp],
         privateRecords: [scannerWatermarkRecord],
         address: patchAddress,
@@ -1254,7 +1254,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [patchedOp],
         privateRecords: [],
         address: patchAddress,
@@ -1295,7 +1295,7 @@ describe("network/utils", () => {
       mockGetTransactionById.mockResolvedValueOnce(mockDetails);
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [publicOp],
         privateRecords: [],
         address: patchAddress,
@@ -1337,7 +1337,7 @@ describe("network/utils", () => {
       mockGetTransactionById.mockResolvedValueOnce(mockDetails);
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [publicOp],
         privateRecords: [],
         address: patchAddress,
@@ -1377,7 +1377,7 @@ describe("network/utils", () => {
 
       await expect(
         patchPublicOperations({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           publicOperations: [publicOp],
           privateRecords: [],
           address: patchAddress,
@@ -1401,7 +1401,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [publicOp],
         privateRecords: [recordWithSpaces],
         address: patchAddress,
@@ -1434,7 +1434,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         publicOperations: [fullyPublicOp, semiPublicOp],
         privateRecords: [matchingRecord],
         address: patchAddress,
@@ -1463,13 +1463,13 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce(records);
 
       const result = await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUUID,
       });
 
       expect(mockGetAccountOwnedRecords).toHaveBeenCalledTimes(1);
       expect(mockGetAccountOwnedRecords).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUUID,
         resultsPerPage: DEFAULT_RECORDS_PAGE_SIZE,
         page: 0,
@@ -1484,20 +1484,20 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce(page0).mockResolvedValueOnce(page1);
 
       const result = await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUUID,
         resultsPerPage: pageSize,
       });
 
       expect(mockGetAccountOwnedRecords).toHaveBeenCalledTimes(2);
       expect(mockGetAccountOwnedRecords).toHaveBeenNthCalledWith(1, {
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUUID,
         resultsPerPage: pageSize,
         page: 0,
       });
       expect(mockGetAccountOwnedRecords).toHaveBeenNthCalledWith(2, {
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUUID,
         resultsPerPage: pageSize,
         page: 1,
@@ -1509,7 +1509,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce([]);
 
       const result = await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUUID,
       });
 
@@ -1522,7 +1522,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce(records);
 
       await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUUID,
         unspent: true,
       });
@@ -1538,7 +1538,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce(records);
 
       await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUUID,
         start: 5000,
       });
@@ -1553,7 +1553,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce([]);
 
       await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUUID,
       });
 
@@ -1567,7 +1567,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce([]);
 
       await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUUID,
       });
 
@@ -1588,7 +1588,7 @@ describe("network/utils", () => {
         .mockResolvedValueOnce(page2);
 
       const result = await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        configOrCurrencyId: mockCurrency.id,
         uuid: mockUUID,
         resultsPerPage: pageSize,
       });
@@ -1603,7 +1603,7 @@ describe("network/utils", () => {
 
       await expect(
         fetchAllOwnedRecords({
-          currency: mockCurrency,
+          configOrCurrencyId: mockCurrency.id,
           uuid: mockUUID,
         }),
       ).rejects.toThrow("Scanner unavailable");

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -1,4 +1,3 @@
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
 import { log } from "@ledgerhq/logs";
 import { LedgerAPI4xx } from "@ledgerhq/errors";
@@ -17,6 +16,7 @@ import type {
   EnrichedPrivateRecord,
   AleoPrivateRecord,
   AleoOperation,
+  AleoCoinConfig,
 } from "../types";
 import { parseMicrocredits } from "../logic/utils";
 import { apiClient } from "./api";
@@ -40,7 +40,7 @@ function hasReachedMinHeight(
 }
 
 export async function fetchAccountTransactionsFromHeight({
-  currency,
+  configOrCurrencyId,
   address,
   fetchAllPages,
   minBlockHeight,
@@ -48,7 +48,7 @@ export async function fetchAccountTransactionsFromHeight({
   limit = 50,
   order = "asc",
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   address: string;
   fetchAllPages: boolean;
   minBlockHeight: number;
@@ -65,7 +65,7 @@ export async function fetchAccountTransactionsFromHeight({
 
   while (hasMorePages) {
     const page = await apiClient.getAccountPublicTransactions({
-      currency,
+      configOrCurrencyId,
       address,
       limit,
       order,
@@ -119,7 +119,7 @@ export async function fetchAccountTransactionsFromHeight({
 /**
  * Fetches all pages of owned records from the scanner
  *
- * @param params.currency - The cryptocurrency being accessed
+ * @param params.configOrCurrencyId - The Aleo coin config or currency ID being accessed
  * @param params.uuid - The scanner UUID for the account
  * @param params.unspent - When true, fetch only unspent records
  * @param params.start - Optional block height to start scanning from
@@ -127,13 +127,13 @@ export async function fetchAccountTransactionsFromHeight({
  * @returns A flat array of all matching records across all pages
  */
 export async function fetchAllOwnedRecords({
-  currency,
+  configOrCurrencyId,
   uuid,
   unspent,
   start,
   resultsPerPage = DEFAULT_RECORDS_PAGE_SIZE,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   uuid: string;
   unspent?: boolean;
   start?: number;
@@ -145,7 +145,7 @@ export async function fetchAllOwnedRecords({
 
   while (hasMore) {
     const records = await apiClient.getAccountOwnedRecords({
-      currency,
+      configOrCurrencyId,
       uuid,
       ...(typeof unspent === "boolean" && { unspent }),
       ...(typeof start === "number" && { start }),
@@ -169,7 +169,7 @@ export async function fetchAllOwnedRecords({
  * - Account registration for scanning records if UUID is not set
  * - Retrieval of current scanner status
  *
- * @param currency - The cryptocurrency being accessed
+ * @param configOrCurrencyId - The Aleo coin config or currency identifier being used to access the API
  * @param viewKey - The view key for the account
  * @param provableApi - Existing Provable API credentials and state, or null for initial setup
  *
@@ -183,11 +183,11 @@ export async function fetchAllOwnedRecords({
  */
 
 export async function accessProvableApi({
-  currency,
+  configOrCurrencyId,
   viewKey,
   provableApi,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   viewKey: string;
   provableApi: ProvableApi | null;
 }): Promise<ProvableApi | null> {
@@ -197,17 +197,17 @@ export async function accessProvableApi({
   let status;
 
   if (!uuid) {
-    const { public_key, key_id } = await apiClient.getScannerPublicKey(currency);
+    const { public_key, key_id } = await apiClient.getScannerPublicKey(configOrCurrencyId);
 
     const { encrypted: encryptedData } = await sdkClient.encryptRegistrationPayload({
-      currency,
+      configOrCurrencyId,
       publicKey: public_key,
       viewKey,
       start: 0,
     });
 
     const { uuid: accountUuid } = await apiClient.registerForScanningAccountRecordsEncrypted({
-      currency,
+      configOrCurrencyId,
       encryptedData,
       keyId: key_id,
     });
@@ -216,7 +216,7 @@ export async function accessProvableApi({
   }
 
   try {
-    status = await apiClient.getRecordScannerStatus(currency, uuid);
+    status = await apiClient.getRecordScannerStatus(configOrCurrencyId, uuid);
   } catch (error) {
     if (error instanceof LedgerAPI4xx && error.status === 422) {
       return null;
@@ -236,18 +236,18 @@ export async function accessProvableApi({
 }
 
 export async function enrichPrivateRecord({
-  currency,
+  configOrCurrencyId,
   rawRecord,
   address,
   viewKey,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   rawRecord: AleoPrivateRecord;
   address: string;
   viewKey: string;
 }): Promise<EnrichedPrivateRecord | null> {
   const transactionId = rawRecord.transaction_id.trim();
-  const details = await apiClient.getTransactionById(currency, transactionId);
+  const details = await apiClient.getTransactionById(configOrCurrencyId, transactionId);
 
   // PUBLIC_TO_PRIVATE where sender is this address is already captured as a public OUT op
   if (
@@ -300,7 +300,7 @@ export async function enrichPrivateRecord({
     } else {
       const [recipientData, amountData] = await Promise.all([
         sdkClient.decryptCiphertext({
-          currency,
+          configOrCurrencyId,
           ciphertext: recipientArgument.value,
           tpk: recordTransition.tpk,
           viewKey,
@@ -309,7 +309,7 @@ export async function enrichPrivateRecord({
           outputIndex: RECIPIENT_ARG_INDEX,
         }),
         sdkClient.decryptCiphertext({
-          currency,
+          configOrCurrencyId,
           ciphertext: amountArgument.value,
           tpk: recordTransition.tpk,
           viewKey,
@@ -324,7 +324,7 @@ export async function enrichPrivateRecord({
     }
   } else {
     const outputRecord = await sdkClient.decryptRecord({
-      currency,
+      configOrCurrencyId,
       ciphertext: rawRecord.record_ciphertext,
       viewKey,
     });
@@ -373,14 +373,14 @@ function splitPublicAndSemiPublicOperations(
  * @returns Array of patched operations including additional operations for semi transparent transfers
  */
 export const patchPublicOperations = async ({
-  currency,
+  configOrCurrencyId,
   publicOperations,
   privateRecords,
   address,
   ledgerAccountId,
   viewKey,
 }: {
-  currency: CryptoCurrency;
+  configOrCurrencyId: AleoCoinConfig | string;
   publicOperations: AleoOperation[];
   privateRecords: AleoPrivateRecord[];
   address: string;
@@ -454,7 +454,7 @@ export const patchPublicOperations = async ({
     // - semi-transparent transfer from another account to another account
     // - semi-transparent transfer from our own account to another account
     else {
-      const txDetails = await apiClient.getTransactionById(currency, operation.hash);
+      const txDetails = await apiClient.getTransactionById(configOrCurrencyId, operation.hash);
       const recordTransition = txDetails.execution.transitions[0] ?? null;
       const recipientInput = recordTransition?.inputs[0] ?? {};
       const recipientArgument = "value" in recipientInput ? recipientInput : null;
@@ -467,7 +467,7 @@ export const patchPublicOperations = async ({
       ) {
         const shouldMarkAsPatched = latestPrivateRecordBlockHeight >= txDetails.block_height;
         const recipientData = await sdkClient.decryptCiphertext({
-          currency,
+          configOrCurrencyId,
           ciphertext: recipientArgument.value,
           tpk: recordTransition.tpk,
           viewKey,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - This PR adds refactor coin-aleo network layer to accept pre-resolved config objects, eliminating redundant `getCoinConfig()` lookups on the Alpaca path.

### 📝 Description

Refactor coin-aleo network layer to accept pre-resolved config objects, eliminating redundant `getCoinConfig()` lookups on the Alpaca path.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-28042

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
