### PR TITLE
test(e2e): add analytics consent info to userdata fixtures

### DIFF
--- a/e2e/desktop/tests/userdata/1AccountBTC1AccountETH.json
+++ b/e2e/desktop/tests/userdata/1AccountBTC1AccountETH.json
@@ -23,6 +23,11 @@
       "loaded": true,
       "shareAnalytics": false,
       "sharePersonalizedRecommandations": false,
+      "analyticsConsentInfo": {
+        "consentDate": "2099-01-01T00:00:00.000Z",
+        "privacyPolicyVersion": 1
+      },
+      "hasSeenAnalyticsOptInPrompt": true,
       "sentryLogs": true,
       "lastUsedVersion": "99.99.99",
       "dismissedBanners": [],

--- a/e2e/desktop/tests/userdata/erc20-0-balance.json
+++ b/e2e/desktop/tests/userdata/erc20-0-balance.json
@@ -18,6 +18,10 @@
       "loaded": true,
       "shareAnalytics": false,
       "sharePersonalizedRecommandations": false,
+      "analyticsConsentInfo": {
+        "consentDate": "2099-01-01T00:00:00.000Z",
+        "privacyPolicyVersion": 1
+      },
       "hasSeenAnalyticsOptInPrompt": true,
       "sentryLogs": true,
       "lastUsedVersion": "99.99.99",

--- a/e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json
+++ b/e2e/desktop/tests/userdata/skip-onboarding-with-last-seen-device.json
@@ -23,6 +23,11 @@
       "loaded": true,
       "shareAnalytics": false,
       "sharePersonalizedRecommandations": false,
+      "analyticsConsentInfo": {
+        "consentDate": "2099-01-01T00:00:00.000Z",
+        "privacyPolicyVersion": 1
+      },
+      "hasSeenAnalyticsOptInPrompt": true,
       "sentryLogs": true,
       "lastUsedVersion": "99.99.99",
       "dismissedBanners": [],

--- a/e2e/desktop/tests/userdata/skip-onboarding.json
+++ b/e2e/desktop/tests/userdata/skip-onboarding.json
@@ -23,6 +23,11 @@
       "loaded": true,
       "shareAnalytics": false,
       "sharePersonalizedRecommandations": false,
+      "analyticsConsentInfo": {
+        "consentDate": "2099-01-01T00:00:00.000Z",
+        "privacyPolicyVersion": 1
+      },
+      "hasSeenAnalyticsOptInPrompt": true,
       "sentryLogs": true,
       "lastUsedVersion": "99.99.99",
       "dismissedBanners": [],

--- a/e2e/desktop/tests/userdata/speculos-subAccount.json
+++ b/e2e/desktop/tests/userdata/speculos-subAccount.json
@@ -17,6 +17,10 @@
       "loaded": true,
       "shareAnalytics": false,
       "sharePersonalizedRecommandations": false,
+      "analyticsConsentInfo": {
+        "consentDate": "2099-01-01T00:00:00.000Z",
+        "privacyPolicyVersion": 1
+      },
       "hasSeenAnalyticsOptInPrompt": true,
       "sentryLogs": true,
       "lastUsedVersion": "99.99.99",

--- a/e2e/desktop/tests/userdata/speculos-tests-app.json
+++ b/e2e/desktop/tests/userdata/speculos-tests-app.json
@@ -18,6 +18,10 @@
       "loaded": true,
       "shareAnalytics": false,
       "sharePersonalizedRecommandations": false,
+      "analyticsConsentInfo": {
+        "consentDate": "2099-01-01T00:00:00.000Z",
+        "privacyPolicyVersion": 1
+      },
       "hasSeenAnalyticsOptInPrompt": true,
       "sentryLogs": true,
       "lastUsedVersion": "99.99.99",

--- a/e2e/desktop/tests/userdata/speculos-x-other-account.json
+++ b/e2e/desktop/tests/userdata/speculos-x-other-account.json
@@ -18,6 +18,10 @@
       "loaded": true,
       "shareAnalytics": true,
       "sharePersonalizedRecommandations": true,
+      "analyticsConsentInfo": {
+        "consentDate": "2099-01-01T00:00:00.000Z",
+        "privacyPolicyVersion": 1
+      },
       "hasSeenAnalyticsOptInPrompt": true,
       "sentryLogs": true,
       "lastUsedVersion": "99.99.99",

--- a/e2e/desktop/tests/userdata/swap-history.json
+++ b/e2e/desktop/tests/userdata/swap-history.json
@@ -20,6 +20,10 @@
       "loaded": true,
       "shareAnalytics": false,
       "sharePersonalizedRecommandations": false,
+      "analyticsConsentInfo": {
+        "consentDate": "2099-01-01T00:00:00.000Z",
+        "privacyPolicyVersion": 1
+      },
       "hasSeenAnalyticsOptInPrompt": true,
       "sentryLogs": true,
       "lastUsedVersion": "99.99.99",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add analyticsConsentInfo and hasSeenAnalyticsOptInPrompt to desktop e2e userdata fixtures to disable the analytics consent dialog during test runs

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
