### PR TITLE
[LWD] fix(desktop): prevent icon shrink in asset name cells

### DIFF
--- a/.changeset/bright-icons-shrink.md
+++ b/.changeset/bright-icons-shrink.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix asset name alignment in crypto tables by preventing icon shrink on long names

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
@@ -45,6 +45,7 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
         enableSorting: false,
         cell: ({ row }) => (
           <TableCellContent
+            className="[&>*:first-child]:shrink-0"
             leadingContent={
               row.original.isPlaceholder ? (
                 <CryptoIcon

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountNameCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountNameCell.tsx
@@ -13,6 +13,7 @@ export function AccountNameCell({ account, displayName }: AccountNameCellProps) 
   const currency = getAccountCurrency(account);
   return (
     <TableCellContent
+      className="[&>*:first-child]:shrink-0"
       leadingContent={<CryptoCurrencyIcon currency={currency} size={32} />}
       title={displayName}
       description={currency.ticker}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual CSS fix — not covered by unit tests._
- [x] **Impact of the changes:**
      - Crypto section on the portfolio page (Wallet V4 with `lwdWallet40` FF)
      - CryptoAddresses table (account name column)
      - Verify that asset names with long names are properly aligned and icons do not shrink

### 📝 Description

With the `lwdWallet40` feature flag enabled, assets with long names in the Crypto section cause misalignment that gets progressively worse down the list.

**Root cause:** Lumen's `TableCellContent` wraps `leadingContent` (the crypto icon) in a bare `<div>` without `flex-shrink: 0`. Since `CryptoIcon` (styled-components) uses `overflow: hidden` internally, its min-content size resolves to `0` — allowing the flex algorithm to shrink the icon wrapper proportionally to the text length. Longer names cause more shrinkage, explaining the progressive misalignment.

**Fix:** Add `className="[&>*:first-child]:shrink-0"` on `TableCellContent` to target the bare icon wrapper and prevent it from shrinking. This is a consumer-side workaround; the proper fix in Lumen would be adding `shrink-0` to the `leadingContent` wrapper div.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28848](https://ledgerhq.atlassian.net/browse/LIVE-28848)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28848]: https://ledgerhq.atlassian.net/browse/LIVE-28848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ