### PR TITLE
[LWM] fix(lwm): revert deferring of the accounts import

### DIFF
--- a/.changeset/lemon-scissors-tan.md
+++ b/.changeset/lemon-scissors-tan.md
@@ -1,5 +1,0 @@
----
-"live-mobile": minor
----
-
-Shorten startup by deferring the accounts import

--- a/.changeset/moody-frogs-poke.md
+++ b/.changeset/moody-frogs-poke.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Revert accounts import deferring

--- a/.changeset/tame-candles-learn.md
+++ b/.changeset/tame-candles-learn.md
@@ -1,5 +1,0 @@
----
-"live-mobile": minor
----
-
-Reread the accounts before importing them on startup

--- a/.changeset/warm-items-punch.md
+++ b/.changeset/warm-items-punch.md
@@ -1,5 +1,0 @@
----
-"live-mobile": minor
----
-
-Override stale accounts data with walletStore after import

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -315,13 +315,11 @@ async function hydrateCryptoAssets(store: Store, cryptoAssetsCache: PersistedCAL
 function getImportAccounts(store: Store, cryptoAssetHydration: Promise<void>) {
   return async () => {
     try {
-      const accountsData = await retry(getAccounts, MAX_RETRIES, RETRY_DELAY);
+      const accountsData = retry(getAccounts, MAX_RETRIES, RETRY_DELAY);
+      const walletStore = retry(getWalletExportState, MAX_RETRIES, RETRY_DELAY);
       await cryptoAssetHydration; // Ensure crypto assets are hydrated before importing accounts
-      store.dispatch(await importAccountsRaw(accountsData));
-      const walletState = await retry(getWalletExportState, MAX_RETRIES, RETRY_DELAY);
-      if (walletState) {
-        store.dispatch(importWalletState(walletState)); // TODO: fix the double source of truth for accounts names
-      }
+      store.dispatch(await importAccountsRaw(await accountsData));
+      store.dispatch(importWalletState(await walletStore)); // TODO: fix the double source of truth for accounts names
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error("Failed to import accounts during initialization:", error);

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -41,6 +41,7 @@ import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/s
 import { importWalletState } from "@ledgerhq/live-wallet/store";
 import { importLargeMoverState } from "~/actions/largeMoverLandingPage";
 import type { SettingsState } from "~/reducers/types";
+import type { AccountRaw } from "@ledgerhq/types-live";
 import {
   restoreTokensToCache,
   PERSISTENCE_VERSION,
@@ -93,6 +94,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       const [
         bleData,
         settingsData,
+        accountsData,
         postOnboardingState,
         marketState,
         trustchainStore,
@@ -106,6 +108,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       ] = await Promise.all([
         retry(getBle, MAX_RETRIES, RETRY_DELAY),
         retry(getSettings, MAX_RETRIES, RETRY_DELAY),
+        retry(getAccounts, MAX_RETRIES, RETRY_DELAY),
         retry(getPostOnboardingState, MAX_RETRIES, RETRY_DELAY),
         retry(getMarketState, MAX_RETRIES, RETRY_DELAY),
         retry(getTrustchainState, MAX_RETRIES, RETRY_DELAY),
@@ -130,6 +133,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       importAccounts.current = getImportAccounts(
         store,
         hydrateCryptoAssets(store, cryptoAssetsCache),
+        accountsData,
       );
 
       if (postOnboardingState) {
@@ -312,12 +316,15 @@ async function hydrateCryptoAssets(store: Store, cryptoAssetsCache: PersistedCAL
 }
 
 // Handle account import with error recovery for async issues
-function getImportAccounts(store: Store, cryptoAssetHydration: Promise<void>) {
+function getImportAccounts(
+  store: Store,
+  cryptoAssetHydration: Promise<void>,
+  accountsData: { active: Array<{ data: AccountRaw }> },
+) {
   return async () => {
     try {
-      const accountsData = retry(getAccounts, MAX_RETRIES, RETRY_DELAY);
       await cryptoAssetHydration; // Ensure crypto assets are hydrated before importing accounts
-      store.dispatch(await importAccountsRaw(await accountsData));
+      store.dispatch(await importAccountsRaw(accountsData));
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error("Failed to import accounts during initialization:", error);

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, ReactNode, useCallback, useRef } from "react";
+import React, { useEffect, useState, ReactNode, useCallback } from "react";
 import { Provider } from "react-redux";
 import { Store } from "redux";
 import { importPostOnboardingState } from "@ledgerhq/live-common/postOnboarding/actions";
@@ -9,7 +9,6 @@ import {
   listSupportedFiats,
 } from "@ledgerhq/live-common/currencies/index";
 import { InitialQueriesProvider } from "LLM/contexts/InitialQueriesContext";
-import type { WaitForAppReadyProps } from "LLM/contexts/WaitForAppReady";
 import mmkvStorageWrapper from "LLM/storage/mmkvStorageWrapper";
 import { logStartupEvent } from "LLM/utils/logStartupTime";
 import type { StorageCurrencyData, StoreStorageData } from "LLM/utils/logLastStartupEvents";
@@ -41,23 +40,20 @@ import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/s
 import { importWalletState } from "@ledgerhq/live-wallet/store";
 import { importLargeMoverState } from "~/actions/largeMoverLandingPage";
 import type { SettingsState } from "~/reducers/types";
-import type { AccountRaw } from "@ledgerhq/types-live";
 import {
   restoreTokensToCache,
   PERSISTENCE_VERSION,
-  type PersistedCAL,
 } from "@ledgerhq/cryptoassets/cal-client/persistence";
 import { identitiesSlice } from "@ledgerhq/client-ids/store";
 import { setAllOverrides, setBannerVisible } from "@shared/feature-flags";
 
 interface Props {
   onInitFinished: () => void;
-  children: (
-    props: {
-      ready: boolean;
-      initialCountervalues?: CounterValuesStateRaw;
-    } & WaitForAppReadyProps,
-  ) => ReactNode;
+  children: (props: {
+    ready: boolean;
+    initialCountervalues?: CounterValuesStateRaw;
+    currencyInitialized: boolean;
+  }) => ReactNode;
   store: Store;
 }
 
@@ -78,9 +74,6 @@ async function retry<T>(fn: () => Promise<T>, retries: number, delay: number): P
 }
 
 const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store }) => {
-  // Defer the accounts import until WaitForAppReady as it blocks the js thread too early during the app startup
-  const importAccounts = useRef(async () => {});
-
   const [ready, setReady] = useState(false);
   const [initialCountervalues, setInitialCountervalues] = useState<
     CounterValuesStateRaw | undefined
@@ -130,11 +123,30 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
 
       store.dispatch(importSettings(settingsData));
 
-      importAccounts.current = getImportAccounts(
-        store,
-        hydrateCryptoAssets(store, cryptoAssetsCache),
-        accountsData,
-      );
+      // Hydrate persisted crypto assets tokens BEFORE importing accounts
+      // This ensures tokens are available when decoding accounts (which now uses findTokenById)
+      // Cross-caching is automatic: tokens are cached under both ID and address lookups
+      if (cryptoAssetsCache?.tokens) {
+        if (cryptoAssetsCache.version === PERSISTENCE_VERSION) {
+          const TOKEN_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+          await restoreTokensToCache(store.dispatch, cryptoAssetsCache, TOKEN_CACHE_TTL);
+        } else {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Crypto assets cache version mismatch (expected ${PERSISTENCE_VERSION}, got ${cryptoAssetsCache.version}), skipping restore`,
+          );
+        }
+      }
+
+      // Handle account import with error recovery for async issues
+      try {
+        store.dispatch(await importAccountsRaw(accountsData));
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to import accounts during initialization:", error);
+        // Continue with app initialization even if account import fails
+        // This prevents blocking deeplink navigation
+      }
 
       if (postOnboardingState) {
         store.dispatch(importPostOnboardingState({ newState: postOnboardingState }));
@@ -224,12 +236,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
   return (
     <Provider store={store}>
       <InitialQueriesProvider>
-        {children({
-          ready,
-          initialCountervalues,
-          currencyInitialized,
-          importAccounts: importAccounts.current,
-        })}
+        {children({ ready, initialCountervalues, currencyInitialized })}
       </InitialQueriesProvider>
     </Provider>
   );
@@ -296,40 +303,4 @@ async function updateSupportedCountervalues(store: Store, settingsData: Partial<
     settingsData.counterValue = settingsState.counterValue;
     store.dispatch(importSettings(settingsData));
   }
-}
-
-// Hydrate persisted crypto assets tokens BEFORE importing accounts
-// This ensures tokens are available when decoding accounts (which now uses findTokenById)
-// Cross-caching is automatic: tokens are cached under both ID and address lookups
-async function hydrateCryptoAssets(store: Store, cryptoAssetsCache: PersistedCAL | null) {
-  if (cryptoAssetsCache?.tokens) {
-    if (cryptoAssetsCache.version === PERSISTENCE_VERSION) {
-      const TOKEN_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
-      await restoreTokensToCache(store.dispatch, cryptoAssetsCache, TOKEN_CACHE_TTL); // TODO check if it can be made non-blocking
-    } else {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `Crypto assets cache version mismatch (expected ${PERSISTENCE_VERSION}, got ${cryptoAssetsCache.version}), skipping restore`,
-      );
-    }
-  }
-}
-
-// Handle account import with error recovery for async issues
-function getImportAccounts(
-  store: Store,
-  cryptoAssetHydration: Promise<void>,
-  accountsData: { active: Array<{ data: AccountRaw }> },
-) {
-  return async () => {
-    try {
-      await cryptoAssetHydration; // Ensure crypto assets are hydrated before importing accounts
-      store.dispatch(await importAccountsRaw(accountsData));
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error("Failed to import accounts during initialization:", error);
-      // Continue with app initialization even if account import fails
-      // This prevents blocking deeplink navigation
-    }
-  };
 }

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -316,10 +316,8 @@ function getImportAccounts(store: Store, cryptoAssetHydration: Promise<void>) {
   return async () => {
     try {
       const accountsData = retry(getAccounts, MAX_RETRIES, RETRY_DELAY);
-      const walletStore = retry(getWalletExportState, MAX_RETRIES, RETRY_DELAY);
       await cryptoAssetHydration; // Ensure crypto assets are hydrated before importing accounts
       store.dispatch(await importAccountsRaw(await accountsData));
-      store.dispatch(importWalletState(await walletStore)); // TODO: fix the double source of truth for accounts names
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error("Failed to import accounts during initialization:", error);

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -348,7 +348,7 @@ export default class Root extends Component {
     logStartupEvent("Root render");
     return (
       <LedgerStoreProvider onInitFinished={this.onInitFinished} store={store}>
-        {({ ready, initialCountervalues, currencyInitialized, importAccounts }) =>
+        {({ ready, initialCountervalues, currencyInitialized }) =>
           ready ? (
             <RebootProvider>
               <SetEnvsFromSettings />
@@ -369,10 +369,7 @@ export default class Root extends Component {
                             <NavBarColorHandler />
                             <AuthPass>
                               <GestureHandlerRootView style={styles.root}>
-                                <WaitForAppReady
-                                  currencyInitialized={currencyInitialized}
-                                  importAccounts={importAccounts}
-                                >
+                                <WaitForAppReady currencyInitialized={currencyInitialized}>
                                   <AppProviders initialCountervalues={initialCountervalues}>
                                     <AppGeoBlocker>
                                       <AppVersionBlocker>

--- a/apps/ledger-live-mobile/src/mvvm/contexts/WaitForAppReady.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/WaitForAppReady.tsx
@@ -6,27 +6,15 @@ import { logStartupEvent } from "../utils/logStartupTime";
 
 const MAX_WAIT = 1_000;
 
-export interface WaitForAppReadyProps {
-  currencyInitialized: boolean;
-  importAccounts: () => Promise<void>;
-}
-
 export function WaitForAppReady({
   children,
   currencyInitialized,
-  importAccounts,
-}: React.PropsWithChildren<WaitForAppReadyProps>) {
+}: React.PropsWithChildren<{ currencyInitialized: boolean }>) {
   logStartupEvent("WaitForAppReady render");
 
   const initialQueries = useContext(InitialQueriesContext);
-  const accountsImported = useWait<boolean>(resolve =>
-    importAccounts().finally(() => resolve(true)),
-  );
   const isLoaded =
-    accountsImported &&
-    currencyInitialized &&
-    !initialQueries.ofacResult.isLoading &&
-    initialQueries.firebaseIsReady;
+    currencyInitialized && !initialQueries.ofacResult.isLoading && initialQueries.firebaseIsReady;
 
   const timedOut = useWait<boolean>(resolve => setTimeout(() => resolve(true), MAX_WAIT)) ?? false;
 

--- a/apps/ledger-live-mobile/src/mvvm/contexts/__tests__/WaitForAppReady.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/__tests__/WaitForAppReady.test.tsx
@@ -2,14 +2,15 @@ import React from "react";
 import { Text } from "react-native";
 import { render, screen } from "@testing-library/react-native";
 import { InitialQueriesContext } from "../InitialQueriesContext";
-import { WaitForAppReady, type WaitForAppReadyProps } from "../WaitForAppReady";
+import { WaitForAppReady } from "../WaitForAppReady";
 
-type RenderParams = Parameters<typeof InitialQueriesContext.Provider>[0]["value"] &
-  Partial<WaitForAppReadyProps>;
+type RenderParams = Parameters<typeof InitialQueriesContext.Provider>[0]["value"] & {
+  currencyInitialized: boolean;
+};
 
 describe("WaitForAppReady", () => {
-  it("renders children when app is ready", async () => {
-    await renderApp({
+  it("renders children when app is ready", () => {
+    renderApp({
       currencyInitialized: true,
       firebaseIsReady: true,
       ofacResult: { blocked: false, isLoading: false },
@@ -17,8 +18,8 @@ describe("WaitForAppReady", () => {
     expect(screen.getByText("App is Ready")).toBeTruthy();
   });
 
-  it("renders null when firebase is not ready", async () => {
-    await renderApp({
+  it("renders null when firebase is not ready", () => {
+    renderApp({
       currencyInitialized: true,
       firebaseIsReady: false,
       ofacResult: { blocked: false, isLoading: false },
@@ -26,8 +27,8 @@ describe("WaitForAppReady", () => {
     expect(screen.toJSON()).toBeNull();
   });
 
-  it("renders null when OFAC check is loading", async () => {
-    await renderApp({
+  it("renders null when OFAC check is loading", () => {
+    renderApp({
       currencyInitialized: true,
       firebaseIsReady: true,
       ofacResult: { blocked: false, isLoading: true },
@@ -35,8 +36,8 @@ describe("WaitForAppReady", () => {
     expect(screen.toJSON()).toBeNull();
   });
 
-  it("renders null when currency is not initialized", async () => {
-    await renderApp({
+  it("renders null when currency is not initialized", () => {
+    renderApp({
       currencyInitialized: false,
       firebaseIsReady: true,
       ofacResult: { blocked: false, isLoading: false },
@@ -44,39 +45,13 @@ describe("WaitForAppReady", () => {
     expect(screen.toJSON()).toBeNull();
   });
 
-  it("renders null while accounts are being imported", async () => {
-    let resolve: (() => void) | undefined;
-    await renderApp({
-      currencyInitialized: true,
-      firebaseIsReady: true,
-      ofacResult: { blocked: false, isLoading: false },
-      importAccounts: () =>
-        new Promise<void>(r => {
-          resolve = r;
-        }),
-    });
-
-    expect(screen.toJSON()).toBeNull();
-    resolve?.();
-    expect(await screen.findByText("App is Ready")).toBeTruthy();
-  });
-
-  async function renderApp({ currencyInitialized, importAccounts, ...value }: RenderParams) {
-    const defaultImportAccounts = async () => Promise.resolve();
-
-    const element = (
+  function renderApp({ currencyInitialized, ...value }: RenderParams) {
+    return render(
       <InitialQueriesContext.Provider value={value}>
-        <WaitForAppReady
-          currencyInitialized={currencyInitialized ?? true}
-          importAccounts={importAccounts ?? defaultImportAccounts}
-        >
+        <WaitForAppReady currencyInitialized={currencyInitialized}>
           <Text>App is Ready</Text>
         </WaitForAppReady>
-      </InitialQueriesContext.Provider>
+      </InitialQueriesContext.Provider>,
     );
-    const result = render(element);
-
-    // Rerender to ensure the importAccounts useWait returned the correct value
-    await result.rerenderAsync(element);
   }
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Same as #16196 but for the `develop` branch.
[LIVE-28741] was not be reproduced so far. In case this bug is related to the defering of the accounts import, this PR reverts #15858 and  #16115 for the release in progress in order to get more time to test these changes later.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28741]
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28741]: https://ledgerhq.atlassian.net/browse/LIVE-28741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ