### PR TITLE
[LWM] fix: stepper logic and padding for post onboarding widget

### DIFF
--- a/.changeset/modern-shoes-arrive.md
+++ b/.changeset/modern-shoes-arrive.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: stepper logic and padding for post onboarding widget

--- a/apps/ledger-live-mobile/src/components/PostOnboarding/PostOnboardingActionRow.tsx
+++ b/apps/ledger-live-mobile/src/components/PostOnboarding/PostOnboardingActionRow.tsx
@@ -8,6 +8,7 @@ import { track } from "~/analytics";
 import { BaseNavigationComposite, StackNavigatorNavigation } from "../RootNavigator/types/helpers";
 import { PostOnboardingNavigatorParamList } from "../RootNavigator/types/PostOnboardingNavigator";
 import { DeviceModelId } from "@ledgerhq/types-devices";
+import { isPostOnboardingHubActionFulfilled } from "~/logic/postOnboarding/postOnboardingHubCompletion";
 import { useCompleteActionCallback } from "~/logic/postOnboarding/useCompleteAction";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
@@ -52,10 +53,14 @@ const PostOnboardingActionRow: React.FC<Props> = props => {
   const completeAction = useCompleteActionCallback();
   const [isActionCompleted, setIsActionCompleted] = useState(false);
 
-  const initIsActionCompleted = useCallback(async () => {
-    const isAlreadyCompleted = getIsAlreadyCompletedByState?.({ isLedgerSyncActive, accounts });
-    setIsActionCompleted(completed || !!isAlreadyCompleted);
-  }, [setIsActionCompleted, completed, getIsAlreadyCompletedByState, isLedgerSyncActive, accounts]);
+  const initIsActionCompleted = useCallback(() => {
+    setIsActionCompleted(
+      isPostOnboardingHubActionFulfilled(
+        { completed, getIsAlreadyCompletedByState },
+        { isLedgerSyncActive: !!isLedgerSyncActive, accounts },
+      ),
+    );
+  }, [completed, getIsAlreadyCompletedByState, isLedgerSyncActive, accounts]);
 
   useEffect(() => {
     initIsActionCompleted();

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/__tests__/postOnboardingHubCompletion.test.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/__tests__/postOnboardingHubCompletion.test.ts
@@ -1,0 +1,34 @@
+import { isPostOnboardingHubActionFulfilled } from "../postOnboardingHubCompletion";
+
+describe("isPostOnboardingHubActionFulfilled", () => {
+  it("is true when Redux marks the action completed", () => {
+    expect(
+      isPostOnboardingHubActionFulfilled(
+        { completed: true, getIsAlreadyCompletedByState: () => false },
+        { isLedgerSyncActive: false },
+      ),
+    ).toBe(true);
+  });
+
+  it("uses getIsAlreadyCompletedByState when Redux completed is false", () => {
+    expect(
+      isPostOnboardingHubActionFulfilled(
+        {
+          completed: false,
+          getIsAlreadyCompletedByState: ({ isLedgerSyncActive }) => !!isLedgerSyncActive,
+        },
+        { isLedgerSyncActive: true, accounts: [] },
+      ),
+    ).toBe(true);
+
+    expect(
+      isPostOnboardingHubActionFulfilled(
+        {
+          completed: false,
+          getIsAlreadyCompletedByState: ({ isLedgerSyncActive }) => !!isLedgerSyncActive,
+        },
+        { isLedgerSyncActive: false },
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/postOnboardingHubCompletion.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/postOnboardingHubCompletion.ts
@@ -1,0 +1,18 @@
+import type { Account, PostOnboardingAction } from "@ledgerhq/types-live";
+
+type CompletionFields = Pick<PostOnboardingAction, "getIsAlreadyCompletedByState"> & {
+  completed: boolean;
+};
+
+export function isPostOnboardingHubActionFulfilled(
+  action: CompletionFields,
+  context: { isLedgerSyncActive: boolean; accounts?: Account[] },
+): boolean {
+  if (action.completed) return true;
+  return Boolean(
+    action.getIsAlreadyCompletedByState?.({
+      isLedgerSyncActive: !!context.isLedgerSyncActive,
+      accounts: context.accounts,
+    }),
+  );
+}

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/usePostOnboardingHubCompletionContext.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/usePostOnboardingHubCompletionContext.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
+import type { Account } from "@ledgerhq/types-live";
+import { useSelector } from "~/context/hooks";
+import { accountsSelector } from "~/reducers/accounts";
+
+export type PostOnboardingHubCompletionContext = {
+  readonly isLedgerSyncActive: boolean;
+  readonly accounts: Account[];
+};
+
+export function usePostOnboardingHubCompletionContext(): PostOnboardingHubCompletionContext {
+  const trustchain = useSelector(trustchainSelector);
+  const accounts = useSelector(accountsSelector);
+
+  return useMemo(
+    () => ({
+      isLedgerSyncActive: Boolean(trustchain?.rootId),
+      accounts,
+    }),
+    [trustchain, accounts],
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/ScreenHeroSection/ScreenHeroSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/ScreenHeroSection/ScreenHeroSectionView.tsx
@@ -17,7 +17,6 @@ const contentAreaStyle: LumenViewStyle = {
 };
 
 const ctasStyle: LumenViewStyle = {
-  paddingHorizontal: "s16",
   paddingBottom: "s8",
 };
 
@@ -27,7 +26,7 @@ export const ScreenHeroSectionView = ({
   testID,
   minContentHeight,
 }: ScreenHeroSectionViewProps) => (
-  <Box lx={{ gap: "s12" }} testID={testID}>
+  <Box lx={{ gap: "s12", paddingHorizontal: "s16" }} testID={testID}>
     <Box lx={contentAreaStyle} style={{ minHeight: minContentHeight ?? CONTENT_AREA_HEIGHT }}>
       {children}
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/OnboardingWidget/__tests__/useOnboardingWidgetViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/OnboardingWidget/__tests__/useOnboardingWidgetViewModel.test.ts
@@ -1,5 +1,8 @@
+import type { Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
+import BigNumber from "bignumber.js";
 import { renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
+import { type Account, PostOnboardingActionId } from "@ledgerhq/types-live";
 import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import { useOnboardingWidgetViewModel } from "../useOnboardingWidgetViewModel";
 
@@ -20,14 +23,14 @@ const makeAction = (completed: boolean) => ({
 
 describe("useOnboardingWidgetViewModel", () => {
   it.each([
-    { completed: 0, total: 3, expectedStep: 0, expectedTotal: 4, expectedLabel: "1/4" },
-    { completed: 1, total: 3, expectedStep: 1, expectedTotal: 4, expectedLabel: "2/4" },
-    { completed: 2, total: 3, expectedStep: 2, expectedTotal: 4, expectedLabel: "3/4" },
-    { completed: 3, total: 3, expectedStep: 3, expectedTotal: 4, expectedLabel: "4/4" },
-    { completed: 0, total: 4, expectedStep: 0, expectedTotal: 5, expectedLabel: "1/5" },
+    { completed: 0, total: 3, expectedArcStep: 0, expectedTotal: 4, expectedLabel: "1/4" },
+    { completed: 1, total: 3, expectedArcStep: 1, expectedTotal: 4, expectedLabel: "2/4" },
+    { completed: 2, total: 3, expectedArcStep: 2, expectedTotal: 4, expectedLabel: "3/4" },
+    { completed: 3, total: 3, expectedArcStep: 4, expectedTotal: 4, expectedLabel: "4/4" },
+    { completed: 0, total: 4, expectedArcStep: 0, expectedTotal: 5, expectedLabel: "1/5" },
   ])(
-    "should return $expectedStep/$expectedTotal (label $expectedLabel) when $completed of $total actions completed",
-    ({ completed, total, expectedStep, expectedTotal, expectedLabel }) => {
+    "should return stepper currentStep $expectedArcStep, total $expectedTotal, label $expectedLabel when $completed of $total actions completed",
+    ({ completed, total, expectedArcStep, expectedTotal, expectedLabel }) => {
       const actions = Array.from({ length: total }, (_, i) => makeAction(i < completed));
       mockedUsePostOnboardingHubState.mockReturnValue({
         deviceModelId: DeviceModelId.nanoX,
@@ -38,9 +41,76 @@ describe("useOnboardingWidgetViewModel", () => {
 
       const { result } = renderHook(() => useOnboardingWidgetViewModel());
 
-      expect(result.current.currentStep).toBe(expectedStep);
+      expect(result.current.currentStep).toBe(expectedArcStep);
       expect(result.current.totalSteps).toBe(expectedTotal);
       expect(result.current.stepperLabel).toBe(expectedLabel);
     },
   );
+
+  it("treats syncAccounts as completed when Ledger Sync is active, matching the hub row", () => {
+    mockedUsePostOnboardingHubState.mockReturnValue({
+      deviceModelId: DeviceModelId.nanoX,
+      actionsState: [
+        {
+          id: PostOnboardingActionId.syncAccounts,
+          completed: false,
+          getIsAlreadyCompletedByState: ({ isLedgerSyncActive }) => !!isLedgerSyncActive,
+          Icon: () => null,
+          title: "",
+          titleCompleted: "",
+        },
+      ],
+      lastActionCompleted: null,
+      postOnboardingInProgress: true,
+    });
+
+    const minimalTrustchain = {
+      rootId: "test-root",
+      walletSyncEncryptionKey: "",
+      applicationPath: "",
+    } as Trustchain;
+
+    const { result } = renderHook(() => useOnboardingWidgetViewModel(), {
+      overrideInitialState: s => ({
+        ...s,
+        trustchain: { ...s.trustchain, trustchain: minimalTrustchain },
+      }),
+    });
+
+    expect(result.current.totalSteps).toBe(2);
+    expect(result.current.stepperLabel).toBe("2/2");
+    expect(result.current.currentStep).toBe(2);
+  });
+
+  it("treats assets transfer as completed when accounts have a positive balance (hub parity)", () => {
+    mockedUsePostOnboardingHubState.mockReturnValue({
+      deviceModelId: DeviceModelId.nanoX,
+      actionsState: [
+        {
+          id: PostOnboardingActionId.assetsTransfer,
+          completed: false,
+          getIsAlreadyCompletedByState: ({ accounts }) =>
+            !!accounts && accounts.some(account => account?.balance.isGreaterThan(0)),
+          Icon: () => null,
+          title: "",
+          titleCompleted: "",
+        },
+      ],
+      lastActionCompleted: null,
+      postOnboardingInProgress: true,
+    });
+
+    const accountWithFunds = { balance: new BigNumber(1) } as Account;
+
+    const { result } = renderHook(() => useOnboardingWidgetViewModel(), {
+      overrideInitialState: s => ({
+        ...s,
+        accounts: { ...s.accounts, active: [accountWithFunds] },
+      }),
+    });
+
+    expect(result.current.totalSteps).toBe(2);
+    expect(result.current.stepperLabel).toBe("2/2");
+    expect(result.current.currentStep).toBe(2);
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/OnboardingWidget/useOnboardingWidgetViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/OnboardingWidget/useOnboardingWidgetViewModel.ts
@@ -1,23 +1,31 @@
 import { useCallback, useMemo } from "react";
-import { track } from "~/analytics";
 import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { track } from "~/analytics";
+import { isPostOnboardingHubActionFulfilled } from "~/logic/postOnboarding/postOnboardingHubCompletion";
+import { usePostOnboardingHubCompletionContext } from "~/logic/postOnboarding/usePostOnboardingHubCompletionContext";
 import { useNavigateToPostOnboardingHubCallback } from "~/logic/postOnboarding/useNavigateToPostOnboardingHubCallback";
 import type { UseOnboardingWidgetViewModelResult } from "./types";
 
 export const useOnboardingWidgetViewModel = (): UseOnboardingWidgetViewModelResult => {
   const { actionsState, deviceModelId } = usePostOnboardingHubState();
   const navigateToPostOnboardingHub = useNavigateToPostOnboardingHubCallback();
+  const hubCompletionContext = usePostOnboardingHubCompletionContext();
 
   const { currentStep, totalSteps, stepperLabel } = useMemo(() => {
     const actionsTotal = actionsState.length;
-    const actionsCompleted = actionsState.filter(a => a.completed).length;
+    const actionsCompleted = actionsState.filter(a =>
+      isPostOnboardingHubActionFulfilled(a, hubCompletionContext),
+    ).length;
     const total = 1 + Math.max(actionsTotal, 1);
+    const displayStep = 1 + actionsCompleted;
+    const arcStep =
+      actionsTotal > 0 && actionsCompleted === actionsTotal ? total : actionsCompleted;
     return {
-      currentStep: actionsCompleted,
+      currentStep: arcStep,
       totalSteps: total,
-      stepperLabel: `${1 + actionsCompleted}/${total}`,
+      stepperLabel: `${displayStep}/${total}`,
     };
-  }, [actionsState]);
+  }, [actionsState, hubCompletionContext]);
 
   const onPress = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
@@ -7,7 +7,7 @@ import {
   usePostOnboardingHubState,
 } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import { clearPostOnboardingLastActionCompleted } from "@ledgerhq/live-common/postOnboarding/actions";
-import { useSelector, useDispatch } from "~/context/hooks";
+import { useDispatch } from "~/context/hooks";
 import { getDeviceModel } from "@ledgerhq/devices";
 import PostOnboardingActionRow from "~/components/PostOnboarding/PostOnboardingActionRow";
 import { TrackScreen } from "~/analytics";
@@ -18,8 +18,7 @@ import ActivationDrawer from "LLM/features/WalletSync/screens/Activation/Activat
 import { Steps } from "LLM/features/WalletSync/types/Activation";
 import useLedgerSyncEntryPointViewModel from "LLM/features/LedgerSyncEntryPoint/useLedgerSyncEntryPointViewModel";
 import { EntryPoint } from "LLM/features/LedgerSyncEntryPoint/types";
-import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
-import { accountsSelector } from "~/reducers/accounts";
+import { usePostOnboardingHubCompletionContext } from "~/logic/postOnboarding/usePostOnboardingHubCompletionContext";
 import { PostOnboardingActionId } from "@ledgerhq/types-live";
 
 const PostOnboardingHub = () => {
@@ -27,8 +26,7 @@ const PostOnboardingHub = () => {
   const { t } = useTranslation();
   const { actionsState, deviceModelId } = usePostOnboardingHubState();
   const closePostOnboarding = useCompletePostOnboarding();
-  const isLedgerSyncActive = Boolean(useSelector(trustchainSelector)?.rootId);
-  const accounts = useSelector(accountsSelector);
+  const { isLedgerSyncActive, accounts } = usePostOnboardingHubCompletionContext();
 
   const { isActivationDrawerVisible, closeActivationDrawer, openActivationDrawer } =
     useLedgerSyncEntryPointViewModel({


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- padding fixed
<img width="404" height="254" alt="Screenshot 2026-04-13 at 16 44 52" src="https://github.com/user-attachments/assets/86a24aa5-3ecc-4749-8d9a-05e165fd7817" />

<img width="382" height="254" alt="Screenshot 2026-04-13 at 16 42 56" src="https://github.com/user-attachments/assets/6203c4b1-e6d7-4271-bf12-1b3d53efa86a" />

- stepper sync with ledger sync step

### ❓ Context

- **JIRA or GitHub link**: [LIVE-24472]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->



---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-24472]: https://ledgerhq.atlassian.net/browse/LIVE-24472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ