### PR TITLE
[LWDM] fix(LIVE-29151): optimize aleo private balance calculation + small fixes

### DIFF
--- a/.changeset/five-snails-remain.md
+++ b/.changeset/five-snails-remain.md
@@ -1,5 +1,0 @@
----
-"@ledgerhq/coin-aleo": minor
----
-
-fix: optimize private balance calculation in coin-aleo

--- a/.changeset/five-snails-remain.md
+++ b/.changeset/five-snails-remain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+fix: optimize private balance calculation in coin-aleo

--- a/.changeset/forty-apes-drum.md
+++ b/.changeset/forty-apes-drum.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-aleo": minor
+"@ledgerhq/live-common": minor
+---
+
+chore: remove unused nodeUrl from coin-aleo config
+fix: optimize private balance calculation in coin-aleo
+fix: aleo pending operation is removed too early

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
@@ -629,6 +629,7 @@ describe("sync.ts", () => {
         currency: mockCurrency,
         viewKey: "AViewKey123",
         privateRecords: mockUnspentRecords,
+        oldUnspentRecords: [],
       });
       expect(result?.aleoResources?.privateBalance).toEqual(new BigNumber(50000));
       expect(result?.aleoResources?.unspentPrivateRecords).toEqual(mockUnspentResult);
@@ -967,6 +968,7 @@ describe("sync.ts", () => {
         currency: mockCurrency,
         viewKey: "AViewKey123",
         privateRecords: [unspentRecord],
+        oldUnspentRecords: [],
       });
     });
   });
@@ -1224,14 +1226,20 @@ describe("sync.ts", () => {
     });
 
     it("should remove only confirmed pending operations and keep unconfirmed ones", () => {
-      const confirmedOp = getMockedOperation({ id: "confirmed", hash: "tx-confirmed" });
-      const pendingConfirmedOp = getMockedOperation({
-        id: "pending-confirmed",
+      const confirmedOp = getMockedOperation({
+        id: "account-tx-confirmed-OUT",
         hash: "tx-confirmed",
+        type: "OUT",
+      });
+      const pendingConfirmedOp = getMockedOperation({
+        id: "account-tx-confirmed-OUT",
+        hash: "tx-confirmed",
+        type: "OUT",
       });
       const pendingUnconfirmedOp = getMockedOperation({
-        id: "pending-unconfirmed",
+        id: "account-tx-pending-OUT",
         hash: "tx-pending",
+        type: "OUT",
       });
 
       const synced: AleoAccount = {
@@ -1243,8 +1251,62 @@ describe("sync.ts", () => {
       const result = postSync(synced, synced);
 
       expect(result.pendingOperations).toEqual([
-        expect.objectContaining({ hash: pendingUnconfirmedOp.hash }),
+        expect.objectContaining({ id: pendingUnconfirmedOp.id }),
       ]);
+    });
+
+    it("should keep a pending OUT op when only the IN side of a private -> public self-transfer is confirmed", () => {
+      const confirmedPublicInOp = getMockedOperation({
+        id: "account-tx-self-transfer-IN",
+        hash: "tx-self-transfer",
+        type: "IN",
+      });
+      const pendingPrivateOutOp = getMockedOperation({
+        id: "account-tx-self-transfer-OUT",
+        hash: "tx-self-transfer",
+        type: "OUT",
+      });
+
+      const synced: AleoAccount = {
+        ...mockInitialAccount,
+        operations: [confirmedPublicInOp],
+        pendingOperations: [pendingPrivateOutOp],
+      };
+
+      const result = postSync(synced, synced);
+
+      // The pending OUT should still be present - the confirmed set only has the "IN" id.
+      expect(result.pendingOperations).toEqual([
+        expect.objectContaining({ id: pendingPrivateOutOp.id }),
+      ]);
+    });
+
+    it("should remove a pending OUT op once the private OUT side of a self-transfer is confirmed", () => {
+      const confirmedPublicInOp = getMockedOperation({
+        id: "account-tx-self-transfer-IN",
+        hash: "tx-self-transfer",
+        type: "IN",
+      });
+      const confirmedPrivateOutOp = getMockedOperation({
+        id: "account-tx-self-transfer-OUT",
+        hash: "tx-self-transfer",
+        type: "OUT",
+      });
+      const pendingPrivateOutOp = getMockedOperation({
+        id: "account-tx-self-transfer-OUT",
+        hash: "tx-self-transfer",
+        type: "OUT",
+      });
+
+      const synced: AleoAccount = {
+        ...mockInitialAccount,
+        operations: [confirmedPublicInOp, confirmedPrivateOutOp],
+        pendingOperations: [pendingPrivateOutOp],
+      };
+
+      const result = postSync(synced, synced);
+
+      expect(result.pendingOperations).toEqual([]);
     });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -61,12 +61,12 @@ export async function performPublicSync(
   const transparentBalance = new BigNumber(nativeBalance.toString());
 
   const shouldSyncFromScratch = !initialAccount;
-  const allOldOperations = shouldSyncFromScratch ? [] : initialAccount?.operations ?? [];
+  const allOldOperations = shouldSyncFromScratch ? [] : (initialAccount?.operations ?? []);
 
   // Keep public and private ops separate so each cursor is derived from the correct op type.
   // Mixing them risks using a private op's blockHeight as the public sync cursor.
   const [oldPrivateOps, oldPublicOps] = splitPrivateAndPublicOperations(allOldOperations);
-  const lastBlockHeight = shouldSyncFromScratch ? 0 : oldPublicOps[0]?.blockHeight ?? 0;
+  const lastBlockHeight = shouldSyncFromScratch ? 0 : (oldPublicOps[0]?.blockHeight ?? 0);
 
   const latestAccountPublicOperations = await listOperations({
     currency,
@@ -432,7 +432,7 @@ export function makeGetAccountShape(): GetAccountShapeStream<AleoAccount> {
  * Confirmed operations lack this field, making the comparison always false and leaving pending operations stuck.
  *
  * Instead pending operations are removed here by matching on operation id:
- * once a confirmed operation with the same id (accountId + hash + type) appears in the confirmed list,
+ * once a confirmed operation with the same id appears in the confirmed list,
  * the corresponding pending operation is no longer needed.
  */
 export function postSync(_initial: AleoAccount, synced: AleoAccount): AleoAccount {

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -252,6 +252,7 @@ export async function performPrivateSync(
     currency,
     viewKey,
     privateRecords: filteredUnspentRecords,
+    oldUnspentRecords: initialAccount.aleoResources?.unspentPrivateRecords ?? [],
   });
   const privateBalance = privateBalanceResult.balance;
   const unspentPrivateRecords: AleoUnspentRecord[] = privateBalanceResult.unspentRecords;

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -61,12 +61,12 @@ export async function performPublicSync(
   const transparentBalance = new BigNumber(nativeBalance.toString());
 
   const shouldSyncFromScratch = !initialAccount;
-  const allOldOperations = shouldSyncFromScratch ? [] : (initialAccount?.operations ?? []);
+  const allOldOperations = shouldSyncFromScratch ? [] : initialAccount?.operations ?? [];
 
   // Keep public and private ops separate so each cursor is derived from the correct op type.
   // Mixing them risks using a private op's blockHeight as the public sync cursor.
   const [oldPrivateOps, oldPublicOps] = splitPrivateAndPublicOperations(allOldOperations);
-  const lastBlockHeight = shouldSyncFromScratch ? 0 : (oldPublicOps[0]?.blockHeight ?? 0);
+  const lastBlockHeight = shouldSyncFromScratch ? 0 : oldPublicOps[0]?.blockHeight ?? 0;
 
   const latestAccountPublicOperations = await listOperations({
     currency,
@@ -431,8 +431,9 @@ export function makeGetAccountShape(): GetAccountShapeStream<AleoAccount> {
  * because without this only one pending operation could be rendered in LW.
  * Confirmed operations lack this field, making the comparison always false and leaving pending operations stuck.
  *
- * Instead pending operations are removed here by matching on transaction hash:
- * once a hash appears in the confirmed operations list, the corresponding pending operation is no longer needed.
+ * Instead pending operations are removed here by matching on operation id:
+ * once a confirmed operation with the same id (accountId + hash + type) appears in the confirmed list,
+ * the corresponding pending operation is no longer needed.
  */
 export function postSync(_initial: AleoAccount, synced: AleoAccount): AleoAccount {
   const pendingOperations = synced.pendingOperations ?? [];
@@ -441,11 +442,11 @@ export function postSync(_initial: AleoAccount, synced: AleoAccount): AleoAccoun
     return synced;
   }
 
-  const confirmedHashes = new Set(synced.operations.map(o => o.hash));
+  const confirmedIds = new Set(synced.operations.map(o => o.id));
 
   return {
     ...synced,
-    pendingOperations: pendingOperations.filter(po => !confirmedHashes.has(po.hash)),
+    pendingOperations: pendingOperations.filter(po => !confirmedIds.has(po.id)),
   };
 }
 

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
@@ -37,6 +37,7 @@ describe("getPrivateBalance", () => {
       currency,
       viewKey: testnetViewKey,
       privateRecords: [testnetPrivateRecord, testnetPrivateRecord],
+      oldUnspentRecords: [],
     });
 
     expect(balance).toEqual(new BigNumber(800000 + 800000));
@@ -47,6 +48,7 @@ describe("getPrivateBalance", () => {
       currency,
       viewKey: testnetViewKey,
       privateRecords: [testnetPrivateRecord],
+      oldUnspentRecords: [],
     });
 
     expect(unspentRecords).toEqual([
@@ -66,6 +68,7 @@ describe("getPrivateBalance", () => {
       currency,
       viewKey: testnetViewKey,
       privateRecords: [],
+      oldUnspentRecords: [],
     });
 
     expect(balance).toEqual(new BigNumber(0));
@@ -77,6 +80,7 @@ describe("getPrivateBalance", () => {
       currency,
       viewKey: testnetViewKey,
       privateRecords: [{ ...testnetPrivateRecord, spent: true }],
+      oldUnspentRecords: [],
     });
 
     expect(balance).toEqual(new BigNumber(0));
@@ -93,6 +97,7 @@ describe("getPrivateBalance", () => {
       currency,
       viewKey: testnetViewKey,
       privateRecords: mixedRecords,
+      oldUnspentRecords: [],
     });
 
     expect(unspentRecords).toEqual([

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.test.ts
@@ -3,6 +3,7 @@ import { sdkClient } from "../network/sdk";
 import { PROGRAM_ID } from "../constants";
 import { testnetPrivateRecord } from "../__tests__/fixtures/api.fixture";
 import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
+import type { AleoUnspentRecord } from "../types";
 import { getPrivateBalance } from "./getPrivateBalance";
 
 jest.mock("../network/sdk");
@@ -28,6 +29,7 @@ describe("getPrivateBalance", () => {
       currency: mockCurrency,
       viewKey: mockViewKey,
       privateRecords: [],
+      oldUnspentRecords: [],
     });
 
     expect(balance).toEqual(new BigNumber(0));
@@ -42,6 +44,7 @@ describe("getPrivateBalance", () => {
       currency: mockCurrency,
       viewKey: mockViewKey,
       privateRecords: [record],
+      oldUnspentRecords: [],
     });
 
     expect(sdkClient.decryptRecord).toHaveBeenCalledTimes(1);
@@ -78,6 +81,7 @@ describe("getPrivateBalance", () => {
       currency: mockCurrency,
       viewKey: mockViewKey,
       privateRecords: [record1, record2],
+      oldUnspentRecords: [],
     });
 
     expect(sdkClient.decryptRecord).toHaveBeenCalledTimes(2);
@@ -92,6 +96,7 @@ describe("getPrivateBalance", () => {
       currency: mockCurrency,
       viewKey: mockViewKey,
       privateRecords: [spentRecord],
+      oldUnspentRecords: [],
     });
 
     expect(sdkClient.decryptRecord).not.toHaveBeenCalled();
@@ -106,6 +111,7 @@ describe("getPrivateBalance", () => {
       currency: mockCurrency,
       viewKey: mockViewKey,
       privateRecords: [nonCreditsRecord],
+      oldUnspentRecords: [],
     });
 
     expect(sdkClient.decryptRecord).not.toHaveBeenCalled();
@@ -125,6 +131,7 @@ describe("getPrivateBalance", () => {
       currency: mockCurrency,
       viewKey: mockViewKey,
       privateRecords: [creditsRecord, otherRecord],
+      oldUnspentRecords: [],
     });
 
     expect(sdkClient.decryptRecord).toHaveBeenCalledTimes(1);
@@ -140,6 +147,7 @@ describe("getPrivateBalance", () => {
       currency: mockCurrency,
       viewKey: mockViewKey,
       privateRecords: [spentRecord, unspentRecord],
+      oldUnspentRecords: [],
     });
 
     expect(sdkClient.decryptRecord).toHaveBeenCalledTimes(1);
@@ -156,7 +164,80 @@ describe("getPrivateBalance", () => {
         currency: mockCurrency,
         viewKey: mockViewKey,
         privateRecords: [testnetPrivateRecord],
+        oldUnspentRecords: [],
       }),
     ).rejects.toThrow("Decryption failed");
+  });
+
+  it("should use cached record from oldUnspentRecords and skip decryptRecord", async () => {
+    const record = { ...testnetPrivateRecord, spent: false };
+    const cachedUnspentRecord: AleoUnspentRecord = {
+      ...record,
+      microcredits: "500000",
+      decryptedData: mockDecryptedRecord,
+    };
+
+    const { balance, unspentRecords } = await getPrivateBalance({
+      currency: mockCurrency,
+      viewKey: mockViewKey,
+      privateRecords: [record],
+      oldUnspentRecords: [cachedUnspentRecord],
+    });
+
+    expect(sdkClient.decryptRecord).not.toHaveBeenCalled();
+    expect(balance).toEqual(new BigNumber(500000));
+    expect(unspentRecords).toEqual([cachedUnspentRecord]);
+  });
+
+  it("should decrypt only records not present in oldUnspentRecords", async () => {
+    const cachedRecord = { ...testnetPrivateRecord, commitment: "cached-commitment" };
+    const newRecord = {
+      ...testnetPrivateRecord,
+      commitment: "new-commitment",
+      record_ciphertext: "new-ciphertext",
+    };
+    const cachedUnspentRecord: AleoUnspentRecord = {
+      ...cachedRecord,
+      microcredits: "300000",
+      decryptedData: mockDecryptedRecord,
+    };
+
+    jest.mocked(sdkClient.decryptRecord).mockResolvedValueOnce({
+      ...mockDecryptedRecord,
+      data: { microcredits: "200000u64.private" },
+    });
+
+    const { balance, unspentRecords } = await getPrivateBalance({
+      currency: mockCurrency,
+      viewKey: mockViewKey,
+      privateRecords: [cachedRecord, newRecord],
+      oldUnspentRecords: [cachedUnspentRecord],
+    });
+
+    expect(sdkClient.decryptRecord).toHaveBeenCalledTimes(1);
+    expect(sdkClient.decryptRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ ciphertext: newRecord.record_ciphertext }),
+    );
+    expect(balance).toEqual(new BigNumber(500000));
+    expect(unspentRecords).toHaveLength(2);
+  });
+
+  it("should not include a cached record in output when it no longer appears in privateRecords (spent, removed by API)", async () => {
+    const spentCachedRecord: AleoUnspentRecord = {
+      ...testnetPrivateRecord,
+      microcredits: "500000",
+      decryptedData: mockDecryptedRecord,
+    };
+
+    const { balance, unspentRecords } = await getPrivateBalance({
+      currency: mockCurrency,
+      viewKey: mockViewKey,
+      privateRecords: [],
+      oldUnspentRecords: [spentCachedRecord],
+    });
+
+    expect(sdkClient.decryptRecord).not.toHaveBeenCalled();
+    expect(balance).toEqual(new BigNumber(0));
+    expect(unspentRecords).toEqual([]);
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.ts
@@ -10,19 +10,31 @@ export async function getPrivateBalance({
   currency,
   viewKey,
   privateRecords,
+  oldUnspentRecords,
 }: {
   currency: CryptoCurrency;
   viewKey: string;
   privateRecords: AleoPrivateRecord[];
+  oldUnspentRecords: AleoUnspentRecord[];
 }): Promise<{
   balance: BigNumber;
   unspentRecords: AleoUnspentRecord[];
 }> {
+  const recordByCiphertext = new Map(oldUnspentRecords.map(r => [r.record_ciphertext, r]));
   const unspentCreditsRecords = privateRecords.filter(
     record => record.program_name === PROGRAM_ID.CREDITS && !record.spent,
   );
 
   const decryptedResults = await promiseAllBatched(2, unspentCreditsRecords, async record => {
+    const cachedRecord = recordByCiphertext.get(record.record_ciphertext);
+
+    if (cachedRecord) {
+      return {
+        microcredits: cachedRecord.microcredits,
+        unspentRecord: cachedRecord,
+      };
+    }
+
     const decryptedRecord = await sdkClient.decryptRecord({
       currency,
       viewKey,

--- a/libs/ledger-live-common/src/families/aleo/config.ts
+++ b/libs/ledger-live-common/src/families/aleo/config.ts
@@ -35,7 +35,6 @@ export const aleoConfig: Record<string, ConfigInfo> = {
       status: {
         type: "active",
       },
-      nodeUrl: getEnv("ALEO_MAINNET_NODE_ENDPOINT"),
       networkType: "mainnet",
       apiUrls: {
         node: getEnv("ALEO_MAINNET_NODE_ENDPOINT"),
@@ -53,7 +52,6 @@ export const aleoConfig: Record<string, ConfigInfo> = {
       status: {
         type: "active",
       },
-      nodeUrl: getEnv("ALEO_TESTNET_NODE_ENDPOINT"),
       networkType: "testnet",
       apiUrls: {
         node: getEnv("ALEO_TESTNET_NODE_ENDPOINT"),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - optimized private balance fetching in coin-aleo module
  - fixed postSync in coin-aleo module
  - removed old config field from coin-aleo

### 📝 Description

This PR fixes performance issue with calculating private balance when Aleo accounts have hundreds of records. It also removes old and unused configuration field + fixes tiny bug in postSync logic.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-29151

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
