### PR TITLE
[LWDM] Polkadot defer getRegistry and get const from dedicated endpoint

### DIFF
--- a/.changeset/spotty-ways-roll.md
+++ b/.changeset/spotty-ways-roll.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-polkadot": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Fix Polkadot freezes on mobile

--- a/libs/coin-modules/coin-polkadot/src/bridge/preload.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/preload.test.ts
@@ -25,16 +25,17 @@ jest.mock("../network", () => {
 });
 
 describe("preload", () => {
-  //TODO make a more complete test
   it("should correctly preload data", async () => {
     getMinimumBondBalanceMock.mockResolvedValue(0n);
 
     const currency = getCryptoCurrencyById(account.currency.id);
     await preload(currency);
 
-    expect(getRegistryMock).toHaveBeenCalledTimes(1);
+    // getRegistry is no longer called in preload (deferred to first transaction)
+    expect(getRegistryMock).toHaveBeenCalledTimes(0);
     expect(getMinimumBondBalanceMock).toHaveBeenCalledTimes(1);
     expect(getStakingProgressMock).toHaveBeenCalledTimes(1);
+    // On cold start (no cached validators), validators are awaited
     expect(getValidatorsMock).toHaveBeenCalledTimes(1);
   });
 

--- a/libs/coin-modules/coin-polkadot/src/bridge/preload.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/preload.ts
@@ -80,7 +80,6 @@ const shouldRefreshValidators = (
 
 export const preload = async (currency: CryptoCurrency): Promise<PolkadotPreloadData> => {
   await loadPolkadotCrypto();
-  await polkadotAPI.getRegistry(currency); // ensure registry is already in cache.
   let minimumBondBalance;
   let currentStakingProgress;
   try {

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.mock.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.mock.ts
@@ -49,6 +49,15 @@ const handlers = [
   http.get(`${SIDECAR_BASE_URL_TEST}/pallets/staking/progress`, () =>
     HttpResponse.json(fixtureStakingProgress),
   ),
+  http.get(`${SIDECAR_BASE_URL_TEST}/pallets/staking/consts`, () =>
+    HttpResponse.json({
+      items: [
+        { name: "SessionsPerEra", value: "0x06000000" },
+        { name: "BondingDuration", value: "0x1c000000" },
+        { name: "MaxExposurePageSize", value: "0x00020000" },
+      ],
+    }),
+  ),
 ];
 
 const mockServer = setupServer(...handlers);

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
@@ -1,8 +1,8 @@
+import { makeLRUCache, hours } from "@ledgerhq/live-network/cache";
 import network from "@ledgerhq/live-network";
-import { hours, makeLRUCache } from "@ledgerhq/live-network/cache";
+import { hexToBn } from "@polkadot/util";
 import { log } from "@ledgerhq/logs";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { QueryableConsts } from "@polkadot/api/types";
 import { TypeRegistry } from "@polkadot/types";
 import { Extrinsics } from "@polkadot/types/metadata/decorate/types";
 import { BigNumber } from "bignumber.js";
@@ -63,6 +63,60 @@ const getElectionOptimisticThreshold = (currency?: CryptoCurrency): number => {
 
 const VALIDATOR_COMISSION_RATIO = 1000000000;
 const UNSUPPORTED_STAKING_NETWORKS = ["polkadot", "westend"];
+
+// Fallback values used when Sidecar const endpoints are unreachable.
+const DEFAULT_CONSTANTS = {
+  expectedBlockTime: 6000, // ms
+  epochDuration: 2400, // blocks
+  sessionsPerEra: 6,
+  maxNominatorRewardedPerValidator: 512,
+  bondingDuration: 28, // eras
+};
+
+type ChainConstants = typeof DEFAULT_CONSTANTS;
+
+type SidecarPalletConstsResponse = {
+  items: Array<{ name: string; value: string }>;
+};
+
+async function fetchPalletConsts(
+  palletId: string,
+  currency?: CryptoCurrency,
+): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  try {
+    const { data } = await callSidecar<SidecarPalletConstsResponse>(
+      `/pallets/${palletId}/consts`,
+      currency,
+    );
+    for (const item of data.items) {
+      const parsed = hexToBn(item.value, { isLe: true }).toNumber();
+      if (Number.isFinite(parsed)) {
+        result.set(item.name, parsed);
+      }
+    }
+  } catch (e) {
+    log("polkadot/sidecar", `failed to fetch ${palletId} consts, using fallbacks`, { error: e });
+  }
+  return result;
+}
+
+const getChainConstants = makeLRUCache(
+  async (currency: CryptoCurrency | undefined): Promise<ChainConstants> => {
+    const stakingConsts = await fetchPalletConsts("staking", currency);
+    return {
+      expectedBlockTime: DEFAULT_CONSTANTS.expectedBlockTime,
+      epochDuration: DEFAULT_CONSTANTS.epochDuration,
+      sessionsPerEra: stakingConsts.get("SessionsPerEra") ?? DEFAULT_CONSTANTS.sessionsPerEra,
+      maxNominatorRewardedPerValidator:
+        stakingConsts.get("MaxExposurePageSize") ??
+        DEFAULT_CONSTANTS.maxNominatorRewardedPerValidator,
+      bondingDuration: stakingConsts.get("BondingDuration") ?? DEFAULT_CONSTANTS.bondingDuration,
+    };
+  },
+  currency => currency?.id || "polkadot",
+  hours(1, 1),
+);
 
 // blocks = 2 minutes 30
 
@@ -151,17 +205,6 @@ const fetchStakingInfo = async (
   currency?: CryptoCurrency,
 ): Promise<SidecarStakingInfo> => {
   return node.fetchStakingInfo(addr, currency);
-};
-
-/**
- * Returns the blockchain's runtime constants.
- *
- * @async
- *
- * @returns {Promise<QueryableConsts<"promise">>}
- */
-const fetchConstants = async (currency?: CryptoCurrency): Promise<QueryableConsts<"promise">> => {
-  return node.fetchConstants(currency);
 };
 
 /**
@@ -391,17 +434,17 @@ export const getStakingInfo = async (addr: string, currency: CryptoCurrency) => 
     };
   }
 
-  const [stakingInfo, activeEra, consts] = await Promise.all([
+  const [stakingInfo, activeEra, chainConsts] = await Promise.all([
     fetchStakingInfo(addr, currency),
     fetchActiveEra(currency),
-    getConstants(currency),
+    getChainConstants(currency),
   ]);
 
   const activeEraIndex = Number(activeEra.value?.index || 0);
   const activeEraStart = Number(activeEra.value?.start || 0);
-  const blockTime = new BigNumber(consts?.babe?.expectedBlockTime?.toNumber() || 6000); // 6000 ms
-  const epochDuration = new BigNumber(consts?.babe?.epochDuration?.toNumber() || 2400); // 2400 blocks
-  const sessionsPerEra = new BigNumber(consts?.staking?.sessionsPerEra?.toNumber() || 6); // 6 sessions
+  const blockTime = new BigNumber(chainConsts.expectedBlockTime);
+  const epochDuration = new BigNumber(chainConsts.epochDuration);
+  const sessionsPerEra = new BigNumber(chainConsts.sessionsPerEra);
 
   const eraLength = sessionsPerEra.multipliedBy(epochDuration).multipliedBy(blockTime).toNumber();
   const unlockings = stakingInfo?.staking.unlocking
@@ -579,9 +622,9 @@ export const getStakingProgress = async (
     };
   }
 
-  const [progress, consts] = await Promise.all([
+  const [progress, chainConsts] = await Promise.all([
     fetchStakingProgress(currency),
-    getConstants(currency),
+    getChainConstants(currency),
   ]);
 
   const activeEra = Number(progress.activeEra);
@@ -602,9 +645,8 @@ export const getStakingProgress = async (
   return {
     activeEra,
     electionClosed: optimisticElectionClosed,
-    maxNominatorRewardedPerValidator:
-      Number(consts?.staking?.maxNominatorRewardedPerValidator?.toString()) || 128,
-    bondingDuration: consts?.staking?.bondingDuration?.toNumber() || 28,
+    maxNominatorRewardedPerValidator: chainConsts.maxNominatorRewardedPerValidator,
+    bondingDuration: chainConsts.bondingDuration,
   };
 };
 
@@ -627,7 +669,6 @@ export const getRegistry = async (
   ]);
   return createRegistryAndExtrinsics(material, spec);
 };
-
 export const getMetadata = async (
   callData: string,
   includedInExtrinsic: string,
@@ -662,23 +703,6 @@ export const getLastBlock = async (
  * CACHED REQUESTS
  * NOTE: we don't use the cache from family's `cache.js` to avoid cyclic imports.
  */
-
-/**
- * Cache the fetchConstants to avoid too many calls
- *
- * @async
- *
- * @returns {Promise<QueryableConsts<"promise">>} consts
- */
-const getConstants = makeLRUCache(
-  async (currency: CryptoCurrency | undefined): Promise<QueryableConsts<"promise">> => {
-    return fetchConstants(currency);
-  },
-  currency => currency?.id || "polkadot",
-  // Store only one constants object since we only have polkadot.
-  hours(1, 1),
-);
-
 /**
  * Cache the fetchTransactionMaterial(true) to avoid too many calls
  *


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

  - Remove ApiPromise.create() from the preload path — replaced getConstants() (which initialized the full Polkadot API client to read runtime constants) with lightweight Sidecar
   REST calls to /pallets/staking/consts, eliminating a ~300-600ms UI freeze on Hermes (React Native)
  - Defer getRegistry() to first transaction — removed the eager registry warm-up from preload(), moving the metadata parsing cost to when it's actually needed (fee estimation /
  signing)
  - Fetch staking constants via Sidecar REST — sessionsPerEra, maxExposurePageSize, and bondingDuration are now fetched from /pallets/staking/consts (single HTTP call,
  SCALE-decoded with @polkadot/util), cached 1h via LRU. expectedBlockTime and epochDuration remain hardcoded as they are immutable BABE genesis constants

Builds:
- [iOS](https://github.com/LedgerHQ/ledger-live-build/actions/runs/24350432328)
- [Android](https://github.com/LedgerHQ/ledger-live-build/actions/runs/24350422142)

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-29168, https://ledgerhq.atlassian.net/browse/LIVE-29247
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


https://github.com/user-attachments/assets/4d738d80-d4a7-4617-9db0-e47a4a9aa00f

On RC build, we have the issue; on the other build, we have the fix.
We can easily see that the app is frozen by hitting the purple button.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
