### PR TITLE
[LWDM] fix(ledger-live-common): use relative path for @tests/* in tsconfig paths

### DIFF
--- a/libs/ledger-live-common/tsconfig.json
+++ b/libs/ledger-live-common/tsconfig.json
@@ -16,7 +16,7 @@
       "*": ["./*"],
       "react": ["../../node_modules/@types/react"],
       "@types/react": ["../../node_modules/@types/react"],
-      "@tests/*": ["src/__tests__/*"]
+      "@tests/*": ["./src/__tests__/*"]
     }
   },
   "files": [


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- This is a config fix; the existing test suite already validates path resolution -->
- [x] **Impact of the changes:**
  - Fixes TypeScript path resolution for `@tests/*` alias in `libs/ledger-live-common`
  - No runtime impact — tsconfig paths only affect the TypeScript compiler and IDE tooling

### 📝 Description

The `@tests/*` path mapping in `libs/ledger-live-common/tsconfig.json` was using a bare relative path `src/__tests__/*` instead of the explicit relative form `./src/__tests__/*`.

While both may work in some contexts, using `./` is the canonical TypeScript way to express relative paths in `compilerOptions.paths`. Without the leading `./`, some tools (e.g. certain ts-jest / tsconfig resolver combinations) may fail to resolve the alias correctly.

This was surfaced as part of the work done in #16278.

### ❓ Context

- **JIRA or GitHub link**: See #16278 for broader context.
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)