### PR TITLE
[LWDM] fix(coin-evm): deduplicate internal root traces in listOperations

### DIFF
--- a/.changeset/fix-evm-internal-root-trace-dedup.md
+++ b/.changeset/fix-evm-internal-root-trace-dedup.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Fix double-counted native OUTs caused by Blockscout root traces in listOperations

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
@@ -1801,6 +1801,147 @@ describe("listOperations", () => {
       });
     });
 
+    it("Case: root trace internal tx is deduplicated against parent coin op (Blockscout bug)", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      const sharedTxHash = "0xRootTraceBug";
+      // Blockscout returns the top-level call as an internal tx with from=EOA.
+      // Regular tx: user → router, value=6 (in txlist)
+      // Internal tx: user → pool, value=6 (in txlistinternal — root trace, same from, same value)
+      // Without dedup: native balance would be double-decremented.
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["router"],
+              value: 6,
+              fee: 1,
+            },
+          ],
+          lastInternalOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["pool"],
+              value: 6,
+              fee: 0,
+            },
+          ],
+        },
+        sharedTxHash,
+      );
+
+      const result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Only the coin op should be emitted; the internal root trace is filtered out.
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["router"],
+        value: 6n,
+        asset: { type: "native" },
+        tx: { fees: 1n, feesPayer: "address1" },
+      });
+      // The surviving op is a coin op, not an internal op.
+      expect(result.items[0].details.internal).toBeUndefined();
+    });
+
+    it("Case: root trace dedup is sender-based, filters even when internal value differs", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      const sharedTxHash = "0xRootTraceDiffValue";
+      // Variant where the internal root trace has a different value than the coin op.
+      // The filter is purely sender-based (not value-based), so it still deduplicates.
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["router"],
+              value: 6,
+              fee: 1,
+            },
+          ],
+          lastInternalOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["pool"],
+              value: 5,
+              fee: 0,
+            },
+          ],
+        },
+        sharedTxHash,
+      );
+
+      const result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["router"],
+        value: 6n,
+        asset: { type: "native" },
+      });
+      expect(result.items[0].details.internal).toBeUndefined();
+    });
+
+    it("Case: legitimate internal tx is NOT filtered when parent sender differs (smart contract wallet)", async () => {
+      setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+      const sharedTxHash = "0xSCWCase";
+      // A relayer sends a tx to the wallet (coin op), then the wallet makes a sub-call (internal tx).
+      // The internal tx sender (wallet) matches the queried address, but the parent sender (relayer) differs.
+      mockGetOperations(
+        {
+          lastCoinOperations: [
+            {
+              type: "FEES",
+              senders: ["relayer"],
+              recipients: ["address1"],
+              value: 0,
+              fee: 1,
+            },
+          ],
+          lastInternalOperations: [
+            {
+              type: "OUT",
+              senders: ["address1"],
+              recipients: ["target"],
+              value: 3,
+              fee: 0,
+            },
+          ],
+        },
+        sharedTxHash,
+      );
+
+      const result = await listOperations({} as CryptoCurrency, "address1", {
+        minHeight: 0,
+        order: "asc",
+      });
+
+      // Both ops should be present — the internal OUT is legitimate (smart contract wallet sub-call).
+      const internalOp = result.items.find(op => op.details.internal === true);
+      expect(internalOp).toBeDefined();
+      expect(internalOp).toMatchObject({
+        type: "OUT",
+        senders: ["address1"],
+        recipients: ["target"],
+        value: 3n,
+        asset: { type: "native" },
+      });
+    });
+
     it("Case 12: Smart contract token minting", async () => {
       setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
       const sharedTxHash = "0xcase12";

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
@@ -1932,7 +1932,6 @@ describe("listOperations", () => {
 
       // Both ops should be present — the internal OUT is legitimate (smart contract wallet sub-call).
       const internalOp = result.items.find(op => op.details.internal === true);
-      expect(internalOp).toBeDefined();
       expect(internalOp).toMatchObject({
         type: "OUT",
         senders: ["address1"],

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
@@ -1848,7 +1848,7 @@ describe("listOperations", () => {
         tx: { fees: 1n, feesPayer: "address1" },
       });
       // The surviving op is a coin op, not an internal op.
-      expect(result.items[0].details.internal).toBeUndefined();
+      expect(result.items[0]!.details?.internal).toBeUndefined();
     });
 
     it("Case: root trace dedup is sender-based, filters even when internal value differs", async () => {
@@ -1893,7 +1893,7 @@ describe("listOperations", () => {
         value: 6n,
         asset: { type: "native" },
       });
-      expect(result.items[0].details.internal).toBeUndefined();
+      expect(result.items[0]!.details?.internal).toBeUndefined();
     });
 
     it("Case: legitimate internal tx is NOT filtered when parent sender differs (smart contract wallet)", async () => {
@@ -1931,7 +1931,7 @@ describe("listOperations", () => {
       });
 
       // Both ops should be present — the internal OUT is legitimate (smart contract wallet sub-call).
-      const internalOp = result.items.find(op => op.details.internal === true);
+      const internalOp = result.items.find(op => op.details?.internal === true);
       expect(internalOp).toMatchObject({
         type: "OUT",
         senders: ["address1"],

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.ts
@@ -231,20 +231,31 @@ export async function listOperations(
       op,
     ),
   );
-  const internalOperations = lastInternalOperations.map<Operation<MemoNotSupported>>(op => {
-    // Explorers don't provide block hash and fees for internal operations.
-    // When a matching parent transaction exists, we take these values from it.
-    // Otherwise, we use the internal operation's defaults.
+  // Some explorers (e.g. Blockscout on Somnia) report the top-level call trace as an
+  // internal transaction, duplicating the native transfer already present in txlist.
+  // When an internal tx and its parent coin tx both have the queried address as sender,
+  // the native value is already accounted for in the coin operation — drop the internal one.
+  // Analogous to the traceAddress.length === 0 check in getBlock's traceBlockItemsToOperationsByHash,
+  // but using sender matching since txlistinternal does not expose traceAddress.
+  const isRootTrace = (op: LiveOperation): boolean => {
     const parent = parents[op.hash];
-    return toOperation(
-      currency.id,
-      address,
-      { type: "native", internal: true, parent },
-      // Explorers don't provide block hash and fees for internal operations.
-      // When a parent exists, we take these values from the parent; otherwise keep the internal op values.
-      parent ? { ...op, fee: parent.fee, blockHash: parent.blockHash } : op,
-    );
-  });
+    if (!parent) return false;
+    const internalSenderMatch = op.senders.some(s => s.toLowerCase() === addressLower);
+    const parentSenderMatch = parent.senders.some(s => s.toLowerCase() === addressLower);
+    return internalSenderMatch && parentSenderMatch;
+  };
+
+  const internalOperations = lastInternalOperations
+    .filter(op => !isRootTrace(op))
+    .map<Operation<MemoNotSupported>>(op => {
+      const parent = parents[op.hash];
+      return toOperation(
+        currency.id,
+        address,
+        { type: "native", internal: true, parent },
+        parent ? { ...op, fee: parent.fee, blockHash: parent.blockHash } : op,
+      );
+    });
 
   const hasValidType = (operation: Operation): boolean =>
     [


### PR DESCRIPTION
## Summary

Some Blockscout instances (e.g. Somnia) include the top-level call trace in `txlistinternal` with `from=EOA`, duplicating the native transfer already reported in `txlist`. This causes `listOperations` to double-count native OUTs, eventually driving computed balances negative.

**Root cause**: Blockscout's address-scoped `txlistinternal&address=<user>` returns entries where `from=user` for the top-level call, but with a different `to` (the downstream contract the router forwards to). These look like separate transfers but represent the same value already counted in `txlist`.

**Evidence** (Somnia, address `0xD3A706...`):
- 44 internal OUTs, all sharing the same `(hash, from, value)` as a regular tx
- Total internal OUTs: 138.33 STT — exactly matching the balance gap
- `getBlock` already handles this via `traceAddress.length === 0` filtering in `traceBlockItemsToOperationsByHash`

**Fix**: Before mapping internal operations, filter out root traces — internal txs where both the internal sender and the parent coin tx sender match the queried address. Smart contract wallet sub-calls (where the parent sender differs) are preserved.

**Repro** (two curl commands showing the same tx hash with different `to`):
```bash
# Regular tx: user → router
curl -sL 'https://explorer.somnia.network/api?module=account&action=txlist&address=0xD3A706e23Ce03Fe4fafb9A60C7abBAf9bc06284E&startblock=88657822&endblock=88657822'

# Internal tx (root trace): user → pool (same hash, same from, same value, different to)
curl -sL 'https://explorer.somnia.network/api?module=account&action=txlistinternal&address=0xD3A706e23Ce03Fe4fafb9A60C7abBAf9bc06284E&startblock=88657822&endblock=88657822'
```

Related: BACK-11037

## Test plan

- [x] New test: root trace internal tx is deduplicated against parent coin op
- [x] New test: legitimate internal tx is NOT filtered when parent sender differs (smart contract wallet)
- [x] All 2441 existing coin-evm tests pass (48 suites)