### PR TITLE
[LWDM] feat(portfolio): add perps portfolio entry position feature flag

### DIFF
--- a/.changeset/fair-pandas-speak.md
+++ b/.changeset/fair-pandas-speak.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/live-common": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Add `portfolio_entry_point_position` to perps live app feature flags to control portfolio entry placement (top or bottom).

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
@@ -29,6 +29,7 @@ export const PortfolioView = memo(function PortfolioView({
   shouldDisplayAssetSection,
   shouldDisplayOperationsList,
   shouldDisplayBrazePlacement,
+  perpsPortfolioEntryPointPosition,
   isWallet40Enabled,
   accounts,
   filterOperations,
@@ -66,8 +67,9 @@ export const PortfolioView = memo(function PortfolioView({
           <PortfolioBannerContent />
           {shouldDisplayMarketBanner && <MarketBanner />}
 
+          {perpsPortfolioEntryPointPosition === "top" ? <PerpsEntryPoint /> : null}
           {shouldDisplayAssetSection ? <Assets /> : <AssetDistribution />}
-          <PerpsEntryPoint />
+          {perpsPortfolioEntryPointPosition === "bottom" ? <PerpsEntryPoint /> : null}
           {shouldDisplayAddAccountCta && <AddAccount />}
           {shouldDisplayAssetSection && <CryptoAddressesBanner />}
           {shouldDisplayBrazePlacement && <BottomCarouselContentCards />}

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -137,6 +137,7 @@ describe("PortfolioView", () => {
     shouldDisplayAssetSection: true,
     shouldDisplayOperationsList: true,
     shouldDisplayBrazePlacement: false,
+    perpsPortfolioEntryPointPosition: "bottom" as const,
     isClearCacheBannerVisible: false,
     filterOperations: () => true,
     accounts: [],
@@ -507,6 +508,38 @@ describe("PortfolioView", () => {
         page: PORTFOLIO_TRACKING_PAGE_NAME,
       });
       expect(mockNavigate).toHaveBeenCalledWith("/perps");
+    });
+
+    it("should render perps entry point above assets when perpsPortfolioEntryPointPosition is top", async () => {
+      render(
+        <PortfolioView
+          {...defaultProps}
+          perpsPortfolioEntryPointPosition="top"
+          shouldDisplayAssetSection={true}
+        />,
+        {
+          initialState: {
+            settings: {
+              ...AFTER_ONBOARDING_STATE,
+            },
+            ...withFlagOverrides({
+              ptxPerpsLiveApp: {
+                enabled: true,
+              },
+            }),
+          },
+        },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Bitcoin")).toBeVisible();
+      });
+
+      const perps = screen.getByTestId("portfolio-perps-entry-point");
+      const bitcoinRow = screen.getByText("Bitcoin");
+      expect(perps.compareDocumentPosition(bitcoinRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING,
+      );
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/usePortfolioViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/usePortfolioViewModel.ts
@@ -22,6 +22,7 @@ export interface PortfolioViewModelResult {
   readonly shouldDisplayAssetSection: boolean;
   readonly shouldDisplayOperationsList: boolean;
   readonly shouldDisplayBrazePlacement: boolean;
+  readonly perpsPortfolioEntryPointPosition: "top" | "bottom";
   readonly isWallet40Enabled: boolean;
   readonly filterOperations: (operation: Operation, account: AccountLike) => boolean;
   readonly accounts: AccountLike[];
@@ -31,6 +32,7 @@ export interface PortfolioViewModelResult {
 
 export const usePortfolioViewModel = (): PortfolioViewModelResult => {
   const accounts = useSelector(accountsSelector);
+  const ptxPerpsLiveApp = useFeature("ptxPerpsLiveApp");
   const portfolioExchangeBanner = useFeature("portfolioExchangeBanner");
   const {
     shouldDisplayMarketBanner,
@@ -74,6 +76,9 @@ export const usePortfolioViewModel = (): PortfolioViewModelResult => {
   const hasExchangeBannerCTA = !!portfolioExchangeBanner?.enabled;
   const isClearCacheBannerVisible = useSelector(showClearCacheBannerSelector);
 
+  const perpsPortfolioEntryPointPosition =
+    ptxPerpsLiveApp?.params?.portfolio_entry_point_position ?? "bottom";
+
   return {
     totalAccounts,
     totalOperations,
@@ -85,6 +90,7 @@ export const usePortfolioViewModel = (): PortfolioViewModelResult => {
     shouldDisplayAssetSection,
     shouldDisplayOperationsList,
     shouldDisplayBrazePlacement,
+    perpsPortfolioEntryPointPosition,
     isWallet40Enabled,
     filterOperations,
     accounts,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioPerpsEntryPoint/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioPerpsEntryPoint/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { NavigatorName, ScreenName } from "~/const";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import FeatureToggle from "@ledgerhq/live-common/featureFlags/FeatureToggle";
+import { usePerpsLiveConfig } from "LLM/features/Perps/hooks/usePerpsLiveConfig";
 import {
   ListItem,
   ListItemLeading,
@@ -23,6 +24,8 @@ import { track } from "~/analytics";
 export const PortfolioPerpsEntryPoint = () => {
   const { t } = useTranslation();
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const perpsConfig = usePerpsLiveConfig();
+  const isTopPosition = perpsConfig?.params?.portfolio_entry_point_position === "top";
 
   const handlePress = useCallback(() => {
     track("button_clicked", {
@@ -35,7 +38,13 @@ export const PortfolioPerpsEntryPoint = () => {
 
   return (
     <FeatureToggle featureId="ptxPerpsLiveAppMobile">
-      <Box lx={{ marginTop: "s16", paddingHorizontal: "s16" }}>
+      <Box
+        lx={{
+          marginTop: "s16",
+          paddingHorizontal: "s16",
+          ...(isTopPosition && { marginBottom: "s16" }),
+        }}
+      >
         <Subheader>
           <SubheaderRow onPress={handlePress} data-testid="portfolio-perps-subheader-row">
             <SubheaderTitle>{t("portfolio.perpsEntry.title")}</SubheaderTitle>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -68,6 +68,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     shouldDisplayWallet40MainNav,
     shouldDisplayOperationsList,
     shouldAddBottomPaddingForLegacyAssets,
+    perpsPortfolioEntryPointPosition,
   } = usePortfolioViewModel(navigation);
 
   const progressViewOffset = getProgressViewOffset(Platform.OS, shouldDisplayWallet40MainNav);
@@ -131,6 +132,10 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
       );
     }
 
+    if (perpsPortfolioEntryPointPosition === "top") {
+      sections.push(<PortfolioPerpsEntryPoint key="perpsEntryPoint" />);
+    }
+
     if (shouldDisplayAssetSection) {
       sections.push(<WalletAssetsView key="categorizedAssets" />);
     } else {
@@ -146,7 +151,9 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
       );
     }
 
-    sections.push(<PortfolioPerpsEntryPoint key="perpsEntryPoint" />);
+    if (perpsPortfolioEntryPointPosition === "bottom") {
+      sections.push(<PortfolioPerpsEntryPoint key="perpsEntryPoint" />);
+    }
 
     if (isAWalletCardDisplayed) {
       sections.push(<PortfolioCarouselSection key="carousel" backgroundColor={backgroundColor} />);
@@ -184,6 +191,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
     goToAnalyticsAllocations,
     shouldDisplayOperationsList,
     shouldAddBottomPaddingForLegacyAssets,
+    perpsPortfolioEntryPointPosition,
   ]);
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/usePortfolioViewModel.ts
@@ -37,6 +37,7 @@ interface UsePortfolioViewModelResult {
   shouldDisplayAssetSection: boolean;
   shouldDisplayMarketBanner: boolean;
   shouldDisplayOperationsList: boolean;
+  perpsPortfolioEntryPointPosition: "top" | "bottom";
   showAssets: boolean;
   isLNSUpsellBannerShown: boolean;
   isAddModalOpened: boolean;
@@ -68,6 +69,7 @@ const usePortfolioViewModel = (navigation: {
     shouldDisplayOperationsList,
   } = useWalletFeaturesConfig("mobile");
   const isAccountListUIEnabled = accountListFF?.enabled ?? false;
+  const ptxPerpsLiveAppMobile = useFeature("ptxPerpsLiveAppMobile");
   const llmDatadog = useFeature("llmDatadog");
   const allAccounts = useSelector(flattenAccountsSelector, shallowEqual);
   const isFocused = useIsFocused();
@@ -150,6 +152,9 @@ const usePortfolioViewModel = (navigation: {
   const shouldAddBottomPaddingForLegacyAssets =
     !isAWalletCardDisplayed && shouldDisplayGraphRework && shouldDisplayOperationsList;
 
+  const perpsPortfolioEntryPointPosition =
+    ptxPerpsLiveAppMobile?.params?.portfolio_entry_point_position ?? "bottom";
+
   return {
     hideEmptyTokenAccount,
     isAWalletCardDisplayed,
@@ -159,6 +164,7 @@ const usePortfolioViewModel = (navigation: {
     shouldDisplayAssetSection,
     shouldDisplayMarketBanner,
     shouldDisplayOperationsList,
+    perpsPortfolioEntryPointPosition,
     showAssets,
     isLNSUpsellBannerShown,
     isAddModalOpened,

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -490,6 +490,7 @@ export const DEFAULT_FEATURES: Features = {
     enabled: false,
     params: {
       manifest_id: "perps-live-app",
+      portfolio_entry_point_position: "bottom",
     },
   },
 
@@ -497,6 +498,7 @@ export const DEFAULT_FEATURES: Features = {
     enabled: false,
     params: {
       manifest_id: "perps-live-app",
+      portfolio_entry_point_position: "bottom",
     },
   },
 

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -651,6 +651,7 @@ export type Feature_PtxSwapLiveApp = Feature<{
 
 export type Feature_PtxPerpsLiveApp = Feature<{
   manifest_id: string;
+  portfolio_entry_point_position: "top" | "bottom";
 }>;
 
 export type Feature_PtxEarnLiveApp = Feature<{

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -651,7 +651,7 @@ export type Feature_PtxSwapLiveApp = Feature<{
 
 export type Feature_PtxPerpsLiveApp = Feature<{
   manifest_id: string;
-  portfolio_entry_point_position: "top" | "bottom";
+  portfolio_entry_point_position?: "top" | "bottom";
 }>;
 
 export type Feature_PtxEarnLiveApp = Feature<{

--- a/shared/feature-flags/src/flags/team-ptx/ptxPerpsLiveApp.ts
+++ b/shared/feature-flags/src/flags/team-ptx/ptxPerpsLiveApp.ts
@@ -4,9 +4,13 @@ import { flagWith } from "../../define";
 export const ptxPerpsLiveApp = flagWith(
   {
     manifest_id: z.string(),
+    portfolio_entry_point_position: z.enum(["top", "bottom"]),
   },
   {
     enabled: false,
-    params: { manifest_id: "perps-live-app" },
+    params: {
+      manifest_id: "perps-live-app",
+      portfolio_entry_point_position: "bottom",
+    },
   },
 );

--- a/shared/feature-flags/src/flags/team-ptx/ptxPerpsLiveApp.ts
+++ b/shared/feature-flags/src/flags/team-ptx/ptxPerpsLiveApp.ts
@@ -4,7 +4,7 @@ import { flagWith } from "../../define";
 export const ptxPerpsLiveApp = flagWith(
   {
     manifest_id: z.string(),
-    portfolio_entry_point_position: z.enum(["top", "bottom"]),
+    portfolio_entry_point_position: z.enum(["top", "bottom"]).default("bottom"),
   },
   {
     enabled: false,

--- a/shared/feature-flags/src/flags/team-ptx/ptxPerpsLiveAppMobile.ts
+++ b/shared/feature-flags/src/flags/team-ptx/ptxPerpsLiveAppMobile.ts
@@ -4,9 +4,13 @@ import { flagWith } from "../../define";
 export const ptxPerpsLiveAppMobile = flagWith(
   {
     manifest_id: z.string(),
+    portfolio_entry_point_position: z.enum(["top", "bottom"]),
   },
   {
     enabled: false,
-    params: { manifest_id: "perps-live-app" },
+    params: {
+      manifest_id: "perps-live-app",
+      portfolio_entry_point_position: "bottom",
+    },
   },
 );

--- a/shared/feature-flags/src/flags/team-ptx/ptxPerpsLiveAppMobile.ts
+++ b/shared/feature-flags/src/flags/team-ptx/ptxPerpsLiveAppMobile.ts
@@ -4,7 +4,7 @@ import { flagWith } from "../../define";
 export const ptxPerpsLiveAppMobile = flagWith(
   {
     manifest_id: z.string(),
-    portfolio_entry_point_position: z.enum(["top", "bottom"]),
+    portfolio_entry_point_position: z.enum(["top", "bottom"]).default("bottom"),
   },
   {
     enabled: false,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Portfolio screen (Wallet 4.0) with perps feature flag enabled on **mobile** and **desktop**
      - Remote feature flags `ptxPerpsLiveApp` / `ptxPerpsLiveAppMobile`: verify `params.portfolio_entry_point_position` as `top` vs `bottom` (default remains `bottom`, same layout as today)
      - Perps live app manifest and navigation to Perps are unchanged

### 📝 Description

**Problem:** The perps portfolio entry point was moved below the assets section. It is not yet decided whether that placement is final, so we need a way to restore the previous order (or A/B it) via remote configuration without reverting the updated entry UI (Lumen list, spacing, etc.).

**Solution:** Extend `ptxPerpsLiveApp` and `ptxPerpsLiveAppMobile` with a new `params` field:

- `portfolio_entry_point_position`: `"top"` | `"bottom"` (default `"bottom"`).

When `top`, the perps block is rendered **before** the assets section; when `bottom`, **after** (current behavior). Missing or partial remote `params` still resolve to `"bottom"` via `?? "bottom"` so existing payloads that only send `manifest_id` keep the current layout.

Changes touch `@ledgerhq/types-live`, `defaultFeatures`, shared Zod flag definitions, mobile `usePortfolioViewModel` + portfolio `sections` ordering, desktop `usePortfolioViewModel` + `PortfolioView`, and a desktop integration test asserting DOM order for the `top` case.


https://github.com/user-attachments/assets/5043f92a-3b69-4dc7-9521-953ed7da408a



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29007](https://ledgerhq.atlassian.net/browse/LIVE-29007)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-29007]: https://ledgerhq.atlassian.net/browse/LIVE-29007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ