### PR TITLE
[LWM] feat(mobile): wire Recover button in My Wallet

### DIFF
--- a/.changeset/bright-lions-press.md
+++ b/.changeset/bright-lions-press.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire Recover button in My Wallet with dynamic label and analytics tracking

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8850,6 +8850,7 @@
   "myWallet": {
     "quickActions": {
       "recover": "[L] Recover",
+      "backup": "Backup",
       "help": "Help",
       "referral": "Referral"
     }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/MyWalletScreen.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/MyWalletScreen.integration.test.tsx
@@ -55,7 +55,7 @@ describe("MyWalletScreen", () => {
     renderScreen();
 
     expect(screen.getByTestId("my-wallet-quick-actions-row")).toBeVisible();
-    expect(screen.getByLabelText("[L] Recover")).toBeVisible();
+    expect(screen.getByLabelText("Backup")).toBeVisible();
     expect(screen.getByLabelText("Help")).toBeVisible();
     expect(screen.getByLabelText("Referral")).toBeVisible();
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
@@ -1,5 +1,8 @@
 import { Linking } from "react-native";
 import { act, renderHook } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import type { State } from "~/reducers/types";
 import { ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { urls } from "~/utils/urls";
@@ -11,6 +14,18 @@ jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
+
+const mockDevice: Device = {
+  modelId: DeviceModelId.nanoX,
+  deviceId: "test-device-id",
+  deviceName: "Nano X",
+  wired: false,
+};
+
+const withDevice = (state: State): State => ({
+  ...state,
+  settings: { ...state.settings, lastConnectedDevice: mockDevice },
+});
 
 describe("useQuickActionsRowViewModel", () => {
   beforeEach(() => {
@@ -35,6 +50,40 @@ describe("useQuickActionsRowViewModel", () => {
         button: "Referral",
         page: ScreenName.MyWallet,
       });
+    });
+  });
+
+  describe("recover action", () => {
+    it("should navigate to Recover screen and track event on press", () => {
+      const { result } = renderHook(() => useQuickActionsRowViewModel());
+      const recoverAction = result.current.actions.find(a => a.id === "recover")!;
+
+      act(() => recoverAction.onPress());
+
+      expect(mockNavigate).toHaveBeenCalledWith(ScreenName.Recover, {
+        platform: "protect-simu",
+        device: undefined,
+      });
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Recover",
+        page: ScreenName.MyWallet,
+      });
+    });
+
+    it('should display "Backup" label when no device is connected', () => {
+      const { result } = renderHook(() => useQuickActionsRowViewModel());
+      const recoverAction = result.current.actions.find(a => a.id === "recover")!;
+
+      expect(recoverAction.label).toBe("Backup");
+    });
+
+    it('should display "[L] Recover" label when a device is connected', () => {
+      const { result } = renderHook(() => useQuickActionsRowViewModel(), {
+        overrideInitialState: withDevice,
+      });
+      const recoverAction = result.current.actions.find(a => a.id === "recover")!;
+
+      expect(recoverAction.label).toBe("[L] Recover");
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
@@ -2,10 +2,15 @@ import { useCallback, useMemo } from "react";
 import { Linking } from "react-native";
 import { TileButtonProps } from "@ledgerhq/lumen-ui-rnative";
 import { ShieldCheckNotification, LifeRing, Gift } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
+import { useSelector } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
 import { ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { urls } from "~/utils/urls";
+import { lastConnectedDeviceSelector } from "~/reducers/settings";
 
 export interface QuickActionRowItem {
   readonly id: string;
@@ -21,10 +26,25 @@ interface QuickActionsRowViewModel {
 
 export const useQuickActionsRowViewModel = (): QuickActionsRowViewModel => {
   const { t } = useTranslation();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<{ [key: string]: object | undefined }>>();
+  const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+  const recoverFeature = useFeature("protectServicesMobile");
+  const protectId = recoverFeature?.params?.protectId ?? "protect-prod";
+
+  const hasDevice = lastConnectedDevice !== null;
+
+  const recoverLabel = hasDevice
+    ? t("myWallet.quickActions.recover")
+    : t("myWallet.quickActions.backup");
 
   const handleRecoverPress = useCallback(() => {
-    // TODO: implement recover navigation
-  }, []);
+    track("button_clicked", { button: "Recover", page: ScreenName.MyWallet });
+    navigation.navigate(ScreenName.Recover, {
+      platform: protectId,
+      device: lastConnectedDevice ?? undefined,
+    });
+  }, [navigation, protectId, lastConnectedDevice]);
 
   const handleHelpPress = useCallback(() => {
     // TODO: implement help navigation
@@ -39,7 +59,7 @@ export const useQuickActionsRowViewModel = (): QuickActionsRowViewModel => {
     () => [
       {
         id: "recover",
-        label: t("myWallet.quickActions.recover"),
+        label: recoverLabel,
         icon: ShieldCheckNotification,
         onPress: handleRecoverPress,
         testID: "my-wallet-quick-action-recover",
@@ -59,7 +79,7 @@ export const useQuickActionsRowViewModel = (): QuickActionsRowViewModel => {
         testID: "my-wallet-quick-action-referral",
       },
     ],
-    [t, handleRecoverPress, handleHelpPress, handleReferralPress],
+    [t, recoverLabel, handleRecoverPress, handleHelpPress, handleReferralPress],
   );
 
   return { actions };


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - My Wallet quick actions: Recover button navigation
  - Dynamic label logic based on device connection state
  - Analytics tracking on button press

### 📝 Description

The Recover quick action button in the My Wallet screen had no behavior — tapping it did nothing.

This PR wires the button to navigate to the existing Recover screen and adds a dynamic label: it shows \`[L] Recover\` when a device is paired, and \`Backup\` when no device is connected. A \`button_clicked\` analytics event is tracked on every tap.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26548](https://ledgerhq.atlassian.net/browse/LIVE-26548)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-26548]: https://ledgerhq.atlassian.net/browse/LIVE-26548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ