### PR TITLE
[LWM] feat(mobile): wire Referral button in My Wallet

### DIFF
--- a/.changeset/silver-wolves-jump.md
+++ b/.changeset/silver-wolves-jump.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire Referral button in My Wallet to open referral URL

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
@@ -1,0 +1,40 @@
+import { Linking } from "react-native";
+import { act, renderHook } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import { track } from "~/analytics";
+import { urls } from "~/utils/urls";
+import { useQuickActionsRowViewModel } from "../useQuickActionsRowViewModel";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+describe("useQuickActionsRowViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return three actions", () => {
+    const { result } = renderHook(() => useQuickActionsRowViewModel());
+    expect(result.current.actions).toHaveLength(3);
+    expect(result.current.actions.map(a => a.id)).toEqual(["recover", "help", "referral"]);
+  });
+
+  describe("referral action", () => {
+    it("should open the referral URL and track event on press", () => {
+      const { result } = renderHook(() => useQuickActionsRowViewModel());
+      const referralAction = result.current.actions.find(a => a.id === "referral")!;
+
+      act(() => referralAction.onPress());
+
+      expect(Linking.openURL).toHaveBeenCalledWith(urls.referralProgram);
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Referral",
+        page: ScreenName.MyWallet,
+      });
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
@@ -1,7 +1,11 @@
 import { useCallback, useMemo } from "react";
+import { Linking } from "react-native";
 import { TileButtonProps } from "@ledgerhq/lumen-ui-rnative";
 import { ShieldCheckNotification, LifeRing, Gift } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useTranslation } from "~/context/Locale";
+import { ScreenName } from "~/const";
+import { track } from "~/analytics";
+import { urls } from "~/utils/urls";
 
 export interface QuickActionRowItem {
   readonly id: string;
@@ -27,7 +31,8 @@ export const useQuickActionsRowViewModel = (): QuickActionsRowViewModel => {
   }, []);
 
   const handleReferralPress = useCallback(() => {
-    // TODO: implement referral navigation
+    track("button_clicked", { button: "Referral", page: ScreenName.MyWallet });
+    Linking.openURL(urls.referralProgram);
   }, []);
 
   const actions: readonly QuickActionRowItem[] = useMemo(


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - My Wallet quick actions: Referral button now opens the referral URL
  - Analytics tracking on button press

### 📝 Description

The Referral quick action button in the My Wallet screen had no behavior.

This PR wires the button to open the referral deep-link (\`ledgerlive://discover/refer-a-friend\`) via \`Linking.openURL\`, and adds a \`button_clicked\` analytics event on tap.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26549](https://ledgerhq.atlassian.net/browse/LIVE-26549)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-26549]: https://ledgerhq.atlassian.net/browse/LIVE-26549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ