### PR TITLE
[LWM] feat(mobile): add Help page structure to My Wallet

### DIFF
--- a/.changeset/fuzzy-bears-run.md
+++ b/.changeset/fuzzy-bears-run.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Help page structure to My Wallet with Support and More sections

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -109,6 +109,7 @@ export enum ScreenName {
   MyLedgerChooseDevice = "MyLedgerChooseDevice",
   MyLedgerDevice = "MyLedgerDevice",
   MyWallet = "MyWallet",
+  MyWalletHelp = "MyWalletHelp",
   NotificationsSettings = "NotificationsSettings",
   OperationDetails = "OperationDetails",
   PasswordAdd = "PasswordAdd",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8859,6 +8859,13 @@
       "backup": "Backup",
       "help": "Help",
       "referral": "Referral"
+    },
+    "help": {
+      "title": "Help",
+      "sections": {
+        "supportAndLearning": "Support and learning",
+        "more": "More"
+      }
     }
   }
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/Navigator.tsx
@@ -3,11 +3,13 @@ import { Platform } from "react-native";
 import type { NativeStackHeaderRightProps } from "@react-navigation/native-stack";
 import { useTheme as useLumenTheme } from "@ledgerhq/lumen-ui-rnative/styles";
 import { ScreenName } from "~/const";
+import { useTranslation } from "~/context/Locale";
 import {
   createLumenNativeStackNavigator,
   getStackNavigationConfigV4,
 } from "LLM/components/Navigation";
 import { MyWalletScreen } from "./index";
+import { MyWalletHelpScreen } from "./screens/Help";
 import { MyWalletNavigatorStackParamList } from "./types";
 import { MyWalletHeaderTrailing } from "./views/Header";
 
@@ -18,6 +20,7 @@ function renderMyWalletHeaderTrailing(_props: NativeStackHeaderRightProps) {
 const Stack = createLumenNativeStackNavigator<MyWalletNavigatorStackParamList>();
 
 export default function MyWalletNavigator() {
+  const { t } = useTranslation();
   const { theme } = useLumenTheme();
 
   const stackNavigationConfig = useMemo(() => getStackNavigationConfigV4(theme), [theme]);
@@ -39,6 +42,11 @@ export default function MyWalletNavigator() {
             renderTrailing: renderMyWalletHeaderTrailing,
           },
         }}
+      />
+      <Stack.Screen
+        name={ScreenName.MyWalletHelp}
+        component={MyWalletHelpScreen}
+        options={{ headerShown: true, title: t("myWallet.help.title"), ...stackNavigationConfig }}
       />
     </Stack.Navigator>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/__tests__/MyWalletHelpScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/__tests__/MyWalletHelpScreen.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { MyWalletHelpScreen } from "../index";
+
+jest.mock("~/analytics", () => ({
+  ...jest.requireActual("~/analytics"),
+  TrackScreen: () => null,
+}));
+
+describe("MyWalletHelpScreen", () => {
+  it("should render both section headers", () => {
+    render(<MyWalletHelpScreen />);
+
+    expect(screen.getByText("Support and learning")).toBeVisible();
+    expect(screen.getByText("More")).toBeVisible();
+  });
+
+  it("should render the scrollable container", () => {
+    render(<MyWalletHelpScreen />);
+
+    expect(screen.getByTestId("my-wallet-help-screen")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/index.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { ScrollView } from "react-native";
+import { Box, Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+import { TrackScreen } from "~/analytics";
+
+export function MyWalletHelpScreen() {
+  const { t } = useTranslation();
+
+  return (
+    <ScrollView testID="my-wallet-help-screen">
+      <TrackScreen category="MyWallet" name="Help" />
+      <Box lx={{ paddingHorizontal: "s16", paddingTop: "s24", gap: "s24" }}>
+        <Subheader>
+          <SubheaderRow testID="my-wallet-help-section-support">
+            <SubheaderTitle>{t("myWallet.help.sections.supportAndLearning")}</SubheaderTitle>
+          </SubheaderRow>
+        </Subheader>
+        <Subheader>
+          <SubheaderRow testID="my-wallet-help-section-more">
+            <SubheaderTitle>{t("myWallet.help.sections.more")}</SubheaderTitle>
+          </SubheaderRow>
+        </Subheader>
+      </Box>
+    </ScrollView>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/types.ts
@@ -2,4 +2,5 @@ import { ScreenName } from "~/const";
 
 export type MyWalletNavigatorStackParamList = {
   [ScreenName.MyWallet]: undefined;
+  [ScreenName.MyWalletHelp]: undefined;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
@@ -3,7 +3,7 @@ import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import type { State } from "~/reducers/types";
-import { ScreenName } from "~/const";
+import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { urls } from "~/utils/urls";
 import { useQuickActionsRowViewModel } from "../useQuickActionsRowViewModel";
@@ -36,6 +36,23 @@ describe("useQuickActionsRowViewModel", () => {
     const { result } = renderHook(() => useQuickActionsRowViewModel());
     expect(result.current.actions).toHaveLength(3);
     expect(result.current.actions.map(a => a.id)).toEqual(["recover", "help", "referral"]);
+  });
+
+  describe("help action", () => {
+    it("should navigate to MyWalletHelp screen and track event on press", () => {
+      const { result } = renderHook(() => useQuickActionsRowViewModel());
+      const helpAction = result.current.actions.find(a => a.id === "help")!;
+
+      act(() => helpAction.onPress());
+
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.MyWallet, {
+        screen: ScreenName.MyWalletHelp,
+      });
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Help",
+        page: ScreenName.MyWallet,
+      });
+    });
   });
 
   describe("referral action", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
@@ -7,10 +7,10 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { useSelector } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
-import { ScreenName } from "~/const";
-import { track } from "~/analytics";
+import { NavigatorName, ScreenName } from "~/const";
 import { urls } from "~/utils/urls";
 import { lastConnectedDeviceSelector } from "~/reducers/settings";
+import { track } from "~/analytics";
 
 export interface QuickActionRowItem {
   readonly id: string;
@@ -47,8 +47,9 @@ export const useQuickActionsRowViewModel = (): QuickActionsRowViewModel => {
   }, [navigation, protectId, lastConnectedDevice]);
 
   const handleHelpPress = useCallback(() => {
-    // TODO: implement help navigation
-  }, []);
+    track("button_clicked", { button: "Help", page: ScreenName.MyWallet });
+    navigation.navigate(NavigatorName.MyWallet, { screen: ScreenName.MyWalletHelp });
+  }, [navigation]);
 
   const handleReferralPress = useCallback(() => {
     track("button_clicked", { button: "Referral", page: ScreenName.MyWallet });


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - New Help screen accessible from My Wallet quick actions
  - MyWalletNavigator gains a new route (MyWalletHelp)
  - Analytics tracking on Help button press

### 📝 Description

The Help quick action button in the My Wallet screen had no behavior, and no dedicated Help screen existed in the My Wallet flow.

This PR creates the \`MyWalletHelpScreen\` with two section headers ("Support and learning" and "More"), registers it as a new route in \`MyWalletNavigator\`, and wires the Help button to navigate to this screen with analytics tracking.

<img width="350" height="750" alt="Simulator Screenshot - Test Ios - 2026-04-20 at 11 26 33" src="https://github.com/user-attachments/assets/3fce6f89-e184-42b7-8e7b-3ca6d5e6f42d" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26558](https://ledgerhq.atlassian.net/browse/LIVE-26558)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-26558]: https://ledgerhq.atlassian.net/browse/LIVE-26558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ