### PR TITLE
[LWD] fix(LIVE-24155): swap app reload

### DIFF
--- a/.changeset/rotten-eels-allow.md
+++ b/.changeset/rotten-eels-allow.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Prevent initial url from recomputing and therfore causing an unexpected app reload

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
@@ -1,0 +1,124 @@
+import { renderHook } from "tests/testSetup";
+import { useWebviewState } from "./helpers";
+import { getInitialURL } from "@ledgerhq/live-common/wallet-api/helpers";
+import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+
+jest.mock("@ledgerhq/live-common/wallet-api/helpers", () => ({
+  getInitialURL: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/wallet-api/manifestDomainUtils", () => ({
+  isUrlAllowedByManifestDomains: jest.fn(() => true),
+}));
+
+jest.mock("@ledgerhq/live-common/wallet-api/react", () => ({
+  safeGetRefValue: jest.fn(),
+}));
+
+const mockManifest: LiveAppManifest = {
+  id: "test-app",
+  name: "Test App",
+  private: false,
+  url: "https://example.com",
+  homepageUrl: "https://example.com",
+  icon: "",
+  platforms: ["desktop"],
+  providerTestBaseUrl: "",
+  providerTestId: "",
+  apiVersion: "^2.0.0",
+  manifestVersion: "2",
+  branch: "stable",
+  categories: [],
+  currencies: "*",
+  content: {
+    shortDescription: { en: "Test" },
+    description: { en: "Test" },
+  },
+  permissions: [],
+  domains: ["https://example.com"],
+  visibility: "complete",
+};
+
+const mockGetInitialURL = jest.mocked(getInitialURL);
+
+describe("useWebviewState", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("webviewProps.src", () => {
+    it("is set to the URL returned by getInitialURL on mount", () => {
+      mockGetInitialURL.mockReturnValue("https://example.com/?theme=dark");
+
+      const { result } = renderHook(() => useWebviewState({ manifest: mockManifest }, null));
+
+      expect(result.current.webviewProps.src).toBe("https://example.com/?theme=dark");
+    });
+
+    it("remains stable when inputs gets a new object reference after mount", () => {
+      // Regression test: when a parent re-renders (e.g. due to a Redux update like
+      // lastSeenDevice), inputs may get a new object reference
+      mockGetInitialURL
+        .mockReturnValueOnce("https://example.com/?theme=dark&lang=en")
+        .mockReturnValue("https://example.com/?theme=light&lang=fr"); // returned on subsequent calls
+
+      const { result, rerender } = renderHook(
+        (props: { inputs: Record<string, string> }) =>
+          useWebviewState({ manifest: mockManifest, inputs: props.inputs }, null),
+        { initialProps: { inputs: { theme: "dark", lang: "en" } } },
+      );
+
+      expect(result.current.webviewProps.src).toBe("https://example.com/?theme=dark&lang=en");
+
+      // Simulate a parent re-render caused by a Redux update (e.g. lastSeenDevice).
+      // inputs gets a new object reference — same values, different identity.
+      rerender({ inputs: { theme: "dark", lang: "en" } });
+
+      // The webview src must not change — no navigation should occur.
+      expect(result.current.webviewProps.src).toBe("https://example.com/?theme=dark&lang=en");
+    });
+
+    it("remains stable even when inputs values change after mount", () => {
+      // The initial URL is intentionally frozen at mount time. Inputs are query
+      // parameters for the initial load; they are not a live binding to the webview.
+      mockGetInitialURL
+        .mockReturnValueOnce("https://example.com/?theme=dark")
+        .mockReturnValue("https://example.com/?theme=light");
+
+      const { result, rerender } = renderHook(
+        (props: { inputs: Record<string, string> }) =>
+          useWebviewState({ manifest: mockManifest, inputs: props.inputs }, null),
+        { initialProps: { inputs: { theme: "dark" } } },
+      );
+
+      expect(result.current.webviewProps.src).toBe("https://example.com/?theme=dark");
+
+      rerender({ inputs: { theme: "light" } });
+
+      expect(result.current.webviewProps.src).toBe("https://example.com/?theme=dark");
+    });
+  });
+
+  describe("webviewPartition", () => {
+    it("is empty when manifest has no cacheBustingId", () => {
+      mockGetInitialURL.mockReturnValue("https://example.com/");
+
+      const { result } = renderHook(() => useWebviewState({ manifest: mockManifest }, null));
+
+      expect(result.current.webviewPartition).toEqual({});
+    });
+
+    it("sets a persist partition keyed to manifest id and cacheBustingId", () => {
+      const manifestWithCache: LiveAppManifest = {
+        ...mockManifest,
+        id: "my-app",
+        cacheBustingId: 2,
+      };
+      mockGetInitialURL.mockReturnValue("https://example.com/");
+
+      const { result } = renderHook(() => useWebviewState({ manifest: manifestWithCache }, null));
+
+      expect(result.current.webviewPartition).toEqual({ partition: "persist:myapp-2" });
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
@@ -67,7 +67,7 @@ export function useWebviewState(
 ): UseWebviewStateReturn {
   const webviewRef = useRef<WebviewTag>(null);
   const { manifest, inputs, manifestDomainCheckEnabled } = params;
-  const initialURL = useMemo(() => getInitialURL(inputs, manifest), [manifest, inputs]);
+  const initialURL = useRef(getInitialURL(inputs, manifest)).current;
 
   // Mirror mobile's originWhitelist: if the feature flag is on, only load URLs that pass
   // the manifest.domains whitelist. Fall back to manifest.url if initialURL is rejected,
@@ -88,50 +88,54 @@ export function useWebviewState(
 
   const [state, setState] = useState<WebviewState>(initialWebviewState);
 
-  useImperativeHandle(webviewAPIRef, () => {
-    return {
-      reload: () => {
-        const webview = safeGetRefValue(webviewRef);
+  useImperativeHandle(
+    webviewAPIRef,
+    () => {
+      return {
+        reload: () => {
+          const webview = safeGetRefValue(webviewRef);
 
-        webview.reload();
-      },
-      goBack: () => {
-        const webview = safeGetRefValue(webviewRef);
+          webview.reload();
+        },
+        goBack: () => {
+          const webview = safeGetRefValue(webviewRef);
 
-        webview.goBack();
-      },
-      goForward: () => {
-        const webview = safeGetRefValue(webviewRef);
+          webview.goBack();
+        },
+        goForward: () => {
+          const webview = safeGetRefValue(webviewRef);
 
-        webview.goForward();
-      },
-      openDevTools: () => {
-        const webview = safeGetRefValue(webviewRef);
+          webview.goForward();
+        },
+        openDevTools: () => {
+          const webview = safeGetRefValue(webviewRef);
 
-        webview.openDevTools();
-      },
-      loadURL: (url: string): Promise<void> => {
-        if (
-          manifestDomainCheckEnabled &&
-          !isUrlAllowedByManifestDomains(url, manifest.domains ?? [])
-        ) {
-          return Promise.reject(new Error("URL not allowed by manifest domains"));
-        }
-        const webview = safeGetRefValue(webviewRef);
+          webview.openDevTools();
+        },
+        loadURL: (url: string): Promise<void> => {
+          if (
+            manifestDomainCheckEnabled &&
+            !isUrlAllowedByManifestDomains(url, manifest.domains ?? [])
+          ) {
+            return Promise.reject(new Error("URL not allowed by manifest domains"));
+          }
+          const webview = safeGetRefValue(webviewRef);
 
-        return webview.loadURL(url);
-      },
-      clearHistory: () => {
-        const webview = safeGetRefValue(webviewRef);
+          return webview.loadURL(url);
+        },
+        clearHistory: () => {
+          const webview = safeGetRefValue(webviewRef);
 
-        webview.clearHistory();
-      },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      notify: (method: `event.${string}`, params: any) => {
-        serverRef?.current?.sendMessage(method, params);
-      },
-    };
-  }, [manifest.domains, manifestDomainCheckEnabled, serverRef]);
+          webview.clearHistory();
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        notify: (method: `event.${string}`, params: any) => {
+          serverRef?.current?.sendMessage(method, params);
+        },
+      };
+    },
+    [manifest.domains, manifestDomainCheckEnabled, serverRef],
+  );
 
   const [isMounted, setMounted] = useState<boolean>(false);
   useEffect(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When switching between ledger devices it was observed that the swap app would navigate back to home unexpectedly. This was actually the whole app reloading due to the `initialUrl` being recomputed.

Before (see ticket)

After:

https://github.com/user-attachments/assets/4f27c92b-89f2-45e2-abfa-f606041f2eb3



### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-24155

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
