### PR TITLE
[LWDM] refactor(common): store transport modules registry on globalThis

### DIFF
--- a/.changeset/twelve-starfishes-greet.md
+++ b/.changeset/twelve-starfishes-greet.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+refactor(common): store transport modules registry on globalThis

--- a/libs/ledger-live-common/src/hw/index.ts
+++ b/libs/ledger-live-common/src/hw/index.ts
@@ -48,13 +48,29 @@ export type TransportModule = {
   discovery?: Discovery;
 };
 
-const modules: TransportModule[] = [];
+declare global {
+  interface GlobalThis {
+    __ledgerTransportModules?: TransportModule[];
+  }
+}
+
+/**
+ * Uses globalThis to ensure a single shared registry across all module instances,
+ * which is critical when modules are lazy-loaded and may resolve to separate copies.
+ */
+function getModules(): TransportModule[] {
+  if (!globalThis.__ledgerTransportModules) {
+    globalThis.__ledgerTransportModules = [];
+  }
+  return globalThis.__ledgerTransportModules;
+}
 
 export const registerTransportModule = (module: TransportModule): void => {
-  modules.push(module);
+  getModules().push(module);
 };
 
 export const unregisterTransportModule = (moduleId: string): void => {
+  const modules = getModules();
   const index = modules.findIndex(m => m.id === moduleId);
   if (index !== -1) {
     modules.splice(index, 1);
@@ -62,7 +78,7 @@ export const unregisterTransportModule = (moduleId: string): void => {
 };
 
 export const unregisterAllTransportModules = (): void => {
-  modules.length = 0;
+  getModules().length = 0;
 };
 
 export const discoverDevices = (
@@ -70,6 +86,7 @@ export const discoverDevices = (
 ): Discovery => {
   const all: Discovery[] = [];
 
+  const modules = getModules();
   for (let i = 0; i < modules.length; i++) {
     const m = modules[i];
 
@@ -122,6 +139,7 @@ export const open = (
   // The first registered Transport (TransportModule) accepting the given device will be returned.
   // The open is not awaited, the check on the device is done synchronously.
   // A TransportModule can check the prefix of the device id to guess if it should use USB or not on LLM for ex.
+  const modules = getModules();
   for (let i = 0; i < modules.length; i++) {
     const m = modules[i];
     const p = m.open(deviceId, options?.openTimeoutMs, context, options?.matchDeviceByName);
@@ -176,6 +194,7 @@ export const close = (
   trace({ type: LOG_TYPE, message: "Trying to close transport", context });
 
   // Tries to call close on the registered TransportModule implementation first
+  const modules = getModules();
   for (let i = 0; i < modules.length; i++) {
     const m = modules[i];
     const p = m.close && m.close(transport, deviceId);
@@ -195,6 +214,7 @@ export const close = (
 };
 
 export const disconnect = (deviceId: string): Promise<void> => {
+  const modules = getModules();
   for (let i = 0; i < modules.length; i++) {
     const dis = modules[i].disconnect;
     const p = dis(deviceId);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - transport registration on all apps and cli

### 📝 Description

Ensure a single shared TransportModule registry across all module instances by moving it from a module-scoped array to globalThis, matching the pattern used for CryptoAssetsStore. This prevents duplicate registries when coin-modules are lazy-loaded and resolve to separate module copies.

### ❓ Context

- **JIRA or GitHub link**: 
- **ADR link (if any)**: 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
