### PR TITLE
[LWDM] feat(lwdm): extractBalance adapt for generic adapter staking evm

### DIFF
--- a/.changeset/rich-avocados-study.md
+++ b/.changeset/rich-avocados-study.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+feat(lwdm): extractBalance adapt for generic adapter staking evm

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/tests/estimateMaxSpendable.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/tests/estimateMaxSpendable.test.ts
@@ -15,6 +15,8 @@ jest.mock("../createTransaction", () => ({
 const mockedGetAlpacaApi = alpaca.getAlpacaApi as jest.Mock;
 
 describe("genericEstimateMaxSpendable", () => {
+  const validateIntentMock = jest.fn();
+  const estimateFeesMock = jest.fn();
   const dummyAccount = {
     id: "account_id",
     type: "Account",
@@ -36,8 +38,8 @@ describe("genericEstimateMaxSpendable", () => {
 
   it("subtracts estimated fee from spendable balance", async () => {
     mockedGetAlpacaApi.mockReturnValue({
-      estimateFees: jest.fn().mockResolvedValue({ value: 10000n }),
-      validateIntent: jest.fn().mockResolvedValue({ amount: 49990000n }),
+      estimateFees: estimateFeesMock.mockResolvedValue({ value: 10000n }),
+      validateIntent: validateIntentMock.mockResolvedValue({ amount: 49990000n }),
     });
 
     const estimate = genericEstimateMaxSpendable("testnet", "local");
@@ -48,6 +50,11 @@ describe("genericEstimateMaxSpendable", () => {
     });
 
     expect(result.toString()).toBe("49990000");
+    expect(validateIntentMock).toHaveBeenCalledWith(
+      expect.anything(),
+      [{ value: 50000000n, locked: 0n, asset: { type: "native" } }],
+      expect.anything(),
+    );
   });
 
   it("returns 0 if fee is higher than spendable", async () => {
@@ -57,8 +64,8 @@ describe("genericEstimateMaxSpendable", () => {
     };
 
     mockedGetAlpacaApi.mockReturnValue({
-      estimateFees: jest.fn().mockResolvedValue({ value: 10000n }),
-      validateIntent: jest.fn().mockResolvedValue({ amount: 0n }),
+      estimateFees: estimateFeesMock.mockResolvedValue({ value: 10000n }),
+      validateIntent: validateIntentMock.mockResolvedValue({ amount: 0n }),
     });
 
     const estimate = genericEstimateMaxSpendable("testnet", "local");
@@ -73,8 +80,8 @@ describe("genericEstimateMaxSpendable", () => {
 
   it("returns full spendable balance if fee is 0", async () => {
     mockedGetAlpacaApi.mockReturnValue({
-      estimateFees: jest.fn().mockResolvedValue({ value: 0n }),
-      validateIntent: jest.fn().mockResolvedValue({ amount: 50000000n }),
+      estimateFees: estimateFeesMock.mockResolvedValue({ value: 0n }),
+      validateIntent: validateIntentMock.mockResolvedValue({ amount: 50000000n }),
     });
 
     const estimate = genericEstimateMaxSpendable("testnet", "local");

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/utils.test.ts
@@ -437,7 +437,7 @@ describe("Alpaca utils", () => {
           spendableBalance: BigNumber(8),
           balance: BigNumber(10),
         } as unknown as Account),
-      ).toEqual([{ value: 10n, locked: 2n, asset: { type: "native" } }]);
+      ).toEqual([{ value: 8n, locked: 0n, asset: { type: "native" } }]);
     });
 
     it("extracts native and token balances", () => {
@@ -469,8 +469,8 @@ describe("Alpaca utils", () => {
             assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
             type: "erc20",
           },
-          locked: 9n,
-          value: 20n,
+          locked: 0n,
+          value: 11n,
         },
       ]);
     });

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/utils.ts
@@ -68,9 +68,11 @@ export function extractBalances(
 ): Balance[] {
   const balances: Balance[] = [
     {
-      value: BigInt(account.balance.toFixed()),
+      // Send flows expect spendable balances here. Using the account total balance
+      // makes `useAllAmount` include staked/locked funds for staking-enabled EVM accounts.
+      value: BigInt(account.spendableBalance.toFixed()),
       asset: { type: "native" },
-      locked: BigInt(account.balance.minus(account.spendableBalance).toFixed()),
+      locked: 0n,
     },
   ];
 
@@ -81,9 +83,9 @@ export function extractBalances(
   for (const subAccount of account.subAccounts) {
     const asset = getAssetFromToken(subAccount.token, account.freshAddress);
     balances.push({
-      value: BigInt(subAccount.balance.toFixed()),
+      value: BigInt(subAccount.spendableBalance.toFixed()),
       asset,
-      locked: BigInt(subAccount.balance.minus(subAccount.spendableBalance).toFixed()),
+      locked: 0n,
     });
   }
 
@@ -202,10 +204,10 @@ export function adaptCoreOperationToLiveOperation(accountId: string, op: CoreOpe
   }
 
   if (op.details?.stake && typeof op.details.stake === "object") {
-    const s = op.details.stake as { address?: string; amount?: bigint | number | string };
+    const s = op.details.stake as { address?: string; amount?: bigint };
     extra.stake = {
       address: s.address ?? "",
-      amount: new BigNumber(s.amount?.toString() ?? "0"),
+      amount: new BigNumber(s.amount !== undefined ? String(s.amount) : "0"),
     };
   }
 
@@ -483,6 +485,8 @@ export const buildOptimisticOperation = (
   const { subAccounts } = account;
   const parentType = subAccountId ? "FEES" : type;
   const tokenAccount = subAccountId ? subAccounts?.find(ta => ta.id === subAccountId) : null;
+  const normalizedSequenceNumber = String(sequenceNumber ?? 0);
+  const nonce = sequenceNumber === undefined ? undefined : new BigNumber(normalizedSequenceNumber);
 
   const operation: Operation = {
     id: encodeOperationId(account.id, "", parentType),
@@ -494,12 +498,12 @@ export const buildOptimisticOperation = (
     blockHeight: null,
     senders: [account.freshAddress.toString()],
     recipients: [transaction.recipient],
-    transactionSequenceNumber: new BigNumber(sequenceNumber?.toString() ?? 0),
+    transactionSequenceNumber: new BigNumber(normalizedSequenceNumber),
     accountId: account.id,
     date: new Date(),
     transactionRaw: toGenericTransactionRaw({
       ...transaction,
-      nonce: sequenceNumber !== undefined ? new BigNumber(sequenceNumber.toString()) : undefined,
+      nonce,
       ...(tokenAccount
         ? { recipient: tokenAccount.token.contractAddress, amount: new BigNumber(0) }
         : {}),
@@ -523,13 +527,12 @@ export const buildOptimisticOperation = (
         blockHeight: null,
         senders: [account.freshAddress],
         recipients: [transaction.recipient],
-        transactionSequenceNumber: new BigNumber(sequenceNumber?.toString() ?? 0),
+        transactionSequenceNumber: new BigNumber(normalizedSequenceNumber),
         accountId: subAccountId,
         date: new Date(),
         transactionRaw: toGenericTransactionRaw({
           ...transaction,
-          nonce:
-            sequenceNumber !== undefined ? new BigNumber(sequenceNumber.toString()) : undefined,
+          nonce,
         }),
         extra: {
           ledgerOpType: type,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This updates the generic adapter so send-related balance checks use the actual spendable balance instead of the account’s total balance. That fixes staking EVM cases like SEI where maxSpendable and send max were incorrectly including delegated funds. In short, delegated/locked assets are no longer treated as sendable by the generic balance extraction used in fee estimation and validation.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-29170)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
