### PR TITLE
[LWD] fix(zcash): update old state if no subscriber [LIVE-29169]

### DIFF
--- a/.changeset/sixty-clouds-work.md
+++ b/.changeset/sixty-clouds-work.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Update state if no subscriber present

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -335,6 +335,13 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
     });
   };
 
+  // Check on mount if there is a subscription for this account, if not update the sync state to "stopped"
+  useEffect(() => {
+    if (syncState === "running" && !shieldedSubscriptions.find(s => s.accountId === account.id)) {
+      stopShieldedSync();
+    }
+  });
+
   return (
     <Wrapper>
       <BalanceDetail>

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -7,13 +7,18 @@ import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SYNC_TYPE_SHIELDED } from "@ledgerhq/types-live";
+import { syncStateUpdater } from "../ZCashExportKeyFlowModal/sync";
 
 jest.mock("~/renderer/hooks/useAccountUnit");
 const mockedUseAccountUnit = jest.mocked(useAccountUnit);
 jest.mock("@ledgerhq/live-common/bridge/index", () => ({
   getAccountBridge: jest.fn(),
 }));
+jest.mock("../ZCashExportKeyFlowModal/sync", () => ({
+  syncStateUpdater: jest.fn(() => ({ type: "test/syncStateUpdater" })),
+}));
 const mockedGetAccountBridge = jest.mocked(getAccountBridge);
+const mockedSyncStateUpdater = jest.mocked(syncStateUpdater);
 
 // Patch Date.prototype.toLocaleString with explicit typing to avoid "this" implicit any error.
 const origDate = global.Date.prototype.toLocaleString;
@@ -207,6 +212,39 @@ describe("Bitcoin Account Balance Summary Footer", () => {
     await waitFor(() => {
       expect(screen.getByTestId("stop-sync-button")).toBeInTheDocument();
       expect(screen.queryByText("Estimated time remaining: 00:00")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should stop shielded sync when sync state is running with no subscription for account", async () => {
+    mockedUseAccountUnit.mockReturnValue({
+      code: "ZEC",
+      name: "Zcash",
+      magnitude: 8,
+    });
+    render(
+      <AccountBalanceSummaryFooter
+        account={{
+          ...account,
+          currency: { id: "zcash" } as CryptoCurrency,
+          privateInfo: {
+            ...DEFAULT_ZCASH_PRIVATE_INFO,
+            syncState: "running",
+          },
+        }}
+      />,
+      {
+        initialState: {
+          ...withFlagOverrides({ zcashShielded: { enabled: true } }),
+          shieldedSyncSubscriptions: [],
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockedSyncStateUpdater).toHaveBeenCalledWith(
+        expect.objectContaining({ id: account.id }),
+        expect.objectContaining({ syncState: "stopped", progress: 0 }),
+      );
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ledger-live-desktop

### 📝 Description

If LWD is closed and a synchronization process is running in the background, the sync state of the account will not be update accordingly. This will update the account state if there's no subscriber present.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-29169


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
