### PR TITLE
[LWD] fix(desktop): fix wallet-api e2e test drawer race condition

### DIFF
--- a/.changeset/calm-drawers-wait.md
+++ b/.changeset/calm-drawers-wait.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix e2e wallet-api test by waiting for drawer account title to disappear and adding feature flags support in test fixtures

--- a/apps/ledger-live-desktop/tests/component/drawer.component.ts
+++ b/apps/ledger-live-desktop/tests/component/drawer.component.ts
@@ -1,3 +1,4 @@
+import { expect } from "@playwright/test";
 import { Component } from "tests/page/abstractClasses";
 import { step } from "tests/misc/reporters/step";
 
@@ -55,5 +56,9 @@ export class Drawer extends Component {
 
   back() {
     return this.backButton.click();
+  }
+
+  async waitForAccountTitleToDisappear() {
+    await expect(this.selectAccountTitle).not.toBeVisible();
   }
 }

--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -83,7 +83,14 @@ export const test = base.extend<TestFixtures>({
       ...settings,
     };
 
-    const userData = merge(fileUserData, { data: { settings: settingsWithConsentDefaults } });
+    const userData = merge(fileUserData, {
+      data: {
+        settings: settingsWithConsentDefaults,
+        ...(featureFlags
+          ? { featureFlags: { overrides: featureFlags, bannerVisible: false } }
+          : {}),
+      },
+    });
     await fsPromises.writeFile(`${userdataDestinationPath}/app.json`, JSON.stringify(userData));
 
     // default environment variables

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -136,6 +136,7 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
       "Ethereum 3 (USDT)71.8174 USDT",
     );
     await drawer.back();
+    await drawer.waitForAccountTitleToDisappear();
     await expect(drawer.selectAssetTitle).toBeVisible();
 
     await drawer.selectCurrency("bitcoin");


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _The fix is directly applied to the e2e test suite._
- [x] **Impact of the changes:**
      - Wallet API e2e smoke test: verify account selection and navigation back in the drawer works reliably without flaky failures.

### 📝 Description

The `Wallet API methods @smoke` e2e test was failing intermittently because after clicking the back button in the drawer, the test immediately checked for the asset title before the account title had time to disappear — creating a race condition.

This fix adds a `waitForAccountTitleToDisappear()` helper on the `Drawer` component and calls it after `drawer.back()` to ensure the transition is complete before asserting on the next screen. Additionally, the test fixtures were updated to support injecting feature flags via `featureFlags` so tests can reliably control flag state without relying on network-fetched overrides.

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)