### PR TITLE
[LWDM] fix: [LIVE-28506] change max amount on send delegated accounts

### DIFF
--- a/.changeset/soft-wasps-approve.md
+++ b/.changeset/soft-wasps-approve.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+The max available amount is now correctly displayed when sending from delegated Tezos accounts.

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -179,7 +179,7 @@ describe("validateIntent", () => {
   });
 
   describe("transaction constraints", () => {
-    it("should return RecommendUndelegation when send-max native XTZ on a delegated account", async () => {
+    it("should return RecommendUndelegation when send-max native XTZ on a delegated account, and still compute max amount", async () => {
       mockGetAccountByAddress.mockResolvedValue({
         type: "user",
         address: senderAddress,
@@ -205,7 +205,11 @@ describe("validateIntent", () => {
       });
 
       expect(result.errors.amount).toBeInstanceOf(RecommendUndelegation);
-      expect(mockEstimateFees).not.toHaveBeenCalled();
+      // estimateFees is called so that estimateMaxSpendable gets a meaningful value
+      expect(mockEstimateFees).toHaveBeenCalled();
+      expect(result.estimatedFees).toBe(1000n);
+      expect(result.amount).toBe(4999000n);
+      expect(result.totalSpent).toBe(5000000n);
     });
 
     it("should return NotEnoughBalanceToDelegate when stake intent and balance is zero", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -253,7 +253,14 @@ export async function validateIntent(intent: TransactionIntent): Promise<Transac
     Object.assign(errors, constraintErrors);
 
     if (Object.keys(errors).length > 0) {
-      return { errors, warnings, estimatedFees: 0n, amount: 0n, totalSpent: 0n };
+      // RecommendUndelegation is a soft UX guidance error; crafting is already independently
+      // blocked in api/index.ts. Continue to calculate a meaningful max amount so
+      // estimateMaxSpendable returns the correct value even for delegated accounts.
+      const hasOnlyRecommendUndelegationError =
+        Object.keys(errors).length === 1 && errors.amount instanceof RecommendUndelegation;
+      if (!hasOnlyRecommendUndelegationError) {
+        return { errors, warnings, estimatedFees: 0n, amount: 0n, totalSpent: 0n };
+      }
     }
 
     const feeResult = await estimateFeesForIntent(intent, senderInfo);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Show on delegated account max available amount

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-28506


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
