### PR TITLE
[LWDM] feat(live-common): migrate getAlpacaApi to async dynamic import() [LIVE-29178]

### DIFF
--- a/.changeset/async-getalpacaapi-import.md
+++ b/.changeset/async-getalpacaapi-import.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Migrate `getAlpacaApi` from synchronous `require()` to async `import()` for true deferred loading of coin Alpaca API modules

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -344,6 +344,13 @@
     "**/fixtures/**"
   ],
   "ignoreUnimported": [
+    "src/bridge/generic-alpaca/alpaca/local/canton.ts",
+    "src/bridge/generic-alpaca/alpaca/local/evm.ts",
+    "src/bridge/generic-alpaca/alpaca/local/solana.ts",
+    "src/bridge/generic-alpaca/alpaca/local/stellar.ts",
+    "src/bridge/generic-alpaca/alpaca/local/tezos.ts",
+    "src/bridge/generic-alpaca/alpaca/local/tron.ts",
+    "src/bridge/generic-alpaca/alpaca/local/xrp.ts",
     "src/account/typeGuards.ts",
     "src/api/ofacGeoBlockApi.ts",
     "src/bot/specs.ts",
@@ -594,6 +601,13 @@
     "yargs"
   ],
   "ignoreUnresolved": [
+    "./local/canton.js",
+    "./local/evm.js",
+    "./local/solana.js",
+    "./local/stellar.js",
+    "./local/tezos.js",
+    "./local/tron.js",
+    "./local/xrp.js",
     "../../Image/Image",
     "../../StyleSheet/PlatformColorValueTypes",
     "../../Utilities/Platform",

--- a/libs/ledger-live-common/jest.config.ts
+++ b/libs/ledger-live-common/jest.config.ts
@@ -85,6 +85,7 @@ const defaultConfig = {
   transformIgnorePatterns: ["/node_modules/(?!|@babel/runtime/helpers/esm/)"],
   moduleDirectories: ["node_modules", "cli/node_modules"],
   moduleNameMapper: {
+    "^(\\.{1,2}/.+)\\.js$": "$1",
     "^@tests/(.*)$": "<rootDir>/src/__tests__/$1",
     "^@tests$": "<rootDir>/src/__tests__/server",
     // TODO: Remove this once we upgrade all projects React 19

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/index.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/index.ts
@@ -7,28 +7,29 @@ import { getNetworkAlpacaApi } from "./network/network-alpaca";
  * Lazy-load coin Alpaca API modules so consumers (e.g. wallet-cli EVM-only) do not evaluate
  * unrelated coin stacks (Tron pulls tronweb/protobuf, which breaks under some Bun runtimes).
  *
- * Uses `require()` so the first `lib/` (CJS) build only loads the module for the matched family.
- * The `lib-es/` build reuses the same source; bundlers / Bun resolve these subpaths on demand.
+ * Uses dynamic `import()` so each build only loads the module for the matched family on demand.
  */
-// TODO: we could also use dynamic import here but we need to update everything to async/await where getAlpacaApi is used
-export function getAlpacaApi(network: string, kind: string): AlpacaApi<any> & BridgeApi {
+export async function getAlpacaApi(
+  network: string,
+  kind: string,
+): Promise<AlpacaApi<any> & BridgeApi> {
   if (kind === "local") {
     const currency = findCryptoCurrencyByNetwork(network);
     switch (currency?.family) {
       case "xrp":
-        return require("./local/xrp").createLocalXrpApi(currency.id);
+        return (await import("./local/xrp.js")).createLocalXrpApi(currency.id);
       case "stellar":
-        return require("./local/stellar").createLocalStellarApi(currency.id);
+        return (await import("./local/stellar.js")).createLocalStellarApi(currency.id);
       case "canton":
-        return require("./local/canton").createLocalCantonApi(currency.id);
+        return (await import("./local/canton.js")).createLocalCantonApi(currency.id);
       case "tron":
-        return require("./local/tron").createLocalTronApi(currency.id);
+        return (await import("./local/tron.js")).createLocalTronApi(currency.id);
       case "evm":
-        return require("./local/evm").createLocalEvmApi(currency.id);
+        return (await import("./local/evm.js")).createLocalEvmApi(currency.id);
       case "tezos":
-        return require("./local/tezos").createLocalTezosApi(currency.id);
+        return (await import("./local/tezos.js")).createLocalTezosApi(currency.id);
       case "solana":
-        return require("./local/solana").createLocalSolanaApi(currency.id);
+        return (await import("./local/solana.js")).createLocalSolanaApi(currency.id);
     }
   }
   return getNetworkAlpacaApi(network) satisfies Partial<AlpacaApi<any> & BridgeApi>;

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/index.unit.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/alpaca/index.unit.test.ts
@@ -91,15 +91,15 @@ describe("getAlpacaApi", () => {
   ];
 
   testCases.forEach(({ network, module, label, params }) => {
-    it(`should return ${label} API for network "${network}" and kind "local"`, () => {
-      const result = getAlpacaApi(network, "local");
+    it(`should return ${label} API for network "${network}" and kind "local"`, async () => {
+      const result = await getAlpacaApi(network, "local");
       expect(result).toEqual(mockApiInstance);
       expect(module.createApi).toHaveBeenCalledWith(...params);
     });
   });
 
-  it("should return network API for kind !== 'local'", () => {
-    const result = getAlpacaApi("xrp", "remote");
+  it("should return network API for kind !== 'local'", async () => {
+    const result = await getAlpacaApi("xrp", "remote");
     expect(networkApi.getNetworkAlpacaApi).toHaveBeenCalledWith("xrp");
     expect(result).toEqual(mockApiInstance);
   });

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/broadcast.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/broadcast.ts
@@ -9,7 +9,7 @@ export const genericBroadcast: (
 ) => AccountBridge<GenericTransaction>["broadcast"] =
   (_network, kind) =>
   async ({ signedOperation: { signature, operation }, account, broadcastConfig }) => {
-    const api = getAlpacaApi(account.currency.id, kind);
+    const api = await getAlpacaApi(account.currency.id, kind);
     if (api.validateTransaction) {
       const validation = await api.validateTransaction(signature);
       if (validation.error !== undefined) {

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/estimateMaxSpendable.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/estimateMaxSpendable.ts
@@ -16,7 +16,7 @@ export function genericEstimateMaxSpendable(
       return account.spendableBalance;
     }
     const mainAccount = getMainAccount(account, parentAccount);
-    const alpacaApi = getAlpacaApi(mainAccount.currency.id, kind);
+    const alpacaApi = await getAlpacaApi(mainAccount.currency.id, kind);
     const bridgeApi = getBridgeApi(mainAccount.currency, network);
     const draftTransaction = {
       ...createTransaction(account),

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/getAccountShape.ts
@@ -302,7 +302,7 @@ function buildParentOperations(
 export function genericGetAccountShape(network: string, kind: string): GetAccountShape {
   return async (info, syncConfig) => {
     const { address, initialAccount, currency, derivationMode } = info;
-    const alpacaApi = getAlpacaApi(currency.id, kind);
+    const alpacaApi = await getAlpacaApi(currency.id, kind);
     const bridgeApi = getBridgeApi(currency, network);
 
     const chainSpecificValidation = bridgeApi.getChainSpecificRules?.();

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/getTransactionStatus.ts
@@ -17,7 +17,7 @@ export function genericGetTransactionStatus(
   kind: string,
 ): AccountBridge<GenericTransaction>["getTransactionStatus"] {
   return async (account, transaction) => {
-    const alpacaApi = getAlpacaApi(account.currency.id, kind);
+    const alpacaApi = await getAlpacaApi(account.currency.id, kind);
     const bridgeApi = getBridgeApi(account.currency, network);
 
     const draftTransaction = {

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/prepareTransaction.ts
@@ -48,7 +48,7 @@ export function genericPrepareTransaction(
   kind: string,
 ): AccountBridge<GenericTransaction>["prepareTransaction"] {
   return async (account, transaction) => {
-    const alpacaApi = getAlpacaApi(account.currency.id, kind);
+    const alpacaApi = await getAlpacaApi(account.currency.id, kind);
     const bridgeApi = getBridgeApi(account.currency, network);
 
     const getAssetFromTokenForCurrency = bridgeApi.getAssetFromToken;

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/signOperation.ts
@@ -50,7 +50,7 @@ export const genericSignOperation =
   }): Observable<SignOperationEvent> =>
     new Observable(o => {
       async function main() {
-        const alpacaApi = getAlpacaApi(account.currency.id, kind);
+        const alpacaApi = await getAlpacaApi(account.currency.id, kind);
         const bridgeApi = getBridgeApi(account.currency, network);
         if (!transaction.fees) throw new FeeNotLoaded();
         const customFees = bigNumberToBigIntDeep({

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/signRawOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/signRawOperation.ts
@@ -25,7 +25,7 @@ export const genericSignRawOperation =
   }): Observable<SignOperationEvent> =>
     new Observable(o => {
       async function main() {
-        const alpacaApi = getAlpacaApi(account.currency.id, kind);
+        const alpacaApi = await getAlpacaApi(account.currency.id, kind);
         const signedInfo = await signerContext(deviceId, async signer => {
           const derivationPath = account.freshAddressPath;
           const { publicKey } = (await signer.getAddress(derivationPath)) as Result;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit tests in `alpaca/index.unit.test.ts` updated to `async/await`.
- [x] **Impact of the changes:**
  - Internal refactor within `libs/ledger-live-common` — no public API change.
  - All callers of `getAlpacaApi` were already in async contexts; adding `await` is the only consumer change.
  - No behavioral change expected; lazy-loading semantics are preserved (now truly async).

### 📝 Description

Replaces the synchronous `require()` lazy-loading in `generic-alpaca/alpaca/index.ts` with proper async `import()`, making `getAlpacaApi` an `async` function that returns `Promise<AlpacaApi & BridgeApi>`.

All 7 call sites (`getAccountShape`, `prepareTransaction`, `getTransactionStatus`, `estimateMaxSpendable`, `signOperation`, `signRawOperation`, `broadcast`) were already inside `async` functions — the migration is purely mechanical (`await getAlpacaApi(...)`).

A `moduleNameMapper` entry (`^(\.{1,2}/.+)\.js$`) was added to `jest.config.ts` to fix module resolution when using `moduleResolution: NodeNext` with Jest (which doesn't understand `.js` imports pointing to `.ts` source files).

### ❓ Context

- **JIRA**: [LIVE-29178](https://ledgerhq.atlassian.net/browse/LIVE-29178) — part of [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) (broader require → import() migration)
- `getSigner` in `signer.ts` is **not** in scope here: its callers are synchronous and the propagation is wider (~100 call sites). Tracked separately.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29178]: https://ledgerhq.atlassian.net/browse/LIVE-29178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ