### PR TITLE
[LWD] fix(desktop): respect asset/address flag on account removal redirect

### DIFF
--- a/.changeset/afraid-planets-rush.md
+++ b/.changeset/afraid-planets-rush.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix account removal redirect to respect asset/address feature flag

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/FundAccount/components/ActionsContainer.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/FundAccount/components/ActionsContainer.tsx
@@ -14,6 +14,8 @@ import {
 } from "../../../analytics/addAccount.types";
 import useAddAccountAnalytics from "../../../analytics/useAddAccountAnalytics";
 import { IconContainer } from "./IconContainer";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { getAccountsSidebarPath } from "LLD/components/SideBar/utils";
 
 const ActionItem = styled(Flex)`
   cursor: pointer;
@@ -48,6 +50,8 @@ const ActionsContainer = ({ account, currencyId }: Props) => {
   const dispatch = useDispatch();
   const { isCurrencyAvailable } = useRampCatalog();
   const { trackAddAccountEvent } = useAddAccountAnalytics();
+  const { shouldDisplayAssetSection } = useWalletFeaturesConfig("desktop");
+  const accountsPath = getAccountsSidebarPath(shouldDisplayAssetSection);
 
   const handleReceive = useCallback(() => {
     trackAddAccountEvent(ADD_ACCOUNT_EVENTS_NAME.ADD_ACCOUNT_BUTTON_CLICKED, {
@@ -55,9 +59,9 @@ const ActionsContainer = ({ account, currencyId }: Props) => {
       page: ADD_ACCOUNT_PAGE_NAME.FUNDING_ACTIONS,
     });
     setDrawer();
-    if (location.pathname === "/manager") navigate("/accounts");
+    if (location.pathname === "/manager") navigate(accountsPath);
     dispatch(openModal("MODAL_RECEIVE", { account }));
-  }, [account, dispatch, location.pathname, navigate, trackAddAccountEvent]);
+  }, [account, accountsPath, dispatch, location.pathname, navigate, trackAddAccountEvent]);
 
   const handleBuy = useCallback(() => {
     trackAddAccountEvent(ADD_ACCOUNT_EVENTS_NAME.ADD_ACCOUNT_BUTTON_CLICKED, {

--- a/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/QuickActions/hooks/useQuickActions.ts
@@ -19,6 +19,8 @@ import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums
 import { track } from "~/renderer/analytics/segment";
 import { hasOnboardedDeviceSelector } from "~/renderer/reducers/settings";
 import { useLazyOnboardingActions } from "LLD/hooks/useLazyOnboardingActions";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { getAccountsSidebarPath } from "LLD/components/SideBar/utils";
 
 export const useQuickActions = (trackingPageName: string): { actionsList: QuickAction[] } => {
   const openSendFlow = useOpenSendFlow();
@@ -29,6 +31,8 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
   const { hasAccount, hasFunds } = useAccountStatus();
   const hasOnboardedDevice = useSelector(hasOnboardedDeviceSelector);
   const { handleConnect, handleBuyDevice } = useLazyOnboardingActions();
+  const { shouldDisplayAssetSection } = useWalletFeaturesConfig("desktop");
+  const accountsPath = getAccountsSidebarPath(shouldDisplayAssetSection);
 
   const { openAssetFlow } = useOpenAssetFlow(
     { location: ModularDrawerLocation.ADD_ACCOUNT },
@@ -45,8 +49,8 @@ export const useQuickActions = (trackingPageName: string): { actionsList: QuickA
   );
 
   const maybeRedirectToAccounts = useCallback(() => {
-    return location.pathname === "/manager" && push("/accounts");
-  }, [location.pathname, push]);
+    return location.pathname === "/manager" && push(accountsPath);
+  }, [accountsPath, location.pathname, push]);
 
   const onSend = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/accounts.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/accounts.handler.test.ts
@@ -2,7 +2,7 @@ import { Account, TokenAccount } from "@ledgerhq/types-live";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { findCryptoCurrencyByKeyword } from "@ledgerhq/live-common/currencies/index";
 import { accountsHandler, accountHandler } from "../accounts.handler";
-import { DeeplinkHandlerContext } from "../../types";
+import { createMockContext } from "./test-utils";
 
 jest.mock("@ledgerhq/live-common/currencies/index", () => ({
   findCryptoCurrencyByKeyword: jest.fn(),
@@ -16,21 +16,6 @@ import { getAccountsOrSubAccountsByCurrency } from "../../utils";
 
 const mockFindCryptoCurrencyByKeyword = jest.mocked(findCryptoCurrencyByKeyword);
 const mockGetAccountsOrSubAccountsByCurrency = jest.mocked(getAccountsOrSubAccountsByCurrency);
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
 
 const createMockAccount = (currencyId: string, address: string = "address123"): Account => {
   const currency = getCryptoCurrencyById(currencyId);
@@ -55,7 +40,7 @@ describe("accounts.handler", () => {
 
       accountsHandler({ type: "accounts" }, context);
 
-      expect(context.navigate).toHaveBeenCalledWith("/accounts");
+      expect(context.navigate).toHaveBeenCalledWith(context.accountsPath);
     });
 
     it("navigates to specific account when valid address is found", () => {
@@ -73,7 +58,24 @@ describe("accounts.handler", () => {
 
       accountsHandler({ type: "accounts", address: "nonexistent" }, context);
 
-      expect(context.navigate).toHaveBeenCalledWith("/accounts");
+      expect(context.navigate).toHaveBeenCalledWith(context.accountsPath);
+    });
+
+    it("navigates to /cryptos when feature flag sets accountsPath to /cryptos", () => {
+      const context = createMockContext({ accountsPath: "/cryptos" });
+
+      accountsHandler({ type: "accounts" }, context);
+
+      expect(context.navigate).toHaveBeenCalledWith("/cryptos");
+    });
+
+    it("navigates to /cryptos when address not found and accountsPath is /cryptos", () => {
+      const mockAccount = createMockAccount("bitcoin", "bc1qtest123");
+      const context = createMockContext({ accounts: [mockAccount], accountsPath: "/cryptos" });
+
+      accountsHandler({ type: "accounts", address: "nonexistent" }, context);
+
+      expect(context.navigate).toHaveBeenCalledWith("/cryptos");
     });
   });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/addAccount.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/addAccount.handler.test.ts
@@ -1,28 +1,13 @@
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { findCryptoCurrencyByKeyword } from "@ledgerhq/live-common/currencies/index";
 import { addAccountHandler } from "../addAccount.handler";
-import { DeeplinkHandlerContext } from "../../types";
+import { createMockContext } from "./test-utils";
 
 jest.mock("@ledgerhq/live-common/currencies/index", () => ({
   findCryptoCurrencyByKeyword: jest.fn(),
 }));
 
 const mockFindCryptoCurrencyByKeyword = jest.mocked(findCryptoCurrencyByKeyword);
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
 
 describe("addAccount.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/bridge.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/bridge.handler.test.ts
@@ -1,6 +1,6 @@
 import { closeAllModal, openModal } from "~/renderer/actions/modals";
 import { bridgeHandler } from "../bridge.handler";
-import { DeeplinkHandlerContext } from "../../types";
+import { createMockContext } from "./test-utils";
 
 jest.mock("~/renderer/actions/modals", () => ({
   openModal: jest.fn(() => ({ type: "OPEN_MODAL" })),
@@ -9,21 +9,6 @@ jest.mock("~/renderer/actions/modals", () => ({
 
 const mockOpenModal = jest.mocked(openModal);
 const mockCloseAllModal = jest.mocked(closeAllModal);
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
 
 describe("bridge.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/buy.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/buy.handler.test.ts
@@ -1,20 +1,5 @@
 import { buyHandler } from "../buy.handler";
-import { DeeplinkHandlerContext } from "../../types";
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
+import { createMockContext } from "./test-utils";
 
 describe("buy.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/default.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/default.handler.test.ts
@@ -1,20 +1,5 @@
 import { defaultHandler } from "../default.handler";
-import { DeeplinkHandlerContext } from "../../types";
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
+import { createMockContext } from "./test-utils";
 
 describe("default.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/discover.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/discover.handler.test.ts
@@ -1,7 +1,7 @@
 import { CARD_APP_ID, WC_ID } from "@ledgerhq/live-common/wallet-api/constants";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { cardHandler, discoverHandler, walletConnectHandler } from "../discover.handler";
-import { DeeplinkHandlerContext } from "../../types";
+import { createMockContext } from "./test-utils";
 
 jest.mock("@ledgerhq/live-common/wallet-api/constants", () => ({
   CARD_APP_ID: "cl-card",
@@ -13,21 +13,6 @@ jest.mock("~/renderer/analytics/TrackPage", () => ({
 }));
 
 const mockSetTrackingSource = jest.mocked(setTrackingSource);
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
 
 describe("discover.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/earn.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/earn.handler.test.ts
@@ -1,20 +1,5 @@
 import { earnHandler } from "../earn.handler";
-import { DeeplinkHandlerContext } from "../../types";
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
+import { createMockContext } from "./test-utils";
 
 describe("earn.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/ledgerSync.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/ledgerSync.handler.test.ts
@@ -1,27 +1,12 @@
 import { setDrawerVisibility } from "~/renderer/actions/walletSync";
 import { ledgerSyncHandler } from "../ledgerSync.handler";
-import { DeeplinkHandlerContext } from "../../types";
+import { createMockContext } from "./test-utils";
 
 jest.mock("~/renderer/actions/walletSync", () => ({
   setDrawerVisibility: jest.fn(() => ({ type: "SET_DRAWER_VISIBILITY" })),
 }));
 
 const mockSetDrawerVisibility = jest.mocked(setDrawerVisibility);
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
 
 describe("ledgerSync.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/manager.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/manager.handler.test.ts
@@ -1,20 +1,5 @@
 import { managerHandler } from "../manager.handler";
-import { DeeplinkHandlerContext } from "../../types";
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
+import { createMockContext } from "./test-utils";
 
 describe("manager.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/market.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/market.handler.test.ts
@@ -1,20 +1,5 @@
 import { marketHandler, assetHandler } from "../market.handler";
-import { DeeplinkHandlerContext } from "../../types";
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
+import { createMockContext } from "./test-utils";
 
 describe("market.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/postOnboarding.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/postOnboarding.handler.test.ts
@@ -1,20 +1,5 @@
 import { postOnboardingHandler } from "../postOnboarding.handler";
-import { DeeplinkHandlerContext } from "../../types";
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
+import { createMockContext } from "./test-utils";
 
 describe("postOnboarding.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/recover.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/recover.handler.test.ts
@@ -1,20 +1,5 @@
 import { recoverHandler, recoverRestoreFlowHandler } from "../recover.handler";
-import { DeeplinkHandlerContext } from "../../types";
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
+import { createMockContext } from "./test-utils";
 
 describe("recover.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/settings.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/settings.handler.test.ts
@@ -1,20 +1,5 @@
 import { settingsHandler } from "../settings.handler";
-import { DeeplinkHandlerContext } from "../../types";
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
+import { createMockContext } from "./test-utils";
 
 describe("settings.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/swap.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/swap.handler.test.ts
@@ -1,20 +1,5 @@
 import { swapHandler } from "../swap.handler";
-import { DeeplinkHandlerContext } from "../../types";
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
+import { createMockContext } from "./test-utils";
 
 describe("swap.handler", () => {
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/test-utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/test-utils.ts
@@ -1,0 +1,17 @@
+import { DeeplinkHandlerContext } from "../../types";
+
+export const createMockContext = (
+  overrides: Partial<DeeplinkHandlerContext> = {},
+): DeeplinkHandlerContext => ({
+  dispatch: jest.fn(),
+  accounts: [],
+  navigate: jest.fn(),
+  openAddAccountFlow: jest.fn(),
+  openAssetFlow: jest.fn(),
+  openSendFlow: jest.fn(),
+  postOnboardingDeeplinkHandler: jest.fn(),
+  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
+  currentPathname: "/",
+  accountsPath: "/accounts",
+  ...overrides,
+});

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/transactionFlow.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/transactionFlow.handler.test.ts
@@ -4,7 +4,7 @@ import { findCryptoCurrencyByKeyword } from "@ledgerhq/live-common/currencies/in
 import { closeAllModal, openModal } from "~/renderer/actions/modals";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { sendHandler, receiveHandler, delegateHandler } from "../transactionFlow.handler";
-import { DeeplinkHandlerContext } from "../../types";
+import { createMockContext } from "./test-utils";
 
 jest.mock("@ledgerhq/live-common/currencies/index", () => ({
   findCryptoCurrencyByKeyword: jest.fn(),
@@ -37,21 +37,6 @@ const mockGetAccountsOrSubAccountsByCurrency = jest.mocked(getAccountsOrSubAccou
 const mockOpenModal = jest.mocked(openModal);
 const mockCloseAllModal = jest.mocked(closeAllModal);
 const mockSetDrawer = jest.mocked(setDrawer);
-
-const createMockContext = (
-  overrides: Partial<DeeplinkHandlerContext> = {},
-): DeeplinkHandlerContext => ({
-  dispatch: jest.fn(),
-  accounts: [],
-  navigate: jest.fn(),
-  openAddAccountFlow: jest.fn(),
-  openAssetFlow: jest.fn(),
-  openSendFlow: jest.fn(),
-  postOnboardingDeeplinkHandler: jest.fn(),
-  tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
-  currentPathname: "/",
-  ...overrides,
-});
 
 const createMockAccount = (currencyId: string): Account => {
   const currency = getCryptoCurrencyById(currencyId);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/accounts.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/accounts.handler.ts
@@ -3,7 +3,10 @@ import { Currency } from "@ledgerhq/types-cryptoassets";
 import { DeeplinkHandler } from "../types";
 import { getAccountsOrSubAccountsByCurrency } from "../utils";
 
-export const accountsHandler: DeeplinkHandler<"accounts"> = (route, { accounts, navigate }) => {
+export const accountsHandler: DeeplinkHandler<"accounts"> = (
+  route,
+  { accounts, navigate, accountsPath },
+) => {
   const { address } = route;
 
   if (address && typeof address === "string") {
@@ -14,7 +17,7 @@ export const accountsHandler: DeeplinkHandler<"accounts"> = (route, { accounts, 
     }
   }
 
-  navigate("/accounts");
+  navigate(accountsPath);
 };
 
 export const accountHandler: DeeplinkHandler<"account"> = (route, { accounts, navigate }) => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
@@ -37,6 +37,8 @@ export interface DeeplinkHandlerContext {
   postOnboardingDeeplinkHandler: PostOnboardingDeeplinkHandlerFn;
   tryRedirectToPostOnboardingOrRecover: TryRedirectToPostOnboardingOrRecoverFn;
   currentPathname: string;
+  /** Feature-flag-aware path to the accounts list screen (`/cryptos` or `/accounts`). */
+  accountsPath: string;
   /** Default Ledger Recover app id (from feature flag) for recover deeplink when no path is given */
   recoverAppId?: string;
 }

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useSelector, useDispatch } from "LLD/hooks/redux";
 import { useLocation, useNavigate } from "react-router";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
@@ -16,6 +16,7 @@ import { trackDeeplinkingEvent } from "./utils";
 import { parseDeepLink, createRoute } from "./parseDeepLink";
 import { executeHandler } from "./registry";
 import { DeeplinkHandlerContext, NavigateFn } from "./types";
+import { getAccountsSidebarPath } from "LLD/components/SideBar/utils";
 
 export function useDeepLinkHandler() {
   const dispatch = useDispatch();
@@ -38,6 +39,8 @@ export function useDeepLinkHandler() {
   const openSendFlow = useOpenSendFlow();
   const recoverFF = useFeature("protectServicesDesktop");
   const recoverAppId = recoverFF?.params?.protectId;
+  const { shouldDisplayAssetSection } = useWalletFeaturesConfig("desktop");
+  const accountsPath = getAccountsSidebarPath(shouldDisplayAssetSection);
 
   const navigate: NavigateFn = useCallback(
     (pathname: string, state?: { [k: string]: string | object }, search?: string) => {
@@ -68,6 +71,7 @@ export function useDeepLinkHandler() {
       postOnboardingDeeplinkHandler,
       tryRedirectToPostOnboardingOrRecover,
       currentPathname: location.pathname,
+      accountsPath,
       recoverAppId,
     }),
     [
@@ -80,6 +84,7 @@ export function useDeepLinkHandler() {
       postOnboardingDeeplinkHandler,
       tryRedirectToPostOnboardingOrRecover,
       location.pathname,
+      accountsPath,
       recoverAppId,
     ],
   );

--- a/apps/ledger-live-desktop/src/renderer/screens/account/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/index.tsx
@@ -35,6 +35,8 @@ import { State } from "~/renderer/reducers";
 import { getLLDCoinFamily } from "~/renderer/families";
 import NftEntryPoint from "LLD/features/NftEntryPoint";
 import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hooks/useAddressPoisoningOperationsFamilies";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { getAccountsSidebarPath } from "LLD/components/SideBar/utils";
 
 type Params = {
   id?: string;
@@ -85,6 +87,8 @@ const AccountPage = ({
   countervalueFirst,
   setCountervalueFirst,
 }: Props) => {
+  const { shouldDisplayAssetSection } = useWalletFeaturesConfig("desktop");
+  const fallbackPath = getAccountsSidebarPath(shouldDisplayAssetSection);
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
   const specific = mainAccount ? getLLDCoinFamily(mainAccount.currency.family) : null;
   const AccountBodyHeader = specific?.AccountBodyHeader;
@@ -114,7 +118,7 @@ const AccountPage = ({
   const currency = mainAccount?.currency;
 
   if (!account || !mainAccount || !currency) {
-    return <Navigate to="/accounts" replace />;
+    return <Navigate to={fallbackPath} replace />;
   }
 
   const color = getCurrencyColor(currency, bgColor);

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/index.tsx
@@ -27,6 +27,8 @@ import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getEnv } from "@ledgerhq/live-env";
 import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums";
 import { useOpenAssetFlow } from "LLD/features/ModularDialog/hooks/useOpenAssetFlow";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { getAccountsSidebarPath } from "LLD/components/SideBar/utils";
 
 // sticky top bar with extra width to cover card boxshadow underneath
 export const StickyTabBar = styled.div`
@@ -98,6 +100,9 @@ const AppsList = ({
     "manager",
   );
 
+  const { shouldDisplayAssetSection } = useWalletFeaturesConfig("desktop");
+  const accountsPath = getAccountsSidebarPath(shouldDisplayAssetSection);
+
   /** clear search field on tab change */
   useEffect(() => {
     setQuery("");
@@ -114,10 +119,10 @@ const AppsList = ({
   const { installed: installedApps, uninstallQueue } = state;
   const addAccount = useCallback(
     (currency: CryptoOrTokenCurrency) => {
-      navigate("/accounts");
+      navigate(accountsPath);
       openAddAccountFlow(currency, true);
     },
-    [navigate, openAddAccountFlow],
+    [accountsPath, navigate, openAddAccountFlow],
   );
   const { update, device, catalog } = useAppsSections(state, {
     query,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing deeplink handler tests updated; no new integration tests for the redirect behavior._
- [x] **Impact of the changes:**
  - Account removal redirect: should navigate to `/cryptos` when asset/address flag is on, `/accounts` when off
  - Deeplink `accounts` handler: same flag-aware navigation
  - Quick actions and Manager "add account": same flag-aware navigation

### 📝 Description

**Problem**: when the Asset/Address feature flag (`lwdWallet40.params.assetSection`) is enabled, removing an account while on that account's page redirects to `/accounts` (legacy screen) instead of `/cryptos` (new Asset/Address screen). The same hardcoded `/accounts` path was used in deeplinks, quick actions, and Manager navigation.

**Solution**:
- `AccountPage` now uses `useWalletFeaturesConfig("desktop")` + `getAccountsSidebarPath()` to compute the redirect path directly
- `accounts.handler.ts` (deeplinks) uses `accountsPath` from `DeeplinkHandlerContext`
- `ActionsContainer`, `AppsList`, and `useQuickActions` use the same pattern
- Factorized duplicated `createMockContext` from 15 test files into a shared `test-utils.ts`


https://github.com/user-attachments/assets/7533c800-9822-44f9-9d04-1b51ba635435



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29148](https://ledgerhq.atlassian.net/browse/LIVE-29148)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29148]: https://ledgerhq.atlassian.net/browse/LIVE-29148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ