### PR TITLE
[LWM] fix(mobile): improve top bar visibility on android

### DIFF
--- a/.changeset/calm-rivers-float.md
+++ b/.changeset/calm-rivers-float.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Android top bar icon visibility and strengthen main navigator header gradient

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigatorTopBarHeader.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigatorTopBarHeader.tsx
@@ -14,8 +14,8 @@ import Config from "react-native-config";
 import { useReduceTransparencyEnabled } from "~/hooks/useReduceTransparencyEnabled";
 
 const GRADIENT_STOPS = [
-  { color: "base", offset: 0, opacity: 0.8 },
-  { color: "base", offset: 0.75, opacity: 0.4 },
+  { color: "base", offset: 0, opacity: 1 },
+  { color: "base", offset: 0.75, opacity: 0.7 },
   { color: "base", offset: 1, opacity: 0 },
 ];
 

--- a/apps/ledger-live-mobile/src/mvvm/components/CustomTopBar/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/CustomTopBar/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Box, IconButton } from "@ledgerhq/lumen-ui-rnative";
+import { Platform } from "react-native";
+import { Box, IconButton, type IconButtonProps } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import type { TopBarActionIcon } from "./useMyLedgerTopBarAction";
 
@@ -12,6 +13,8 @@ type CustomTopBarProps = {
 };
 
 export function CustomTopBar({ leadingIcons, trailingIcons }: Readonly<CustomTopBarProps>) {
+  const isAndroid = Platform.OS === "android";
+  const appearance: IconButtonProps["appearance"] = isAndroid ? "gray" : "transparent";
   return (
     <Box lx={rowLx}>
       <Box lx={iconsGroupLayout}>
@@ -21,7 +24,7 @@ export function CustomTopBar({ leadingIcons, trailingIcons }: Readonly<CustomTop
             onPress={item.callback}
             testID={item.testID}
             accessibilityLabel={item.accessibilityLabel}
-            appearance="transparent"
+            appearance={appearance}
             icon={item.icon}
             size="md"
             loading={item.loading}
@@ -36,7 +39,7 @@ export function CustomTopBar({ leadingIcons, trailingIcons }: Readonly<CustomTop
             onPress={item.callback}
             testID={item.testID}
             accessibilityLabel={item.accessibilityLabel}
-            appearance="transparent"
+            appearance={appearance}
             icon={item.icon}
             size="md"
             loading={item.loading}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing `CustomTopBar` tests cover interactions; platform-specific `IconButton` appearance is not asserted._
- [x] **Impact of the changes:**
  - Main tab navigator header gradient over scrolling content (Android and iOS)
  - `CustomTopBar` leading and trailing icon buttons on Android vs iOS

### 📝 Description

**Problem:** On Android, top bar action icons used a transparent `IconButton` treatment while the main navigator header gradient was relatively light, which reduced contrast when content scrolled behind the bar.

**Solution:**
- On Android only, use the `gray` `IconButton` appearance in `CustomTopBar`; keep `transparent` on iOS.
- Increase opacity on the header gradient stops in `MainNavigatorTopBarHeader` so the scrim reads more clearly over the feed.

### 🎬 Demo

https://github.com/user-attachments/assets/64a9bb77-3a10-4927-b07a-bea15edc01f9



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29009](https://ledgerhq.atlassian.net/browse/LIVE-29009)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29009]: https://ledgerhq.atlassian.net/browse/LIVE-29009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ