### PR TITLE
fix(dummy-wallet-app): disable react-in-jsx-scope and no-unassigned-import oxlint rules

### DIFF
--- a/tests/dummy-wallet-app/.oxlintrc.json
+++ b/tests/dummy-wallet-app/.oxlintrc.json
@@ -31,6 +31,8 @@
       }
     ],
     "unicorn/no-useless-fallback-in-spread": "off",
-    "unicorn/no-useless-spread": "off"
+    "unicorn/no-useless-spread": "off",
+    "react/react-in-jsx-scope": "off",
+    "import/no-unassigned-import": "off"
   }
 }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** CI lint job validates the fix directly.
- [x] **Impact of the changes:**
  - Fixes CI failure in `@ledgerhq/dummy-wallet-app` lint step (55 warnings treated as errors via `--deny-warnings`)
  - No runtime behaviour changed — config-only fix

### 📝 Description

The `@ledgerhq/dummy-wallet-app` lint job was failing in CI with 55 warnings and exit code 1 because `oxlint` is run with `--deny-warnings`.

Two rules were producing false positives:

- **`react/react-in-jsx-scope`**: flags every JSX element because `React` is not explicitly imported. This rule is obsolete since React 17 introduced the new JSX transform, which no longer requires `React` to be in scope.
- **`import/no-unassigned-import`**: flags CSS side-effect imports (`import "./App.css"`), which is a standard and intentional pattern.

Both rules are turned off in `.oxlintrc.json`.

### ❓ Context

- **JIRA or GitHub link**: N/A — caught from CI output

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)