### PR TITLE
fix(wallet-cli): set LiveConfig on both ESM and CJS singletons to fix Solana "Config not set"

### DIFF
--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -3,7 +3,6 @@ import { setSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
 import { liveConfig } from "@ledgerhq/live-common/config/sharedConfig";
 import { registerCoinModules } from "@ledgerhq/live-common/coin-modules/registry";
 import type { CoinModuleLoader } from "@ledgerhq/live-common/coin-modules/types";
-import { setSolanaLdmkEnabled } from "@ledgerhq/live-common/families/solana/setup";
 import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
@@ -56,11 +55,20 @@ const walletCliLoaders: CoinModuleLoader[] = [
 setWalletAPIVersion(WALLET_API_VERSION);
 registerCoinModules(walletCliLoaders);
 setSupportedCurrencies(["bitcoin", "ethereum", "solana"]);
+// Set config on the ESM singleton (used by alpacaized families like EVM whose
+// bridge code is reached through ESM imports).
 LiveConfig.setConfig(liveConfig);
+// Also set on the CJS singleton — Bun's bundler resolves ESM imports to lib-es/
+// and require() to lib/, creating separate LiveConfig.instance singletons.
+// Non-alpacaized families (solana, bitcoin) load their bridge via require() in
+// the lazy loaders above, so they read from the CJS instance.
+(require("@ledgerhq/live-config/LiveConfig") as typeof import("@ledgerhq/live-config/LiveConfig")).LiveConfig.setConfig(liveConfig);
 // TODO: wallet-cli should own its Redux store setup (createRtkCryptoAssetsStore + RTK middleware)
 // instead of relying on setupCalClientStore from @ledgerhq/cryptoassets/cal-client (test-helpers).
 setupCalClientStore();
-setSolanaLdmkEnabled(true);
+// Also require() — the ESM import would set the flag on a different module instance
+// than the CJS setup.ts loaded by the lazy loaders above.
+(require("@ledgerhq/live-common/families/solana/setup") as typeof import("@ledgerhq/live-common/families/solana/setup")).setSolanaLdmkEnabled(true);
 registerWalletCliDmkTransport();
 
 setEnv("LEDGER_CLIENT_VERSION", "wallet-cli/0.1.0");


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli

### 📝 Description

Bun's --compile bundler resolves ESM imports to lib-es/ and CJS require() to lib/, creating separate module instances with independent singletons.

LiveConfig.setConfig() was only called on the ESM instance, but non-alpacaized families (solana, bitcoin) load their bridge via require() in the lazy coin-module loaders, reading from the CJS instance which remained empty — causing "Config not set" at runtime.

Set config on both singletons: keep the ESM call for alpacaized families (EVM) and add a CJS require() call for the rest. Apply the same fix to setSolanaLdmkEnabled() so the DMK signer flag reaches the CJS setup module.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
