### PR TITLE
[LWM] feat(mobile): sync analytics balance with portfolio display state

### DIFF
--- a/.changeset/calm-badgers-bridge.md
+++ b/.changeset/calm-badgers-bridge.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Sync analytics portfolio balance with portfolio display state via Redux

--- a/apps/ledger-live-mobile/src/components/GraphCard.tsx
+++ b/apps/ledger-live-mobile/src/components/GraphCard.tsx
@@ -21,6 +21,8 @@ import { readOnlyModeEnabledSelector } from "~/reducers/settings";
 import { Item } from "./Graph/types";
 import { GestureResponderEvent } from "react-native";
 import GraphSection from "./GraphSection";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { AnalyticsBalanceDisplay } from "LLM/features/Analytics/components/AnalyticsBalanceDisplay";
 
 type Props = {
   areAccountsEmpty: boolean;
@@ -58,6 +60,7 @@ function GraphCard({
   hideGraph,
 }: Props) {
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
+  const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
 
   const { countervalueChange, balanceHistory } = portfolio;
   const item = balanceHistory[balanceHistory.length - 1];
@@ -129,7 +132,9 @@ function GraphCard({
             ) : (
               <>
                 <Flex px={6}>
-                  {!balanceHistory ? (
+                  {shouldDisplayBalanceRefreshRework ? (
+                    <AnalyticsBalanceDisplay hoveredValue={hoveredItem?.value ?? null} />
+                  ) : !balanceHistory ? (
                     <BigPlaceholder mt="8px" />
                   ) : (
                     <Text

--- a/apps/ledger-live-mobile/src/components/RootNavigator/WalletTabNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/WalletTabNavigator.tsx
@@ -9,6 +9,7 @@ import { NavigationContainerEventMap } from "@react-navigation/native";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useWallet40Theme } from "LLM/hooks/useWallet40Theme";
 import MarketWalletTabNavigator from "LLM/features/Market/WalletTabNavigator";
+import { PortfolioBalanceSync } from "LLM/features/Portfolio/components/PortfolioBalanceSync";
 import {
   Portfolio as NewPortfolio,
   ReadOnlyPortfolio as NewReadOnlyPortfolio,
@@ -77,6 +78,7 @@ export default function WalletTabNavigator() {
 
   return (
     <WalletTabNavigatorScrollManager currentRouteName={currentRouteName}>
+      <PortfolioBalanceSync />
       <Box flexGrow={1} bg={backgroundColor}>
         {shouldHideTabs && <WalletTabBackgroundGradient />}
         <WalletTab.Navigator

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/__tests__/AnalyticsBalanceDisplay.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/__tests__/AnalyticsBalanceDisplay.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { AnalyticsBalanceDisplay } from "..";
+import { State } from "~/reducers/types";
+import { INITIAL_STATE as portfolioBalanceDisplayInitialState } from "~/reducers/portfolioBalanceDisplay";
+
+const withBalance =
+  (overrides: Partial<State["portfolioBalanceDisplay"]> = {}) =>
+  (state: State): State => ({
+    ...state,
+    portfolioBalanceDisplay: {
+      ...portfolioBalanceDisplayInitialState,
+      ...overrides,
+    },
+  });
+
+describe("AnalyticsBalanceDisplay", () => {
+  describe("when balance is not yet available", () => {
+    it("renders the skeleton placeholder", () => {
+      render(<AnalyticsBalanceDisplay />, {
+        overrideInitialState: withBalance({ isBalanceAvailable: false }),
+      });
+
+      expect(screen.getByTestId("analytics-balance-skeleton")).toBeVisible();
+      expect(screen.queryByTestId("analytics-balance-amount")).toBeNull();
+    });
+  });
+
+  describe("when balance is available", () => {
+    it("renders AmountDisplay with the slice balance", () => {
+      render(<AnalyticsBalanceDisplay />, {
+        overrideInitialState: withBalance({ isBalanceAvailable: true, displayedBalance: 5000 }),
+      });
+
+      expect(screen.getByTestId("analytics-balance-amount")).toBeVisible();
+      expect(screen.queryByTestId("analytics-balance-skeleton")).toBeNull();
+    });
+  });
+
+  describe("hoveredValue prop", () => {
+    it("renders AmountDisplay when hoveredValue is provided, even if slice balance is 0", () => {
+      render(<AnalyticsBalanceDisplay hoveredValue={9999} />, {
+        overrideInitialState: withBalance({ isBalanceAvailable: true, displayedBalance: 0 }),
+      });
+
+      expect(screen.getByTestId("analytics-balance-amount")).toBeVisible();
+    });
+
+    it("does not show skeleton when hoveredValue is provided and balance is available", () => {
+      render(<AnalyticsBalanceDisplay hoveredValue={42} />, {
+        overrideInitialState: withBalance({ isBalanceAvailable: true }),
+      });
+
+      expect(screen.queryByTestId("analytics-balance-skeleton")).toBeNull();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/index.tsx
@@ -16,14 +16,19 @@ type Props = {
  * value is shown instead of the portfolio balance, and the loading indicator is
  * suppressed because a historical value is already resolved.
  */
-export function AnalyticsBalanceDisplay({ hoveredValue }: Props) {
-  const { value, formatter, discreet, isHovering, isLoading, isBalanceAvailable, shouldDisplayBalanceRefreshRework } =
-    useAnalyticsBalanceDisplayViewModel({ hoveredValue });
+export function AnalyticsBalanceDisplay({ hoveredValue }: Readonly<Props>) {
+  const {
+    value,
+    formatter,
+    discreet,
+    isHovering,
+    isLoading,
+    isBalanceAvailable,
+    shouldDisplayBalanceRefreshRework,
+  } = useAnalyticsBalanceDisplayViewModel({ hoveredValue });
 
   if (!isBalanceAvailable) {
-    return (
-      <Skeleton testID="analytics-balance-skeleton" lx={{ height: "s48", width: "s256" }} />
-    );
+    return <Skeleton testID="analytics-balance-skeleton" lx={{ height: "s48", width: "s256" }} />;
   }
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/index.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { AmountDisplay, Skeleton } from "@ledgerhq/lumen-ui-rnative";
+import { useAnalyticsBalanceDisplayViewModel } from "./useAnalyticsBalanceDisplayViewModel";
+
+type Props = {
+  hoveredValue?: number | null;
+};
+
+/**
+ * Balance display for the Analytics screen.
+ *
+ * Reads the authoritative display state from the portfolioBalanceDisplay Redux slice
+ * (written by the Portfolio ViewModel) so both screens stay in sync during navigation.
+ *
+ * When hoveredValue is provided (user scrubbing the graph) the hovered data-point
+ * value is shown instead of the portfolio balance, and the loading indicator is
+ * suppressed because a historical value is already resolved.
+ */
+export function AnalyticsBalanceDisplay({ hoveredValue }: Props) {
+  const { value, formatter, discreet, isHovering, isLoading, isBalanceAvailable, shouldDisplayBalanceRefreshRework } =
+    useAnalyticsBalanceDisplayViewModel({ hoveredValue });
+
+  if (!isBalanceAvailable) {
+    return (
+      <Skeleton testID="analytics-balance-skeleton" lx={{ height: "s48", width: "s256" }} />
+    );
+  }
+
+  return (
+    <AmountDisplay
+      value={value}
+      formatter={formatter}
+      hidden={discreet}
+      loading={!isHovering && shouldDisplayBalanceRefreshRework && isLoading}
+      testID="analytics-balance-amount"
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/useAnalyticsBalanceDisplayViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/useAnalyticsBalanceDisplayViewModel.ts
@@ -1,0 +1,55 @@
+import { useCallback } from "react";
+import { type FormattedValue } from "@ledgerhq/lumen-ui-rnative";
+import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
+import { BigNumber } from "bignumber.js";
+import { useSelector } from "~/context/hooks";
+import { useLocale } from "~/context/Locale";
+import { discreetModeSelector } from "~/reducers/settings";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { usePortfolioBalanceForDisplay } from "LLM/hooks/usePortfolioBalanceForDisplay";
+
+type Params = {
+  hoveredValue?: number | null;
+};
+
+export type AnalyticsBalanceDisplayViewModel = {
+  value: number;
+  formatter: (value: number) => FormattedValue;
+  discreet: boolean;
+  isHovering: boolean;
+  isLoading: boolean;
+  isBalanceAvailable: boolean;
+  shouldDisplayBalanceRefreshRework: boolean;
+};
+
+export function useAnalyticsBalanceDisplayViewModel({
+  hoveredValue,
+}: Params): AnalyticsBalanceDisplayViewModel {
+  const { locale } = useLocale();
+  const { displayedBalance, isLoading, isBalanceAvailable, unit } =
+    usePortfolioBalanceForDisplay();
+  const discreet = useSelector(discreetModeSelector);
+  const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
+
+  const formatter = useCallback(
+    (val: number): FormattedValue =>
+      formatCurrencyUnitFragment(unit, new BigNumber(val), {
+        locale,
+        showCode: true,
+      }),
+    [unit, locale],
+  );
+
+  const isHovering = hoveredValue != null;
+  const value = isHovering ? hoveredValue : displayedBalance;
+
+  return {
+    value,
+    formatter,
+    discreet,
+    isHovering,
+    isLoading,
+    isBalanceAvailable,
+    shouldDisplayBalanceRefreshRework,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/useAnalyticsBalanceDisplayViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/useAnalyticsBalanceDisplayViewModel.ts
@@ -26,8 +26,7 @@ export function useAnalyticsBalanceDisplayViewModel({
   hoveredValue,
 }: Params): AnalyticsBalanceDisplayViewModel {
   const { locale } = useLocale();
-  const { displayedBalance, isLoading, isBalanceAvailable, unit } =
-    usePortfolioBalanceForDisplay();
+  const { displayedBalance, isLoading, isBalanceAvailable, unit } = usePortfolioBalanceForDisplay();
   const discreet = useSelector(discreetModeSelector);
   const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
@@ -1,12 +1,11 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useBalanceSyncState } from "@ledgerhq/live-common/bridge/react/index";
-import { useSelector, useDispatch } from "~/context/hooks";
+import { useSelector } from "~/context/hooks";
 import { useToggleDiscreetMode } from "~/hooks/useToggleDiscreetMode";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { usePortfolioBalance } from "LLM/hooks/usePortfolioBalance";
 import { usePersistedPortfolioBalance } from "./usePersistedPortfolioBalance";
-import { setPortfolioBalanceDisplay } from "~/reducers/portfolioBalanceDisplay";
 import {
   PortfolioBalanceState,
   PortfolioBalanceSectionProps,
@@ -17,7 +16,6 @@ export const usePortfolioBalanceSectionViewModel = ({
   showAssets,
   isReadOnlyMode,
 }: PortfolioBalanceSectionProps): UsePortfolioBalanceSectionViewModelResult => {
-  const dispatch = useDispatch();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const { toggleDiscreetMode } = useToggleDiscreetMode();
   const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
@@ -47,16 +45,6 @@ export const usePortfolioBalanceSectionViewModel = ({
   });
 
   const effectiveIsLoading = syncPhase === "syncing";
-
-  useEffect(() => {
-    dispatch(
-      setPortfolioBalanceDisplay({
-        displayedBalance,
-        isLoading: effectiveIsLoading,
-        isBalanceAvailable: balanceAvailable,
-      }),
-    );
-  }, [displayedBalance, effectiveIsLoading, balanceAvailable, dispatch]);
 
   const state: PortfolioBalanceState = useMemo(() => {
     if (isReadOnlyMode) {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
@@ -1,11 +1,12 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { useBalanceSyncState } from "@ledgerhq/live-common/bridge/react/index";
-import { useSelector } from "~/context/hooks";
+import { useSelector, useDispatch } from "~/context/hooks";
 import { useToggleDiscreetMode } from "~/hooks/useToggleDiscreetMode";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { usePortfolioBalance } from "LLM/hooks/usePortfolioBalance";
 import { usePersistedPortfolioBalance } from "./usePersistedPortfolioBalance";
+import { setPortfolioBalanceDisplay } from "~/reducers/portfolioBalanceDisplay";
 import {
   PortfolioBalanceState,
   PortfolioBalanceSectionProps,
@@ -16,6 +17,7 @@ export const usePortfolioBalanceSectionViewModel = ({
   showAssets,
   isReadOnlyMode,
 }: PortfolioBalanceSectionProps): UsePortfolioBalanceSectionViewModelResult => {
+  const dispatch = useDispatch();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const { toggleDiscreetMode } = useToggleDiscreetMode();
   const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
@@ -45,6 +47,16 @@ export const usePortfolioBalanceSectionViewModel = ({
   });
 
   const effectiveIsLoading = syncPhase === "syncing";
+
+  useEffect(() => {
+    dispatch(
+      setPortfolioBalanceDisplay({
+        displayedBalance,
+        isLoading: effectiveIsLoading,
+        isBalanceAvailable: balanceAvailable,
+      }),
+    );
+  }, [displayedBalance, effectiveIsLoading, balanceAvailable, dispatch]);
 
   const state: PortfolioBalanceState = useMemo(() => {
     if (isReadOnlyMode) {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/__tests__/PortfolioBalanceSync.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/__tests__/PortfolioBalanceSync.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { render } from "@tests/test-renderer";
+import { PortfolioBalanceSync } from "..";
+import * as usePortfolioBalanceModule from "LLM/hooks/usePortfolioBalance";
+import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/index";
+import { State } from "~/reducers/types";
+import { INITIAL_STATE } from "~/reducers/portfolioBalanceDisplay";
+
+jest.mock("LLM/hooks/usePortfolioBalance");
+jest.mock("../../PortfolioBalanceSection/usePersistedPortfolioBalance", () => ({
+  usePersistedPortfolioBalance: (b: number) => b,
+}));
+
+const mockUsePortfolioBalance = jest.mocked(usePortfolioBalanceModule.usePortfolioBalance);
+
+const defaultPortfolio = {
+  balanceHistory: [{ date: new Date(), value: 5000 }],
+  countervalueChange: { percentage: 0, value: 0 },
+  balanceAvailable: true,
+  availableAccounts: [],
+  unavailableCurrencies: [],
+  accounts: [],
+  range: "day" as const,
+  histories: [],
+  countervalueReceiveSum: 0,
+  countervalueSendSum: 0,
+};
+
+function makeReturn(overrides: Partial<{ balanceAvailable: boolean; syncPhase: SyncPhase }> = {}) {
+  return {
+    portfolio: defaultPortfolio,
+    balanceAvailable: true,
+    syncPhase: "synced" as SyncPhase,
+    isBalanceLoading: false,
+    isColdStart: false,
+    isManualRefreshLoading: false,
+    allAccounts: [],
+    accountsWithError: [],
+    accountsImpactedByError: [],
+    errorCurrencyIds: [],
+    listOfErrorAccountNames: "",
+    areAllAccountsUpToDate: true,
+    hasAccounts: true,
+    handleSync: jest.fn(),
+    isBridgeSyncPending: false,
+    triggerRefresh: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("PortfolioBalanceSync", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePortfolioBalance.mockReturnValue(makeReturn());
+  });
+
+  it("renders nothing", () => {
+    const { toJSON } = render(<PortfolioBalanceSync />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it("populates the portfolioBalanceDisplay slice with balance and availability", () => {
+    const { store } = render(<PortfolioBalanceSync />);
+    const state = store.getState() as State;
+
+    expect(state.portfolioBalanceDisplay.displayedBalance).toBe(5000);
+    expect(state.portfolioBalanceDisplay.isBalanceAvailable).toBe(true);
+  });
+
+  it("sets isLoading true when syncPhase is syncing", () => {
+    mockUsePortfolioBalance.mockReturnValue(makeReturn({ syncPhase: "syncing" }));
+
+    const { store } = render(<PortfolioBalanceSync />);
+    const state = store.getState() as State;
+
+    expect(state.portfolioBalanceDisplay.isLoading).toBe(true);
+  });
+
+  it("sets isLoading false when syncPhase is synced", () => {
+    mockUsePortfolioBalance.mockReturnValue(makeReturn({ syncPhase: "synced" }));
+
+    const { store } = render(<PortfolioBalanceSync />);
+    const state = store.getState() as State;
+
+    expect(state.portfolioBalanceDisplay.isLoading).toBe(false);
+  });
+
+  it("sets isBalanceAvailable false on cold start with no cached balance", () => {
+    // No cached MMKV balance (mock returns 0) and portfolio not yet available
+    mockUsePortfolioBalance.mockReturnValue({
+      ...makeReturn({ balanceAvailable: false, syncPhase: "syncing" }),
+      portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 0 }] },
+    });
+
+    const { store } = render(<PortfolioBalanceSync />, {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        portfolioBalanceDisplay: INITIAL_STATE,
+      }),
+    });
+    const storeState = store.getState() as State;
+
+    // effectiveLatestBalance = 0 (mocked pass-through) → effectiveRawBalanceAvailable = false
+    // useBalanceSyncState gates availability until sync settles
+    expect(storeState.portfolioBalanceDisplay.isBalanceAvailable).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/index.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { useBalanceSyncState } from "@ledgerhq/live-common/bridge/react/index";
+import { useSelector, useDispatch } from "~/context/hooks";
+import { counterValueCurrencySelector } from "~/reducers/settings";
+import { setPortfolioBalanceDisplay } from "~/reducers/portfolioBalanceDisplay";
+import { usePortfolioBalance } from "LLM/hooks/usePortfolioBalance";
+import { usePersistedPortfolioBalance } from "../PortfolioBalanceSection/usePersistedPortfolioBalance";
+
+/**
+ * Renderless component — mounts once in WalletTabNavigator and owns the
+ * portfolio balance display state for the entire wallet flow.
+ *
+ * It runs the full computation chain (bridge sync → MMKV persistence →
+ * freeze-on-sync) and writes the result to the portfolioBalanceDisplay Redux
+ * slice. Both the Portfolio and Analytics screens consume that slice via
+ * usePortfolioBalanceForDisplay(), so they always show the same value
+ * regardless of which screen mounted first.
+ *
+ * Moving the computation here (rather than inside the Portfolio ViewModel)
+ * means Analytics is never blocked by whether Portfolio has rendered yet —
+ * including when arriving via a deep link directly to Analytics.
+ */
+export function PortfolioBalanceSync(): null {
+  const dispatch = useDispatch();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
+
+  const { portfolio, balanceAvailable: rawBalanceAvailable, syncPhase } = usePortfolioBalance();
+
+  const lastItem = portfolio.balanceHistory[portfolio.balanceHistory.length - 1];
+  const latestBalance = lastItem?.value ?? 0;
+
+  const effectiveLatestBalance = usePersistedPortfolioBalance(
+    latestBalance,
+    syncPhase,
+    counterValueCurrency.ticker,
+  );
+
+  const effectiveRawBalanceAvailable = rawBalanceAvailable || effectiveLatestBalance > 0;
+
+  const { balanceAvailable, displayedBalance } = useBalanceSyncState({
+    rawBalanceAvailable: effectiveRawBalanceAvailable,
+    syncPhase,
+    latestBalance: effectiveLatestBalance,
+    shouldFreezeOnSync: shouldDisplayBalanceRefreshRework,
+  });
+
+  const isLoading = syncPhase === "syncing";
+
+  useEffect(() => {
+    dispatch(
+      setPortfolioBalanceDisplay({
+        displayedBalance,
+        isLoading,
+        isBalanceAvailable: balanceAvailable,
+      }),
+    );
+  }, [displayedBalance, isLoading, balanceAvailable, dispatch]);
+
+  return null;
+}

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/usePortfolioBalanceForDisplay.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/usePortfolioBalanceForDisplay.test.ts
@@ -1,0 +1,51 @@
+import { renderHook } from "@tests/test-renderer";
+import { usePortfolioBalanceForDisplay } from "LLM/hooks/usePortfolioBalanceForDisplay";
+import { State } from "~/reducers/types";
+import { INITIAL_STATE as portfolioBalanceDisplayInitialState } from "~/reducers/portfolioBalanceDisplay";
+
+describe("usePortfolioBalanceForDisplay", () => {
+  it("returns initial state values when slice is at default", () => {
+    const { result } = renderHook(() => usePortfolioBalanceForDisplay());
+
+    expect(result.current.displayedBalance).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isBalanceAvailable).toBe(false);
+  });
+
+  it("reflects displayedBalance from the slice", () => {
+    const { result } = renderHook(() => usePortfolioBalanceForDisplay(), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        portfolioBalanceDisplay: {
+          ...portfolioBalanceDisplayInitialState,
+          displayedBalance: 98765,
+          isBalanceAvailable: true,
+        },
+      }),
+    });
+
+    expect(result.current.displayedBalance).toBe(98765);
+    expect(result.current.isBalanceAvailable).toBe(true);
+  });
+
+  it("reflects isLoading from the slice", () => {
+    const { result } = renderHook(() => usePortfolioBalanceForDisplay(), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        portfolioBalanceDisplay: {
+          ...portfolioBalanceDisplayInitialState,
+          isLoading: true,
+        },
+      }),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns a unit derived from the counter-value currency", () => {
+    const { result } = renderHook(() => usePortfolioBalanceForDisplay());
+
+    expect(result.current.unit).toBeDefined();
+    expect(result.current.unit.code).toBeDefined();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalanceForDisplay.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalanceForDisplay.ts
@@ -1,0 +1,25 @@
+import { useSelector } from "~/context/hooks";
+import { counterValueCurrencySelector } from "~/reducers/settings";
+import { selectPortfolioBalanceDisplay } from "~/reducers/portfolioBalanceDisplay";
+
+/**
+ * Read-only hook that exposes the shared portfolio balance display state.
+ *
+ * Portfolio ViewModel is the single writer (via setPortfolioBalanceDisplay).
+ * Both the portfolio and analytics screens consume this hook so they always
+ * show the same balance value and loading state, regardless of when each
+ * screen mounts relative to the sync lifecycle.
+ */
+export function usePortfolioBalanceForDisplay() {
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const { displayedBalance, isLoading, isBalanceAvailable } = useSelector(
+    selectPortfolioBalanceDisplay,
+  );
+
+  return {
+    displayedBalance,
+    isLoading,
+    isBalanceAvailable,
+    unit: counterValueCurrency.units[0],
+  };
+}

--- a/apps/ledger-live-mobile/src/reducers/__tests__/portfolioBalanceDisplay.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/portfolioBalanceDisplay.test.ts
@@ -1,0 +1,59 @@
+import reducer, {
+  INITIAL_STATE,
+  setPortfolioBalanceDisplay,
+  selectPortfolioBalanceDisplay,
+} from "../portfolioBalanceDisplay";
+import type { State } from "../types";
+
+describe("portfolioBalanceDisplay reducer", () => {
+  it("has correct initial state", () => {
+    expect(reducer(undefined, { type: "@@INIT" })).toEqual(INITIAL_STATE);
+  });
+
+  it("setPortfolioBalanceDisplay updates all fields", () => {
+    const payload = { displayedBalance: 42000, isLoading: true, isBalanceAvailable: true };
+    const state = reducer(INITIAL_STATE, setPortfolioBalanceDisplay(payload));
+
+    expect(state).toEqual(payload);
+  });
+
+  it("setPortfolioBalanceDisplay with isLoading false and balance unavailable", () => {
+    const payload = { displayedBalance: 0, isLoading: false, isBalanceAvailable: false };
+    const state = reducer(INITIAL_STATE, setPortfolioBalanceDisplay(payload));
+
+    expect(state).toEqual(payload);
+  });
+
+  it("does not mutate initial state", () => {
+    const payload = { displayedBalance: 999, isLoading: false, isBalanceAvailable: true };
+    reducer(INITIAL_STATE, setPortfolioBalanceDisplay(payload));
+
+    expect(INITIAL_STATE.displayedBalance).toBe(0);
+  });
+});
+
+describe("selectPortfolioBalanceDisplay", () => {
+  it("returns the portfolioBalanceDisplay slice", () => {
+    const mockState = {
+      portfolioBalanceDisplay: {
+        displayedBalance: 12345,
+        isLoading: false,
+        isBalanceAvailable: true,
+      },
+    } as unknown as State;
+
+    expect(selectPortfolioBalanceDisplay(mockState)).toEqual({
+      displayedBalance: 12345,
+      isLoading: false,
+      isBalanceAvailable: true,
+    });
+  });
+
+  it("returns initial state when slice is at default", () => {
+    const mockState = {
+      portfolioBalanceDisplay: INITIAL_STATE,
+    } as unknown as State;
+
+    expect(selectPortfolioBalanceDisplay(mockState)).toEqual(INITIAL_STATE);
+  });
+});

--- a/apps/ledger-live-mobile/src/reducers/index.ts
+++ b/apps/ledger-live-mobile/src/reducers/index.ts
@@ -29,6 +29,7 @@ import wallet from "./wallet";
 import walletconnect from "./walletconnect";
 import walletSync from "./walletSync";
 import portfolioRefresh from "./portfolioRefresh";
+import portfolioBalanceDisplay from "./portfolioBalanceDisplay";
 import { identitiesSlice } from "@ledgerhq/client-ids/store";
 import type { UnknownAction } from "@reduxjs/toolkit";
 
@@ -64,6 +65,7 @@ const appReducer = combineReducers({
   walletconnect,
   walletSync,
   portfolioRefresh,
+  portfolioBalanceDisplay,
   ...llmRTKApiReducers,
 });
 

--- a/apps/ledger-live-mobile/src/reducers/portfolioBalanceDisplay.ts
+++ b/apps/ledger-live-mobile/src/reducers/portfolioBalanceDisplay.ts
@@ -1,0 +1,33 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { State } from "~/reducers/types";
+
+export interface PortfolioBalanceDisplayState {
+  displayedBalance: number;
+  isLoading: boolean;
+  isBalanceAvailable: boolean;
+}
+
+export const INITIAL_STATE: PortfolioBalanceDisplayState = {
+  displayedBalance: 0,
+  isLoading: false,
+  isBalanceAvailable: false,
+};
+
+const portfolioBalanceDisplaySlice = createSlice({
+  name: "portfolioBalanceDisplay",
+  initialState: INITIAL_STATE,
+  reducers: {
+    setPortfolioBalanceDisplay: (state, action: PayloadAction<PortfolioBalanceDisplayState>) => {
+      state.displayedBalance = action.payload.displayedBalance;
+      state.isLoading = action.payload.isLoading;
+      state.isBalanceAvailable = action.payload.isBalanceAvailable;
+    },
+  },
+});
+
+export const { setPortfolioBalanceDisplay } = portfolioBalanceDisplaySlice.actions;
+
+export const selectPortfolioBalanceDisplay = (state: State): PortfolioBalanceDisplayState =>
+  state.portfolioBalanceDisplay;
+
+export default portfolioBalanceDisplaySlice.reducer;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -1,11 +1,4 @@
-import type {
-  Account,
-  DeviceInfo,
-  DeviceModelInfo,
-  Feature,
-  FeatureId,
-  PortfolioRange,
-} from "@ledgerhq/types-live";
+import type { Account, DeviceInfo, DeviceModelInfo, PortfolioRange } from "@ledgerhq/types-live";
 import type { FeatureFlagsState } from "@shared/feature-flags";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import type { DeviceModelId } from "@ledgerhq/devices";

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -40,6 +40,7 @@ import { IdentitiesState } from "@ledgerhq/client-ids/store";
 import type { FirebaseMessagingTypes } from "@react-native-firebase/messaging";
 import { RebornBuyDeviceDrawerState } from "./rebornBuyDeviceDrawer";
 import type { PortfolioRefreshState } from "./portfolioRefresh";
+import type { PortfolioBalanceDisplayState } from "./portfolioBalanceDisplay";
 
 // === ACCOUNT STATE ===
 
@@ -427,4 +428,5 @@ export type State = LLMRTKApiState & {
   walletconnect: WalletConnectState;
   walletSync: WalletSyncState;
   portfolioRefresh: PortfolioRefreshState;
+  portfolioBalanceDisplay: PortfolioBalanceDisplayState;
 };

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -9,6 +9,7 @@ export default class PortfolioPage {
   baseAssetItem = "assetItem-";
   zeroBalance = "$0.00";
   graphCardBalanceId = "graphCard-balance";
+  analyticsBalanceAmountId = "analytics-balance-amount";
   graphCardChart = "graphCard-chart";
   assetBalanceId = "asset-balance";
   readOnlyItemsId = "PortfolioReadOnlyItems";
@@ -108,9 +109,9 @@ export default class PortfolioPage {
     jestExpect(text).toContain(counterValue);
   }
 
-  @Step("Expect chart to be visible")
+  @Step("Expect balance to be visible")
   async expectBalanceToBeVisible() {
-    await detoxExpect(getElementById(this.graphCardBalanceId)).toBeVisible();
+    await detoxExpect(getElementById(this.analyticsBalanceAmountId)).toBeVisible();
   }
 
   @Step("Expect total balance value")


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - New `portfolioBalanceDisplay` Redux slice (sole writer: `PortfolioBalanceSync`, readers: Portfolio ViewModel + Analytics)
      - New `PortfolioBalanceSync` renderless component mounted once in `WalletTabNavigator` — owns the full computation chain regardless of which screen is active
      - New `usePortfolioBalanceForDisplay` hook consumed by Analytics (pure Redux reader)
      - Portfolio ViewModel: removed dispatch `useEffect` — now a pure reader too, no longer a writer
      - Analytics `GraphCard` headline balance replaced by `AnalyticsBalanceDisplay` when `shouldDisplayBalanceRefreshRework` is enabled; legacy `CurrencyUnitValue` path untouched
      - Navigation Portfolio → Analytics: balance value and loading state match immediately, no recompute mismatch
      - Deep-link to Analytics before Portfolio mounts: balance state is already populated because `PortfolioBalanceSync` lives in `WalletTabNavigator`, not inside the Portfolio screen
      - Graph scrub / hover: `hoveredValue` prop overrides slice balance; loading spinner suppressed while hovering
      - Discreet mode handled via Redux settings selector inside `AnalyticsBalanceDisplay`
      - e2e wallet40 portfolio spec: `expectBalanceToBeVisible` updated to use `analytics-balance-amount` testID

### 📝 Description

#### Problem

The Portfolio and Analytics screens both display the total portfolio balance, but they were computing it independently:

- **Portfolio** uses `useBalanceSyncState` with `shouldFreezeOnSync=true` + MMKV persistence (`usePersistedPortfolioBalance`) to produce a stable, cached `displayedBalance`.
- **Analytics** is pushed on top of Portfolio (not a tab sibling), so it remounts fresh and previously derived its own balance from `usePortfolioAllAccounts()` — with no freezing and no MMKV fallback.

During navigation the two could show different values: one frozen, one live; one with a cached cold-start value, one starting from zero.

A first attempt wrote to the Redux slice from `usePortfolioBalanceSectionViewModel` via a `useEffect`. That worked for the Portfolio → Analytics path, but left a gap: if the user deep-linked directly to Analytics (before Portfolio had ever mounted), the slice would be empty and Analytics would show a skeleton indefinitely.

#### Solution

**`PortfolioBalanceSync`** — a renderless component (`return null`) mounted once inside `WalletTabNavigator` — is the **sole writer** to the `portfolioBalanceDisplay` Redux slice.

```
WalletTabNavigator
  ├── <PortfolioBalanceSync />   ← always alive, sole writer
  └── <WalletTab.Navigator>
        ├── Portfolio            ← pure reader (usePortfolioBalanceForDisplay)
        └── [Market tab]
            …
Analytics (pushed on top via BaseNavigator)
  └── <AnalyticsBalanceDisplay> ← pure reader (usePortfolioBalanceForDisplay)
```

Because `WalletTabNavigator` is always mounted while the wallet is open, `PortfolioBalanceSync` runs the full computation chain (bridge sync → MMKV persistence → freeze-on-sync) continuously — independent of which screen is on screen. Both Portfolio and Analytics consume the exact same already-computed values from the slice.

```
portfolioBalanceDisplay slice
  { displayedBalance, isLoading, isBalanceAvailable }
```

- **Single writer:** `PortfolioBalanceSync` dispatches `setPortfolioBalanceDisplay` whenever derived state changes.
- **Read-only consumers:** `usePortfolioBalanceForDisplay` reads from the slice — zero recomputation, zero mismatch window.
- **Portfolio ViewModel** no longer writes; it keeps its own local computation for the analytics pill and its own loading/display logic, but no longer dispatches.

#### Why a Redux slice and not a context?

A context placed at the navigator level would work structurally, but Redux is the established pattern in this codebase (see `portfolioRefresh` slice). More importantly, Redux persists across navigation transitions without being tied to component lifecycle — a context provider can re-initialise if the tree remounts, whereas the slice value is always stable.

#### Why computation can't live in the reducer itself?

`useBalanceSyncState` uses internal ref-based state to track sync phase transitions (freeze on sync start, release on settle). `usePersistedPortfolioBalance` reads/writes MMKV. Both are inherently stateful React hooks — they cannot be pure reducer functions. The renderless component pattern is the right layer: it has access to hooks, lives at the correct point in the component tree, and writes a serialisable snapshot to Redux.

#### Performance

`PortfolioBalanceSync` calls the same hooks that `usePortfolioBalanceSectionViewModel` was already calling (`usePortfolioBalance`, `useBalanceSyncState`, `usePersistedPortfolioBalance`). The Portfolio ViewModel still calls them too for its own local display needs. There is no extra network/bridge work — both hook instances share the same underlying RxJS subscriptions.

The Redux store is updated **infrequently** — only when one of the three derived values actually changes. The `useEffect` dependency array (`[displayedBalance, isLoading, isBalanceAvailable]`) means a dispatch only fires on sync lifecycle transitions, not on every render:

| Event | Dispatches |
|---|---|
| Cold start | ~2 (idle → syncing → synced) |
| Background / manual sync | 2 per cycle (start + settle) |
| Navigation between screens | 0 (values unchanged) |

`displayedBalance` is frozen during sync by `useBalanceSyncState` (internal ref), so it only changes once sync settles — not on every bridge data emission. `isLoading` and `isBalanceAvailable` are similarly coarse-grained booleans that flip at most twice per sync cycle. In practice the store receives a handful of dispatches over the lifetime of a session.

#### Analytics balance component

`AnalyticsBalanceDisplay` is structured with MVVM:

```
Analytics/components/AnalyticsBalanceDisplay/
  index.tsx                               ← view only (Skeleton or AmountDisplay)
  useAnalyticsBalanceDisplayViewModel.ts  ← all hook logic
  __tests__/AnalyticsBalanceDisplay.test.tsx
```

It accepts a `hoveredValue?: number | null` prop: when the user scrubs the graph, `GraphCard` passes the hovered data-point value, and the component displays it instead of the slice balance (loading spinner suppressed — a historical value is already resolved).

| State | Behaviour |
|---|---|
| `isBalanceAvailable: false` | Lumen `Skeleton` (same dimensions as Portfolio placeholder) |
| Idle | Lumen `AmountDisplay` from slice, loading spinner if applicable |
| Hovering graph | `AmountDisplay` with hovered value, no spinner |

#### Files changed

| File | Change |
|---|---|
| `reducers/portfolioBalanceDisplay.ts` | New slice |
| `reducers/index.ts` + `reducers/types.ts` | Wire slice into root reducer |
| `mvvm/hooks/usePortfolioBalanceForDisplay.ts` | New read-only hook |
| `mvvm/features/Portfolio/components/PortfolioBalanceSync/index.tsx` | New renderless component (sole writer) |
| `mvvm/features/Portfolio/components/PortfolioBalanceSync/__tests__/` | Tests for PortfolioBalanceSync |
| `PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts` | Removed dispatch `useEffect` — now pure reader |
| `components/RootNavigator/WalletTabNavigator.tsx` | Mount `<PortfolioBalanceSync />` |
| `Analytics/components/AnalyticsBalanceDisplay/` | New MVVM component (view + hook + tests) |
| `components/GraphCard.tsx` | Conditional render behind feature flag |
| `e2e/mobile/page/wallet/portfolio.page.ts` | Add `analyticsBalanceAmountId`, update `expectBalanceToBeVisible` |


E2E test: https://github.com/LedgerHQ/ledger-live/actions/runs/24406323017

https://github.com/user-attachments/assets/c42a6ca5-c2c8-40aa-b07f-a592b3937977



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29124](https://ledgerhq.atlassian.net/browse/LIVE-29124)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29124]: https://ledgerhq.atlassian.net/browse/LIVE-29124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ