### PR TITLE
fix(wallet-cli): replace sharedConfig with a minimal wallet-cli-specific LiveConfig

### DIFF
--- a/apps/wallet-cli/src/config.ts
+++ b/apps/wallet-cli/src/config.ts
@@ -1,0 +1,24 @@
+import type { ConfigSchema } from "@ledgerhq/live-config/LiveConfig";
+import { appConfig } from "@ledgerhq/live-common/apps/config";
+import { bitcoinConfig } from "@ledgerhq/live-common/families/bitcoin/config";
+import { evmConfig } from "@ledgerhq/live-common/families/evm/config";
+import { solanaConfig } from "@ledgerhq/live-common/families/solana/config";
+
+const countervaluesConfig: ConfigSchema = {
+  config_countervalues_refreshRate: {
+    type: "number",
+    default: 60 * 1000,
+  },
+  config_countervalues_marketCapBatchingAfterRank: {
+    type: "number",
+    default: 20,
+  },
+};
+
+export const walletCliConfig: ConfigSchema = {
+  ...countervaluesConfig,
+  ...appConfig,
+  ...bitcoinConfig,
+  ...evmConfig,
+  ...solanaConfig,
+};

--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -1,6 +1,6 @@
 import { setupCalClientStore } from "@ledgerhq/cryptoassets/cal-client";
 import { setSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
-import { liveConfig } from "@ledgerhq/live-common/config/sharedConfig";
+import { walletCliConfig } from "./config";
 import { registerCoinModules } from "@ledgerhq/live-common/coin-modules/registry";
 import type { CoinModuleLoader } from "@ledgerhq/live-common/coin-modules/types";
 import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
@@ -57,12 +57,12 @@ registerCoinModules(walletCliLoaders);
 setSupportedCurrencies(["bitcoin", "ethereum", "solana"]);
 // Set config on the ESM singleton (used by alpacaized families like EVM whose
 // bridge code is reached through ESM imports).
-LiveConfig.setConfig(liveConfig);
+LiveConfig.setConfig(walletCliConfig);
 // Also set on the CJS singleton — Bun's bundler resolves ESM imports to lib-es/
 // and require() to lib/, creating separate LiveConfig.instance singletons.
 // Non-alpacaized families (solana, bitcoin) load their bridge via require() in
 // the lazy loaders above, so they read from the CJS instance.
-(require("@ledgerhq/live-config/LiveConfig") as typeof import("@ledgerhq/live-config/LiveConfig")).LiveConfig.setConfig(liveConfig);
+(require("@ledgerhq/live-config/LiveConfig") as typeof import("@ledgerhq/live-config/LiveConfig")).LiveConfig.setConfig(walletCliConfig);
 // TODO: wallet-cli should own its Redux store setup (createRtkCryptoAssetsStore + RTK middleware)
 // instead of relying on setupCalClientStore from @ledgerhq/cryptoassets/cal-client (test-helpers).
 setupCalClientStore();


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli

### 📝 Description

`sharedConfig` imports coin configs for all ~25 families, pulling their full dependency trees into the bundle. Since wallet-cli only supports bitcoin, evm, and solana, introduce `src/config.ts` that composes only the required configs (countervalues, appConfig, bitcoin, evm, solana) and use it instead.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
