### PR TITLE
fix(wallet-cli): resolve USBDevice TypeScript errors in node-webusb transport

### DIFF
--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -65,6 +65,7 @@
     "@oxlint/binding-win32-x64-msvc": "1.51.0",
     "@types/debug": "4.1.12",
     "@types/node": "catalog:",
+    "@types/w3c-web-usb": "^1.0.10",
     "bun-types": "1.3.12",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.ts
@@ -12,6 +12,7 @@ import type {
   SendApduResult,
 } from "@ledgerhq/device-management-kit";
 import { Just, Left, Maybe, Nothing, Right } from "purify-ts";
+import { WebUSBDevice } from "usb";
 import {
   FRAME_SIZE,
   LEDGER_WEBUSB_CONFIGURATION_VALUE,
@@ -19,7 +20,7 @@ import {
 } from "./node-webusb-constants";
 
 export type NodeWebUsbApduSenderDependencies = {
-  device: USBDevice;
+  device: WebUSBDevice;
   interfaceNumber: number;
 };
 
@@ -30,7 +31,7 @@ export type NodeWebUsbApduSenderConstructorArgs = {
   loggerFactory: (tag: string) => LoggerPublisherService;
 };
 
-async function gracefullyResetDevice(device: USBDevice): Promise<void> {
+async function gracefullyResetDevice(device: WebUSBDevice): Promise<void> {
   try {
     await device.reset();
   } catch {
@@ -174,7 +175,7 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
         const raw = frame.getRawData();
         const out = new Uint8Array(raw.byteLength);
         out.set(raw);
-        const result = await device.transferOut(LEDGER_WEBUSB_ENDPOINT_NUMBER, out);
+        const result = await device.transferOut(LEDGER_WEBUSB_ENDPOINT_NUMBER, out.buffer);
         if (result.status !== "ok") {
           this.resolvePendingApdu(
             Left(new OpeningConnectionError(`WebUSB transferOut status: ${result.status}`)),
@@ -211,7 +212,7 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
    * so that the abort timeout can resolve the caller's promise even when
    * `transferIn` is blocked.
    */
-  private async receiveResponseFrames(device: USBDevice, generation: number): Promise<void> {
+  private async receiveResponseFrames(device: WebUSBDevice, generation: number): Promise<void> {
     try {
       while (this.sendApduPromiseResolver.isJust() && this.readLoopGeneration === generation) {
         const r = await device.transferIn(LEDGER_WEBUSB_ENDPOINT_NUMBER, FRAME_SIZE);

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
@@ -38,11 +38,11 @@ import { RECONNECT_DEVICE_TIMEOUT_MS } from "./node-webusb-constants";
 export const nodeWebUsbIdentifier: TransportIdentifier = "NODE-WEBUSB";
 
 type WebUsbDiscoveredInternal = TransportDiscoveredDevice & {
-  webUsbDevice: USBDevice;
+  webUsbDevice: WebUSBDevice;
   interfaceNumber: number;
 };
 
-function getVendorInterfaceNumber(device: USBDevice): number | null {
+function getVendorInterfaceNumber(device: WebUSBDevice): number | null {
   const cfg = device.configurations[0];
   if (!cfg) {
     return null;
@@ -55,10 +55,10 @@ function getVendorInterfaceNumber(device: USBDevice): number | null {
   return null;
 }
 
-type ScannedWebUsbDevice = { device: USBDevice; interfaceNumber: number };
+type ScannedWebUsbDevice = { device: WebUSBDevice; interfaceNumber: number };
 
 /** Uses serialNumber when available so two same-model devices are distinguishable. */
-function deviceIdentityKey(device: USBDevice): string {
+function deviceIdentityKey(device: WebUSBDevice): string {
   const serial = device.serialNumber;
   return serial
     ? `${device.vendorId}:${device.productId}:${serial}`
@@ -88,7 +88,7 @@ export class NodeWebUsbTransport implements Transport {
     [],
   );
   private readonly _deviceConnectionsByWebUsbDevice = new Map<
-    USBDevice,
+    WebUSBDevice,
     DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>
   >();
   private readonly _deviceConnectionsPendingReconnection = new Set<
@@ -132,7 +132,7 @@ export class NodeWebUsbTransport implements Transport {
     return true;
   }
 
-  private getDeviceModel(device: USBDevice): Maybe<TransportDeviceModel> {
+  private getDeviceModel(device: WebUSBDevice): Maybe<TransportDeviceModel> {
     const { productId } = device;
     const model = this._deviceModelDataSource
       .getAllDeviceModels()
@@ -140,7 +140,7 @@ export class NodeWebUsbTransport implements Transport {
     return model ? Maybe.of(model) : Maybe.zero();
   }
 
-  private getUsbProductIdForMatch(device: USBDevice): number {
+  private getUsbProductIdForMatch(device: WebUSBDevice): number {
     return this.getDeviceModel(device).caseOf({
       Just: m => m.usbProductId,
       Nothing: () => device.productId >> 8,
@@ -163,7 +163,10 @@ export class NodeWebUsbTransport implements Transport {
     return dedupeLedgerWebUsbDevices(collected);
   }
 
-  private mapWebUsbToDiscovered(web: USBDevice, interfaceNumber: number): WebUsbDiscoveredInternal {
+  private mapWebUsbToDiscovered(
+    web: WebUSBDevice,
+    interfaceNumber: number,
+  ): WebUsbDiscoveredInternal {
     const key = deviceIdentityKey(web);
     const existing = this._transportDiscoveredDevices
       .getValue()
@@ -417,7 +420,7 @@ export class NodeWebUsbTransport implements Transport {
 
   async handleDeviceReconnection(
     machine: DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
-    web: USBDevice,
+    web: WebUSBDevice,
     interfaceNumber: number,
   ): Promise<void> {
     try {

--- a/apps/wallet-cli/tsconfig.json
+++ b/apps/wallet-cli/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": true,
     "rootDir": ".",
-    "types": ["node", "bun-types"],
+    "types": ["node", "bun-types", "w3c-web-usb"],
     "customConditions": ["import", "types", "default"],
     "moduleResolution": "Bundler",
     "module": "ESNext"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2342,6 +2342,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
+      '@types/w3c-web-usb':
+        specifier: ^1.0.10
+        version: 1.0.10
       bun-types:
         specifier: 1.3.12
         version: 1.3.12
@@ -39474,7 +39477,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
@@ -39532,19 +39535,19 @@ snapshots:
 
   '@babel/helper-function-name@7.23.0':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-hoist-variables@7.22.5':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -39558,14 +39561,14 @@ snapshots:
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.27.1(supports-color@5.5.0)':
     dependencies:
       '@babel/traverse': 7.28.5(supports-color@5.5.0)
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -39580,7 +39583,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
@@ -39605,7 +39608,7 @@ snapshots:
   '@babel/helper-simple-access@7.25.9':
     dependencies:
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -39618,7 +39621,7 @@ snapshots:
 
   '@babel/helper-split-export-declaration@7.22.6':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -39630,9 +39633,9 @@ snapshots:
 
   '@babel/helper-wrap-function@7.27.1':
     dependencies:
-      '@babel/template': 7.27.2
+      '@babel/template': 7.28.6
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -39650,7 +39653,7 @@ snapshots:
 
   '@babel/parser@7.24.1':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.27.0':
     dependencies:
@@ -40668,14 +40671,14 @@ snapshots:
 
   '@babel/traverse@7.24.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@babel/generator': 7.28.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
@@ -47665,7 +47668,7 @@ snapshots:
       '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/template': 7.27.2
+      '@babel/template': 7.28.6
       '@react-native/babel-plugin-codegen': 0.77.3(@babel/preset-env@7.28.5(@babel/core@7.28.5))
       babel-plugin-syntax-hermes-parser: 0.25.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.28.5)
@@ -47766,7 +47769,7 @@ snapshots:
       '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/template': 7.27.2
+      '@babel/template': 7.28.6
       '@react-native/babel-plugin-codegen': 0.79.6(@babel/core@7.28.5)
       babel-plugin-syntax-hermes-parser: 0.25.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.28.5)
@@ -47826,7 +47829,7 @@ snapshots:
 
   '@react-native/codegen@0.77.3(@babel/preset-env@7.28.5(@babel/core@7.28.5))':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
       glob: 7.2.3
       hermes-parser: 0.25.1
@@ -47849,7 +47852,7 @@ snapshots:
   '@react-native/codegen@0.79.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       glob: 7.2.3
       hermes-parser: 0.25.1
       invariant: 2.2.4
@@ -52193,16 +52196,16 @@ snapshots:
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/bchaddrjs@0.4.3': {}
 
@@ -53590,7 +53593,7 @@ snapshots:
 
   '@vue/compiler-core@3.4.21':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@vue/shared': 3.4.21
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -53605,7 +53608,7 @@ snapshots:
 
   '@vue/compiler-sfc@2.7.16':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       postcss: 8.5.6
       source-map: 0.6.1
     optionalDependencies:
@@ -53613,7 +53616,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.4.21':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-ssr': 3.4.21
@@ -55052,8 +55055,8 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
@@ -59708,7 +59711,7 @@ snapshots:
 
   fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@6.0.2)(vue-template-compiler@2.7.16)(webpack@5.94.0(@swc/core@1.15.11)):
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@types/json-schema': 7.0.15
       chalk: 4.1.2
       chokidar: 3.6.0
@@ -61358,7 +61361,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -62012,7 +62015,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -62479,7 +62482,7 @@ snapshots:
   jscodeshift@17.3.0(@babel/preset-env@7.28.5(@babel/core@7.28.5)):
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.28.5)
@@ -62893,7 +62896,7 @@ snapshots:
 
   konan@2.1.1:
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -64114,7 +64117,7 @@ snapshots:
   metro-source-map@0.81.5:
     dependencies:
       '@babel/traverse': 7.27.0
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.28.5'
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.0'
       '@babel/types': 7.27.0
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
@@ -64129,7 +64132,7 @@ snapshots:
   metro-source-map@0.82.5:
     dependencies:
       '@babel/traverse': 7.28.5
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.28.5'
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.0'
       '@babel/types': 7.28.5
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
@@ -64178,7 +64181,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
-      '@babel/template': 7.27.2
+      '@babel/template': 7.28.6
       '@babel/traverse': 7.28.5
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
@@ -64220,8 +64223,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
       metro: 0.82.5
       metro-babel-transformer: 0.82.5
@@ -64285,13 +64288,13 @@ snapshots:
 
   metro@0.82.5:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       accepts: 1.3.8
       chalk: 4.1.2
       ci-info: 2.0.0
@@ -70485,7 +70488,7 @@ snapshots:
 
   ts-checker-rspack-plugin@1.2.6(@rspack/core@1.7.3)(typescript@6.0.2):
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
       is-glob: 4.0.3
@@ -70498,7 +70501,7 @@ snapshots:
 
   ts-checker-rspack-plugin@1.2.6(typescript@6.0.2):
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
       is-glob: 4.0.3


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:**
  - wallet-cli

### 📝 Description

The tsconfig restricted types to ["node", "bun-types"], so the global USBDevice type from @types/w3c-web-usb was unavailable.

- Add @types/w3c-web-usb as a devDependency and include it in tsconfig types so USBConfiguration, USBInterface, USBAlternateInterface and the full WebUSB global hierarchy resolve correctly
- Replace all USBDevice type annotations with WebUSBDevice (the concrete class from the usb package that implements USBDevice), which is the correct type for a Node.js context
- Fix transferOut call to pass out.buffer (ArrayBuffer) instead of a Uint8Array, matching the type definition

### ❓ Context

- **JIRA or GitHub link**:
- **ADR link (if any)**:

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
