### PR TITLE
[LWDM] feat(back-10907,coin-evm): return SC interaction details

### DIFF
--- a/.changeset/wise-bananas-allow.md
+++ b/.changeset/wise-bananas-allow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+coin-evm: return contract interaction details

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.test.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.test.ts
@@ -76,7 +76,12 @@ describe("EVM Family", () => {
             subOperations: [],
             internalOperations: [],
             type: "FEES",
-            extra: {},
+            extra: {
+              contractInteraction: "SmartContractDeployment",
+              contractAddress: "0x4969D9fD2542e71e6b3EA87bE54EA9a736bcC4E9",
+              contractPayload:
+                "0xa9059cbb000000000000000000000000313143c4088a47c469d06fe3fa5fd4196be6a4d600000000000000000000000000000000000000000003b8e97d229a2d54800000",
+            },
           };
 
           expect(etherscanOperationToOperations(accountId, etherscanOp)).toEqual([
@@ -134,7 +139,12 @@ describe("EVM Family", () => {
             subOperations: [],
             internalOperations: [],
             type: "FEES",
-            extra: {},
+            extra: {
+              contractInteraction: "SmartContractInteraction",
+              contractAddress: "0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC",
+              contractPayload:
+                "0xa9059cbb000000000000000000000000313143c4088a47c469d06fe3fa5fd4196be6a4d600000000000000000000000000000000000000000003b8e97d229a2d54800000",
+            },
           };
 
           expect(etherscanOperationToOperations(accountId, etherscanOp)).toEqual([
@@ -1743,7 +1753,12 @@ describe("EVM Family", () => {
             subOperations: [],
             internalOperations: [],
             type: "DELEGATE",
-            extra: {},
+            extra: {
+              contractInteraction: "SmartContractInteraction",
+              contractAddress: "0x0000000000000000000000000000000000001005",
+              contractPayload:
+                "0x9ddb511a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a73656976616c6f7065723178797a616263313233343536373839300000000000",
+            },
           };
 
           expect(etherscanOperationToOperations(accountId, etherscanOp)).toEqual([
@@ -1801,7 +1816,12 @@ describe("EVM Family", () => {
             subOperations: [],
             internalOperations: [],
             type: "REDELEGATE",
-            extra: {},
+            extra: {
+              contractInteraction: "SmartContractInteraction",
+              contractAddress: "0x0000000000000000000000000000000000001005",
+              contractPayload:
+                "0x7dd0209d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a76616c696461746f723100000000000000000000000000000000000000000000000000000000000000000a76616c696461746f72320000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003e8",
+            },
           };
 
           expect(etherscanOperationToOperations(accountId, etherscanOp)).toEqual([
@@ -1857,7 +1877,11 @@ describe("EVM Family", () => {
             subOperations: [],
             internalOperations: [],
             type: "UNDELEGATE",
-            extra: {},
+            extra: {
+              contractInteraction: "SmartContractInteraction",
+              contractAddress: "0x0000000000000000000000000000000000001005",
+              contractPayload: "0x8dfc88970000000000000000000000",
+            },
           };
 
           expect(etherscanOperationToOperations(accountId, etherscanOp)).toEqual([

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
@@ -27,7 +27,7 @@ import {
   EtherscanERC1155Event,
   EtherscanInternalTransaction,
 } from "../types";
-import { safeEncodeEIP55 } from "../utils";
+import { buildSmartContractDetails, safeEncodeEIP55 } from "../utils";
 
 /**
  * Helper to safely convert a value to BigNumber, defaulting to 0 if invalid.
@@ -89,6 +89,12 @@ export const etherscanOperationToOperations = (
     types.push("NONE");
   }
 
+  const contractExtra = buildSmartContractDetails(
+    etherscanOp.to,
+    etherscanOp.input,
+    etherscanOp.contractAddress,
+  );
+
   // Value = transferred amount only (same whether tx failed or not); fee is separate. Ledger Wallet contract is applied by generic-alpaca bridge.
   return types.map(
     type =>
@@ -109,7 +115,7 @@ export const etherscanOperationToOperations = (
         nftOperations: [],
         internalOperations: [],
         hasFailed,
-        extra: {},
+        extra: contractExtra ? { ...contractExtra } : {},
       }) as Operation,
   );
 };

--- a/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
@@ -787,6 +787,97 @@ describe.each([
   });
 });
 
+describe("EVM Api: external node and explorer ONLY", () => {
+  let module: AlpacaApi<MemoNotSupported, BufferTxData> & BridgeApi;
+
+  beforeAll(() => {
+    setupCalClientStore();
+    module = createApi(
+      {
+        node: { type: "external", uri: "https://ethereum-rpc.publicnode.com" },
+        explorer: {
+          type: "etherscan",
+          uri: "https://proxyetherscan.api.live.ledger.com/v2/api/1",
+        },
+        showNfts: true,
+      } as EvmConfig,
+      "ethereum",
+    );
+  });
+
+  describe("getBlock", () => {
+    it("returns details for a smart contract creation tx in block 24883766", async () => {
+      const txHash = "0xd66967e32c71db2f1ecaed67d710efc3fa97f498d25499cc5817563e4c2ae863";
+      const result = await module.getBlock(24883766);
+      const tx = result.transactions.find(t => t.hash.toLowerCase() === txHash);
+
+      expect(tx!.details).toMatchObject({
+        contractInteraction: "SmartContractDeployment",
+        contractAddress: expect.stringMatching(/^0x2d9fc5315307e7bab64bc175dffdb54ffecbe25f$/i),
+        contractPayload: expect.stringMatching(/0x60a080604052346100c2/i),
+      });
+    });
+
+    it("returns details for a smart contract interaction tx in block 24883766", async () => {
+      const txHash = "0xa669162b91ea2ebc5133148fb946360e51226b0252bec88768761eb065afea93";
+      const result = await module.getBlock(24883766);
+      const tx = result.transactions.find(t => t.hash.toLowerCase() === txHash);
+
+      expect(tx!.details).toMatchObject({
+        contractInteraction: "SmartContractInteraction",
+        contractAddress: expect.stringMatching(/^0x0de8bf93da2f7eecb3d9169422413a9bef4ef628$/i),
+        contractPayload: expect.stringMatching(/59635f6f/i),
+      });
+    });
+  });
+
+  describe("listOperations", () => {
+    describe("transactions non-regression", () => {
+      const opsForTx = (items: Operation[], txHash: string) =>
+        items.filter(op => op.tx.hash.toLowerCase() === txHash.toLowerCase());
+
+      it("smart contract creation tx", async () => {
+        const txHash = "0xd66967e32c71db2f1ecaed67d710efc3fa97f498d25499cc5817563e4c2ae863";
+        const blockHeight = 24883766;
+        const deployer = "0x2463BF4cf17c040ea7beB1F46847c91D45e34608";
+
+        const { items } = await module.listOperations(deployer, {
+          minHeight: blockHeight,
+          order: "asc",
+          limit: 50,
+        });
+        const txOps = opsForTx(items, txHash);
+
+        expect(txOps.length).toBeGreaterThan(0);
+        expect(txOps[0].details).toMatchObject({
+          contractInteraction: "SmartContractDeployment",
+          contractAddress: expect.stringMatching(/^0x2d9fc5315307e7bab64bc175dffdb54ffecbe25f$/i),
+          contractPayload: expect.stringMatching(/0x60a080604052346100c2/i),
+        });
+      });
+
+      it("smart contract interaction tx", async () => {
+        const txHash = "0xa669162b91ea2ebc5133148fb946360e51226b0252bec88768761eb065afea93";
+        const blockHeight = 24883766;
+        const caller = "0x11f84552D846325385eCB2242e2887e3f5B535Ea";
+        const { items } = await module.listOperations(caller, {
+          minHeight: blockHeight,
+          order: "asc",
+          limit: 50,
+        });
+        const txOps = opsForTx(items, txHash);
+
+        expect(txOps.length).toBeGreaterThan(0);
+        expect(txOps[0].details).toMatchObject({
+          contractInteraction: "SmartContractInteraction",
+          contractAddress: expect.stringMatching(/^0x0de8bf93da2f7eecb3d9169422413a9bef4ef628$/i),
+          contractPayload: expect.stringMatching(/59635f6f/i),
+        });
+      });
+    });
+  });
+});
+
 describe("EVM Api (Moonbeam Network)", () => {
   let module: AlpacaApi<MemoNotSupported, BufferTxData> & BridgeApi;
 

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
@@ -211,6 +211,164 @@ describe("getBlock", () => {
     });
   });
 
+  it("adds SmartContractInteraction details on prefetched tx with non-trivial input", async () => {
+    setCoinConfig(
+      () =>
+        ({ info: { node: { type: "external" as const, retries: 0 } } }) as unknown as EvmCoinConfig,
+    );
+
+    const calldata = "0xa9059cbb00000000";
+    const mockGetNodeApi = jest.mocked(getNodeApi);
+    mockGetNodeApi.mockReturnValue({
+      getBlockByHeight: jest.fn().mockResolvedValueOnce(
+        makeNodeBlock({
+          transactions: [
+            makeNodeBlockTx({
+              hash: "0xtx1",
+              from: address1,
+              to: address2,
+              value: "0",
+              input: calldata,
+            }),
+          ],
+        }),
+      ),
+      getBlockReceipts: jest.fn().mockResolvedValueOnce([
+        makeNodeBlockReceipt({ hash: "0xtx1", erc20Transfers: [] }),
+      ]),
+      getTransaction: jest.fn(),
+    } as any);
+
+    const result = await getBlock({} as CryptoCurrency, 12345);
+
+    expect(result.transactions[0]).toMatchObject({
+      hash: "0xtx1",
+      details: {
+        contractInteraction: "SmartContractInteraction",
+        contractAddress: safeEncodeEIP55(address2),
+        contractPayload: calldata,
+      },
+    });
+  });
+
+  it("adds SmartContractDeployment details when prefetched tx has input but no to", async () => {
+    setCoinConfig(
+      () =>
+        ({ info: { node: { type: "external" as const, retries: 0 } } }) as unknown as EvmCoinConfig,
+    );
+
+    const initCode = "0x6001600055";
+    const mockGetNodeApi = jest.mocked(getNodeApi);
+    mockGetNodeApi.mockReturnValue({
+      getBlockByHeight: jest.fn().mockResolvedValueOnce(
+        makeNodeBlock({
+          transactions: [
+            makeNodeBlockTx({
+              hash: "0xdeploy",
+              from: address1,
+              to: undefined,
+              value: "0",
+              input: initCode,
+            }),
+          ],
+        }),
+      ),
+      getBlockReceipts: jest.fn().mockResolvedValueOnce([
+        makeNodeBlockReceipt({ hash: "0xdeploy", erc20Transfers: [], contractAddress: address2 }),
+      ]),
+      getTransaction: jest.fn(),
+    } as any);
+
+    const result = await getBlock({} as CryptoCurrency, 12345);
+
+    expect(result.transactions[0]).toMatchObject({
+      hash: "0xdeploy",
+      details: {
+        contractInteraction: "SmartContractDeployment",
+        contractAddress: safeEncodeEIP55(address2),
+        contractPayload: initCode,
+      },
+    });
+  });
+
+  it("omits contract details for prefetched tx with trivial input", async () => {
+    setCoinConfig(
+      () =>
+        ({ info: { node: { type: "external" as const, retries: 0 } } }) as unknown as EvmCoinConfig,
+    );
+
+    const mockGetNodeApi = jest.mocked(getNodeApi);
+    mockGetNodeApi.mockReturnValue({
+      getBlockByHeight: jest.fn().mockResolvedValueOnce(
+        makeNodeBlock({
+          transactions: [
+            makeNodeBlockTx({
+              hash: "0xtx1",
+              input: "0x",
+            }),
+          ],
+        }),
+      ),
+      getBlockReceipts: jest.fn().mockResolvedValueOnce([
+        makeNodeBlockReceipt({ hash: "0xtx1", erc20Transfers: [] }),
+      ]),
+      getTransaction: jest.fn(),
+    } as any);
+
+    const result = await getBlock({} as CryptoCurrency, 12345);
+
+    expect({
+      hash: result.transactions[0].hash,
+      hasDetails: "details" in result.transactions[0],
+    }).toEqual({ hash: "0xtx1", hasDetails: false });
+  });
+
+  it("adds contract details when falling back to getTransaction with non-trivial input", async () => {
+    setCoinConfig(
+      () =>
+        ({ info: { node: { type: "external" as const, retries: 0 } } }) as unknown as EvmCoinConfig,
+    );
+
+    const calldata = "0xdeadbeef";
+    const mockGetNodeApi = jest.mocked(getNodeApi);
+    const mockGetBlockByHeight = jest.fn().mockResolvedValueOnce(
+      makeNodeBlock({
+        transactions: [makeNodeBlockTx({ hash: "0xtx1" })],
+      }),
+    );
+    const mockGetBlockReceipts = jest.fn().mockRejectedValueOnce(
+      new UnsupportedRpcMethodError("eth_getBlockReceipts is not supported by this RPC provider", {
+        method: "eth_getBlockReceipts",
+        rawError: { code: -32601 },
+      }),
+    );
+    const mockGetTransaction = jest.fn().mockResolvedValueOnce(
+      makeNodeTxInfo({
+        hash: "0xtx1",
+        value: "1000",
+        to: address2,
+        input: calldata,
+      }),
+    );
+
+    mockGetNodeApi.mockReturnValue({
+      getBlockByHeight: mockGetBlockByHeight,
+      getBlockReceipts: mockGetBlockReceipts,
+      getTransaction: mockGetTransaction,
+    } as any);
+
+    const result = await getBlock({} as CryptoCurrency, 12345);
+
+    expect(result.transactions[0]).toMatchObject({
+      hash: "0xtx1",
+      details: {
+        contractInteraction: "SmartContractInteraction",
+        contractAddress: safeEncodeEIP55(address2),
+        contractPayload: calldata,
+      },
+    });
+  });
+
   it("falls back to per-transaction calls when bulk receipts are unavailable", async () => {
     setCoinConfig(
       () =>

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.ts
@@ -18,6 +18,7 @@ import { getInternalTransactionsByBlock } from "../network/explorer/etherscan";
 import { isEtherscanLikeExplorerConfig } from "../network/explorer/types";
 import { getNodeApi } from "../network/node";
 import { BlockReceiptInfo, NodeApi, PrefetchedBlockTransaction } from "../network/node/types";
+import { buildSmartContractDetails } from "../utils";
 
 function internalTransactionsFetcher(
   nodeApi: NodeApi,
@@ -193,12 +194,15 @@ function prefetchedTransactionToBlockTransaction(
     erc20Transfers: receipt.erc20Transfers,
   });
 
+  const details = buildSmartContractDetails(tx.to, tx.input, receipt.contractAddress);
+
   return {
     hash: tx.hash,
     failed,
     operations,
     fees,
     feesPayer: tx.from,
+    ...(details ? { details } : {}),
   };
 }
 
@@ -214,11 +218,14 @@ async function getTransactionFromHash(
 
   const operations = rpcTransactionToBlockOperations(txInfo);
 
+  const details = buildSmartContractDetails(txInfo.to, txInfo.input, txInfo.contractAddress);
+
   return {
     hash: txHash,
     failed,
     operations,
     fees,
     feesPayer: txInfo.from,
+    ...(details ? { details } : {}),
   };
 }

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
@@ -1059,6 +1059,51 @@ describe("listOperations", () => {
     expect(items[0].recipients[0]).toBe(stakingContract);
   });
 
+  it("copies smart contract fields from explorer extra into operation details", async () => {
+    setCoinConfig(() => ({ info: { explorer: { type: "ledger" } } }) as unknown as EvmCoinConfig);
+    const contractAddr = "0x1111111111111111111111111111111111111111";
+    const payload = "0xabcd";
+    jest.spyOn(ledgerExplorer, "getOperations").mockResolvedValue({
+      lastCoinOperations: [
+        {
+          id: "sci-op",
+          accountId: "",
+          type: "OUT",
+          senders: ["address"],
+          recipients: [contractAddr],
+          value: new BigNumber(0),
+          hash: "0xsci-hash",
+          blockHeight: 10,
+          blockHash: "0xblock",
+          fee: new BigNumber(1),
+          date: new Date("2025-02-20"),
+          transactionSequenceNumber: new BigNumber(1),
+          extra: {
+            contractInteraction: "SmartContractInteraction",
+            contractAddress: contractAddr,
+            contractPayload: payload,
+          },
+        },
+      ],
+      lastTokenOperations: [],
+      lastNftOperations: [],
+      lastInternalOperations: [],
+      nextPagingToken: "",
+    });
+
+    const { items } = await listOperations({} as CryptoCurrency, "address", {
+      minHeight: 1,
+      order: "asc",
+    });
+
+    expect(items[0].details).toEqual({
+      sequence: BigNumber(1),
+      contractInteraction: "SmartContractInteraction",
+      contractAddress: contractAddr,
+      contractPayload: payload,
+    });
+  });
+
   describe("Transaction to operation mapping should match the specification", () => {
     const blockHeight = 100;
     const blockHash = "0xblock";

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.ts
@@ -10,6 +10,40 @@ import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { Operation as LiveOperation, OperationType } from "@ledgerhq/types-live";
 import { getExplorerApi } from "../network/explorer";
 
+const CONTRACT_INTERACTION_KINDS = new Set<string>([
+  "SmartContractInteraction",
+  "SmartContractDeployment",
+]);
+
+/** Smart-contract fields copied from explorer `extra` into framework `details`. */
+function contractDetailsFromLiveExtra(
+  extra: LiveOperation["extra"],
+): Record<string, unknown> | undefined {
+  if (!extra || typeof extra !== "object") return undefined;
+  const src = extra as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+
+  const contractInteraction = src.contractInteraction;
+  if (
+    typeof contractInteraction === "string" &&
+    CONTRACT_INTERACTION_KINDS.has(contractInteraction)
+  ) {
+    out.contractInteraction = contractInteraction;
+  }
+
+  const contractAddress = src.contractAddress;
+  if (typeof contractAddress === "string") {
+    out.contractAddress = contractAddress;
+  }
+
+  const contractPayload = src.contractPayload;
+  if (typeof contractPayload === "string") {
+    out.contractPayload = contractPayload;
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 type AssetConfig =
   | { type: "native"; internal?: boolean; parent?: LiveOperation }
   | { type: "token"; owner: string; parent?: LiveOperation };
@@ -129,6 +163,12 @@ function toOperation(
 
   const txFee = computeTxFee(asset, op);
 
+  const contractDetail =
+    contractDetailsFromLiveExtra(op.extra) ??
+    (asset.type === "token" && asset.parent
+      ? contractDetailsFromLiveExtra(asset.parent.extra)
+      : undefined);
+
   return {
     id: op.id,
     type,
@@ -152,6 +192,7 @@ function toOperation(
       sequence: op.transactionSequenceNumber,
       ...internalOpDetail,
       ...tokenOpDetail,
+      ...contractDetail,
     },
   };
 }

--- a/libs/coin-modules/coin-evm/src/network/node/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/ledger.ts
@@ -60,6 +60,7 @@ async function getTransaction(
     method: "GET",
     url: `${getEnv("EXPLORER")}/blockchain/v4/${config.explorerId}/tx/${hash}`,
   });
+
   return {
     hash: ledgerTransaction.hash,
     blockHeight: ledgerTransaction.block?.height,

--- a/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
@@ -12,7 +12,7 @@ import ScrollGasPriceOracleAbi from "../../abis/scrollGasPriceOracle.abi.json";
 import { ExternalNodeConfig } from "../../config";
 import { GasEstimationError, InsufficientFunds, UnsupportedRpcMethodError } from "../../errors";
 import { FeeHistory, FeeData, Transaction as EvmTransaction } from "../../types";
-import { safeEncodeEIP55, normalizeAddress } from "../../utils";
+import { isSmartContractInput, safeEncodeEIP55, normalizeAddress } from "../../utils";
 import { withRetries } from "../withRetries";
 import { gethCallTracerToTraceBlockItems } from "./gethCallTracerToTraceBlockItems";
 import {
@@ -204,6 +204,12 @@ async function getTransaction(
     value: tx.value.toString(),
     from: tx.from,
     to: tx.to ?? undefined,
+    ...(tx.data !== null && tx.data !== undefined && isSmartContractInput(tx.data)
+        ? { input: tx.data }
+        : {}),
+    ...(receipt.contractAddress
+      ? { contractAddress: receipt.contractAddress }
+      : {}),
     erc20Transfers: parseERC20TransfersFromLogs(receipt.logs),
   };
 }
@@ -426,11 +432,15 @@ async function getBlockByHeight(
         `Block ${blockHeight} contains malformed prefetched transaction at index ${index}`,
       );
 
+    const rawTx = tx as { data?: string };
     return {
       hash: tx.hash,
       value: tx.value.toString(),
       from: tx.from,
       to: tx.to ?? undefined,
+      ...(rawTx.data !== null && rawTx.data !== undefined && isSmartContractInput(rawTx.data)
+          ? { input: rawTx.data }
+          : {}),
     };
   });
 
@@ -524,12 +534,26 @@ async function getBlockByHeightFromRawRpc(
             throw new Error(
               "Malformed prefetched transaction value in eth_getBlockByNumber response",
             );
+          if (
+            "input" in tx &&
+            tx.input !== undefined &&
+            tx.input !== null &&
+            typeof tx.input !== "string"
+          )
+            throw new Error(
+              "Malformed prefetched transaction input in eth_getBlockByNumber response",
+            );
 
           return {
             hash: tx.hash,
             value: BigInt(tx.value ?? "0x0").toString(),
             from: tx.from,
             to: tx.to ?? undefined,
+            ...("input" in tx &&
+            typeof tx.input === "string" &&
+            isSmartContractInput(tx.input)
+              ? { input: tx.input }
+              : {}),
           };
         })
       : undefined;
@@ -572,12 +596,20 @@ async function getBlockReceipts(
     if (!isTransactionReceipt(receipt))
       throw new Error(`Malformed eth_getBlockReceipts response at index ${index}`);
 
+    const raw = receipt as Record<string, unknown>;
+    const contractAddressRaw = raw.contractAddress;
+    const contractAddress =
+      typeof contractAddressRaw === "string" && contractAddressRaw.startsWith("0x")
+        ? contractAddressRaw
+        : undefined;
+
     return {
       hash: receipt.transactionHash,
       gasUsed: BigInt(receipt.gasUsed).toString(),
       gasPrice: BigInt(receipt.effectiveGasPrice ?? receipt.gasPrice ?? "0x0").toString(),
       status: receipt.status === null ? null : Number(receipt.status),
       erc20Transfers: parseERC20TransfersFromLogs(receipt.logs),
+      ...(contractAddress ? { contractAddress } : {}),
     };
   });
 }
@@ -666,7 +698,11 @@ function isPrefetchedBlockTransaction(value: unknown): value is PrefetchedBlockT
       : true) &&
     typeof value.hash === "string" &&
     (typeof value.value === "string" || typeof value.value === "bigint") &&
-    typeof value.from === "string"
+    typeof value.from === "string" &&
+    (!("data" in value) ||
+      value.data === undefined ||
+      value.data === null ||
+      typeof value.data === "string")
   );
 }
 

--- a/libs/coin-modules/coin-evm/src/network/node/types.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/types.ts
@@ -134,15 +134,22 @@ export type TransactionInfo = {
   status: number | null;
   from: string;
   to: string | undefined;
+  /** Calldata / init code (hex), when available from the node */
+  input?: string;
+  /** Created contract address (contract-creation txs), when known from the receipt or explorer */
+  contractAddress?: string;
   /** ERC20 Transfer events extracted from receipt logs */
   erc20Transfers: ERC20Transfer[];
 };
 
-export type PrefetchedBlockTransaction = Pick<TransactionInfo, "hash" | "value" | "from" | "to">;
+export type PrefetchedBlockTransaction = Pick<
+  TransactionInfo,
+  "hash" | "value" | "from" | "to" | "input"
+>;
 
 export type BlockReceiptInfo = Pick<
   TransactionInfo,
-  "hash" | "gasUsed" | "gasPrice" | "status" | "erc20Transfers"
+  "hash" | "gasUsed" | "gasPrice" | "status" | "erc20Transfers" | "contractAddress"
 >;
 
 export type BlockByHeightResult = {

--- a/libs/coin-modules/coin-evm/src/types/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/types/etherscan.ts
@@ -18,7 +18,6 @@ export type EtherscanOperation = {
   gasPrice: string;
   isError: string;
   txreceipt_status: string;
-  /** @deprecated do not use can be deprecated */
   input?: string;
   contractAddress: string;
   cumulativeGasUsed: string;

--- a/libs/coin-modules/coin-evm/src/utils.test.ts
+++ b/libs/coin-modules/coin-evm/src/utils.test.ts
@@ -1,0 +1,59 @@
+import { buildSmartContractDetails, isSmartContractInput, safeEncodeEIP55 } from "./utils";
+
+describe("isSmartContractInput", () => {
+  it.each([
+    [undefined, false],
+    [null, false],
+    ["", false],
+    ["   ", false],
+    ["0x", false],
+    ["0X", false],
+    [" 0x ", false],
+    ["0x00", true],
+    ["0Xabcdef", true],
+    ["0x1234567890abcdef", true],
+    [" 0x01 ", true],
+  ] as const)("isSmartContractInput(%p) === %s", (input, expected) => {
+    expect(isSmartContractInput(input)).toBe(expected);
+  });
+});
+
+describe("buildSmartContractDetails", () => {
+  const calldata = "0x1234567890abcdef";
+
+  it.each([
+    ["0x", calldata],
+    ["0x0", calldata],
+  ] as const)(
+    "classifies sentinel to %s with calldata as deployment and omits contractAddress without deployed address",
+    (to, input) => {
+      expect(buildSmartContractDetails(to, input)).toEqual({
+        contractInteraction: "SmartContractDeployment",
+        contractPayload: calldata,
+      });
+    },
+  );
+
+  it("sets contractAddress from deployed address when to is sentinel", () => {
+    const deployed = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb";
+    expect(buildSmartContractDetails("0x", calldata, deployed)).toEqual({
+      contractInteraction: "SmartContractDeployment",
+      contractAddress: safeEncodeEIP55(deployed),
+      contractPayload: calldata,
+    });
+  });
+
+  it("normalizes uppercase 0X hex prefix to a single 0x-prefixed payload", () => {
+    expect(buildSmartContractDetails(undefined, "0Xabcdef")).toEqual({
+      contractInteraction: "SmartContractDeployment",
+      contractPayload: "0xabcdef",
+    });
+  });
+
+  it("builds contractPayload from trim-aware input (matches isSmartContractInput)", () => {
+    expect(buildSmartContractDetails(undefined, "  0xabcdef  ")).toEqual({
+      contractInteraction: "SmartContractDeployment",
+      contractPayload: "0xabcdef",
+    });
+  });
+});

--- a/libs/coin-modules/coin-evm/src/utils.ts
+++ b/libs/coin-modules/coin-evm/src/utils.ts
@@ -79,6 +79,64 @@ export function isEthAddress(address: string): boolean {
   return /^(0x)?[0-9a-fA-F]{40}$/.test(address);
 }
 
+/** Discriminant for smart contract call vs contract creation (deployment). */
+export type ContractInteractionKind = "SmartContractInteraction" | "SmartContractDeployment";
+
+/**
+ * True when `input` carries non-trivial calldata or init code (not empty / whitespace-only /
+ * bare hex prefix). Leading and trailing whitespace are ignored; `0x` / `0X` with no payload
+ * after trim are treated as empty.
+ */
+export function isSmartContractInput(input: string | null | undefined): input is string {
+  if (input === null || input === undefined) {
+    return false;
+  }
+  const trimmed = input.trim();
+  if (trimmed === "") {
+    return false;
+  }
+  if (trimmed.length === 2 && trimmed.toLowerCase() === "0x") {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Builds flat `details` fields for Alpaca when a tx has smart contract input.
+ *
+ * `contractAddress` (when present) identifies the relevant contract: for
+ * `SmartContractInteraction` it is the called address (`to`); for
+ * `SmartContractDeployment` it is the created contract when
+ * `deployedContractAddress` is known (e.g. from a receipt), otherwise omitted.
+ */
+export function buildSmartContractDetails(
+  to: string | undefined,
+  input: string | undefined,
+  deployedContractAddress?: string | undefined,
+): Record<string, unknown> | undefined {
+  if (!isSmartContractInput(input)) {
+    return undefined;
+  }
+  const trimmedInput = input.trim();
+  const encodedTo = to ? safeEncodeEIP55(to) : "";
+  const contractInteraction: ContractInteractionKind = encodedTo
+    ? "SmartContractInteraction"
+    : "SmartContractDeployment";
+  const contractPayload = /^0x/i.test(trimmedInput)
+    ? `0x${trimmedInput.slice(2)}`
+    : `0x${trimmedInput}`;
+  const encodedDeployed =
+    deployedContractAddress
+      ? safeEncodeEIP55(deployedContractAddress)
+      : "";
+  const contractAddress = encodedDeployed || encodedTo;
+  return {
+    contractInteraction,
+    ...(contractAddress ? { contractAddress } : {}),
+    contractPayload,
+  };
+}
+
 /**
  * Normalizes an Ethereum address to lowercase to avoid checksum validation issues.
  *


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no performance (aside small local computing) impact
  - add **new** information

### 📝 Description

Add Smart Contract Interaction details.

The coin module  emit three fields flat, directly under details:

```
details: {
  // ... existing fields (sequence, etc.) ...
  contractInteraction: "SmartContractInteraction", // or "SmartContractDeployment"
  contractAddress: "0x...",  
  contractPayload: "0x..."
}
```

- `contractInteraction`: "SmartContractInteraction" when to is present (calling an existing contract), "SmartContractDeployment" when to is absent (deploying a new contract).
- `contractAddress`: the to address (the contract being called). Only present for SCI.
- `contractPayload`: the input data (calldata or init code).

#### Implemented for external explorer (Etherscan like)
- for list operations: it gets the input straight from etherscan (already pulled)
- for get block: the data is in the details of the tx (already pulled)


#### Not implemented for the Atlas ("Ledger") explorer

This feature has been asked by LES for 1 stack project. I took a minimalist approach where it's only implemented when the explorer is external. It's not implemented when the explorer is Atlas (named "ledger" in coin evm). 

Implementation for Atlas is doable, unfortunately it requires to set "noinput=false" on atlas get tx by address (for list operations) and get tx by hash (for getBlock). This increases significantly the payload (at least 2 folds) for a feature not needed by LedgerWallet users. 

Another possible decision would have been to do a degraded implementation with only the `contractInteraction` and `contractAddress` without the `contractPayload`. Still it would have been unecessary data and incomplete.

A4 wise, when Atlas is available, we shortcut the coin module and query Atlas directly. So it's not necessary either in that case.  


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
