### PR TITLE
[LWDM] chore(live-common): async prep — account serialization & sign chain

### DIFF
--- a/.changeset/live-29184-async-bridge-prep.md
+++ b/.changeset/live-29184-async-bridge-prep.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-cli": patch
+---
+
+chore(live-common): async prep — account serialization & sign chain (LIVE-29184)
+
+Make `fromOperationRaw`, `toAccountRaw`, `canSend`, `toScanAccountEventRaw`, `encodeModel`, `getConcordiumBridge`, `fromSignedOperationRaw`, `fromSignOperationEventRaw`, `serializePlatformSignedTransaction`, and `deserializePlatformSignedTransaction` return Promises. All call sites across desktop, mobile, CLI, and live-common are updated to await the new async signatures. This is a no-op at runtime (bridges are still synchronous); the change prepares the codebase for `getAccountBridgeByFamily` becoming async.

--- a/apps/cli/src/commands/blockchain/botPortfolio.ts
+++ b/apps/cli/src/commands/blockchain/botPortfolio.ts
@@ -1,5 +1,5 @@
 import { from, defer, throwError } from "rxjs";
-import { catchError, filter, map, mergeAll, timeout } from "rxjs/operators";
+import { catchError, filter, map, mergeAll, mergeMap, timeout } from "rxjs/operators";
 import { listSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
 import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
 import { accountFormatters } from "@ledgerhq/live-common/account/index";
@@ -43,7 +43,9 @@ export default {
       ),
       mergeAll(5),
       filter(e => e.type === "discovered"),
-      map(e => (accountFormatters[opts.format] || accountFormatters.default)(e.account)),
+      mergeMap(async e =>
+        (accountFormatters[opts.format] || accountFormatters.default)(e.account),
+      ),
     );
   },
 };

--- a/apps/cli/src/commands/blockchain/generateTestTransaction.ts
+++ b/apps/cli/src/commands/blockchain/generateTestTransaction.ts
@@ -120,20 +120,19 @@ ${apdus.map(a => "  " + a).join("\n")}
             ),
           ),
           reduce((jsCodes, code) => jsCodes.concat(code), []),
-          map(
-            codes => `{
+          switchMap(async codes => {
+            const raw = await toAccountRaw({
+              ...account,
+              operations: [],
+            });
+            return `{
   name: "${getDefaultAccountNameForCurrencyIndex(account)}",
-  raw: ${JSON.stringify(
-    toAccountRaw({
-      ...account,
-      operations: [],
-    }),
-  )},
+  raw: ${JSON.stringify(raw)},
   transactions: [
     ${codes.join(",")}
   ]
-  }`,
-          ),
+  }`;
+          }),
         ),
       ),
     ),

--- a/apps/cli/src/commands/blockchain/send.ts
+++ b/apps/cli/src/commands/blockchain/send.ts
@@ -109,7 +109,7 @@ export default {
                                               account,
                                             )(
                                               // @ts-expect-error we are supposed to give an OperationRaw and yet it's an Operation
-                                              fromOperationRaw(op, account.id),
+                                              await fromOperationRaw(op, account.id),
                                             )}`,
                                           );
                                           if (

--- a/apps/cli/src/commands/blockchain/sync.ts
+++ b/apps/cli/src/commands/blockchain/sync.ts
@@ -1,4 +1,4 @@
-import { map, switchMap } from "rxjs/operators";
+import { mergeMap } from "rxjs/operators";
 import { accountFormatters, decodeAccountId } from "@ledgerhq/live-common/account/index";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
@@ -23,7 +23,7 @@ export default {
   ],
   job: (opts: SyncJobOpts) =>
     scan(opts).pipe(
-      switchMap(async account => {
+      mergeMap(async account => {
         const { currencyId } = decodeAccountId(account.id);
         const currency = getCryptoCurrencyById(currencyId);
         const currencyBridge = getCurrencyBridge(currency);
@@ -46,6 +46,8 @@ export default {
             }
           : account;
       }),
-      map(account => (accountFormatters[opts.format] || accountFormatters.default)(account)),
+      mergeMap(async account =>
+        (accountFormatters[opts.format] || accountFormatters.default)(account),
+      ),
     ),
 };

--- a/apps/cli/src/commands/live/liveData.ts
+++ b/apps/cli/src/commands/live/liveData.ts
@@ -1,4 +1,3 @@
-import { of, throwError } from "rxjs";
 import { reduce, mergeMap } from "rxjs/operators";
 import fs from "fs";
 import { scan, scanCommonOpts } from "../../scan";
@@ -38,7 +37,7 @@ export default {
   job: (opts: LiveDataJobOpts) =>
     scan(opts).pipe(
       reduce<Account, Account[]>((accounts, account) => accounts.concat(account), []),
-      mergeMap(accounts => {
+      mergeMap(async accounts => {
         const appjsondata = opts.appjson
           ? JSON.parse(fs.readFileSync(opts.appjson, "utf-8"))
           : {
@@ -48,18 +47,20 @@ export default {
             };
 
         if (typeof appjsondata.data.accounts === "string") {
-          return throwError(() => new Error("encrypted ledger live data is not supported"));
+          throw new Error("encrypted ledger live data is not supported");
         }
 
         const existingIds = appjsondata.data.accounts.map(
           (a: { data: { id: string } }) => a.data.id,
         );
-        const append = accounts
-          .filter(a => !existingIds.includes(a.id))
-          .map(account => ({
-            data: toAccountRaw(account),
-            version: 1,
-          }));
+        const append = await Promise.all(
+          accounts
+            .filter(a => !existingIds.includes(a.id))
+            .map(async account => ({
+              data: await toAccountRaw(account),
+              version: 1,
+            })),
+        );
         appjsondata.data.accounts = appjsondata.data.accounts.concat(append);
 
         // Extract persisted tokens from the RTK Query cache
@@ -71,9 +72,9 @@ export default {
 
         if (opts.appjson) {
           fs.writeFileSync(opts.appjson, JSON.stringify(appjsondata), "utf-8");
-          return of(append.length + " accounts added.");
+          return append.length + " accounts added.";
         } else {
-          return of(JSON.stringify(appjsondata));
+          return JSON.stringify(appjsondata);
         }
       }),
     ),

--- a/apps/cli/src/signedOperation.ts
+++ b/apps/cli/src/signedOperation.ts
@@ -1,5 +1,5 @@
 import type { Observable } from "rxjs";
-import { map } from "rxjs/operators";
+import { switchMap } from "rxjs/operators";
 import invariant from "invariant";
 import type { SignedOperation, Account } from "@ledgerhq/types-live";
 import { fromSignedOperationRaw } from "@ledgerhq/live-common/transaction/signOperation";
@@ -22,7 +22,7 @@ export function inferSignedOperations(
   const file = opts["signed-operation"];
   invariant(file, "--signed-operation file is required");
   return jsonFromFile(file as string).pipe(
-    map(json => {
+    switchMap(async json => {
       invariant(typeof json === "object", "not an object JSON");
       invariant(typeof json.signature === "string", "missing signature");
       invariant(typeof json.operation === "object", "missing operation object");
@@ -30,7 +30,7 @@ export function inferSignedOperations(
         json.operation.accountId === mainAccount.id,
         "the operation does not match the specified account",
       );
-      return fromSignedOperationRaw(json, mainAccount.id);
+      return await fromSignedOperationRaw(json, mainAccount.id);
     }),
   );
 }

--- a/apps/ledger-live-desktop/src/helpers/accountModel.ts
+++ b/apps/ledger-live-desktop/src/helpers/accountModel.ts
@@ -80,7 +80,7 @@ const accountModel: DataModel<AccountRaw, [Account, AccountUserData]> = createDa
   ],
 
   decode: async (raw: AccountRaw) => [await fromAccountRaw(raw), accountRawToAccountUserData(raw)],
-  encode: ([account, userData]: [Account, AccountUserData]): AccountRaw =>
+  encode: async ([account, userData]: [Account, AccountUserData]): Promise<AccountRaw> =>
     toAccountRaw(
       {
         ...account,

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -217,9 +217,9 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
                   account,
                   parentAccount,
                   location: HOOKS_TRACKING_LOCATIONS.genericDAppTransactionSend,
-                  onResult: (signedOperation: SignedOperation) => {
+                  onResult: async (signedOperation: SignedOperation) => {
                     tracking.platformSignTransactionSuccess(manifest);
-                    resolve(serializePlatformSignedTransaction(signedOperation));
+                    resolve(await serializePlatformSignedTransaction(signedOperation));
                   },
                   onCancel: (error: Error) => {
                     tracking.platformSignTransactionFail(manifest);

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/index.tsx
@@ -90,6 +90,7 @@ class OnboardModal extends PureComponent<Props, State> {
 
   concordiumWalletConnect: ConcordiumWalletConnect | null = null;
   concordiumBridge: ConcordiumCurrencyBridge | null = null;
+  private concordiumBridgePromise: Promise<ConcordiumCurrencyBridge> | null = null;
   pairingSubscription: Subscription | null = null;
   onboardingSubscription: Subscription | null = null;
   stepTransitionTimeout: NodeJS.Timeout | null = null;
@@ -139,8 +140,29 @@ class OnboardModal extends PureComponent<Props, State> {
     this.mounted = true;
     this.concordiumWalletConnect = setWalletConnect();
     if (this.props.currency) {
-      this.concordiumBridge = await getConcordiumBridge(this.props.currency);
+      this.concordiumBridgePromise = getConcordiumBridge(this.props.currency);
+      try {
+        this.concordiumBridge = await this.concordiumBridgePromise;
+      } catch (error) {
+        this.concordiumBridgePromise = null;
+        if (!this.mounted) return;
+        this.setState({ error: toError(error) });
+        return;
+      }
       if (!this.mounted) return;
+    }
+  }
+
+  private async ensureBridgeReady(): Promise<boolean> {
+    if (this.concordiumBridge) return true;
+    if (!this.concordiumBridgePromise) return true;
+    try {
+      this.concordiumBridge = await this.concordiumBridgePromise;
+      return true;
+    } catch (error) {
+      this.concordiumBridgePromise = null;
+      this.setState({ error: toError(error) });
+      return false;
     }
   }
 
@@ -218,11 +240,12 @@ class OnboardModal extends PureComponent<Props, State> {
     this.pairingSubscription = null;
   };
 
-  handlePair = (isRetry = false) => {
+  handlePair = async (isRetry = false) => {
     this.clearPairingSubscription();
 
     const { currency, device } = this.props;
 
+    if (!(await this.ensureBridgeReady())) return;
     invariant(this.concordiumBridge, "concordiumBridge is required");
     invariant(device, "device is required");
     invariant(currency, "currency is required");
@@ -309,12 +332,13 @@ class OnboardModal extends PureComponent<Props, State> {
     this.onboardingSubscription = null;
   };
 
-  handleCreateAccount = () => {
+  handleCreateAccount = async () => {
     this.clearOnboardingSubscription();
 
     const { currency, device, selectedAccounts } = this.props;
     const creatableAccount = getCreatableAccount(selectedAccounts);
 
+    if (!(await this.ensureBridgeReady())) return;
     invariant(this.concordiumBridge, "concordiumBridge is required");
     invariant(creatableAccount, "creatableAccount is required");
     invariant(device, "device is required");

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/index.tsx
@@ -133,14 +133,15 @@ class OnboardModal extends PureComponent<Props, State> {
       walletConnectUri: null,
     };
 
-    if (props.currency) {
-      this.concordiumBridge = getConcordiumBridge(props.currency);
-    }
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     this.mounted = true;
     this.concordiumWalletConnect = setWalletConnect();
+    if (this.props.currency) {
+      this.concordiumBridge = await getConcordiumBridge(this.props.currency);
+      if (!this.mounted) return;
+    }
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
@@ -224,9 +224,13 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
   const [canSendResult, setCanSendResult] = useState(false);
   useEffect(() => {
     let active = true;
-    canSend(account, parentAccount).then(result => {
-      if (active) setCanSendResult(result);
-    });
+    canSend(account, parentAccount)
+      .then(result => {
+        if (active) setCanSendResult(result);
+      })
+      .catch(() => {
+        if (active) setCanSendResult(false);
+      });
     return () => {
       active = false;
     };

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
@@ -7,7 +7,7 @@ import {
 import { useRampCatalog } from "@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog";
 
 import { Account, AccountLike } from "@ledgerhq/types-live";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { TFunction } from "i18next";
 import { withTranslation } from "react-i18next";
 import { connect } from "react-redux";
@@ -221,6 +221,17 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
   const walletState = useSelector(walletSelector);
   const routeToStakePlatformApp = getRouteToPlatformApp(account, walletState, parentAccount);
 
+  const [canSendResult, setCanSendResult] = useState(false);
+  useEffect(() => {
+    let active = true;
+    canSend(account, parentAccount).then(result => {
+      if (active) setCanSendResult(result);
+    });
+    return () => {
+      active = false;
+    };
+  }, [account, parentAccount]);
+
   // don't show buttons until we know whether or not we can show swap button, otherwise possible click jacking
   const showButtons = !!getAvailableProviders();
   const availableOnSwap = currenciesAll.includes(currency.id);
@@ -357,7 +368,7 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
       {availableOnSwap ? swapHeader : null}
       {availableOnBuy ? buyHeader : null}
       {availableOnSell && sellHeader}
-      {canSend(account, parentAccount) ? (
+      {canSendResult ? (
         <SendAction account={account} parentAccount={parentAccount} onClick={onSend} />
       ) : null}
       <ReceiveAction account={account} parentAccount={parentAccount} onClick={onReceive} />

--- a/apps/ledger-live-desktop/src/renderer/storage.ts
+++ b/apps/ledger-live-desktop/src/renderer/storage.ts
@@ -78,7 +78,7 @@ type Transform<R, M> = {
   ) => Promise<Awaited<ReturnType<DataModel<R, M>["decode"]>>[] | null>;
   set: (
     raws: Parameters<DataModel<R, M>["encode"]>[0][],
-  ) => ReturnType<DataModel<R, M>["encode"]>[];
+  ) => Promise<Awaited<ReturnType<DataModel<R, M>["encode"]>>[]>;
 };
 
 // A map of transformers.
@@ -103,7 +103,7 @@ const transforms: Transforms = {
       }
       return accounts;
     },
-    set: accounts => (accounts || []).map(accountModel.encode),
+    set: async accounts => Promise.all((accounts || []).map(accountModel.encode)),
   },
 };
 
@@ -140,15 +140,22 @@ if (getEnv("PLAYWRIGHT_RUN")) {
 
 const debouncedSetKey = memoize(
   <K extends keyof DatabaseValues, V = DatabaseValue<K>>(ns: string, keyPath: K) =>
-    debounceToUse((value: V) => {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      const transform = transforms[keyPath as keyof Transforms];
-      ipcRenderer.invoke("setKey", {
-        ns,
-        keyPath,
+    debounceToUse(async (value: V) => {
+      try {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        value: transform ? transform.set(value as Parameters<typeof transform.set>[0]) : value,
-      });
+        const transform = transforms[keyPath as keyof Transforms];
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const transformedValue = transform
+          ? await transform.set(value as Parameters<typeof transform.set>[0])
+          : value;
+        await ipcRenderer.invoke("setKey", {
+          ns,
+          keyPath,
+          value: transformedValue,
+        });
+      } catch (e) {
+        logger.error("debouncedSetKey failed", { ns, keyPath }, e);
+      }
     }, 1000),
   (ns: string, keyPath: string) => `${ns}:${keyPath}`,
 );

--- a/apps/ledger-live-mobile/e2e/bridge/server.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/server.ts
@@ -149,10 +149,12 @@ export async function loadAccounts(accounts: Account[]) {
   await postMessage({
     type: "importAccounts",
     id: uniqueId(),
-    payload: accounts.map(account => ({
-      version: 1,
-      data: toAccountRaw(account),
-    })),
+    payload: await Promise.all(
+      accounts.map(async account => ({
+        version: 1,
+        data: await toAccountRaw(account),
+      })),
+    ),
   });
 }
 

--- a/apps/ledger-live-mobile/e2e/specs/unknown-currency-resilience.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/unknown-currency-resilience.spec.ts
@@ -3,15 +3,15 @@ import { loadAccountsRaw } from "../bridge/server";
 import { initTestAccounts } from "../models/currencies";
 
 describe("Portfolio to load with unknown currency data in accounts", () => {
-  const [badAccount1, badAccount2] = initTestAccounts(["bitcoin", "bitcoin"]).map(account =>
-    toAccountRaw(account),
-  );
-  badAccount1.currencyId = "DO_NOT_EXIST";
-  badAccount1.id = badAccount1.id.replace("bitcoin", "DO_NOT_EXIST");
-  badAccount2.id += "DO_NOT_EXIST";
-  badAccount2.derivationMode += "DO_NOT_EXIST";
-
   beforeAll(async () => {
+    const [badAccount1, badAccount2] = await Promise.all(
+      initTestAccounts(["bitcoin", "bitcoin"]).map(account => toAccountRaw(account)),
+    );
+    badAccount1.currencyId = "DO_NOT_EXIST";
+    badAccount1.id = badAccount1.id.replace("bitcoin", "DO_NOT_EXIST");
+    badAccount2.id += "DO_NOT_EXIST";
+    badAccount2.derivationMode += "DO_NOT_EXIST";
+
     await loadAccountsRaw([
       { data: badAccount1, version: 0 },
       { data: badAccount2, version: 0 },

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -47,7 +47,7 @@ type Props<Data, Stats> = {
   /** Selector for the minimal state slice this effect cares about. Avoids subscribing to root state. */
   stateSelector: (state: State) => unknown;
   throttle: number;
-  lense: (_: State) => Data;
+  lense: (_: State) => Data | Promise<Data>;
   getChangesStats: (next: State, prev: State) => Stats;
   save: (data: Data, changedStats: Stats) => Promise<void>;
   saveAtStart?: boolean;
@@ -87,7 +87,7 @@ function useDBSaveEffect<D, S>({
           if (!changedStats && !forceSave.current) return; // if it's falsy, it means there is no changes
           isSaving.current = true;
           try {
-            await save(lense(state), changedStats); // we save it for real
+            await save(await lense(state), changedStats); // we save it for real
           } finally {
             isSaving.current = false;
           }

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -244,11 +244,11 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
                   accountId,
                   parentId: parentAccount?.id,
                   appName: params?.useApp,
-                  onSuccess: signedOperation => {
+                  onSuccess: async signedOperation => {
                     if (done) return;
                     done = true;
                     tracking.platformSignTransactionSuccess(manifest);
-                    resolve(serializePlatformSignedTransaction(signedOperation));
+                    resolve(await serializePlatformSignedTransaction(signedOperation));
                   },
                   onError,
                 },

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/__tests__/useOnboarding.test.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/__tests__/useOnboarding.test.ts
@@ -51,6 +51,7 @@ describe("useOnboarding", () => {
       useOnboarding(currency, "device-id", creatableAccount, sessionTopic, onSessionExpired),
     );
 
+    await waitFor(() => expect(onboardSubject.observed).toBe(true));
     act(() => {
       onboardSubject.next({ status: AccountOnboardStatus.SIGN });
     });
@@ -66,6 +67,7 @@ describe("useOnboarding", () => {
       useOnboarding(currency, "device-id", creatableAccount, sessionTopic, onSessionExpired),
     );
 
+    await waitFor(() => expect(onboardSubject.observed).toBe(true));
     act(() => {
       onboardSubject.next({ status: AccountOnboardStatus.SUBMIT });
     });
@@ -81,6 +83,7 @@ describe("useOnboarding", () => {
       useOnboarding(currency, "device-id", creatableAccount, sessionTopic, onSessionExpired),
     );
 
+    await waitFor(() => expect(onboardSubject.observed).toBe(true));
     act(() => {
       onboardSubject.next({ account: creatableAccount });
     });
@@ -97,6 +100,7 @@ describe("useOnboarding", () => {
       useOnboarding(currency, "device-id", creatableAccount, sessionTopic, onSessionExpired),
     );
 
+    await waitFor(() => expect(onboardSubject.observed).toBe(true));
     act(() => {
       onboardSubject.error(new ConcordiumSessionExpiredError());
     });
@@ -112,6 +116,7 @@ describe("useOnboarding", () => {
       useOnboarding(currency, "device-id", creatableAccount, sessionTopic, onSessionExpired),
     );
 
+    await waitFor(() => expect(onboardSubject.observed).toBe(true));
     act(() => {
       onboardSubject.error(new LockedDeviceError());
     });
@@ -128,6 +133,7 @@ describe("useOnboarding", () => {
       useOnboarding(currency, "device-id", creatableAccount, sessionTopic, onSessionExpired),
     );
 
+    await waitFor(() => expect(onboardSubject.observed).toBe(true));
     act(() => {
       onboardSubject.error(new Error("network failure"));
     });
@@ -138,13 +144,13 @@ describe("useOnboarding", () => {
     });
   });
 
-  it("should unsubscribe on unmount", () => {
+  it("should unsubscribe on unmount", async () => {
     const onSessionExpired = jest.fn();
     const { unmount } = renderHook(() =>
       useOnboarding(currency, "device-id", creatableAccount, sessionTopic, onSessionExpired),
     );
 
-    expect(onboardSubject.observed).toBe(true);
+    await waitFor(() => expect(onboardSubject.observed).toBe(true));
 
     act(() => {
       unmount();

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/__tests__/usePairing.test.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/__tests__/usePairing.test.ts
@@ -33,6 +33,7 @@ describe("usePairing", () => {
     const onPaired = jest.fn();
     const { result } = renderHook(() => usePairing(currency, onPaired));
 
+    await waitFor(() => expect(pairingSubject.observed).toBe(true));
     act(() => {
       pairingSubject.next({
         status: ConcordiumPairingStatus.PREPARE,
@@ -50,6 +51,7 @@ describe("usePairing", () => {
     const onPaired = jest.fn();
     const { result } = renderHook(() => usePairing(currency, onPaired));
 
+    await waitFor(() => expect(pairingSubject.observed).toBe(true));
     act(() => {
       pairingSubject.next({
         status: ConcordiumPairingStatus.SUCCESS,
@@ -67,8 +69,7 @@ describe("usePairing", () => {
     const onPaired = jest.fn();
     const { result } = renderHook(() => usePairing(currency, onPaired));
 
-    expect(pairingSubject.observed).toBe(true);
-
+    await waitFor(() => expect(pairingSubject.observed).toBe(true));
     act(() => {
       pairingSubject.next({
         status: ConcordiumPairingStatus.ERROR,
@@ -85,6 +86,7 @@ describe("usePairing", () => {
     const onPaired = jest.fn();
     const { result } = renderHook(() => usePairing(currency, onPaired));
 
+    await waitFor(() => expect(pairingSubject.observed).toBe(true));
     act(() => {
       pairingSubject.error(new Error("connection failed"));
     });
@@ -94,11 +96,11 @@ describe("usePairing", () => {
     });
   });
 
-  it("should unsubscribe on unmount", () => {
+  it("should unsubscribe on unmount", async () => {
     const onPaired = jest.fn();
     const { unmount } = renderHook(() => usePairing(currency, onPaired));
 
-    expect(pairingSubject.observed).toBe(true);
+    await waitFor(() => expect(pairingSubject.observed).toBe(true));
 
     act(() => {
       unmount();

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
@@ -45,13 +45,13 @@ export function useOnboarding(
     }
   }, []);
 
-  const startOnboarding = useCallback(() => {
+  const startOnboarding = useCallback(async () => {
     unsubscribe();
     completedRef.current = false;
     setCompletedAccount(null);
     setCreateStatus(CreateStatus.PREPARING);
 
-    const bridge = getConcordiumBridge(currency);
+    const bridge = await getConcordiumBridge(currency);
     subscriptionRef.current = bridge
       .onboardAccount(currency.id, deviceId, creatableAccount)
       .subscribe({

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
@@ -51,7 +51,14 @@ export function useOnboarding(
     setCompletedAccount(null);
     setCreateStatus(CreateStatus.PREPARING);
 
-    const bridge = await getConcordiumBridge(currency);
+    let bridge;
+    try {
+      bridge = await getConcordiumBridge(currency);
+    } catch {
+      unsubscribe();
+      setCreateStatus(CreateStatus.ERROR);
+      return;
+    }
     subscriptionRef.current = bridge
       .onboardAccount(currency.id, deviceId, creatableAccount)
       .subscribe({

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
@@ -35,10 +35,10 @@ export function usePairing(currency: CryptoCurrency, onPaired: (sessionTopic: st
     setPairStatus(PairStatus.CONNECTING);
     setWalletConnectUri(null);
 
-    startPairingInternal();
+    void startPairingInternal();
 
-    function startPairingInternal() {
-      const bridge = getConcordiumBridge(currency);
+    async function startPairingInternal() {
+      const bridge = await getConcordiumBridge(currency);
       subscriptionRef.current = bridge.pairWalletConnect(currency.id, "").subscribe({
         next: (data: ConcordiumPairingProgress) => {
           switch (data.status) {
@@ -72,7 +72,7 @@ export function usePairing(currency: CryptoCurrency, onPaired: (sessionTopic: st
             });
             setPairStatus(PairStatus.CONNECTING);
             setWalletConnectUri(null);
-            startPairingInternal();
+            void startPairingInternal();
             return;
           }
           unsubscribe();

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
@@ -38,7 +38,14 @@ export function usePairing(currency: CryptoCurrency, onPaired: (sessionTopic: st
     void startPairingInternal();
 
     async function startPairingInternal() {
-      const bridge = await getConcordiumBridge(currency);
+      let bridge;
+      try {
+        bridge = await getConcordiumBridge(currency);
+      } catch {
+        unsubscribe();
+        setPairStatus(PairStatus.ERROR);
+        return;
+      }
       subscriptionRef.current = bridge.pairWalletConnect(currency.id, "").subscribe({
         next: (data: ConcordiumPairingProgress) => {
           switch (data.status) {

--- a/apps/ledger-live-mobile/src/logic/accountModel.ts
+++ b/apps/ledger-live-mobile/src/logic/accountModel.ts
@@ -17,7 +17,7 @@ const opRetentionFilter = opRetentionStategy(366, 500);
 const accountModel: DataModel<AccountRaw, [Account, AccountUserData]> = createDataModel({
   migrations: [],
   decode: async (raw: AccountRaw) => [await fromAccountRaw(raw), accountRawToAccountUserData(raw)],
-  encode: ([account, userData]: [Account, AccountUserData]): AccountRaw =>
+  encode: async ([account, userData]: [Account, AccountUserData]): Promise<AccountRaw> =>
     toAccountRaw(
       {
         ...account,

--- a/apps/ledger-live-mobile/src/reducers/accounts.ts
+++ b/apps/ledger-live-mobile/src/reducers/accounts.ts
@@ -124,17 +124,17 @@ const handlers: ReducerMap<AccountsState, Payload> = {
 
 // Selectors
 
-export function exportSelector(state: State): {
+export async function exportSelector(state: State): Promise<{
   active: {
     data: AccountRaw;
     version: number;
   }[];
-} {
+}> {
   const active = [];
   for (const account of state.accounts.active) {
     const accountUserData = accountUserDataExportSelector(state.wallet, { account });
     if (accountUserData) {
-      active.push(accountModel.encode([account, accountUserData]));
+      active.push(await accountModel.encode([account, accountUserData]));
     }
   }
   return { active };

--- a/apps/ledger-live-mobile/src/reducers/accounts.ts
+++ b/apps/ledger-live-mobile/src/reducers/accounts.ts
@@ -130,13 +130,17 @@ export async function exportSelector(state: State): Promise<{
     version: number;
   }[];
 }> {
-  const active = [];
-  for (const account of state.accounts.active) {
-    const accountUserData = accountUserDataExportSelector(state.wallet, { account });
-    if (accountUserData) {
-      active.push(await accountModel.encode([account, accountUserData]));
-    }
-  }
+  const active = await Promise.all(
+    state.accounts.active
+      .map(account => {
+        const accountUserData = accountUserDataExportSelector(state.wallet, { account });
+        if (!accountUserData) return null;
+        return accountModel.encode([account, accountUserData]);
+      })
+      .filter(
+        (p): p is Promise<{ data: AccountRaw; version: number }> => p !== null,
+      ),
+  );
   return { active };
 }
 

--- a/libs/ledger-live-common/src/DataModel.test.ts
+++ b/libs/ledger-live-common/src/DataModel.test.ts
@@ -18,7 +18,7 @@ const opRetentionStategy =
 const schema = {
   migrations: [raw => raw],
   decode: async (raw: AccountRaw) => [await fromAccountRaw(raw), accountRawToAccountUserData(raw)],
-  encode: ([account, userData]: [Account, AccountUserData]): AccountRaw =>
+  encode: async ([account, userData]: [Account, AccountUserData]): Promise<AccountRaw> =>
     toAccountRaw(
       {
         ...account,

--- a/libs/ledger-live-common/src/DataModel.ts
+++ b/libs/ledger-live-common/src/DataModel.ts
@@ -12,10 +12,10 @@ export type DataModel<R, M> = {
   // import a given version of rawData back into model
   decode(rawModel: { data: R; version: number }): Promise<M>;
   // export data into a serializable object (can be saved to a JSON file)
-  encode(model: M): {
+  encode(model: M): Promise<{
     data: R;
     version: number;
-  };
+  }>;
   // current version of the model
   version: number;
 };
@@ -28,7 +28,7 @@ export type DataSchema<R, M> = {
   // write extra logic to transform raw data into your model
   decode(raw: R): Promise<M>;
   // reverse version of wrap, that will transform it back to a serializable object
-  encode(data: M): R;
+  encode(data: M): R | Promise<R>;
   // A map of migrations functions that are unrolled when an old version is imported
   migrations: Array<(arg0: any) => R | any>;
 };
@@ -80,8 +80,8 @@ export function createDataModel<R, M>(schema: DataSchema<R, M>): DataModel<R, M>
     return data;
   }
 
-  function encodeModel(model) {
-    const data = encode(model);
+  async function encodeModel(model) {
+    const data = await encode(model);
     return {
       data,
       version,

--- a/libs/ledger-live-common/src/__tests__/migration/account-migration.ts
+++ b/libs/ledger-live-common/src/__tests__/migration/account-migration.ts
@@ -201,7 +201,7 @@ const testSync = async (currencyId: string, xpubOrAddress: string) => {
       .pipe(reduce((acc, f: (arg0: Account) => Account) => f(acc), mockAccount)),
   );
 
-  const accountRaw = toAccountRaw(syncedAccount);
+  const accountRaw = await toAccountRaw(syncedAccount);
 
   console.log("finishing sync on", currencyId, xpubOrAddress);
   return accountRaw;
@@ -221,7 +221,7 @@ const testSyncAccount = async (account: Account) => {
       .pipe(reduce((acc, f: (arg0: Account) => Account) => f(acc), account)),
   );
 
-  const accountRaw = toAccountRaw(syncedAccount);
+  const accountRaw = await toAccountRaw(syncedAccount);
 
   console.log("finishing sync on", account.currency.id, account.xpub ?? account.freshAddress);
   return accountRaw;

--- a/libs/ledger-live-common/src/__tests__/mock-bridges.ts
+++ b/libs/ledger-live-common/src/__tests__/mock-bridges.ts
@@ -60,10 +60,10 @@ mockedCoins.map(getCryptoCurrencyById).forEach(currency => {
               })
               .pipe(reduce((a, f) => f(a), a)),
           );
-          const m: Record<string, any> = toAccountRaw(a);
+          const m: Record<string, any> = await toAccountRaw(a);
           delete m.lastSyncDate;
           delete m.blockHeight;
-          expect(toAccountRaw(synced)).toMatchObject(m);
+          expect(await toAccountRaw(synced)).toMatchObject(m);
           return synced;
         }),
       );

--- a/libs/ledger-live-common/src/__tests__/test-helpers/bridge.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/bridge.ts
@@ -1,7 +1,6 @@
 import invariant from "invariant";
 import { BigNumber } from "bignumber.js";
 import { reduce, filter, map } from "rxjs/operators";
-import flatMap from "lodash/flatMap";
 import omit from "lodash/omit";
 import { InvalidAddress, RecipientRequired, AmountRequired } from "@ledgerhq/errors";
 import {
@@ -208,11 +207,18 @@ export function testBridge<T extends TransactionCommon>(data: DatasetTest<T>): v
               });
 
               if (!sa.unstableAccounts) {
-                const raws: AccountRawLike[] = flatMap(accounts, a => {
-                  const main = toAccountRaw(a);
-                  if (!main.subAccounts) return [main];
-                  return [{ ...main, subAccounts: [] }, ...main.subAccounts] as AccountRawLike[];
-                });
+                const raws: AccountRawLike[] = (
+                  await Promise.all(
+                    accounts.map(async a => {
+                      const main = await toAccountRaw(a);
+                      if (!main.subAccounts) return [main];
+                      return [
+                        { ...main, subAccounts: [] },
+                        ...main.subAccounts,
+                      ] as AccountRawLike[];
+                    }),
+                  )
+                ).flat();
                 const heads = raws.map(a => {
                   const copy = omit(
                     a,
@@ -413,7 +419,7 @@ export function testBridge<T extends TransactionCommon>(data: DatasetTest<T>): v
           describe("sync", () => {
             makeTest("succeed", async () => {
               const account = await getSynced();
-              expect(fromAccountRaw(toAccountRaw(account))).toBeDefined();
+              expect(await fromAccountRaw(await toAccountRaw(account))).toBeDefined();
             });
 
             if (impl !== "mock") {

--- a/libs/ledger-live-common/src/account/formatters.ts
+++ b/libs/ledger-live-common/src/account/formatters.ts
@@ -186,7 +186,7 @@ const operationBalanceHistory = account => {
 export const accountFormatters: { [_: string]: (Account) => any } = {
   operationBalanceHistoryBackwards,
   operationBalanceHistory,
-  json: account => JSON.stringify(toAccountRaw(account)),
+  json: async account => JSON.stringify(await toAccountRaw(account)),
   head: account => cliFormat(account, "head"),
   default: account => cliFormat(account),
   basic: account => cliFormat(account, "basic"),

--- a/libs/ledger-live-common/src/account/serialization.test.ts
+++ b/libs/ledger-live-common/src/account/serialization.test.ts
@@ -36,7 +36,7 @@ describe("serialization", () => {
     tokenAcc.state = "initialized";
     acc.subAccounts = [tokenAcc];
 
-    const accRaw: any = toAccountRaw(acc);
+    const accRaw: any = await toAccountRaw(acc);
     expect(accRaw.subAccounts?.[0]?.state).toBe("initialized");
 
     const deserializedAcc: any = await fromAccountRaw(accRaw);

--- a/libs/ledger-live-common/src/account/serialization.ts
+++ b/libs/ledger-live-common/src/account/serialization.ts
@@ -43,18 +43,18 @@ export const toOperationRaw = (
   return commonToOperationRaw(operation, preserveSubOperation, toOperationRaw);
 };
 
-export const fromOperationRaw = (
+export const fromOperationRaw = async (
   operationRaw: OperationRaw,
   accountId: string,
   subAccounts?: TokenAccount[] | null | undefined,
-): Operation => {
+): Promise<Operation> => {
   let fromOperationRaw: AccountBridge<TransactionCommon>["fromOperationExtraRaw"] | undefined;
 
   if (operationRaw.extra) {
     const family = inferFamilyFromAccountId(operationRaw.accountId);
 
     if (family) {
-      const bridge = getAccountBridgeByFamily(family, accountId);
+      const bridge = await getAccountBridgeByFamily(family, accountId);
       fromOperationRaw = bridge.fromOperationExtraRaw;
     }
   }
@@ -73,8 +73,8 @@ export async function fromAccountRaw(rawAccount: AccountRaw): Promise<Account> {
   });
 }
 
-export function toAccountRaw(account: Account, userData?: AccountUserData): AccountRaw {
-  const bridge = getAccountBridge(account);
+export async function toAccountRaw(account: Account, userData?: AccountUserData): Promise<AccountRaw> {
+  const bridge = await getAccountBridge(account);
 
   const commonAccountRaw = commonToAccountRaw(account, {
     assignToAccountRaw: bridge.assignToAccountRaw,

--- a/libs/ledger-live-common/src/account/support.ts
+++ b/libs/ledger-live-common/src/account/support.ts
@@ -7,9 +7,12 @@ export {
   checkAccountSupported,
 } from "@ledgerhq/ledger-wallet-framework/account/support";
 
-export function canSend(account: AccountLike, parentAccount: Account | null | undefined): boolean {
+export async function canSend(
+  account: AccountLike,
+  parentAccount: Account | null | undefined,
+): Promise<boolean> {
   try {
-    getAccountBridge(account, parentAccount).createTransaction(
+    (await getAccountBridge(account, parentAccount)).createTransaction(
       getMainAccount(account, parentAccount),
     );
     return true;

--- a/libs/ledger-live-common/src/bot/index.ts
+++ b/libs/ledger-live-common/src/bot/index.ts
@@ -59,26 +59,30 @@ function convertMutation<T extends Transaction>(
   };
 }
 
-function convertSpecReport<T extends Transaction>(
+async function convertSpecReport<T extends Transaction>(
   result: SpecReport<T>,
-): MinimalSerializedSpecReport {
-  const accounts = result.accountsAfter?.map(a => {
-    // remove the "expensive" data fields
-    const raw = toAccountRaw(a);
-    raw.operations = [];
-    delete raw.balanceHistoryCache;
-    if (raw.subAccounts) {
-      raw.subAccounts.forEach(a => {
-        a.operations = [];
-        delete a.balanceHistoryCache;
-      });
-    }
-    const unsafe = raw as any;
-    if (unsafe.bitcoinResources) {
-      delete unsafe.bitcoinResources.walletAccount;
-    }
-    return raw;
-  });
+): Promise<MinimalSerializedSpecReport> {
+  const accounts = result.accountsAfter
+    ? await Promise.all(
+        result.accountsAfter.map(async a => {
+          // remove the "expensive" data fields
+          const raw = await toAccountRaw(a);
+          raw.operations = [];
+          delete raw.balanceHistoryCache;
+          if (raw.subAccounts) {
+            raw.subAccounts.forEach(a => {
+              a.operations = [];
+              delete a.balanceHistoryCache;
+            });
+          }
+          const unsafe = raw as any;
+          if (unsafe.bitcoinResources) {
+            delete unsafe.bitcoinResources.walletAccount;
+          }
+          return raw;
+        }),
+      )
+    : undefined;
   const mutations = result.mutations?.map(convertMutation);
   return {
     specName: result.spec.name,
@@ -90,16 +94,18 @@ function convertSpecReport<T extends Transaction>(
   };
 }
 
-function makeAppJSON(accounts: Account[]) {
+async function makeAppJSON(accounts: Account[]) {
   const jsondata = {
     data: {
       settings: {
         hasCompletedOnboarding: true,
       },
-      accounts: accounts.map(account => ({
-        data: toAccountRaw(account),
-        version: 1,
-      })),
+      accounts: await Promise.all(
+        accounts.map(async account => ({
+          data: await toAccountRaw(account),
+          version: 1,
+        })),
+      ),
     },
   };
   return JSON.stringify(jsondata);
@@ -713,7 +719,7 @@ export async function bot({ disabled, filter }: Arg = {}): Promise<void> {
 
   if (BOT_REPORT_FOLDER) {
     const serializedReport: MinimalSerializedReport = {
-      results: results.map(convertSpecReport),
+      results: await Promise.all(results.map(convertSpecReport)),
       environment: BOT_ENVIRONMENT,
       seedHash: sha256(getEnv("SEED")).toString("hex"),
     };
@@ -728,7 +734,7 @@ export async function bot({ disabled, filter }: Arg = {}): Promise<void> {
       ),
       fs.promises.writeFile(
         path.join(BOT_REPORT_FOLDER, "app.json"),
-        makeAppJSON(allAccountsAfter),
+        await makeAppJSON(allAccountsAfter),
         "utf-8",
       ),
       fs.promises.writeFile(

--- a/libs/ledger-live-common/src/bot/portfolio/process-sync.ts
+++ b/libs/ledger-live-common/src/bot/portfolio/process-sync.ts
@@ -117,7 +117,7 @@ async function main(): Promise<Report> {
 
     audit.end();
 
-    const accountsRaw = JSON.stringify(accounts.map(a => toAccountRaw(a)));
+    const accountsRaw = JSON.stringify(await Promise.all(accounts.map(a => toAccountRaw(a))));
     const preloadJSON = JSON.stringify(localCache);
     audit.setAccountsJSONSize(accountsRaw.length);
     audit.setPreloadJSONSize(preloadJSON.length);

--- a/libs/ledger-live-common/src/bridge/index.ts
+++ b/libs/ledger-live-common/src/bridge/index.ts
@@ -14,12 +14,12 @@ export async function fromScanAccountEventRaw(raw: ScanAccountEventRaw): Promise
       throw new Error("unsupported ScanAccountEvent " + raw.type);
   }
 }
-export function toScanAccountEventRaw(e: ScanAccountEvent): ScanAccountEventRaw {
+export async function toScanAccountEventRaw(e: ScanAccountEvent): Promise<ScanAccountEventRaw> {
   switch (e.type) {
     case "discovered":
       return {
         type: e.type,
-        account: toAccountRaw(e.account),
+        account: await toAccountRaw(e.account),
       };
 
     default:

--- a/libs/ledger-live-common/src/families/concordium/bridgeHelper.ts
+++ b/libs/ledger-live-common/src/families/concordium/bridgeHelper.ts
@@ -12,8 +12,10 @@ function isConcordiumCurrencyBridge(bridge: CurrencyBridge): bridge is Concordiu
   );
 }
 
-export function getConcordiumBridge(currency: CryptoCurrency): ConcordiumCurrencyBridge {
-  const bridge = getCurrencyBridge(currency);
+export async function getConcordiumBridge(
+  currency: CryptoCurrency,
+): Promise<ConcordiumCurrencyBridge> {
+  const bridge = await getCurrencyBridge(currency);
   if (!isConcordiumCurrencyBridge(bridge)) {
     throw new Error(`Expected ConcordiumCurrencyBridge for ${currency.id}`);
   }

--- a/libs/ledger-live-common/src/platform/logic.test.ts
+++ b/libs/ledger-live-common/src/platform/logic.test.ts
@@ -392,7 +392,7 @@ describe("broadcastTransactionLogic", () => {
       // Given
       const expectedResult = "Function called";
       const signedOperation = createSignedOperation();
-      mockedDeserializePlatformSignedTransaction.mockReturnValueOnce(signedOperation);
+      mockedDeserializePlatformSignedTransaction.mockResolvedValueOnce(signedOperation);
       uiNavigation.mockResolvedValueOnce(expectedResult);
 
       // When
@@ -427,7 +427,7 @@ describe("broadcastTransactionLogic", () => {
       // Given
       const expectedResult = "Function called";
       const signedOperation = createSignedOperation();
-      mockedDeserializePlatformSignedTransaction.mockReturnValueOnce(signedOperation);
+      mockedDeserializePlatformSignedTransaction.mockResolvedValueOnce(signedOperation);
       uiNavigation.mockResolvedValueOnce(expectedResult);
 
       // When

--- a/libs/ledger-live-common/src/platform/logic.ts
+++ b/libs/ledger-live-common/src/platform/logic.ts
@@ -139,7 +139,7 @@ export async function broadcastTransactionLogic(
 
   const parentAccount = getParentAccount(account, accounts);
 
-  const signedOperation = deserializePlatformSignedTransaction(signedTransaction, accountId);
+  const signedOperation = await deserializePlatformSignedTransaction(signedTransaction, accountId);
 
   return uiNavigation(account, parentAccount, signedOperation);
 }

--- a/libs/ledger-live-common/src/platform/serializers.test.ts
+++ b/libs/ledger-live-common/src/platform/serializers.test.ts
@@ -50,14 +50,14 @@ const RAW_SIGNED_TRANSACTION: SignedOperationRaw = {
 
 const ACCOUNT_ID = "js:2:ethereum:0x3f87926741ecaXXXXXXXXXXXXXXXXXXXXXXXXXXX:";
 
-test("should serialize a platform signed transaction", () => {
-  const serializedSignedTransaction = serializePlatformSignedTransaction(SIGNED_TRANSACTION);
+test("should serialize a platform signed transaction", async () => {
+  const serializedSignedTransaction = await serializePlatformSignedTransaction(SIGNED_TRANSACTION);
 
   expect(serializedSignedTransaction).toEqual(RAW_SIGNED_TRANSACTION);
 });
 
-test("should deserialize a raw platform signed transaction", () => {
-  const signedTransaction = deserializePlatformSignedTransaction(
+test("should deserialize a raw platform signed transaction", async () => {
+  const signedTransaction = await deserializePlatformSignedTransaction(
     RAW_SIGNED_TRANSACTION,
     ACCOUNT_ID,
   );
@@ -66,19 +66,19 @@ test("should deserialize a raw platform signed transaction", () => {
 });
 
 describe("Serialize -> Deserialize flow", () => {
-  test("should not alter signedTransaction", () => {
-    const serializedSignedTransaction = serializePlatformSignedTransaction(SIGNED_TRANSACTION);
+  test("should not alter signedTransaction", async () => {
+    const serializedSignedTransaction = await serializePlatformSignedTransaction(SIGNED_TRANSACTION);
 
     const stringifiedSignedTransaction = JSON.stringify(serializedSignedTransaction);
 
     const parsedSignedTransaction = JSON.parse(stringifiedSignedTransaction) as SignedOperationRaw;
 
-    const expectedSignedTransaction = deserializePlatformSignedTransaction(
+    const expectedSignedTransaction = await deserializePlatformSignedTransaction(
       parsedSignedTransaction,
       ACCOUNT_ID,
     );
 
-    const signedTransaction = deserializePlatformSignedTransaction(
+    const signedTransaction = await deserializePlatformSignedTransaction(
       RAW_SIGNED_TRANSACTION,
       ACCOUNT_ID,
     );

--- a/libs/ledger-live-common/src/platform/serializers.ts
+++ b/libs/ledger-live-common/src/platform/serializers.ts
@@ -10,23 +10,14 @@ export {
 } from "@ledgerhq/live-app-sdk";
 
 // FIXME: can't use SDK implementations here because SDK don't know how to properly serialize / deserialize Operation object
-export function serializePlatformSignedTransaction(
+export async function serializePlatformSignedTransaction(
   signedTransaction: PlatformSignedTransaction,
-): RawPlatformSignedTransaction {
-  return toSignedOperationRaw(signedTransaction, true);
+): Promise<RawPlatformSignedTransaction> {
+  return await toSignedOperationRaw(signedTransaction, true);
 }
-/**
- * Deserializes a raw platform signed transaction.
- *
- * @remarks
- * This function is currently synchronous but will become `async` in a future
- * migration step (LIVE-29183 — transaction serialization async prep).
- * Callers should already `await` this call so that no further changes are
- * needed once the function signature is updated.
- */
-export function deserializePlatformSignedTransaction(
+export async function deserializePlatformSignedTransaction(
   rawSignedTransaction: RawPlatformSignedTransaction,
   accountId: string,
-): PlatformSignedTransaction {
-  return fromSignedOperationRaw(rawSignedTransaction, accountId);
+): Promise<PlatformSignedTransaction> {
+  return await fromSignedOperationRaw(rawSignedTransaction, accountId);
 }

--- a/libs/ledger-live-common/src/transaction/signOperation.ts
+++ b/libs/ledger-live-common/src/transaction/signOperation.ts
@@ -5,13 +5,13 @@ import type {
   SignedOperation,
 } from "@ledgerhq/types-live";
 import { fromOperationRaw, toOperationRaw } from "../account";
-export const fromSignedOperationRaw = (
+export const fromSignedOperationRaw = async (
   signedOp: SignedOperationRaw,
   accountId: string,
-): SignedOperation => {
+): Promise<SignedOperation> => {
   const { operation, signature, expirationDate, rawData } = signedOp;
   const out: SignedOperation = {
-    operation: fromOperationRaw(operation, accountId),
+    operation: await fromOperationRaw(operation, accountId),
     signature,
   };
 
@@ -45,15 +45,15 @@ export const toSignedOperationRaw = (
 
   return out;
 };
-export const fromSignOperationEventRaw = (
+export const fromSignOperationEventRaw = async (
   e: SignOperationEventRaw,
   accountId: string,
-): SignOperationEvent => {
+): Promise<SignOperationEvent> => {
   switch (e.type) {
     case "signed":
       return {
         type: "signed",
-        signedOperation: fromSignedOperationRaw(e.signedOperation, accountId),
+        signedOperation: await fromSignedOperationRaw(e.signedOperation, accountId),
       };
 
     default:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- Existing unit tests cover the affected code paths; all pass after the change. -->
- [x] **Impact of the changes:**
  - `@ledgerhq/live-common`: return types of `fromOperationRaw`, `toAccountRaw`, `canSend`, `toScanAccountEventRaw`, `encodeModel`, `getConcordiumBridge`, `fromSignedOperationRaw`, `fromSignOperationEventRaw`, `serializePlatformSignedTransaction`, `deserializePlatformSignedTransaction` changed from `T` to `Promise<T>`.
  - All call sites in desktop, mobile, CLI, and live-common are updated to `await` the new async return values.
  - No runtime behavior change — all underlying bridge calls are still synchronous today.

### 📝 Description

Part of [LIVE-29176 — Coin Implementation Defer Loading](https://ledgerhq.atlassian.net/browse/LIVE-29176).

The bigger plan is to move coin bridge loading (`getAccountBridgeByFamily`) from synchronous to async, enabling true deferred loading of coin modules on both desktop and mobile. When that happens, every function that calls the bridge will need to return a `Promise`.

This PR anticipates that upcoming change by converting those functions to `async` **now**, while the bridge itself is still synchronous. Updating callers first means the actual bridge flip will be a small, low-risk follow-up.

**Functions made async in `@ledgerhq/live-common`:**
- Account serialization: `fromOperationRaw`, `toAccountRaw`
- Sendability: `canSend`
- Data model: `encodeModel`
- Bridge scan: `toScanAccountEventRaw`
- Concordium bridge: `getConcordiumBridge`
- Sign chain: `fromSignedOperationRaw`, `fromSignOperationEventRaw`
- Platform serializers: `serializePlatformSignedTransaction`, `deserializePlatformSignedTransaction`

All callers in `apps/cli`, `apps/ledger-live-desktop`, and `apps/ledger-live-mobile` are updated to `await` the new Promises (RxJS `map` → `switchMap`/`mergeMap` where needed).

**No runtime behavior change** — all bridge calls remain synchronous today; we're just propagating the `async` shape ahead of time.

### ❓ Context

- **JIRA**: [LIVE-29184](https://ledgerhq.atlassian.net/browse/LIVE-29184)
- **Epic**: [LIVE-29176 — Coin Implementation Defer Loading](https://ledgerhq.atlassian.net/browse/LIVE-29176)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29184]: https://ledgerhq.atlassian.net/browse/LIVE-29184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ