### PR TITLE
[LWDM] fix(common): apply legacyIdToApiId to DaDa currencyIds for API compat

### DIFF
--- a/.changeset/empty-bananas-tickle.md
+++ b/.changeset/empty-bananas-tickle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Apply legacyIdToApiId to DaDa currencyIds for Stellar and MultiversX API compatibility

--- a/libs/ledger-live-common/src/dada-client/state-manager/__tests__/api.test.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { fetchAllAssetsByCategory } from "../api";
+import { fetchAllAssetsByCategory, buildAssetsQueryParams } from "../api";
 import { AssetCategory } from "../types";
 import type { RawApiResponse } from "../../entities";
 import { getEnv } from "@ledgerhq/live-env";
@@ -52,6 +52,53 @@ const defaultArgs = {
   product: "lld" as const,
   version: "1.0.0",
 };
+
+const baseQueryArg = { product: "lld" as const, version: "1.0.0" };
+
+describe("buildAssetsQueryParams", () => {
+  it.each([
+    {
+      scenario: "standard IDs unchanged",
+      input: ["ethereum/erc20/usdc", "ton/jetton/some_address", "bitcoin"],
+      expected: ["ethereum/erc20/usdc", "ton/jetton/some_address", "bitcoin"],
+    },
+    {
+      scenario: "Stellar lowercased",
+      input: ["stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"],
+      expected: ["stellar/asset/usdc:ga5zsejyb37jrc5avcia5mop4rhtm335x2kgx3ihojapp5re34k4kzvn"],
+    },
+    {
+      scenario: "MultiversX renamed to elrond",
+      input: ["multiversx/esdt/USDC-c76f1f"],
+      expected: ["elrond/esdt/USDC-c76f1f"],
+    },
+    {
+      scenario: "mixed array transformed independently",
+      input: [
+        "ethereum/erc20/usdc",
+        "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+        "multiversx/esdt/USDC-c76f1f",
+        "bitcoin",
+      ],
+      expected: [
+        "ethereum/erc20/usdc",
+        "stellar/asset/usdc:ga5zsejyb37jrc5avcia5mop4rhtm335x2kgx3ihojapp5re34k4kzvn",
+        "elrond/esdt/USDC-c76f1f",
+        "bitcoin",
+      ],
+    },
+  ])("should transform currencyIds: $scenario", ({ input, expected }) => {
+    const params = buildAssetsQueryParams({ ...baseQueryArg, currencyIds: input });
+    expect(params.currencyIds).toEqual(expected);
+  });
+
+  it("should omit currencyIds when empty or not provided", () => {
+    expect(
+      buildAssetsQueryParams({ ...baseQueryArg, currencyIds: [] }).currencyIds,
+    ).toBeUndefined();
+    expect(buildAssetsQueryParams(baseQueryArg).currencyIds).toBeUndefined();
+  });
+});
 
 describe("fetchAllAssetsByCategory", () => {
   afterEach(() => {

--- a/libs/ledger-live-common/src/dada-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/api.ts
@@ -5,7 +5,7 @@ import {
   FetchBaseQueryMeta,
   QueryReturnValue,
 } from "@reduxjs/toolkit/query/react";
-import { convertApiAssets } from "@ledgerhq/cryptoassets";
+import { convertApiAssets, legacyIdToApiId } from "@ledgerhq/cryptoassets";
 import { RawApiResponse, AssetsData } from "../entities";
 import { getEnv } from "@ledgerhq/live-env";
 import {
@@ -56,7 +56,7 @@ function emptyAssetsData(): AssetsData {
   };
 }
 
-function buildAssetsQueryParams(
+export function buildAssetsQueryParams(
   queryArg: GetAssetsDataParams,
   opts?: { pageSize?: number; cursor?: string },
 ): Record<string, unknown> {
@@ -65,7 +65,10 @@ function buildAssetsQueryParams(
     ...(opts?.cursor && { cursor: opts.cursor }),
     ...(queryArg.useCase && { transaction: queryArg.useCase }),
     ...(queryArg.currencyIds &&
-      queryArg.currencyIds.length > 0 && { currencyIds: queryArg.currencyIds }),
+      queryArg.currencyIds.length > 0 && {
+        // FIXME: Transform legacy ID to API format before querying
+        currencyIds: queryArg.currencyIds.map(legacyIdToApiId),
+      }),
     ...(queryArg.search && { search: queryArg.search }),
     product: queryArg.product,
     minVersion: queryArg.version,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - DaDa API requests for Stellar and MultiversX currencies now use correct ID format
      - No impact on other currencies (passthrough)

### 📝 Description

The DaDa client was sending `currencyIds` to the API without transforming them to the expected backend format. This caused Stellar IDs (which use uppercase in Ledger Live) and MultiversX IDs (which use `multiversx/` prefix in LL vs `elrond/` in the API) to not match on the backend.

Applied the same `legacyIdToApiId` transformation already used in cal-client's `findTokenById` to `buildAssetsQueryParams`, so all DaDa endpoints (`getAssetsData`, `getAssetData`, `getChunkedAssetsData`) benefit from a single fix point.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28490](https://ledgerhq.atlassian.net/browse/LIVE-28490)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28490]: https://ledgerhq.atlassian.net/browse/LIVE-28490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ