### PR TITLE
fix(wallet-cli): fix init-cwd for dist/<platform>/cli binary layout

### DIFF
--- a/apps/wallet-cli/src/init-cwd.ts
+++ b/apps/wallet-cli/src/init-cwd.ts
@@ -3,18 +3,25 @@ import { join, dirname } from "node:path";
 
 /**
  * Native addons such as `usb` (node-gyp-build) can misbehave when the process cwd is unrelated to the app
- * (e.g. monorepo root, /tmp). The standalone binary is emitted as dist/cli; package root is one
- * level up. When running via `bun src/cli.ts`, execPath points at the Bun binary — skip chdir.
+ * (e.g. monorepo root, /tmp). When running via `bun src/cli.ts`, execPath points at the Bun binary — skip chdir.
+ *
+ * Standalone binaries are emitted under dist/<platform>/ (e.g. dist/darwin-arm64/cli), so the
+ * package root is two levels above the binary. The JS bundle (dist/cli) is only one level up.
+ * Check both to handle either layout.
  */
-const nextToExec = join(dirname(process.execPath), "..");
-const looksLikePackageRoot =
-  existsSync(join(nextToExec, "bunli.config.ts")) ||
-  existsSync(join(nextToExec, "bunli.config.js")) ||
-  existsSync(join(nextToExec, "bunli.config.mjs"));
+const isPackageRoot = (dir: string): boolean =>
+  existsSync(join(dir, "bunli.config.ts")) ||
+  existsSync(join(dir, "bunli.config.js")) ||
+  existsSync(join(dir, "bunli.config.mjs"));
 
-if (looksLikePackageRoot) {
+const execDir = dirname(process.execPath);
+// dist/<platform>/cli  →  ../.. reaches the package root
+// dist/cli             →  ..    reaches the package root
+const packageRoot = [join(execDir, "../.."), join(execDir, "..")].find(isPackageRoot) ?? null;
+
+if (packageRoot) {
   try {
-    process.chdir(nextToExec);
+    process.chdir(packageRoot);
   } catch {
     // ignore
   }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli

### 📝 Description

Standalone binaries are emitted under `dist/<platform>/` (e.g. `dist/darwin-arm64/cli`), so the package root is two levels above the binary — not one. The previous logic used `join(execDir, "..")` which landed in `dist/`, found no `bunli.config.ts` there, and skipped the chdir. With cwd left at the monorepo root, `createCLI()` would hang trying to dynamically import `.bunli/commands.gen.ts` from there.

Check `../..` first (`dist/<platform>/cli` layout), then fall back to `..` (`dist/cli` bundle layout) so both paths keep working.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
