### PR TITLE
[LWD] fix(desktop): prevent Save logs button from shrinking on broadcast error

### DIFF
--- a/.changeset/six-suits-jam.md
+++ b/.changeset/six-suits-jam.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Send broadcast error Save logs button shrinking when error message is long

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/Confirmation/NodeError/TechnicalErrorSection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/Confirmation/NodeError/TechnicalErrorSection.tsx
@@ -77,14 +77,16 @@ const TechnicalErrorSection = ({ error, onSaveLogs }: Props) => {
           <Text color="neutral.c70">{error.message}</Text>
         </StyledText>
       </Box>
-      <Flex columnGap={2} alignSelf="start">
-        <InteractFlex onClick={onSaveLogs} flexShrink={1}>
+      <Flex columnGap={2} flexShrink={0} alignSelf="start">
+        <InteractFlex onClick={onSaveLogs} flexShrink={0} flexGrow={0} alignSelf="start">
           <Icons.Download color="neutral.c100" size="S" />
-          <Text variant="bodyLineHeight" fontSize={13}>
+          <Text variant="bodyLineHeight" fontSize={13} style={{ whiteSpace: "nowrap" }}>
             {t("errors.TransactionBroadcastError.saveLogs")}
           </Text>
         </InteractFlex>
-        <InteractFlex onClick={handleCopyError}>{icon}</InteractFlex>
+        <InteractFlex onClick={handleCopyError} flexShrink={0} flexGrow={0} alignSelf="start">
+          {icon}
+        </InteractFlex>
       </Flex>
     </Container>
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _UI layout fix — visual verification only._
- [x] **Impact of the changes:**
      - Send flow broadcast error screen (last step)
      - Save logs / copy buttons no longer shrink when the error message is long

### 📝 Description

When a transaction broadcast fails (e.g. XRP `invalidTransaction`), the technical error section displays a long error string. The "Save logs" and copy buttons were using `flexShrink={1}`, causing them to compress and wrap their labels onto multiple lines.

This fix aligns the action buttons with the "Get Help" button in `HelpSection` by setting `flexShrink={0}`, `flexGrow={0}`, and `alignSelf="start"` on the actions wrapper and both `InteractFlex` controls. A `whiteSpace: "nowrap"` guard is added to the Save logs label to prevent any remaining edge-case wrapping.

<img width="593" height="706" alt="Screenshot 2026-04-14 at 18 20 55" src="https://github.com/user-attachments/assets/d63210f1-ad9b-410f-b59f-302f4f6a847a" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29201](https://ledgerhq.atlassian.net/browse/LIVE-29201)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29201]: https://ledgerhq.atlassian.net/browse/LIVE-29201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ