### PR TITLE
[LWDM] fix(lwdm): fix getAddress signer XRP - EVM - XLM

### DIFF
--- a/.changeset/small-stingrays-occur.md
+++ b/.changeset/small-stingrays-occur.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix(lwdm): fix getAddress signer XRP - EVM - XLM

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/evm/signer.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/evm/signer.test.ts
@@ -1,0 +1,151 @@
+import { createSigner } from "./signer";
+import { LegacySignerEth, DmkSignerEth } from "@ledgerhq/live-signer-evm";
+import Transport from "@ledgerhq/hw-transport";
+import type { DeviceManagementKit } from "@ledgerhq/device-management-kit";
+
+jest.mock("@ledgerhq/live-signer-evm");
+jest.mock("@ledgerhq/coin-evm/hw-getAddress", () => jest.fn());
+
+const MockedLegacySignerEth = LegacySignerEth as jest.MockedClass<typeof LegacySignerEth>;
+const mockTransport = {} as Transport;
+
+describe("createSigner (EVM)", () => {
+  let mockGetAddress: jest.Mock;
+
+  beforeEach(() => {
+    mockGetAddress = jest.fn().mockResolvedValue({
+      publicKey: "deadbeef",
+      address: "0x1234567890abcdef",
+    });
+    MockedLegacySignerEth.mockImplementation(
+      () =>
+        ({
+          getAddress: mockGetAddress,
+          setLoadConfig: jest.fn(),
+          clearSignTransaction: jest.fn(),
+        }) as unknown as LegacySignerEth,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getAddress — display flag forwarded to LegacySignerEth", () => {
+    it("should NOT display address on device when called with a derivationMode options object (send flow)", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0", { derivationMode: "ethM" });
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", false);
+    });
+
+    it("should NOT display address on device when called without options", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0");
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", false);
+    });
+
+    it("should NOT display address on device when called with verify: false", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0", { verify: false });
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", false);
+    });
+
+    it("should display address on device when called with boolean true (receive flow)", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0", true);
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", true);
+    });
+
+    it("should display address on device when called with verify: true", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0", { verify: true });
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", true);
+    });
+
+    it("should forward boolChaincode and chainId to the underlying signer (receive flow)", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0", true, false, "1");
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", true, false, "1");
+    });
+  });
+
+  describe("DMK transport", () => {
+    const MockedDmkSignerEth = DmkSignerEth as jest.MockedClass<typeof DmkSignerEth>;
+    const mockDmk = {} as DeviceManagementKit;
+    const dmkTransport = {
+      dmk: mockDmk,
+      sessionId: "test-session",
+    } as unknown as Transport & { dmk: DeviceManagementKit; sessionId: string };
+
+    beforeEach(() => {
+      MockedDmkSignerEth.mockImplementation(
+        () =>
+          ({
+            getAddress: mockGetAddress,
+            setLoadConfig: jest.fn(),
+            clearSignTransaction: jest.fn(),
+          }) as unknown as DmkSignerEth,
+      );
+    });
+
+    it("should NOT display address on device when called with a derivationMode options object (send flow)", async () => {
+      const signer = createSigner(dmkTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0", { derivationMode: "ethM" });
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", false);
+    });
+
+    it("should NOT display address on device when called without options", async () => {
+      const signer = createSigner(dmkTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0");
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", false);
+    });
+
+    it("should NOT display address on device when called with verify: false", async () => {
+      const signer = createSigner(dmkTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0", { verify: false });
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", false);
+    });
+
+    it("should display address on device when called with boolean true (receive flow)", async () => {
+      const signer = createSigner(dmkTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0", true);
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", true);
+    });
+
+    it("should display address on device when called with verify: true", async () => {
+      const signer = createSigner(dmkTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0", { verify: true });
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", true);
+    });
+
+    it("should forward boolChaincode and chainId to the underlying signer (receive flow)", async () => {
+      const signer = createSigner(dmkTransport);
+
+      await signer.getAddress("44'/60'/0'/0/0", true, false, "1");
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0", true, false, "1");
+    });
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/evm/signer.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/evm/signer.ts
@@ -12,7 +12,12 @@ import { CreateSigner, executeWithSigner } from "../../../setup";
 import type { AlpacaSigner } from "../../types";
 
 export type Signer = {
-  getAddress: (path: string) => Promise<EvmAddress>;
+  getAddress: (
+    path: string,
+    options?: boolean | { verify?: boolean; derivationMode?: string },
+    boolChaincode?: boolean,
+    chainId?: string,
+  ) => Promise<EvmAddress>;
   signTransaction: (path: string, tx: string, domain?: DomainServiceResolution) => Promise<string>;
 };
 
@@ -39,7 +44,17 @@ export const createSigner: CreateSigner<Signer> = (transport: Transport) => {
   const signer = createLiveSigner(transport);
 
   return {
-    getAddress: signer.getAddress.bind(signer),
+    getAddress: async (
+      path: string,
+      options?: boolean | { verify?: boolean; derivationMode?: string },
+      boolChaincode?: boolean,
+      chainId?: string,
+    ) => {
+      const display = typeof options === "boolean" ? options : Boolean(options?.verify);
+      return boolChaincode === undefined && chainId === undefined
+        ? signer.getAddress(path, display)
+        : signer.getAddress(path, display, boolChaincode, chainId);
+    },
     signTransaction: async (path, tx, domain) => {
       // Configure type of resolutions necessary for the clear signing
       const resolutionConfig: ResolutionConfig = {

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/stellar/signer.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/stellar/signer.test.ts
@@ -1,0 +1,85 @@
+import { createSignerStellar } from "./signer";
+import Stellar from "@ledgerhq/hw-app-str";
+import Transport from "@ledgerhq/hw-transport";
+
+jest.mock("@ledgerhq/hw-app-str");
+jest.mock("../../../../families/stellar/getAddress", () => jest.fn());
+
+const MockedStellar = Stellar as jest.MockedClass<typeof Stellar>;
+const mockTransport = {} as Transport;
+
+describe("createSignerStellar", () => {
+  let mockGetPublicKey: jest.Mock;
+  let mockSignTransaction: jest.Mock;
+
+  beforeEach(() => {
+    // 32 bytes — valid Ed25519 raw public key
+    mockGetPublicKey = jest.fn().mockResolvedValue({ rawPublicKey: Buffer.alloc(32, 0x01) });
+    mockSignTransaction = jest.fn();
+    MockedStellar.mockImplementation(
+      () =>
+        ({
+          getPublicKey: mockGetPublicKey,
+          signTransaction: mockSignTransaction,
+        }) as unknown as Stellar,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getAddress — display flag forwarded to hw-app-str", () => {
+    it("should NOT display address on device when called without options", async () => {
+      const signer = createSignerStellar(mockTransport);
+
+      await signer.getAddress("44'/148'/0'");
+
+      expect(mockGetPublicKey).toHaveBeenCalledWith("44'/148'/0'", false);
+    });
+
+    it("should NOT display address on device when called with verify: false", async () => {
+      const signer = createSignerStellar(mockTransport);
+
+      await signer.getAddress("44'/148'/0'", { verify: false });
+
+      expect(mockGetPublicKey).toHaveBeenCalledWith("44'/148'/0'", false);
+    });
+
+    it("should display address on device when called with boolean true (receive flow)", async () => {
+      const signer = createSignerStellar(mockTransport);
+
+      await signer.getAddress("44'/148'/0'", true);
+
+      expect(mockGetPublicKey).toHaveBeenCalledWith("44'/148'/0'", true);
+    });
+
+    it("should display address on device when called with verify: true", async () => {
+      const signer = createSignerStellar(mockTransport);
+
+      await signer.getAddress("44'/148'/0'", { verify: true });
+
+      expect(mockGetPublicKey).toHaveBeenCalledWith("44'/148'/0'", true);
+    });
+  });
+
+  describe("getAddress — return value", () => {
+    it("should return a Base58-encoded Stellar address starting with G", async () => {
+      const signer = createSignerStellar(mockTransport);
+
+      const result = await signer.getAddress("44'/148'/0'");
+
+      expect(result.address).toMatch(/^G/);
+      expect(result.publicKey).toMatch(/^G/);
+      expect(result.path).toBe("44'/148'/0'");
+    });
+
+    it("should return the same value for address and publicKey", async () => {
+      const signer = createSignerStellar(mockTransport);
+
+      const result = await signer.getAddress("44'/148'/0'");
+
+      expect(result.address).toBe(result.publicKey);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/stellar/signer.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/stellar/signer.ts
@@ -5,18 +5,26 @@ import Transport from "@ledgerhq/hw-transport";
 import Stellar from "@ledgerhq/hw-app-str";
 import { StrKey } from "@stellar/stellar-sdk";
 
-const createSignerStellar: CreateSigner<Stellar> = (transport: Transport) => {
+type StellarSigner = Stellar & {
+  signTransaction: (path: string, transaction: string) => Promise<string>;
+  getAddress: (
+    path: string,
+    options?: boolean | { verify?: boolean; derivationMode?: string },
+  ) => Promise<{ path: string; address: string; publicKey: string }>;
+};
+
+export const createSignerStellar: CreateSigner<StellarSigner> = (transport: Transport) => {
   const stellar = new Stellar(transport);
   const originalSignTransaction = stellar.signTransaction;
-  // Return the original Stellar instance with overridden methods
   return Object.assign(stellar, {
     signTransaction: async (path: string, transaction: string) => {
       const unsignedPayload: Buffer = Buffer.from(transaction, "base64");
       const { signature } = await originalSignTransaction(path, unsignedPayload);
       return signature.toString("base64");
     },
-    getAddress: async (path: string, verify?: boolean) => {
-      const { rawPublicKey } = await stellar.getPublicKey(path, verify);
+    getAddress: async (path: string, options?: boolean | { verify?: boolean }) => {
+      const verify = typeof options === "boolean" ? options : options?.verify;
+      const { rawPublicKey } = await stellar.getPublicKey(path, !!verify);
       const publicKey = StrKey.encodeEd25519PublicKey(rawPublicKey);
       return {
         path,

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/xrp/signer.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/xrp/signer.test.ts
@@ -1,0 +1,81 @@
+import { createSigner } from "./signer";
+import Xrp from "@ledgerhq/hw-app-xrp";
+import Transport from "@ledgerhq/hw-transport";
+
+jest.mock("@ledgerhq/hw-app-xrp");
+jest.mock("../../../../families/xrp/getAddress", () => jest.fn());
+
+const MockedXrp = Xrp as jest.MockedClass<typeof Xrp>;
+const mockTransport = {} as Transport;
+
+describe("createSigner (XRP)", () => {
+  let mockGetAddress: jest.Mock;
+
+  beforeEach(() => {
+    mockGetAddress = jest.fn().mockResolvedValue({
+      publicKey: "deadbeef",
+      address: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+    });
+    MockedXrp.mockImplementation(
+      () =>
+        ({
+          getAddress: mockGetAddress,
+          signTransaction: jest.fn(),
+        }) as unknown as Xrp,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getAddress — display flag forwarded to hw-app-xrp", () => {
+    it("should NOT display address on device when called with a derivationMode options object (send flow)", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/144'/0'/0/0", { derivationMode: "xrp" });
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", false);
+    });
+
+    it("should NOT display address on device when called without options", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/144'/0'/0/0");
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", false);
+    });
+
+    it("should NOT display address on device when called with verify: false", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/144'/0'/0/0", { verify: false });
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", false);
+    });
+
+    it("should display address on device when called with boolean true (receive flow)", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/144'/0'/0/0", true);
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", true);
+    });
+
+    it("should display address on device when called with verify: true", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/144'/0'/0/0", { verify: true });
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", true);
+    });
+
+    it("should forward chainCode arg to the underlying signer (receive flow)", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/144'/0'/0/0", true, false);
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", true, false);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/xrp/signer.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/xrp/signer.ts
@@ -1,11 +1,28 @@
 import resolver from "../../../../families/xrp/getAddress";
-import { CreateSigner, executeWithSigner } from "../../../setup";
+import { executeWithSigner } from "../../../setup";
 import type { AlpacaSigner } from "../../types";
 import Xrp from "@ledgerhq/hw-app-xrp";
 import Transport from "@ledgerhq/hw-transport";
 
-export const createSigner: CreateSigner<Xrp> = (transport: Transport) => {
-  return new Xrp(transport);
+export const createSigner = (transport: Transport) => {
+  const xrp = new Xrp(transport);
+  const originalGetAddress = xrp.getAddress.bind(xrp);
+  const originalSignTransaction = xrp.signTransaction.bind(xrp);
+  return {
+    getAddress: async (
+      path: string,
+      options?: boolean | { verify?: boolean; derivationMode?: string },
+      chainCode?: boolean,
+      ed25519?: boolean,
+    ) => {
+      const display = typeof options === "boolean" ? options : Boolean(options?.verify);
+      const extra = [chainCode, ed25519].filter((v): v is boolean => v !== undefined);
+      return originalGetAddress(path, display, ...(extra as [boolean?, boolean?]));
+    },
+    signTransaction: async (path: string, rawTxHex: string, ed25519?: boolean) => {
+      return originalSignTransaction(path, rawTxHex, ed25519);
+    },
+  };
 };
 
 const context = executeWithSigner(createSigner);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix a bug in the generic-alpaca bridge where `genericSignOperation` passes `{ derivationMode }` as the second argument to `signer.getAddress`, but several signers (Stellar, XRP, EVM) were treating any truthy second argument as `display = true`, triggering an unexpected "Verify address" prompt on the device during send flows. Each affected signer now accepts `boolean | { verify?, derivationMode? }` and only enables display when `verify` is explicitly `true`.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-29198)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
