### PR TITLE
[LWM] fix(e2e): add testID to EarnMenuBottomSheet list items

### DIFF
--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuBottomSheet.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuBottomSheet.tsx
@@ -107,6 +107,7 @@ export function EarnMenuBottomSheet({ navigation }: EarnMenuBottomSheetProps) {
           return link ? (
             <ListItem
               key={label}
+              testID={`earn-menu-option-${label.toLowerCase().replace(/\s+/g, "-")}`}
               onPress={() => handleMenuItemPress(link, live_app, tracked)}
               style={{ marginHorizontal: -8 }}
             >


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* The EarnMenuBottomSheet ListItem elements were missing testID props, causing e2e tests to time out when looking for earn-menu-option-* elements. Add the same testID pattern used by the legacy EarnMenuDrawer.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
