### PR TITLE
test(mobile): add zec add-account e2e coverage

### DIFF
--- a/.changeset/calm-pens-wave.md
+++ b/.changeset/calm-pens-wave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add ZEC mobile add-account e2e coverage.

--- a/e2e/mobile/specs/addAccount/addAccountZEC.spec.ts
+++ b/e2e/mobile/specs/addAccount/addAccountZEC.spec.ts
@@ -1,0 +1,8 @@
+import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
+import { runAddAccountTest } from "./addAccount";
+
+runAddAccountTest(
+  Currency.ZEC,
+  ["B2CQA-4296", "B2CQA-4297", "B2CQA-4298"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", `@zcash`, `@family-zcash`],
+);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile add-account e2e coverage for a supported network (ZEC)
  - Stability of add-account scenario selection via tags/devices
  - QA messaging: ALEO is not available on LWM for now

### 📝 Description

This PR adds a dedicated mobile e2e spec for ZEC add-account, **ALEO is not available on Ledger Wallet Mobile (LWM) for now**; ALEO support is not introduced by this change.

https://github.com/LedgerHQ/ledger-live/actions/runs/24443345333

### ❓ Context

- **JIRA or GitHub link**: [QAA-1132](https://ledgerhq.atlassian.net/browse/QAA-1132)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1132]: https://ledgerhq.atlassian.net/browse/QAA-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ