### PR TITLE
ci: move to workflow scoped token for pushing tags

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -28,12 +28,17 @@ on:
         required: false
         default: main
 
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-24.04
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: write
     steps:
       - name: generate token
         id: generate-token
@@ -49,7 +54,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 2
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup git user
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop


### PR DESCRIPTION
Moving token to workflow scoped token to prevent workflow rule timeouts when using app scoped tokens