### PR TITLE
test(e2e): link B2CQA-786 to BTC add account test on desktop

### DIFF
--- a/e2e/desktop/tests/specs/add.account.spec.ts
+++ b/e2e/desktop/tests/specs/add.account.spec.ts
@@ -10,7 +10,7 @@ import { getModularSelector } from "tests/utils/modularSelectorUtils";
 const currencies = [
   {
     currency: Currency.BTC,
-    xrayTicket: "B2CQA-2499, B2CQA-2644, B2CQA-2672, B2CQA-2073",
+    xrayTicket: "B2CQA-2499, B2CQA-2644, B2CQA-2672, B2CQA-2073, B2CQA-786",
   },
   { currency: Currency.ETH, xrayTicket: "B2CQA-2503, B2CQA-929, B2CQA-2645, B2CQA-2673" },
   { currency: Currency.ETC, xrayTicket: "B2CQA-2502, B2CQA-2646, B2CQA-2674" },


### PR DESCRIPTION
### Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Desktop E2E `add.account.spec.ts` test traceability (Xray ticket linkage)
      - No functional change — existing test behavior is unchanged

### Description

**Problem**: The Xray ticket [B2CQA-786](https://ledgerhq.atlassian.net/browse/B2CQA-786) ("Add account when no account exists before — BTC") was only covered by the mobile E2E test suite, but the JIRA platform field indicates it should also be tracked on Desktop (Windows/MacOS/Linux).

**Solution**: Added `B2CQA-786` to the `xrayTicket` field of the BTC entry in the desktop `add.account.spec.ts` currencies array. This links the existing desktop BTC add account test to the Xray ticket for proper traceability — no test logic changes.

> **Note**: No changeset is required — this is a test metadata change only, with no impact on published packages.

### Context

- **JIRA or GitHub link**: [QAA-1139](https://ledgerhq.atlassian.net/browse/QAA-1139)

[B2CQA-786]: https://ledgerhq.atlassian.net/browse/B2CQA-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QAA-1139]: https://ledgerhq.atlassian.net/browse/QAA-1139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ