### PR TITLE
[LWDM] fix(mobile, desktop): remove onboarded optimisation

### DIFF
--- a/.changeset/popular-donuts-shave.md
+++ b/.changeset/popular-donuts-shave.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+fix: remove onboarded optimisation

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
@@ -77,6 +77,10 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
   >(null);
   const [fwUpdateInterrupted, setFwUpdateInterrupted] = useState<FinalFirmware | null>(null);
 
+  // True when the device reported isOnboarded=true during polling. Used to bypass
+  // the exit toggle after ESC (the device was never put into ESC mode via toggle).
+  const [deviceDetectedOnboarded, setDeviceDetectedOnboarded] = useState<boolean>(false);
+
   /* The early security checks are run again after a firmware update. */
   const [isInitialRunOfSecurityChecks, setIsInitialRunOfSecurityChecks] = useState(true);
 
@@ -100,8 +104,14 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
 
   // Called when the ESC is complete
   const notifyOnboardingEarlyCheckEnded = useCallback(() => {
-    setToggleOnboardingEarlyCheckType("exit");
-  }, []);
+    if (deviceDetectedOnboarded) {
+      // The device was not put into ESC mode via the toggle APDU, so there is
+      // nothing to exit. Go directly to the companion step.
+      setCurrentStep("companion");
+    } else {
+      setToggleOnboardingEarlyCheckType("exit");
+    }
+  }, [deviceDetectedOnboarded]);
 
   // Called when the companion component thinks the device is not in a correct state anymore
   const notifyOnboardingEarlyCheckShouldReset = useCallback(() => {
@@ -173,6 +183,14 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
       // Resets the `useToggleOnboardingEarlyCheck` hook. Avoids having a case where for ex
       // check type == "exit" and toggle status still being == "success" from the previous toggle
       setToggleOnboardingEarlyCheckType(null);
+      setCurrentStep("early-security-check");
+      setMustRecoverIfBootloader(false);
+    } else if (isOnboarded) {
+      // Device reports itself as already onboarded, force the ESC so the genuine check always
+      // runs. We skip the toggle APDU because the device is not in its onboarding state machine.
+      setIsPollingOn(false);
+      setToggleOnboardingEarlyCheckType(null);
+      setDeviceDetectedOnboarded(true);
       setCurrentStep("early-security-check");
       setMustRecoverIfBootloader(false);
     } else {

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -61,6 +61,10 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
 
   const [isPreviousUpdateCancelled, setIsPreviousUpdateCancelled] = useState<boolean>(false);
 
+  // True when the device reported isOnboarded=true during polling. Used to bypass
+  // the exit toggle after ESC (the device was never put into ESC mode via toggle).
+  const [deviceDetectedOnboarded, setDeviceDetectedOnboarded] = useState<boolean>(false);
+
   // States handling a UI trick to hide the header while the desync alert overlay
   // is displayed from the companion
   const [isHeaderOverlayOpen, setIsHeaderOverlayOpen] = useState<boolean>(false);
@@ -158,8 +162,14 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
 
   // Called when the ESC is complete
   const notifyOnboardingEarlyCheckEnded = useCallback(() => {
-    setToggleOnboardingEarlyCheckType("exit");
-  }, []);
+    if (deviceDetectedOnboarded) {
+      // The device was not put into ESC mode via the toggle APDU, so there is
+      // nothing to exit. Go directly to the companion step.
+      setCurrentStep("companion");
+    } else {
+      setToggleOnboardingEarlyCheckType("exit");
+    }
+  }, [deviceDetectedOnboarded]);
 
   // Called when the device seems not to be in the correct state anymore.
   // Probably because the device restarted.
@@ -218,6 +228,13 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
       // Resets the `useToggleOnboardingEarlyCheck` hook. Avoids having a case where for ex
       // check type == "exit" and toggle status still being == "success" from the previous toggle
       setToggleOnboardingEarlyCheckType(null);
+      setCurrentStep("early-security-check");
+    } else if (isOnboarded) {
+      // Device reports itself as already onboarded, force the ESC so the genuine check always
+      // runs. We skip the toggle APDU because the device is not in its onboarding state machine.
+      setIsPollingOn(false);
+      setToggleOnboardingEarlyCheckType(null);
+      setDeviceDetectedOnboarded(true);
       setCurrentStep("early-security-check");
     } else {
       setIsPollingOn(false);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Sync onboarding flow on desktop and mobile when a device reports itself as already onboarded during polling
  - The early security check step is now always reached regardless of the device's onboarded state

### 📝 Description

Previously, when a device reported `isOnboarded=true` during the sync onboarding polling phase, it would skip ahead to the companion step. This change ensures the early security check (ESC) step is always entered, even for devices that are already onboarded.

Because the device is not in its onboarding state machine in this scenario, the toggle APDU is skipped — the device was never put into ESC mode via toggle. A new `deviceDetectedOnboarded` state flag tracks this so the exit toggle is also bypassed after ESC completes, going directly to the companion step.

The same logic is applied symmetrically to both desktop (`SyncOnboarding/Manual/index.tsx`) and mobile (`SyncOnboarding/index.tsx`).

### ❓ Context

- **JIRA or GitHub link**: <!-- N/A -->

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)