### PR TITLE
[LWDM] feat(mobile): add analytics preferences settings screen

### DIFF
--- a/.changeset/calm-settings-preferences.md
+++ b/.changeset/calm-settings-preferences.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add analytics preferences settings screen and wire consent drawer navigation

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -346,6 +346,7 @@ apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioCarousel
 apps/ledger-live-mobile/src/mvvm/features/Portfolio/hooks/**/useOnboardingWidgetVisibility*.ts @ledgerhq/engagement
 apps/ledger-live-mobile/src/reducers/dynamicContent.ts                                         @ledgerhq/engagement
 apps/ledger-live-mobile/src/reducers/largeMover.ts                                             @ledgerhq/engagement
+apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/                                     @ledgerhq/engagement
 
 # Common
 libs/ledger-live-common/src/analyticsConsent/                                                  @ledgerhq/engagement

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7898,7 +7898,7 @@
       },
       "personalizedExperience": {
         "title": "Personalized experience",
-        "description": "Enable Ledger to collect app usage to provide personalized contents"
+        "description": "Enable Ledger to collect app usage to provide personalized content"
       },
       "ctaConfirm": "Confirm"
     },

--- a/apps/ledger-live-mobile/__tests__/test-renderer.tsx
+++ b/apps/ledger-live-mobile/__tests__/test-renderer.tsx
@@ -4,7 +4,7 @@ import { INITIAL_STATE as TRUSTCHAIN_INITIAL_STATE } from "@ledgerhq/ledger-key-
 import { initialState as POST_ONBOARDING_INITIAL_STATE } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { CountervaluesBridge, CountervaluesProvider } from "@ledgerhq/live-countervalues-react";
 import { initialState as WALLET_INITIAL_STATE } from "@ledgerhq/live-wallet/store";
-import { NavigationContainer } from "@react-navigation/native";
+import { NavigationContainer, type InitialState } from "@react-navigation/native";
 import { configureStore } from "@reduxjs/toolkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
@@ -89,6 +89,7 @@ const INITIAL_STATE: State = {
 type ExtraOptions = RenderOptions & {
   overrideInitialState?: (state: State) => State;
   userEventOptions?: Parameters<typeof userEvent.setup>[0];
+  navigationInitialState?: InitialState;
 };
 
 enum RenderType {
@@ -223,20 +224,22 @@ function Providers({
   withReactQuery = false,
   withLiveApp = false,
   renderType = RenderType.DEFAULT,
+  navigationInitialState,
 }: {
   children: NavigationChildren;
   store: ReduxStore;
   withReactQuery?: boolean;
   withLiveApp?: boolean;
   renderType?: RenderType;
+  navigationInitialState?: InitialState;
 }): React.JSX.Element {
   // Custom live app provider
   const content = withLiveApp ? (
     <CustomLiveAppProvider>
-      <NavigationContainer>{children}</NavigationContainer>
+      <NavigationContainer initialState={navigationInitialState}>{children}</NavigationContainer>
     </CustomLiveAppProvider>
   ) : (
-    <NavigationContainer>{children}</NavigationContainer>
+    <NavigationContainer initialState={navigationInitialState}>{children}</NavigationContainer>
   );
 
   // Conditionally wraps content with additional providers unless using hook-based rendering
@@ -280,6 +283,7 @@ const customRender = (
   {
     overrideInitialState: overrideInitialState = state => state,
     userEventOptions = {},
+    navigationInitialState,
     ...renderOptions
   }: ExtraOptions = {},
 ) => {
@@ -288,7 +292,11 @@ const customRender = (
   });
 
   const ProvidersWrapper = ({ children }: WrapperProps): React.JSX.Element => {
-    return <Providers store={store}>{children}</Providers>;
+    return (
+      <Providers navigationInitialState={navigationInitialState} store={store}>
+        {children}
+      </Providers>
+    );
   };
 
   return {
@@ -303,6 +311,7 @@ const renderWithReactQuery = (
   {
     overrideInitialState: overrideInitialState = state => state,
     userEventOptions = {},
+    navigationInitialState,
     ...renderOptions
   }: ExtraOptions = {},
 ) => {
@@ -312,7 +321,7 @@ const renderWithReactQuery = (
 
   const ProvidersWrapper = ({ children }: WrapperProps): React.JSX.Element => {
     return (
-      <Providers store={store} withReactQuery>
+      <Providers navigationInitialState={navigationInitialState} store={store} withReactQuery>
         {children}
       </Providers>
     );

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -46,6 +46,7 @@ import AccountsSettings from "~/screens/Settings/Accounts";
 import AboutSettings from "~/screens/Settings/About";
 import Resources from "~/screens/Settings/Resources";
 import GeneralSettings from "~/screens/Settings/General";
+import AnalyticsPreferencesSettings from "~/screens/Settings/AnalyticsPreferencesSettings";
 import CountervalueSettings from "~/screens/Settings/General/CountervalueSettings";
 import NotificationsSettings from "~/screens/Settings/Notifications";
 import HelpSettings from "~/screens/Settings/Help";
@@ -125,6 +126,16 @@ export default function SettingsNavigator() {
         layout={unmountOnBlur}
         options={{
           title: t("settings.display.title"),
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.AnalyticsPreferencesSettings}
+        component={AnalyticsPreferencesSettings}
+        options={{
+          title: "",
+          headerStyle: {
+            backgroundColor: colors.neutral.c00,
+          }
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -9,6 +9,7 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.CountervalueSettings]: undefined;
   [ScreenName.RegionSettings]: undefined;
   [ScreenName.GeneralSettings]: undefined;
+  [ScreenName.AnalyticsPreferencesSettings]: { initialTogglesOff?: boolean } | undefined;
   [ScreenName.AccountsSettings]: undefined;
   [ScreenName.AboutSettings]: undefined;
   [ScreenName.NotificationsSettings]: undefined;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -1,5 +1,6 @@
 export enum ScreenName {
   Analytics = "Analytics",
+  AnalyticsPreferencesSettings = "AnalyticsPreferencesSettings",
   AboutSettings = "AboutSettings",
   Account = "Account",
   Accounts = "Accounts",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8141,6 +8141,18 @@
       "privacyLink": "Privacy policy"
     }
   },
+  "analyticsPreferencesSettings": {
+    "screenTitle": "Set preferences",
+    "appPerformance": {
+      "title": "App performance",
+      "description": "Enable Ledger to collect app usage to enhance the experience."
+    },
+    "personalizedExperience": {
+      "title": "Personalized experience",
+      "description": "Enable Ledger to collect app usage to provide personalized content."
+    },
+    "confirmCta": "Confirm"
+  },
   "walletSync": {
     "title": "Ledger Sync",
     "banner": {

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__integrations__/AnalyticsConsentDrawer.portfolio.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__integrations__/AnalyticsConsentDrawer.portfolio.integration.test.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import { View } from "react-native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import { renderWithReactQuery, screen, waitFor } from "@tests/test-renderer";
 import { overrideInitialStateWithFeatureFlag } from "LLM/features/Portfolio/__integrations__/shared";
+import * as analytics from "~/analytics";
 import { AnalyticsConsentDrawer } from "../index";
 import { withConsentDrawerState } from "../__tests__/helpers";
 import { ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
 import subDays from "date-fns/subDays";
+import AnalyticsPreferencesSettings from "~/screens/Settings/AnalyticsPreferencesSettings";
 
 const consentIsoOlderThanValidityWindow = () => subDays(new Date(), 366).toISOString();
 
@@ -20,9 +23,20 @@ function GeneralSettingsStub() {
 
 function SettingsNavigator() {
   return (
-    <SettingsStack.Navigator screenOptions={{ headerShown: false }}>
-      <SettingsStack.Screen name={ScreenName.GeneralSettings} component={GeneralSettingsStub} />
-    </SettingsStack.Navigator>
+    <SafeAreaProvider
+      initialMetrics={{
+        frame: { x: 0, y: 0, width: 375, height: 812 },
+        insets: { top: 0, left: 0, right: 0, bottom: 0 },
+      }}
+    >
+      <SettingsStack.Navigator screenOptions={{ headerShown: false }}>
+        <SettingsStack.Screen name={ScreenName.GeneralSettings} component={GeneralSettingsStub} />
+        <SettingsStack.Screen
+          name={ScreenName.AnalyticsPreferencesSettings}
+          component={AnalyticsPreferencesSettings}
+        />
+      </SettingsStack.Navigator>
+    </SafeAreaProvider>
   );
 }
 
@@ -118,7 +132,7 @@ describe("AnalyticsConsentDrawer on Portfolio", () => {
       expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
     });
 
-    it("should close the drawer when the user taps Set preferences", async () => {
+    it("should close the drawer and open analytics preferences when the user taps Set preferences", async () => {
       const { user } = renderWithReactQuery(<IntegrationNavigator />, {
         overrideInitialState: overridePortfolioWithAnalyticsConsentDrawer,
       });
@@ -131,6 +145,36 @@ describe("AnalyticsConsentDrawer on Portfolio", () => {
       await waitFor(() => {
         expect(screen.queryByText("Help us improve Ledger")).toBeNull();
       });
+      expect(await screen.findByTestId("analytics-preferences-screen-title")).toBeVisible();
+    });
+
+    it("should return to Portfolio after Set preferences and Confirm with toggles left off", async () => {
+      const updateIdentifySpy = jest.spyOn(analytics, "updateIdentify").mockResolvedValue(undefined);
+      try {
+        const { user, store } = renderWithReactQuery(<IntegrationNavigator />, {
+          overrideInitialState: overridePortfolioWithAnalyticsConsentDrawer,
+        });
+
+        await screen.findByTestId("PortfolioEmptyList");
+        await screen.findByText("Help us improve Ledger");
+
+        await user.press(screen.getByText("Set preferences"));
+
+        expect(await screen.findByTestId("analytics-preferences-screen-title")).toBeVisible();
+
+        await user.press(screen.getByRole("button", { name: "Confirm" }));
+
+        await waitFor(() => {
+          expect(screen.queryByTestId("analytics-preferences-screen-title")).toBeNull();
+        });
+        expect(await screen.findByTestId("PortfolioEmptyList")).toBeVisible();
+
+        expect(store.getState().settings.analyticsEnabled).toBe(false);
+        expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(false);
+        expect(store.getState().settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+      } finally {
+        updateIdentifySpy.mockRestore();
+      }
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__tests__/useAnalyticsConsentDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/__tests__/useAnalyticsConsentDrawerViewModel.test.ts
@@ -160,7 +160,7 @@ describe("useAnalyticsConsentDrawerViewModel", () => {
       expect(track).toHaveBeenCalledWith("drawer_closed", drawerEventPayload);
     });
 
-    it("should navigate to General settings and close when onSetPreferences is called", async () => {
+    it("should navigate to analytics preferences and close when onSetPreferences is called", async () => {
       const { result } = renderHook(() => useAnalyticsConsentDrawerViewModel(), {
         overrideInitialState: withConsentDrawerOpeningFresh(),
       });
@@ -174,7 +174,8 @@ describe("useAnalyticsConsentDrawerViewModel", () => {
 
       expect(result.current.phase).toBe("closed");
       expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Settings, {
-        screen: ScreenName.GeneralSettings,
+        screen: ScreenName.AnalyticsPreferencesSettings,
+        params: { initialTogglesOff: true },
       });
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "analytics_consent_set_preferences",

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/DescriptionWithPreferencesLink.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/components/DescriptionWithPreferencesLink.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text } from "@ledgerhq/lumen-ui-rnative";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
 import { useTranslation } from "~/context/Locale";
 
 type DescriptionWithPreferencesLinkProps = Readonly<{
@@ -10,11 +10,18 @@ type DescriptionWithPreferencesLinkProps = Readonly<{
 export function DescriptionWithPreferencesLink({ text, onSetPreferences }: DescriptionWithPreferencesLinkProps) {
   const { t } = useTranslation();
   return (
-    <Text typography="body2" lx={{ color: "muted", textAlign: "center", width: "full" }}>
-      {text}{" "}
-      <Text accessibilityRole="link" onPress={onSetPreferences} typography="body2" lx={{ color: "interactive" }}>
+    <Box lx={{ width: "full", alignItems: "center", gap: "s4" }}>
+      <Text typography="body2" lx={{ color: "muted", textAlign: "center", width: "full" }}>
+        {text}
+      </Text>
+      <Text
+        accessibilityRole="link"
+        onPress={onSetPreferences}
+        typography="body2"
+        lx={{ color: "interactive", textAlign: "center", width: "full" }}
+      >
         {t("analyticsConsentDrawer.setPreferences")}
       </Text>
-    </Text>
+    </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/hooks/useAnalyticsConsentDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AnalyticsConsentDrawer/hooks/useAnalyticsConsentDrawerViewModel.ts
@@ -161,7 +161,8 @@ export function useAnalyticsConsentDrawerViewModel() {
     });
     handleCloseDrawer();
     navigation.navigate(NavigatorName.Settings, {
-      screen: ScreenName.GeneralSettings,
+      screen: ScreenName.AnalyticsPreferencesSettings,
+      params: { initialTogglesOff: true },
     });
   }, [navigation, handleCloseDrawer]);
 

--- a/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/__tests__/AnalyticsPreferencesSettings.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/__tests__/AnalyticsPreferencesSettings.test.tsx
@@ -1,0 +1,227 @@
+import React from "react";
+import { Linking, View } from "react-native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import type { InitialState } from "@react-navigation/native";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import { CURRENT_PRIVACY_POLICY_VERSION } from "@ledgerhq/live-common/privacyConsent";
+import * as analytics from "~/analytics";
+import { ScreenName } from "~/const";
+import type { State } from "~/reducers/types";
+import AnalyticsPreferencesSettings from "../index";
+
+const Stack = createNativeStackNavigator();
+
+function GeneralSettingsStub() {
+  return <View testID="analytics-preferences-general-settings-stub" />;
+}
+
+function createSettingsStackInitialState(
+  params?: Readonly<{ initialTogglesOff?: boolean }>,
+): InitialState {
+  return {
+    routes: [
+      { name: ScreenName.GeneralSettings },
+      {
+        name: ScreenName.AnalyticsPreferencesSettings,
+        ...(params !== undefined ? { params } : {}),
+      },
+    ],
+    index: 1,
+  };
+}
+
+function SettingsTestStack() {
+  return (
+    <SafeAreaProvider
+      initialMetrics={{
+        frame: { x: 0, y: 0, width: 375, height: 812 },
+        insets: { top: 0, left: 0, right: 0, bottom: 0 },
+      }}
+    >
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        <Stack.Screen name={ScreenName.GeneralSettings} component={GeneralSettingsStub} />
+        <Stack.Screen name={ScreenName.AnalyticsPreferencesSettings} component={AnalyticsPreferencesSettings} />
+      </Stack.Navigator>
+    </SafeAreaProvider>
+  );
+}
+
+type RenderOptions = Readonly<{
+  params?: Readonly<{ initialTogglesOff?: boolean }>;
+  overrideInitialState?: (state: State) => State;
+}>;
+
+function renderAnalyticsPreferencesSettings(options: RenderOptions = {}) {
+  const { params, overrideInitialState } = options;
+
+  return render(<SettingsTestStack />, {
+    ...(overrideInitialState ? { overrideInitialState } : {}),
+    navigationInitialState: createSettingsStackInitialState(params),
+  });
+}
+
+describe("AnalyticsPreferencesSettings", () => {
+  let trackSpy: jest.SpiedFunction<typeof analytics.track>;
+  let updateIdentifySpy: jest.SpiedFunction<typeof analytics.updateIdentify>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    trackSpy = jest.spyOn(analytics, "track").mockResolvedValue(undefined);
+    updateIdentifySpy = jest.spyOn(analytics, "updateIdentify").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    trackSpy.mockRestore();
+    updateIdentifySpy.mockRestore();
+  });
+
+  describe("rendering", () => {
+    it("shows title and confirm CTA", () => {
+      renderAnalyticsPreferencesSettings();
+
+      expect(screen.getByTestId("analytics-preferences-screen-title")).toHaveTextContent("Set preferences");
+      expect(screen.getByRole("button", { name: "Confirm" })).toBeTruthy();
+    });
+
+    it("initializes switches from Redux when route omits initialTogglesOff", () => {
+      renderAnalyticsPreferencesSettings({
+        overrideInitialState: state => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            analyticsEnabled: false,
+            personalizedRecommendationsEnabled: true,
+          },
+        }),
+      });
+
+      const [appPerformanceSwitch, personalizedSwitch] = screen.getAllByRole("switch");
+      expect(appPerformanceSwitch.props.accessibilityState).toEqual(
+        expect.objectContaining({ checked: false }),
+      );
+      expect(personalizedSwitch.props.accessibilityState).toEqual(
+        expect.objectContaining({ checked: true }),
+      );
+    });
+
+    it("forces both switches off when route sets initialTogglesOff despite store defaults", () => {
+      renderAnalyticsPreferencesSettings({
+        params: { initialTogglesOff: true },
+        overrideInitialState: state => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            analyticsEnabled: true,
+            personalizedRecommendationsEnabled: true,
+          },
+        }),
+      });
+
+      const [appPerformanceSwitch, personalizedSwitch] = screen.getAllByRole("switch");
+      expect(appPerformanceSwitch.props.accessibilityState).toEqual(
+        expect.objectContaining({ checked: false }),
+      );
+      expect(personalizedSwitch.props.accessibilityState).toEqual(
+        expect.objectContaining({ checked: false }),
+      );
+    });
+  });
+
+  describe("footer", () => {
+    it("opens the privacy policy URL when the footer link is pressed", async () => {
+      const openSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined as never);
+      try {
+        const { user } = renderAnalyticsPreferencesSettings();
+
+        await user.press(screen.getByRole("link", { name: "Privacy policy" }));
+
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(String(openSpy.mock.calls[0][0])).toMatch(/^https?:\/\//);
+      } finally {
+        openSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("confirm", () => {
+    it("persists toggles, consent metadata, analytics, identify, and navigates back", async () => {
+      const { store, user } = renderAnalyticsPreferencesSettings({
+        overrideInitialState: state => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            analyticsEnabled: true,
+            personalizedRecommendationsEnabled: false,
+          },
+        }),
+      });
+
+      await user.press(screen.getByRole("switch", { checked: true }));
+      await user.press(screen.getAllByRole("switch")[1]);
+
+      await user.press(screen.getByRole("button", { name: "Confirm" }));
+
+      const settings = store.getState().settings;
+      expect(settings.analyticsEnabled).toBe(false);
+      expect(settings.personalizedRecommendationsEnabled).toBe(true);
+      expect(settings.hasSeenAnalyticsOptInPrompt).toBe(true);
+      expect(settings.analyticsConsentInfo.privacyPolicyVersion).toBe(CURRENT_PRIVACY_POLICY_VERSION);
+
+      const consentDate = settings.analyticsConsentInfo.consentDate;
+      expect(consentDate).toEqual(expect.any(String));
+      expect(Number.isNaN(Date.parse(consentDate!))).toBe(false);
+
+      expect(analytics.track).toHaveBeenCalledTimes(1);
+      expect(analytics.track).toHaveBeenCalledWith(
+        "button_clicked",
+        expect.objectContaining({
+          button: "analytics_preferences_confirm",
+          page: "Analytics preferences settings",
+          appPerformance: false,
+          personalizedExperience: true,
+        }),
+        true,
+      );
+      expect(analytics.updateIdentify).toHaveBeenCalledTimes(1);
+      expect(analytics.updateIdentify).toHaveBeenCalledWith(undefined, true);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("analytics-preferences-screen-title")).toBeNull();
+      });
+      expect(screen.getByTestId("analytics-preferences-general-settings-stub")).toBeTruthy();
+    });
+
+    it("persists both preferences off when confirming with initialTogglesOff without edits", async () => {
+      const { store, user } = renderAnalyticsPreferencesSettings({
+        params: { initialTogglesOff: true },
+        overrideInitialState: state => ({
+          ...state,
+          settings: {
+            ...state.settings,
+            analyticsEnabled: true,
+            personalizedRecommendationsEnabled: true,
+          },
+        }),
+      });
+
+      await user.press(screen.getByRole("button", { name: "Confirm" }));
+
+      expect(store.getState().settings.analyticsEnabled).toBe(false);
+      expect(store.getState().settings.personalizedRecommendationsEnabled).toBe(false);
+
+      expect(analytics.track).toHaveBeenCalledWith(
+        "button_clicked",
+        expect.objectContaining({
+          appPerformance: false,
+          personalizedExperience: false,
+        }),
+        true,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("analytics-preferences-screen-title")).toBeNull();
+      });
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/__tests__/AnalyticsPreferencesSettings.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/__tests__/AnalyticsPreferencesSettings.test.tsx
@@ -4,7 +4,8 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import type { InitialState } from "@react-navigation/native";
 import { render, screen, waitFor } from "@tests/test-renderer";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import { CURRENT_PRIVACY_POLICY_VERSION } from "@ledgerhq/live-common/privacyConsent";
+import { DEFAULT_FEATURES } from "@ledgerhq/live-common/featureFlags/index";
+import { resolveAnalyticsOptInParams } from "@ledgerhq/live-common/analyticsConsent/index";
 import * as analytics from "~/analytics";
 import { ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
@@ -60,6 +61,10 @@ function renderAnalyticsPreferencesSettings(options: RenderOptions = {}) {
     navigationInitialState: createSettingsStackInitialState(params),
   });
 }
+
+const { policyVersion: expectedPrivacyPolicyVersion } = resolveAnalyticsOptInParams(
+  DEFAULT_FEATURES.analyticsOptIn,
+);
 
 describe("AnalyticsPreferencesSettings", () => {
   let trackSpy: jest.SpiedFunction<typeof analytics.track>;
@@ -166,7 +171,7 @@ describe("AnalyticsPreferencesSettings", () => {
       expect(settings.analyticsEnabled).toBe(false);
       expect(settings.personalizedRecommendationsEnabled).toBe(true);
       expect(settings.hasSeenAnalyticsOptInPrompt).toBe(true);
-      expect(settings.analyticsConsentInfo.privacyPolicyVersion).toBe(CURRENT_PRIVACY_POLICY_VERSION);
+      expect(settings.analyticsConsentInfo.privacyPolicyVersion).toBe(expectedPrivacyPolicyVersion);
 
       const consentDate = settings.analyticsConsentInfo.consentDate;
       expect(consentDate).toEqual(expect.any(String));

--- a/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/index.tsx
@@ -39,7 +39,13 @@ export default function AnalyticsPreferencesSettings({ navigation, route }: Prop
   );
 
   const onConfirm = useCallback(async () => {
-    track(
+    const wasFullyOptedOut = !analyticsFromStore && !personalizedFromStore;
+    const willBeFullyOptedOut = !appPerformanceEnabled && !personalizedEnabled;
+    // Same idea as analytics consent `applyOptOut`: do not force tracking when the user was already
+    // fully opted out in the store and confirms without enabling either toggle.
+    const mandatory = !(wasFullyOptedOut && willBeFullyOptedOut);
+
+    await track(
       "button_clicked",
       {
         button: "analytics_preferences_confirm",
@@ -47,7 +53,7 @@ export default function AnalyticsPreferencesSettings({ navigation, route }: Prop
         appPerformance: appPerformanceEnabled,
         personalizedExperience: personalizedEnabled,
       },
-      true,
+      mandatory,
     );
     dispatch(setAnalytics(appPerformanceEnabled));
     dispatch(setPersonalizedRecommendations(personalizedEnabled));
@@ -58,13 +64,20 @@ export default function AnalyticsPreferencesSettings({ navigation, route }: Prop
       }),
     );
     dispatch(setHasSeenAnalyticsOptInPrompt(true));
-    await updateIdentify(undefined, true);
+    await updateIdentify(undefined, mandatory);
     navigation.goBack();
-  }, [appPerformanceEnabled, dispatch, navigation, personalizedEnabled]);
+  }, [
+    analyticsFromStore,
+    appPerformanceEnabled,
+    dispatch,
+    navigation,
+    personalizedEnabled,
+    personalizedFromStore,
+  ]);
 
   return (
     <Box lx={{ flex: 1, backgroundColor: "canvas" }}>
-      <TrackScreen category="Analytics preferences settings" name="Set preferences" refreshSource={false} />
+      <TrackScreen category="Analytics preferences settings" name="Set preferences" />
       <Box lx={{ paddingHorizontal: "s16", paddingBottom: "s12" }}>
         <Text
           typography="heading3SemiBold"

--- a/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/index.tsx
@@ -11,7 +11,8 @@ import {
 import { setAnalytics, setAnalyticsConsentInfo, setHasSeenAnalyticsOptInPrompt, setPersonalizedRecommendations } from "~/actions/settings";
 import { ScreenName } from "~/const";
 import { TrackScreen, track, updateIdentify } from "~/analytics";
-import { CURRENT_PRIVACY_POLICY_VERSION } from "@ledgerhq/live-common/privacyConsent";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { resolveAnalyticsOptInParams } from "@ledgerhq/live-common/analyticsConsent/index";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import { urls } from "~/utils/urls";
 import { ConsentFooter } from "LLM/features/AnalyticsConsentDrawer/components/ConsentFooter";
@@ -26,6 +27,8 @@ export default function AnalyticsPreferencesSettings({ navigation, route }: Prop
   const { bottom: bottomInset } = useSafeAreaInsets();
   const privacyPolicyUrl = useLocalizedUrl(urls.privacyPolicy.en);
   const footerBottomPadding = bottomInset + 16;
+  const analyticsOptInFeature = useFeature("analyticsOptIn");
+  const { policyVersion } = resolveAnalyticsOptInParams(analyticsOptInFeature);
 
   const initialTogglesOff = route.params?.initialTogglesOff === true;
   const analyticsFromStore = useSelector(analyticsEnabledSelector);
@@ -60,7 +63,7 @@ export default function AnalyticsPreferencesSettings({ navigation, route }: Prop
     dispatch(
       setAnalyticsConsentInfo({
         consentDate: new Date().toISOString(),
-        privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+        privacyPolicyVersion: policyVersion,
       }),
     );
     dispatch(setHasSeenAnalyticsOptInPrompt(true));
@@ -73,6 +76,7 @@ export default function AnalyticsPreferencesSettings({ navigation, route }: Prop
     navigation,
     personalizedEnabled,
     personalizedFromStore,
+    policyVersion,
   ]);
 
   return (

--- a/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/AnalyticsPreferencesSettings/index.tsx
@@ -1,0 +1,168 @@
+import React, { useCallback, useState } from "react";
+import { ScrollView } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Box, Button, Switch, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "~/context/Locale";
+import { useDispatch, useSelector } from "~/context/hooks";
+import {
+  analyticsEnabledSelector,
+  personalizedRecommendationsEnabledSelector,
+} from "~/reducers/settings";
+import { setAnalytics, setAnalyticsConsentInfo, setHasSeenAnalyticsOptInPrompt, setPersonalizedRecommendations } from "~/actions/settings";
+import { ScreenName } from "~/const";
+import { TrackScreen, track, updateIdentify } from "~/analytics";
+import { CURRENT_PRIVACY_POLICY_VERSION } from "@ledgerhq/live-common/privacyConsent";
+import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
+import { urls } from "~/utils/urls";
+import { ConsentFooter } from "LLM/features/AnalyticsConsentDrawer/components/ConsentFooter";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import type { SettingsNavigatorStackParamList } from "~/components/RootNavigator/types/SettingsNavigator";
+
+type Props = StackNavigatorProps<SettingsNavigatorStackParamList, ScreenName.AnalyticsPreferencesSettings>;
+
+export default function AnalyticsPreferencesSettings({ navigation, route }: Props) {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const privacyPolicyUrl = useLocalizedUrl(urls.privacyPolicy.en);
+  const footerBottomPadding = bottomInset + 16;
+
+  const initialTogglesOff = route.params?.initialTogglesOff === true;
+  const analyticsFromStore = useSelector(analyticsEnabledSelector);
+  const personalizedFromStore = useSelector(personalizedRecommendationsEnabledSelector);
+
+  const [appPerformanceEnabled, setAppPerformanceEnabled] = useState(
+    initialTogglesOff ? false : analyticsFromStore,
+  );
+  const [personalizedEnabled, setPersonalizedEnabled] = useState(
+    initialTogglesOff ? false : personalizedFromStore,
+  );
+
+  const onConfirm = useCallback(async () => {
+    track(
+      "button_clicked",
+      {
+        button: "analytics_preferences_confirm",
+        page: "Analytics preferences settings",
+        appPerformance: appPerformanceEnabled,
+        personalizedExperience: personalizedEnabled,
+      },
+      true,
+    );
+    dispatch(setAnalytics(appPerformanceEnabled));
+    dispatch(setPersonalizedRecommendations(personalizedEnabled));
+    dispatch(
+      setAnalyticsConsentInfo({
+        consentDate: new Date().toISOString(),
+        privacyPolicyVersion: CURRENT_PRIVACY_POLICY_VERSION,
+      }),
+    );
+    dispatch(setHasSeenAnalyticsOptInPrompt(true));
+    await updateIdentify(undefined, true);
+    navigation.goBack();
+  }, [appPerformanceEnabled, dispatch, navigation, personalizedEnabled]);
+
+  return (
+    <Box lx={{ flex: 1, backgroundColor: "canvas" }}>
+      <TrackScreen category="Analytics preferences settings" name="Set preferences" refreshSource={false} />
+      <Box lx={{ paddingHorizontal: "s16", paddingBottom: "s12" }}>
+        <Text
+          typography="heading3SemiBold"
+          lx={{ color: "base" }}
+          testID="analytics-preferences-screen-title"
+        >
+          {t("analyticsPreferencesSettings.screenTitle")}
+        </Text>
+      </Box>
+
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{
+          flexGrow: 1,
+          paddingHorizontal: 16,
+          paddingBottom: 8,
+        }}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Box lx={{ gap: "s32", paddingVertical: "s16" }}>
+          <PreferenceSection
+            title={t("analyticsPreferencesSettings.appPerformance.title")}
+            description={t("analyticsPreferencesSettings.appPerformance.description")}
+            value={appPerformanceEnabled}
+            onValueChange={setAppPerformanceEnabled}
+            testID="analytics-preferences-app-performance-switch"
+          />
+          <PreferenceSection
+            title={t("analyticsPreferencesSettings.personalizedExperience.title")}
+            description={t("analyticsPreferencesSettings.personalizedExperience.description")}
+            value={personalizedEnabled}
+            onValueChange={setPersonalizedEnabled}
+            testID="analytics-preferences-personalized-switch"
+          />
+        </Box>
+      </ScrollView>
+
+      <Box
+        lx={{
+          paddingHorizontal: "s16",
+          paddingTop: "s16",
+          gap: "s16",
+        }}
+        style={{ paddingBottom: footerBottomPadding }}
+      >
+        <Button appearance="base" size="lg" onPress={onConfirm}>
+          {t("analyticsPreferencesSettings.confirmCta")}
+        </Button>
+        <ConsentFooter privacyPolicyUrl={privacyPolicyUrl} />
+      </Box>
+    </Box>
+  );
+}
+
+type PreferenceSectionProps = Readonly<{
+  title: string;
+  description: string;
+  value: boolean;
+  onValueChange: (next: boolean) => void;
+  testID: string;
+}>;
+
+function PreferenceSection({
+  title,
+  description,
+  value,
+  onValueChange,
+  testID,
+}: PreferenceSectionProps) {
+  return (
+    <Box>
+      <Box
+        lx={{
+          width: "full",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          paddingHorizontal: "s12",
+          paddingVertical: "s20",
+          backgroundColor: "surface",
+          borderRadius: "md",
+          marginBottom: "s12",
+        }}
+      >
+        <Text typography="body2" lx={{ color: "base", flex: 1, flexShrink: 1 }}>
+          {title}
+        </Text>
+        <Switch
+          checked={value}
+          onCheckedChange={onValueChange}
+          accessibilityLabel={title}
+          testID={testID}
+        />
+      </Box>
+      <Text typography="body3" lx={{ color: "muted" }}>
+        {description}
+      </Text>
+    </Box>
+  );
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Settings → Analytics preferences: layout, scroll, footer above tab bar, back navigation
      - Analytics consent drawer: “Set preferences” opens the new screen and closes the drawer
      - Portfolio integration test path for the preferences flow

### 📝 Description

**Problem:** Users who tap “Set preferences” from the analytics consent flow had no dedicated settings screen to adjust analytics choices in line with the consent UX.

**Solution:** This PR adds an **Analytics preferences** screen under Settings (with navigation route and English copy), wires the consent drawer’s “Set preferences” action to that screen, and reserves bottom space so the footer is not hidden behind the main tab bar. `CODEOWNERS` is updated so the new screen and related consent drawer paths are owned by Engagement.

Video: https://www.loom.com/share/497729d119fb4a5a9ef09b4b5875ca08

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-25915

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)