### PR TITLE
[LWDM] fix(LIVE-29036): ignore incomplete hedera operations

### DIFF
--- a/.changeset/clean-bears-press.md
+++ b/.changeset/clean-bears-press.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix: ignore incomplete hedera operations

--- a/libs/coin-modules/coin-hedera/jest.integ.config.js
+++ b/libs/coin-modules/coin-hedera/jest.integ.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: "node",
   testRegex: ".integ.test.ts$",
   testPathIgnorePatterns: ["lib/", "lib-es/"],
-  testTimeout: 60_000,
+  testTimeout: 90_000,
   forceExit: true,
   transform: {
     "^.+\\.(t|j)sx?$": [

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -833,6 +833,20 @@ describe("createApi", () => {
         }),
       ]);
     });
+
+    it("filters out ERC20 operations with null sender or recipient address", async () => {
+      const blockHeight = 177564534;
+      const txHashWithNullAddress =
+        "tSFV6McHlh0v6tZEZVGlwavk/QRoMabPIOtVbyJ1/j3gvTHMZP97URu4Vw6JbMmC";
+
+      const block = await api.getBlock(blockHeight);
+      const transaction = block.transactions.find(tx => tx.hash === txHashWithNullAddress);
+      const operationAddresses = transaction?.operations.map(op => op.address);
+
+      expect(transaction).not.toBeUndefined();
+      expect(transaction?.operations.length).toBeGreaterThan(0);
+      expect(operationAddresses).not.toContain(null);
+    });
   });
 
   describe("lastBlock", () => {

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
@@ -441,6 +441,55 @@ describe("getBlockV2", () => {
     ]);
   });
 
+  it.each([
+    {
+      label: "sender evm address is null",
+      transferOverrides: { sender_account_id: null, sender_evm_address: null },
+    },
+    {
+      label: "recipient evm address is null",
+      transferOverrides: { receiver_account_id: null, receiver_evm_address: null },
+    },
+  ])("should skip ERC20 operations when $label", async ({ transferOverrides }) => {
+    const mockMirrorAccount = getMockedMirrorAccount({ account: "0.0.12345" });
+    const mockTokenERC20 = getMockedERC20TokenCurrency();
+    const mockMirrorTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_hash: "erc20-transfer-hash",
+      result: "SUCCESS",
+      name: "CONTRACTCALL",
+      transfers: [{ account: mockMirrorAccount.account, amount: -300000 }],
+    });
+    const mockERC20Transfer = getMockedERC20TokenTransfer({
+      token_evm_address: mockTokenERC20.contractAddress,
+      transaction_hash: mockMirrorTransaction.transaction_hash,
+      ...transferOverrides,
+    });
+
+    const mockContractCallResult = getMockedMirrorContractCallResult();
+    const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
+      mirrorTransaction: mockMirrorTransaction,
+      contractCallResult: mockContractCallResult,
+      transfers: [mockERC20Transfer],
+    });
+
+    (apiClient.getTransactionsByTimestampRange as jest.Mock).mockResolvedValue([
+      mockMirrorTransaction,
+    ]);
+    (hgraphClient.getERC20TransfersByTimestampRange as jest.Mock).mockResolvedValue([
+      mockERC20Transfer,
+    ]);
+    (enrichERC20Transfers as jest.Mock).mockReturnValue([mockEnrichedERC20Transfer]);
+
+    const result = await getBlockV2(100);
+    const operations = result.transactions[0]?.operations;
+    const erc20Operations = operations?.filter(
+      op => op.type === "transfer" && op.asset.type === "erc20",
+    );
+
+    expect(erc20Operations).toEqual([]);
+  });
+
   it("should mark failed transactions", async () => {
     const mockTx = getMockedMirrorTransaction({
       transaction_id: "0.0.999-1234567890-000000000",

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.ts
@@ -107,6 +107,11 @@ function createBlockOperationFromERC20TokenTransfer({
     assetReference: transfer.token_evm_address,
   };
 
+  // if we don't have either sender or recipient info, we cannot create a meaningful operation, so we skip it
+  if (!sender || !recipient) {
+    return [];
+  }
+
   return [
     {
       type: "transfer",

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -77,7 +77,7 @@ describe("listOperationsV2", () => {
     (utils.extractFeesPayer as jest.Mock).mockImplementation(input =>
       typeof input === "string"
         ? input.split("-")[0]
-        : (input.transaction_id?.split("-")[0] ?? "0.0.0"),
+        : input.transaction_id?.split("-")[0] ?? "0.0.0",
     );
     (utils.analyzeStakingOperation as jest.Mock).mockResolvedValue(null);
     (networkUtils.enrichERC20Transfers as jest.Mock).mockReturnValue([]);
@@ -408,6 +408,65 @@ describe("listOperationsV2", () => {
         recipients: [mockERC20Transfer.receiver_evm_address],
       }),
     ]);
+  });
+
+  it("should skip ERC20 operations when sender evm address is null", async () => {
+    const mockTokenERC20 = getMockedERC20TokenCurrency();
+    const sharedHash = "erc20-null-sender-hash";
+    const sharedTimestamp = "1625097600.000000000";
+    const mockMirrorTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: sharedTimestamp,
+      transaction_hash: sharedHash,
+      name: "CONTRACTCALL",
+      transfers: [{ account: mockMirrorAccount.account, amount: -300000 }],
+    });
+    const mockERC20Transfer = getMockedERC20TokenTransfer({
+      transaction_hash: sharedHash,
+      consensus_timestamp: Number(sharedTimestamp.split(".")[0]) * 10 ** 9,
+      sender_account_id: null,
+      receiver_account_id: 67890,
+      sender_evm_address: null,
+      receiver_evm_address: "0xrecipient",
+      payer_account_id: 12345,
+      amount: 5000000,
+    });
+    const mockContractCallResult = getMockedMirrorContractCallResult();
+    const mockEnrichedERC20Transfer = getMockedEnrichedERC20Transfer({
+      mirrorTransaction: mockMirrorTransaction,
+      contractCallResult: mockContractCallResult,
+      transfers: [mockERC20Transfer],
+    });
+
+    jest.spyOn(networkUtils, "enrichERC20Transfers").mockResolvedValue([mockEnrichedERC20Transfer]);
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [],
+      nextCursor: null,
+    });
+    (hgraphClient.getERC20Transfers as jest.Mock).mockResolvedValue([mockERC20Transfer]);
+    (hgraphClient.getLatestIndexedConsensusTimestamp as jest.Mock).mockResolvedValue(
+      new BigNumber(sharedTimestamp),
+    );
+
+    setupMockCryptoAssetsStore({
+      findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenERC20),
+    });
+
+    const result = await listOperations({
+      limit: mockLimit,
+      order: mockOrder,
+      currency: mockCurrency,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      erc20Tokens: [{ token: mockTokenERC20, balance: new BigNumber(10000000) }],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+    });
+
+    expect(result.tokenOperations).toEqual([]);
+    expect(result.coinOperations).toEqual([]);
   });
 
   it("should parse token associate transactions correctly", async () => {

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -77,7 +77,7 @@ describe("listOperationsV2", () => {
     (utils.extractFeesPayer as jest.Mock).mockImplementation(input =>
       typeof input === "string"
         ? input.split("-")[0]
-        : input.transaction_id?.split("-")[0] ?? "0.0.0",
+        : (input.transaction_id?.split("-")[0] ?? "0.0.0"),
     );
     (utils.analyzeStakingOperation as jest.Mock).mockResolvedValue(null);
     (networkUtils.enrichERC20Transfers as jest.Mock).mockReturnValue([]);

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -163,6 +163,9 @@ async function processERC20TokenTransfer({
       ? toEntityId({ num: transfer.receiver_account_id })
       : transfer.receiver_evm_address;
 
+    // meaningful operation cannot be created without correct addresses, so we skip it
+    if (!senderEvmAddress || !senderAddress || !recipientAddress) continue;
+
     const commonFields = {
       ...commonData,
       type: getOperationTypeFromERC20Details({

--- a/libs/coin-modules/coin-hedera/src/types/hgraph.ts
+++ b/libs/coin-modules/coin-hedera/src/types/hgraph.ts
@@ -23,9 +23,9 @@ export interface ERC20TokenAccount {
 export interface ERC20TokenTransfer {
   token_id: number;
   token_evm_address: string;
-  sender_evm_address: string;
+  sender_evm_address: string | null;
   sender_account_id: number | null;
-  receiver_evm_address: string;
+  receiver_evm_address: string | null;
   receiver_account_id: number | null;
   payer_account_id: number;
   amount: number;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - getBlock and listOperations in coin-hedera

### 📝 Description

This PR:
- adds logic to ignore incomplete Hedera ERC20 operations
- increases integration tests timeout in coin-hedera to avoid job re-runs (the listOperations process relies on two data sources and is quite complex)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-29036

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
