### PR TITLE
feat(wallet-cli): support arbitrary EVM calldata in TransactionIntent

### DIFF
--- a/.changeset/wallet-cli-evm-calldata.md
+++ b/.changeset/wallet-cli-evm-calldata.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Add optional `data` (0x-prefixed hex calldata) field to `EvmTransactionIntentSchema`, enabling arbitrary EVM contract interactions. The bridge adapter propagates it to the live-common EVM transaction's `data: Buffer` field.

--- a/apps/wallet-cli/src/commands/send.ts
+++ b/apps/wallet-cli/src/commands/send.ts
@@ -21,6 +21,7 @@ type SendFlags = {
   validator?: string;
   "stake-account"?: string;
   memo?: string;
+  data?: string;
   "dry-run": boolean;
   output: "human" | "json";
 };
@@ -39,6 +40,7 @@ const INTENT_BUILDERS: Record<string, IntentBuilder> = {
     family: "evm",
     recipient: flags.to,
     amount: flags.amount,
+    data: flags.data,
   }),
   solana: flags => ({
     family: "solana",
@@ -89,6 +91,15 @@ export default defineCommand({
     memo: option(z.string().min(1).optional(), {
       description: "Memo/tag (Solana only)",
     }),
+    data: option(
+      z
+        .string()
+        .regex(/^0x([0-9a-fA-F]{2})*$/, "data must be 0x-prefixed hex with an even number of digits")
+        .optional(),
+      {
+        description: "EVM calldata as 0x-prefixed hex (e.g. 0xd0e30db0)",
+      },
+    ),
     "dry-run": option(z.boolean().default(false), {
       description: "Prepare and validate transaction but do not sign or broadcast",
     }),

--- a/apps/wallet-cli/src/wallet/compatibility/bridge.ts
+++ b/apps/wallet-cli/src/wallet/compatibility/bridge.ts
@@ -183,19 +183,27 @@ export class BridgeAdapter {
   }
 
   private buildTxExtras(intent: TransactionIntent, tokenAccount: TokenAccount | undefined) {
-    return {
-      ...(tokenAccount ? { subAccountId: tokenAccount.id } : {}),
-      ...("feePerByte" in intent && intent.feePerByte
-        ? { feePerByte: new BigNumber(intent.feePerByte) }
-        : {}),
-      ...("rbf" in intent && intent.rbf != null ? { rbf: intent.rbf } : {}),
-      ...("mode" in intent && intent.mode ? { mode: intent.mode } : {}),
-      ...("validator" in intent && intent.validator ? { validator: intent.validator } : {}),
-      ...("stakeAccount" in intent && intent.stakeAccount
-        ? { stakeAccountId: intent.stakeAccount }
-        : {}),
-      ...("memo" in intent && intent.memo ? { memo: intent.memo } : {}),
-    };
+    const patch: Record<string, unknown> = {};
+    if (tokenAccount) patch.subAccountId = tokenAccount.id;
+    switch (intent.family) {
+      case "bitcoin":
+        if (intent.feePerByte) patch.feePerByte = new BigNumber(intent.feePerByte);
+        if (intent.rbf != null) patch.rbf = intent.rbf;
+        break;
+      case "evm":
+        if (intent.data) {
+          const hexData = intent.data.slice(2);
+          if (hexData.length > 0) patch.data = Buffer.from(hexData, "hex");
+        }
+        break;
+      case "solana":
+        if (intent.mode) patch.mode = intent.mode;
+        if (intent.validator) patch.validator = intent.validator;
+        if (intent.stakeAccount) patch.stakeAccountId = intent.stakeAccount;
+        if (intent.memo) patch.memo = intent.memo;
+        break;
+    }
+    return patch;
   }
 
   private async buildValidatedTx(account: Account, intent: TransactionIntent) {

--- a/apps/wallet-cli/src/wallet/intents/families/evm.ts
+++ b/apps/wallet-cli/src/wallet/intents/families/evm.ts
@@ -5,4 +5,8 @@ export const EvmTransactionIntentSchema = z.object({
   family: z.literal("evm"),
   recipient: z.string(),
   amount: AmountWithTickerSchema,
+  data: z
+    .string()
+    .regex(/^0x([0-9a-fA-F]{2})*$/, "data must be 0x-prefixed hex with an even number of digits")
+    .optional(),
 });

--- a/apps/wallet-cli/src/wallet/intents/index.test.ts
+++ b/apps/wallet-cli/src/wallet/intents/index.test.ts
@@ -77,6 +77,53 @@ describe("EvmTransactionIntentSchema", () => {
   it("rejects missing recipient", () => {
     expect(EvmTransactionIntentSchema.safeParse({ family: "evm", amount: "0.5 ETH" }).success).toBe(false);
   });
+
+  it("parses valid calldata", () => {
+    const result = EvmTransactionIntentSchema.safeParse({
+      family: "evm",
+      recipient: "0x71C7656EC7ab88b098defB751B7401B5f6d8976F",
+      amount: "0.5 ETH",
+      data: "0xd0e30db0",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.data).toBe("0xd0e30db0");
+  });
+
+  it("accepts empty calldata (0x)", () => {
+    expect(EvmTransactionIntentSchema.safeParse({
+      family: "evm",
+      recipient: "0x71C7656EC7ab88b098defB751B7401B5f6d8976F",
+      amount: "0.5 ETH",
+      data: "0x",
+    }).success).toBe(true);
+  });
+
+  it("rejects odd-length hex (0x0)", () => {
+    expect(EvmTransactionIntentSchema.safeParse({
+      family: "evm",
+      recipient: "0x71C7656EC7ab88b098defB751B7401B5f6d8976F",
+      amount: "0.5 ETH",
+      data: "0x0",
+    }).success).toBe(false);
+  });
+
+  it("rejects non-hex characters in data", () => {
+    expect(EvmTransactionIntentSchema.safeParse({
+      family: "evm",
+      recipient: "0x71C7656EC7ab88b098defB751B7401B5f6d8976F",
+      amount: "0.5 ETH",
+      data: "0xzzzz",
+    }).success).toBe(false);
+  });
+
+  it("rejects data without 0x prefix", () => {
+    expect(EvmTransactionIntentSchema.safeParse({
+      family: "evm",
+      recipient: "0x71C7656EC7ab88b098defB751B7401B5f6d8976F",
+      amount: "0.5 ETH",
+      data: "d0e30db0",
+    }).success).toBe(false);
+  });
 });
 
 describe("SolanaTransactionIntentSchema", () => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- no existing test harness for wallet-cli intents; manual dry-run validation via `prepareSend` with `data` field -->
- [x] **Impact of the changes:**
  - `EvmTransactionIntentSchema` gains an optional `data` field (0x-prefixed hex calldata) — fully backward-compatible, existing sends unaffected
  - `BridgeAdapter.buildTxExtras` now propagates `data` to the live-common EVM transaction as `Buffer`
  - `buildTxExtras` refactored from flat spread-ternary + `"key" in intent` guards to a `switch (intent.family)` block — no behaviour change, maintainability improvement

### 📝 Description

Adds support for arbitrary EVM calldata in the `wallet-cli` `TransactionIntent` layer.

**Before:** `EvmTransactionIntentSchema` only had `recipient` and `amount`. No way to express contract calls, approvals, or any transaction with custom calldata.

**After:** An optional `data` field (0x-prefixed hex string, even-digit enforced by regex) can be passed. The `BridgeAdapter` converts it to a `Buffer` and forwards it to the live-common EVM transaction, where `coin-evm` already gives it priority over auto-generated ERC-20 calldata.

For pure contract calls with no ETH value, callers pass `amount: "0 ETH"` (already supported by `parseAmountWithTicker`).

Also refactors `buildTxExtras`:
- Before: flat list of `...("key" in intent && intent.key ? { key: val } : {})` — no TypeScript narrowing, fragile as new families/fields were added
- After: `switch (intent.family)` — TypeScript narrows each case fully, per-family logic is isolated, adding a field touches only one case

### ❓ Context

- **JIRA or GitHub link**: N/A (internal `wallet-cli` improvement)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)