### PR TITLE
feat(wallet-cli): add account fresh-address command

### DIFF
--- a/.changeset/wallet-cli-fresh-address-command.md
+++ b/.changeset/wallet-cli-fresh-address-command.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Add `account fresh-address` command: resolves the fresh receive address from a V1 descriptor without requiring a device. For address-based chains (EVM, Solana) the address is extracted directly — no sync. For UTXO chains (Bitcoin) the bridge sync finds the next unused address.

--- a/apps/wallet-cli/.bunli/commands.gen.ts
+++ b/apps/wallet-cli/.bunli/commands.gen.ts
@@ -7,18 +7,20 @@ import { createGeneratedHelpers, registerGeneratedStore } from '@bunli/core'
 import Account from '../src/commands/account/index.js'
 import Balances from '../src/commands/balances.js'
 import Discover from '../src/commands/account/discover.js'
+import FreshAddress from '../src/commands/account/fresh-address.js'
 import Operations from '../src/commands/operations.js'
 import Receive from '../src/commands/receive.js'
 import Send from '../src/commands/send.js'
 
 // Narrow list of command names to avoid typeof-cycles in types
-const names = ['account', 'balances', 'discover', 'operations', 'receive', 'send'] as const
+const names = ['account', 'balances', 'discover', 'fresh-address', 'operations', 'receive', 'send'] as const
 type GeneratedNames = typeof names[number]
 
 const modules: Record<GeneratedNames, Command<any>> = {
   'account': Account,
   'balances': Balances,
   'discover': Discover,
+  'fresh-address': FreshAddress,
   'operations': Operations,
   'receive': Receive,
   'send': Send
@@ -37,6 +39,15 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
             'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
           },
           path: './src/commands/account/discover'
+        },
+        {
+          name: 'fresh-address',
+          description: 'Resolve the fresh receive address for an account descriptor (no device required)',
+          options: {
+            'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor (V1 format), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+            'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+          },
+          path: './src/commands/account/fresh-address'
         }
       ],
       path: './src/commands/account/index'
@@ -58,6 +69,15 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
         'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
       },
       path: './src/commands/account/discover'
+    },
+  'fresh-address': {
+      name: 'fresh-address',
+      description: 'Resolve the fresh receive address for an account descriptor (no device required)',
+      options: {
+        'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor (V1 format), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+        'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+      },
+      path: './src/commands/account/fresh-address'
     },
   'operations': {
       name: 'operations',

--- a/apps/wallet-cli/src/commands/account/fresh-address.ts
+++ b/apps/wallet-cli/src/commands/account/fresh-address.ts
@@ -1,0 +1,44 @@
+import { defineCommand, option } from "@bunli/core";
+import { z } from "zod";
+import { WalletAdapter } from "../../wallet";
+import { parseV1, toV0, serializeNetwork } from "../../shared/accountDescriptor";
+import { resolveAccountArg, OutputFormatSchema } from "../../wallet/models";
+import { makeEnvelope } from "../../shared/response";
+import { withSpinner, writeStdout } from "../../shared/ui";
+
+export default defineCommand({
+  name: "fresh-address",
+  description: "Resolve the fresh receive address for an account descriptor (no device required)",
+  options: {
+    account: option(z.string().min(1).optional(), {
+      description: "Account descriptor (V1 format), or pass as first positional arg",
+      short: "a",
+    }),
+    output: option(OutputFormatSchema.default("human"), {
+      description: "Output format: human (default) or json",
+    }),
+  },
+  handler: async ({ flags, positional }) => {
+    const input = resolveAccountArg(flags.account, positional);
+    const v1 = parseV1(input);
+    const isHuman = flags.output === "human";
+    const wallet = new WalletAdapter();
+    // address-based (EVM, Solana…): no sync needed, address is in the descriptor
+    // utxo (Bitcoin…): next unused address requires a blockchain scan
+    const address =
+      v1.type === "address"
+        ? v1.address
+        : await withSpinner(
+            `Scanning ${v1.network.name} blockchain for fresh address…`,
+            "Fresh address resolved",
+            () => wallet.getFreshAddress(toV0(v1)),
+            isHuman,
+          );
+    const network = serializeNetwork(v1.network);
+    writeStdout(
+      isHuman
+        ? address
+        : JSON.stringify(makeEnvelope("account fresh-address", network, { address }, input), null, 2),
+    );
+  },
+});

--- a/apps/wallet-cli/src/commands/account/index.ts
+++ b/apps/wallet-cli/src/commands/account/index.ts
@@ -1,8 +1,9 @@
 import { defineGroup } from "@bunli/core";
 import DiscoverCommand from "./discover";
+import FreshAddressCommand from "./fresh-address";
 
 export default defineGroup({
   name: "account",
   description: "Account management commands",
-  commands: [DiscoverCommand],
+  commands: [DiscoverCommand, FreshAddressCommand],
 });


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - New `account fresh-address <descriptor>` command in wallet-cli
  - No changes to existing commands or bridge layer

### 📝 Description

Adds `account fresh-address` to wallet-cli: resolves the fresh receive address from a V1 account descriptor without requiring a device.

- **EVM / Solana** (`type: address`): address is extracted directly from the descriptor — zero network, zero sync
- **Bitcoin** (`type: utxo`): delegates to the existing bridge sync to find the next unused external address

Only V1 descriptors are accepted (`account:1:...`).

```bash
# EVM — instantaneous, no network
pnpm --silent wallet-cli start account fresh-address \
  "account:1:address:ethereum:main:0xABC...:m/44h/60h/0h/0/0"

# Bitcoin — blockchain scan via existing bridge
pnpm --silent wallet-cli start account fresh-address \
  "account:1:utxo:bitcoin:main:xpub...:m/84h/0h/0h"
```

### ❓ Context

- **JIRA or GitHub link**: N/A