### PR TITLE
ci: preserve nx config if already in place

### DIFF
--- a/tools/actions/composites/configure-nx-remote-cache-profile/README.md
+++ b/tools/actions/composites/configure-nx-remote-cache-profile/README.md
@@ -16,6 +16,8 @@ After clone or when `nx.workspace.json` / `nx.s3.defaults.json` change, regenera
 pnpm run nx:write-cache-config
 ```
 
+If `nx.cache-config.json` already exists, the script skips overwriting it; run `pnpm run nx:write-cache-config -- --force` to regenerate after changing the tracked inputs.
+
 `nx.cache-config.json` is gitignored; do not commit it.
 
 ## Nx activation key

--- a/tools/nx/write-nx-cache-config.mjs
+++ b/tools/nx/write-nx-cache-config.mjs
@@ -2,10 +2,16 @@
 /**
  * Merges nx.workspace.json + nx.s3.defaults.json + cacheKeyPrefix into gitignored nx.cache-config.json.
  * CI sets NX_CACHE_KEY_PREFIX (develop | branch); local default is "local".
+ *
+ * If nx.cache-config.json already exists, the script exits without overwriting unless `--force` is passed.
  */
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+
+function parseForce(argv) {
+  return argv.includes("--force");
+}
 
 function parseCacheKeyPrefix(argv, env) {
   for (let i = 0; i < argv.length; i += 1) {
@@ -21,11 +27,21 @@ function parseCacheKeyPrefix(argv, env) {
 }
 
 const workspaceRoot = process.env.GITHUB_WORKSPACE || process.cwd();
-const cacheKeyPrefix = parseCacheKeyPrefix(process.argv.slice(2), process.env);
+const argv = process.argv.slice(2);
+const force = parseForce(argv);
 
 const workspacePath = path.join(workspaceRoot, "nx.workspace.json");
 const s3DefaultsPath = path.join(workspaceRoot, "nx.s3.defaults.json");
 const outPath = path.join(workspaceRoot, "nx.cache-config.json");
+
+if (fs.existsSync(outPath) && !force) {
+  console.error(
+    `nx.cache-config.json already exists at ${outPath}; skipping write. Use --force to regenerate.`,
+  );
+  process.exit(0);
+}
+
+const cacheKeyPrefix = parseCacheKeyPrefix(argv, process.env);
 
 const workspace = JSON.parse(fs.readFileSync(workspacePath, "utf8"));
 const s3Defaults = JSON.parse(fs.readFileSync(s3DefaultsPath, "utf8"));


### PR DESCRIPTION
Adjust default behaviour to preserve nx config if already in place. Enabling safety for edits