### PR TITLE
[LWM] fix(mobile): disable async chunk creation in re-pack bundle

### DIFF
--- a/.changeset/fix-mobile-repack-async-chunks.md
+++ b/.changeset/fix-mobile-repack-async-chunks.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: disable async chunk creation in re-pack to prevent chunk loading errors

--- a/apps/ledger-live-mobile/rspack.config.mjs
+++ b/apps/ledger-live-mobile/rspack.config.mjs
@@ -141,6 +141,9 @@ export default withRozeniteUrlFix(
         mode,
         context: __dirname,
         entry: "./index.js",
+        // Mobile uses a single Hermes bytecode bundle — async chunks are not supported
+        // and hurt performance with Hermes. Disable async chunk creation globally.
+        output: { asyncChunks: false },
         resolve: {
           ...Repack.getResolveOptions(platform, {
             enablePackageExports: true,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
  - Detox should have seen it, there were cache issue before.
- [x] **Impact of the changes:**
  - Fixes "Loading chunk libs_ledger-live-common_lib_bridge_generic-alpaca..." error introduced by #16333
  - No functional change — mobile already had no code splitting; this makes it explicit

### 📝 Description

PR #16333 introduced dynamic `import()` in `ledger-live-common/bridge/generic-alpaca/alpaca/index.ts`. By default, rspack (re-pack) emits async chunks for every dynamic `import()`. Since the mobile app has no `ScriptManager` configured and no chunk server, those chunks cannot be loaded at runtime — causing the error shown above.

Claude notes:

> Fix: set `output.asyncChunks: false` in the mobile rspack config. This is the correct layer to fix this:
> - **Not in `live-common`** — desktop may legitimately use async chunks from those same imports
> - **Mobile-specific policy** — Hermes + bytecode bundles already make local chunks worse for perf (per re-pack docs)

### ❓ Context

- **GitHub link**: fixes regression introduced by #16333
- See doc https://rspack.rs/config/output#outputasyncchunks