### PR TITLE
[LWDM] Support/adjust nx hashing

### DIFF
--- a/apps/ledger-live-desktop/project.json
+++ b/apps/ledger-live-desktop/project.json
@@ -5,6 +5,7 @@
       "cache": false,
       "inputs": [
         "default",
+        "^default",
         "desktopEnv",
         "sharedEnv"
       ]
@@ -24,6 +25,7 @@
     "lint": {
       "inputs": [
         "default",
+        "^default",
         {
           "env": "CI_OS"
         }
@@ -35,6 +37,7 @@
       ],
       "inputs": [
         "default",
+        "^default",
         {
           "env": "CI_OS"
         }

--- a/apps/ledger-live-mobile/project.json
+++ b/apps/ledger-live-mobile/project.json
@@ -35,7 +35,7 @@
         "@ledgerhq/dummy-wallet-app:build",
         "@ledgerhq/dummy-ptx-app:build"
       ],
-      "cache": false,
+      "cache": true,
       "outputs": [
         "{projectRoot}/artifacts/**",
         "{workspaceRoot}/e2e/mobile/artifacts/**",

--- a/apps/ledger-live-mobile/project.json
+++ b/apps/ledger-live-mobile/project.json
@@ -4,6 +4,7 @@
     "lint": {
       "inputs": [
         "default",
+        "^default",
         {
           "env": "CI_OS"
         }
@@ -12,6 +13,7 @@
     "lint:ci": {
       "inputs": [
         "default",
+        "^default",
         {
           "env": "CI_OS"
         }
@@ -20,6 +22,7 @@
     "lint:i18n": {
       "inputs": [
         "default",
+        "^default",
         {
           "env": "CI_OS"
         }
@@ -44,6 +47,7 @@
       ],
       "inputs": [
         "default",
+        "^default",
         "mobileEnv",
         "sharedEnv",
         {
@@ -61,6 +65,7 @@
       ],
       "inputs": [
         "default",
+        "^default",
         "mobileEnv",
         "sharedEnv"
       ]
@@ -71,6 +76,7 @@
       ],
       "inputs": [
         "default",
+        "^default",
         "mobileEnv",
         "sharedEnv"
       ]
@@ -81,6 +87,7 @@
       ],
       "inputs": [
         "default",
+        "^default",
         "mobileEnv",
         "sharedEnv"
       ]

--- a/nx.workspace.json
+++ b/nx.workspace.json
@@ -331,6 +331,7 @@
       "cache": true,
       "inputs": [
         "default",
+        "^default",
         {
           "env": "CI_OS"
         }
@@ -346,6 +347,7 @@
       "cache": true,
       "inputs": [
         "default",
+        "^default",
         {
           "env": "CI_OS"
         }
@@ -358,6 +360,7 @@
       "cache": true,
       "inputs": [
         "default",
+        "^default",
         {
           "env": "CI_OS"
         }
@@ -404,6 +407,7 @@
       "cache": true,
       "inputs": [
         "default",
+        "^default",
         "mobileEnv",
         "sharedEnv"
       ]
@@ -415,6 +419,7 @@
       "cache": true,
       "inputs": [
         "default",
+        "^default",
         "mobileEnv",
         "sharedEnv"
       ]
@@ -426,6 +431,7 @@
       "cache": true,
       "inputs": [
         "default",
+        "^default",
         "mobileEnv",
         "sharedEnv"
       ]
@@ -437,6 +443,7 @@
       "cache": true,
       "inputs": [
         "default",
+        "^default",
         "mobileEnv",
         "sharedEnv"
       ]
@@ -448,6 +455,7 @@
       "cache": false,
       "inputs": [
         "default",
+        "^default",
         "desktopEnv",
         "sharedEnv"
       ]
@@ -459,6 +467,7 @@
       "cache": false,
       "inputs": [
         "default",
+        "^default",
         "desktopEnv",
         "sharedEnv"
       ]
@@ -470,6 +479,7 @@
       "cache": false,
       "inputs": [
         "default",
+        "^default",
         "desktopEnv",
         "sharedEnv"
       ]


### PR DESCRIPTION
Adjust nx project files to include dependencies when computing hashes - meaning if live-common is updated, the hash for upstream apps (e.g. live-mobile) is updated

Initial test (uncached mocks): 
https://github.com/LedgerHQ/ledger-live/actions/runs/24509146235/job/71637658677?pr=16407
Re-test (cached mocks):
https://github.com/LedgerHQ/ledger-live/actions/runs/24509146235/job/71640464750
Dummy update to live-common (cache busts tests):
https://github.com/LedgerHQ/ledger-live/actions/runs/24511253674/job/71643078365
