### PR TITLE
[LWM] fix(mobile): disable async chunk creation in re-pack bundle

### DIFF
--- a/.changeset/fix-mobile-repack-async-chunks.md
+++ b/.changeset/fix-mobile-repack-async-chunks.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: disable async chunk creation in re-pack to prevent chunk loading errors

--- a/apps/ledger-live-mobile/project.json
+++ b/apps/ledger-live-mobile/project.json
@@ -32,7 +32,7 @@
         "@ledgerhq/dummy-wallet-app:build",
         "@ledgerhq/dummy-ptx-app:build"
       ],
-      "cache": true,
+      "cache": false,
       "outputs": [
         "{projectRoot}/artifacts/**",
         "{workspaceRoot}/e2e/mobile/artifacts/**",

--- a/apps/ledger-live-mobile/rspack.config.mjs
+++ b/apps/ledger-live-mobile/rspack.config.mjs
@@ -141,6 +141,9 @@ export default withRozeniteUrlFix(
         mode,
         context: __dirname,
         entry: "./index.js",
+        // Mobile uses a single Hermes bytecode bundle — async chunks are not supported
+        // and hurt performance with Hermes. Disable async chunk creation globally.
+        output: { asyncChunks: false },
         resolve: {
           ...Repack.getResolveOptions(platform, {
             enablePackageExports: true,


### PR DESCRIPTION
cherry-pick for `release`

Dynamic import() in dependencies (e.g. ledger-live-common's generic-alpaca) causes re-pack to emit async chunks that the mobile runtime cannot load — no ScriptManager/chunk server is configured, and local chunks hurt Hermes bytecode perf. Set output.asyncChunks=false to keep a single bundle.

PR ref https://github.com/LedgerHQ/ledger-live/pull/16408