### PR TITLE
ci: move wallet cli coverage to wallet cli build step

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -162,15 +162,17 @@ jobs:
       - test-mobile
       - test-libraries
       - test-features
+      - build-wallet-cli
       - determine-affected
     uses: LedgerHQ/ledger-live/.github/workflows/scan-sonar-reusable.yml@develop
-    if: ${{ always() && !cancelled() && !github.event.pull_request.head.repo.fork && (needs.test-desktop.result == 'success' || needs.test-mobile.result == 'success' || needs.test-libraries.result == 'success' || needs.test-features.result == 'success' || contains(needs.determine-affected.outputs.paths, 'e2e')) }}
+    if: ${{ always() && !cancelled() && !github.event.pull_request.head.repo.fork && (needs.test-desktop.result == 'success' || needs.test-mobile.result == 'success' || needs.test-libraries.result == 'success' || needs.test-features.result == 'success' || needs.build-wallet-cli.result == 'success' || contains(needs.determine-affected.outputs.paths, 'e2e')) }}
     secrets: inherit
     with:
       should_download_desktop_coverage: ${{ needs.test-desktop.outputs.coverage_generated }}
       should_download_mobile_coverage: ${{ needs.test-mobile.outputs.coverage_generated }}
       should_download_libs_coverage: ${{ needs.test-libraries.outputs.coverage_generated }}
       should_download_features_coverage: ${{ needs.test-features.outputs.coverage_generated }}
+      should_download_wallet_cli_coverage: ${{ needs.build-wallet-cli.outputs.coverage_generated }}
 
   # Final Check required
   ok:

--- a/.github/workflows/build-wallet-cli-reusable.yml
+++ b/.github/workflows/build-wallet-cli-reusable.yml
@@ -6,6 +6,9 @@ on:
       ref:
         type: string
         required: false
+    outputs:
+      coverage_generated:
+        value: ${{ jobs.build-wallet-cli.outputs.coverage_generated }}
   workflow_dispatch:
     inputs:
       ref:
@@ -27,6 +30,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     continue-on-error: true
+    outputs:
+      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -39,11 +44,13 @@ jobs:
         with:
           use-mise: true
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          skip-turbo-cache: "false"
+          skip-turbo-cache: "true"
+          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+          nx-key: ${{ secrets.NX_KEY }}
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
-          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
@@ -54,11 +61,20 @@ jobs:
         run: pnpm i --filter "@ledgerhq/wallet-cli..." --filter "ledger-live"
 
       - name: Build wallet-cli
-        env:
-          TURBO_API: "http://127.0.0.1:${{ steps.setup-caches.outputs.port }}"
-          TURBO_TOKEN: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
-          TURBO_TEAM: "foo"
-        run: pnpm turbo build --filter "@ledgerhq/wallet-cli"
+        run: pnpm exec nx run @ledgerhq/wallet-cli:build
+
+      - name: Generate unit test coverage for wallet-cli
+        run: |
+          mkdir -p apps/wallet-cli/coverage
+          pnpm exec nx run @ledgerhq/wallet-cli:coverage
+
+      - name: Upload wallet-cli unit test coverage
+        id: generate_coverage
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: coverage-wallet-cli
+          path: ${{ github.workspace }}/apps/wallet-cli/coverage
 
       - name: Upload darwin-arm64 binary
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/scan-sonar-reusable.yml
+++ b/.github/workflows/scan-sonar-reusable.yml
@@ -19,6 +19,10 @@ on:
         required: false
         default: "false"
         type: string
+      should_download_wallet_cli_coverage:
+        required: false
+        default: "false"
+        type: string
 
 permissions:
   id-token: write
@@ -82,22 +86,12 @@ jobs:
           name: coverage-features
           path: coverage-features
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+      - name: Download wallet-cli unit test coverage
+        if: ${{ inputs.should_download_wallet_cli_coverage == 'true' }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          bun-version: "1.3.11"
-
-      - name: Generate Unit test coverage for wallet-cli
-        env:
-          TURBO_API: "http://127.0.0.1:${{ steps.setup-caches.outputs.port }}"
-          TURBO_TOKEN: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
-          TURBO_TEAM: "foo"
-        run: |
-          pnpm i --filter="@ledgerhq/wallet-cli..." --no-frozen-lockfile --unsafe-perm
-          pnpm turbo build --filter="@ledgerhq/wallet-cli^..."
-          mkdir -p apps/wallet-cli/coverage
-          touch apps/wallet-cli/coverage/sonar-executionTests-report.xml
-          pnpm --filter="@ledgerhq/wallet-cli" coverage
+          name: coverage-wallet-cli
+          path: coverage-wallet-cli
 
       - name: Merge coverage files
         run: |
@@ -121,10 +115,9 @@ jobs:
             cat ./coverage-features/lcov.info >> ./lcov.info
             cat ./coverage-features/sonar-executionTests-report.xml >> ./sonar-executionTests-report.xml
           fi
-          if [ -d ./apps/wallet-cli/coverage ]; then
+          if [ -d ./coverage-wallet-cli ]; then
             echo "Merging wallet-cli coverage files"
-            cat ./apps/wallet-cli/coverage/lcov.info >> ./lcov.info
-            cat ./apps/wallet-cli/coverage/sonar-executionTests-report.xml >> ./sonar-executionTests-report.xml
+            cat ./coverage-wallet-cli/lcov.info >> ./lcov.info
           fi
           if [ ! -f ./sonar-executionTests-report.xml ]; then
             echo "No report found, creating empty report to avoid sonar scan failing!"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -121,13 +121,12 @@ jobs:
           pnpm turbo build --filter="@ledgerhq/wallet-cli^..."
           mkdir -p apps/wallet-cli/coverage
           touch apps/wallet-cli/coverage/lcov.info
-          touch apps/wallet-cli/coverage/sonar-executionTests-report.xml
           pnpm --filter="@ledgerhq/wallet-cli" coverage
 
       - name: Merge coverage files
         run: |
           cat libs/coverage/lcov.info features/coverage/lcov.info apps/ledger-live-desktop/coverage/lcov.info apps/ledger-live-mobile/coverage/lcov.info apps/wallet-cli/coverage/lcov.info > ./lcov.info
-          cat libs/coverage/sonar-executionTests-report.xml features/coverage/sonar-executionTests-report.xml apps/ledger-live-desktop/coverage/sonar-executionTests-report.xml apps/ledger-live-mobile/coverage/sonar-executionTests-report.xml apps/wallet-cli/coverage/sonar-executionTests-report.xml > ./sonar-executionTests-report.xml
+          cat libs/coverage/sonar-executionTests-report.xml features/coverage/sonar-executionTests-report.xml apps/ledger-live-desktop/coverage/sonar-executionTests-report.xml apps/ledger-live-mobile/coverage/sonar-executionTests-report.xml > ./sonar-executionTests-report.xml
 
       - name: Sonarqube Scan
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6

--- a/apps/wallet-cli/project.json
+++ b/apps/wallet-cli/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "@ledgerhq/wallet-cli",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "targets": {
+    "coverage": {
+      "outputs": ["{projectRoot}/coverage/**"]
+    },
+    "build": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
Move coverage of wallet cli to the build step, resulting in > 10 minutes time savings on sonar scanning and bringing in line with other steps

Test run: https://github.com/LedgerHQ/ledger-live/pull/16412/checks