### PR TITLE
test(wallet-cli): integration tests with HTTP-level mocking

### DIFF
--- a/apps/wallet-cli/src/test/helpers/cli-runner.ts
+++ b/apps/wallet-cli/src/test/helpers/cli-runner.ts
@@ -1,0 +1,35 @@
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "../../..");
+const WRAPPER = path.resolve(import.meta.dir, "./wrapper.ts");
+
+export type RunResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+export async function runCli(
+  args: string[],
+  env: Record<string, string> = {},
+): Promise<RunResult> {
+  // --cwd (NOT the cwd: subprocess option) makes Bun resolve tsconfig and workspace packages from the wallet-cli root.
+  const proc = Bun.spawn(["bun", "--cwd", ROOT, WRAPPER, ...args], {
+    env: {
+      ...process.env,
+      NO_COLOR: "1",
+      CLAUDECODE: "1", // triggers isInteractive() === false → disables spinner
+      ...env,
+    },
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}

--- a/apps/wallet-cli/src/test/helpers/constants.ts
+++ b/apps/wallet-cli/src/test/helpers/constants.ts
@@ -1,0 +1,2 @@
+export const ETH_ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+export const ETH_DESCRIPTOR = `account:1:address:ethereum:main:${ETH_ADDRESS}:m/44h/60h/0h/0/0`;

--- a/apps/wallet-cli/src/test/helpers/http-intercept.ts
+++ b/apps/wallet-cli/src/test/helpers/http-intercept.ts
@@ -1,0 +1,141 @@
+/**
+ * Test-only HTTP interceptor. Import before the CLI entry point.
+ * Requires WALLET_CLI_MOCK_PORT in process.env.
+ *
+ * Two interception layers:
+ *   1. globalThis.fetch  — all fetch-based callers and axios (forced to fetch adapter)
+ *   2. node:http/https   — fallback for any remaining node:http callers
+ *
+ * Axios uses node:http adapter by default in Bun (process is defined). We force it
+ * onto the fetch adapter so its calls go through the globalThis.fetch patch below.
+ * axios is not a direct dep of wallet-cli, so we resolve it via @ledgerhq/coin-evm
+ * (which is) and patch both CJS and ESM instances.
+ */
+import path from "node:path";
+
+const mockPort = process.env.WALLET_CLI_MOCK_PORT;
+if (!mockPort) {
+  throw new Error("[http-intercept] WALLET_CLI_MOCK_PORT is not set");
+}
+
+const mockBase = `http://localhost:${mockPort}`;
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const coinEvmDir = path.dirname(require.resolve("@ledgerhq/coin-evm/package.json"));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const axiosPkgDir = path.dirname(require.resolve("axios/package.json", { paths: [coinEvmDir] }));
+
+// Patch CJS axios instance
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any
+(require(path.join(axiosPkgDir, "dist/node/axios.cjs")) as any).defaults.adapter = "fetch";
+// Patch ESM axios instance (coin-evm's `import axios from "axios"` resolves here)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+((await import(path.join(axiosPkgDir, "index.js"))) as any).default.defaults.adapter = "fetch";
+
+function isLocal(urlStr: string): boolean {
+  return (
+    urlStr.startsWith("http://localhost") ||
+    urlStr.startsWith("https://localhost") ||
+    urlStr.startsWith("http://127.0.0.1") ||
+    urlStr.startsWith("https://127.0.0.1")
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1: globalThis.fetch
+// ---------------------------------------------------------------------------
+const origFetch = globalThis.fetch;
+(globalThis as Record<string, unknown>).fetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => {
+  const urlStr =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : (input as Request).url;
+  if (urlStr && !isLocal(urlStr)) {
+    const u = new URL(urlStr);
+    const redirected = `${mockBase}${u.pathname}${u.search}`;
+    if (input instanceof Request) {
+      // Preserve the original request's method/headers/body; apply caller's init on top.
+      return origFetch(new Request(redirected, input), init);
+    }
+    return origFetch(redirected, init);
+  }
+  return origFetch(input, init);
+};
+
+// ---------------------------------------------------------------------------
+// Layer 2: node:http / node:https — fallback for non-fetch callers.
+// HTTPS requests are redirected to the plain-HTTP mock server.
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const http = require("node:http") as typeof import("node:http");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const https = require("node:https") as typeof import("node:https");
+
+const origHttpRequest = http.request.bind(http);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildMockOptions(options: any): Record<string, unknown> {
+  if (typeof options === "string" || options instanceof URL) {
+    const u = new URL(typeof options === "string" ? options : (options as URL).href);
+    return { hostname: "localhost", port: Number(mockPort), path: u.pathname + u.search, method: "GET" };
+  }
+  return {
+    hostname: "localhost",
+    port: Number(mockPort),
+    path: options.path ?? "/",
+    method: options.method ?? "GET",
+    headers: options.headers ?? {},
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isExternalOptions(options: any): boolean {
+  if (typeof options === "string" || options instanceof URL) {
+    const s = typeof options === "string" ? options : (options as URL).href;
+    return !isLocal(s);
+  }
+  if (options && typeof options === "object") {
+    const host: string = options.hostname ?? (options.host ?? "").split(":")[0];
+    return Boolean(host) && host !== "localhost" && host !== "127.0.0.1";
+  }
+  return false;
+}
+
+// Resolves the correct [mergedOptions, callback] pair from the Node http.request overloads:
+//   (options[, callback])
+//   (url[, options][, callback])
+// When the first arg is a URL/string and rest[0] is a non-function, it is an options object.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function resolveHttpArgs(base: Record<string, unknown>, firstArg: any, rest: any[]): [Record<string, unknown>, ((...a: unknown[]) => unknown) | undefined] {
+  if ((typeof firstArg === "string" || firstArg instanceof URL) && rest.length > 0 && typeof rest[0] !== "function") {
+    const extra = rest[0] as Record<string, unknown>;
+    const merged = {
+      ...base,
+      ...(extra.method != null ? { method: extra.method } : {}),
+      ...(extra.headers != null ? { headers: extra.headers } : {}),
+    };
+    return [merged, rest[1] as ((...a: unknown[]) => unknown) | undefined];
+  }
+  return [base, rest[0] as ((...a: unknown[]) => unknown) | undefined];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(http as any).request = function (options: any, ...rest: any[]) {
+  if (isExternalOptions(options)) {
+    const [mockOpts, cb] = resolveHttpArgs(buildMockOptions(options), options, rest);
+    return origHttpRequest(mockOpts as unknown as Parameters<typeof http.request>[0], cb);
+  }
+  return origHttpRequest(options, ...rest);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(https as any).request = function (options: any, ...rest: any[]) {
+  const [mockOpts, cb] = resolveHttpArgs(buildMockOptions(options), options, rest);
+  return origHttpRequest(mockOpts as unknown as Parameters<typeof http.request>[0], cb);
+};

--- a/apps/wallet-cli/src/test/helpers/mock-server.ts
+++ b/apps/wallet-cli/src/test/helpers/mock-server.ts
@@ -1,0 +1,58 @@
+export type Route = {
+  method?: string;
+  /** URL path pattern to match (string = substring, RegExp = test against pathname+search) */
+  match: RegExp | string;
+  response: unknown;
+  status?: number;
+  headers?: Record<string, string>;
+};
+
+export class MockServer {
+  private _server: ReturnType<typeof Bun.serve> | null = null;
+  private _port = 0;
+
+  constructor(private readonly routes: Route[]) {}
+
+  start(): void {
+    const { routes } = this;
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        const pathAndQuery = url.pathname + url.search;
+
+        for (const route of routes) {
+          const matches =
+            typeof route.match === "string"
+              ? url.pathname.includes(route.match)
+              : route.match.test(pathAndQuery);
+
+          if (matches && (!route.method || route.method === req.method)) {
+            return Response.json(route.response, {
+              status: route.status ?? 200,
+              headers: { "Content-Type": "application/json", ...(route.headers ?? {}) },
+            });
+          }
+        }
+
+        console.warn(`[mock-server] UNMATCHED: ${req.method} ${url.pathname}`);
+        return new Response(`[mock-server] 404 Not Found: ${req.method} ${url.pathname}`, {
+          status: 404,
+        });
+      },
+    });
+    this._server = server;
+    this._port = server.port ?? 0;
+  }
+
+  stop(): void {
+    this._server?.stop();
+    this._server = null;
+    this._port = 0;
+  }
+
+  get port(): number {
+    if (!this._server) throw new Error("MockServer not started");
+    return this._port;
+  }
+}

--- a/apps/wallet-cli/src/test/helpers/wrapper.ts
+++ b/apps/wallet-cli/src/test/helpers/wrapper.ts
@@ -1,0 +1,6 @@
+// Dynamic import ensures polyfill and HTTP interception (static deps above) are
+// fully evaluated before Bun links the CLI's CJS dependency graph.
+import "../../polyfill";
+import "./http-intercept";
+
+await import("../../cli");

--- a/apps/wallet-cli/src/test/integration/balances.test.ts
+++ b/apps/wallet-cli/src/test/integration/balances.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { MockServer } from "../helpers/mock-server";
+import { runCli } from "../helpers/cli-runner";
+import { ETH_DESCRIPTOR, ETH_ADDRESS } from "../helpers/constants";
+
+// 1.5 ETH in wei
+const ETH_BALANCE_WEI = "1500000000000000000";
+
+describe("balances command", () => {
+  const server = new MockServer([
+    {
+      method: "GET",
+      match: /\/address\/[^/]+\/balance$/,
+      response: { address: ETH_ADDRESS, balance: ETH_BALANCE_WEI },
+    },
+    {
+      method: "GET",
+      match: /\/address\/[^/]+\/txs/,
+      response: { data: [], token: null },
+    },
+    {
+      method: "POST",
+      match: /erc20\/balances/,
+      response: [],
+    },
+  ]);
+
+  beforeAll(() => server.start());
+  afterAll(() => server.stop());
+
+  it("human output: prints ETH balance line", async () => {
+    const { stdout, exitCode, stderr } = await runCli(
+      ["balances", "--account", ETH_DESCRIPTOR],
+      { WALLET_CLI_MOCK_PORT: String(server.port) },
+    );
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+    expect(stdout).toMatch(/ETH/i);
+    expect(stdout).toMatch(/1\.5/);
+  });
+
+  it("json output: returns a valid balances envelope", async () => {
+    const { stdout, exitCode, stderr } = await runCli(
+      ["balances", "--account", ETH_DESCRIPTOR, "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port) },
+    );
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+
+    const data = JSON.parse(stdout);
+    expect(data.command).toBe("balances");
+    expect(data.network).toBe("ethereum:main");
+    expect(Array.isArray(data.balances)).toBe(true);
+    expect(data.balances.length).toBeGreaterThanOrEqual(1);
+
+    const native = data.balances.find((b: { asset: string }) => b.asset === "ethereum");
+    expect(native).toBeDefined();
+    expect(native.amount).toMatch(/1\.5/);
+  });
+
+  it("json output: invalid descriptor exits with code 1", async () => {
+    const { stdout, stderr, exitCode } = await runCli(
+      ["balances", "--account", "not-a-valid-descriptor", "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port) },
+    );
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe("");
+    const err = JSON.parse(stderr);
+    expect(err.ok).toBe(false);
+    expect(err.error.command).toBe("balances");
+    expect(err.error.message).toMatch(/invalid/i);
+  });
+});

--- a/apps/wallet-cli/src/test/integration/operations.test.ts
+++ b/apps/wallet-cli/src/test/integration/operations.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { MockServer } from "../helpers/mock-server";
+import { runCli } from "../helpers/cli-runner";
+import { ETH_DESCRIPTOR, ETH_ADDRESS } from "../helpers/constants";
+
+const CURRENT_BLOCK = {
+  hash: "0xblock1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  height: 20_000_000,
+  time: "2024-06-15T12:00:00.000Z",
+  txs: [],
+};
+
+const POINT_ONE_ETH_OUT_TX = {
+  hash: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  transaction_type: 2,
+  nonce: "0x5",
+  nonce_value: 5,
+  value: "100000000000000000", // 0.1 ETH
+  gas: "21000",
+  gas_price: "20000000000", // 20 Gwei
+  max_fee_per_gas: "30000000000",
+  max_priority_fee_per_gas: "1000000000",
+  from: ETH_ADDRESS,
+  to: "0xc79c7a29c40Ce8F5746af2c956F93F27e2820307",
+  transfer_events: [],
+  erc721_transfer_events: [],
+  erc1155_transfer_events: [],
+  approval_events: [],
+  actions: [],
+  confirmations: 500,
+  input: null,
+  gas_used: "21000",
+  cumulative_gas_used: "21000",
+  status: 1,
+  received_at: "2024-06-15T12:00:00.000Z",
+  block: {
+    hash: "0xblock1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    height: 20_000_000,
+    time: "2024-06-15T12:00:00.000Z",
+  },
+};
+
+// Common routes needed by the bridge sync (getAccountShape):
+//   lastBlock → /block/current
+//   getBalance → /balance + /txs (token detection)
+//   listOperations → /txs
+//   getSyncHash → /v1/currencies (CAL client, getTokensSyncHash via getSyncHash())
+function baseRoutes(txsFixture: object) {
+  return [
+    {
+      method: "GET",
+      match: /\/block\/current$/,
+      response: CURRENT_BLOCK,
+    },
+    {
+      method: "GET",
+      match: /\/address\/[^/]+\/balance$/,
+      response: { address: ETH_ADDRESS, balance: "0" },
+    },
+    {
+      method: "GET",
+      match: /\/address\/[^/]+\/txs/,
+      response: txsFixture,
+    },
+    {
+      method: "POST",
+      match: /erc20\/balances/,
+      response: [],
+    },
+    // getSyncHash (via getTokensSyncHash): must return non-empty array + X-Ledger-Commit header
+    // otherwise the store throws LedgerAPI4xx (empty array → status 404 → remapRtkQueryError)
+    {
+      method: "GET",
+      match: /\/v1\/currencies/,
+      response: [{ id: "ethereum" }],
+      headers: { "X-Ledger-Commit": "mock-sync-hash-0000000000000000" },
+    },
+  ];
+}
+
+describe("operations command — empty history", () => {
+  const server = new MockServer(baseRoutes({ data: [], token: null }));
+
+  beforeAll(() => server.start());
+  afterAll(() => server.stop());
+
+  it("json output: returns empty operations array", async () => {
+    const { stdout, exitCode, stderr } = await runCli(
+      ["operations", "--account", ETH_DESCRIPTOR, "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port) },
+    );
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+
+    const data = JSON.parse(stdout);
+    expect(data.command).toBe("operations");
+    expect(data.network).toBe("ethereum:main");
+    expect(Array.isArray(data.operations)).toBe(true);
+    expect(data.operations.length).toBe(0);
+  });
+});
+
+describe("operations command — one OUT transaction", () => {
+  const server = new MockServer(baseRoutes({ data: [POINT_ONE_ETH_OUT_TX], token: null }));
+
+  beforeAll(() => server.start());
+  afterAll(() => server.stop());
+
+  it("json output: returns one OUT operation", async () => {
+    const { stdout, exitCode, stderr } = await runCli(
+      ["operations", "--account", ETH_DESCRIPTOR, "--output", "json"],
+      { WALLET_CLI_MOCK_PORT: String(server.port) },
+    );
+    expect(exitCode, `stderr: ${stderr}`).toBe(0);
+
+    const data = JSON.parse(stdout);
+    expect(data.command).toBe("operations");
+    expect(Array.isArray(data.operations)).toBe(true);
+    expect(data.operations.length).toBeGreaterThanOrEqual(1);
+
+    const op = data.operations[0];
+    expect(op.type).toBe("OUT");
+    expect(op.hash).toBe(POINT_ONE_ETH_OUT_TX.hash);
+    expect(op.senders).toContain(ETH_ADDRESS);
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - New `tests/` directory under `apps/wallet-cli` — no production code changed, no new dependencies.
  - New scripts: `test:integration` (runs integration tests), `build:bundle` (CI bundle target).

### 📝 Description

Adds subprocess-based integration tests for `wallet-cli`. The goal is to test the CLI in real conditions while mocking only what we don't control (HTTP and hardware).

Each test spawns the CLI via `Bun.spawn()` and intercepts all outbound HTTP at two layers:

1. **`globalThis.fetch` patch** — covers fetch-based callers and axios (forced onto the fetch adapter, since Bun picks `node:http` by default).
2. **`node:http` / `node:https` patch** — fallback for any remaining non-fetch callers.

A `MockServer` class (`Bun.serve()` on a random port) routes requests to fixture responses. No new test framework or dependency is introduced — everything runs on Bun primitives already in the project.

**Phase 1 coverage** (HTTP-only, no device): balances, operations, fresh-address

**Phase 2** will extend the same approach to commands that require a hardware device, by introducing a mock layer for the device transport.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A