### PR TITLE
feat(wallet-cli): shared options and CommandOutput abstraction

### DIFF
--- a/.changeset/wallet-cli-shared-output.md
+++ b/.changeset/wallet-cli-shared-output.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": patch
+---
+
+Refactor: shared option definitions and unified CommandOutput abstraction across all commands

--- a/apps/wallet-cli/.bunli/commands.gen.ts
+++ b/apps/wallet-cli/.bunli/commands.gen.ts
@@ -44,7 +44,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
           name: 'fresh-address',
           description: 'Resolve the fresh receive address for an account descriptor (no device required)',
           options: {
-            'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor (V1 format), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+            'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor (from account discover), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
             'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
           },
           path: './src/commands/account/fresh-address'
@@ -56,7 +56,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       name: 'balances',
       description: 'Fetch native and token balances for an account descriptor (no device required)',
       options: {
-        'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Short account descriptor (output of account discover), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+        'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor (from account discover), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
       },
       path: './src/commands/balances'
@@ -74,7 +74,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       name: 'fresh-address',
       description: 'Resolve the fresh receive address for an account descriptor (no device required)',
       options: {
-        'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor (V1 format), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+        'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor (from account discover), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
       },
       path: './src/commands/account/fresh-address'
@@ -83,7 +83,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       name: 'operations',
       description: 'List operations for an account descriptor (no device required)',
       options: {
-        'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Short account descriptor (output of account discover), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+        'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor (from account discover), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'limit': { type: 'z.coerce.number.int.min.optional', required: false, hasDefault: false, description: 'Max number of operations to return (Alpaca families only)', short: 'l', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'cursor': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Pagination cursor from a previous call\'s nextCursor (Alpaca families only)', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
@@ -94,8 +94,8 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       name: 'receive',
       description: 'Get receive address for an account (optionally verify on device)',
       options: {
-        'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Short account descriptor (output of account discover), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-        'verify': { type: 'z.boolean.default', required: true, hasDefault: true, default: true, description: 'Verify address on device screen (default: true). Use --no-verify to skip device.', short: 'v', schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"BooleanLiteral","start":1015,"end":1019,"loc":{"start":{"line":21,"column":39,"index":1015},"end":{"line":21,"column":43,"index":1019}},"value":true}}]}, validator: '(val) => true' },
+        'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor (from account discover), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+        'verify': { type: 'z.boolean.default', required: true, hasDefault: true, default: true, description: 'Verify address on device screen (default: true). Use --no-verify to skip device.', short: 'v', schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"BooleanLiteral","start":795,"end":799,"loc":{"start":{"line":17,"column":39,"index":795},"end":{"line":17,"column":43,"index":799}},"value":true}}]}, validator: '(val) => true' },
         'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
       },
       path: './src/commands/receive'
@@ -104,16 +104,16 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       name: 'send',
       description: 'Sign and broadcast a transaction (bridge only, no Alpaca)',
       options: {
-        'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Short account descriptor (output of account discover), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-        'to': { type: 'z.string.min', required: true, hasDefault: false, description: 'Recipient address', short: 't', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":2004,"end":2005,"loc":{"start":{"line":63,"column":30,"index":2004},"end":{"line":63,"column":31,"index":2005}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Recipient address is required (--to <address>)"}]}, validator: '(val) => true' },
-        'amount': { type: 'z.string.min', required: true, hasDefault: false, description: 'Amount including ticker, e.g. \'0.001 BTC\', \'0.01 ETH\', \'0.4 USDT\'', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":2167,"end":2168,"loc":{"start":{"line":68,"column":21,"index":2167},"end":{"line":68,"column":22,"index":2168}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Amount is required (--amount '<value> <TICKER>', e.g. '0.01 ETH')"}]}, validator: '(val) => true' },
+        'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor (from account discover), or pass as first positional arg', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+        'to': { type: 'z.string.min', required: true, hasDefault: false, description: 'Recipient address', short: 't', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1760,"end":1761,"loc":{"start":{"line":59,"column":30,"index":1760},"end":{"line":59,"column":31,"index":1761}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Recipient address is required (--to <address>)"}]}, validator: '(val) => true' },
+        'amount': { type: 'z.string.min', required: true, hasDefault: false, description: 'Amount including ticker, e.g. \'0.001 BTC\', \'0.01 ETH\', \'0.4 USDT\'', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1923,"end":1924,"loc":{"start":{"line":64,"column":21,"index":1923},"end":{"line":64,"column":22,"index":1924}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Amount is required (--amount '<value> <TICKER>', e.g. '0.01 ETH')"}]}, validator: '(val) => true' },
         'fee-per-byte': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Fee per byte in satoshis (Bitcoin only)', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'rbf': { type: 'z.boolean.optional', required: false, hasDefault: false, description: 'Enable Replace-By-Fee (Bitcoin only)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'mode': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Transaction mode for Solana: send, stake.createAccount, stake.delegate, stake.undelegate, stake.withdraw', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'validator': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Validator address (Solana staking only)', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'stake-account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Stake account address (Solana staking only)', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'memo': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Memo/tag (Solana only)', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-        'dry-run': { type: 'z.boolean.default', required: true, hasDefault: true, default: false, description: 'Prepare and validate transaction but do not sign or broadcast', schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"BooleanLiteral","start":3186,"end":3191,"loc":{"start":{"line":92,"column":42,"index":3186},"end":{"line":92,"column":47,"index":3191}},"value":false}}]}, validator: '(val) => true' },
+        'dry-run': { type: 'z.boolean.default', required: true, hasDefault: true, default: false, description: 'Prepare and validate transaction but do not sign or broadcast', schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"BooleanLiteral","start":2942,"end":2947,"loc":{"start":{"line":88,"column":42,"index":2942},"end":{"line":88,"column":47,"index":2947}},"value":false}}]}, validator: '(val) => true' },
         'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
       },
       path: './src/commands/send'

--- a/apps/wallet-cli/src/commands/account/discover.ts
+++ b/apps/wallet-cli/src/commands/account/discover.ts
@@ -1,17 +1,13 @@
 import { defineCommand, option } from "@bunli/core";
 import { z } from "zod";
-import { firstValueFrom } from "rxjs";
-import { toArray } from "rxjs/operators";
-import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets";
 import { WalletAdapter } from "../../wallet";
-import { HumanFormatter, JsonFormatter } from "../../wallet/formatter";
-import { OutputFormatSchema } from "../../wallet/models";
 import { WALLET_CLI_DMK_DEVICE_ID } from "../../device/register-dmk-transport";
 import { withCurrencyDeviceSession } from "../../session/bridge-device-session";
 import { walletCliDebug } from "../../shared/log";
-import { spinner, colors, writeStdout } from "../../shared/ui";
-import { makeEnvelope, makeErrorEnvelope } from "../../shared/response";
+import { colors } from "../../shared/ui";
 import { parseNetworkArg, currencyIdFromNetwork } from "../../shared/accountDescriptor";
+import { createCommandOutput } from "../../output";
+import { outputOption } from "../shared-options";
 
 export default defineCommand({
   name: "discover",
@@ -22,9 +18,7 @@ export default defineCommand({
         'Network to scan, e.g. "bitcoin", "ethereum", "ethereum:goerli" (or first positional arg). No env = mainnet.',
       short: "n",
     }),
-    output: option(OutputFormatSchema.default("human"), {
-      description: "Output format: human (default) or json",
-    }),
+    output: outputOption,
   },
   handler: async ({ flags, positional }) => {
     const networkArg = flags.network ?? positional[0];
@@ -36,73 +30,40 @@ export default defineCommand({
 
     const network = parseNetworkArg(networkArg);
     const currencyId = currencyIdFromNetwork(network);
-    const isHuman = flags.output === "human";
-    walletCliDebug(
-      `account discover: network=${network.name}:${network.env}, output=${flags.output}`,
-    );
+    const networkStr = `${network.name}:${network.env}`;
+    walletCliDebug(`account discover: network=${networkStr}, output=${flags.output}`);
 
-    const spin = isHuman
-      ? spinner(`Connect device and open ${colors.bold(network.name)} app…`)
-      : null;
+    const out = createCommandOutput(flags.output, { command: "account discover", network: networkStr });
 
-    try {
+    await out.run(async () => {
+      const spin = out.spin(`Connect device and open ${colors.bold(network.name)} app…`);
       await withCurrencyDeviceSession(currencyId, async () => {
         spin?.success("Device session established");
 
         const wallet = new WalletAdapter();
+        const scanSpin = out.spin(`Scanning for ${colors.bold(network.name)} accounts…`);
+        let count = 0;
 
-        if (isHuman) {
-          const store = getCryptoAssetsStore();
-          const fmt = new HumanFormatter(store);
-          const scanSpin = spinner(`Scanning for ${colors.bold(network.name)} accounts…`);
-          let count = 0;
-          await new Promise<void>((resolve, reject) => {
-            wallet.discoverAccounts(network, WALLET_CLI_DMK_DEVICE_ID).subscribe({
-              next: d => {
-                scanSpin.clear();
-                writeStdout(fmt.formatDiscoveredAccount(d));
-                count++;
-                scanSpin.text = `Scanning… (${count} found so far)`;
-              },
-              error: err => {
-                scanSpin.error("Scan failed");
-                reject(err);
-              },
-              complete: () => {
-                scanSpin.success(`Found ${count} account${count === 1 ? "" : "s"}`);
-                resolve();
-              },
-            });
+        await new Promise<void>((resolve, reject) => {
+          wallet.discoverAccounts(network, WALLET_CLI_DMK_DEVICE_ID).subscribe({
+            next: d => {
+              out.discoveredAccount(d);
+              count++;
+              if (scanSpin) scanSpin.text = `Scanning… (${count} found so far)`;
+            },
+            error: err => {
+              scanSpin?.error("Scan failed");
+              reject(err);
+            },
+            complete: () => {
+              scanSpin?.success(`Found ${count} account${count === 1 ? "" : "s"}`);
+              resolve();
+            },
           });
-        } else {
-          const accounts = await firstValueFrom(
-            wallet.discoverAccounts(network, WALLET_CLI_DMK_DEVICE_ID).pipe(toArray()),
-          );
-          writeStdout(
-            JSON.stringify(
-              makeEnvelope("account discover", `${network.name}:${network.env}`, {
-                accounts: JsonFormatter.discoveredAccounts(accounts),
-              }),
-              null,
-              2,
-            ),
-          );
-        }
+        });
+
+        out.flushDiscovery();
       });
-    } catch (e) {
-      if (isHuman) throw e;
-      writeStdout(
-        JSON.stringify(
-          makeErrorEnvelope(
-            "account discover",
-            HumanFormatter.formatError(e),
-            `${network.name}:${network.env}`,
-          ),
-          null,
-          2,
-        ),
-      );
-      process.exit(1);
-    }
+    });
   },
 });

--- a/apps/wallet-cli/src/commands/account/fresh-address.ts
+++ b/apps/wallet-cli/src/commands/account/fresh-address.ts
@@ -1,44 +1,36 @@
-import { defineCommand, option } from "@bunli/core";
-import { z } from "zod";
+import { defineCommand } from "@bunli/core";
 import { WalletAdapter } from "../../wallet";
 import { parseV1, toV0, serializeNetwork } from "../../shared/accountDescriptor";
-import { resolveAccountArg, OutputFormatSchema } from "../../wallet/models";
-import { makeEnvelope } from "../../shared/response";
-import { withSpinner, writeStdout } from "../../shared/ui";
+import { resolveAccountArg } from "../../wallet/models";
+import { createCommandOutput } from "../../output";
+import { accountOption, outputOption } from "../shared-options";
 
 export default defineCommand({
   name: "fresh-address",
   description: "Resolve the fresh receive address for an account descriptor (no device required)",
   options: {
-    account: option(z.string().min(1).optional(), {
-      description: "Account descriptor (V1 format), or pass as first positional arg",
-      short: "a",
-    }),
-    output: option(OutputFormatSchema.default("human"), {
-      description: "Output format: human (default) or json",
-    }),
+    account: accountOption,
+    output: outputOption,
   },
   handler: async ({ flags, positional }) => {
     const input = resolveAccountArg(flags.account, positional);
     const v1 = parseV1(input);
-    const isHuman = flags.output === "human";
-    const wallet = new WalletAdapter();
-    // address-based (EVM, Solana…): no sync needed, address is in the descriptor
-    // utxo (Bitcoin…): next unused address requires a blockchain scan
-    const address =
-      v1.type === "address"
-        ? v1.address
-        : await withSpinner(
-            `Scanning ${v1.network.name} blockchain for fresh address…`,
-            "Fresh address resolved",
-            () => wallet.getFreshAddress(toV0(v1)),
-            isHuman,
-          );
     const network = serializeNetwork(v1.network);
-    writeStdout(
-      isHuman
-        ? address
-        : JSON.stringify(makeEnvelope("account fresh-address", network, { address }, input), null, 2),
-    );
+    const wallet = new WalletAdapter();
+    const out = createCommandOutput(flags.output, { command: "account fresh-address", network, account: input });
+
+    await out.run(async () => {
+      // address-based (EVM, Solana…): no sync needed, address is in the descriptor
+      // utxo (Bitcoin…): next unused address requires a blockchain scan
+      const address =
+        v1.type === "address"
+          ? v1.address
+          : await out.withActivity(
+              `Scanning ${v1.network.name} blockchain for fresh address…`,
+              "Fresh address resolved",
+              () => wallet.getFreshAddress(toV0(v1)),
+            );
+      out.address(address);
+    });
   },
 });

--- a/apps/wallet-cli/src/commands/balances.ts
+++ b/apps/wallet-cli/src/commands/balances.ts
@@ -1,70 +1,32 @@
-import { defineCommand, option } from "@bunli/core";
-import { z } from "zod";
-import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets";
+import { defineCommand } from "@bunli/core";
 import { WalletAdapter } from "../wallet";
-import { HumanFormatter, JsonFormatter } from "../wallet/formatter";
-import { parseAccountDescriptor, resolveAccountArg, OutputFormatSchema } from "../wallet/models";
+import { parseAccountDescriptor, resolveAccountArg } from "../wallet/models";
 import { networkStringFromCurrencyId } from "../shared/accountDescriptor";
 import { walletCliDebug } from "../shared/log";
-import { withSpinner, writeStdout } from "../shared/ui";
-import { makeEnvelope, makeErrorEnvelope } from "../shared/response";
+import { createCommandOutput } from "../output";
+import { accountOption, outputOption } from "./shared-options";
 
 export default defineCommand({
   name: "balances",
   description: "Fetch native and token balances for an account descriptor (no device required)",
   options: {
-    account: option(z.string().min(1).optional(), {
-      description:
-        "Short account descriptor (output of account discover), or pass as first positional arg",
-      short: "a",
-    }),
-    output: option(OutputFormatSchema.default("human"), {
-      description: "Output format: human (default) or json",
-    }),
+    account: accountOption,
+    output: outputOption,
   },
   handler: async ({ flags, positional }) => {
     const descriptor = parseAccountDescriptor(resolveAccountArg(flags.account, positional));
     const network = networkStringFromCurrencyId(descriptor.currencyId);
     walletCliDebug(`balances: account=${descriptor.id}, output=${flags.output}`);
     const wallet = new WalletAdapter();
-    const isHuman = flags.output === "human";
+    const out = createCommandOutput(flags.output, { command: "balances", network, account: descriptor.id });
 
-    try {
-      const balances = await withSpinner(
+    await out.run(async () => {
+      const balances = await out.withActivity(
         `Fetching balances for ${network}…`,
         "Balances fetched",
         () => wallet.getAccountBalances(descriptor),
-        isHuman,
       );
-
-      const store = getCryptoAssetsStore();
-      const fmt = new HumanFormatter(store);
-      if (isHuman) {
-        for (const b of balances) {
-          const line = await fmt.formatBalance(b);
-          writeStdout(line);
-        }
-      } else {
-        const jsonFmt = new JsonFormatter(fmt);
-        const jsonBalances = await jsonFmt.balances(balances);
-        writeStdout(
-          JSON.stringify(
-            makeEnvelope("balances", network, { balances: jsonBalances }, descriptor.id),
-            null,
-            2,
-          ),
-        );
-      }
-    } catch (e) {
-      if (isHuman) throw e;
-      writeStdout(
-        JSON.stringify(
-          makeErrorEnvelope("balances", HumanFormatter.formatError(e), network),
-          null,
-          2,
-        ),
-      );
-      process.exit(1);
-    }
+      await out.balances(balances);
+    });
   },
 });

--- a/apps/wallet-cli/src/commands/operations.ts
+++ b/apps/wallet-cli/src/commands/operations.ts
@@ -1,23 +1,17 @@
 import { defineCommand, option } from "@bunli/core";
 import { z } from "zod";
-import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets";
 import { WalletAdapter } from "../wallet";
-import { HumanFormatter, JsonFormatter } from "../wallet/formatter";
-import { parseAccountDescriptor, resolveAccountArg, OutputFormatSchema } from "../wallet/models";
+import { parseAccountDescriptor, resolveAccountArg } from "../wallet/models";
 import { toV1, serializeV1, networkStringFromCurrencyId } from "../shared/accountDescriptor";
 import { walletCliDebug } from "../shared/log";
-import { withSpinner, colors, writeStdout } from "../shared/ui";
-import { makeEnvelope, makeErrorEnvelope } from "../shared/response";
+import { createCommandOutput } from "../output";
+import { accountOption, outputOption } from "./shared-options";
 
 export default defineCommand({
   name: "operations",
   description: "List operations for an account descriptor (no device required)",
   options: {
-    account: option(z.string().min(1).optional(), {
-      description:
-        "Short account descriptor (output of account discover), or pass as first positional arg",
-      short: "a",
-    }),
+    account: accountOption,
     limit: option(z.coerce.number().int().min(1).optional(), {
       description: "Max number of operations to return (Alpaca families only)",
       short: "l",
@@ -25,70 +19,26 @@ export default defineCommand({
     cursor: option(z.string().min(1).optional(), {
       description: "Pagination cursor from a previous call's nextCursor (Alpaca families only)",
     }),
-    output: option(OutputFormatSchema.default("human"), {
-      description: "Output format: human (default) or json",
-    }),
+    output: outputOption,
   },
   handler: async ({ flags, positional }) => {
     const descriptor = parseAccountDescriptor(resolveAccountArg(flags.account, positional));
     const network = networkStringFromCurrencyId(descriptor.currencyId);
+    // accountId remapped to V1 descriptor — internal live-common id is intentionally dropped
     const descriptorV1Str = serializeV1(toV1(descriptor));
     walletCliDebug(
       `operations: account=${descriptor.id}, limit=${flags.limit ?? "default"}, output=${flags.output}`,
     );
     const wallet = new WalletAdapter();
-    const isHuman = flags.output === "human";
+    const out = createCommandOutput(flags.output, { command: "operations", network, account: descriptorV1Str });
 
-    try {
-      const page = await withSpinner(
+    await out.run(async () => {
+      const page = await out.withActivity(
         `Fetching operations for ${network}…`,
         "Operations fetched",
         () => wallet.getAccountOperations(descriptor, { limit: flags.limit, cursor: flags.cursor }),
-        isHuman,
       );
-
-      const store = getCryptoAssetsStore();
-      const fmt = new HumanFormatter(store);
-      if (isHuman) {
-        for (const op of page.operations) {
-          const line = await fmt.formatOperation(op, descriptor.currencyId);
-          writeStdout(op.parentId ? `  ${line}` : line);
-        }
-        if (page.nextCursor) {
-          const cursorLabel = colors.dim(`nextCursor: ${page.nextCursor}`);
-          process.stderr.write(`\n${cursorLabel}\n`);
-        }
-      } else {
-        // accountId remapped to V1 descriptor — internal live-common id is intentionally dropped
-        const jsonFmt = new JsonFormatter(fmt);
-        const jsonOperations = await jsonFmt.operations(
-          page.operations,
-          descriptor.currencyId,
-          descriptorV1Str,
-        );
-        writeStdout(
-          JSON.stringify(
-            makeEnvelope(
-              "operations",
-              network,
-              { operations: jsonOperations, nextCursor: page.nextCursor },
-              descriptorV1Str,
-            ),
-            null,
-            2,
-          ),
-        );
-      }
-    } catch (e) {
-      if (isHuman) throw e;
-      writeStdout(
-        JSON.stringify(
-          makeErrorEnvelope("operations", HumanFormatter.formatError(e), network),
-          null,
-          2,
-        ),
-      );
-      process.exit(1);
-    }
+      await out.operations(page.operations, descriptor.currencyId, page.nextCursor);
+    });
   },
 });

--- a/apps/wallet-cli/src/commands/receive.ts
+++ b/apps/wallet-cli/src/commands/receive.ts
@@ -1,74 +1,45 @@
 import { defineCommand, option } from "@bunli/core";
 import { z } from "zod";
 import { WalletAdapter } from "../wallet";
-import { HumanFormatter } from "../wallet/formatter";
-import { parseAccountDescriptor, resolveAccountArg, OutputFormatSchema } from "../wallet/models";
+import { parseAccountDescriptor, resolveAccountArg } from "../wallet/models";
 import { networkStringFromCurrencyId } from "../shared/accountDescriptor";
 import { WALLET_CLI_DMK_DEVICE_ID } from "../device/register-dmk-transport";
 import { withCurrencyDeviceSession } from "../session/bridge-device-session";
-import { spinner, colors, writeStdout } from "../shared/ui";
-import { makeEnvelope, makeErrorEnvelope } from "../shared/response";
+import { colors } from "../shared/ui";
+import { createCommandOutput } from "../output";
+import { accountOption, outputOption } from "./shared-options";
 
 export default defineCommand({
   name: "receive",
   description: "Get receive address for an account (optionally verify on device)",
   options: {
-    account: option(z.string().min(1).optional(), {
-      description:
-        "Short account descriptor (output of account discover), or pass as first positional arg",
-      short: "a",
-    }),
+    account: accountOption,
     verify: option(z.boolean().default(true), {
       description:
         "Verify address on device screen (default: true). Use --no-verify to skip device.",
       short: "v",
     }),
-    output: option(OutputFormatSchema.default("human"), {
-      description: "Output format: human (default) or json",
-    }),
+    output: outputOption,
   },
   handler: async ({ flags, positional }) => {
     const descriptor = parseAccountDescriptor(resolveAccountArg(flags.account, positional));
     const network = networkStringFromCurrencyId(descriptor.currencyId);
     const wallet = new WalletAdapter();
-    const isHuman = flags.output === "human";
+    const out = createCommandOutput(flags.output, { command: "receive", network, account: descriptor.id });
 
-    const outputAddress = (address: string) =>
-      writeStdout(
-        isHuman
-          ? address
-          : JSON.stringify(
-              makeEnvelope("receive", network, { address }, descriptor.id),
-              null,
-              2,
-            ),
-      );
-
-    try {
+    await out.run(async () => {
       if (flags.verify) {
-        const spin = isHuman
-          ? spinner(`Connect device and open ${colors.bold(descriptor.currencyId)} app…`)
-          : null;
-
-        let address = "";
+        const spin = out.spin(`Connect device and open ${colors.bold(descriptor.currencyId)} app…`);
         await withCurrencyDeviceSession(descriptor.currencyId, async () => {
           spin?.success("Device session established");
-          const verifySpin = isHuman ? spinner("Confirm address on your Ledger device…") : null;
-          address = await wallet.verifyAddress(descriptor, WALLET_CLI_DMK_DEVICE_ID);
+          const verifySpin = out.spin("Confirm address on your Ledger device…");
+          const address = await wallet.verifyAddress(descriptor, WALLET_CLI_DMK_DEVICE_ID);
           verifySpin?.success("Address confirmed on device");
+          out.address(address);
         });
-
-        outputAddress(address);
       } else {
-        const address = await wallet.getFreshAddress(descriptor);
-        outputAddress(address);
+        out.address(await wallet.getFreshAddress(descriptor));
       }
-    } catch (e) {
-      if (isHuman) throw e;
-      writeStdout(
-        JSON.stringify(makeErrorEnvelope("receive", HumanFormatter.formatError(e), network), null, 2),
-      );
-      process.exit(1);
-    }
+    });
   },
 });

--- a/apps/wallet-cli/src/commands/send.ts
+++ b/apps/wallet-cli/src/commands/send.ts
@@ -2,14 +2,14 @@ import { defineCommand, option } from "@bunli/core";
 import { z } from "zod";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { WalletAdapter } from "../wallet";
-import { HumanFormatter } from "../wallet/formatter";
-import { parseAccountDescriptor, resolveAccountArg, OutputFormatSchema } from "../wallet/models";
-import { TransactionIntentSchema, type TransactionIntent } from "../wallet/intents";
+import { parseAccountDescriptor, resolveAccountArg } from "../wallet/models";
+import { TransactionIntentSchema } from "../wallet/intents";
 import { WALLET_CLI_DMK_DEVICE_ID } from "../device/register-dmk-transport";
 import { withCurrencyDeviceSession } from "../session/bridge-device-session";
 import { networkStringFromCurrencyId } from "../shared/accountDescriptor";
-import { spinner, colors, writeStdout } from "../shared/ui";
-import { makeEnvelope, makeErrorEnvelope } from "../shared/response";
+import { colors } from "../shared/ui";
+import { createCommandOutput } from "../output";
+import { accountOption, outputOption } from "./shared-options";
 
 type SendFlags = {
   account?: string;
@@ -55,11 +55,7 @@ export default defineCommand({
   name: "send",
   description: "Sign and broadcast a transaction (bridge only, no Alpaca)",
   options: {
-    account: option(z.string().min(1).optional(), {
-      description:
-        "Short account descriptor (output of account discover), or pass as first positional arg",
-      short: "a",
-    }),
+    account: accountOption,
     to: option(z.string().min(1, "Recipient address is required (--to <address>)"), {
       description: "Recipient address",
       short: "t",
@@ -92,16 +88,14 @@ export default defineCommand({
     "dry-run": option(z.boolean().default(false), {
       description: "Prepare and validate transaction but do not sign or broadcast",
     }),
-    output: option(OutputFormatSchema.default("human"), {
-      description: "Output format: human (default) or json",
-    }),
+    output: outputOption,
   },
   handler: async ({ flags, positional }) => {
     const descriptor = parseAccountDescriptor(resolveAccountArg(flags.account, positional));
     const network = networkStringFromCurrencyId(descriptor.currencyId);
     const wallet = new WalletAdapter();
-    const isHuman = flags.output === "human";
     const dryRun = flags["dry-run"];
+    const out = createCommandOutput(flags.output, { command: "send", network, account: descriptor.id });
 
     // Build the TransactionIntent based on the currency family
     const { family } = getCryptoCurrencyById(descriptor.currencyId);
@@ -113,139 +107,34 @@ export default defineCommand({
     }
     const intentData = builder(flags as SendFlags);
 
-    let intent: TransactionIntent;
-    try {
-      intent = TransactionIntentSchema.parse(intentData);
-    } catch (e) {
-      if (!isHuman) {
-        writeStdout(
-          JSON.stringify(
-            makeErrorEnvelope("send", HumanFormatter.formatError(e), network),
-            null,
-            2,
-          ),
-        );
-        process.exit(1);
-      }
-      throw e;
-    }
+    await out.run(async () => {
+      // Intent schema parse may throw (ZodError) — out.run catches it in json mode
+      const intent = TransactionIntentSchema.parse(intentData);
 
-    try {
-      // Phase 4a: dry-run should NOT open the device
       if (dryRun) {
-        const dryRunSpin = isHuman ? spinner("Preparing transaction (dry run)…") : null;
+        const spin = out.spin("Preparing transaction (dry run)…");
         const prepared = await wallet.prepareSend(descriptor, intent);
-        if (isHuman) {
-          dryRunSpin!.clear();
-          writeStdout(`  To:     ${prepared.recipient}`);
-          writeStdout(`  Amount: ${colors.bold(colors.green(prepared.amount))}`);
-          writeStdout(`  Fees:   ${colors.dim(prepared.fees)}`);
-          dryRunSpin!.success("Dry run complete (transaction not broadcasted)");
-        } else {
-          writeStdout(
-            JSON.stringify(
-              makeEnvelope(
-                "send",
-                network,
-                {
-                  dry_run: true,
-                  recipient: prepared.recipient,
-                  amount: prepared.amount,
-                  fee: prepared.fees,
-                },
-                descriptor.id,
-              ),
-              null,
-              2,
-            ),
-          );
-        }
+        spin?.clear();
+        out.sendDryRun(prepared);
+        spin?.success("Dry run complete (transaction not broadcasted)");
         return;
       }
 
-      const spin = isHuman
-        ? spinner(`Connect device and open ${colors.bold(descriptor.currencyId)} app…`)
-        : null;
-
+      const spin = out.spin(`Connect device and open ${colors.bold(descriptor.currencyId)} app…`);
       await withCurrencyDeviceSession(descriptor.currencyId, async () => {
         spin?.success("Device session established");
-
-        const sendSpin = isHuman
-          ? spinner(`Preparing ${colors.bold(descriptor.currencyId)} transaction…`)
-          : null;
-        const result: Record<string, unknown> = {};
+        out.spin(`Preparing ${colors.bold(descriptor.currencyId)} transaction…`);
 
         await new Promise<void>((resolve, reject) => {
           wallet.send(descriptor, intent, WALLET_CLI_DMK_DEVICE_ID, dryRun).subscribe({
-            next: event => {
-              if (!isHuman) {
-                if (event.type === "prepared") {
-                  result.recipient = event.recipient;
-                  result.amount = event.amount;
-                  result.fee = event.fees;
-                } else if (event.type === "broadcasted") {
-                  result.tx_hash = event.txHash;
-                } else if (event.type === "dry-run") {
-                  result.dry_run = true;
-                }
-                return;
-              }
-              switch (event.type) {
-                case "prepared":
-                  sendSpin!.clear();
-                  writeStdout(`  To:     ${event.recipient}`);
-                  writeStdout(`  Amount: ${colors.bold(colors.green(event.amount))}`);
-                  writeStdout(`  Fees:   ${colors.dim(event.fees)}`);
-                  sendSpin!.text = "Confirm transaction on device…";
-                  break;
-                case "device-streaming":
-                  sendSpin!.text = `Streaming to device… ${Math.round(event.progress * 100)}%`;
-                  break;
-                case "device-signature-requested":
-                  sendSpin!.text = "Please confirm on device…";
-                  break;
-                case "device-signature-granted":
-                  sendSpin!.text = "Signed, broadcasting…";
-                  break;
-                case "dry-run":
-                  sendSpin!.success("Dry run complete (transaction not broadcasted)");
-                  break;
-                case "broadcasted":
-                  sendSpin!.success(`Broadcasted  ${colors.dim(event.txHash)}`);
-                  break;
-              }
-            },
-            error: (e: unknown) => {
-              const msg = HumanFormatter.formatError(e);
-              sendSpin?.error(msg);
-              reject(new Error(msg));
-            },
+            next: event => out.sendEvent(event),
+            error: (e: unknown) => reject(e),
             complete: resolve,
           });
         });
 
-        if (!isHuman) {
-          writeStdout(
-            JSON.stringify(
-              makeEnvelope("send", network, result, descriptor.id),
-              null,
-              2,
-            ),
-          );
-        }
+        out.sendComplete();
       });
-    } catch (e) {
-      if (!isHuman) {
-        writeStdout(
-          JSON.stringify(
-            makeErrorEnvelope("send", HumanFormatter.formatError(e), network),
-            null,
-            2,
-          ),
-        );
-        process.exit(1);
-      }
-      throw e;
-    }
+    });
   },
 });

--- a/apps/wallet-cli/src/commands/shared-options.ts
+++ b/apps/wallet-cli/src/commands/shared-options.ts
@@ -1,0 +1,19 @@
+import { option } from "@bunli/core";
+import { z } from "zod";
+import { OutputFormatSchema } from "../wallet/models";
+
+/**
+ * Shared --account / -a option used by all commands that operate on an account descriptor.
+ * Accepts both V1 format ("account:1:...") and legacy V0 short form ("js:2:bitcoin:...").
+ */
+export const accountOption = option(z.string().min(1).optional(), {
+  description: "Account descriptor (from account discover), or pass as first positional arg",
+  short: "a",
+});
+
+/**
+ * Shared --output option used by all commands. Defaults to human-readable output.
+ */
+export const outputOption = option(OutputFormatSchema.default("human"), {
+  description: "Output format: human (default) or json",
+});

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -100,7 +100,13 @@ class HumanCommandOutput implements CommandOutput {
   }
 
   async run(fn: () => Promise<void>): Promise<void> {
-    await fn();
+    try {
+      await fn();
+    } catch (err) {
+      this._activeSpin?.error(HumanFormatter.formatError(err));
+      this._activeSpin = null;
+      throw err;
+    }
   }
 
   fail(e: unknown): never {
@@ -128,6 +134,7 @@ class HumanCommandOutput implements CommandOutput {
   }
 
   discoveredAccount(d: DiscoveredAccount): void {
+    this._activeSpin?.clear();
     writeStdout(this._fmt.formatDiscoveredAccount(d));
   }
 

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -1,0 +1,281 @@
+/**
+ * CommandOutput — unified output abstraction for all wallet-cli commands.
+ *
+ * Instead of scattering `if (isHuman)` branches across every command handler, each handler
+ * creates one CommandOutput instance and calls semantic methods. The implementation (Human or
+ * Json) handles formatting, spinning, envelope building, and error exit transparently.
+ *
+ * Factory: createCommandOutput(format, ctx)
+ */
+
+import type { Spinner } from "yocto-spinner";
+import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets";
+import { HumanFormatter } from "./wallet/formatter/human";
+import { JsonFormatter } from "./wallet/formatter/json";
+import { makeEnvelope, makeErrorEnvelope } from "./shared/response";
+import { spinner, colors, writeStdout } from "./shared/ui";
+import type { Balance, Operation, DiscoveredAccount, SendEvent } from "./wallet/models";
+
+// ---------------------------------------------------------------------------
+// Context & interface
+// ---------------------------------------------------------------------------
+
+export type OutputContext = {
+  /** Command name as it appears in the JSON envelope, e.g. "balances", "account discover". */
+  command: string;
+  /** Network string, e.g. "bitcoin", "ethereum:goerli". */
+  network: string;
+  /** Account identifier included in JSON envelopes (optional — not all commands have one). */
+  account?: string;
+};
+
+export interface CommandOutput {
+  /** Wrap an async operation with an activity indicator (spinner in human mode, silent in json). */
+  withActivity<T>(loadingText: string, doneText: string, fn: () => Promise<T>): Promise<T>;
+
+  /**
+   * Create a spinner (human mode) or return null (json mode).
+   * The created spinner is stored as the active spinner and used by sendEvent.
+   */
+  spin(text: string): Spinner | null;
+
+  /**
+   * Error-handling boundary for the command handler body.
+   * Human: re-throws errors (Bunli handles display).
+   * Json: catches errors, writes a JSON error envelope, and exits with code 1.
+   */
+  run(fn: () => Promise<void>): Promise<void>;
+
+  /**
+   * Immediately handle an error.
+   * Human: throws it. Json: writes error envelope + exits.
+   */
+  fail(e: unknown): never;
+
+  // ---- Data output methods ----
+
+  balances(items: Balance[]): Promise<void>;
+  operations(items: Operation[], currencyId: string, nextCursor?: string): Promise<void>;
+  /** Output a receive / fresh address. */
+  address(addr: string): void;
+
+  /** Stream one discovered account (human: print immediately; json: buffer). */
+  discoveredAccount(d: DiscoveredAccount): void;
+  /** Signal end of discovery stream. Json: flush buffered accounts as envelope. Human: noop. */
+  flushDiscovery(): void;
+
+  /** Output a dry-run prepared transaction (human: formatted lines; json: envelope). */
+  sendDryRun(p: { recipient: string; amount: string; fees: string }): void;
+  /** Handle one send observable event (human: update active spinner; json: accumulate data). */
+  sendEvent(event: SendEvent): void;
+  /** Signal send stream complete. Json: write result envelope (account from ctx). Human: noop. */
+  sendComplete(): void;
+}
+
+// ---------------------------------------------------------------------------
+// HumanCommandOutput
+// ---------------------------------------------------------------------------
+
+class HumanCommandOutput implements CommandOutput {
+  private _activeSpin: Spinner | null = null;
+
+  constructor(private readonly _fmt: HumanFormatter) {}
+
+  spin(text: string): Spinner | null {
+    const s = spinner(text);
+    this._activeSpin = s;
+    return s;
+  }
+
+  async withActivity<T>(loadingText: string, doneText: string, fn: () => Promise<T>): Promise<T> {
+    const s = this.spin(loadingText);
+    try {
+      const result = await fn();
+      s?.success(doneText);
+      return result;
+    } catch (err) {
+      s?.error("Failed");
+      throw err;
+    }
+  }
+
+  async run(fn: () => Promise<void>): Promise<void> {
+    await fn();
+  }
+
+  fail(e: unknown): never {
+    throw e;
+  }
+
+  async balances(items: Balance[]): Promise<void> {
+    for (const b of items) {
+      writeStdout(await this._fmt.formatBalance(b));
+    }
+  }
+
+  async operations(items: Operation[], currencyId: string, nextCursor?: string): Promise<void> {
+    for (const op of items) {
+      const line = await this._fmt.formatOperation(op, currencyId);
+      writeStdout(op.parentId ? `  ${line}` : line);
+    }
+    if (nextCursor) {
+      process.stderr.write(`\n${colors.dim(`nextCursor: ${nextCursor}`)}\n`);
+    }
+  }
+
+  address(addr: string): void {
+    writeStdout(addr);
+  }
+
+  discoveredAccount(d: DiscoveredAccount): void {
+    writeStdout(this._fmt.formatDiscoveredAccount(d));
+  }
+
+  flushDiscovery(): void {}
+
+  private _printTransactionLines(p: { recipient: string; amount: string; fees: string }): void {
+    writeStdout(`  To:     ${p.recipient}`);
+    writeStdout(`  Amount: ${colors.bold(colors.green(p.amount))}`);
+    writeStdout(`  Fees:   ${colors.dim(p.fees)}`);
+  }
+
+  sendDryRun(p: { recipient: string; amount: string; fees: string }): void {
+    this._printTransactionLines(p);
+  }
+
+  sendEvent(event: SendEvent): void {
+    const s = this._activeSpin;
+    switch (event.type) {
+      case "prepared":
+        s?.clear();
+        this._printTransactionLines(event);
+        if (s) s.text = "Confirm transaction on device…";
+        break;
+      case "device-streaming":
+        if (s) s.text = `Streaming to device… ${Math.round(event.progress * 100)}%`;
+        break;
+      case "device-signature-requested":
+        if (s) s.text = "Please confirm on device…";
+        break;
+      case "device-signature-granted":
+        if (s) s.text = "Signed, broadcasting…";
+        break;
+      case "dry-run":
+        s?.success("Dry run complete (transaction not broadcasted)");
+        break;
+      case "broadcasted":
+        s?.success(`Broadcasted  ${colors.dim(event.txHash)}`);
+        break;
+    }
+  }
+
+  sendComplete(): void {}
+}
+
+// ---------------------------------------------------------------------------
+// JsonCommandOutput
+// ---------------------------------------------------------------------------
+
+class JsonCommandOutput implements CommandOutput {
+  private readonly _jsonFmt: JsonFormatter;
+  private _discoveredAccounts: DiscoveredAccount[] = [];
+  private _sendResult: Record<string, unknown> = {};
+
+  constructor(
+    private readonly _ctx: OutputContext,
+    fmt: HumanFormatter,
+  ) {
+    this._jsonFmt = new JsonFormatter(fmt);
+  }
+
+  private _envelope(data: Record<string, unknown>): string {
+    return JSON.stringify(makeEnvelope(this._ctx.command, this._ctx.network, data, this._ctx.account), null, 2);
+  }
+
+  private _errorEnvelope(e: unknown): string {
+    return JSON.stringify(
+      makeErrorEnvelope(this._ctx.command, HumanFormatter.formatError(e), this._ctx.network),
+      null,
+      2,
+    );
+  }
+
+  spin(_text: string): null {
+    return null;
+  }
+
+  async withActivity<T>(_loadingText: string, _doneText: string, fn: () => Promise<T>): Promise<T> {
+    return fn();
+  }
+
+  async run(fn: () => Promise<void>): Promise<void> {
+    try {
+      await fn();
+    } catch (e) {
+      writeStdout(this._errorEnvelope(e));
+      process.exit(1);
+    }
+  }
+
+  fail(e: unknown): never {
+    writeStdout(this._errorEnvelope(e));
+    process.exit(1);
+  }
+
+  async balances(items: Balance[]): Promise<void> {
+    const balances = await this._jsonFmt.balances(items);
+    writeStdout(this._envelope({ balances }));
+  }
+
+  async operations(items: Operation[], currencyId: string, nextCursor?: string): Promise<void> {
+    const operations = await this._jsonFmt.operations(items, currencyId, this._ctx.account ?? "");
+    writeStdout(this._envelope({ operations, nextCursor }));
+  }
+
+  address(addr: string): void {
+    writeStdout(this._envelope({ address: addr }));
+  }
+
+  discoveredAccount(d: DiscoveredAccount): void {
+    this._discoveredAccounts.push(d);
+  }
+
+  flushDiscovery(): void {
+    const accounts = JsonFormatter.discoveredAccounts(this._discoveredAccounts);
+    writeStdout(this._envelope({ accounts }));
+  }
+
+  sendDryRun(p: { recipient: string; amount: string; fees: string }): void {
+    writeStdout(this._envelope({ dry_run: true, recipient: p.recipient, amount: p.amount, fee: p.fees }));
+  }
+
+  sendEvent(event: SendEvent): void {
+    if (event.type === "prepared") {
+      this._sendResult.recipient = event.recipient;
+      this._sendResult.amount = event.amount;
+      this._sendResult.fee = event.fees;
+    } else if (event.type === "broadcasted") {
+      this._sendResult.tx_hash = event.txHash;
+    } else if (event.type === "dry-run") {
+      this._sendResult.dry_run = true;
+    }
+  }
+
+  sendComplete(): void {
+    writeStdout(this._envelope(this._sendResult));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createCommandOutput(
+  format: "human" | "json",
+  ctx: OutputContext,
+): CommandOutput {
+  const humanFmt = new HumanFormatter(getCryptoAssetsStore());
+  if (format === "json") return new JsonCommandOutput(ctx, humanFmt);
+  return new HumanCommandOutput(humanFmt);
+}
+


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- refactor only, no behaviour change; existing typecheck passes -->
- [ ] **Impact of the changes:**
  - `wallet-cli` only — no other packages affected
  - All 6 commands behave identically to before
  - `account fresh-address --output json` now returns a proper error envelope on failure (was unhandled before)

### 📝 Description

Every command in `wallet-cli` duplicated the same `--account` and `--output` option definitions and contained ~20 lines of `if (isHuman)` branching for output formatting, spinner management, error handling, and JSON envelope building.

Two changes fix this:

**1. Shared option definitions** (`src/commands/shared-options.ts`)
`accountOption` and `outputOption` are defined once and imported by all commands.

**2. `CommandOutput` abstraction** (`src/output.ts`)
Each command creates one `CommandOutput` instance via `createCommandOutput(format, ctx)` and calls semantic methods:
- `out.run(fn)` — error boundary (human: re-throw; json: error envelope + exit)
- `out.withActivity(loading, done, fn)` / `out.spin(text)` — spinner or silent
- `out.balances(items)`, `out.operations(...)`, `out.address(...)`, `out.discoveredAccount(d)` / `out.flushDiscovery()` — data output
- `out.sendDryRun(p)`, `out.sendEvent(event)`, `out.sendComplete()` — send flow

`HumanCommandOutput` writes to stdout with colors and spinners. `JsonCommandOutput` builds envelopes and buffers streaming data. Command handlers never check `isHuman` anymore.

### ❓ Context

- **JIRA or GitHub link**: N/A (internal refactor)
- **ADR link (if any)**: N/A