### PR TITLE
ci(wallet-cli): consolidate CI tasks into a single nx run-many step

### DIFF
--- a/.github/workflows/build-wallet-cli-reusable.yml
+++ b/.github/workflows/build-wallet-cli-reusable.yml
@@ -60,16 +60,10 @@ jobs:
       - name: Install dependencies
         run: pnpm i --filter "@ledgerhq/wallet-cli..." --filter "ledger-live"
 
-      - name: Check wallet-cli generated commands
-        run: pnpm exec nx run "@ledgerhq/wallet-cli:generate:check"
-
-      - name: Build wallet-cli
-        run: pnpm exec nx run @ledgerhq/wallet-cli:build
-
-      - name: Generate unit test coverage for wallet-cli
+      - name: Build, lint, typecheck and test wallet-cli
         run: |
           mkdir -p apps/wallet-cli/coverage
-          pnpm exec nx run @ledgerhq/wallet-cli:coverage
+          pnpm exec nx run-many --projects=@ledgerhq/wallet-cli --targets=generate:check,lint:ci,typecheck,build,coverage
 
       - name: Upload wallet-cli unit test coverage
         id: generate_coverage


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** CI-only change, no application code modified.
- [x] **Impact of the changes:**
  - The wallet-cli CI job now runs `lint:ci`, `build`, `typecheck`, and `coverage` in a single `nx run-many` call instead of 4 separate steps.

### 📝 Description

The `build-wallet-cli-reusable.yml` workflow had separate steps for `build` and `coverage`. This replaces them with one `nx run-many` step so NX can resolve task dependencies and schedule them efficiently.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A