### PR TITLE
test(e2e): link B2CQA-1879 to market filter starred test on desktop

### DIFF
--- a/e2e/desktop/tests/specs/market.spec.ts
+++ b/e2e/desktop/tests/specs/market.spec.ts
@@ -36,7 +36,7 @@ test.describe("Market", () => {
       tag: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
       annotation: {
         type: "TMS",
-        description: "B2CQA-4315",
+        description: "B2CQA-4315, B2CQA-1879",
       },
     },
     async ({ app }) => {


### PR DESCRIPTION
### Checklist

- [ ] `npx changeset` was attached. _Not required: metadata-only change to an Xray TMS annotation in a private e2e-tests package; no runtime/test behavior impact._
- [x] **Covered by automatic tests.** _The change itself is test metadata (Xray/TMS link) on an existing, already-covered spec._
- [x] **Impact of the changes:**
  - Market page filter starred
  - Allure TMS links

### Description

Link Xray test case `B2CQA-1879` to the existing "market filter starred" Playwright test on desktop so it is correctly reported in Xray/Allure alongside `B2CQA-4315`.

**Problem**: The TMS annotation on the market filter starred spec only referenced `B2CQA-4315`, leaving `B2CQA-1879` unlinked in Xray.

**Solution**: Extended the `description` field of the TMS annotation on the affected `test` in `e2e/desktop/tests/specs/market.spec.ts` to include `B2CQA-1879` alongside the existing ID.

### Context

- **JIRA or GitHub link**: [QAA-1141](https://ledgerhq.atlassian.net/browse/QAA-1141)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1141]: https://ledgerhq.atlassian.net/browse/QAA-1141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ