### PR TITLE
[LWM] fix(mobile): show analytics consent drawer on readonly portfolio

### DIFF
--- a/.changeset/calm-drawers-reconfirm.md
+++ b/.changeset/calm-drawers-reconfirm.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix analytics consent drawer visibility on Wallet v4 read-only portfolio

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/readOnlyPortfolio.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/__integrations__/readOnlyPortfolio.integration.test.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { renderWithReactQuery, screen } from "@tests/test-renderer";
+import { renderWithReactQuery, screen, withFlagOverrides } from "@tests/test-renderer";
 import {
   ReadOnlyPortfolioTest,
   overrideInitialStateWithFeatureFlag,
   overrideInitialStateWithGraphReworkEnabled,
 } from "./shared";
+import { withConsentDrawerState } from "LLM/features/AnalyticsConsentDrawer/__tests__/helpers";
 
 describe("ReadOnly Portfolio Screen", () => {
   it("should render ReadOnly Portfolio when feature flag is enabled", async () => {
@@ -25,5 +26,32 @@ describe("ReadOnly Portfolio Screen", () => {
 
       expect(screen.queryByTestId("graphCard-chart")).toBeNull();
     });
+  });
+
+  it("should show the reconfirm consent drawer on Wallet v4 read-only portfolio", async () => {
+    renderWithReactQuery(<ReadOnlyPortfolioTest />, {
+      overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true } }, state =>
+        withConsentDrawerState({
+          hasCompletedOnboarding: true,
+          analyticsOptInEnabled: true,
+          analyticsEnabled: true,
+          personalizedRecommendationsEnabled: true,
+          consentDate: null,
+          privacyPolicyVersion: 1,
+        })({
+          ...state,
+          accounts: {
+            active: [],
+          },
+          settings: {
+            ...state.settings,
+            readOnlyModeEnabled: true,
+          },
+        }),
+      ),
+    });
+
+    await screen.findByTestId("PortfolioReadOnlyItems");
+    expect(await screen.findByText("Continue improving Ledger?")).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/index.tsx
@@ -15,6 +15,7 @@ import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/t
 import { WalletTabNavigatorStackParamList } from "~/components/RootNavigator/types/WalletTabNavigator";
 import { ScreenName } from "~/const";
 import { PortfolioNoSignerContent } from "../../components/PortfolioEmptySection/PortfolioNoSignerContent";
+import { AnalyticsConsentDrawer } from "LLM/features/AnalyticsConsentDrawer";
 import useReadOnlyPortfolioViewModel from "./useReadOnlyPortfolioViewModel";
 
 type NavigationProps = BaseComposite<
@@ -80,6 +81,7 @@ function ReadOnlyPortfolioScreen({ navigation }: NavigationProps) {
         useSafeArea={!shouldDisplayWallet40MainNav}
         testID="PortfolioReadOnlyItems"
       />
+      <AnalyticsConsentDrawer />
     </>
   );
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Wallet v4 read-only portfolio consent entry point
      - Analytics consent reconfirmation visibility for read-only users
      - Regression check that standard Wallet v4 portfolio behavior remains unchanged

### 📝 Description

This PR fixes a Wallet v4 mobile inconsistency where the analytics opt-in drawer was not shown on the read-only portfolio path, even when the existing consent logic required a renewal or reconfirmation step.

The fix mounts the existing `AnalyticsConsentDrawer` in the Wallet v4 read-only portfolio screen and adds integration coverage for the reconfirmation case. This keeps the read-only path aligned with the standard Wallet v4 portfolio without introducing a separate consent flow.

<img width="390" height="782" alt="image" src="https://github.com/user-attachments/assets/fc807cc8-090a-4436-99e9-31ebdd669f93" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29275](https://ledgerhq.atlassian.net/browse/LIVE-29275)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)

[LIVE-29275]: https://ledgerhq.atlassian.net/browse/LIVE-29275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ