### PR TITLE
feat(cryptoassets): add optional tokenIdentifier to findTokenByAddressInCurrency

### DIFF
--- a/.changeset/token-identifier-find-by-address.md
+++ b/.changeset/token-identifier-find-by-address.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/cryptoassets": minor
+---
+
+Add optional `tokenIdentifier` param to `findTokenByAddressInCurrency` for chains where contract address alone is not unique (e.g. MultiversX, Cardano, Algorand).

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/persistence.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/persistence.test.ts
@@ -18,6 +18,7 @@ import {
   type PersistedCAL,
   type StateWithCryptoAssets,
 } from "./persistence";
+import { configureStore } from "@reduxjs/toolkit";
 import { cryptoAssetsApi } from "./state-manager/api";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
@@ -238,6 +239,87 @@ describe("Token Persistence", () => {
 
       expect(tokens).toEqual([]);
     });
+
+    it("should extract token_identifier from findTokenByAddressInCurrency originalArgs", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenByAddressInCurrency({"contract_address":"0xdac17f958d2ee523a2206206994597c13d831ec7","network":"ethereum","token_identifier":"MYTOKEN-abc123"})':
+              {
+                status: "fulfilled",
+                data: mockToken,
+                endpointName: "findTokenByAddressInCurrency",
+                originalArgs: {
+                  contract_address: mockToken.contractAddress,
+                  network: mockToken.parentCurrency.id,
+                  token_identifier: "MYTOKEN-abc123",
+                },
+                fulfilledTimeStamp: Date.now(),
+              },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const tokens = extractTokensFromState(mockState);
+
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].token_identifier).toBe("MYTOKEN-abc123");
+    });
+
+    it("should not set token_identifier for findTokenById queries", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              originalArgs: { id: mockToken.id },
+              fulfilledTimeStamp: Date.now(),
+            },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const tokens = extractTokensFromState(mockState);
+
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].token_identifier).toBeUndefined();
+    });
+
+    it("should deduplicate when same token appears in both findTokenById and findTokenByAddressInCurrency caches", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              originalArgs: { id: mockToken.id },
+              fulfilledTimeStamp: Date.now(),
+            },
+            'findTokenByAddressInCurrency({"contract_address":"0xdac17f958d2ee523a2206206994597c13d831ec7","network":"ethereum","token_identifier":"MYTOKEN-abc123"})':
+              {
+                status: "fulfilled",
+                data: mockToken,
+                endpointName: "findTokenByAddressInCurrency",
+                originalArgs: {
+                  contract_address: mockToken.contractAddress,
+                  network: mockToken.parentCurrency.id,
+                  token_identifier: "MYTOKEN-abc123",
+                },
+                fulfilledTimeStamp: Date.now(),
+              },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const tokens = extractTokensFromState(mockState);
+
+      // token.id is unique — same token in multiple cache entries collapses to one
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].data.id).toBe(mockToken.id);
+    });
   });
 
   describe("filterExpiredTokens", () => {
@@ -443,12 +525,7 @@ describe("Token Persistence", () => {
 
       mockDispatch.mockImplementation(async action => {
         if (typeof action === "function") {
-          const actionStr = String(action);
-          if (actionStr.includes("getTokensSyncHash")) {
-            return { data: currentHash, error: undefined };
-          }
-          const result = await action(mockDispatch, () => ({}), undefined);
-          return result;
+          return { data: currentHash, error: undefined };
         }
         const actionType = (action as any)?.type || "";
         if (actionType.includes("upsertQueryEntries") || actionType.includes("upsert")) {
@@ -483,12 +560,7 @@ describe("Token Persistence", () => {
 
       mockDispatch.mockImplementation(async action => {
         if (typeof action === "function") {
-          const actionStr = String(action);
-          if (actionStr.includes("getTokensSyncHash")) {
-            return { data: currentHash, error: undefined };
-          }
-          const result = await action(mockDispatch, () => ({}), undefined);
-          return result;
+          return { data: currentHash, error: undefined };
         }
         const actionType = (action as any)?.type || "";
         if (actionType.includes("upsertQueryEntries") || actionType.includes("upsert")) {
@@ -522,12 +594,7 @@ describe("Token Persistence", () => {
 
       mockDispatch.mockImplementation(async action => {
         if (typeof action === "function") {
-          const actionStr = String(action);
-          if (actionStr.includes("getTokensSyncHash")) {
-            throw new Error("Network error");
-          }
-          const result = await action(mockDispatch, () => ({}), undefined);
-          return result;
+          throw new Error("Network error");
         }
         const actionType = (action as any)?.type || "";
         if (actionType.includes("upsertQueryEntries") || actionType.includes("upsert")) {
@@ -818,6 +885,91 @@ describe("Token Persistence", () => {
     });
   });
 
+  describe("integration: token_identifier round-trip", () => {
+    const ttl = 24 * 60 * 60 * 1000;
+
+    function makeStore() {
+      return configureStore({
+        reducer: { [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer },
+        middleware: getDefaultMiddleware =>
+          getDefaultMiddleware({ serializableCheck: false }).concat(cryptoAssetsApi.middleware),
+      });
+    }
+
+    it("should restore cache entry with token_identifier after extract → restore cycle", async () => {
+      // Simulate RTK Query state after a real findTokenByAddressInCurrency fetch with token_identifier
+      const sourceState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenByAddressInCurrency({"contract_address":"0xdac17f958d2ee523a2206206994597c13d831ec7","network":"ethereum","token_identifier":"MYTOKEN-abc123"})':
+              {
+                status: "fulfilled",
+                data: mockToken,
+                endpointName: "findTokenByAddressInCurrency",
+                originalArgs: {
+                  contract_address: mockToken.contractAddress,
+                  network: mockToken.parentCurrency.id,
+                  token_identifier: "MYTOKEN-abc123",
+                },
+                fulfilledTimeStamp: Date.now(),
+              },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const persisted = extractPersistedCALFromState(sourceState);
+      expect(persisted.tokens[0].token_identifier).toBe("MYTOKEN-abc123");
+
+      // Restore into a real Redux store
+      const newStore = makeStore();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await restoreTokensToCache(newStore.dispatch as any, persisted, ttl);
+
+      // Verify the store has the cache entry with token_identifier in originalArgs
+      const newQueries = newStore.getState()[cryptoAssetsApi.reducerPath].queries;
+      const restoredEntry = Object.values(newQueries).find(
+        entry =>
+          entry?.endpointName === "findTokenByAddressInCurrency" &&
+          (entry.originalArgs as { token_identifier?: string } | undefined)?.token_identifier ===
+            "MYTOKEN-abc123",
+      );
+      expect(restoredEntry).toBeDefined();
+      expect(restoredEntry?.data).toMatchObject({ id: mockToken.id });
+    });
+
+    it("should restore cache entry without token_identifier unchanged after round-trip", async () => {
+      const sourceState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              originalArgs: { id: mockToken.id },
+              fulfilledTimeStamp: Date.now(),
+            },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const persisted = extractPersistedCALFromState(sourceState);
+      expect(persisted.tokens[0].token_identifier).toBeUndefined();
+
+      const newStore = makeStore();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await restoreTokensToCache(newStore.dispatch as any, persisted, ttl);
+
+      const newQueries = newStore.getState()[cryptoAssetsApi.reducerPath].queries;
+      const addressEntry = Object.values(newQueries).find(
+        entry => entry?.endpointName === "findTokenByAddressInCurrency",
+      );
+      expect(addressEntry).toBeDefined();
+      expect(
+        (addressEntry?.originalArgs as { token_identifier?: string } | undefined)?.token_identifier,
+      ).toBeUndefined();
+    });
+  });
+
   describe("persistedCALContentEqual", () => {
     const baseTokenData: TokenCurrencyRaw = {
       id: "ethereum/erc20/usdt",
@@ -919,5 +1071,6 @@ describe("Token Persistence", () => {
       };
       expect(persistedCALContentEqual(a, b)).toBe(false);
     });
+
   });
 });

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/persistence.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/persistence.test.ts
@@ -18,6 +18,7 @@ import {
   type PersistedCAL,
   type StateWithCryptoAssets,
 } from "./persistence";
+import { configureStore } from "@reduxjs/toolkit";
 import { cryptoAssetsApi } from "./state-manager/api";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
@@ -237,6 +238,87 @@ describe("Token Persistence", () => {
       const tokens = extractTokensFromState(mockState);
 
       expect(tokens).toEqual([]);
+    });
+
+    it("should extract token_identifier from findTokenByAddressInCurrency originalArgs", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenByAddressInCurrency({"contract_address":"0xdac17f958d2ee523a2206206994597c13d831ec7","network":"ethereum","token_identifier":"MYTOKEN-abc123"})':
+              {
+                status: "fulfilled",
+                data: mockToken,
+                endpointName: "findTokenByAddressInCurrency",
+                originalArgs: {
+                  contract_address: mockToken.contractAddress,
+                  network: mockToken.parentCurrency.id,
+                  token_identifier: "MYTOKEN-abc123",
+                },
+                fulfilledTimeStamp: Date.now(),
+              },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const tokens = extractTokensFromState(mockState);
+
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].token_identifier).toBe("MYTOKEN-abc123");
+    });
+
+    it("should not set token_identifier for findTokenById queries", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              originalArgs: { id: mockToken.id },
+              fulfilledTimeStamp: Date.now(),
+            },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const tokens = extractTokensFromState(mockState);
+
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].token_identifier).toBeUndefined();
+    });
+
+    it("should deduplicate when same token appears in both findTokenById and findTokenByAddressInCurrency caches", () => {
+      const mockState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              originalArgs: { id: mockToken.id },
+              fulfilledTimeStamp: Date.now(),
+            },
+            'findTokenByAddressInCurrency({"contract_address":"0xdac17f958d2ee523a2206206994597c13d831ec7","network":"ethereum","token_identifier":"MYTOKEN-abc123"})':
+              {
+                status: "fulfilled",
+                data: mockToken,
+                endpointName: "findTokenByAddressInCurrency",
+                originalArgs: {
+                  contract_address: mockToken.contractAddress,
+                  network: mockToken.parentCurrency.id,
+                  token_identifier: "MYTOKEN-abc123",
+                },
+                fulfilledTimeStamp: Date.now(),
+              },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const tokens = extractTokensFromState(mockState);
+
+      // token.id is unique — same token in multiple cache entries collapses to one
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].data.id).toBe(mockToken.id);
     });
   });
 
@@ -818,6 +900,91 @@ describe("Token Persistence", () => {
     });
   });
 
+  describe("integration: token_identifier round-trip", () => {
+    const ttl = 24 * 60 * 60 * 1000;
+
+    function makeStore() {
+      return configureStore({
+        reducer: { [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer },
+        middleware: getDefaultMiddleware =>
+          getDefaultMiddleware({ serializableCheck: false }).concat(cryptoAssetsApi.middleware),
+      });
+    }
+
+    it("should restore cache entry with token_identifier after extract → restore cycle", async () => {
+      // Simulate RTK Query state after a real findTokenByAddressInCurrency fetch with token_identifier
+      const sourceState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenByAddressInCurrency({"contract_address":"0xdac17f958d2ee523a2206206994597c13d831ec7","network":"ethereum","token_identifier":"MYTOKEN-abc123"})':
+              {
+                status: "fulfilled",
+                data: mockToken,
+                endpointName: "findTokenByAddressInCurrency",
+                originalArgs: {
+                  contract_address: mockToken.contractAddress,
+                  network: mockToken.parentCurrency.id,
+                  token_identifier: "MYTOKEN-abc123",
+                },
+                fulfilledTimeStamp: Date.now(),
+              },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const persisted = extractPersistedCALFromState(sourceState);
+      expect(persisted.tokens[0].token_identifier).toBe("MYTOKEN-abc123");
+
+      // Restore into a real Redux store
+      const newStore = makeStore();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await restoreTokensToCache(newStore.dispatch as any, persisted, ttl);
+
+      // Verify the store has the cache entry with token_identifier in originalArgs
+      const newQueries = newStore.getState()[cryptoAssetsApi.reducerPath].queries;
+      const restoredEntry = Object.values(newQueries).find(
+        entry =>
+          entry?.endpointName === "findTokenByAddressInCurrency" &&
+          (entry.originalArgs as { token_identifier?: string } | undefined)?.token_identifier ===
+            "MYTOKEN-abc123",
+      );
+      expect(restoredEntry).toBeDefined();
+      expect(restoredEntry?.data).toMatchObject({ id: mockToken.id });
+    });
+
+    it("should restore cache entry without token_identifier unchanged after round-trip", async () => {
+      const sourceState = {
+        [cryptoAssetsApi.reducerPath]: {
+          queries: {
+            'findTokenById({"id":"ethereum/erc20/usdt"})': {
+              status: "fulfilled",
+              data: mockToken,
+              endpointName: "findTokenById",
+              originalArgs: { id: mockToken.id },
+              fulfilledTimeStamp: Date.now(),
+            },
+          },
+        },
+      } as unknown as StateWithCryptoAssets;
+
+      const persisted = extractPersistedCALFromState(sourceState);
+      expect(persisted.tokens[0].token_identifier).toBeUndefined();
+
+      const newStore = makeStore();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await restoreTokensToCache(newStore.dispatch as any, persisted, ttl);
+
+      const newQueries = newStore.getState()[cryptoAssetsApi.reducerPath].queries;
+      const addressEntry = Object.values(newQueries).find(
+        entry => entry?.endpointName === "findTokenByAddressInCurrency",
+      );
+      expect(addressEntry).toBeDefined();
+      expect(
+        (addressEntry?.originalArgs as { token_identifier?: string } | undefined)?.token_identifier,
+      ).toBeUndefined();
+    });
+  });
+
   describe("persistedCALContentEqual", () => {
     const baseTokenData: TokenCurrencyRaw = {
       id: "ethereum/erc20/usdt",
@@ -919,5 +1086,6 @@ describe("Token Persistence", () => {
       };
       expect(persistedCALContentEqual(a, b)).toBe(false);
     });
+
   });
 });

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/persistence.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/persistence.ts
@@ -7,7 +7,7 @@ import isEqual from "lodash/isEqual";
 import { log } from "@ledgerhq/logs";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { findCryptoCurrencyById } from "../currencies";
-import { cryptoAssetsApi } from "./state-manager/api";
+import { cryptoAssetsApi, type TokenByAddressInCurrencyParams } from "./state-manager/api";
 import type { ThunkDispatch } from "@reduxjs/toolkit";
 
 /**
@@ -41,6 +41,12 @@ export interface PersistedTokenEntry {
   data: TokenCurrencyRaw;
   /** When this token was fetched (Unix timestamp in ms) */
   timestamp: number;
+  /**
+   * The token_identifier used in the findTokenByAddressInCurrency query, if any.
+   * Required to reconstruct the correct RTK Query cache key on hydration for chains
+   * where contract_address alone is not unique (e.g. MultiversX, Algorand, Cardano).
+   */
+  token_identifier?: string;
 }
 
 /**
@@ -131,17 +137,22 @@ export function extractTokensFromState(state: StateWithCryptoAssets): PersistedT
       (query.endpointName === "findTokenById" ||
         query.endpointName === "findTokenByAddressInCurrency")
     ) {
-      const token = query.data as TokenCurrency | undefined;
+      const token = query.data as TokenCurrency;
+      if (!token?.id) continue;
 
-      // Deduplicate by token ID
-      if (token && token.id && !seenIds.has(token.id)) {
-        seenIds.add(token.id);
+      const tokenIdentifier =
+        query.endpointName === "findTokenByAddressInCurrency"
+          ? (query.originalArgs as TokenByAddressInCurrencyParams | undefined)?.token_identifier
+          : undefined;
 
-        tokens.push({
-          data: toTokenCurrencyRaw(token),
-          timestamp: query.fulfilledTimeStamp || Date.now(),
-        });
-      }
+      if (seenIds.has(token.id)) continue;
+      seenIds.add(token.id);
+
+      tokens.push({
+        data: toTokenCurrencyRaw(token),
+        timestamp: query.fulfilledTimeStamp || Date.now(),
+        token_identifier: tokenIdentifier,
+      });
     }
   }
 
@@ -214,9 +225,7 @@ export function persistedCALContentEqual(a: PersistedCAL | null, b: PersistedCAL
   if (a.tokens.length !== b.tokens.length) return false;
   const tokensByIdA = new Map(a.tokens.map(t => [t.data.id, t.data]));
   const tokensByIdB = new Map(b.tokens.map(t => [t.data.id, t.data]));
-  const entriesA = Array.from(tokensByIdA.entries());
-  for (let i = 0; i < entriesA.length; i++) {
-    const [id, dataA] = entriesA[i];
+  for (const [id, dataA] of tokensByIdA) {
     const dataB = tokensByIdB.get(id);
     if (!dataB || !tokenCurrencyRawEqual(dataA, dataB)) return false;
   }
@@ -312,7 +321,7 @@ export async function restoreTokensToCache(
     | { endpointName: "findTokenById"; arg: { id: string }; value: TokenCurrency | undefined }
     | {
         endpointName: "findTokenByAddressInCurrency";
-        arg: { contract_address: string; network: string };
+        arg: { contract_address: string; network: string; token_identifier?: string };
         value: TokenCurrency | undefined;
       }
   > = [];
@@ -336,9 +345,25 @@ export async function restoreTokensToCache(
       arg: {
         contract_address: token.contractAddress,
         network: token.parentCurrency.id,
+        ...(entry.token_identifier === undefined
+          ? {}
+          : { token_identifier: entry.token_identifier }),
       },
       value: token,
     });
+
+    // Also restore the address-only key so lookups without token_identifier hit the cache.
+    // Collision on chains where address is not unique is a coin-level concern.
+    if (entry.token_identifier !== undefined) {
+      entries.push({
+        endpointName: "findTokenByAddressInCurrency",
+        arg: {
+          contract_address: token.contractAddress,
+          network: token.parentCurrency.id,
+        },
+        value: token,
+      });
+    }
   }
 
   if (entries.length > 0) {

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.test.ts
@@ -10,6 +10,7 @@ import {
   transformApiTokenToTokenCurrency,
   validateAndTransformSingleTokenResponse,
 } from "./api";
+import type { TokenByIdParams, TokenByAddressInCurrencyParams } from "./api";
 import type { ApiTokenResponse } from "../entities";
 import { getEnv } from "@ledgerhq/live-env";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
@@ -145,19 +146,36 @@ describe("api.ts", () => {
 
   describe("API integration tests", () => {
     it("should have correct interface types for TokenByIdParams", () => {
-      const params: import("./api").TokenByIdParams = {
+      const params: TokenByIdParams = {
         id: "ethereum/erc20/usdc",
       };
       expect(params.id).toBe("ethereum/erc20/usdc");
     });
 
     it("should have correct interface types for TokenByAddressInCurrencyParams", () => {
-      const params: import("./api").TokenByAddressInCurrencyParams = {
+      const params: TokenByAddressInCurrencyParams = {
         contract_address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         network: "ethereum",
       };
       expect(params.contract_address).toBe("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
       expect(params.network).toBe("ethereum");
+    });
+
+    it("should accept optional token_identifier in TokenByAddressInCurrencyParams", () => {
+      const params: TokenByAddressInCurrencyParams = {
+        contract_address: "EGLD-123",
+        network: "elrond",
+        token_identifier: "MYTOKEN-abc123",
+      };
+      expect(params.token_identifier).toBe("MYTOKEN-abc123");
+    });
+
+    it("should allow TokenByAddressInCurrencyParams without token_identifier", () => {
+      const params: TokenByAddressInCurrencyParams = {
+        contract_address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        network: "ethereum",
+      };
+      expect(params.token_identifier).toBeUndefined();
     });
   });
 

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.test.ts
@@ -159,6 +159,23 @@ describe("api.ts", () => {
       expect(params.contract_address).toBe("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
       expect(params.network).toBe("ethereum");
     });
+
+    it("should accept optional token_identifier in TokenByAddressInCurrencyParams", () => {
+      const params: import("./api").TokenByAddressInCurrencyParams = {
+        contract_address: "EGLD-123",
+        network: "elrond",
+        token_identifier: "MYTOKEN-abc123",
+      };
+      expect(params.token_identifier).toBe("MYTOKEN-abc123");
+    });
+
+    it("should allow TokenByAddressInCurrencyParams without token_identifier", () => {
+      const params: import("./api").TokenByAddressInCurrencyParams = {
+        contract_address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        network: "ethereum",
+      };
+      expect(params.token_identifier).toBeUndefined();
+    });
   });
 
   describe("baseQuery configuration", () => {

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/api.ts
@@ -25,6 +25,7 @@ export interface TokenByIdParams {
 export interface TokenByAddressInCurrencyParams {
   contract_address: string;
   network: string;
+  token_identifier?: string;
 }
 
 function transformTokensResponse(
@@ -132,6 +133,9 @@ export const cryptoAssetsApi = createApi({
             network: params.network,
             limit: "1",
             output: TOKEN_OUTPUT_FIELDS.join(","),
+            ...(params.token_identifier === undefined
+              ? {}
+              : { token_identifier: params.token_identifier }),
           },
         };
       },

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/store.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/store.test.ts
@@ -256,6 +256,25 @@ describe("RtkCryptoAssetsStore", () => {
       expect(result).toEqual(mockToken);
     });
 
+    it("should call initiate with token_identifier when provided", async () => {
+      mockDispatch.mockResolvedValue({ data: undefined });
+      await store.findTokenByAddressInCurrency("EGLD-123", "elrond", "MYTOKEN-abc123");
+      expect(mockApi.endpoints.findTokenByAddressInCurrency.initiate).toHaveBeenCalledWith({
+        contract_address: "EGLD-123",
+        network: "elrond",
+        token_identifier: "MYTOKEN-abc123",
+      });
+    });
+
+    it("should call initiate without token_identifier when not provided", async () => {
+      mockDispatch.mockResolvedValue({ data: undefined });
+      await store.findTokenByAddressInCurrency("0xABC", "ethereum");
+      expect(mockApi.endpoints.findTokenByAddressInCurrency.initiate).toHaveBeenCalledWith({
+        contract_address: "0xABC",
+        network: "ethereum",
+      });
+    });
+
     it("should return data when getTokensSyncHash succeeds", async () => {
       const mockHash = "abc123def456";
       mockDispatch.mockResolvedValue({ data: mockHash });

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/store.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/store.ts
@@ -25,11 +25,13 @@ export class RtkCryptoAssetsStore implements CryptoAssetsStore {
   async findTokenByAddressInCurrency(
     address: string,
     currencyId: string,
+    tokenIdentifier?: string,
   ): Promise<TokenCurrency | undefined> {
     const result = await this.dispatch(
       this.api.endpoints.findTokenByAddressInCurrency.initiate({
         contract_address: address,
         network: currencyId,
+        ...(tokenIdentifier === undefined ? {} : { token_identifier: tokenIdentifier }),
       }),
     );
     if (result.error) throw remapRtkQueryError(result.error);

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/test-helpers.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/test-helpers.ts
@@ -70,6 +70,7 @@ export function createMockCryptoAssetsStore(
     findTokenByAddressInCurrency: async (
       _address: string,
       _currencyId: string,
+      _tokenIdentifier?: string,
     ): Promise<TokenCurrency | undefined> => {
       return undefined;
     },

--- a/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
+++ b/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
@@ -30,6 +30,11 @@ export type CryptoAssetsStore = {
    *
    * @param address - The contract address of the token
    * @param currencyId - The ID of the parent currency/blockchain (e.g., "ethereum", "polygon")
+   * @param tokenIdentifier - Optional discriminator for chains where contract_address alone is not
+   *   unique (e.g. MultiversX ESDT identifier, Cardano asset policy+name, Algorand asset ID,
+   *   Stellar classic asset code+issuer). When provided, it is forwarded as `token_identifier`
+   *   in the CAL query so the correct token is returned. Omit only for chains where address
+   *   uniquely identifies a token (e.g. EVM).
    * @returns Promise resolving to the TokenCurrency if found, undefined otherwise
    * @example
    * ```typescript
@@ -37,11 +42,18 @@ export type CryptoAssetsStore = {
    *   "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
    *   "polygon"
    * );
+   * // MultiversX — token_identifier needed to disambiguate
+   * const mxToken = await store.findTokenByAddressInCurrency(
+   *   "EGLD-abc123",
+   *   "elrond",
+   *   "MYTOKEN-def456"
+   * );
    * ```
    */
   findTokenByAddressInCurrency(
     address: string,
     currencyId: string,
+    tokenIdentifier?: string,
   ): Promise<TokenCurrency | undefined>;
 
   /**

--- a/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
+++ b/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
@@ -30,6 +30,10 @@ export type CryptoAssetsStore = {
    *
    * @param address - The contract address of the token
    * @param currencyId - The ID of the parent currency/blockchain (e.g., "ethereum", "polygon")
+   * @param tokenIdentifier - Optional discriminator for chains where contract_address alone is not
+   *   unique (e.g. MultiversX ESDT identifier, Cardano asset policy+name, Algorand asset ID).
+   *   When provided, it is forwarded as `token_identifier` in the CAL query so the correct token
+   *   is returned. Omit for chains where address uniquely identifies a token (e.g. EVM, Stellar).
    * @returns Promise resolving to the TokenCurrency if found, undefined otherwise
    * @example
    * ```typescript
@@ -37,11 +41,18 @@ export type CryptoAssetsStore = {
    *   "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
    *   "polygon"
    * );
+   * // MultiversX — token_identifier needed to disambiguate
+   * const mxToken = await store.findTokenByAddressInCurrency(
+   *   "EGLD-abc123",
+   *   "elrond",
+   *   "MYTOKEN-def456"
+   * );
    * ```
    */
   findTokenByAddressInCurrency(
     address: string,
     currencyId: string,
+    tokenIdentifier?: string,
   ): Promise<TokenCurrency | undefined>;
 
   /**


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - `@ledgerhq/types-live`: `CryptoAssetsStore.findTokenByAddressInCurrency` gains an optional 3rd param — no breaking change for existing callers.
  - `@ledgerhq/cryptoassets`: CAL API sends `token_identifier` query param only when provided; persistence layer stores and restores it to reconstruct the correct RTK Query cache key.

### 📝 Description

Some blockchains (MultiversX, Algorand, Cardano) have tokens where `contract_address` is not unique. The CAL already provides a `token_identifier` field to discriminate between them. Without it, `findTokenByAddressInCurrency` can return the wrong token on those chains.

This PR adds an optional `tokenIdentifier` parameter to `findTokenByAddressInCurrency` across the full stack: interface → API query params → store → persistence (extract + restore).

**Persistence detail:** RTK Query cache keys include `token_identifier` when present, so the persistence layer must preserve it. `PersistedTokenEntry` now stores `token_identifier?` from `query.originalArgs`, and `restoreTokensToCache` reconstructs the correct cache key on hydration. No version bump needed — old data without the field degrades gracefully.

**Stellar context ([ADR-030](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/6993608705)):** ADR-030 proposes using `findTokenByAddressInCurrency` with `network` + `contract_address` (+optionally `token_identifier` for disambiguation) to discover Stellar tokens. The parameter added here is the plumbing needed for ADR-030 Proposition 2 Variant, where classic Stellar assets are queried as `?network=stellar&token_identifier={asset_code}&contract_address={asset_issuer}`.

Coin-side callers (MultiversX, Algorand, Cardano, Canton, Tezos, Stellar) are out of scope and will pass `tokenIdentifier` in follow-up per-chain tickets.

### 🧪 Local e2e playground (not committed — run manually)

Save as `src/cal-client/playground.test.ts` then run `pnpm test -- playground.test`.

Validates against the production CAL: Stellar USDC case-sensitivity regression (LIVE-22558) + persistence round-trip.

```typescript
/**
 * @jest-environment node
 *
 * PERSONAL PLAYGROUND — not part of the regular test suite.
 * Makes real network calls to the production CAL.
 *
 * Run: pnpm test -- playground.test
 */

import { configureStore } from "@reduxjs/toolkit";
import { setupCalClientStore, getReduxStore } from "./test-helpers";
import { createRtkCryptoAssetsStore } from "./state-manager";
import { extractPersistedCALFromState, restoreTokensToCache } from "./persistence";
import { cryptoAssetsApi } from "./state-manager/api";

jest.setTimeout(30_000);

const STELLAR_NETWORK = "stellar";
const STELLAR_USDC_ADDRESS = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
const STELLAR_USDC_ID_UPPER =
  "stellar/asset/USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";

function makeReduxStore() {
  return configureStore({
    reducer: { [cryptoAssetsApi.reducerPath]: cryptoAssetsApi.reducer },
    middleware: getDefaultMiddleware =>
      getDefaultMiddleware({ serializableCheck: false }).concat(cryptoAssetsApi.middleware),
  });
}

// Stellar USDC — case-sensitivity regression (LIVE-22558)
describe("Stellar USDC e2e", () => {
  it("findTokenById with legacy uppercase id resolves correctly", async () => {
    const store = setupCalClientStore();
    const token = await store.findTokenById(STELLAR_USDC_ID_UPPER);
    expect(token?.ticker).toBe("USDC");
  });

  it("findTokenByAddressInCurrency returns token and stores no token_identifier", async () => {
    const store = setupCalClientStore();
    const token = await store.findTokenByAddressInCurrency(STELLAR_USDC_ADDRESS, STELLAR_NETWORK);
    expect(token?.ticker).toBe("USDC");

    const queries = getReduxStore().getState()[cryptoAssetsApi.reducerPath].queries;
    const entry = Object.values(queries).find(
      q => q?.endpointName === "findTokenByAddressInCurrency",
    );
    expect((entry?.originalArgs as any)?.token_identifier).toBeUndefined();
  });

  it("persistence round-trip: restore from cache, serve without re-fetch", async () => {
    const store = setupCalClientStore();
    await store.findTokenByAddressInCurrency(STELLAR_USDC_ADDRESS, STELLAR_NETWORK);

    const persisted = extractPersistedCALFromState(getReduxStore().getState());
    expect(persisted.tokens[0]?.token_identifier).toBeUndefined();

    const freshReduxStore = makeReduxStore();
    await restoreTokensToCache(freshReduxStore.dispatch as any, persisted, 24 * 60 * 60 * 1000);

    const networkCalls: string[] = [];
    const freshStore = createRtkCryptoAssetsStore(cryptoAssetsApi, async <T>(action: T) => {
      if ((action as any)?.type?.includes("executeQuery")) networkCalls.push("network");
      return freshReduxStore.dispatch(action as any) as unknown;
    });

    const cached = await freshStore.findTokenByAddressInCurrency(
      STELLAR_USDC_ADDRESS,
      STELLAR_NETWORK,
    );
    expect(cached?.ticker).toBe("USDC");
    expect(networkCalls.length).toBe(0);
  });
});
```

### ❓ Context

- **JIRA**: [LIVE-29274](https://ledgerhq.atlassian.net/browse/LIVE-29274)
- **ADR**: [ADR-030 — Stellar tokens discovery on the CAL](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/6993608705)

[LIVE-29274]: https://ledgerhq.atlassian.net/browse/LIVE-29274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ