### PR TITLE
[LWDM] feat(dmk): upgrade dmk deps and set evm signer app source

### DIFF
--- a/.changeset/bright-otters-dance.md
+++ b/.changeset/bright-otters-dance.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+Update DMK dependencies

--- a/.changeset/quiet-foxes-signal.md
+++ b/.changeset/quiet-foxes-signal.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-signer-evm": minor
+---
+
+Configure EVM signer context module with `ledger-wallet` app source

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -16,6 +16,7 @@ import {
   DeviceManagementKit,
   hexaStringToBuffer,
 } from "@ledgerhq/device-management-kit";
+import { ContextModuleBuilder } from "@ledgerhq/context-module";
 import { EIP712Message } from "@ledgerhq/types-live";
 import {
   EthAppPleaseEnableContractData,
@@ -37,11 +38,17 @@ export class DmkSignerEth implements EvmSigner {
     readonly dmk: DeviceManagementKit,
     readonly sessionId: string,
   ) {
+    const originToken = "1e55ba3959f4543af24809d9066a2120bd2ac9246e626e26a1ff77eb109ca0e5";
+    const contextModule = new ContextModuleBuilder({ originToken })
+      .setAppSource("ledger-wallet")
+      .build();
     this.signer = new SignerEthBuilder({
       dmk,
       sessionId,
-      originToken: "1e55ba3959f4543af24809d9066a2120bd2ac9246e626e26a1ff77eb109ca0e5",
-    }).build();
+      originToken,
+    })
+      .withContextModule(contextModule)
+      .build();
   }
 
   private _mapError<E extends DAError>(error: E): Error {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       specifier: 1.0.0
       version: 1.0.0
     '@ledgerhq/device-signer-kit-ethereum':
-      specifier: 1.12.0
-      version: 1.12.0
+      specifier: 1.14.0
+      version: 1.14.0
     '@ledgerhq/device-signer-kit-hyperliquid':
       specifier: 1.0.2
       version: 1.0.2
@@ -440,7 +440,7 @@ overrides:
   remove-flow-types-loader>loader-utils: '*'
   '@ledgerhq/devices': workspace:*
   '@ledgerhq/hw-transport': workspace:*
-  '@ledgerhq/context-module': 1.15.0
+  '@ledgerhq/context-module': 1.16.0
   tslib: 2.6.2
   '@ethersproject/providers>ws': 7.5.10
   elliptic: 6.6.1
@@ -1555,8 +1555,8 @@ importers:
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-stacks
       '@ledgerhq/context-module':
-        specifier: 1.15.0
-        version: 1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+        specifier: 1.16.0
+        version: 1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 1.4.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(styled-components@6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react@19.0.0))
@@ -1571,7 +1571,7 @@ importers:
         version: 1.2.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.12.0(@ledgerhq/context-module@1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+        version: 1.14.0(@ledgerhq/context-module@1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
         version: 1.0.3(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(rxjs@7.8.2)
@@ -10740,14 +10740,14 @@ importers:
         specifier: workspace:^
         version: link:../coin-modules/coin-aleo
       '@ledgerhq/context-module':
-        specifier: 1.15.0
-        version: 1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+        specifier: 1.16.0
+        version: 1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.2.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-aleo':
         specifier: 0.2.0
-        version: 0.2.0(@ledgerhq/context-module@1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+        version: 0.2.0(@ledgerhq/context-module@1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -10982,14 +10982,14 @@ importers:
         specifier: workspace:^
         version: link:../coin-modules/coin-evm
       '@ledgerhq/context-module':
-        specifier: 1.15.0
-        version: 1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+        specifier: 1.16.0
+        version: 1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.2.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.12.0(@ledgerhq/context-module@1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+        version: 1.14.0(@ledgerhq/context-module@1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -16748,8 +16748,8 @@ packages:
       '@ledgerhq/live-network': ^2.4.0
       '@ledgerhq/logs': ^6.17.0
 
-  '@ledgerhq/context-module@1.15.0':
-    resolution: {integrity: sha512-PzO/2JdOL29C2NhiVX85K7ZI9kDQN2E0s74d6lOe8kYb8XfN06ETN3RPdzBnTgO0jkLQUHCjS5aKpPa40S14qA==}
+  '@ledgerhq/context-module@1.16.0':
+    resolution: {integrity: sha512-yiKKL525f6ou6wbFTAU/IVIli/R0OXV2fH+mcmfA5QRHnkagCFCNPJmZ+TzhbdaRzBK/MQa/vAc5miYZ0X774w==}
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.2.0
 
@@ -16779,7 +16779,7 @@ packages:
   '@ledgerhq/device-signer-kit-aleo@0.2.0':
     resolution: {integrity: sha512-tGrs2G9K54zs3sS1qcDa5Qs6n08vnB7/YFPDJvn3KJjlIT3YUUHZ+XIYyY/2VJubqss0MlfDGmnDWnXbA1PyGA==}
     peerDependencies:
-      '@ledgerhq/context-module': 1.15.0
+      '@ledgerhq/context-module': 1.16.0
       '@ledgerhq/device-management-kit': ^1.2.0
 
   '@ledgerhq/device-signer-kit-concordium@0.2.0':
@@ -16792,10 +16792,10 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.2.0
 
-  '@ledgerhq/device-signer-kit-ethereum@1.12.0':
-    resolution: {integrity: sha512-Uj3C3UaoaX/pcqSuCHgfQZn1lwqqp60eQr8wyQOY5OCV4zttoWKmB1MRBn+t4LB08eBRAgokcFdsG2dGwFEhiA==}
+  '@ledgerhq/device-signer-kit-ethereum@1.14.0':
+    resolution: {integrity: sha512-K0H4SqTMeOdSjRgq5flproMPtqlCvP4T4z0W0gZL67cNwephEKEIa96NiLXP5VRUjvckaDFwJeif3oI1dbvj7w==}
     peerDependencies:
-      '@ledgerhq/context-module': 1.15.0
+      '@ledgerhq/context-module': 1.16.0
       '@ledgerhq/device-management-kit': ^1.2.0
 
   '@ledgerhq/device-signer-kit-hyperliquid@1.0.2':
@@ -44988,7 +44988,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/context-module@1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))':
+  '@ledgerhq/context-module@1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.2.0(rxjs@7.8.2)
       axios: 1.13.5
@@ -45076,9 +45076,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-aleo@0.2.0(@ledgerhq/context-module@1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-aleo@0.2.0(@ledgerhq/context-module@1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.2.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -45104,11 +45104,11 @@ snapshots:
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-ethereum@1.12.0(@ledgerhq/context-module@1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-ethereum@1.14.0(@ledgerhq/context-module@1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.2.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+      '@ledgerhq/signer-utils': 1.2.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       ethers: 6.15.0
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
@@ -45121,7 +45121,7 @@ snapshots:
 
   '@ledgerhq/device-signer-kit-hyperliquid@1.0.2(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.2.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -45134,7 +45134,7 @@ snapshots:
 
   '@ledgerhq/device-signer-kit-solana@1.7.1(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))(typescript@6.0.2)':
     dependencies:
-      '@ledgerhq/context-module': 1.15.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.2.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(typescript@6.0.2))(typescript@6.0.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,17 +18,17 @@ packages:
 
 catalog:
   "@jest/globals": 30.2.0
-  "@ledgerhq/context-module": 1.15.0
+  "@ledgerhq/context-module": 1.16.0
   "@ledgerhq/crypto-icons": "1.4.0"
   "@ledgerhq/device-management-kit": 1.2.0
-  "@ledgerhq/device-signer-kit-ethereum": 1.12.0
+  "@ledgerhq/device-signer-kit-ethereum": 1.14.0
   "@ledgerhq/device-signer-kit-hyperliquid": 1.0.2
   "@ledgerhq/device-signer-kit-solana": 1.7.1
   "@ledgerhq/device-signer-kit-cosmos": 1.0.0
   "@ledgerhq/device-transport-kit-react-native-ble": 1.3.2
   "@ledgerhq/device-transport-kit-react-native-hid": 1.0.3
   "@ledgerhq/device-transport-kit-speculos": 1.2.0
-  "@ledgerhq/signer-utils": 1.1.3
+  "@ledgerhq/signer-utils": 1.2.0
   "@ledgerhq/device-transport-kit-web-hid": 1.2.3
   "@ledgerhq/speculos-device-controller": 0.2.3
   "@ledgerhq/lumen-design-core": 0.1.9


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Dependency bump and signer configuration change; exercised by existing EVM signing suites and manual QA._
- [x] **Impact of the changes:**
  - EVM signing flows on mobile and desktop (transaction, personal message, EIP-712 typed data) via the DMK-backed signer
  - Context module / clear-signing behavior and blind-signing reporting (app source now reported as `ledger-wallet`)
  - Any feature transitively consuming updated DMK / device-signer-kit packages across mobile and desktop apps

### Description

This PR bumps the Device Management Kit (DMK) dependencies in the workspace catalog and wires the EVM signer to provide an explicit app source to the context module.

**Changes:**

- Upgrade DMK-related dependencies in `pnpm-workspace.yaml` (and resulting `pnpm-lock.yaml` update)
- In `libs/live-signer-evm`, build a `ContextModuleBuilder` with `setAppSource("ledger-wallet")` and inject it into `SignerEthBuilder` via `withContextModule(...)`, so blind-signing reports and context-module traffic are tagged with the wallet's app source.

### Context

- **JIRA or GitHub link**: _No ticket — maintenance branch (`feat/no-issue-upgrade-dmk-deps`)_

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

Made with [Cursor](https://cursor.com)