### PR TITLE
ci: use nick-fields/retry for apt install in setup-caches

### DIFF
--- a/tools/actions/composites/setup-caches/action.yml
+++ b/tools/actions/composites/setup-caches/action.yml
@@ -108,10 +108,11 @@ runs:
 
     - name: Install Linux native build dependencies
       if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential pkg-config
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+      with:
+        max_attempts: 3
+        timeout_minutes: 5
+        command: sudo apt-get update && sudo apt-get install -y build-essential pkg-config
 
     - name: Setup the toolchain
       # If we're not using mise, keep this behaviour of activating proto tools


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Green Runs

- ✅ https://github.com/LedgerHQ/ledger-live/actions/runs/24558856017/job/71803797972?pr=16441

### 📝 Description

GitHub Actions Linux runners occasionally fail during apt-get with transient mirror errors — typically a locked package index, a stale mirror returning 404s, or a temporary network blip mid-install. Because the Install Linux native build dependencies step in setup-caches had no retry logic, a single flaky apt response would fail the entire job with no recourse.

This PR wraps that step with nick-fields/retry@v3 (already used elsewhere in this repo for pnpm installs) to automatically retry up to 3 times before giving up, making the step resilient to these transient failures.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
