### PR TITLE
chore(automation): add wallet-cli label for apps/wallet-cli changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,6 +22,9 @@ automation:
 cli:
   - apps/cli/**/*
 
+wallet-cli:
+  - apps/wallet-cli/**/*
+
 translations:
   - apps/ledger-live-desktop/static/i18n/**/*
   - apps/ledger-live-mobile/src/locales/**/*


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** N/A — config-only change.
- [x] **Impact of the changes:**
  - PRs touching `apps/wallet-cli/**` will automatically receive the `wallet-cli` label, consistent with existing labels for `desktop`, `mobile`, `cli`, etc.

### 📝 Description

Adds a `wallet-cli` entry to `.github/labeler.yml` so the labeler workflow auto-tags PRs that modify files under `apps/wallet-cli/`.

### ❓ Context

- **JIRA or GitHub link**: N/A