### PR TITLE
[LWDM] chore(mobile,desktop): bump lumen-ui packages and migrate appearance to density

### DIFF
--- a/.changeset/lumen-density-breaking-change.md
+++ b/.changeset/lumen-density-breaking-change.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+Bump `@ledgerhq/lumen-ui-react` to `0.1.21` and `@ledgerhq/lumen-ui-rnative` to `0.1.22`, and rename the `appearance` prop to `density` on `NavBar`, `BottomSheetHeader`, and `DialogHeader` usages.

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/components/EditCryptoAddressNameDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/components/EditCryptoAddressNameDialog.tsx
@@ -71,7 +71,7 @@ export const EditCryptoAddressNameDialog = ({
         onPointerDownOutside={handlePointerDownOutside}
       >
         <DialogHeader
-          appearance="expanded"
+          density="expanded"
           title={t("cryptoAddresses.editName.title")}
           onClose={() => handleOpenChange(false)}
         />

--- a/apps/ledger-live-desktop/src/mvvm/features/FearAndGreed/components/FearAndGreedDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FearAndGreed/components/FearAndGreedDialog.tsx
@@ -20,7 +20,7 @@ export const FearAndGreedDialog = ({ children }: { children: React.ReactNode }) 
 
       <DialogContent data-testid="fear-and-greed-dialog-content">
         <DialogHeader
-          appearance="expanded"
+          density="expanded"
           title={t("fearAndGreed.dialog.title")}
           onClose={() => setOpen(false)}
         />

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/components/ExportResultScene.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryExportDialog/components/ExportResultScene.tsx
@@ -44,7 +44,7 @@ export function ExportResultScene({ variant, onAction }: Props) {
 
   return (
     <DialogContent>
-      <DialogHeader appearance="compact" className="relative" />
+      <DialogHeader density="compact" className="relative" />
       <DialogBody>
         <div className="flex flex-col items-center gap-24">
           <div

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/ModularDialogContent.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/ModularDialogContent.tsx
@@ -32,7 +32,7 @@ export const ModularDialogContent = ({
   return (
     <>
       <DialogHeader
-        appearance="expanded"
+        density="expanded"
         title={t(TranslationKeyMap[currentStep])}
         description={description}
         onClose={handleClose}

--- a/apps/ledger-live-desktop/src/mvvm/features/PtxInfoDialog/PtxInfoDialogView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PtxInfoDialog/PtxInfoDialogView.tsx
@@ -12,7 +12,7 @@ const PtxInfoDialogView = ({
 }: PtxInfoDialogViewProps) => (
   <Dialog open={isOpen} onOpenChange={onClose}>
     <DialogContent aria-describedby={undefined}>
-      <DialogHeader appearance="compact" title={title} onClose={onClose} />
+      <DialogHeader density="compact" title={title} onClose={onClose} />
       <DialogBody className="gap-0 px-24 pb-24">
         <p className="body-1 text-base whitespace-pre-line">
           {message}

--- a/apps/ledger-live-desktop/src/mvvm/features/Receive/screens/ReceiveOptions/ReceiveOptionsDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Receive/screens/ReceiveOptions/ReceiveOptionsDialog.tsx
@@ -17,7 +17,7 @@ export function ReceiveOptionsDialog({ onClose, onGoToAccount }: ReceiveOptionsD
     <Dialog open onOpenChange={open => !open && onClose()}>
       <DialogContent>
         <TrackPage category="receive_drawer" type="drawer" />
-        <DialogHeader appearance="expanded" title={t("receive.title")} />
+        <DialogHeader density="expanded" title={t("receive.title")} />
         <DialogBody className="px-16! pt-12">
           <ReceiveOptionsView onGoToBank={handleGoToBank} onGoToCrypto={handleGoToCrypto} />
         </DialogBody>

--- a/apps/ledger-live-desktop/src/mvvm/features/ReleaseNotes/ReleaseNotesDialogView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ReleaseNotes/ReleaseNotesDialogView.tsx
@@ -33,7 +33,7 @@ const ReleaseNotesDialogView = ({ isOpen, notes, onClose, onGotIt }: ReleaseNote
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-h-[90vh]" aria-describedby={undefined}>
-        <DialogHeader appearance="compact" title={t("releaseNotes.title")} onClose={onClose} />
+        <DialogHeader density="compact" title={t("releaseNotes.title")} onClose={onClose} />
         <DialogBody className="min-h-0 flex-1 gap-24 overflow-y-auto px-24">
           {releaseNoteImage ? (
             <img

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
@@ -187,7 +187,7 @@ export function SendHeader() {
     <div className="flex flex-col">
       <div data-testid="send-dialog-header">
         <DialogHeader
-          appearance="compact"
+          density="compact"
           title={title}
           description={descriptionText || undefined}
           onBack={showBackButton ? handleBack : undefined}

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletV4Tour/Drawer/WalletV4TourDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletV4Tour/Drawer/WalletV4TourDialog.tsx
@@ -60,7 +60,7 @@ export const WalletV4TourDialog = ({
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent className="flex h-screen min-h-0 flex-col">
-        <DialogHeader appearance="compact" onClose={onClose} />
+        <DialogHeader density="compact" onClose={onClose} />
         <Slides initialSlideIndex={0} onSlideChange={onSlideChange}>
           <Slides.Content>
             {slides.map((slide, index) => (

--- a/apps/ledger-live-mobile/src/components/RootNavigator/AccountsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/AccountsNavigator.tsx
@@ -78,22 +78,6 @@ function handleAccountsCryptoBackPress(
   nav.goBack();
 }
 
-function AccountsCryptoNavBarLeading() {
-  const navigation = useNavigation<NavType>();
-  const route = useRoute();
-  const onPress = useCallback(
-    (nav: NavType) => {
-      handleAccountsCryptoBackPress(nav, () => navigation.getState(), route.name);
-    },
-    [navigation, route.name],
-  );
-  return <NavigationHeaderBackButton onPress={onPress} />;
-}
-
-function renderAccountsCryptoNavBarLeading() {
-  return <AccountsCryptoNavBarLeading />;
-}
-
 export default function AccountsNavigator() {
   const { colors } = useTheme();
   const { theme: lumenTheme } = useLumenTheme();
@@ -121,9 +105,6 @@ export default function AccountsNavigator() {
     return {
       ...stackNavConfigV4Expanded,
       title: t("cryptoAddresses.title"),
-      lumenNavBar: {
-        renderLeading: renderAccountsCryptoNavBarLeading,
-      },
     };
   }, [stackNavConfigV4Expanded, t]);
 
@@ -138,31 +119,33 @@ export default function AccountsNavigator() {
         (cryptoRoute.params?.variant ?? "all") === "stablecoin"
           ? t("crypto.stablecoinTitle")
           : t("crypto.title"),
-      lumenNavBar: {
-        renderLeading: renderAccountsCryptoNavBarLeading,
-      },
     }),
     [stackNavConfigV4Expanded, t],
   );
 
   return (
-    <Stack.Navigator screenOptions={stackNavConfig}>
+    <Stack.Navigator>
       <Stack.Screen
         name={ScreenName.Accounts}
         component={readOnlyModeEnabled ? ReadOnlyAccounts : Accounts}
         options={{
+          ...stackNavConfig,
           headerShown: false,
         }}
       />
       <Stack.Screen
         name={ScreenName.Account}
         component={readOnlyModeEnabled ? ReadOnlyAccount : Account}
-        options={{ headerShown: false }}
+        options={{
+          ...stackNavConfig,
+          headerShown: false,
+        }}
       />
       <Stack.Screen
         name={ScreenName.Assets}
         component={readOnlyModeEnabled ? ReadOnlyAssets : Assets}
         options={{
+          ...stackNavConfig,
           headerShown: false,
         }}
       />
@@ -171,6 +154,7 @@ export default function AccountsNavigator() {
           name={ScreenName.AccountsList}
           component={AccountsList}
           options={{
+            ...stackNavConfig,
             headerTitle: "",
             headerLeft: () => <NavigationHeaderBackButton onPress={onPressBack} />,
             headerRight: () => <AccountsListHeaderRight />,
@@ -191,6 +175,7 @@ export default function AccountsNavigator() {
         name={ScreenName.Asset}
         component={readOnlyModeEnabled ? ReadOnlyAsset : Asset}
         options={{
+          ...stackNavConfig,
           headerShown: false,
         }}
       />

--- a/apps/ledger-live-mobile/src/mvvm/components/Navigation/NavBarHeader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/Navigation/NavBarHeader.tsx
@@ -11,7 +11,6 @@ import {
   NavBarDescription,
   NavBarTitle,
   NavBarTrailing,
-  type NavBarAppearance,
 } from "@ledgerhq/lumen-ui-rnative";
 import type { TextStyle } from "react-native";
 import HeaderBackButton from "./HeaderBackButton";
@@ -19,11 +18,12 @@ import type {
   LumenNavBarScreenOptions,
   LumenNativeStackNavigationOptions,
   LumenStackNavBarDefaults,
+  NavBarDensity,
 } from "./lumenNativeStack";
 
 type NavBarHeaderProps = Omit<NativeStackHeaderProps, "options"> & {
   options: LumenNativeStackNavigationOptions;
-  appearance?: NavBarAppearance;
+  density?: NavBarDensity;
   navBarDefaults?: LumenStackNavBarDefaults;
 };
 
@@ -31,8 +31,8 @@ const defaultRenderLeading: NonNullable<LumenNativeStackNavigationOptions["heade
   <HeaderBackButton testID="navigation-header-back-button" />
 );
 
-const getNavBarTitleStyle = (appearance: NavBarAppearance): TextStyle => {
-  if (appearance === "expanded") {
+const getNavBarTitleStyle = (density: NavBarDensity): TextStyle => {
+  if (density === "expanded") {
     return { textAlign: "left" };
   }
   return { textAlign: "center" };
@@ -65,7 +65,7 @@ function renderNavBarCenter(title: string, lumen: LumenNavBarScreenOptions | und
 export default function NavBarHeader({
   options,
   route,
-  appearance: stackAppearance = "compact",
+  density: stackDensity = "compact",
   navBarDefaults,
 }: NavBarHeaderProps) {
   const insets = useSafeAreaInsets();
@@ -75,9 +75,9 @@ export default function NavBarHeader({
   const lumen = options.lumenNavBar;
   const HeaderLeft = lumen?.renderLeading ?? options.headerLeft ?? defaultRenderLeading;
   const HeaderRight = lumen?.renderTrailing ?? options.headerRight;
-  const effectiveAppearance = lumen?.appearance ?? stackAppearance;
+  const effectiveDensity = lumen?.density ?? stackDensity;
 
-  const navBarTitleStyle = getNavBarTitleStyle(effectiveAppearance);
+  const navBarTitleStyle = getNavBarTitleStyle(effectiveDensity);
   const title = getHeaderTitle(options, route.name);
 
   const { style: contentStyle, ...navBarContentRest } = lumen?.navBarContentProps ?? {};
@@ -92,11 +92,7 @@ export default function NavBarHeader({
         options.headerStyle,
       ]}
     >
-      <NavBar
-        appearance={effectiveAppearance}
-        {...navBarDefaults?.navBarProps}
-        {...lumen?.navBarProps}
-      >
+      <NavBar density={effectiveDensity} {...navBarDefaults?.navBarProps} {...lumen?.navBarProps}>
         {HeaderLeft && (
           <NavBarBackButtonSlot>
             <HeaderLeft />

--- a/apps/ledger-live-mobile/src/mvvm/components/Navigation/getStackNavigationConfigV4.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/Navigation/getStackNavigationConfigV4.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import type { LumenStyleSheetTheme } from "@ledgerhq/lumen-ui-rnative/styles";
-import type { NavBarAppearance } from "@ledgerhq/lumen-ui-rnative";
 import HeaderTitle from "./HeaderTitle";
 import NavBarHeader from "./NavBarHeader";
 import NavigationHeaderCloseButton from "./HeaderCloseButton";
 import type {
   LumenNativeStackNavigationOptions,
   LumenStackNavBarDefaults,
+  NavBarDensity,
 } from "./lumenNativeStack";
 
 export type {
@@ -28,7 +28,7 @@ export const defaultNavigationOptions: Partial<LumenNativeStackNavigationOptions
 
 export type GetLumenStackScreenOptionsParams = {
   theme: Pick<LumenStyleSheetTheme, "colors">;
-  appearance?: NavBarAppearance;
+  density?: NavBarDensity;
   closable?: boolean;
   onClose?: () => void;
   isOnboarding?: boolean;
@@ -37,7 +37,7 @@ export type GetLumenStackScreenOptionsParams = {
 
 export function getLumenStackScreenOptions({
   theme,
-  appearance = "compact",
+  density = "compact",
   closable = false,
   onClose,
   isOnboarding,
@@ -55,9 +55,7 @@ export function getLumenStackScreenOptions({
     headerTitleStyle: {
       color: theme.colors.text.base,
     },
-    header: props => (
-      <NavBarHeader {...props} appearance={appearance} navBarDefaults={navBarDefaults} />
-    ),
+    header: props => <NavBarHeader {...props} density={density} navBarDefaults={navBarDefaults} />,
     ...(closable
       ? {
           lumenNavBar: isOnboarding
@@ -70,7 +68,7 @@ export function getLumenStackScreenOptions({
 
 export const getStackNavigationConfigV4 = (
   theme: Pick<LumenStyleSheetTheme, "colors">,
-  appearance: NavBarAppearance = "compact",
+  density: NavBarDensity = "compact",
   closable = false,
   onClose?: () => void,
   isOnboarding?: boolean,
@@ -78,7 +76,7 @@ export const getStackNavigationConfigV4 = (
 ): Partial<LumenNativeStackNavigationOptions> =>
   getLumenStackScreenOptions({
     theme,
-    appearance,
+    density,
     closable,
     onClose,
     isOnboarding,

--- a/apps/ledger-live-mobile/src/mvvm/components/Navigation/lumenNativeStack.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/Navigation/lumenNativeStack.ts
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 import type { NativeStackNavigationOptions } from "@react-navigation/native-stack";
 
 import type {
-  NavBarAppearance,
   NavBarCoinCapsuleProps,
   NavBarContentProps,
   NavBarDescriptionProps,
@@ -11,9 +10,11 @@ import type {
   NavBarTrailingProps,
 } from "@ledgerhq/lumen-ui-rnative";
 
+export type NavBarDensity = NavBarProps["density"];
+
 export type LumenNavBarScreenOptions = {
-  appearance?: NavBarAppearance;
-  navBarProps?: Omit<NavBarProps, "appearance" | "children">;
+  density?: NavBarDensity;
+  navBarProps?: Omit<NavBarProps, "density" | "children">;
   navBarContentProps?: Omit<NavBarContentProps, "children">;
   navBarTitleProps?: Omit<NavBarTitleProps, "children">;
   navBarDescriptionProps?: Omit<NavBarDescriptionProps, "children">;
@@ -26,7 +27,7 @@ export type LumenNavBarScreenOptions = {
 };
 
 export type LumenStackNavBarDefaults = {
-  navBarProps?: Omit<NavBarProps, "appearance" | "children">;
+  navBarProps?: Omit<NavBarProps, "density" | "children">;
 };
 
 export type LumenNativeStackNavigationOptions = NativeStackNavigationOptions & {

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/SyncErrorBottomSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/SyncErrorBottomSheet/index.tsx
@@ -24,7 +24,7 @@ export function SyncErrorBottomSheet({
   return (
     <QueuedDrawerBottomSheet isRequestingToBeOpened={isOpen} onClose={onClose} enableDynamicSizing>
       <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
-        <BottomSheetHeader appearance="compact" />
+        <BottomSheetHeader density="compact" />
         <SyncErrorBottomSheetContent
           onClose={onClose}
           listOfErrorAccountNames={listOfErrorAccountNames}

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AccountSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AccountSelection/index.tsx
@@ -91,7 +91,7 @@ const AccountSelectionContent = ({
     <>
       <TrackDrawerScreen page={EVENTS_NAME.MODULAR_ACCOUNT_SELECTION} flow={flow} source={source} />
       {useLumenBottomSheet && (
-        <BottomSheetHeader spacing title={t("modularDrawer.selectAccount")} appearance="expanded" />
+        <BottomSheetHeader spacing title={t("modularDrawer.selectAccount")} density="expanded" />
       )}
       <BottomSheetVirtualizedList
         ref={listRef}

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -184,7 +184,7 @@ const AssetSelection = ({
             spacing
             title={t("modularDrawer.selectAsset")}
             testID="modular-drawer-Asset-title"
-            appearance="expanded"
+            density="expanded"
           />
           <SearchInputContainer
             source={source}

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/index.tsx
@@ -98,7 +98,7 @@ const NetworkSelection = ({
         formatNetworkConfig
       />
       {useLumenBottomSheet && (
-        <BottomSheetHeader spacing title={t("modularDrawer.selectNetwork")} appearance="expanded" />
+        <BottomSheetHeader spacing title={t("modularDrawer.selectNetwork")} density="expanded" />
       )}
       <BottomSheetFlatList
         scrollEnabled={true}

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/TransferDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/TransferDrawerView.tsx
@@ -12,7 +12,7 @@ interface TransferDrawerViewProps {
 export const TransferDrawerView = ({ actions, title, bottomInset }: TransferDrawerViewProps) => {
   return (
     <BottomSheetView style={{ paddingBottom: bottomInset + 24, paddingHorizontal: 16 }}>
-      <BottomSheetHeader title={title} appearance="expanded" />
+      <BottomSheetHeader title={title} density="expanded" />
       <Box
         style={{ marginHorizontal: -8 }}
         testID={QUICK_ACTIONS_TEST_IDS.transferDrawer.container}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
@@ -137,7 +137,7 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
 
       <BottomSheet ref={infoBottomSheetRef} snapPoints="small">
         <BottomSheetView>
-          <BottomSheetHeader title={viewModel.label} appearance="compact" />
+          <BottomSheetHeader title={viewModel.label} density="compact" />
           <View style={styles.infoContent}>
             <Text typography="body2" lx={{ color: "muted" }} style={styles.infoDescription}>
               {t("send.newSendFlow.feesPaid")}
@@ -151,7 +151,7 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
 
       <BottomSheet ref={selectorBottomSheetRef} snapPoints="medium">
         <BottomSheetView>
-          <BottomSheetHeader title={viewModel.label} appearance="compact" />
+          <BottomSheetHeader title={viewModel.label} density="compact" />
 
           {viewModel.feePresetLabelsOptions.map(option => {
             const isSelected = viewModel.selectedFeeStrategy === option.id;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
@@ -47,7 +47,7 @@ export function SendHeader({ headerRight }: SendHeaderProps) {
 
   return (
     <>
-      <NavBar appearance="compact">
+      <NavBar density="compact">
         {viewModel.canGoBack ? (
           <NavBarBackButton
             onPress={viewModel.handleBackPress}

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/LanguageSelect.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/LanguageSelect.tsx
@@ -143,7 +143,7 @@ const LanguageSelect = () => {
           <BottomSheetHeader
             spacing
             title={t("syncOnboarding.languageSelect.title")}
-            appearance="expanded"
+            density="expanded"
           />
           <LumenBottomSheetScrollView contentContainerStyle={{ paddingBottom: 24 }}>
             <SelectableList currentValue={currentLocale} onChange={handleLanguageSelectOnChange}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,14 +52,14 @@ catalogs:
       specifier: 1.2.3
       version: 1.2.3
     '@ledgerhq/lumen-design-core':
-      specifier: 0.1.9
-      version: 0.1.9
+      specifier: 0.1.10
+      version: 0.1.10
     '@ledgerhq/lumen-ui-react':
-      specifier: 0.1.20
-      version: 0.1.20
+      specifier: 0.1.21
+      version: 0.1.21
     '@ledgerhq/lumen-ui-rnative':
-      specifier: 0.1.20
-      version: 0.1.20
+      specifier: 0.1.22
+      version: 0.1.22
     '@ledgerhq/speculos-device-controller':
       specifier: 0.2.3
       version: 0.2.3
@@ -546,7 +546,7 @@ importers:
         version: link:tools/create-release-hash
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.9
+        version: 0.1.10
       '@ledgerhq/pnpm-utils':
         specifier: workspace:*
         version: link:tools/pnpm-utils
@@ -978,10 +978,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.9
+        version: 0.1.10
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.20(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.21(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -1637,10 +1637,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.9
+        version: 0.1.10
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.20(86429e051cab61f3619270fef622fc08)
+        version: 0.1.22(21e9a359707e785152ab2c1431c8d633)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -2444,10 +2444,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.9
+        version: 0.1.10
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.20(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.21(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -3070,13 +3070,13 @@ importers:
         version: 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.9
+        version: 0.1.10
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.20(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
+        version: 0.1.21(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.20(c93f8ced60089c42caa4a9162fe9ed8c)
+        version: 0.1.22(3b894868e64c416e231ac1b4ac49c4bc)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -16884,11 +16884,11 @@ packages:
   '@ledgerhq/logs@6.14.0':
     resolution: {integrity: sha512-kJFu1+asWQmU9XlfR1RM3lYR76wuEoPyZvkI/CNjpft78BQr3+MMf3Nu77ABzcKFnhIcmAkOLlDQ6B8L6hDXHA==}
 
-  '@ledgerhq/lumen-design-core@0.1.9':
-    resolution: {integrity: sha512-vFhej/eWrfbrhB/Jd7/8yMBMcSU95vYcrTnR0e0PtEbX4H4fyEPCOcfiFPMyNGNlqnynzMyLjQVpmLqXF08rdA==}
+  '@ledgerhq/lumen-design-core@0.1.10':
+    resolution: {integrity: sha512-DRgwcloCDixf/ctP1OaDyvMIxgUjUH2GgkwAxUAAnWoGThUgitvVAi4dVLEExDtEBzgpvJQeK9kF5TCKbL+HoQ==}
 
-  '@ledgerhq/lumen-ui-react@0.1.20':
-    resolution: {integrity: sha512-YO5eTV9alSATkVE9qDIZgnlZhLU6/9qZjHyL6pEvOhWhUPRr5BpeLQJ15agxm7h7GZPn+fXay0p3yejpPSSSFQ==}
+  '@ledgerhq/lumen-ui-react@0.1.21':
+    resolution: {integrity: sha512-YwZomvqbJBoi7dF1ld8uRriW95LkpyqPyC+HgeUE9KFcTFwt/Jip8EiM3OPn8lye/DN2gT21u8dKDdnktF6E9A==}
     peerDependencies:
       '@base-ui/react': ^1.3.0
       '@radix-ui/react-checkbox': ^1.3.2
@@ -16904,8 +16904,8 @@ packages:
       react-dom: 19.0.0
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-rnative@0.1.20':
-    resolution: {integrity: sha512-p3taJHEIUdvJW719UaE44ErNfakLip3cOge5Q5NsEw9WcDxeaIe2sIcr4qu6X2QNgidTfjbgRXyqqftLLoTeOg==}
+  '@ledgerhq/lumen-ui-rnative@0.1.22':
+    resolution: {integrity: sha512-ViIGYK2q+x5MLAG0Jkhk9Dn1Mqw6Db5reu5VfPycKVDCFe9oAXgG/Kuk+Xjz5cLhfyEmEzB6VjfEpa0aRICuPg==}
     peerDependencies:
       '@gorhom/bottom-sheet': ^5.0.0
       '@ledgerhq/lumen-design-core': 0.1.10
@@ -45260,12 +45260,12 @@ snapshots:
 
   '@ledgerhq/logs@6.14.0': {}
 
-  '@ledgerhq/lumen-design-core@0.1.9':
+  '@ledgerhq/lumen-design-core@0.1.10':
     dependencies:
       tailwindcss: 4.1.18
       tslib: 2.6.2
 
-  '@ledgerhq/lumen-ui-react@0.1.20(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.21(@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.0.0))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/react-table@8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -45285,7 +45285,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.20(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.21(clsx@2.1.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(tailwind-merge@3.4.0)':
     dependencies:
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       clsx: 2.1.1
@@ -45297,10 +45297,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-rnative@0.1.20(86429e051cab61f3619270fef622fc08)':
+  '@ledgerhq/lumen-ui-rnative@0.1.22(21e9a359707e785152ab2c1431c8d633)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(beb07f7799bea5989bf46dbe8fcef3d9)
-      '@ledgerhq/lumen-design-core': 0.1.9
+      '@ledgerhq/lumen-design-core': 0.1.10
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       '@sbaiahmed1/react-native-blur': 4.5.5(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@types/react': 19.0.14
@@ -45316,10 +45316,10 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.20(c93f8ced60089c42caa4a9162fe9ed8c)':
+  '@ledgerhq/lumen-ui-rnative@0.1.22(3b894868e64c416e231ac1b4ac49c4bc)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.1.6(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
-      '@ledgerhq/lumen-design-core': 0.1.9
+      '@ledgerhq/lumen-design-core': 0.1.10
       '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
       '@types/react': 19.0.14
       i18next: 23.10.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,9 +31,9 @@ catalog:
   "@ledgerhq/signer-utils": 1.1.3
   "@ledgerhq/device-transport-kit-web-hid": 1.2.3
   "@ledgerhq/speculos-device-controller": 0.2.3
-  "@ledgerhq/lumen-design-core": 0.1.9
-  "@ledgerhq/lumen-ui-react": 0.1.20
-  "@ledgerhq/lumen-ui-rnative": 0.1.20
+  "@ledgerhq/lumen-design-core": 0.1.10
+  "@ledgerhq/lumen-ui-react": 0.1.21
+  "@ledgerhq/lumen-ui-rnative": 0.1.22
   # React Native
   react-native: 0.79.7
   "@react-native/assets-registry": 0.79.7


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Dependency bump and prop rename; no new tests added._
- [x] **Impact of the changes:**
      - Mobile: stack navigation and NavBar, accounts navigator, modular drawers, send flow headers and network fees, sync error bottom sheet, onboarding language screen
      - Desktop: dialog headers across send, receive, export, release notes, wallet tour, modular dialogs, and related flows

### 📝 Description

**Problem:** Lumen UI replaced the `appearance` prop with `density` on navigation and dialog surfaces. The monorepo catalog needed to match the published packages: `@ledgerhq/lumen-ui-react` at `0.1.21` and `@ledgerhq/lumen-ui-rnative` at `0.1.22` (not `0.1.21`).

**Solution:** Bump the catalog versions and lockfile, then migrate call sites from `appearance` to `density` on `NavBar`, `BottomSheetHeader`, and `DialogHeader` usages. Mobile stack navigation options were updated to use `density` in line with the new API.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29280](https://ledgerhq.atlassian.net/browse/LIVE-29280) & [LIVE-29155](https://ledgerhq.atlassian.net/browse/LIVE-29155) 

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29280]: https://ledgerhq.atlassian.net/browse/LIVE-29280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ