### PR TITLE
[LWDM] fix validateIntent logic to account for locked funds and update…

### DIFF
--- a/.changeset/brave-eagle-whistle.md
+++ b/.changeset/brave-eagle-whistle.md
@@ -1,6 +1,7 @@
 ---
 "@ledgerhq/live-common": patch
 "@ledgerhq/coin-evm": patch
+"ledger-live-desktop": minor
 ---
 
 Fix balance semantics in generic-alpaca extractBalances: expose total balance as `value` and non-spendable part as `locked`, restoring staking flows (e.g. Solana stake withdraw fee covered by the unstake reserve). Update coin-evm `computeAmount`/`validateAmount` to compute spendable funds as `value - locked`, preserving the existing EVM send-all behavior for staking-enabled accounts.

--- a/.changeset/brave-eagle-whistle.md
+++ b/.changeset/brave-eagle-whistle.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"@ledgerhq/coin-evm": patch
+---
+
+Fix balance semantics in generic-alpaca extractBalances: expose total balance as `value` and non-spendable part as `locked`, restoring staking flows (e.g. Solana stake withdraw fee covered by the unstake reserve). Update coin-evm `computeAmount`/`validateAmount` to compute spendable funds as `value - locked`, preserving the existing EVM send-all behavior for staking-enabled accounts.

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
@@ -681,6 +681,32 @@ describe("validateIntent", () => {
           );
         });
 
+        it("includes additionalFees (L2 L1-data fee) when deciding NotEnoughGas", async () => {
+          // gas fee alone fits in the available balance, but the additionalFees
+          // (e.g. L1 data fee on L2s) push the total above the native balance.
+          const res = await validateIntent(
+            { units: [{ code: "ETH", name: "ETH", magnitude: 18 }] } as CryptoCurrency,
+            createIntent({ recipient: "recipient-address" }),
+            [{ value: 10n, asset: { type: "native" } }],
+            {
+              value: 9n,
+              parameters: {
+                gasLimit: 9n,
+                gasPrice: 1n,
+                maxFeePerGas: 1n,
+                maxPriorityFeePerGas: 1n,
+                additionalFees: 5n,
+              },
+            },
+          );
+
+          expect(res.errors).toEqual(
+            expect.objectContaining({
+              gasPrice: new NotEnoughGas(),
+            }),
+          );
+        });
+
         it("if the recipient has not been set, does not detect gas being too high", async () => {
           const notEnoughBalanceRes = await validateIntent(
             { units: [{ code: "ETH", name: "ETH", magnitude: 18 }] } as CryptoCurrency,

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
@@ -357,6 +357,56 @@ describe("validateIntent", () => {
         }),
       );
     });
+
+    it("detects NotEnoughBalance when spending would dip into locked funds", async () => {
+      const res = await validateIntent(
+        {} as CryptoCurrency,
+        eip1559Intent({
+          recipient: "0xe2ca7390e76c5A992749bB622087310d2e63ca29",
+          amount: 60n,
+          asset: { type: "native" },
+        }),
+        [{ value: 100n, locked: 50n, asset: { type: "native" } }],
+        {
+          value: 5n,
+          parameters: { gasLimit: 1n, maxFeePerGas: 5n, maxPriorityFeePerGas: 1n },
+        },
+      );
+
+      expect(res.errors).toEqual(
+        expect.objectContaining({
+          amount: new NotEnoughBalance(),
+        }),
+      );
+    });
+
+    it("computes useAllAmount on a locked native balance as value - locked - fees", async () => {
+      jest.spyOn(ledgerExplorer, "getOperations").mockResolvedValue({
+        lastCoinOperations: [],
+        lastInternalOperations: [],
+        lastNftOperations: [],
+        lastTokenOperations: [],
+        nextPagingToken: "",
+      });
+
+      const res = await validateIntent(
+        {} as CryptoCurrency,
+        legacyIntent({
+          recipient: "0xe2ca7390e76c5A992749bB622087310d2e63ca29",
+          useAllAmount: true,
+          asset: { type: "native" },
+        }),
+        [{ value: 20000000n, locked: 8000000n, asset: { type: "native" } }],
+        {
+          value: 105000n,
+          parameters: { gasLimit: 21000n, gasPrice: 5n },
+        },
+      );
+
+      expect(res.errors).toEqual({});
+      expect(res.amount).toBe(20000000n - 8000000n - 105000n);
+      expect(res.totalSpent).toBe(20000000n - 8000000n);
+    });
   });
 
   describe("staking", () => {

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
@@ -137,6 +137,11 @@ async function validateGas(
   const warnings: Record<string, Error> = {};
 
   const nativeBalance = findBalance({ type: "native" }, balances);
+  const additionalFees =
+    typeof estimatedFees.parameters?.additionalFees === "bigint"
+      ? estimatedFees.parameters.additionalFees
+      : 0n;
+  const totalFees = estimatedFees.value + additionalFees;
 
   const gasLimit =
     typeof estimatedFees.parameters?.gasLimit === "bigint" ? estimatedFees.parameters.gasLimit : 0n;
@@ -177,15 +182,12 @@ async function validateGas(
     errors.gasPrice = new FeeNotLoaded();
   } else if (
     intent.recipient &&
-    estimatedFees.value > nativeBalance.value - (nativeBalance.locked ?? 0n) &&
+    totalFees > nativeBalance.value - (nativeBalance.locked ?? 0n) &&
     !intent.sponsored
   ) {
     errors.gasPrice = new NotEnoughGas(undefined, {
       // "You need {{fees}} {{ticker}} for network fees to swap as you are on {{cryptoName}} network. <link0>Buy {{ticker}}</link0>"
-      fees: formatCurrencyUnit(
-        getFeesUnit(currency),
-        new BigNumber(estimatedFees.value.toString()),
-      ),
+      fees: formatCurrencyUnit(getFeesUnit(currency), new BigNumber(totalFees.toString())),
       ticker: currency.ticker,
       cryptoName: currency.name,
       links: ["ledgerlive://buy"],

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
@@ -71,7 +71,8 @@ async function validateAmount(
     return { errors: { amount: new AmountRequired() }, warnings: {} };
   }
 
-  if (totalSpent > balance.value) {
+  const available = balance.value - (balance.locked ?? 0n);
+  if (totalSpent > available) {
     return { errors: { amount: new NotEnoughBalance() }, warnings: {} };
   }
 
@@ -174,7 +175,11 @@ async function validateGas(
   // Gas Price
   if (!(hasLegacyGasPrice || hasEip1559GasPrice)) {
     errors.gasPrice = new FeeNotLoaded();
-  } else if (intent.recipient && estimatedFees.value > nativeBalance.value && !intent.sponsored) {
+  } else if (
+    intent.recipient &&
+    estimatedFees.value > nativeBalance.value - (nativeBalance.locked ?? 0n) &&
+    !intent.sponsored
+  ) {
     errors.gasPrice = new NotEnoughGas(undefined, {
       // "You need {{fees}} {{ticker}} for network fees to swap as you are on {{cryptoName}} network. <link0>Buy {{ticker}}</link0>"
       fees: formatCurrencyUnit(
@@ -286,6 +291,8 @@ function computeAmount(
 ): bigint {
   if (!intent.useAllAmount) return intent.amount;
 
+  const available = balance.value - (balance.locked ?? 0n);
+
   if (isNative(intent.asset)) {
     const additionalFees =
       typeof estimatedFees.parameters?.additionalFees === "bigint"
@@ -293,10 +300,10 @@ function computeAmount(
         : 0n;
     const totalFees = estimatedFees.value + additionalFees;
 
-    return balance.value > totalFees ? balance.value - totalFees : 0n;
+    return available > totalFees ? available - totalFees : 0n;
   }
 
-  return balance.value;
+  return available;
 }
 
 function refreshEstimationValue(

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/tests/estimateMaxSpendable.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/tests/estimateMaxSpendable.test.ts
@@ -52,7 +52,7 @@ describe("genericEstimateMaxSpendable", () => {
     expect(result.toString()).toBe("49990000");
     expect(validateIntentMock).toHaveBeenCalledWith(
       expect.anything(),
-      [{ value: 50000000n, locked: 0n, asset: { type: "native" } }],
+      [{ value: 60000000n, locked: 10000000n, asset: { type: "native" } }],
       expect.anything(),
     );
   });

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/utils.test.ts
@@ -437,7 +437,7 @@ describe("Alpaca utils", () => {
           spendableBalance: BigNumber(8),
           balance: BigNumber(10),
         } as unknown as Account),
-      ).toEqual([{ value: 8n, locked: 0n, asset: { type: "native" } }]);
+      ).toEqual([{ value: 10n, locked: 2n, asset: { type: "native" } }]);
     });
 
     it("extracts native and token balances", () => {
@@ -469,8 +469,8 @@ describe("Alpaca utils", () => {
             assetReference: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
             type: "erc20",
           },
-          locked: 0n,
-          value: 11n,
+          locked: 9n,
+          value: 20n,
         },
       ]);
     });

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/utils.ts
@@ -68,11 +68,11 @@ export function extractBalances(
 ): Balance[] {
   const balances: Balance[] = [
     {
-      // Send flows expect spendable balances here. Using the account total balance
-      // makes `useAllAmount` include staked/locked funds for staking-enabled EVM accounts.
-      value: BigInt(account.spendableBalance.toFixed()),
+      // `value` is the total balance, `locked` is the non-spendable part of it.
+      // Consumers must compute available funds as `value - locked`.
+      value: BigInt(account.balance.toFixed()),
       asset: { type: "native" },
-      locked: 0n,
+      locked: BigInt(BigNumber.max(account.balance.minus(account.spendableBalance), 0).toFixed()),
     },
   ];
 
@@ -83,9 +83,11 @@ export function extractBalances(
   for (const subAccount of account.subAccounts) {
     const asset = getAssetFromToken(subAccount.token, account.freshAddress);
     balances.push({
-      value: BigInt(subAccount.spendableBalance.toFixed()),
+      value: BigInt(subAccount.balance.toFixed()),
       asset,
-      locked: 0n,
+      locked: BigInt(
+        BigNumber.max(subAccount.balance.minus(subAccount.spendableBalance), 0).toFixed(),
+      ),
     });
   }
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - All coin families using the `generic-alpaca` bridge: `Balance` contract restored (`value` = total, `locked` = non-spendable part).
  - `coin-evm`: native send-max and balance checks now compute `available = value - locked`, preserving the intent of PR #16326 (delegated funds excluded from send-max).
  - QA focus: Solana stake withdraw/deactivate, EVM send-max on staking chains (SEI).

### 📝 Description

PR #16326 changed `extractBalances` in `generic-alpaca/utils.ts` to fix an EVM send-max bug on SEI (delegated funds were incorrectly included). The fix exposed `spendableBalance` as `value` and forced `locked = 0n`, violating the `Balance` contract (`value` = total on-chain, `locked` = non-spendable part of `value`).

As a result, every family plugged into `generic-alpaca` loses the `locked` signal. The Solana coin-tester "Withdraw From Stake Account" scenario (`generic-adapter` strategy) fails with `NotEnoughBalance` because the `unstakeReserve` — which covers the withdraw fee — is no longer visible through `locked`.

This PR:
- Restores `extractBalances` semantics (native + sub-accounts): `value = balance`, `locked = balance - spendableBalance`.
- Fixes `coin-evm` `computeAmount` / `validateAmount` to compute `available = value - (locked ?? 0n)`. EVM native send-max keeps the intent of PR #16326 without breaking the `Balance` contract.
- Updates impacted tests (`utils.test.ts`, `estimateMaxSpendable.test.ts`) and adds two regression tests in `coin-evm/validateIntent.test.ts` covering `locked > 0`.

#### Validation
- `@ledgerhq/coin-evm`: 68/68 tests OK.
- `@ledgerhq/coin-solana` `validateIntent`: 29/29 tests OK.
- `@ledgerhq/live-common`: 262 suites / 2502 tests OK.
- Coin-tester Solana: both `legacy` and `generic-adapter` strategies pass, including "Withdraw From Stake Account".
- Coin-tester EVM: 8/8 scenarios pass (Ethereum, Sonic, Polygon, Core, Scroll, Blast, Base, BNB), all "Send Max" included.

### ❓ Context

- **JIRA**: LIVE-29284
- **Regression introduced by**: PR #16326 / commit fca6219737
  (original ticket LIVE-29170)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)