### PR TITLE
[LWD] fix(desktop): prevent Live Apps from launching external OS apps via custom URL schemes [LIVE-29182]

### DIFF
--- a/.changeset/tiny-icons-yawn.md
+++ b/.changeset/tiny-icons-yawn.md
@@ -1,0 +1,8 @@
+---
+"ledger-live-desktop": minor
+---
+
+Prevent Live Apps from launching external OS apps via custom URL schemes.
+
+Harden Live App <webview> guests against Chromium external-protocol handoff (itms-apps:, ms-word:, file:, ...) across every navigation vector: iframe src, window.open, window.location, HTTP 3xx redirects, subframe navigations and form submissions.
+A restrictive frame-src / child-src / form-action CSP is injected on every guest document response, preserving any CSP already set by the Live App. Ledger Live's own ledgerlive: / ledgerwallet: deep links remain allowed.

--- a/apps/ledger-live-desktop/src/main/index.ts
+++ b/apps/ledger-live-desktop/src/main/index.ts
@@ -2,16 +2,7 @@ import fs from "fs";
 import path from "path";
 import "./starts-console";
 import "./setup"; // Needs to be imported first
-import {
-  app,
-  Menu,
-  ipcMain,
-  session,
-  webContents,
-  type BrowserWindow,
-  dialog,
-  protocol,
-} from "electron";
+import { app, Menu, ipcMain, session, type BrowserWindow, dialog, protocol } from "electron";
 import Store from "electron-store";
 import menu from "./menu";
 import {
@@ -36,8 +27,7 @@ import {
   setupZcashNativeHost,
   cleanupZcashNativeHost,
 } from "@ledgerhq/zcash-shielded/ipc/main-host";
-import { openURL } from "./openURL";
-import { isUrlAllowedByManifestDomains } from "@ledgerhq/live-common/wallet-api/manifestDomainUtils";
+import { setupWebviewHandlers } from "./webviewHandlers";
 // End import timing, start initialization
 console.timeEnd("T-imports");
 console.time("T-init");
@@ -183,54 +173,7 @@ app.on("ready", async () => {
   ipcMain.handle("set-sentry-tags", (event, tags) => {
     setTags(tags);
   });
-
-  // Tracks the active will-navigate handler per WebContents id so we can remove only
-  // that specific listener on subsequent dom-ready events, without disturbing any other
-  // will-navigate listeners that may exist on the same WebContents.
-  const willNavigateHandlers = new Map<number, (event: Electron.Event, url: string) => void>();
-
-  // To handle opening new windows from webview
-  // cf. https://gist.github.com/codebytere/409738fcb7b774387b5287db2ead2ccb
-  ipcMain.on("webview-dom-ready", (_, id: number, domains?: string[]) => {
-    const wc = webContents.fromId(id);
-
-    if (!wc) return;
-
-    wc.setWindowOpenHandler(({ url }) => {
-      const protocol = new URL(url).protocol;
-      if (["https:", "http:"].includes(protocol)) {
-        openURL(url);
-      }
-      return {
-        action: "deny",
-      };
-    });
-
-    // dom-ready fires on every reload — remove only the previously registered handler
-    // for this WebContents to avoid listener accumulation without touching other listeners.
-    const previousHandler = willNavigateHandlers.get(id);
-    if (previousHandler) {
-      wc.off("will-navigate", previousHandler);
-      willNavigateHandlers.delete(id);
-    }
-
-    // When manifest domains are provided (feature flag on), enforce origin whitelist on navigation
-    if (Array.isArray(domains) && domains.length > 0) {
-      const handler = (event: Electron.Event, url: string) => {
-        if (!isUrlAllowedByManifestDomains(url, domains)) {
-          event.preventDefault();
-        }
-      };
-      wc.on("will-navigate", handler);
-      willNavigateHandlers.set(id, handler);
-
-      // Guard against the WebContents being destroyed before the next dom-ready
-      // (e.g. webview unmounted or window closed) so the Map entry doesn't leak.
-      wc.once("destroyed", () => {
-        willNavigateHandlers.delete(id);
-      });
-    }
-  });
+  setupWebviewHandlers(SUPPORTED_SCHEMES);
   Menu.setApplicationMenu(menu);
 
   // Apply window parameters now that we have DB data
@@ -382,8 +325,8 @@ async function installExtensions() {
   });
 }
 
-function clearSessionCache(session: Electron.Session): Promise<void> {
-  return session.clearCache();
+function clearSessionCache(targetSession: Electron.Session): Promise<void> {
+  return targetSession.clearCache();
 }
 function show(win: BrowserWindow) {
   win.show();

--- a/apps/ledger-live-desktop/src/main/webviewHandlers.helpers.test.ts
+++ b/apps/ledger-live-desktop/src/main/webviewHandlers.helpers.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  WEBVIEW_GUEST_CSP,
+  createLiveAppSchemeChecker,
+  mergeCspHeaders,
+} from "./webviewHandlers.helpers";
+
+describe("createLiveAppSchemeChecker", () => {
+  const isAllowed = createLiveAppSchemeChecker(["ledgerlive", "ledgerwallet"]);
+
+  describe("allowed schemes", () => {
+    it.each([
+      ["https://example.com"],
+      ["https://app.example.com/path?q=1"],
+      ["http://localhost:3000"],
+      ["about:blank"],
+      ["ledgerlive://discover"],
+      ["ledgerwallet://deeplink"],
+    ])("allows %s", url => {
+      expect(isAllowed(url)).toBe(true);
+    });
+  });
+
+  describe("blocked schemes", () => {
+    it.each([
+      ["itms-apps://itunes.apple.com/app/id1234"],
+      ["ms-word://open?file=..."],
+      ["ms-notepad://"],
+      ["ms-paint://"],
+      ["file:///etc/passwd"],
+      ["javascript:alert(1)"],
+      ["mailto:foo@bar.com"],
+      ["ftp://example.com"],
+      ["data:text/html,<h1>hi</h1>"],
+      ["blob:https://example.com/abc-123"],
+    ])("blocks %s", url => {
+      expect(isAllowed(url)).toBe(false);
+    });
+  });
+
+  describe("malformed input", () => {
+    it.each([[""], ["not a url"], ["://missing-scheme"], ["https:/"]])(
+      "rejects malformed input %j",
+      url => {
+        expect(isAllowed(url)).toBe(false);
+      },
+    );
+  });
+
+  it("respects the supportedSchemes argument", () => {
+    const noDeepLinks = createLiveAppSchemeChecker([]);
+    expect(noDeepLinks("ledgerlive://discover")).toBe(false);
+    expect(noDeepLinks("https://example.com")).toBe(true);
+
+    const custom = createLiveAppSchemeChecker(["myscheme"]);
+    expect(custom("myscheme://foo")).toBe(true);
+    expect(custom("ledgerlive://discover")).toBe(false);
+  });
+});
+
+describe("mergeCspHeaders", () => {
+  const INJECTED = "frame-src 'self' https:;";
+
+  it("sets our CSP when no Content-Security-Policy header exists", () => {
+    const merged = mergeCspHeaders(
+      {
+        "Content-Type": ["text/html"],
+      },
+      INJECTED,
+    );
+
+    expect(merged["Content-Security-Policy"]).toEqual([INJECTED]);
+    expect(merged["Content-Type"]).toEqual(["text/html"]);
+  });
+
+  it("handles an undefined responseHeaders argument", () => {
+    const merged = mergeCspHeaders(undefined, INJECTED);
+    expect(merged["Content-Security-Policy"]).toEqual([INJECTED]);
+  });
+
+  it("appends to an existing Content-Security-Policy header (canonical casing)", () => {
+    const original = "default-src 'self'";
+    const merged = mergeCspHeaders(
+      {
+        "Content-Security-Policy": [original],
+      },
+      INJECTED,
+    );
+
+    expect(merged["Content-Security-Policy"]).toEqual([original, INJECTED]);
+  });
+
+  it("normalises lowercase content-security-policy to the canonical key", () => {
+    const original = "default-src 'self'";
+    const merged = mergeCspHeaders(
+      {
+        "content-security-policy": [original],
+      },
+      INJECTED,
+    );
+
+    expect(merged["Content-Security-Policy"]).toEqual([original, INJECTED]);
+    expect(merged["content-security-policy"]).toBeUndefined();
+  });
+
+  it("normalises mixed-case CoNtEnT-SeCuRiTy-PoLiCy to the canonical key", () => {
+    const original = "default-src 'self'";
+    const merged = mergeCspHeaders(
+      {
+        "CoNtEnT-SeCuRiTy-PoLiCy": [original],
+      },
+      INJECTED,
+    );
+
+    expect(merged["Content-Security-Policy"]).toEqual([original, INJECTED]);
+    expect(merged["CoNtEnT-SeCuRiTy-PoLiCy"]).toBeUndefined();
+  });
+
+  it("preserves multiple existing CSP values when appending", () => {
+    const merged = mergeCspHeaders(
+      {
+        "Content-Security-Policy": ["default-src 'self'", "script-src 'self'"],
+      },
+      INJECTED,
+    );
+
+    expect(merged["Content-Security-Policy"]).toEqual([
+      "default-src 'self'",
+      "script-src 'self'",
+      INJECTED,
+    ]);
+  });
+
+  it("leaves Content-Security-Policy-Report-Only untouched", () => {
+    const merged = mergeCspHeaders(
+      {
+        "Content-Security-Policy-Report-Only": ["default-src 'self'"],
+      },
+      INJECTED,
+    );
+
+    expect(merged["Content-Security-Policy-Report-Only"]).toEqual(["default-src 'self'"]);
+    expect(merged["Content-Security-Policy"]).toEqual([INJECTED]);
+  });
+
+  it("does not mutate the input headers object", () => {
+    const input = {
+      "Content-Security-Policy": ["default-src 'self'"],
+      "Content-Type": ["text/html"],
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+
+    mergeCspHeaders(input, INJECTED);
+
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("WEBVIEW_GUEST_CSP", () => {
+  it("contains frame-src, child-src and form-action directives", () => {
+    expect(WEBVIEW_GUEST_CSP).toContain("frame-src");
+    expect(WEBVIEW_GUEST_CSP).toContain("child-src");
+    expect(WEBVIEW_GUEST_CSP).toContain("form-action");
+  });
+
+  it("does not allow the app-store / office external protocol schemes", () => {
+    expect(WEBVIEW_GUEST_CSP).not.toContain("itms-apps");
+    expect(WEBVIEW_GUEST_CSP).not.toContain("ms-word");
+    expect(WEBVIEW_GUEST_CSP).not.toContain("file:");
+  });
+
+  it("does not allow data or blob document sources", () => {
+    expect(WEBVIEW_GUEST_CSP).not.toContain("data:");
+    expect(WEBVIEW_GUEST_CSP).not.toContain("blob:");
+  });
+});

--- a/apps/ledger-live-desktop/src/main/webviewHandlers.helpers.ts
+++ b/apps/ledger-live-desktop/src/main/webviewHandlers.helpers.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure helpers for the webview hardening layer. Kept free of any `electron`
+ * imports so they can be unit-tested without mocking the Electron runtime.
+ */
+
+/**
+ * Builds a scheme-allow checker for Live App <webview> navigations.
+ *
+ * Everything not in the allow list (itms-apps:, ms-word:, ms-notepad:,
+ * ms-paint:, file:, javascript:, ...) is rejected so the OS's external
+ * protocol handler cannot be triggered from within the webview via
+ * <iframe src>, window.location, <a href target=_blank>, HTTP 3xx redirects,
+ * etc.
+ *
+ * `ledgerlive:` / `ledgerwallet:` are allowed via `supportedSchemes`: these
+ * are Ledger Live's own deep-link schemes (registered via `protocol.handle`
+ * in dev mode and via `setAsDefaultProtocolClient` in production).
+ * Navigations to them are handled internally by Ledger Live itself, never by
+ * a third-party OS app, so they don't carry the external-handoff risk that
+ * motivated this guard.
+ */
+export function createLiveAppSchemeChecker(supportedSchemes: string[]): (url: string) => boolean {
+  const allowed = new Set([
+    "http:",
+    "https:",
+    "about:",
+    ...supportedSchemes.map(scheme => `${scheme}:`),
+  ]);
+
+  return (url: string): boolean => {
+    try {
+      return allowed.has(new URL(url).protocol);
+    } catch {
+      return false;
+    }
+  };
+}
+
+/**
+ * Merges an extra Content-Security-Policy value into an existing set of
+ * response headers without dropping any CSP already returned by the Live App.
+ *
+ * Browsers intersect multiple CSP headers, so stacking is safe and strictly
+ * additive - our injected directives can only further restrict, not relax,
+ * the effective policy.
+ *
+ * HTTP header names are case-insensitive; we normalise to the canonical
+ * `Content-Security-Policy` key on write and leave any
+ * `Content-Security-Policy-Report-Only` header untouched.
+ */
+export function mergeCspHeaders(
+  responseHeaders: Record<string, string[]> | undefined,
+  cspValue: string,
+): Record<string, string[]> {
+  const headers: Record<string, string[]> = { ...responseHeaders };
+
+  const existingCspKey = Object.keys(headers).find(
+    k => k.toLowerCase() === "content-security-policy",
+  );
+  const existingCsp = existingCspKey ? (headers[existingCspKey] ?? []) : [];
+  if (existingCspKey) delete headers[existingCspKey];
+  headers["Content-Security-Policy"] = [...existingCsp, cspValue];
+
+  return headers;
+}
+
+/**
+ * The CSP value injected on every guest <webview> document response.
+ *
+ * Scoped narrowly to the attack surface we care about (external-protocol
+ * handoff from framed content and form submissions). We intentionally do
+ * NOT set `default-src` / `script-src` here so we don't break Live App JS.
+ */
+export const WEBVIEW_GUEST_CSP =
+  "frame-src 'self' http: https:; " +
+  "child-src 'self' http: https:; " +
+  "form-action 'self' http: https:;";

--- a/apps/ledger-live-desktop/src/main/webviewHandlers.test.ts
+++ b/apps/ledger-live-desktop/src/main/webviewHandlers.test.ts
@@ -1,0 +1,187 @@
+import { app, ipcMain, session, webContents } from "electron";
+import { setupWebviewHandlers } from "./webviewHandlers";
+
+jest.mock("electron", () => ({
+  app: {
+    on: jest.fn(),
+  },
+  ipcMain: {
+    on: jest.fn(),
+  },
+  session: {
+    defaultSession: {
+      webRequest: {
+        onHeadersReceived: jest.fn(),
+      },
+    },
+  },
+  webContents: {
+    fromId: jest.fn(),
+  },
+}));
+
+type DomReadyHandler = (
+  event: Electron.IpcMainEvent,
+  id: number,
+  domains?: string[],
+) => void;
+type WebContentsCreatedHandler = (
+  event: Electron.Event,
+  contents: Electron.WebContents,
+) => void;
+type SchemeGuard = (event: Electron.Event<{ url: string }>) => void;
+
+describe("setupWebviewHandlers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete (globalThis as typeof globalThis & { __ledgerLiveWebviewHandlersSetup__?: boolean })
+      .__ledgerLiveWebviewHandlersSetup__;
+  });
+
+  const getDomReadyHandler = () =>
+    (jest.mocked(ipcMain.on) as jest.Mock).mock.calls.find(
+      ([eventName]) => eventName === "webview-dom-ready",
+    )?.[1] as DomReadyHandler | undefined;
+
+  const getWebContentsCreatedHandler = () =>
+    (jest.mocked(app.on) as jest.Mock).mock.calls.find(
+      ([eventName]) => eventName === "web-contents-created",
+    )?.[1] as WebContentsCreatedHandler | undefined;
+
+  it("ignores webview-dom-ready events for non-webview contents", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+
+    const domReadyHandler = getDomReadyHandler();
+
+    const nonWebviewContents = {
+      getType: jest.fn(() => "window"),
+      off: jest.fn(),
+      on: jest.fn(),
+    };
+    jest.mocked(webContents.fromId).mockReturnValue(nonWebviewContents as never);
+
+    domReadyHandler?.({} as Electron.IpcMainEvent, 42, ["https://app.example.com"]);
+
+    expect(nonWebviewContents.getType).toHaveBeenCalled();
+    expect(nonWebviewContents.off).not.toHaveBeenCalled();
+    expect(nonWebviewContents.on).not.toHaveBeenCalled();
+  });
+
+  it("attaches a will-navigate handler for webview contents", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+
+    const domReadyHandler = getDomReadyHandler();
+
+    const webviewContents = {
+      getType: jest.fn(() => "webview"),
+      off: jest.fn(),
+      on: jest.fn(),
+    };
+    jest.mocked(webContents.fromId).mockReturnValue(webviewContents as never);
+
+    domReadyHandler?.({} as Electron.IpcMainEvent, 7, ["https://app.example.com"]);
+
+    expect(webviewContents.on).toHaveBeenCalledWith("will-navigate", expect.any(Function));
+    expect(webviewContents.off).not.toHaveBeenCalled();
+  });
+
+  it("registers its one-time listeners during setup", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+
+    expect(jest.mocked(app.on)).toHaveBeenCalledWith("session-created", expect.any(Function));
+    expect(jest.mocked(app.on)).toHaveBeenCalledWith("web-contents-created", expect.any(Function));
+    expect(jest.mocked(session.defaultSession.webRequest.onHeadersReceived)).toHaveBeenCalledWith(
+      expect.any(Function),
+    );
+  });
+
+  it("attaches will-navigate, will-redirect and will-frame-navigate handlers for webview contents", () => {
+    setupWebviewHandlers(["ledgerlive"]);
+
+    const webContentsCreatedHandler = getWebContentsCreatedHandler();
+    const guestContents = {
+      id: 7,
+      getType: jest.fn(() => "webview"),
+      on: jest.fn(),
+      once: jest.fn(),
+      setWindowOpenHandler: jest.fn(),
+    };
+
+    webContentsCreatedHandler?.(
+      {} as Electron.Event,
+      guestContents as unknown as Electron.WebContents,
+    );
+
+    expect(guestContents.on).toHaveBeenCalledWith("will-navigate", expect.any(Function));
+    expect(guestContents.on).toHaveBeenCalledWith("will-redirect", expect.any(Function));
+    expect(guestContents.on).toHaveBeenCalledWith("will-frame-navigate", expect.any(Function));
+  });
+
+  it.each(["will-navigate", "will-redirect", "will-frame-navigate"])(
+    "prevents %s for disallowed schemes",
+    eventName => {
+      setupWebviewHandlers(["ledgerlive"]);
+
+      const webContentsCreatedHandler = getWebContentsCreatedHandler();
+      const guestContents = {
+        id: 7,
+        getType: jest.fn(() => "webview"),
+        on: jest.fn(),
+        once: jest.fn(),
+        setWindowOpenHandler: jest.fn(),
+      };
+
+      webContentsCreatedHandler?.(
+        {} as Electron.Event,
+        guestContents as unknown as Electron.WebContents,
+      );
+
+      const schemeGuard = (jest.mocked(guestContents.on) as jest.Mock).mock.calls.find(
+        ([registeredEventName]) => registeredEventName === eventName,
+      )?.[1] as SchemeGuard | undefined;
+      const preventDefault = jest.fn();
+
+      schemeGuard?.({
+        url: "itms-apps://itunes.apple.com/app/id1234",
+        defaultPrevented: false,
+        preventDefault,
+      } as unknown as Electron.Event<{ url: string }>);
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["will-navigate", "will-redirect", "will-frame-navigate"])(
+    "allows %s for supported schemes",
+    eventName => {
+      setupWebviewHandlers(["ledgerlive"]);
+
+      const webContentsCreatedHandler = getWebContentsCreatedHandler();
+      const guestContents = {
+        id: 7,
+        getType: jest.fn(() => "webview"),
+        on: jest.fn(),
+        once: jest.fn(),
+        setWindowOpenHandler: jest.fn(),
+      };
+
+      webContentsCreatedHandler?.(
+        {} as Electron.Event,
+        guestContents as unknown as Electron.WebContents,
+      );
+
+      const schemeGuard = (jest.mocked(guestContents.on) as jest.Mock).mock.calls.find(
+        ([registeredEventName]) => registeredEventName === eventName,
+      )?.[1] as SchemeGuard | undefined;
+      const preventDefault = jest.fn();
+
+      schemeGuard?.({
+        url: "ledgerlive://discover",
+        defaultPrevented: false,
+        preventDefault,
+      } as unknown as Electron.Event<{ url: string }>);
+
+      expect(preventDefault).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/apps/ledger-live-desktop/src/main/webviewHandlers.ts
+++ b/apps/ledger-live-desktop/src/main/webviewHandlers.ts
@@ -1,0 +1,173 @@
+import { app, ipcMain, session, webContents } from "electron";
+import { isUrlAllowedByManifestDomains } from "@ledgerhq/live-common/wallet-api/manifestDomainUtils";
+import { openURL } from "./openURL";
+import {
+  WEBVIEW_GUEST_CSP,
+  createLiveAppSchemeChecker,
+  mergeCspHeaders,
+} from "./webviewHandlers.helpers";
+
+type WebviewHandlersGlobal = typeof globalThis & {
+  __ledgerLiveWebviewHandlersSetup__?: boolean;
+};
+
+const webviewHandlersGlobal = globalThis as WebviewHandlersGlobal;
+
+/**
+ * Wires up all security-sensitive handlers for Live App <webview> guests
+ * (CSP injection, external-protocol handoff guards, manifest-domain
+ * whitelist, window-open routing).
+ *
+ * Enforces one-time setup during `app.on("ready", ...)` to avoid stacking
+ * duplicate `onHeadersReceived`, `web-contents-created`, and IPC listeners.
+ */
+export function setupWebviewHandlers(supportedSchemes: string[]) {
+  if (webviewHandlersGlobal.__ledgerLiveWebviewHandlersSetup__) {
+    throw new Error("setupWebviewHandlers must only be called once");
+  }
+  webviewHandlersGlobal.__ledgerLiveWebviewHandlersSetup__ = true;
+
+  // Tracks the active manifest-domain will-navigate handler per WebContents id
+  // so we can remove only that specific listener on subsequent dom-ready
+  // events, without disturbing any other will-navigate listeners that may
+  // exist on the same WebContents.
+  const willNavigateHandlers = new Map<number, (event: Electron.Event, url: string) => void>();
+
+  // Tracks sessions we've already attached CSP + external-protocol hardening to,
+  // so we don't register duplicate onHeadersReceived listeners when multiple
+  // Live App webviews share the same session partition.
+  const hardenedSessions = new WeakSet<Electron.Session>();
+
+  const isLiveAppSchemeAllowed = createLiveAppSchemeChecker(supportedSchemes);
+
+  // IPC from the renderer on webview `dom-ready`. Only the manifest-domain
+  // whitelist lives here because it needs the renderer-supplied `domains`
+  // array from the Live App manifest. This channel is only meant for guest
+  // <webview> contents, so unexpected ids are ignored defensively. The
+  // window-open handler and the scheme guard are registered earlier via
+  // `web-contents-created` so they are in place BEFORE the guest's first
+  // script runs.
+  ipcMain.on("webview-dom-ready", (_, id: number, domains?: string[]) => {
+    const wc = webContents.fromId(id);
+
+    if (wc?.getType() !== "webview") return;
+
+    // dom-ready fires on every reload - remove only the previously registered
+    // handler for this WebContents to avoid listener accumulation without
+    // touching other listeners.
+    const previousHandler = willNavigateHandlers.get(id);
+    if (previousHandler) {
+      wc.off("will-navigate", previousHandler);
+      willNavigateHandlers.delete(id);
+    }
+
+    // When manifest domains are provided (feature flag on), enforce origin whitelist on navigation
+    if (Array.isArray(domains) && domains.length > 0) {
+      const handler = (event: Electron.Event, url: string) => {
+        if (!isUrlAllowedByManifestDomains(url, domains)) {
+          event.preventDefault();
+        }
+      };
+      wc.on("will-navigate", handler);
+      willNavigateHandlers.set(id, handler);
+    }
+  });
+
+  // Inject a restrictive Content-Security-Policy on document responses served
+  // to any <webview> guest session. Chromium enforces `frame-src` before
+  // attempting any external-protocol handoff, which is the only layer that can
+  // block `<iframe src="itms-apps://...">` style exploits - Electron's JS
+  // navigation events (`will-navigate`, `will-frame-navigate`,
+  // `setWindowOpenHandler`, permission handlers, `shell.openExternal`,
+  // `webRequest`) all bypass that code path.
+  //
+  // Multiple CSP headers are enforced as an intersection by the browser, so
+  // adding ours on top of any CSP already returned by the Live App can only
+  // further restrict, not relax, the effective policy.
+  //
+  // We attach on session-creation (rather than on `webview-dom-ready`) so the
+  // handler is in place BEFORE the guest's first navigation request returns,
+  // which is when the top-level document's CSP is parsed by Chromium.
+  const hardenWebviewSession = (s: Electron.Session) => {
+    if (hardenedSessions.has(s)) return;
+    hardenedSessions.add(s);
+
+    s.webRequest.onHeadersReceived((details, callback) => {
+      // Only harden responses loaded by a guest <webview> to avoid affecting
+      // the host renderer or unrelated BrowserViews. `getType()` returns
+      // "webview" for guest WebContents.
+      const isWebviewGuest = details.webContents?.getType() === "webview";
+      const isFrameDocument =
+        details.resourceType === "mainFrame" || details.resourceType === "subFrame";
+      if (!isWebviewGuest || !isFrameDocument) {
+        callback({});
+        return;
+      }
+
+      callback({
+        responseHeaders: mergeCspHeaders(details.responseHeaders, WEBVIEW_GUEST_CSP),
+      });
+    });
+  };
+
+  app.on("session-created", hardenWebviewSession);
+  // Also harden any sessions that already exist (defaultSession + any
+  // partitioned sessions that were spun up before this listener attached).
+  hardenWebviewSession(session.defaultSession);
+
+  // Per-WebContents hardening for Live App <webview> guests, attached on
+  // `web-contents-created` so every listener is in place BEFORE the guest's
+  // first navigation / first script runs. Registering these on
+  // `webview-dom-ready` is too late: `dom-ready` does not fire for pages
+  // that immediately navigate away (e.g. an inline `<script>` assigning
+  // `window.location.href = "itms-apps://..."`), which would allow the
+  // external-protocol handoff to run unchallenged. Calling
+  // `event.preventDefault()` inside the scheme guard stops Chromium from
+  // delegating the URL to the OS's external-protocol handler.
+  app.on("web-contents-created", (_appEvent, contents) => {
+    if (contents.getType() !== "webview") return;
+
+    // Route same-tab `window.open` attempts: http(s) goes to the user's
+    // default browser via `openURL`; everything else (including
+    // `itms-apps:`, `javascript:`, malformed URLs) is denied.
+    contents.setWindowOpenHandler(({ url }) => {
+      try {
+        const protocol = new URL(url).protocol;
+        if (protocol === "https:" || protocol === "http:") {
+          openURL(url);
+        }
+      } catch {
+        // Malformed URL - fall through to deny.
+      }
+      return { action: "deny" };
+    });
+
+    // Clean up the per-WebContents manifest-domain handler exactly once when
+    // the guest goes away, instead of stacking one-shot listeners on every
+    // dom-ready / reload cycle. The authoritative cleanup site for the
+    // `willNavigateHandlers` map is here.
+    contents.once("destroyed", () => {
+      willNavigateHandlers.delete(contents.id);
+    });
+
+    // Block disallowed schemes for:
+    //   - `will-navigate`:       top-level navigations from link clicks / JS
+    //   - `will-redirect`:       HTTP 3xx redirects (not covered by
+    //                            `will-navigate`), e.g. a trusted https:// URL
+    //                            that 302s to itms-apps://
+    //   - `will-frame-navigate`: subframe navigations that `will-navigate`
+    //                            skips, as a belt-and-braces layer on top of
+    //                            the CSP frame-src policy injected above.
+    //
+    // All three events expose the target URL directly on the event object
+    // in modern Electron, so a single guard function covers every signature.
+    const schemeGuard = (event: Electron.Event<{ url: string }>) => {
+      if (!isLiveAppSchemeAllowed(event.url)) {
+        event.preventDefault();
+      }
+    };
+    contents.on("will-navigate", schemeGuard);
+    contents.on("will-redirect", schemeGuard);
+    contents.on("will-frame-navigate", schemeGuard);
+  });
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - desktop webviews

### 📝 Description

A malicious Live App could launch external OS applications (e.g. the App Store via `itms-apps://`) from inside its webview via several navigation vectors: embedding an iframe with a custom scheme, assigning such a URL to `window.location.href`, opening it through `window.open`, submitting a form, or — subtler — serving a trusted `https://` URL that returns an HTTP 3xx redirect to a custom scheme. Electron's JS navigation events (`will-navigate`, `will-frame-navigate`, `setWindowOpenHandler`, permission handlers, `shell.openExternal`, `webRequest`) are bypassed by Chromium's external-protocol handoff, so the existing guards never fired.

All the new logic lives in the dedicated [`apps/ledger-live-desktop/src/main/webviewHandlers.ts`](apps/ledger-live-desktop/src/main/webviewHandlers.ts) module, wired in from `main/index.ts` via a single `setupWebviewHandlers(SUPPORTED_SCHEMES)` call. Pure helpers (`createLiveAppSchemeChecker`, `mergeCspHeaders`, `WEBVIEW_GUEST_CSP`) are split out into [`webviewHandlers.helpers.ts`](apps/ledger-live-desktop/src/main/webviewHandlers.helpers.ts) with no `electron` imports so they can be unit-tested without mocking the runtime.

Hardening layers:

- **CSP injection on every webview session response.** Attached on `session-created` (plus `defaultSession`) via `webRequest.onHeadersReceived`, adding `frame-src` / `child-src` / `form-action 'self' http: https:`. Chromium enforces `frame-src` *before* the external-protocol handoff, which is the only layer capable of blocking `<iframe src="itms-apps://…">`. `form-action` covers `<form action="itms-apps://…">` submissions. Existing CSP headers from the Live App are preserved (browsers intersect multiple CSP headers, so stacking is strictly additive). `Content-Security-Policy-Report-Only` is left untouched.

- **Early navigation scheme guard, attached on `web-contents-created`** (not on `webview-dom-ready`, which is too late: `dom-ready` never fires for a page that immediately assigns `window.location.href = "itms-apps://…"`). A single guard function is registered on three events to cover every navigation vector that can trigger external-protocol handoff:
  - `will-navigate` — top-level navigations from link clicks / JS.
  - `will-redirect` — HTTP 3xx redirects, which don't re-trigger `will-navigate`.
  - `will-frame-navigate` — subframe navigations that `will-navigate` skips, belt-and-braces on top of the CSP `frame-src` policy.

- **`setWindowOpenHandler` also attached on `web-contents-created`** (previously registered on `webview-dom-ready`, which left an inline `<script>window.open("itms-apps://…")</script>` running during initial parse unguarded). The `new URL(url)` call is now wrapped in `try/catch` so malformed input is denied rather than throwing. http/https URLs are routed to the user's default browser via `openURL`; everything else is denied.

The scheme allow-list covers `http:`, `https:`, `about:`, and Ledger Live's own deep-link schemes (`ledgerlive:`, `ledgerwallet:`, sourced from `SUPPORTED_SCHEMES` so they cannot drift). The Ledger schemes are safe to allow because they are handled internally by Ledger Live itself — via `protocol.handle` in dev and `setAsDefaultProtocolClient` in production — and never result in a handoff to a third-party OS app.

Session hardening is deduplicated via a `WeakSet` so shared partitions don't register the header listener more than once, and the per-`WebContents` manifest-domain `will-navigate` handler is cleaned up on `destroyed` to avoid leaks. `setupWebviewHandlers` is documented as must-call-exactly-once.

### 🧪 Tests

31 unit tests in [`webviewHandlers.helpers.test.ts`](apps/ledger-live-desktop/src/main/webviewHandlers.helpers.test.ts) cover:

- Scheme checker: allowed (`https:`, `http:`, `about:blank`, `ledgerlive:`, `ledgerwallet:`), blocked (`itms-apps:`, `ms-word:`, `ms-notepad:`, `ms-paint:`, `file:`, `javascript:`, `mailto:`, `ftp:`), malformed input (empty string, free text, missing scheme), and the `supportedSchemes` argument.
- CSP header merge: no existing CSP, canonical / lowercase / mixed-case `Content-Security-Policy` key normalisation, multi-value preservation, input immutability, `Content-Security-Policy-Report-Only` untouched, `undefined` responseHeaders.
- CSP string invariants (`frame-src`, `child-src`, `form-action` present; no `itms-apps` / `ms-word` / `file:` tokens).

Manual smoke tests to run during QA: see the checklist shared in the thread (covers Live App `window.open("https://...")` still opening the system browser, `ledgerlive://` / `ledgerwallet://` deep links unchanged, and every attack vector above verified to be blocked).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29182]
- **ADR link (if any)**: 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29182]: https://ledgerhq.atlassian.net/browse/LIVE-29182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ