### PR TITLE
[LWDM] chore(coin-testers): add and wait for healthchecks

### DIFF
--- a/.changeset/khaki-goats-melt.md
+++ b/.changeset/khaki-goats-melt.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-tester-polkadot": patch
+"@ledgerhq/coin-tester-bitcoin": patch
+"@ledgerhq/coin-tester-solana": patch
+"@ledgerhq/coin-tester-evm": patch
+---
+
+chore(coin-testers): add and wait for healthchecks

--- a/libs/coin-tester-modules/coin-tester-bitcoin/src/atlas.ts
+++ b/libs/coin-tester-modules/coin-tester-bitcoin/src/atlas.ts
@@ -1,48 +1,25 @@
 import chalk from "chalk";
 import * as compose from "docker-compose";
 
-const cwd = `${__dirname}/docker`;
-
-const delay = (timing: number): Promise<void> =>
-  new Promise(resolve => setTimeout(resolve, timing));
-
 export const spawnAtlas = async (): Promise<void> => {
   console.log("Starting atlas...");
   await compose.upAll({
-    cwd,
+    cwd: `${__dirname}/docker`,
     log: Boolean(process.env.DEBUG),
-    env: {
-      ...process.env,
-    },
+    env: process.env,
+    commandOptions: ["--wait"],
   });
 
-  const checkAtlasLogs = async (): Promise<void> => {
-    const { out } = await compose.logs("atlas", {
-      cwd,
-      env: {
-        ...process.env,
-      },
-    });
-
-    if (out.includes("Started Atlas Bitcoin")) {
-      console.log(chalk.bgBlueBright(" -  ATLAS READY ✅  - "));
-      return;
-    }
-
-    await delay(200);
-    return checkAtlasLogs();
-  };
-
-  await checkAtlasLogs();
+  console.log(chalk.bgBlueBright(" -  ATLAS READY ✅  - "));
 };
 
 export const killAtlas = async (): Promise<void> => {
   console.log("Stopping atlas...");
   await compose.down({
-    cwd,
+    cwd: `${__dirname}/docker`,
     log: Boolean(process.env.DEBUG),
     env: process.env,
-    commandOptions: ["--remove-orphans", "-v"],
+    commandOptions: ["--remove-orphans", "--volumes"],
   });
 };
 

--- a/libs/coin-tester-modules/coin-tester-bitcoin/src/docker/docker-compose.yml
+++ b/libs/coin-tester-modules/coin-tester-bitcoin/src/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
         condition: service_started
     restart: on-failure
     healthcheck:
-      test: curl --fail http://localhost:9877/_health || exit 1
+      test: curl --fail http://localhost:9877/_health
       interval: 10s
       retries: 5
       timeout: 5s
@@ -54,7 +54,7 @@ services:
         condition: service_started
     restart: on-failure
     healthcheck:
-      test: curl --fail http://localhost:9877/_health || exit 1
+      test: curl --fail http://localhost:9877/_health
       interval: 10s
       retries: 5
       timeout: 5s
@@ -71,6 +71,12 @@ services:
     volumes:
       - "./nginx:/etc/nginx/conf.d/"
     depends_on:
-      - atlas
+      atlas:
+        condition: service_healthy
     ports:
       - "9876:9876"
+    healthcheck:
+      test: curl --fail http://localhost:9876/blockchain/v4/btc_regtest/block/current
+      interval: 10s
+      retries: 5
+      timeout: 5s

--- a/libs/coin-tester-modules/coin-tester-evm/anvil.Dockerfile
+++ b/libs/coin-tester-modules/coin-tester-evm/anvil.Dockerfile
@@ -3,6 +3,8 @@ FROM ghcr.io/foundry-rs/foundry:latest
 # Set user to 'root' to install cURL
 USER root
 
-RUN apt install curl -y
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 
 USER foundry

--- a/libs/coin-tester-modules/coin-tester-evm/anvil.Dockerfile
+++ b/libs/coin-tester-modules/coin-tester-evm/anvil.Dockerfile
@@ -1,0 +1,8 @@
+FROM ghcr.io/foundry-rs/foundry:latest
+
+# Set user to 'root' to install cURL
+USER root
+
+RUN apt install curl -y
+
+USER foundry

--- a/libs/coin-tester-modules/coin-tester-evm/docker-compose.yml
+++ b/libs/coin-tester-modules/coin-tester-evm/docker-compose.yml
@@ -1,8 +1,17 @@
 services:
   anvil:
-    image: ghcr.io/foundry-rs/foundry:latest
     container_name: anvil
     platform: linux/amd64
+    build:
+      context: .
+      dockerfile: anvil.Dockerfile
+      tags:
+        - "coin-tester-anvil:latest"
+    healthcheck:
+        test: ["CMD", "curl", "-f", "http://127.0.0.1:8545", "-H", "Content-Type: application/json", "-H", "Accept: application/json", "-d", '{ "jsonrpc": "2.0", "id": "healthcheck", "method": "eth_getBlockByNumber", "params": ["latest", false] }']
+        interval: 5s
+        timeout: 10s
+        retries: 12
     ports:
       - "8545:8545"
     command: -c "anvil --host 0.0.0.0 --fork-url ${RPC} --no-storage-caching --steps-tracing --mnemonic='${SEED}'"

--- a/libs/coin-tester-modules/coin-tester-evm/src/anvil.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/anvil.ts
@@ -1,48 +1,26 @@
 import chalk from "chalk";
 import * as compose from "docker-compose";
 
-const cwd = __dirname;
-
-const delay = (timing: number): Promise<void> =>
-  new Promise(resolve => setTimeout(resolve, timing));
-
 export const spawnAnvil = async (rpc: string, seed: string): Promise<void> => {
   console.log("Starting anvil...");
   await compose.upOne("anvil", {
-    cwd,
+    cwd: __dirname,
     log: Boolean(process.env.DEBUG),
     env: {
       ...process.env,
       RPC: rpc,
       SEED: seed,
     },
+    commandOptions: ["--wait"],
   });
 
-  const checkAnvilLogs = async (): Promise<void> => {
-    const { out } = await compose.logs("anvil", {
-      cwd,
-      env: {
-        ...process.env,
-        RPC: rpc,
-      },
-    });
-
-    if (out.includes("Listening on 0.0.0.0:")) {
-      console.log(chalk.bgBlueBright(" -  ANVIL READY ✅  - "));
-      return;
-    }
-
-    await delay(200);
-    return checkAnvilLogs();
-  };
-
-  await checkAnvilLogs();
+  console.log(chalk.bgBlueBright(" -  ANVIL READY ✅  - "));
 };
 
 export const killAnvil = async (): Promise<void> => {
   console.log("Stopping anvil...");
   await compose.down({
-    cwd,
+    cwd: __dirname,
     log: Boolean(process.env.DEBUG),
     env: process.env,
     commandOptions: ["--remove-orphans"],

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii.test.ts
@@ -14,9 +14,6 @@ import "./tokenFixtures";
 global.console = require("console");
 jest.setTimeout(100_000);
 
-// Note this config runs with NanoX
-// https://github.com/LedgerHQ/ledger-live/blob/develop/libs/coin-tester/docker-compose.yml
-
 describe("EVM Deterministic Tester", () => {
   it("scenario Ethereum", async () => {
     try {

--- a/libs/coin-tester-modules/coin-tester-polkadot/chopsticks.Dockerfile
+++ b/libs/coin-tester-modules/coin-tester-polkadot/chopsticks.Dockerfile
@@ -2,10 +2,7 @@ FROM --platform=linux/amd64 node:20
 WORKDIR /coin-tester-polkadot
 COPY . .
 
-HEALTHCHECK --interval=10s --timeout=30s --start-period=5s --retries=10 CMD [ "curl", "-f", "http://127.0.0.1:8000", "-H", "Accept: application/json", "-d", '{"jsonrpc":"2.0","id":1, "method":"system_health"}' ]
-
 RUN npm install -g @acala-network/chopsticks@latest
-
 
 ENV CHOPSTICKS_CONFIG=/coin-tester-chopsticks/polkadot.yml
 

--- a/libs/coin-tester-modules/coin-tester-polkadot/docker-compose.yml
+++ b/libs/coin-tester-modules/coin-tester-polkadot/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "8000:8000"
     healthcheck:
-        test: ["CMD", "curl", "-f", "http://127.0.0.1:8000", "-H", "Accept: application/json", "-d", '{"jsonrpc":"2.0","id":1, "method":"system_health"}']
+        test: ["CMD", "curl", "-f", "http://127.0.0.1:8000", "-H", "Accept: application/json", "-d", '{ "jsonrpc": "2.0", "id": "healthcheck", "method": "system_health" }']
         interval: 5s
         timeout: 10s
         retries: 12
@@ -25,8 +25,13 @@ services:
         condition: service_healthy
     environment:
       - SAS_EXPRESS_BIND_HOST=0.0.0.0
-      - SAS_SUBSTRATE_URL=ws://chopsticks:${CHOPSTICKS_NODE_PORT-8000}
-      - SAS_EXPRESS_KEEP_ALIVE_TIMEOUT=${SIDECAR_KEEP_ALIVE_TIMEOUT-60000}
-      - SAS_EXPRESS_PORT=${SIDECAR_PORT-8080}
+      - SAS_SUBSTRATE_URL=ws://chopsticks:8000
+      - SAS_EXPRESS_KEEP_ALIVE_TIMEOUT=60000
+      - SAS_EXPRESS_PORT=8080
     ports:
       - "8080:8080"
+    healthcheck:
+        test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/node/version", "-H", "Accept: application/json"]
+        interval: 5s
+        timeout: 10s
+        retries: 12

--- a/libs/coin-tester-modules/coin-tester-polkadot/src/chopsticks-sidecar.ts
+++ b/libs/coin-tester-modules/coin-tester-polkadot/src/chopsticks-sidecar.ts
@@ -1,50 +1,23 @@
 import chalk from "chalk";
 import * as compose from "docker-compose";
 
-const cwd = __dirname;
-const delay = (timing: number) => new Promise(resolve => setTimeout(resolve, timing));
-
 export async function spawnChopsticksAndSidecar(chopsticksConfig: string): Promise<void> {
   console.log("Starting chopsticks and sidecar...");
   await compose.upAll({
-    cwd,
+    cwd: __dirname,
     log: Boolean(process.env.DEBUG),
     env: { ...process.env, CHOPSTICKS_CONFIG: chopsticksConfig },
+    commandOptions: ["--wait"],
   });
 
-  let chopsticksStarted = false;
-  let sidecarStarted = false;
-  async function checkChopsticksLogs(maxRetries = 50) {
-    if (maxRetries === 0) {
-      throw new Error("Failed to start chopsticks and/or sidecar container(s)");
-    }
-
-    const [{ out: outChopsticks }, { out: outSidecar }] = await Promise.all([
-      compose.logs("chopsticks", { cwd }),
-      compose.logs("sidecar-api", { cwd }),
-    ]);
-
-    if (!chopsticksStarted && outChopsticks.includes("listening on http://[::]:8000")) {
-      console.log(chalk.bgBlueBright(" -  CHOPSTICKS READY ✅  - "));
-      chopsticksStarted = true;
-    }
-    if (!sidecarStarted && outSidecar.includes("Listening on http://0.0.0.0:8080/")) {
-      console.log(chalk.bgRedBright(" -  SIDECAR READY ✅  - "));
-      sidecarStarted = true;
-    }
-    if (chopsticksStarted && sidecarStarted) return;
-
-    await delay(200);
-    return checkChopsticksLogs(maxRetries - 1);
-  }
-
-  await checkChopsticksLogs();
+  console.log(chalk.bgBlueBright(" -  CHOPSTICKS READY ✅  - "));
+  console.log(chalk.bgRedBright(" -  SIDECAR READY ✅  - "));
 }
 
 export const killChopsticksAndSidecar = async (): Promise<void> => {
   console.log("Stopping chopsticks...");
   await compose.down({
-    cwd,
+    cwd: __dirname,
     log: Boolean(process.env.DEBUG),
     env: process.env,
   });

--- a/libs/coin-tester-modules/coin-tester-solana/src/agave.ts
+++ b/libs/coin-tester-modules/coin-tester-solana/src/agave.ts
@@ -1,46 +1,15 @@
 import chalk from "chalk";
 import * as compose from "docker-compose";
 
-async function waitForRpc(maxRetries = 30, intervalMs = 2000): Promise<void> {
-  for (let i = 0; i < maxRetries; i++) {
-    try {
-      const res = await fetch("http://127.0.0.1:8899", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getHealth" }),
-      });
-      if (res.ok) {
-        // Ensure the validator has produced blocks with a usable recent blockhash
-        const bh = await fetch("http://127.0.0.1:8899", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            jsonrpc: "2.0",
-            id: 2,
-            method: "getLatestBlockhash",
-            params: [{ commitment: "confirmed" }],
-          }),
-        });
-        const data = (await bh.json()) as { result?: { value?: { blockhash?: string } } };
-        if (data?.result?.value?.blockhash) return;
-      }
-    } catch {
-      // not ready yet
-    }
-    await new Promise(r => setTimeout(r, intervalMs));
-  }
-  throw new Error("Agave RPC did not become healthy in time");
-}
-
 export async function spawnAgave() {
   console.log("Starting Agave...");
   await compose.upOne("agave", {
     cwd: __dirname,
     log: Boolean(process.env.DEBUG),
     env: process.env,
+    commandOptions: ["--wait"],
   });
 
-  await waitForRpc();
   console.log(chalk.bgBlueBright(" -  AGAVE READY ✅  - "));
 }
 
@@ -50,7 +19,7 @@ export async function killAgave() {
     cwd: __dirname,
     log: Boolean(process.env.DEBUG),
     env: process.env,
-    commandOptions: ["--remove-orphans"],
+    commandOptions: ["--remove-orphans", "--volumes"],
   });
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

#### Summary

Coin-tester used readiness checks in TypeScript (polling `docker-compose` logs or HTTP from the host). This change moves readiness to Docker Compose healthchecks and `docker compose up --wait`, so Compose only returns once dependencies are actually healthy.

#### Changes

- Bitcoin (Atlas): Healthchecks on `atlas-pending`, `atlas`, and `atlas-nginx`; `spawnAtlas` uses `commandOptions: ["--wait"]` and drops the recursive log-based “Started Atlas Bitcoin” wait; remove redundatnt `|| exit 1`
- EVM (Anvil): Healthcheck on anvil (JSON-RPC `eth_getBlockByNumber`); `anvil.Dockerfile` installs `curl` so the healthcheck can run; `spawnAnvil` uses `--wait` and removes log polling for “Listening on 0.0.0.0:”.
- Polkadot (Chopsticks + sidecar): Healthchecks in `docker-compose.yml` for `chopsticks` and `sidecar-api`; duplicate `HEALTHCHECK` removed from `chopsticks.Dockerfile`; `spawnChopsticksAndSidecar` uses `--wait` and removes dual log polling.
- Solana (Agave): `spawnAgave` uses `--wait` and removes the in-test `waitForRpc` / `getHealth` + `getLatestBlockhash` loop

#### Why

- Deterministic startup: Waits on real HTTP/RPC readiness instead of log substrings that can drift with image updates.
- Less TS complexity: Removes retry loops and tight coupling to log wording.
- CI/local parity: Same mechanism everywhere Compose is used.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
