### PR TITLE
[LWD] feat(desktop): aggregate assets in crypto addresses page

### DIFF
--- a/.changeset/bright-dogs-dance.md
+++ b/.changeset/bright-dogs-dance.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Aggregate accounts in CryptoAddresses table when shouldDisplayAggregatedAssets is enabled: collapse to one row per main account with squared icon, aggregated countervalue, and asset count

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountNameCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountNameCell.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import type { Account } from "@ledgerhq/types-live";
+import { SquaredCryptoIcon } from "LLD/components/SquaredCryptoIcon";
+
+type AggregatedAccountNameCellProps = {
+  readonly account: Account;
+  readonly displayName: string;
+};
+
+export function AggregatedAccountNameCell({
+  account,
+  displayName,
+}: AggregatedAccountNameCellProps) {
+  return (
+    <TableCellContent
+      leadingContent={
+        <SquaredCryptoIcon
+          ledgerId={account.currency.id}
+          ticker={account.currency.ticker}
+          size="32px"
+        />
+      }
+      title={displayName}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountValueCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountValueCell.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import { BigNumber } from "bignumber.js";
+import { useTranslation } from "react-i18next";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { useSelector } from "LLD/hooks/redux";
+import {
+  counterValueCurrencySelector,
+  localeSelector,
+  discreetModeSelector,
+} from "~/renderer/reducers/settings";
+
+type AggregatedAccountValueCellProps = {
+  readonly aggregatedCountervalue: BigNumber;
+  readonly assetsCount: number;
+};
+
+export function AggregatedAccountValueCell({
+  aggregatedCountervalue,
+  assetsCount,
+}: AggregatedAccountValueCellProps) {
+  const { t } = useTranslation();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const locale = useSelector(localeSelector);
+  const discreet = useSelector(discreetModeSelector);
+
+  const formattedValue = formatCurrencyUnit(counterValueCurrency.units[0], aggregatedCountervalue, {
+    showCode: true,
+    locale,
+    discreet,
+  });
+
+  return (
+    <TableCellContent
+      align="end"
+      title={formattedValue}
+      description={t("cryptoAddresses.table.assetCount", { count: assetsCount })}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/__tests__/AggregatedAccountValueCell.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/__tests__/AggregatedAccountValueCell.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { BigNumber } from "bignumber.js";
+import { AggregatedAccountValueCell } from "../AggregatedAccountValueCell";
+
+describe("AggregatedAccountValueCell", () => {
+  it('renders the formatted counter value amount and "1 asset" when assetsCount is 1', () => {
+    render(
+      <AggregatedAccountValueCell aggregatedCountervalue={new BigNumber(100000)} assetsCount={1} />,
+    );
+
+    expect(screen.getByText("1 asset")).toBeVisible();
+    expect(screen.getByText(/1,000\.00/)).toBeVisible();
+  });
+
+  it('renders the formatted counter value amount and "3 assets" when assetsCount is 3', () => {
+    render(
+      <AggregatedAccountValueCell aggregatedCountervalue={new BigNumber(500000)} assetsCount={3} />,
+    );
+
+    expect(screen.getByText("3 assets")).toBeVisible();
+    expect(screen.getByText(/5,000\.00/)).toBeVisible();
+  });
+
+  it('renders "0 asset" (singular) when assetsCount is 0', () => {
+    render(
+      <AggregatedAccountValueCell aggregatedCountervalue={new BigNumber(0)} assetsCount={0} />,
+    );
+
+    expect(screen.getByText("0 asset")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/index.ts
@@ -2,3 +2,5 @@ export { AccountNameCell } from "./AccountNameCell";
 export { AccountAddressCell } from "./AccountAddressCell";
 export { AccountValueCell } from "./AccountValueCell";
 export { AccountRowActionCell } from "./AccountRowActionCell";
+export { AggregatedAccountNameCell } from "./AggregatedAccountNameCell";
+export { AggregatedAccountValueCell } from "./AggregatedAccountValueCell";

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/__tests__/useCryptoAccountRows.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/__tests__/useCryptoAccountRows.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "tests/testSetup";
+import { renderHook, withFlagOverrides } from "tests/testSetup";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import {
   BTC_ACCOUNT,
@@ -7,6 +7,10 @@ import {
 } from "LLD/features/__mocks__/accounts.mock";
 import { createWalletState } from "../../../../testUtils/createWalletState";
 import { useCryptoAccountRows } from "../useCryptoAccountRows";
+
+const aggregatedFlags = withFlagOverrides({
+  lwdWallet40: { enabled: true, params: { aggregatedAssets: true } },
+});
 
 describe("useCryptoAccountRows", () => {
   it("should return lookupParentAccount that resolves a main account by id", () => {
@@ -127,5 +131,48 @@ describe("useCryptoAccountRows", () => {
     });
 
     expect(result.current.rows.some(r => r.id === token.id)).toBe(true);
+  });
+
+  describe("when shouldDisplayAggregatedAssets is ON", () => {
+    it("should return only main accounts, not token sub-accounts", () => {
+      const parent = ETH_ACCOUNT_WITH_USDC;
+      const token = parent.subAccounts![0];
+
+      const { result } = renderHook(() => useCryptoAccountRows(""), {
+        initialState: {
+          accounts: [parent],
+          ...aggregatedFlags,
+          ...createWalletState(
+            new Map([
+              [parent.id, "Ethereum main"],
+              [token.id, "USDC token"],
+            ]),
+          ),
+        },
+      });
+
+      expect(result.current.rows.some(r => r.id === parent.id)).toBe(true);
+      expect(result.current.rows.some(r => r.id === token.id)).toBe(false);
+    });
+
+    it("should match parent account when searching by token name (subMatch)", () => {
+      const parent = ETH_ACCOUNT_WITH_USDC;
+      const token = parent.subAccounts![0];
+
+      const { result } = renderHook(() => useCryptoAccountRows("usdc"), {
+        initialState: {
+          accounts: [parent],
+          ...aggregatedFlags,
+          ...createWalletState(
+            new Map([
+              [parent.id, "Ethereum main"],
+              [token.id, "USDC token"],
+            ]),
+          ),
+        },
+      });
+
+      expect(result.current.rows.some(r => r.id === parent.id)).toBe(true);
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoAccountRows.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoAccountRows.ts
@@ -1,16 +1,19 @@
 import { useCallback, useMemo } from "react";
 import type { Account } from "@ledgerhq/types-live";
 import { useSelector } from "LLD/hooks/redux";
-import { useFlattenSortAccounts } from "~/renderer/actions/general";
+import { useFlattenSortAccounts, useSortAccountsComparator } from "~/renderer/actions/general";
 import { useHideEmptyTokenAccounts } from "~/renderer/actions/settings";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/index";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { walletSelector } from "~/renderer/reducers/wallet";
 import { accountMatchesSearch } from "LLD/utils/accountMatchesSearch";
 
 export function useCryptoAccountRows(searchValue: string) {
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const [hideEmptyTokenAccounts] = useHideEmptyTokenAccounts();
   const walletState = useSelector(walletSelector);
   const nestedAccounts = useSelector(accountsSelector);
+  const comparator = useSortAccountsComparator();
 
   const flattenOptions = useMemo(
     () => ({
@@ -30,7 +33,17 @@ export function useCryptoAccountRows(searchValue: string) {
     return map;
   }, [nestedAccounts]);
 
+  const sortedMainAccounts = useMemo(() => {
+    const mainAccounts = nestedAccounts.filter((a): a is Account => a.type === "Account");
+    return mainAccounts.sort(comparator);
+  }, [nestedAccounts, comparator]);
+
   const rows = useMemo(() => {
+    if (shouldDisplayAggregatedAssets) {
+      return sortedMainAccounts.filter(account =>
+        accountMatchesSearch(walletState, searchValue, account, true),
+      );
+    }
     return flattenedAccounts.filter(account => {
       const parentAddress =
         account.type === "TokenAccount"
@@ -38,7 +51,14 @@ export function useCryptoAccountRows(searchValue: string) {
           : undefined;
       return accountMatchesSearch(walletState, searchValue, account, false, parentAddress);
     });
-  }, [flattenedAccounts, searchValue, walletState, accountById]);
+  }, [
+    shouldDisplayAggregatedAssets,
+    sortedMainAccounts,
+    flattenedAccounts,
+    searchValue,
+    walletState,
+    accountById,
+  ]);
 
   const lookupParentAccount = useCallback(
     (id: string): Account | undefined | null => {

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
@@ -5,17 +5,23 @@ import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import { accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
-import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/index";
 import { useCalculateCountervalueCallback } from "~/renderer/actions/general";
 import { walletSelector } from "~/renderer/reducers/wallet";
 import type { ColumnDef, Row, SortingState, Updater } from "@tanstack/react-table";
 import { track } from "~/renderer/analytics/segment";
 import { CRYPTO_TRACKING_PAGE_NAME } from "../../../constants";
 import {
+  computeAggregatedAccountsData,
+  computeBalanceSortCountervalueByAccountId,
+} from "../../../utils/aggregateAccounts";
+import {
   AccountAddressCell,
   AccountNameCell,
   AccountRowActionCell,
   AccountValueCell,
+  AggregatedAccountNameCell,
+  AggregatedAccountValueCell,
 } from "../Cell";
 import { useSyncPhase } from "LLD/hooks/useSyncPhase";
 
@@ -31,20 +37,30 @@ export function useCryptoDataTable({
   onRowClick,
 }: UseCryptoDataTableParams) {
   const { t } = useTranslation();
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const walletState = useSelector(walletSelector);
   const calculateCountervalue = useCalculateCountervalueCallback();
   const syncPhase = useSyncPhase();
   const isSyncing = syncPhase === "syncing";
 
-  /** One countervalue per row; avoids recalculations in sorting. */
-  const balanceSortFiatByAccountId = useMemo(() => {
-    const map = new Map<string, BigNumber>();
-    for (const account of rows) {
-      const currency = getAccountCurrency(account);
-      map.set(account.id, calculateCountervalue(currency, account.balance) ?? new BigNumber(0));
+  const aggregatedDataByAccountId = useMemo(
+    () =>
+      shouldDisplayAggregatedAssets
+        ? computeAggregatedAccountsData(rows, calculateCountervalue)
+        : null,
+    [shouldDisplayAggregatedAssets, rows, calculateCountervalue],
+  );
+
+  const getSortCountervalue = useMemo(() => {
+    if (aggregatedDataByAccountId) {
+      return (id: string) => aggregatedDataByAccountId.get(id)?.countervalue ?? new BigNumber(0);
     }
-    return map;
-  }, [rows, calculateCountervalue]);
+    const countervalueByAccountId = computeBalanceSortCountervalueByAccountId(
+      rows,
+      calculateCountervalue,
+    );
+    return (id: string) => countervalueByAccountId.get(id) ?? new BigNumber(0);
+  }, [aggregatedDataByAccountId, rows, calculateCountervalue]);
 
   const columns = useMemo<ColumnDef<AccountLike>[]>(
     () => [
@@ -58,12 +74,18 @@ export function useCryptoDataTable({
             { sensitivity: "base" },
           ),
         header: t("cryptoAddresses.table.columns.name"),
-        cell: ({ row }) => (
-          <AccountNameCell
-            account={row.original}
-            displayName={accountNameWithDefaultSelector(walletState, row.original)}
-          />
-        ),
+        cell: ({ row }) =>
+          shouldDisplayAggregatedAssets && row.original.type === "Account" ? (
+            <AggregatedAccountNameCell
+              account={row.original}
+              displayName={accountNameWithDefaultSelector(walletState, row.original)}
+            />
+          ) : (
+            <AccountNameCell
+              account={row.original}
+              displayName={accountNameWithDefaultSelector(walletState, row.original)}
+            />
+          ),
       },
       {
         id: "address",
@@ -77,13 +99,20 @@ export function useCryptoDataTable({
       {
         id: "balance",
         accessorKey: "balance",
-        sortingFn: (rowA, rowB) => {
-          const fiatA = balanceSortFiatByAccountId.get(rowA.original.id) ?? new BigNumber(0);
-          const fiatB = balanceSortFiatByAccountId.get(rowB.original.id) ?? new BigNumber(0);
-          return fiatA.comparedTo(fiatB);
-        },
+        sortingFn: (rowA, rowB) =>
+          getSortCountervalue(rowA.original.id).comparedTo(getSortCountervalue(rowB.original.id)),
         header: t("cryptoAddresses.table.columns.value"),
-        cell: ({ row }) => <AccountValueCell account={row.original} />,
+        cell: ({ row }) => {
+          const entry = aggregatedDataByAccountId?.get(row.original.id);
+          return shouldDisplayAggregatedAssets && aggregatedDataByAccountId ? (
+            <AggregatedAccountValueCell
+              aggregatedCountervalue={entry?.countervalue ?? new BigNumber(0)}
+              assetsCount={entry?.count ?? 0}
+            />
+          ) : (
+            <AccountValueCell account={row.original} />
+          );
+        },
         meta: { align: "end" },
       },
       {
@@ -100,7 +129,15 @@ export function useCryptoDataTable({
         meta: { align: "end" },
       },
     ],
-    [t, walletState, lookupParentAccount, balanceSortFiatByAccountId, isSyncing],
+    [
+      t,
+      walletState,
+      shouldDisplayAggregatedAssets,
+      lookupParentAccount,
+      getSortCountervalue,
+      aggregatedDataByAccountId,
+      isSyncing,
+    ],
   );
 
   const [sorting, setSorting] = useState<SortingState>([{ id: "balance", desc: true }]);

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/__tests__/aggregateAccounts.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/__tests__/aggregateAccounts.test.ts
@@ -1,0 +1,114 @@
+import { BigNumber } from "bignumber.js";
+import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
+import {
+  BTC_ACCOUNT,
+  ETH_ACCOUNT,
+  ETH_ACCOUNT_WITH_USDC,
+} from "LLD/features/__mocks__/accounts.mock";
+import {
+  type CalculateCountervalue,
+  computeAggregatedAccountsData,
+  computeBalanceSortCountervalueByAccountId,
+} from "../aggregateAccounts";
+
+const calculateCountervalue: jest.Mock<ReturnType<CalculateCountervalue>> = jest.fn(
+  (_from, value: BigNumber) => value.times(2),
+);
+
+beforeEach(() => {
+  calculateCountervalue.mockReset();
+  calculateCountervalue.mockImplementation((_from, value: BigNumber) => value.times(2));
+});
+
+function withBalance<T extends AccountLike>(account: T, balance: BigNumber): T {
+  return { ...account, balance };
+}
+
+function firstSubAccount(account: Account): TokenAccount {
+  const sub = account.subAccounts?.[0];
+  if (!sub) throw new Error("Fixture must expose a sub-account");
+  return sub;
+}
+
+describe("computeAggregatedAccountsData", () => {
+  it("returns an empty map when rows are empty", () => {
+    const map = computeAggregatedAccountsData([], calculateCountervalue);
+    expect(map.size).toBe(0);
+  });
+
+  it("ignores rows that are not main accounts", () => {
+    const tokenAccount = firstSubAccount(ETH_ACCOUNT_WITH_USDC);
+    const map = computeAggregatedAccountsData([tokenAccount], calculateCountervalue);
+    expect(map.size).toBe(0);
+  });
+
+  it("counts a main account with non-zero balance as 1 asset", () => {
+    const account = withBalance(BTC_ACCOUNT, new BigNumber(100));
+    const map = computeAggregatedAccountsData([account], calculateCountervalue);
+    expect(map.get(account.id)?.count).toBe(1);
+    expect(map.get(account.id)?.countervalue.toString()).toBe("200");
+  });
+
+  it("excludes the main account from count and countervalue when its balance is zero", () => {
+    const account = withBalance(BTC_ACCOUNT, new BigNumber(0));
+    const map = computeAggregatedAccountsData([account], calculateCountervalue);
+    expect(map.get(account.id)?.count).toBe(0);
+    expect(map.get(account.id)?.countervalue.toString()).toBe("0");
+  });
+
+  it("always includes sub-accounts in count and countervalue, regardless of their balance", () => {
+    const usdc = firstSubAccount(ETH_ACCOUNT_WITH_USDC);
+    const parent: Account = {
+      ...ETH_ACCOUNT_WITH_USDC,
+      balance: new BigNumber(0),
+      subAccounts: [
+        { ...usdc, balance: new BigNumber(0) },
+        { ...usdc, id: `${usdc.id}-2`, balance: new BigNumber(50) },
+      ],
+    };
+
+    const map = computeAggregatedAccountsData([parent], calculateCountervalue);
+    expect(map.get(parent.id)?.count).toBe(2);
+    expect(map.get(parent.id)?.countervalue.toString()).toBe("100");
+  });
+
+  it("aggregates main account + sub-accounts when all have non-zero balances", () => {
+    const usdc = firstSubAccount(ETH_ACCOUNT_WITH_USDC);
+    const parent: Account = {
+      ...ETH_ACCOUNT_WITH_USDC,
+      balance: new BigNumber(100),
+      subAccounts: [{ ...usdc, balance: new BigNumber(50) }],
+    };
+
+    const map = computeAggregatedAccountsData([parent], calculateCountervalue);
+    expect(map.get(parent.id)?.count).toBe(2);
+    expect(map.get(parent.id)?.countervalue.toString()).toBe("300");
+  });
+
+  it("treats null/undefined countervalues as zero", () => {
+    calculateCountervalue.mockReturnValueOnce(null).mockReturnValueOnce(undefined);
+    const account = withBalance(BTC_ACCOUNT, new BigNumber(100));
+    const map = computeAggregatedAccountsData([account], calculateCountervalue);
+    expect(map.get(account.id)?.count).toBe(1);
+    expect(map.get(account.id)?.countervalue.toString()).toBe("0");
+  });
+});
+
+describe("computeBalanceSortCountervalueByAccountId", () => {
+  it("returns per-account countervalues", () => {
+    const a = withBalance(BTC_ACCOUNT, new BigNumber(100));
+    const b = withBalance(ETH_ACCOUNT, new BigNumber(250));
+
+    const map = computeBalanceSortCountervalueByAccountId([a, b], calculateCountervalue);
+
+    expect(map.get(a.id)?.toString()).toBe("200");
+    expect(map.get(b.id)?.toString()).toBe("500");
+  });
+
+  it("defaults to zero when countervalue is not available", () => {
+    calculateCountervalue.mockReturnValueOnce(null);
+    const account = withBalance(BTC_ACCOUNT, new BigNumber(100));
+    const map = computeBalanceSortCountervalueByAccountId([account], calculateCountervalue);
+    expect(map.get(account.id)?.toString()).toBe("0");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/aggregateAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/aggregateAccounts.ts
@@ -1,0 +1,63 @@
+import { BigNumber } from "bignumber.js";
+import type { AccountLike } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+import { getAccountCurrency, listSubAccounts } from "@ledgerhq/live-common/account/helpers";
+
+export type CalculateCountervalue = (
+  from: Currency,
+  value: BigNumber,
+) => BigNumber | null | undefined;
+
+export type AggregatedEntry = {
+  readonly countervalue: BigNumber;
+  readonly count: number;
+};
+
+export type AggregatedAccountData = ReadonlyMap<string, AggregatedEntry>;
+
+export function computeAggregatedAccountsData(
+  rows: readonly AccountLike[],
+  calculateCountervalue: CalculateCountervalue,
+): AggregatedAccountData {
+  const map = new Map<string, AggregatedEntry>();
+
+  for (const account of rows) {
+    if (account.type !== "Account") continue;
+
+    let countervalue = new BigNumber(0);
+    let count = 0;
+
+    if (!account.balance.isZero()) {
+      const mainCurrency = getAccountCurrency(account);
+      countervalue = countervalue.plus(
+        calculateCountervalue(mainCurrency, account.balance) ?? new BigNumber(0),
+      );
+      count += 1;
+    }
+
+    const subs = listSubAccounts(account);
+    for (const sub of subs) {
+      const subCurrency = getAccountCurrency(sub);
+      countervalue = countervalue.plus(
+        calculateCountervalue(subCurrency, sub.balance) ?? new BigNumber(0),
+      );
+    }
+    count += subs.length;
+
+    map.set(account.id, { countervalue, count });
+  }
+
+  return map;
+}
+
+export function computeBalanceSortCountervalueByAccountId(
+  rows: readonly AccountLike[],
+  calculateCountervalue: CalculateCountervalue,
+): Map<string, BigNumber> {
+  const map = new Map<string, BigNumber>();
+  for (const account of rows) {
+    const currency = getAccountCurrency(account);
+    map.set(account.id, calculateCountervalue(currency, account.balance) ?? new BigNumber(0));
+  }
+  return map;
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8302,7 +8302,10 @@
       },
       "editName": "Edit name",
       "emptyState": "No crypto address yet",
-      "emptySearchState": "No accounts match your search"
+      "emptySearchState": "No accounts match your search",
+      "assetCount_zero": "{{count}} asset",
+      "assetCount_one": "{{count}} asset",
+      "assetCount_other": "{{count}} assets"
     },
     "editName": {
       "title": "Edit address name",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - CryptoAddresses page rendering in aggregated mode (one row per main account, showing squared crypto icon, aggregated countervalue and asset count)
  - Default (non-aggregated) rendering of the CryptoAddresses page — must remain unchanged
  - Sort behavior on the "Value" column (aggregated and non-aggregated)
  - Behavior for accounts with zero balance / missing countervalues
  - Feature flag gating via `shouldDisplayAggregatedAssets`

### 📝 Description

Extend the CryptoAddresses page to support an aggregated-assets view, gated by the `shouldDisplayAggregatedAssets` wallet feature config.

**Problem**: in default mode, each main account and each sub-account is displayed as a separate row, which makes the list long and noisy when users hold many tokens across several parent accounts.

**Solution**: when the feature flag is on, the table now collapses to **one row per main account** with:

- a squared crypto icon
- the account name (ticker removed for a cleaner look)
- an aggregated countervalue that sums the main balance and all sub-account balances
- an asset count reflecting the number of aggregated assets

Internals:

- New `computeAggregatedAccountsData` util returns a single `Map<accountId, { countervalue, count }>`
- New `AggregatedAccountNameCell` and `AggregatedAccountValueCell` cells
- Sort comparator on the "Value" column reads the aggregated countervalue via a lookup function (same signature for both modes)
- Vocabulary aligned with the rest of the stack: `countervalue` is used everywhere (no more `fiat`)

### 🖼️ Before / After

<img width="741" height="454" alt="Screenshot 2026-04-17 at 13 45 13" src="https://github.com/user-attachments/assets/f85f7457-d1c2-489b-9970-acb6bdef12eb" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29027](https://ledgerhq.atlassian.net/browse/LIVE-29027)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29027]: https://ledgerhq.atlassian.net/browse/LIVE-29027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ