### PR TITLE
[LWDM] chore(live-common): async prep — getAccountBridge and getCurrencyBridge

### DIFF
--- a/.changeset/live-29186-async-bridge-impl.md
+++ b/.changeset/live-29186-async-bridge-impl.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+chore(live-common): async prep — getAccountBridge and getCurrencyBridge (LIVE-29186)
+
+Prepare all async callers of `getAccountBridge` and `getCurrencyBridge` to `await` the result.
+Functions remain synchronous for now; the `async` keyword will be added in the follow-up PR.

--- a/apps/cli/src/commands/blockchain/botTransfer.ts
+++ b/apps/cli/src/commands/blockchain/botTransfer.ts
@@ -80,7 +80,7 @@ export default {
           device = r.device;
           await cache.prepareCurrency(currency);
           const maybeAddress = await firstValueFrom(
-            getCurrencyBridge(currency)
+            (await getCurrencyBridge(currency))
               .scanAccounts({
                 currency,
                 deviceId: device.id,
@@ -124,7 +124,7 @@ export default {
           if (!r) return;
           device = r.device;
           await firstValueFrom(
-            getCurrencyBridge(currency)
+            (await getCurrencyBridge(currency))
               .scanAccounts({
                 currency,
                 deviceId: r.device.id,
@@ -184,7 +184,7 @@ export default {
           console.log("no recipient to empty account " + account.id);
           return;
         }
-        const accountBridge = getAccountBridge(account);
+        const accountBridge = await getAccountBridge(account);
 
         // TODO in case of cosmos & other funds that can be delegated, we need to also schedule these txs first..
         const plannedTransactions: TransactionCommon[] = [];

--- a/apps/cli/src/commands/blockchain/sync.ts
+++ b/apps/cli/src/commands/blockchain/sync.ts
@@ -26,7 +26,7 @@ export default {
       mergeMap(async account => {
         const { currencyId } = decodeAccountId(account.id);
         const currency = getCryptoCurrencyById(currencyId);
-        const currencyBridge = getCurrencyBridge(currency);
+        const currencyBridge = await getCurrencyBridge(currency);
         const { nftResolvers } = currencyBridge;
 
         return account.nfts?.length && nftResolvers?.nftMetadata

--- a/apps/cli/src/transaction.ts
+++ b/apps/cli/src/transaction.ts
@@ -106,7 +106,7 @@ export async function inferTransactions(
   mainAccount: Account,
   opts: InferTransactionsOpts,
 ): Promise<[Transaction, TransactionStatusCommon][]> {
-  const bridge = getAccountBridge(mainAccount, null);
+  const bridge = await getAccountBridge(mainAccount, null);
   const specific = loadSetupForFamily(mainAccount.currency.family).cliTools;
 
   const inferAccounts: (account: Account, opts: Record<string, unknown>) => AccountLikeArray =

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useFeePresetFiatValues.ts
@@ -202,10 +202,9 @@ export function useFeePresetFiatValues({
     requestIdRef.current += 1;
     const requestId = requestIdRef.current;
 
-    const bridge = getAccountBridge(account, parentAccount ?? undefined);
-
-    queueMicrotask(() => {
-      estimateFiatValuesForPresets({
+    queueMicrotask(async () => {
+      const bridge = await getAccountBridge(account, parentAccount ?? undefined);
+      await estimateFiatValuesForPresets({
         bridge,
         mainAccount,
         transaction,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/EvmGasOptionsSync.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/EvmGasOptionsSync.tsx
@@ -29,12 +29,12 @@ export function EvmGasOptionsSync({
     // schedule transaction update as a microtask
     if (!isEqual(scheduledGasOptionsRef.current ?? null, evmGasOptions)) {
       scheduledGasOptionsRef.current = evmGasOptions;
-      queueMicrotask(() => {
+      queueMicrotask(async () => {
+        const bridge = await getAccountBridge(account, parentAccount ?? undefined);
         transactionActions.updateTransaction(currentTx => {
           if ("gasOptions" in currentTx && currentTx.gasOptions) {
             if (isEqual(currentTx.gasOptions, evmGasOptions)) return currentTx;
           }
-          const bridge = getAccountBridge(account, parentAccount ?? undefined);
           return bridge.updateTransaction(currentTx, { gasOptions: evmGasOptions });
         });
       });

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/hooks/useBridgeFeeEstimation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/hooks/useBridgeFeeEstimation.ts
@@ -83,12 +83,12 @@ export function useBridgeFeeEstimation({
     setBridgeHasInsufficientBalance(false);
     bridgeEstimationRequestIdRef.current += 1;
     const requestId = bridgeEstimationRequestIdRef.current;
-    const bridge = getAccountBridge(account, parentAccount ?? undefined);
-    const patch = customFeeConfig.buildTransactionPatch(values);
-    const nextTransaction = bridge.updateTransaction(transaction, patch as Partial<Transaction>);
 
     queueMicrotask(async () => {
       try {
+        const bridge = await getAccountBridge(account, parentAccount ?? undefined);
+        const patch = customFeeConfig.buildTransactionPatch(values);
+        const nextTransaction = bridge.updateTransaction(transaction, patch as Partial<Transaction>);
         const preparedTx = await bridge.prepareTransaction(mainAccount, nextTransaction);
         const nextStatus = await bridge.getTransactionStatus(mainAccount, preparedTx);
         if (bridgeEstimationRequestIdRef.current !== requestId) return;

--- a/apps/ledger-live-desktop/src/renderer/components/SpendableAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SpendableAmount.tsx
@@ -29,16 +29,17 @@ const SpendableAmount = <T extends TransactionCommon>({
   useEffect(() => {
     if (!account) return;
     let cancelled = false;
-    getAccountBridge(account, parentAccount)
-      .estimateMaxSpendable({
+    (async () => {
+      const bridge = await getAccountBridge(account, parentAccount);
+      if (cancelled) return;
+      const estimate = await bridge.estimateMaxSpendable({
         account,
         parentAccount,
         transaction: debouncedTransaction,
-      })
-      .then(estimate => {
-        if (cancelled) return;
-        setMaxSpendable(estimate);
       });
+      if (cancelled) return;
+      setMaxSpendable(estimate);
+    })();
     return () => {
       cancelled = true;
     };

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/LiveAppSDKLogic.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/LiveAppSDKLogic.ts
@@ -94,7 +94,7 @@ export const broadcastTransactionLogic = (
       parentAccount: Account | undefined,
       signedOperation: SignedOperation,
     ): Promise<string> => {
-      const bridge = getAccountBridge(account, parentAccount);
+      const bridge = await getAccountBridge(account, parentAccount);
       const mainAccount = getMainAccount(account, parentAccount);
 
       let optimisticOperation: Operation = signedOperation.operation;

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/getFee.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/getFee.ts
@@ -122,7 +122,7 @@ export const getFee =
     // Setup accounts and bridge
     const fromParentAccount = getParentAccount(fromAccount, accounts);
     let mainAccount = getMainAccount(fromAccount, fromParentAccount);
-    const bridge = getAccountBridge(fromAccount, fromParentAccount);
+    const bridge = await getAccountBridge(fromAccount, fromParentAccount);
 
     if (mainAccount.currency.id === "bitcoin") {
       try {

--- a/apps/wallet-cli/src/wallet/compatibility/bridge.ts
+++ b/apps/wallet-cli/src/wallet/compatibility/bridge.ts
@@ -107,7 +107,7 @@ export class BridgeAdapter {
 
   async verifyAddress(descriptor: AccountDescriptor, deviceId: string): Promise<string> {
     const account = await this.sync(descriptor);
-    const bridge = getAccountBridge(account);
+    const bridge = await getAccountBridge(account);
     const result = await firstValueFrom(bridge.receive(account, { deviceId, verify: true }));
     return result.address;
   }
@@ -207,7 +207,7 @@ export class BridgeAdapter {
   }
 
   private async buildValidatedTx(account: Account, intent: TransactionIntent) {
-    const bridge = getAccountBridge(account);
+    const bridge = await getAccountBridge(account);
     const nativeUnit = account.currency.units[0];
     const parsed = parseAmountWithTicker(intent.amount, account);
     const tokenAccount =
@@ -242,7 +242,7 @@ export class BridgeAdapter {
 
   private async sync(descriptor: AccountDescriptor): Promise<Account> {
     const account = this.buildAccount(descriptor);
-    const bridge = getAccountBridge(account);
+    const bridge = await getAccountBridge(account);
     await BridgeAdapter.cache.prepareCurrency(account.currency);
     return lastValueFrom(
       bridge

--- a/apps/web-tools/src/pages/sync.tsx
+++ b/apps/web-tools/src/pages/sync.tsx
@@ -71,7 +71,7 @@ function inferAccount(id: string): Account {
 
 async function syncAccount(id: string) {
   const account = inferAccount(id);
-  const bridge = getAccountBridge(account);
+  const bridge = await getAccountBridge(account);
   await bridgeCache.prepareCurrency(account.currency);
   const syncConfig = {
     paginationConfig: {},

--- a/libs/ledger-live-common/src/bot/engine.ts
+++ b/libs/ledger-live-common/src/bot/engine.ts
@@ -130,7 +130,7 @@ export async function runWithAppSpec<T extends TransactionCommon>(
   try {
     device = await createSpeculosDevice(deviceParams);
     appReport.appPath = device.appPath;
-    const bridge = getCurrencyBridge(currency);
+    const bridge = await getCurrencyBridge(currency);
     const syncConfig = {
       paginationConfig: {},
     };
@@ -374,7 +374,7 @@ export async function runOnAccount<T extends TransactionCommon>({
   };
 
   try {
-    const accountBridge = getAccountBridge(account);
+    const accountBridge = await getAccountBridge(account);
     const accountBeforeTransaction = account;
     report.account = account;
     log("engine", `spec ${spec.name}/${getDefaultAccountNameForCurrencyIndex(account)}`);
@@ -737,8 +737,9 @@ export async function runOnAccount<T extends TransactionCommon>({
 }
 
 async function syncAccount(initialAccount: Account): Promise<Account> {
+  const bridge = await getAccountBridge(initialAccount);
   const acc = await firstValueFrom(
-    getAccountBridge(initialAccount)
+    bridge
       .sync(initialAccount, {
         paginationConfig: {},
       })

--- a/libs/ledger-live-common/src/bot/portfolio/process-sync.ts
+++ b/libs/ledger-live-common/src/bot/portfolio/process-sync.ts
@@ -90,7 +90,7 @@ async function main(): Promise<Report> {
       },
     });
 
-    const bridge = getCurrencyBridge(currency);
+    const bridge = await getCurrencyBridge(currency);
     const syncConfig = {
       paginationConfig: {},
     };

--- a/libs/ledger-live-common/src/bridge/cache.ts
+++ b/libs/ledger-live-common/src/bridge/cache.ts
@@ -15,7 +15,7 @@ export function makeBridgeCacheSystem({
 }): BridgeCacheSystem {
   const hydrateCurrency = async (currency: CryptoCurrency) => {
     const value = await getData(currency);
-    const bridge = getCurrencyBridge(currency);
+    const bridge = await getCurrencyBridge(currency);
     bridge.hydrate(value, currency);
     return value;
   };
@@ -26,7 +26,7 @@ export function makeBridgeCacheSystem({
     currency: CryptoCurrency,
     { forceUpdate }: { forceUpdate: boolean } = { forceUpdate: false },
   ) => {
-    const bridge = getCurrencyBridge(currency);
+    const bridge = await getCurrencyBridge(currency);
     const { preloadMaxAge } = {
       ...defaultCacheStrategy,
       ...(bridge.getPreloadStrategy && bridge.getPreloadStrategy(currency)),

--- a/libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
@@ -67,7 +67,7 @@ const completeExchange = (
         );
 
         const mainAccount = getMainAccount(fromAccount, fromParentAccount);
-        const accountBridge = getAccountBridge(mainAccount);
+        const accountBridge = await getAccountBridge(mainAccount);
         const mainPayoutCurrency = getAccountCurrency(mainAccount);
         const payoutCurrency = getAccountCurrency(fromAccount);
 

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
@@ -73,8 +73,8 @@ const completeExchange = (
 
         const refundAccount = getMainAccount(fromAccount, fromParentAccount);
         const payoutAccount = getMainAccount(toAccount, toParentAccount);
-        const accountBridge = getAccountBridge(refundAccount);
-        const payoutAccountBridge = getAccountBridge(payoutAccount);
+        const accountBridge = await getAccountBridge(refundAccount);
+        const payoutAccountBridge = await getAccountBridge(payoutAccount);
         const mainPayoutCurrency = getAccountCurrency(payoutAccount);
         const payoutCurrency = getAccountCurrency(toAccount);
         const refundCurrency = getAccountCurrency(fromAccount);

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useUpdateMaxAmount.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useUpdateMaxAmount.ts
@@ -67,7 +67,7 @@ export const useUpdateMaxAmount = ({
     () => {
       const updateAmountUsingMax = async () => {
         if (!account) return;
-        const bridge = getAccountBridge(account, parentAccount);
+        const bridge = await getAccountBridge(account, parentAccount);
         setIsMaxLoading(true);
         const amount = await bridge.estimateMaxSpendable({
           account,

--- a/libs/ledger-live-common/src/families/canton/react.ts
+++ b/libs/ledger-live-common/src/families/canton/react.ts
@@ -29,13 +29,12 @@ export function useCantonAcceptOrRejectOffer({
   account,
   partyId,
 }: UseCantonAcceptOrRejectOfferOptions) {
-  const cantonBridge = getCurrencyBridge(currency) as CantonCurrencyBridge;
-
   const transferInstruction = useCallback(
-    (
+    async (
       { contractId, deviceId, reason }: TransferInstructionParams,
       type: TransferInstructionType,
     ) => {
+      const cantonBridge = (await getCurrencyBridge(currency)) as CantonCurrencyBridge;
       return cantonBridge.transferInstruction(
         currency,
         deviceId,
@@ -46,7 +45,7 @@ export function useCantonAcceptOrRejectOffer({
         reason,
       );
     },
-    [cantonBridge, currency, account, partyId],
+    [currency, account, partyId],
   );
 
   return transferInstruction;

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/useBridgeRecipientValidation.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/useBridgeRecipientValidation.ts
@@ -91,7 +91,7 @@ export function useBridgeRecipientValidation({
 
     try {
       const mainAccount = getMainAccount(account, parentAccount);
-      const bridge = getAccountBridge(account, parentAccount);
+      const bridge = await getAccountBridge(account, parentAccount);
 
       let transaction = bridge.createTransaction(mainAccount);
       transaction = bridge.updateTransaction(transaction, { recipient });

--- a/libs/ledger-live-common/src/hooks/useBroadcast.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.ts
@@ -23,7 +23,7 @@ export const useBroadcast = ({ account, parentAccount, broadcastConfig }: SignTr
     async (signedOperation: SignedOperation): Promise<Operation> => {
       if (!account) throw new Error("account not present");
       const mainAccount = getMainAccount(account, parentAccount);
-      const bridge = getAccountBridge(account, parentAccount);
+      const bridge = await getAccountBridge(account, parentAccount);
 
       if (getEnv("DISABLE_TRANSACTION_BROADCAST")) {
         return Promise.resolve(signedOperation.operation);

--- a/libs/ledger-live-common/src/hw/actions/rawTransaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/rawTransaction.ts
@@ -155,28 +155,34 @@ export const createAction = (
         return;
       }
 
-      const bridge = getAccountBridge(mainAccount);
-      const sub = bridge
-        .signRawOperation({
-          account: mainAccount,
-          transaction,
-          deviceId: device.deviceId,
-          deviceModelId: device.modelId,
-          broadcast,
-        })
-        .pipe(
-          catchError(error =>
-            of<{ type: "error"; error: Error }>({
-              type: "error",
-              error,
-            }),
-          ),
-          tap((e: Event) => log("actions-transaction-event", e.type, e)),
-          scan(reducer, initialState),
-        )
-        .subscribe((x: any) => setState(x));
+      let cancelled = false;
+      let sub: { unsubscribe: () => void } | undefined;
+      (async () => {
+        const bridge = await getAccountBridge(mainAccount);
+        if (cancelled) return;
+        sub = bridge
+          .signRawOperation({
+            account: mainAccount,
+            transaction,
+            deviceId: device.deviceId,
+            deviceModelId: device.modelId,
+            broadcast,
+          })
+          .pipe(
+            catchError(error =>
+              of<{ type: "error"; error: Error }>({
+                type: "error",
+                error,
+              }),
+            ),
+            tap((e: Event) => log("actions-transaction-event", e.type, e)),
+            scan(reducer, initialState),
+          )
+          .subscribe((x: any) => setState(x));
+      })();
       return () => {
-        sub.unsubscribe();
+        cancelled = true;
+        sub?.unsubscribe();
       };
     }, [device, mainAccount, transaction, broadcast, opened, inWrongDeviceForAccount, error]);
     return {

--- a/libs/ledger-live-common/src/hw/actions/transaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/transaction.ts
@@ -155,30 +155,36 @@ export const createAction = (
         return;
       }
 
-      const bridge = isACRE
-        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (ACREBridge.accountBridge as unknown as AccountBridge<any>)
-        : getAccountBridge(mainAccount);
-      const sub = bridge
-        .signOperation({
-          account: mainAccount,
-          transaction,
-          deviceId: device.deviceId,
-          deviceModelId: device.modelId,
-        })
-        .pipe(
-          catchError(error =>
-            of<{ type: "error"; error: Error }>({
-              type: "error",
-              error,
-            }),
-          ),
-          tap((e: Event) => log("actions-transaction-event", e.type, e)),
-          scan(reducer, initialState),
-        )
-        .subscribe((x: any) => setState(x));
+      let cancelled = false;
+      let sub: { unsubscribe: () => void } | undefined;
+      (async () => {
+        const bridge = isACRE
+          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (ACREBridge.accountBridge as unknown as AccountBridge<any>)
+          : await getAccountBridge(mainAccount);
+        if (cancelled) return;
+        sub = bridge
+          .signOperation({
+            account: mainAccount,
+            transaction,
+            deviceId: device.deviceId,
+            deviceModelId: device.modelId,
+          })
+          .pipe(
+            catchError(error =>
+              of<{ type: "error"; error: Error }>({
+                type: "error",
+                error,
+              }),
+            ),
+            tap((e: Event) => log("actions-transaction-event", e.type, e)),
+            scan(reducer, initialState),
+          )
+          .subscribe((x: any) => setState(x));
+      })();
       return () => {
-        sub.unsubscribe();
+        cancelled = true;
+        sub?.unsubscribe();
       };
     }, [device, mainAccount, transaction, opened, inWrongDeviceForAccount, error, isACRE]);
     return {

--- a/libs/ledger-live-common/src/platform/logic.ts
+++ b/libs/ledger-live-common/src/platform/logic.ts
@@ -206,7 +206,7 @@ export async function completeExchangeLogic(
     toCurrency: toAccount ? getCurrencyForAccount(toAccount) : undefined,
   };
 
-  const accountBridge = getAccountBridge(fromAccount, fromParentAccount);
+  const accountBridge = await getAccountBridge(fromAccount, fromParentAccount);
   const mainFromAccount = getMainAccount(fromAccount, fromParentAccount);
   const mainFromAccountFamily = mainFromAccount.currency.family;
 

--- a/libs/ledger-live-common/src/wallet-api/ACRE/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/ACRE/server.ts
@@ -389,7 +389,7 @@ export const handlers = ({
       const mainAccount = getMainAccount(account, parentAccount);
       const signerAccount = currency ? makeEmptyTokenAccount(mainAccount, currency) : account;
 
-      const bridge = getAccountBridge(signerAccount, parentAccount);
+      const bridge = await getAccountBridge(signerAccount, parentAccount);
       const broadcastAccount = getMainAccount(signerAccount, parentAccount);
 
       const networkId =

--- a/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
@@ -299,7 +299,7 @@ export const handlers = ({
           );
         }
 
-        const accountBridge = getAccountBridge(fromAccount, fromParentAccount);
+        const accountBridge = await getAccountBridge(fromAccount, fromParentAccount);
 
         /**
          * 'subAccountId' is used for ETH and it's ERC-20 tokens.
@@ -552,7 +552,7 @@ export const handlers = ({
           );
         }
 
-        const accountBridge = getAccountBridge(fromAccount, fromParentAccount);
+        const accountBridge = await getAccountBridge(fromAccount, fromParentAccount);
 
         /**
          * 'subAccountId' is used for ETH and it's ERC-20 tokens.

--- a/libs/ledger-live-common/src/wallet-api/logic.ts
+++ b/libs/ledger-live-common/src/wallet-api/logic.ts
@@ -589,7 +589,7 @@ export async function completeExchangeLogic(
     toCurrency: toAccount ? getToCurrency(toAccount, newTokenAccount) : undefined,
   };
 
-  const accountBridge = getAccountBridge(fromAccount, fromParentAccount);
+  const accountBridge = await getAccountBridge(fromAccount, fromParentAccount);
   const mainFromAccount = getMainAccount(fromAccount, fromParentAccount);
   const mainFromAccountFamily = mainFromAccount.currency.family;
 

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -744,7 +744,7 @@ export function useWalletAPIServer({
           accountId,
           signedOperation,
           async (account, parentAccount, signedOperation) => {
-            const bridge = getAccountBridge(account, parentAccount);
+            const bridge = await getAccountBridge(account, parentAccount);
             const mainAccount = getMainAccount(account, parentAccount);
 
             let optimisticOperation: Operation = signedOperation.operation;
@@ -878,7 +878,7 @@ export function useWalletAPIServer({
             accountId,
             signedOperation,
             async (account, parentAccount, signedOperation) => {
-              const bridge = getAccountBridge(account, parentAccount);
+              const bridge = await getAccountBridge(account, parentAccount);
               const mainAccount = getMainAccount(account, parentAccount);
 
               const networkId =
@@ -974,7 +974,7 @@ export function useWalletAPIServer({
           accountId,
           signedTransaction,
           async (account, parentAccount, signedOperation) => {
-            const bridge = getAccountBridge(account, parentAccount);
+            const bridge = await getAccountBridge(account, parentAccount);
             const mainAccount = getMainAccount(account, parentAccount);
 
             const networkId =

--- a/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
+++ b/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
@@ -532,7 +532,7 @@ export function useDappLogic({
                 }),
               );
 
-              const bridge = getAccountBridge(currentAccount, undefined);
+              const bridge = await getAccountBridge(currentAccount, undefined);
               const mainAccount = getMainAccount(currentAccount, undefined);
 
               let optimisticOperation: Operation = signedTransaction.operation;


### PR DESCRIPTION
- [x] PRs #16350 #16351 #16352 must be merged first

### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- no logic change, callers only add `await` on still-sync functions -->
- [x] **Impact of the changes:**
  - No runtime behavior change — functions remain synchronous, `await syncFn()` resolves immediately.
  - Prepares call sites so the follow-up PR can add `async` to `getAccountBridge`/`getCurrencyBridge` without requiring a second round of caller updates.

### 📝 Description

Prepares some async call sites of `getAccountBridge` and `getCurrencyBridge` to `await` the result. The functions themselves remain synchronous; adding `await` on a sync function is valid TypeScript and a no-op at runtime.

**TLDR for callers after the follow-up `async` PR merges:**
```diff
- const bridge = getAccountBridge(account);
+ const bridge = await getAccountBridge(account);
```
Already done here — no follow-up changes needed at these call sites.

Patterns used:
- Direct `await` in already-async functions
- Async IIFE in `useEffect` callbacks with `cancelled` guard
- `async` promoted on `useCallback` / `queueMicrotask` callbacks

Remaining call sites not covered (separate PRs):
- `useBridgeTransaction` and its ~100 consumer files
- `createTransaction`/`updateTransaction` sync-contract callers (MemoField, AmountField components, etc.)

### ❓ Context

- **JIRA**: [LIVE-29186](https://ledgerhq.atlassian.net/browse/LIVE-29186) but without the `useBridgeTransaction` part

[LIVE-29186]: https://ledgerhq.atlassian.net/browse/LIVE-29186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ