### PR TITLE
fix: exclude apps with @ledgerhq/ prefix from build:libs script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "changelog": "changeset add",
     "prerelease": "pnpm run build:libs",
     "release": "changeset publish",
-    "build:libs": "nx run-many -t build -p \"@ledgerhq/*\" --exclude \"@ledgerhq/dummy-*-app\" --parallel=20",
+    "build:libs": "nx run-many -t build -p \"@ledgerhq/*\" --exclude \"@ledgerhq/dummy-*-app,@ledgerhq/live-cli,@ledgerhq/web-tools,@ledgerhq/wallet-cli\" --parallel=20",
     "build:libs:force": "pnpm run build:libs --skip-nx-cache",
     "build:tests": "nx run-many -t build --include \"@ledgerhq/dummy-*-app\"",
     "build:dummy-apps": "nx run-many -t build -p \"@ledgerhq/dummy-*-app\"",


### PR DESCRIPTION
### ✅ Checklist

- [x] No changeset needed (build script / tooling change only)
- [x] **Covered by automatic tests.** N/A — tooling change only
- [x] **Impact of the changes:**
  - The `build:libs` script no longer tries to build `@ledgerhq/live-cli`, `@ledgerhq/web-tools`, and `@ledgerhq/wallet-cli`, which are apps (not libraries) that happen to carry the `@ledgerhq/` package-name prefix.

### 📝 Description

`build:libs` uses the `@ledgerhq/*` glob to select all library packages, but a few apps (`live-cli`, `web-tools`, `wallet-cli`) also use that prefix. Including them in a library build step caused unnecessary failures or noise. This change adds them to the `--exclude` list alongside the existing `dummy-*-app` exclusions.

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)