### PR TITLE
[LWD] feat(desktop): add MyWallet context menu in TopBar

### DIFF
--- a/.changeset/chatty-camels-hide.md
+++ b/.changeset/chatty-camels-hide.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+add context menu for mywallet

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/TopBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/TopBarView.tsx
@@ -7,6 +7,7 @@ import { TopBarViewProps } from "./types";
 import { TopBarActionsList } from "./components/ActionsList";
 import FirmwareUpdateBanner from "~/renderer/components/FirmwareUpdateBanner";
 import Updater from "LLD/features/Updater";
+import { MyWallet } from "LLD/features/MyWallet";
 
 const TopBarView = ({ slots, shouldShowFirmwareUpdateBanner }: TopBarViewProps) => {
   return (
@@ -19,6 +20,7 @@ const TopBarView = ({ slots, shouldShowFirmwareUpdateBanner }: TopBarViewProps) 
         {shouldShowFirmwareUpdateBanner && <FirmwareUpdateBanner />}
         <Updater />
         <TopBarActionsList slots={slots} />
+        <MyWallet />
       </NavBarTrailing>
     </NavBar>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Popover, PopoverTrigger, PopoverContent, IconButton } from "@ledgerhq/lumen-ui-react";
+import { Airplane } from "@ledgerhq/lumen-ui-react/symbols";
+
+const side = "bottom";
+const align = "end";
+
+export function ContextMenu() {
+  return (
+    <Popover>
+      <PopoverTrigger render={<IconButton icon={Airplane} aria-label="Airplane" size="sm" />} />
+
+      <PopoverContent width="fixed" side={side} align={align}>
+        <p className="body-2 text-base">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos.
+        </p>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { ContextMenu } from "./components/ContextMenu";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/walletFeaturesConfig/useWalletFeaturesConfig";
+
+export function MyWallet() {
+  const { shouldDisplayMyWallet } = useWalletFeaturesConfig("desktop");
+  if (!shouldDisplayMyWallet) return null;
+  return <ContextMenu />;
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _UI component, covered by visual review._
- [x] **Impact of the changes:**
  - TopBar rendering on the Wallet 4.0 dashboard (desktop only)
  - MyWallet feature entry point — visible only when \`shouldDisplayMyWallet\` flag is ON
  - Popover/context menu interaction in the NavBar trailing area

### 📝 Description

The MyWallet feature needs a context menu entry point in the desktop TopBar.

This PR adds a \`MyWallet\` component to the TopBar's trailing slot. It is gated behind the \`shouldDisplayMyWallet\` wallet-features-config flag so it is invisible in production until the flag is enabled. The context menu itself is a \`Popover\` from Lumen UI React, currently rendering a placeholder body pending final designs.


https://github.com/user-attachments/assets/f92c33c1-bc3f-4a46-b289-fa252c58b8e0




### ❓ Context

- **JIRA or GitHub link**: [LIVE-26016](https://ledgerhq.atlassian.net/browse/LIVE-26016)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26016]: https://ledgerhq.atlassian.net/browse/LIVE-26016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ