### PR TITLE
fix(wallet-cli): preload polyfill via bunfig.toml to fix tronweb proto crash

### DIFF
--- a/apps/wallet-cli/bunfig.toml
+++ b/apps/wallet-cli/bunfig.toml
@@ -1,5 +1,12 @@
 # Bun runtime configuration for wallet-cli.
 
+# Preload the proto/goog stub before any module is evaluated.
+# tronweb's CJS protobuf files reference `proto` as a bare global; without this
+# they crash non-deterministically because Bun can evaluate CJS modules in the
+# transitive import graph before cli.ts top-level imports settle.
+# (account/helpers.js → @ledgerhq/coin-tron/index → tronweb)
+preload = ["./src/polyfill.ts"]
+
 [test]
 coverageReporter = ["lcov"]
 coverageDir = "coverage"

--- a/apps/wallet-cli/src/cli.ts
+++ b/apps/wallet-cli/src/cli.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env bun
-import "./polyfill";
 import "./init-cwd";
 import "./embed-usb-native";
 import { createCLI } from "@bunli/core";

--- a/apps/wallet-cli/src/test/helpers/wrapper.ts
+++ b/apps/wallet-cli/src/test/helpers/wrapper.ts
@@ -1,6 +1,3 @@
-// Dynamic import ensures polyfill and HTTP interception (static deps above) are
-// fully evaluated before Bun links the CLI's CJS dependency graph.
-import "../../polyfill";
 import "./http-intercept";
 
 await import("../../cli");


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Validated manually: 10/10 runs succeed after fix vs ~50% before.
- [ ] **Impact of the changes:**
  - Fixes non-deterministic `ReferenceError: proto is not defined` crash at wallet-cli startup (~50% failure rate)
  - No behaviour change — same polyfill, different loading mechanism

### 📝 Description

`import "./polyfill"` as the first line of `cli.ts` was not reliable. Bun can evaluate CJS modules in the transitive import graph before top-level ESM side-effect imports settle. The path pulling in tronweb:

```
@ledgerhq/live-common/account/helpers.js
  → @ledgerhq/coin-tron/index
    → tronweb CJS protobuf files (reference bare global `proto`)
```

This caused a non-deterministic crash (~50% failure rate):

```
ReferenceError: proto is not defined
  at tronweb/lib/esm/protocol/core/contract/balance_contract_pb.cjs
```

Moving the polyfill to `bunfig.toml` `preload` guarantees it runs before any module is evaluated by Bun, making the fix reliable.

```diff
+preload = ["./src/polyfill.ts"]
```

### ❓ Context

- **JIRA or GitHub link**: <!-- missing — please add if applicable -->
- **ADR link (if any)**: N/A