### PR TITLE
chore(ci): add bun 1.3.11 to mise toolchain

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -15,6 +15,7 @@ cocoapods = "mise-plugins/mise-cocoapods"
 node = '24.14.0'
 pnpm = '10.24.0'
 npm = '10.3.0'
+bun = '1.3.11'
 gitleaks = '8.30.1'
 hk = '1.40.0'
 pkl = '0.31.1'


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** N/A — toolchain config only
- [ ] **Impact of the changes:**
  - Adds `bun 1.3.11` to the mise-managed toolchain so it is available in local dev and CI environments.

### 📝 Description

Adds `bun = '1.3.11'` to the `[tools]` section of `mise.toml` to make Bun available as a managed tool via mise.

### ❓ Context

- **JIRA or GitHub link**: N/A