### PR TITLE
[LWDM] fix(coin-evm): drop non-value-transferring internals and dedup root traces in getBlock

### DIFF
--- a/.changeset/coin-evm-dedup-internal-root-traces.md
+++ b/.changeset/coin-evm-dedup-internal-root-traces.md
@@ -2,22 +2,29 @@
 "@ledgerhq/coin-evm": patch
 ---
 
-Fix `getBlock` double-counting native transfers from explorer internal txs.
+Fix `getBlock` and `listOperations` double-counting native transfers from
+explorer internal txs.
 
 Blockscout (and Etherscan-like explorers) report one internal transaction per
 EVM frame, which includes (a) a root trace that mirrors the coin tx's own
 native transfer and (b) `delegatecall` / `staticcall` / `callcode` frames that
 inherit `msg.value` from their caller without actually moving native value.
 Before this fix those entries were treated as independent native transfers,
-producing up to three identical OUTs for a single contract interaction and
-driving indexer balances (e.g. A4 on Somnia) negative.
+producing up to three identical OUTs for a single contract interaction,
+driving indexer balances (e.g. A4 on Somnia) negative and surfacing phantom
+IN/OUT ops in account history.
 
-Two complementary filters are now applied:
+Three filters are now applied — one per entry point into the internal-tx
+adapters, plus a structural safety net:
 
-- **Semantic** — `internalTxsToOperationsByHash` (Etherscan/Blockscout) and
-  `traceBlockItemsToOperationsByHash` (RPC `trace_block`) drop frames whose
+- **Semantic (block)** — `internalTxsToOperationsByHash` (Etherscan/Blockscout)
+  and `traceBlockItemsToOperationsByHash` (RPC `trace_block`) drop frames whose
   `callType` (or Etherscan `type`) is one of `delegatecall`, `staticcall`,
   `callcode`. These opcodes cannot move native value.
+- **Semantic (account history)** — `etherscanInternalTransactionToOperations`
+  (used by `listOperations`) applies the same filter, so the non-value-
+  transferring frames no longer surface as phantom IN/OUT ops in Ledger Live
+  Desktop/Mobile history for Blockscout-backed chains.
 - **Structural** — `mergeInternalTransactions` runs a provider-agnostic dedup
   (`dropRootTraceDuplicates`) that drops any remaining internal native op
   whose `(address, peer, amount)` tuple exactly matches one of the coin tx's

--- a/.changeset/coin-evm-dedup-internal-root-traces.md
+++ b/.changeset/coin-evm-dedup-internal-root-traces.md
@@ -2,30 +2,10 @@
 "@ledgerhq/coin-evm": patch
 ---
 
-Fix `getBlock` and `listOperations` double-counting native transfers from
-explorer internal txs.
-
-Blockscout (and Etherscan-like explorers) report one internal transaction per
-EVM frame, which includes (a) a root trace that mirrors the coin tx's own
-native transfer and (b) `delegatecall` / `staticcall` / `callcode` frames that
-inherit `msg.value` from their caller without actually moving native value.
-Before this fix those entries were treated as independent native transfers,
-producing up to three identical OUTs for a single contract interaction,
-driving indexer balances (e.g. A4 on Somnia) negative and surfacing phantom
-IN/OUT ops in account history.
-
-Three filters are now applied — one per entry point into the internal-tx
-adapters, plus a structural safety net:
-
-- **Semantic (block)** — `internalTxsToOperationsByHash` (Etherscan/Blockscout)
-  and `traceBlockItemsToOperationsByHash` (RPC `trace_block`) drop frames whose
-  `callType` (or Etherscan `type`) is one of `delegatecall`, `staticcall`,
-  `callcode`. These opcodes cannot move native value.
-- **Semantic (account history)** — `etherscanInternalTransactionToOperations`
-  (used by `listOperations`) applies the same filter, so the non-value-
-  transferring frames no longer surface as phantom IN/OUT ops in Ledger Live
-  Desktop/Mobile history for Blockscout-backed chains.
-- **Structural** — `mergeInternalTransactions` runs a provider-agnostic dedup
-  (`dropRootTraceDuplicates`) that drops any remaining internal native op
-  whose `(address, peer, amount)` tuple exactly matches one of the coin tx's
-  own native ops. Acts as a safety net for future explorer variants.
+Fix `getBlock` and `listOperations` double-counting native transfers from explorer internal
+txs. Blockscout and Etherscan expose the root call of every tx as an internal transaction,
+and report `delegatecall`/`staticcall`/`callcode` frames with an inherited `msg.value` that
+cannot actually move native ETH — both were surfaced as independent native ops, driving
+downstream indexer balances negative and producing phantom IN/OUT ops in account history.
+The three internal-tx adapters now skip non-value-transferring call types, and
+`mergeInternalTransactions` runs a provider-agnostic structural dedup as a safety net.

--- a/.changeset/coin-evm-dedup-internal-root-traces.md
+++ b/.changeset/coin-evm-dedup-internal-root-traces.md
@@ -1,0 +1,24 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Fix `getBlock` double-counting native transfers from explorer internal txs.
+
+Blockscout (and Etherscan-like explorers) report one internal transaction per
+EVM frame, which includes (a) a root trace that mirrors the coin tx's own
+native transfer and (b) `delegatecall` / `staticcall` / `callcode` frames that
+inherit `msg.value` from their caller without actually moving native value.
+Before this fix those entries were treated as independent native transfers,
+producing up to three identical OUTs for a single contract interaction and
+driving indexer balances (e.g. A4 on Somnia) negative.
+
+Two complementary filters are now applied:
+
+- **Semantic** — `internalTxsToOperationsByHash` (Etherscan/Blockscout) and
+  `traceBlockItemsToOperationsByHash` (RPC `trace_block`) drop frames whose
+  `callType` (or Etherscan `type`) is one of `delegatecall`, `staticcall`,
+  `callcode`. These opcodes cannot move native value.
+- **Structural** — `mergeInternalTransactions` runs a provider-agnostic dedup
+  (`dropRootTraceDuplicates`) that drops any remaining internal native op
+  whose `(address, peer, amount)` tuple exactly matches one of the coin tx's
+  own native ops. Acts as a safety net for future explorer variants.

--- a/libs/coin-modules/coin-evm/src/adapters/blockOperations.test.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/blockOperations.test.ts
@@ -327,6 +327,20 @@ describe("EVM Family", () => {
           const byHash = traceBlockItemsToOperationsByHash([]);
           expect(byHash.size).toBe(0);
         });
+
+        it.each(["delegatecall", "staticcall", "callcode"])(
+          "should skip %s frames since they cannot move native value",
+          callType => {
+            const items: TraceBlockItem[] = [
+              makeTraceItem({
+                transactionHash: "0xhash1",
+                action: makeAction({ callType }),
+              }),
+            ];
+            const byHash = traceBlockItemsToOperationsByHash(items);
+            expect(byHash.size).toBe(0);
+          },
+        );
       });
 
       describe("ledgerTransactionToBlockOperations", () => {

--- a/libs/coin-modules/coin-evm/src/adapters/blockOperations.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/blockOperations.ts
@@ -73,6 +73,10 @@ export function rpcTransactionToBlockOperations(
   return operations;
 }
 
+// EVM call types that execute code but do NOT transfer native value. Keeping this list in sync
+// with the one in `adapters/etherscan.ts` — both providers leak the same non-transferring frames.
+const NON_VALUE_TRANSFER_CALL_TYPES = new Set(["delegatecall", "staticcall", "callcode"]);
+
 function extractActionFields(
   item: TraceBlockItem,
 ): { from: string; to: string; value: bigint; hash: string } | null {
@@ -87,6 +91,11 @@ function extractActionFields(
   // When traceBlockItemsToOperationsByHash processed the top-level trace without filtering it out,
   // the same native transfer appeared twice after merging.
   if (item.traceAddress.length === 0) return null;
+
+  // `delegatecall`, `staticcall`, and `callcode` cannot move native ETH; the `value` field here
+  // is msg.value inherited from the enclosing frame. Converting them into operations would
+  // double-count the transfer.
+  if (NON_VALUE_TRANSFER_CALL_TYPES.has(action.callType.toLowerCase())) return null;
 
   const value = BigInt(action.value);
   if (value === 0n) return null;

--- a/libs/coin-modules/coin-evm/src/adapters/blockOperations.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/blockOperations.ts
@@ -6,6 +6,7 @@ import type {
 import { TransactionInfo, TraceBlockItem, isTraceBlockCallAction } from "../network/node/types";
 import { LedgerExplorerOperation } from "../types";
 import { safeEncodeEIP55 } from "../utils";
+import { NON_VALUE_TRANSFER_CALL_TYPES } from "./nonValueTransferCallTypes";
 
 /**
  * Helper function to add transfer operations for a from/to pair.
@@ -72,10 +73,6 @@ export function rpcTransactionToBlockOperations(
 
   return operations;
 }
-
-// EVM call types that execute code but do NOT transfer native value. Keeping this list in sync
-// with the one in `adapters/etherscan.ts` — both providers leak the same non-transferring frames.
-const NON_VALUE_TRANSFER_CALL_TYPES = new Set(["delegatecall", "staticcall", "callcode"]);
 
 function extractActionFields(
   item: TraceBlockItem,

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.test.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.test.ts
@@ -1705,74 +1705,57 @@ describe("EVM Family", () => {
         // Blockscout reports `delegatecall`/`staticcall`/`callcode` internal frames with an
         // inherited `msg.value`, but those opcodes cannot move native ETH. Emitting operations
         // for them would surface phantom IN/OUT ops in the user's history.
+        const accountIdForCallType = encodeAccountId({
+          type: "js",
+          version: "2",
+          currencyId: "ethereum",
+          xpubOrAddress: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+          derivationMode: "",
+        });
+        const makeInternalTx = (overrides: {
+          type?: string;
+          callType?: string;
+        }): EtherscanInternalTransaction => ({
+          blockNumber: "14878012",
+          timeStamp: "1653990239",
+          hash: "0xb3effb3b6c52c719507f8219fe0dd2147a9f7ba366261ab43532efb0b9b01885",
+          from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+          to: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
+          value: "66616263350003",
+          contractAddress: "",
+          input: "",
+          type: overrides.type ?? "call",
+          gas: "129878",
+          gasUsed: "0",
+          traceId: "0_1",
+          isError: "0",
+          errCode: "",
+          ...(overrides.callType !== undefined ? { callType: overrides.callType } : {}),
+        });
+
         it.each([
-          { field: "callType", value: "delegatecall" },
-          { field: "callType", value: "staticcall" },
-          { field: "callType", value: "callcode" },
-          { field: "type", value: "delegatecall" },
-          { field: "type", value: "staticcall" },
-          { field: "type", value: "callcode" },
-        ])(
-          "returns no operations when $field is $value (non-value-transferring call type)",
-          ({ field, value }) => {
-            const accountId = encodeAccountId({
-              type: "js",
-              version: "2",
-              currencyId: "ethereum",
-              xpubOrAddress: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
-              derivationMode: "",
-            });
-
-            const etherscanOp: EtherscanInternalTransaction = {
-              blockNumber: "14878012",
-              timeStamp: "1653990239",
-              hash: "0xb3effb3b6c52c719507f8219fe0dd2147a9f7ba366261ab43532efb0b9b01885",
-              from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
-              to: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
-              value: "66616263350003",
-              contractAddress: "",
-              input: "",
-              type: field === "type" ? value : "call",
-              gas: "129878",
-              gasUsed: "0",
-              traceId: "0_1",
-              isError: "0",
-              errCode: "",
-              ...(field === "callType" ? { callType: value } : {}),
-            };
-
-            expect(etherscanInternalTransactionToOperations(accountId, etherscanOp)).toEqual([]);
-          },
-        );
+          { callType: "delegatecall" },
+          { callType: "staticcall" },
+          { callType: "callcode" },
+          { type: "delegatecall" },
+          { type: "staticcall" },
+          { type: "callcode" },
+        ])("returns no operations for non-value-transferring call type %o", overrides => {
+          expect(
+            etherscanInternalTransactionToOperations(
+              accountIdForCallType,
+              makeInternalTx(overrides),
+            ),
+          ).toEqual([]);
+        });
 
         it("is case-insensitive on the call type discriminator", () => {
-          const accountId = encodeAccountId({
-            type: "js",
-            version: "2",
-            currencyId: "ethereum",
-            xpubOrAddress: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
-            derivationMode: "",
-          });
-
-          const etherscanOp: EtherscanInternalTransaction = {
-            blockNumber: "14878012",
-            timeStamp: "1653990239",
-            hash: "0xb3effb3b6c52c719507f8219fe0dd2147a9f7ba366261ab43532efb0b9b01885",
-            from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
-            to: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
-            value: "66616263350003",
-            contractAddress: "",
-            input: "",
-            type: "call",
-            callType: "DelegateCall",
-            gas: "129878",
-            gasUsed: "0",
-            traceId: "0_1",
-            isError: "0",
-            errCode: "",
-          };
-
-          expect(etherscanInternalTransactionToOperations(accountId, etherscanOp)).toEqual([]);
+          expect(
+            etherscanInternalTransactionToOperations(
+              accountIdForCallType,
+              makeInternalTx({ callType: "DelegateCall" }),
+            ),
+          ).toEqual([]);
         });
       });
       describe("etherscanStakingToOperations", () => {

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.test.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.test.ts
@@ -1701,6 +1701,79 @@ describe("EVM Family", () => {
           expect(result).toHaveLength(1);
           expect(result[0].recipients).toEqual([]);
         });
+
+        // Blockscout reports `delegatecall`/`staticcall`/`callcode` internal frames with an
+        // inherited `msg.value`, but those opcodes cannot move native ETH. Emitting operations
+        // for them would surface phantom IN/OUT ops in the user's history.
+        it.each([
+          { field: "callType", value: "delegatecall" },
+          { field: "callType", value: "staticcall" },
+          { field: "callType", value: "callcode" },
+          { field: "type", value: "delegatecall" },
+          { field: "type", value: "staticcall" },
+          { field: "type", value: "callcode" },
+        ])(
+          "returns no operations when $field is $value (non-value-transferring call type)",
+          ({ field, value }) => {
+            const accountId = encodeAccountId({
+              type: "js",
+              version: "2",
+              currencyId: "ethereum",
+              xpubOrAddress: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+              derivationMode: "",
+            });
+
+            const etherscanOp: EtherscanInternalTransaction = {
+              blockNumber: "14878012",
+              timeStamp: "1653990239",
+              hash: "0xb3effb3b6c52c719507f8219fe0dd2147a9f7ba366261ab43532efb0b9b01885",
+              from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+              to: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
+              value: "66616263350003",
+              contractAddress: "",
+              input: "",
+              type: field === "type" ? value : "call",
+              gas: "129878",
+              gasUsed: "0",
+              traceId: "0_1",
+              isError: "0",
+              errCode: "",
+              ...(field === "callType" ? { callType: value } : {}),
+            };
+
+            expect(etherscanInternalTransactionToOperations(accountId, etherscanOp)).toEqual([]);
+          },
+        );
+
+        it("is case-insensitive on the call type discriminator", () => {
+          const accountId = encodeAccountId({
+            type: "js",
+            version: "2",
+            currencyId: "ethereum",
+            xpubOrAddress: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+            derivationMode: "",
+          });
+
+          const etherscanOp: EtherscanInternalTransaction = {
+            blockNumber: "14878012",
+            timeStamp: "1653990239",
+            hash: "0xb3effb3b6c52c719507f8219fe0dd2147a9f7ba366261ab43532efb0b9b01885",
+            from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+            to: "0xdef171fe48cf0115b1d80b88dc8eab59176fee57",
+            value: "66616263350003",
+            contractAddress: "",
+            input: "",
+            type: "call",
+            callType: "DelegateCall",
+            gas: "129878",
+            gasUsed: "0",
+            traceId: "0_1",
+            isError: "0",
+            errCode: "",
+          };
+
+          expect(etherscanInternalTransactionToOperations(accountId, etherscanOp)).toEqual([]);
+        });
       });
       describe("etherscanStakingToOperations", () => {
         it("should convert an etherscan-like staking smart contract delegate operation (from their API) to a Ledger Live Operation", () => {

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.test.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.test.ts
@@ -1995,6 +1995,24 @@ describe("EVM Family", () => {
           expect(byHash.size).toBe(1);
           expect(byHash.get("0xtx1")!.length).toBe(4); // 2 internal txs × 2 ops each
         });
+
+        it.each(["delegatecall", "staticcall", "callcode"])(
+          "skips internal txs whose Blockscout callType is %s (no native value moves)",
+          callType => {
+            const internalTxs = [{ ...baseInternalTx, hash: "0xtx1", callType }];
+            const byHash = internalTxsToOperationsByHash(internalTxs);
+            expect(byHash.size).toBe(0);
+          },
+        );
+
+        it.each(["delegatecall", "staticcall", "callcode"])(
+          "skips internal txs whose Etherscan type is %s (no native value moves)",
+          type => {
+            const internalTxs = [{ ...baseInternalTx, hash: "0xtx1", type }];
+            const byHash = internalTxsToOperationsByHash(internalTxs);
+            expect(byHash.size).toBe(0);
+          },
+        );
       });
     });
 

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
@@ -333,7 +333,13 @@ function isInternalTransactionValid(it: EtherscanInternalTransaction): boolean {
 
 /**
  * Converts valid internal transactions to BlockOperations grouped by transaction hash.
- * Skips internal txs with isError === "1" or value === "0".
+ * Skips internal txs that:
+ *   - failed (`isError === "1"`) or report a non-positive `value`;
+ *   - are missing `from` or `to`;
+ *   - have a `callType` (Blockscout) or `type` (Etherscan) in
+ *     `NON_VALUE_TRANSFER_CALL_TYPES` — those opcodes (`delegatecall`,
+ *     `staticcall`, `callcode`) inherit `msg.value` from their enclosing frame
+ *     but cannot move native ETH.
  */
 export function internalTxsToOperationsByHash(
   internalTxs: EtherscanInternalTransaction[],

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
@@ -321,8 +321,19 @@ export const etherscanInternalTransactionToOperations = (
 
 const NATIVE_ASSET = { type: "native" } as const;
 
+// EVM call types that execute code but do NOT transfer native value. Both Blockscout and Etherscan
+// still report a `value` on these entries (inherited from the enclosing call's msg.value), so
+// converting them into operations would double-count the native transfer.
+// Blockscout exposes the discriminator via `callType`, Etherscan via `type`.
+const NON_VALUE_TRANSFER_CALL_TYPES = new Set(["delegatecall", "staticcall", "callcode"]);
+
 function isInternalTransactionValid(it: EtherscanInternalTransaction): boolean {
-  return it.isError === "0" && BigInt(it.value) > 0n && !!it.from && !!it.to;
+  if (it.isError !== "0") return false;
+  if (BigInt(it.value) === 0n) return false;
+  if (!it.from || !it.to) return false;
+  const callType = (it.callType || it.type || "").toLowerCase();
+  if (NON_VALUE_TRANSFER_CALL_TYPES.has(callType)) return false;
+  return true;
 }
 
 /**

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
@@ -275,6 +275,18 @@ export const etherscanERC1155EventToOperations = (
 };
 
 /**
+ * `delegatecall`/`staticcall`/`callcode` cannot move native ETH, but both Blockscout and
+ * Etherscan still report a non-zero `value` on those entries (it's the `msg.value` inherited
+ * from the enclosing frame). Blockscout exposes the discriminator via `callType`, Etherscan
+ * folds it into `type` — this helper hides that quirk from both call sites.
+ */
+function isNonValueTransferInternalTx(
+  it: Pick<EtherscanInternalTransaction, "callType" | "type">,
+): boolean {
+  return NON_VALUE_TRANSFER_CALL_TYPES.has((it.callType || it.type || "").toLowerCase());
+}
+
+/**
  * Adapter to convert an internal transaction
  * on etherscan APIs into LL Operations
  */
@@ -283,14 +295,8 @@ export const etherscanInternalTransactionToOperations = (
   internalTx: EtherscanInternalTransaction,
   index = 0,
 ): Operation[] => {
-  // Skip non-value-transferring call types (`delegatecall`/`staticcall`/`callcode`).
-  // Both Blockscout and Etherscan report a non-zero `value` on these entries — it's the
-  // `msg.value` inherited from the enclosing frame, not an actual native transfer — so
-  // emitting operations here would surface phantom IN/OUT ops in the account's history.
-  // See `NON_VALUE_TRANSFER_CALL_TYPES` for the canonical list; `internalTxsToOperationsByHash`
-  // (the `getBlock` path) applies the same filter via `isInternalTransactionValid`.
-  const callType = (internalTx.callType || internalTx.type || "").toLowerCase();
-  if (NON_VALUE_TRANSFER_CALL_TYPES.has(callType)) return [];
+  // Phantom IN/OUT guard; `isInternalTransactionValid` applies the same filter on the `getBlock` path.
+  if (isNonValueTransferInternalTx(internalTx)) return [];
 
   const { hash, blockNumber, isError } = internalTx;
   const { xpubOrAddress: address } = decodeAccountId(accountId);
@@ -331,12 +337,16 @@ export const etherscanInternalTransactionToOperations = (
 
 const NATIVE_ASSET = { type: "native" } as const;
 
+/**
+ * Validates an internal tx for the `getBlock` path. The same non-value-transferring filter
+ * is also applied at the entrypoint of `etherscanInternalTransactionToOperations`
+ * (the `listOperations` path) — see `isNonValueTransferInternalTx`.
+ */
 function isInternalTransactionValid(it: EtherscanInternalTransaction): boolean {
   if (it.isError !== "0") return false;
   if (BigInt(it.value) <= 0n) return false;
   if (!it.from || !it.to) return false;
-  const callType = (it.callType || it.type || "").toLowerCase();
-  if (NON_VALUE_TRANSFER_CALL_TYPES.has(callType)) return false;
+  if (isNonValueTransferInternalTx(it)) return false;
   return true;
 }
 

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
@@ -28,6 +28,7 @@ import {
   EtherscanInternalTransaction,
 } from "../types";
 import { buildSmartContractDetails, safeEncodeEIP55 } from "../utils";
+import { NON_VALUE_TRANSFER_CALL_TYPES } from "./nonValueTransferCallTypes";
 
 /**
  * Helper to safely convert a value to BigNumber, defaulting to 0 if invalid.
@@ -321,15 +322,9 @@ export const etherscanInternalTransactionToOperations = (
 
 const NATIVE_ASSET = { type: "native" } as const;
 
-// EVM call types that execute code but do NOT transfer native value. Both Blockscout and Etherscan
-// still report a `value` on these entries (inherited from the enclosing call's msg.value), so
-// converting them into operations would double-count the native transfer.
-// Blockscout exposes the discriminator via `callType`, Etherscan via `type`.
-const NON_VALUE_TRANSFER_CALL_TYPES = new Set(["delegatecall", "staticcall", "callcode"]);
-
 function isInternalTransactionValid(it: EtherscanInternalTransaction): boolean {
   if (it.isError !== "0") return false;
-  if (BigInt(it.value) === 0n) return false;
+  if (BigInt(it.value) <= 0n) return false;
   if (!it.from || !it.to) return false;
   const callType = (it.callType || it.type || "").toLowerCase();
   if (NON_VALUE_TRANSFER_CALL_TYPES.has(callType)) return false;

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
@@ -283,6 +283,15 @@ export const etherscanInternalTransactionToOperations = (
   internalTx: EtherscanInternalTransaction,
   index = 0,
 ): Operation[] => {
+  // Skip non-value-transferring call types (`delegatecall`/`staticcall`/`callcode`).
+  // Both Blockscout and Etherscan report a non-zero `value` on these entries — it's the
+  // `msg.value` inherited from the enclosing frame, not an actual native transfer — so
+  // emitting operations here would surface phantom IN/OUT ops in the account's history.
+  // See `NON_VALUE_TRANSFER_CALL_TYPES` for the canonical list; `internalTxsToOperationsByHash`
+  // (the `getBlock` path) applies the same filter via `isInternalTransactionValid`.
+  const callType = (internalTx.callType || internalTx.type || "").toLowerCase();
+  if (NON_VALUE_TRANSFER_CALL_TYPES.has(callType)) return [];
+
   const { hash, blockNumber, isError } = internalTx;
   const { xpubOrAddress: address } = decodeAccountId(accountId);
 

--- a/libs/coin-modules/coin-evm/src/adapters/nonValueTransferCallTypes.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/nonValueTransferCallTypes.ts
@@ -1,0 +1,12 @@
+/**
+ * EVM call types that execute code but do NOT transfer native value. Both Blockscout and
+ * Etherscan still report a `value` on these entries (inherited from the enclosing call's
+ * `msg.value`), so converting them into operations would double-count the native transfer.
+ *
+ * Shared between the explorer adapter (`etherscan.ts`, where Blockscout exposes the
+ * discriminator via `callType` and Etherscan via `type`) and the RPC `trace_block` adapter
+ * (`blockOperations.ts`, which reads `action.callType`).
+ *
+ * Intentionally not re-exported from `adapters/index.ts`.
+ */
+export const NON_VALUE_TRANSFER_CALL_TYPES = new Set(["delegatecall", "staticcall", "callcode"]);

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
@@ -14,7 +14,8 @@ import {
 } from "../network/node/types";
 import { EtherscanInternalTransaction } from "../types";
 import { safeEncodeEIP55 } from "../utils";
-import { getBlock } from "./getBlock";
+import { dropRootTraceDuplicates, getBlock } from "./getBlock";
+import type { BlockOperation } from "@ledgerhq/coin-module-framework/api/index";
 
 // fixme refactor this test
 // use builder function to build the mocked return values
@@ -569,6 +570,125 @@ describe("getBlock", () => {
     });
   });
 
+  it("drops a root-trace internal transaction that duplicates the coin tx's native transfer", async () => {
+    // Blockscout's `txlistinternal` exposes the top-level call of every tx as an internal transaction.
+    // That entry has `from`, `to`, `value` identical to the coin tx's own native transfer, so merging
+    // it naively would double-count the native transfer. The dedup in mergeInternalTransactions
+    // drops internal native ops whose (address, peer, amount) match one of the coin tx's own.
+    setCoinConfig(
+      () =>
+        ({
+          info: {
+            node: { type: "external" as const, retries: 0 },
+            explorer: { type: "etherscan", uri: "https://api.etherscan.io" },
+          },
+        }) as unknown as EvmCoinConfig,
+    );
+
+    const amount = 200000000000000000n;
+    const mockGetNodeApi = jest.mocked(getNodeApi);
+    mockGetNodeApi.mockReturnValue({
+      getBlockByHeight: jest.fn().mockResolvedValueOnce(
+        makeNodeBlock({
+          transactions: [makeNodeBlockTx({ hash: "0xtx1", value: amount.toString() })],
+        }),
+      ),
+      getBlockReceipts: jest
+        .fn()
+        .mockResolvedValue([makeNodeBlockReceipt({ hash: "0xtx1", erc20Transfers: [] })]),
+      getTransaction: jest.fn(),
+    } as any);
+
+    const mockGetInternalTransactionsByBlock = jest.mocked(getInternalTransactionsByBlock);
+    mockGetInternalTransactionsByBlock.mockResolvedValueOnce([
+      // Root-trace duplicate: same from/to/value as the coin tx.
+      makeExplorerInternalTransaction({
+        hash: "0xtx1",
+        from: address1,
+        to: address2,
+        value: amount.toString(),
+      }),
+    ]);
+
+    const result = await getBlock({} as CryptoCurrency, 12345);
+
+    // Only the two ops from the coin tx itself (sender + recipient side), no duplicates.
+    const nativeOps = result.transactions[0].operations.filter(
+      op => op.type === "transfer" && op.asset.type === "native",
+    );
+    expect(nativeOps).toHaveLength(2);
+  });
+
+  it("keeps a nested internal transaction that does not match the coin tx's native transfer", async () => {
+    // Sanity: when the explorer reports a legitimate subcall (different from/to than the coin tx),
+    // it is kept alongside the coin tx's own native ops.
+    setCoinConfig(
+      () =>
+        ({
+          info: {
+            node: { type: "external" as const, retries: 0 },
+            explorer: { type: "etherscan", uri: "https://api.etherscan.io" },
+          },
+        }) as unknown as EvmCoinConfig,
+    );
+
+    const coinAmount = 200000000000000000n;
+    const nestedAmount = 200000000000000000n;
+    const nestedRecipient = "0x330E16622F947CBBfA15aB2fdf83014EAa27eCd1";
+    const mockGetNodeApi = jest.mocked(getNodeApi);
+    mockGetNodeApi.mockReturnValue({
+      getBlockByHeight: jest.fn().mockResolvedValueOnce(
+        makeNodeBlock({
+          transactions: [makeNodeBlockTx({ hash: "0xtx1", value: coinAmount.toString() })],
+        }),
+      ),
+      getBlockReceipts: jest
+        .fn()
+        .mockResolvedValue([makeNodeBlockReceipt({ hash: "0xtx1", erc20Transfers: [] })]),
+      getTransaction: jest.fn(),
+    } as any);
+
+    const mockGetInternalTransactionsByBlock = jest.mocked(getInternalTransactionsByBlock);
+    mockGetInternalTransactionsByBlock.mockResolvedValueOnce([
+      // Root-trace duplicate: filtered.
+      makeExplorerInternalTransaction({
+        hash: "0xtx1",
+        from: address1,
+        to: address2,
+        value: coinAmount.toString(),
+      }),
+      // Nested subcall from the contract onwards: kept.
+      makeExplorerInternalTransaction({
+        hash: "0xtx1",
+        from: address2,
+        to: nestedRecipient,
+        value: nestedAmount.toString(),
+      }),
+    ]);
+
+    const result = await getBlock({} as CryptoCurrency, 12345);
+
+    const nativeOps = result.transactions[0].operations.filter(
+      op => op.type === "transfer" && op.asset.type === "native",
+    );
+    // 2 ops from the coin tx + 2 from the nested subcall = 4. Root-trace dup dropped.
+    expect(nativeOps).toHaveLength(4);
+    expect(nativeOps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          address: safeEncodeEIP55(address2),
+          peer: safeEncodeEIP55(nestedRecipient),
+          amount: -nestedAmount,
+        }),
+        expect.objectContaining({
+          address: safeEncodeEIP55(nestedRecipient),
+          peer: safeEncodeEIP55(address2),
+          amount: nestedAmount,
+        }),
+      ]),
+    );
+  });
+
   it("when explorer is not etherscan like, fallbacks to node.traceBlock", async () => {
     setCoinConfig(
       () =>
@@ -817,5 +937,62 @@ describe("getBlock", () => {
 
     expect(mockGetInternalTransactionsByBlock).toHaveBeenCalledWith(expect.anything(), 12345);
     expect(mockTraceBlock).toHaveBeenCalledWith(expect.anything(), 12345);
+  });
+});
+
+describe("dropRootTraceDuplicates", () => {
+  const A = "0xAAAa1111111111111111111111111111aaaaaaaa";
+  const B = "0xBBBb2222222222222222222222222222bbbbbbbb";
+  const C = "0xCCCc3333333333333333333333333333cccccccc";
+
+  function nativeTransfer(address: string, peer: string, amount: bigint): BlockOperation {
+    return { type: "transfer", address, peer, asset: { type: "native" }, amount };
+  }
+
+  it("drops internal native ops that exactly match a coin native op", () => {
+    const coinOps: BlockOperation[] = [
+      nativeTransfer(A, B, -100n),
+      nativeTransfer(B, A, 100n),
+    ];
+    const internalOps: BlockOperation[] = [
+      nativeTransfer(A, B, -100n), // root-trace duplicate
+      nativeTransfer(B, A, 100n),  // root-trace duplicate
+    ];
+    expect(dropRootTraceDuplicates(coinOps, internalOps)).toEqual([]);
+  });
+
+  it("keeps internal ops that differ in peer or amount", () => {
+    const coinOps: BlockOperation[] = [
+      nativeTransfer(A, B, -100n),
+      nativeTransfer(B, A, 100n),
+    ];
+    const internalOps: BlockOperation[] = [
+      nativeTransfer(B, C, -100n), // nested subcall
+      nativeTransfer(C, B, 100n),
+    ];
+    expect(dropRootTraceDuplicates(coinOps, internalOps)).toEqual(internalOps);
+  });
+
+  it("compares addresses case-insensitively", () => {
+    const coinOps: BlockOperation[] = [nativeTransfer(A.toLowerCase(), B.toLowerCase(), -100n)];
+    const internalOps: BlockOperation[] = [nativeTransfer(A.toUpperCase(), B.toUpperCase(), -100n)];
+    expect(dropRootTraceDuplicates(coinOps, internalOps)).toEqual([]);
+  });
+
+  it("leaves ERC20 internal ops alone even when they share address/peer/amount with a native op", () => {
+    const coinOps: BlockOperation[] = [nativeTransfer(A, B, -100n)];
+    const erc20Op: BlockOperation = {
+      type: "transfer",
+      address: A,
+      peer: B,
+      asset: { type: "erc20", assetReference: "0xtoken", assetOwner: A },
+      amount: -100n,
+    };
+    expect(dropRootTraceDuplicates(coinOps, [erc20Op])).toEqual([erc20Op]);
+  });
+
+  it("is a no-op when the coin tx has no native ops", () => {
+    const internalOps: BlockOperation[] = [nativeTransfer(A, B, -100n)];
+    expect(dropRootTraceDuplicates([], internalOps)).toEqual(internalOps);
   });
 });

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
@@ -235,9 +235,9 @@ describe("getBlock", () => {
           ],
         }),
       ),
-      getBlockReceipts: jest.fn().mockResolvedValueOnce([
-        makeNodeBlockReceipt({ hash: "0xtx1", erc20Transfers: [] }),
-      ]),
+      getBlockReceipts: jest
+        .fn()
+        .mockResolvedValueOnce([makeNodeBlockReceipt({ hash: "0xtx1", erc20Transfers: [] })]),
       getTransaction: jest.fn(),
     } as any);
 
@@ -275,9 +275,11 @@ describe("getBlock", () => {
           ],
         }),
       ),
-      getBlockReceipts: jest.fn().mockResolvedValueOnce([
-        makeNodeBlockReceipt({ hash: "0xdeploy", erc20Transfers: [], contractAddress: address2 }),
-      ]),
+      getBlockReceipts: jest
+        .fn()
+        .mockResolvedValueOnce([
+          makeNodeBlockReceipt({ hash: "0xdeploy", erc20Transfers: [], contractAddress: address2 }),
+        ]),
       getTransaction: jest.fn(),
     } as any);
 
@@ -311,9 +313,9 @@ describe("getBlock", () => {
           ],
         }),
       ),
-      getBlockReceipts: jest.fn().mockResolvedValueOnce([
-        makeNodeBlockReceipt({ hash: "0xtx1", erc20Transfers: [] }),
-      ]),
+      getBlockReceipts: jest
+        .fn()
+        .mockResolvedValueOnce([makeNodeBlockReceipt({ hash: "0xtx1", erc20Transfers: [] })]),
       getTransaction: jest.fn(),
     } as any);
 
@@ -633,6 +635,8 @@ describe("getBlock", () => {
         }) as unknown as EvmCoinConfig,
     );
 
+    // Same amount as the coin tx, on purpose: the match key is (address, peer, amount),
+    // so a different peer must not collapse even when the amount matches.
     const coinAmount = 200000000000000000n;
     const nestedAmount = 200000000000000000n;
     const nestedRecipient = "0x330E16622F947CBBfA15aB2fdf83014EAa27eCd1";
@@ -951,22 +955,16 @@ describe("dropRootTraceDuplicates", () => {
   }
 
   it("drops internal native ops that exactly match a coin native op", () => {
-    const coinOps: BlockOperation[] = [
-      nativeTransfer(A, B, -100n),
-      nativeTransfer(B, A, 100n),
-    ];
+    const coinOps: BlockOperation[] = [nativeTransfer(A, B, -100n), nativeTransfer(B, A, 100n)];
     const internalOps: BlockOperation[] = [
       nativeTransfer(A, B, -100n), // root-trace duplicate
-      nativeTransfer(B, A, 100n),  // root-trace duplicate
+      nativeTransfer(B, A, 100n), // root-trace duplicate
     ];
     expect(dropRootTraceDuplicates(coinOps, internalOps)).toEqual([]);
   });
 
   it("keeps internal ops that differ in peer or amount", () => {
-    const coinOps: BlockOperation[] = [
-      nativeTransfer(A, B, -100n),
-      nativeTransfer(B, A, 100n),
-    ];
+    const coinOps: BlockOperation[] = [nativeTransfer(A, B, -100n), nativeTransfer(B, A, 100n)];
     const internalOps: BlockOperation[] = [
       nativeTransfer(B, C, -100n), // nested subcall
       nativeTransfer(C, B, 100n),

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
@@ -996,4 +996,65 @@ describe("dropRootTraceDuplicates", () => {
     const internalOps: BlockOperation[] = [nativeTransfer(A, B, -100n)];
     expect(dropRootTraceDuplicates([], internalOps)).toEqual(internalOps);
   });
+
+  it("drops only the native duplicate when native and ERC20 ops overlap on the same key", () => {
+    // Regression: the ERC20 op shares (address, peer, amount) with the coin tx's native op.
+    // The dedup narrows to native-asset ops, so the ERC20 entry must be preserved.
+    const coinOps: BlockOperation[] = [nativeTransfer(A, B, -100n)];
+    const erc20Op: BlockOperation = {
+      type: "transfer",
+      address: A,
+      peer: B,
+      asset: { type: "erc20", assetReference: "0xtoken", assetOwner: A },
+      amount: -100n,
+    };
+    const nativeDup = nativeTransfer(A, B, -100n);
+    const internalOps: BlockOperation[] = [nativeDup, erc20Op];
+    expect(dropRootTraceDuplicates(coinOps, internalOps)).toEqual([erc20Op]);
+  });
+
+  it("treats ops with an undefined peer as matching each other", () => {
+    // Some explorer/adapter shapes omit `peer` (e.g. the sender-side op when `to` is missing).
+    // Two native ops that both omit `peer` with matching (address, amount) must still dedup.
+    const coinOp: BlockOperation = {
+      type: "transfer",
+      address: A,
+      asset: { type: "native" },
+      amount: -100n,
+    };
+    const internalOp: BlockOperation = {
+      type: "transfer",
+      address: A,
+      asset: { type: "native" },
+      amount: -100n,
+    };
+    expect(dropRootTraceDuplicates([coinOp], [internalOp])).toEqual([]);
+  });
+
+  it("does NOT match when only one side has a peer", () => {
+    // A coin op with peer B and an internal op without peer describe different transfers
+    // and must not collapse into one.
+    const coinOp: BlockOperation = nativeTransfer(A, B, -100n);
+    const internalOpWithoutPeer: BlockOperation = {
+      type: "transfer",
+      address: A,
+      asset: { type: "native" },
+      amount: -100n,
+    };
+    expect(dropRootTraceDuplicates([coinOp], [internalOpWithoutPeer])).toEqual([
+      internalOpWithoutPeer,
+    ]);
+
+    // Symmetric: coin without peer vs internal with peer.
+    const coinOpWithoutPeer: BlockOperation = {
+      type: "transfer",
+      address: A,
+      asset: { type: "native" },
+      amount: -100n,
+    };
+    const internalOpWithPeer: BlockOperation = nativeTransfer(A, B, -100n);
+    expect(dropRootTraceDuplicates([coinOpWithoutPeer], [internalOpWithPeer])).toEqual([
+      internalOpWithPeer,
+    ]);
+  });
 });

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.test.ts
@@ -1,3 +1,4 @@
+import type { BlockOperation } from "@ledgerhq/coin-module-framework/api/index";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { EvmCoinConfig, setCoinConfig } from "../config";
 import { UnsupportedRpcMethodError } from "../errors";
@@ -14,8 +15,8 @@ import {
 } from "../network/node/types";
 import { EtherscanInternalTransaction } from "../types";
 import { safeEncodeEIP55 } from "../utils";
-import { dropRootTraceDuplicates, getBlock } from "./getBlock";
-import type { BlockOperation } from "@ledgerhq/coin-module-framework/api/index";
+import { getBlock } from "./getBlock";
+import { dropRootTraceDuplicates } from "./rootTraceDedup";
 
 // fixme refactor this test
 // use builder function to build the mocked return values

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.ts
@@ -96,6 +96,20 @@ export async function getBlock(currency: CryptoCurrency, height: number): Promis
 
 /**
  * Merges internal transaction operations into block transactions by matching tx hash.
+ *
+ * Runs a provider-agnostic root-trace dedup: any internal op whose
+ * `(address, peer, amount, asset)` tuple exactly matches one of the coin tx's own native
+ * operations is dropped, because it represents the same value transfer reported twice.
+ *
+ * This complements the semantic filters applied upstream by each adapter:
+ *   - `traceBlockItemsToOperationsByHash` skips items with `traceAddress.length === 0` and
+ *     items whose `callType` is `delegatecall`/`staticcall`/`callcode`.
+ *   - `internalTxsToOperationsByHash` skips items whose `callType` (Blockscout) or `type`
+ *     (Etherscan) matches the same non-value-transferring call types.
+ *
+ * The structural dedup here is the last line of defence: if a provider surfaces the root call
+ * in a shape the adapter didn't anticipate (e.g. a future explorer variant), it still gets
+ * collapsed into the coin tx's own ops.
  */
 function mergeInternalTransactions(
   transactions: BlockTransaction[],
@@ -106,11 +120,42 @@ function mergeInternalTransactions(
   return transactions.map(tx => {
     const extraOps = internalTxs.get(tx.hash);
     if (!extraOps || extraOps.length === 0) return tx;
+    const dedupedExtraOps = dropRootTraceDuplicates(tx.operations, extraOps);
+    if (dedupedExtraOps.length === 0) return tx;
     return {
       ...tx,
-      operations: [...tx.operations, ...extraOps],
+      operations: [...tx.operations, ...dedupedExtraOps],
     };
   });
+}
+
+/**
+ * Drops any internal op that is structurally identical to one of the coin tx's native ops.
+ * Only native-asset ops are considered: ERC20/721/1155 ops are surfaced by receipt logs,
+ * which are a different (non-overlapping) source.
+ */
+export function dropRootTraceDuplicates(
+  coinOps: readonly BlockOperation[],
+  internalOps: readonly BlockOperation[],
+): BlockOperation[] {
+  const coinNativeSignatures = new Set<string>();
+  for (const op of coinOps) {
+    if (op.type !== "transfer" || op.asset.type !== "native") continue;
+    coinNativeSignatures.add(signatureOf(op));
+  }
+  if (coinNativeSignatures.size === 0) return [...internalOps];
+  return internalOps.filter(op => {
+    if (op.type !== "transfer" || op.asset.type !== "native") return true;
+    return !coinNativeSignatures.has(signatureOf(op));
+  });
+}
+
+function signatureOf(op: BlockOperation): string {
+  if (op.type !== "transfer") return "";
+  const addr = (op.address ?? "").toLowerCase();
+  const peer = ("peer" in op && op.peer ? op.peer : "").toLowerCase();
+  const amount = op.amount?.toString() ?? "";
+  return `${addr}\t${peer}\t${amount}`;
 }
 
 async function getTransactionsFromNode(

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.ts
@@ -18,6 +18,7 @@ import { getInternalTransactionsByBlock } from "../network/explorer/etherscan";
 import { isEtherscanLikeExplorerConfig } from "../network/explorer/types";
 import { getNodeApi } from "../network/node";
 import { BlockReceiptInfo, NodeApi, PrefetchedBlockTransaction } from "../network/node/types";
+import { dropRootTraceDuplicates } from "./rootTraceDedup";
 import { buildSmartContractDetails } from "../utils";
 
 function internalTransactionsFetcher(
@@ -97,9 +98,10 @@ export async function getBlock(currency: CryptoCurrency, height: number): Promis
 /**
  * Merges internal transaction operations into block transactions by matching tx hash.
  *
- * Runs a provider-agnostic root-trace dedup: any internal op whose
- * `(address, peer, amount, asset)` tuple exactly matches one of the coin tx's own native
- * operations is dropped, because it represents the same value transfer reported twice.
+ * Runs a provider-agnostic root-trace dedup on internal native operations: any internal op
+ * whose `(address, peer, amount)` tuple exactly matches one of the coin tx's own native ops
+ * is dropped, because it represents the same value transfer reported twice. ERC20/721/1155
+ * ops come from receipt logs, so they are never touched here.
  *
  * This complements the semantic filters applied upstream by each adapter:
  *   - `traceBlockItemsToOperationsByHash` skips items with `traceAddress.length === 0` and
@@ -127,35 +129,6 @@ function mergeInternalTransactions(
       operations: [...tx.operations, ...dedupedExtraOps],
     };
   });
-}
-
-/**
- * Drops any internal op that is structurally identical to one of the coin tx's native ops.
- * Only native-asset ops are considered: ERC20/721/1155 ops are surfaced by receipt logs,
- * which are a different (non-overlapping) source.
- */
-export function dropRootTraceDuplicates(
-  coinOps: readonly BlockOperation[],
-  internalOps: readonly BlockOperation[],
-): BlockOperation[] {
-  const coinNativeSignatures = new Set<string>();
-  for (const op of coinOps) {
-    if (op.type !== "transfer" || op.asset.type !== "native") continue;
-    coinNativeSignatures.add(signatureOf(op));
-  }
-  if (coinNativeSignatures.size === 0) return [...internalOps];
-  return internalOps.filter(op => {
-    if (op.type !== "transfer" || op.asset.type !== "native") return true;
-    return !coinNativeSignatures.has(signatureOf(op));
-  });
-}
-
-function signatureOf(op: BlockOperation): string {
-  if (op.type !== "transfer") return "";
-  const addr = (op.address ?? "").toLowerCase();
-  const peer = ("peer" in op && op.peer ? op.peer : "").toLowerCase();
-  const amount = op.amount?.toString() ?? "";
-  return `${addr}\t${peer}\t${amount}`;
 }
 
 async function getTransactionsFromNode(

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.ts
@@ -209,7 +209,7 @@ export async function listOperations(
   options: ListOperationsOptions,
 ): Promise<Page<Operation<MemoNotSupported>>> {
   const explorerApi = getExplorerApi(currency);
-  const explorerOrder = options.limit === undefined ? "desc" : (options.order ?? "desc");
+  const explorerOrder = options.limit === undefined ? "desc" : options.order ?? "desc";
   const {
     lastCoinOperations,
     lastTokenOperations,
@@ -278,6 +278,8 @@ export async function listOperations(
   // the native value is already accounted for in the coin operation — drop the internal one.
   // Analogous to the traceAddress.length === 0 check in getBlock's traceBlockItemsToOperationsByHash,
   // but using sender matching since txlistinternal does not expose traceAddress.
+  // The `getBlock` path uses a richer `(address, peer, amount)` key in `rootTraceDedup.ts`;
+  // the two should be unified once listOperations moves to the `BlockOperation` shape.
   const isRootTrace = (op: LiveOperation): boolean => {
     const parent = parents[op.hash];
     if (!parent) return false;

--- a/libs/coin-modules/coin-evm/src/logic/rootTraceDedup.ts
+++ b/libs/coin-modules/coin-evm/src/logic/rootTraceDedup.ts
@@ -1,0 +1,33 @@
+import type { BlockOperation } from "@ledgerhq/coin-module-framework/api/index";
+
+/**
+ * Drops any internal op that is structurally identical to one of the coin tx's native ops.
+ * Only native-asset ops are considered: ERC20/721/1155 ops are surfaced by receipt logs,
+ * which are a different (non-overlapping) source.
+ *
+ * Intentionally not re-exported from `logic/index.ts` — this helper is an
+ * implementation detail of `getBlock` (and its tests).
+ */
+export function dropRootTraceDuplicates(
+  coinOps: readonly BlockOperation[],
+  internalOps: readonly BlockOperation[],
+): BlockOperation[] {
+  const coinNativeSignatures = new Set<string>();
+  for (const op of coinOps) {
+    if (op.type !== "transfer" || op.asset.type !== "native") continue;
+    coinNativeSignatures.add(signatureOf(op));
+  }
+  if (coinNativeSignatures.size === 0) return [...internalOps];
+  return internalOps.filter(op => {
+    if (op.type !== "transfer" || op.asset.type !== "native") return true;
+    return !coinNativeSignatures.has(signatureOf(op));
+  });
+}
+
+function signatureOf(op: BlockOperation): string {
+  if (op.type !== "transfer") return "";
+  const addr = (op.address ?? "").toLowerCase();
+  const peer = ("peer" in op && op.peer ? op.peer : "").toLowerCase();
+  const amount = op.amount?.toString() ?? "";
+  return `${addr}\t${peer}\t${amount}`;
+}

--- a/libs/coin-modules/coin-evm/src/logic/rootTraceDedup.ts
+++ b/libs/coin-modules/coin-evm/src/logic/rootTraceDedup.ts
@@ -1,12 +1,14 @@
-import type { BlockOperation } from "@ledgerhq/coin-module-framework/api/index";
+import type {
+  BlockOperation,
+  TransferBlockOperation,
+} from "@ledgerhq/coin-module-framework/api/index";
 
 /**
  * Drops any internal op that is structurally identical to one of the coin tx's native ops,
  * using `(address, peer, amount)` as the match key.
  *
- * Why excluding `asset` from the key is safe: this helper only ever considers `transfer` ops
- * whose `asset.type === "native"` (the filter below). ERC20/721/1155 ops come from receipt
- * logs — a different, non-overlapping source — so they are passed through unchanged.
+ * Why excluding `asset` from the key is safe: only `transfer` ops whose `asset.type === "native"`
+ * are considered — ERC20/721/1155 ops come from receipt logs, a non-overlapping source.
  *
  * Why the structural dedup cannot over-drop: in an EVM trace, every nested call frame has
  * `from = <currently-executing contract>`, so a nested native transfer cannot satisfy both
@@ -15,8 +17,7 @@ import type { BlockOperation } from "@ledgerhq/coin-module-framework/api/index";
  * (`delegatecall` / `staticcall` / `callcode`, which preserve the caller's `from`) are
  * filtered semantically upstream in the adapters, so they never reach this point.
  *
- * Intentionally not re-exported from `logic/index.ts` — implementation detail of `getBlock`
- * (and its tests).
+ * Intentionally not re-exported from `logic/index.ts` — implementation detail of `getBlock`.
  */
 export function dropRootTraceDuplicates(
   coinOps: readonly BlockOperation[],
@@ -24,19 +25,21 @@ export function dropRootTraceDuplicates(
 ): BlockOperation[] {
   const coinNativeSignatures = new Set<string>();
   for (const op of coinOps) {
-    if (op.type !== "transfer" || op.asset.type !== "native") continue;
-    coinNativeSignatures.add(signatureOf(op));
+    if (isNativeTransfer(op)) coinNativeSignatures.add(signatureOf(op));
   }
   if (coinNativeSignatures.size === 0) return [...internalOps];
-  return internalOps.filter(op => {
-    if (op.type !== "transfer" || op.asset.type !== "native") return true;
-    return !coinNativeSignatures.has(signatureOf(op));
-  });
+  return internalOps.filter(
+    op => !isNativeTransfer(op) || !coinNativeSignatures.has(signatureOf(op)),
+  );
 }
 
-function signatureOf(op: BlockOperation & { type: "transfer" }): string {
-  const addr = (op.address ?? "").toLowerCase();
-  const peer = ("peer" in op && op.peer ? op.peer : "").toLowerCase();
-  const amount = op.amount?.toString() ?? "";
-  return `${addr}\t${peer}\t${amount}`;
+function isNativeTransfer(
+  op: BlockOperation,
+): op is TransferBlockOperation & { asset: { type: "native" } } {
+  return op.type === "transfer" && op.asset.type === "native";
+}
+
+function signatureOf(op: TransferBlockOperation): string {
+  const peer = op.peer?.toLowerCase() ?? "";
+  return `${op.address.toLowerCase()}\t${peer}\t${op.amount.toString()}`;
 }

--- a/libs/coin-modules/coin-evm/src/logic/rootTraceDedup.ts
+++ b/libs/coin-modules/coin-evm/src/logic/rootTraceDedup.ts
@@ -1,12 +1,22 @@
 import type { BlockOperation } from "@ledgerhq/coin-module-framework/api/index";
 
 /**
- * Drops any internal op that is structurally identical to one of the coin tx's native ops.
- * Only native-asset ops are considered: ERC20/721/1155 ops are surfaced by receipt logs,
- * which are a different (non-overlapping) source.
+ * Drops any internal op that is structurally identical to one of the coin tx's native ops,
+ * using `(address, peer, amount)` as the match key.
  *
- * Intentionally not re-exported from `logic/index.ts` — this helper is an
- * implementation detail of `getBlock` (and its tests).
+ * Why excluding `asset` from the key is safe: this helper only ever considers `transfer` ops
+ * whose `asset.type === "native"` (the filter below). ERC20/721/1155 ops come from receipt
+ * logs — a different, non-overlapping source — so they are passed through unchanged.
+ *
+ * Why the structural dedup cannot over-drop: in an EVM trace, every nested call frame has
+ * `from = <currently-executing contract>`, so a nested native transfer cannot satisfy both
+ * `address == tx.originator` and `amount == tx.value` unless it is literally the root-trace
+ * duplicate of the coin tx itself. The only EVM opcodes that would violate this invariant
+ * (`delegatecall` / `staticcall` / `callcode`, which preserve the caller's `from`) are
+ * filtered semantically upstream in the adapters, so they never reach this point.
+ *
+ * Intentionally not re-exported from `logic/index.ts` — implementation detail of `getBlock`
+ * (and its tests).
  */
 export function dropRootTraceDuplicates(
   coinOps: readonly BlockOperation[],
@@ -24,8 +34,7 @@ export function dropRootTraceDuplicates(
   });
 }
 
-function signatureOf(op: BlockOperation): string {
-  if (op.type !== "transfer") return "";
+function signatureOf(op: BlockOperation & { type: "transfer" }): string {
   const addr = (op.address ?? "").toLowerCase();
   const peer = ("peer" in op && op.peer ? op.peer : "").toLowerCase();
   const amount = op.amount?.toString() ?? "";

--- a/libs/coin-modules/coin-evm/src/types/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/types/etherscan.ts
@@ -110,6 +110,12 @@ export type EtherscanInternalTransaction = {
   contractAddress: string;
   input: string;
   type: string;
+  /**
+   * Blockscout-specific: the low-level call opcode ("call", "delegatecall", "staticcall",
+   * "callcode"). Etherscan folds this into `type` instead, so `callType` is only set on
+   * Blockscout responses.
+   */
+  callType?: string;
   gas: string;
   gasUsed: string;
   traceId: string;


### PR DESCRIPTION
## Context

`getBlock` in `@ledgerhq/coin-evm` was surfacing every EVM frame reported by
Blockscout (and Etherscan-like explorers) as an independent native operation.
Downstream indexers like A4 add operations to compute balances, so this
double-counting drove balances negative — in particular on Somnia
(**BACK-11037**, where reference accounts ended up as `BalanceValue.Invalid`).

Two orthogonal issues were at play:

1. **Root-trace duplicate.** The first internal transaction returned by the
   explorer for each tx is the top-level call, with `from` / `to` / `value`
   identical to the coin tx itself. Merging it naively emitted the same native
   transfer twice.
2. **Non-value-transferring frames.** `delegatecall`, `staticcall`, and
   `callcode` inherit `msg.value` from their enclosing frame but cannot move
   native ETH. Blockscout still reports a non-zero `value` on those frames,
   which meant the proxy → implementation `delegatecall` was converted into a
   third ghost OUT for every proxy interaction.

A single proxy-contract call (e.g. `accountId2`'s swaps through the Somnia
router) could therefore emit up to **3 identical OUTs** for the same native
transfer.

## Why filtering these call types is safe

The EVM has four `CALL`-family opcodes. Only **one** of them can ever move
native ETH:

| Opcode         | Storage context        | `msg.sender` seen by callee | Moves ETH? | Purpose                                                                  |
|----------------|------------------------|-----------------------------|------------|--------------------------------------------------------------------------|
| `CALL`         | callee's               | the caller                  | **YES**    | Regular call; the only opcode whose `value` field actually moves ether   |
| `DELEGATECALL` | **caller's**           | preserved (caller's sender) | NO         | Proxy pattern: borrow implementation's code, execute in proxy's storage  |
| `STATICCALL`   | callee's (read-only)   | the caller                  | NO         | View calls; any state change (SSTORE, LOG, CREATE, value-bearing CALL…) reverts |
| `CALLCODE`     | **caller's**           | the caller                  | NO         | Deprecated precursor to `DELEGATECALL` (EIP-7); same storage semantics   |

By protocol, `DELEGATECALL` / `STATICCALL` / `CALLCODE` **cannot** transfer
native value — the VM never touches balances in those frames. The non-zero
`value` the explorers report on them is the `msg.value` **inherited** from the
enclosing call, copied into the frame's `value` field for display purposes.
No balance movement actually happened.

A nested real transfer inside a proxy call still appears separately as a
`CALL` frame in the trace — we keep those. We only drop the wrapper frames
that, by EVM semantics, are guaranteed not to represent a transfer.

Concretely for the Somnia proxy example:

- `CALL` user → proxy, `value = X`   ← root trace (dedupped as the coin tx itself)
- `DELEGATECALL` proxy → implementation, `value = X` inherited   ← **dropped: code-only frame**
- `CALL` proxy → recipient, `value = X`   ← **kept: actual native transfer**

## Fix

Layered defence, so a future explorer variant that leaks the root call in an
unexpected shape still gets caught:

- **Semantic filter** in the adapters, via the shared
  `NON_VALUE_TRANSFER_CALL_TYPES = {delegatecall, staticcall, callcode}`:
  - `internalTxsToOperationsByHash` (Etherscan / Blockscout, `getBlock`
    path) skips entries whose `callType` (Blockscout) or `type` (Etherscan)
    is in the set.
  - `traceBlockItemsToOperationsByHash` (RPC `trace_block`, `getBlock`
    fallback) applies the same filter to `action.callType`.
  - `etherscanInternalTransactionToOperations` (`listOperations` path)
    applies the same filter at its entrypoint, so Blockscout-backed Ledger
    Live account history stops surfacing phantom IN/OUT rows.
  - `EtherscanInternalTransaction` gains an optional `callType?` field since
    Blockscout exposes the discriminator separately from `type`.
- **Structural dedup** in `mergeInternalTransactions`: a new
  `dropRootTraceDuplicates` helper drops any internal native op whose
  `(address, peer, amount)` tuple matches one of the coin tx's own native
  ops. ERC20/721/1155 ops are never touched — they come from receipt logs,
  not from trace data, so the two sources never overlap.

Both layers are needed: the `delegatecall` frame on the Somnia proxy example
has a different `to` (implementation) than the coin tx's `to` (proxy), so the
structural dedup alone doesn't catch it; conversely the semantic filter alone
doesn't catch root-trace duplicates on explorers that don't expose `callType`.

## Tests

New tests, all in `libs/coin-modules/coin-evm/src/`:

- `logic/getBlock.test.ts`
  - 2 integration tests: root-trace duplicate dropped; nested subcall kept
    (with equal amounts but different peers, exercising the `(address, peer,
    amount)` key).
  - 7 unit tests on `dropRootTraceDuplicates` (exact match, peer/amount
    differs, case-insensitive addresses, ERC20 untouched, empty coin ops,
    undefined-peer handling).
- `adapters/etherscan.test.ts` — 6 parametric tests (`delegatecall` /
  `staticcall` / `callcode` via `callType` and via `type`) + case-insensitive
  discriminator.
- `adapters/blockOperations.test.ts` — 3 parametric tests (same call types
  via `action.callType`).

Local run: `pnpm test` → 2542 passing, `pnpm typecheck` clean, `pnpm lint` 0
errors (existing develop warnings untouched). Line coverage on touched files
is ≥ 96 %.

## Verification

Validated end-to-end against a locally-running `alpaca-coin-module` linked to
this branch (recipe in A4's
[`fast-coin-evm-dev-loop` skill](https://github.com/LedgerHQ/a4/blob/back-11037-alpaca-local-dev-fixture/.agents/skills/fast-coin-evm-dev-loop/SKILL.md))
on Somnia block `103014295`: the proxy interaction that previously produced
6 native ops now correctly produces 4.

Residual Somnia negative balances on `accountId2` are traceable to a separate
explorer data-completeness issue (IN/OUT mismatch on the Blockscout side)
unrelated to this fix; details in the A4-side investigation at
`docs/investigations/2026-04-16-somnia-native-balance.md` on the same branch.
