### PR TITLE
test(e2e): add mobile swap E2E tests aligned with desktop

### DIFF
--- a/.changeset/swift-swaps-arrive.md
+++ b/.changeset/swift-swaps-arrive.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Add mobile swap E2E tests matching desktop send.swap pairs and TMS IDs

--- a/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
+++ b/e2e/desktop/tests/specs/entrypoint.swap.spec.ts
@@ -219,12 +219,12 @@ const swapMax = [
   {
     fromAccount: Account.ETH_1,
     toAccount: Account.BTC_NATIVE_SEGWIT_1,
-    xrayTicket: "B2CQA-3365, B2CQA-3450, B2CQA-3281",
+    xrayTicket: "B2CQA-3365, B2CQA-3281",
   },
   {
     fromAccount: TokenAccount.ETH_USDT_1,
     toAccount: Account.BTC_NATIVE_SEGWIT_1,
-    xrayTicket: "B2CQA-3366, B2CQA-3450, B2CQA-3281",
+    xrayTicket: "B2CQA-3366",
   },
 ];
 

--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -15,7 +15,7 @@ const swaps = [
   {
     fromAccount: Account.ETH_1,
     toAccount: Account.BTC_NATIVE_SEGWIT_1,
-    xrayTicket: "B2CQA-2750, B2CQA-3135, B2CQA-620, B2CQA-3450",
+    xrayTicket: "B2CQA-2750, B2CQA-3135, B2CQA-620",
     tag: [
       "@NanoSP",
       "@LNS",
@@ -50,7 +50,7 @@ const swaps = [
   {
     fromAccount: Account.ETH_1,
     toAccount: TokenAccount.ETH_USDT_1,
-    xrayTicket: "B2CQA-2749, B2CQA-3450",
+    xrayTicket: "B2CQA-2749",
     tag: [
       "@NanoSP",
       "@LNS",
@@ -66,7 +66,7 @@ const swaps = [
   {
     fromAccount: Account.BTC_NATIVE_SEGWIT_1,
     toAccount: TokenAccount.ETH_USDT_1,
-    xrayTicket: "B2CQA-2746, B2CQA-3450",
+    xrayTicket: "B2CQA-2746",
     tag: [
       "@NanoSP",
       "@LNS",
@@ -83,7 +83,7 @@ const swaps = [
   {
     fromAccount: TokenAccount.ETH_USDT_1,
     toAccount: Account.BTC_NATIVE_SEGWIT_1,
-    xrayTicket: "B2CQA-2753, B2CQA-3450",
+    xrayTicket: "B2CQA-2753",
     tag: [
       "@NanoSP",
       "@LNS",
@@ -101,7 +101,7 @@ const swaps = [
   {
     fromAccount: Account.SOL_1,
     toAccount: Account.ETH_1,
-    xrayTicket: "B2CQA-2775, B2CQA-3450",
+    xrayTicket: "B2CQA-2775",
     tag: [
       "@NanoSP",
       "@LNS",
@@ -118,7 +118,7 @@ const swaps = [
   {
     fromAccount: Account.SOL_1,
     toAccount: Account.BTC_NATIVE_SEGWIT_1,
-    xrayTicket: "B2CQA-2776, B2CQA-3450",
+    xrayTicket: "B2CQA-2776",
     tag: [
       "@NanoSP",
       "@LNS",
@@ -136,7 +136,7 @@ const swaps = [
   {
     fromAccount: TokenAccount.ETH_USDC_1,
     toAccount: Account.BTC_NATIVE_SEGWIT_1,
-    xrayTicket: "B2CQA-2832, B2CQA-3450, B2CQA-3281",
+    xrayTicket: "B2CQA-2832, B2CQA-3281",
     tag: [
       "@NanoSP",
       "@LNS",
@@ -153,7 +153,7 @@ const swaps = [
   {
     fromAccount: Account.XRP_1,
     toAccount: Account.BTC_NATIVE_SEGWIT_1,
-    xrayTicket: "B2CQA-3077, B2CQA-3450, B2CQA-3281",
+    xrayTicket: "B2CQA-3077, B2CQA-3281",
     tag: [
       "@NanoSP",
       "@LNS",
@@ -171,7 +171,7 @@ const swaps = [
   // {
   //   fromAccount: Account.APTOS_1,
   //   toAccount: Account.SOL_1,
-  //   xrayTicket: "B2CQA-3081, B2CQA-3450, B2CQA-3281",
+  //   xrayTicket: "B2CQA-3081, B2CQA-3281",
   //   tag: ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@aptos", "@solana", "@family-solana","@family-aptos"],
   // },
   {

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH.spec.ts
@@ -1,0 +1,21 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapTest } from "./swap";
+
+const swap = new Swap(Account.BTC_NATIVE_SEGWIT_1, Account.ETH_1, "0.0006", undefined, Fee.MEDIUM);
+runSwapTest(
+  swap,
+  ["B2CQA-2744", "B2CQA-2432", "B2CQA-3450"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@swapSmoke",
+    "@ethereum",
+    "@family-evm",
+    "@bitcoin",
+    "@family-bitcoin",
+  ],
+);

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH_USDT.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH_USDT.spec.ts
@@ -1,0 +1,26 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapTest } from "./swap";
+
+const swap = new Swap(
+  Account.BTC_NATIVE_SEGWIT_1,
+  TokenAccount.ETH_USDT_1,
+  "0.0006",
+  undefined,
+  Fee.MEDIUM,
+);
+runSwapTest(
+  swap,
+  ["B2CQA-2746", "B2CQA-3450"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@bitcoin",
+    "@family-bitcoin",
+    "@ethereum",
+    "@family-evm",
+  ],
+);

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH_USDT.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH_USDT.spec.ts
@@ -10,7 +10,7 @@ const swap = new Swap(
 );
 runSwapTest(
   swap,
-  ["B2CQA-2746", "B2CQA-3450"],
+  ["B2CQA-2746"],
   [
     "@NanoSP",
     "@LNS",

--- a/e2e/mobile/specs/swap/swapETH_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_BTC.spec.ts
@@ -4,7 +4,7 @@ import { runSwapTest } from "./swap";
 const swap = new Swap(Account.ETH_1, Account.BTC_NATIVE_SEGWIT_1, "0.018", undefined, Fee.MEDIUM);
 runSwapTest(
   swap,
-  ["B2CQA-2750", "B2CQA-3135", "B2CQA-620", "B2CQA-3450"],
+  ["B2CQA-2750", "B2CQA-3135", "B2CQA-620"],
   [
     "@NanoSP",
     "@LNS",

--- a/e2e/mobile/specs/swap/swapETH_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_BTC.spec.ts
@@ -1,0 +1,20 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapTest } from "./swap";
+
+const swap = new Swap(Account.ETH_1, Account.BTC_NATIVE_SEGWIT_1, "0.018", undefined, Fee.MEDIUM);
+runSwapTest(
+  swap,
+  ["B2CQA-2750", "B2CQA-3135", "B2CQA-620", "B2CQA-3450"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@ethereum",
+    "@family-evm",
+    "@bitcoin",
+    "@family-bitcoin",
+  ],
+);

--- a/e2e/mobile/specs/swap/swapETH_ETH_USDT.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_ETH_USDT.spec.ts
@@ -1,0 +1,9 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapTest } from "./swap";
+
+const swap = new Swap(Account.ETH_1, TokenAccount.ETH_USDT_1, "0.018", undefined, Fee.MEDIUM);
+runSwapTest(
+  swap,
+  ["B2CQA-2749", "B2CQA-3450"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
+);

--- a/e2e/mobile/specs/swap/swapETH_ETH_USDT.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_ETH_USDT.spec.ts
@@ -4,6 +4,6 @@ import { runSwapTest } from "./swap";
 const swap = new Swap(Account.ETH_1, TokenAccount.ETH_USDT_1, "0.018", undefined, Fee.MEDIUM);
 runSwapTest(
   swap,
-  ["B2CQA-2749", "B2CQA-3450"],
+  ["B2CQA-2749"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
 );

--- a/e2e/mobile/specs/swap/swapETH_USDC_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDC_BTC.spec.ts
@@ -1,0 +1,26 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapTest } from "./swap";
+
+const swap = new Swap(
+  TokenAccount.ETH_USDC_1,
+  Account.BTC_NATIVE_SEGWIT_1,
+  "65",
+  undefined,
+  Fee.MEDIUM,
+);
+runSwapTest(
+  swap,
+  ["B2CQA-2832", "B2CQA-3450", "B2CQA-3281"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@ethereum",
+    "@family-evm",
+    "@bitcoin",
+    "@family-bitcoin",
+  ],
+);

--- a/e2e/mobile/specs/swap/swapETH_USDC_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDC_BTC.spec.ts
@@ -10,7 +10,7 @@ const swap = new Swap(
 );
 runSwapTest(
   swap,
-  ["B2CQA-2832", "B2CQA-3450", "B2CQA-3281"],
+  ["B2CQA-2832", "B2CQA-3281"],
   [
     "@NanoSP",
     "@LNS",

--- a/e2e/mobile/specs/swap/swapETH_USDT_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDT_BTC.spec.ts
@@ -1,0 +1,26 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapTest } from "./swap";
+
+const swap = new Swap(
+  TokenAccount.ETH_USDT_1,
+  Account.BTC_NATIVE_SEGWIT_1,
+  "40",
+  undefined,
+  Fee.MEDIUM,
+);
+runSwapTest(
+  swap,
+  ["B2CQA-2753", "B2CQA-3450"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@ethereum",
+    "@family-evm",
+    "@bitcoin",
+    "@family-bitcoin",
+  ],
+);

--- a/e2e/mobile/specs/swap/swapETH_USDT_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapETH_USDT_BTC.spec.ts
@@ -10,7 +10,7 @@ const swap = new Swap(
 );
 runSwapTest(
   swap,
-  ["B2CQA-2753", "B2CQA-3450"],
+  ["B2CQA-2753"],
   [
     "@NanoSP",
     "@LNS",

--- a/e2e/mobile/specs/swap/swapHBAR_XRP.spec.ts
+++ b/e2e/mobile/specs/swap/swapHBAR_XRP.spec.ts
@@ -1,0 +1,20 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapTest } from "./swap";
+
+const swap = new Swap(Account.HEDERA_1, Account.XRP_1, "15", undefined, Fee.MEDIUM);
+runSwapTest(
+  swap,
+  ["B2CQA-3753"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@hedera",
+    "@family-hedera",
+    "@ripple",
+    "@family-xrp",
+  ],
+);

--- a/e2e/mobile/specs/swap/swapSOL_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapSOL_BTC.spec.ts
@@ -1,0 +1,20 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapTest } from "./swap";
+
+const swap = new Swap(Account.SOL_1, Account.BTC_NATIVE_SEGWIT_1, "0.3", undefined, Fee.MEDIUM);
+runSwapTest(
+  swap,
+  ["B2CQA-2776", "B2CQA-3450"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@solana",
+    "@family-solana",
+    "@bitcoin",
+    "@family-bitcoin",
+  ],
+);

--- a/e2e/mobile/specs/swap/swapSOL_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapSOL_BTC.spec.ts
@@ -4,7 +4,7 @@ import { runSwapTest } from "./swap";
 const swap = new Swap(Account.SOL_1, Account.BTC_NATIVE_SEGWIT_1, "0.3", undefined, Fee.MEDIUM);
 runSwapTest(
   swap,
-  ["B2CQA-2776", "B2CQA-3450"],
+  ["B2CQA-2776"],
   [
     "@NanoSP",
     "@LNS",

--- a/e2e/mobile/specs/swap/swapSOL_ETH.spec.ts
+++ b/e2e/mobile/specs/swap/swapSOL_ETH.spec.ts
@@ -4,7 +4,7 @@ import { runSwapTest } from "./swap";
 const swap = new Swap(Account.SOL_1, Account.ETH_1, "0.3", undefined, Fee.MEDIUM);
 runSwapTest(
   swap,
-  ["B2CQA-2775", "B2CQA-3450"],
+  ["B2CQA-2775"],
   [
     "@NanoSP",
     "@LNS",

--- a/e2e/mobile/specs/swap/swapSOL_ETH.spec.ts
+++ b/e2e/mobile/specs/swap/swapSOL_ETH.spec.ts
@@ -1,0 +1,20 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapTest } from "./swap";
+
+const swap = new Swap(Account.SOL_1, Account.ETH_1, "0.3", undefined, Fee.MEDIUM);
+runSwapTest(
+  swap,
+  ["B2CQA-2775", "B2CQA-3450"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@solana",
+    "@family-solana",
+    "@ethereum",
+    "@family-evm",
+  ],
+);

--- a/e2e/mobile/specs/swap/swapXRP_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapXRP_BTC.spec.ts
@@ -4,7 +4,7 @@ import { runSwapTest } from "./swap";
 const swap = new Swap(Account.XRP_1, Account.BTC_NATIVE_SEGWIT_1, "15", undefined, Fee.MEDIUM);
 runSwapTest(
   swap,
-  ["B2CQA-3077", "B2CQA-3450", "B2CQA-3281"],
+  ["B2CQA-3077", "B2CQA-3281"],
   [
     "@NanoSP",
     "@LNS",

--- a/e2e/mobile/specs/swap/swapXRP_BTC.spec.ts
+++ b/e2e/mobile/specs/swap/swapXRP_BTC.spec.ts
@@ -1,0 +1,20 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runSwapTest } from "./swap";
+
+const swap = new Swap(Account.XRP_1, Account.BTC_NATIVE_SEGWIT_1, "15", undefined, Fee.MEDIUM);
+runSwapTest(
+  swap,
+  ["B2CQA-3077", "B2CQA-3450", "B2CQA-3281"],
+  [
+    "@NanoSP",
+    "@LNS",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@ripple",
+    "@family-xrp",
+    "@bitcoin",
+    "@family-bitcoin",
+  ],
+);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Mobile swap E2E coverage added for 10 missing pairs
      - Desktop/mobile TMS alignment updated after review so `B2CQA-3450` stays only on the `BTC -> ETH` flow
      - Gabriel added the test coverage to non-regression

### 📝 Description

**Problem**: The mobile E2E test suite was missing swap transaction tests that were already covered on desktop (`send.swap.spec.ts`). JIRA ticket QAA-1126 requested automating these on mobile.

**Solution**: Added 10 mobile swap E2E spec files that mirror the desktop `send.swap.spec.ts` pairs. After review, `B2CQA-3450` was kept only on the `BTC -> ETH` flow on desktop and mobile, and the remaining duplicated IDs used in this PR were audited.

| Mobile spec | Pair | TMS IDs |
|---|---|---|
| `swapETH_BTC` | ETH → BTC | B2CQA-2750, B2CQA-3135, B2CQA-620 |
| `swapBTC_NATIVE_SEGWIT_ETH` | BTC → ETH | B2CQA-2744, B2CQA-2432, B2CQA-3450 |
| `swapETH_ETH_USDT` | ETH → USDT | B2CQA-2749 |
| `swapBTC_NATIVE_SEGWIT_ETH_USDT` | BTC → USDT | B2CQA-2746 |
| `swapETH_USDT_BTC` | USDT → BTC | B2CQA-2753 |
| `swapSOL_ETH` | SOL → ETH | B2CQA-2775 |
| `swapSOL_BTC` | SOL → BTC | B2CQA-2776 |
| `swapETH_USDC_BTC` | USDC → BTC | B2CQA-2832, B2CQA-3281 |
| `swapXRP_BTC` | XRP → BTC | B2CQA-3077, B2CQA-3281 |
| `swapHBAR_XRP` | HEDERA → XRP | B2CQA-3753 |

@gbecerra-ledger added the B2CQA-3450 to non-regression.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1126](https://ledgerhq.atlassian.net/browse/QAA-1126)
- **ADR link (if any)**:

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1126]: https://ledgerhq.atlassian.net/browse/QAA-1126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ