### PR TITLE
[LWM] test(e2e-mocks): prefix button testID with enabled/disabled state

### DIFF
--- a/.changeset/prefix-button-testid-with-state.md
+++ b/.changeset/prefix-button-testid-with-state.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Prefix explicit `testID` on the mobile `Button` component with `enabled-` or `disabled-` so e2e tests can distinguish a rendered-but-disabled button from a missing button.

--- a/apps/ledger-live-mobile/e2e/page/accounts/addAccount.drawer.ts
+++ b/apps/ledger-live-mobile/e2e/page/accounts/addAccount.drawer.ts
@@ -7,7 +7,7 @@ export default class AddAccountDrawer extends CommonPage {
   deselectAllButtonId = "add-accounts-deselect-all";
   accountId = (currency: string, index: number) => `mock:1:${currency}:MOCK_${currency}_${index}:`;
   modalButtonId = "add-accounts-modal-add-button";
-  continueButtonId = "add-accounts-continue-button";
+  continueButtonId = "enabled-add-accounts-continue-button";
   closeAddAccountButtonId = "button-close-add-account";
   addFundsButtonId = "button-add-funds";
   actionDrawerReceiveButtonId = "action-drawer-receive-button";

--- a/apps/ledger-live-mobile/e2e/page/common.page.ts
+++ b/apps/ledger-live-mobile/e2e/page/common.page.ts
@@ -8,7 +8,7 @@ import { delay } from "../helpers/commonHelpers";
 export default class CommonPage {
   searchBarId = "common-search-field";
   searchBar = () => getElementById(this.searchBarId);
-  successCloseButtonId = "success-close-button";
+  successCloseButtonId = "enabled-success-close-button";
   closeButton = () => getElementById("NavigationHeaderCloseButton");
 
   accountCardPrefix = "account-card-";

--- a/apps/ledger-live-mobile/e2e/page/onboarding/onboardingSteps.page.ts
+++ b/apps/ledger-live-mobile/e2e/page/onboarding/onboardingSteps.page.ts
@@ -3,7 +3,7 @@ import { expect } from "detox";
 
 export default class OnboardingStepsPage {
   getStartedButtonId = "onboarding-getStarted-button";
-  acceptAnalyticsButtonId = "accept-analytics-button";
+  acceptAnalyticsButtonId = "enabled-accept-analytics-button";
   exploreWithoutDeviceButtonId = "discoverLive-exploreWithoutADevice";
   discoverLiveTitle = (index: number) => `onboarding-discoverLive-${index}-title`;
   onboardingGetStartedButton = () => getElementById(this.getStartedButtonId);

--- a/apps/ledger-live-mobile/e2e/page/trade/send.page.ts
+++ b/apps/ledger-live-mobile/e2e/page/trade/send.page.ts
@@ -7,15 +7,16 @@ export default class SendPage {
   baseLink = "send";
   summaryAmountId = "send-summary-amount";
   getStep1HeaderTitle = () => getElementById("send-header-step1-title");
-  recipientContinueButtonId = "recipient-continue-button";
+  recipientContinueEnabledButtonId = "enabled-recipient-continue-button";
+  recipientContinueDisabledButtonId = "disabled-recipient-continue-button";
   recipientInputId = "recipient-input";
   memoTagInputId = "memo-tag-input";
   memoTagDrawerTitleId = "memo-tag-drawer-title";
-  memoTagIgnoreButtonId = "memo-tag-ignore-button";
+  memoTagIgnoreButtonId = "enabled-memo-tag-ignore-button";
   amountInputId = "amount-input";
   amountMaxSwitch = () => getElementById("send-amount-max-switch");
-  amountContinueButton = () => getElementById("amount-continue-button");
-  summaryContinueButton = () => getElementById("summary-continue-button");
+  amountContinueButton = () => getElementById("enabled-amount-continue-button");
+  summaryContinueButton = () => getElementById("enabled-summary-continue-button");
   recipientErrorId = "send-recipient-error";
   recipientErrorDescriptionId = "send-recipient-error-description";
   learnMoreLinkId = "learn-more-link";
@@ -47,8 +48,8 @@ export default class SendPage {
 
   @Step("Continue to next step and skip memo tag if needed")
   async recipientContinue(memoTag?: string) {
-    await waitForElementById(this.recipientContinueButtonId); // To prevent flakiness
-    await tapById(this.recipientContinueButtonId);
+    await waitForElementById(this.recipientContinueEnabledButtonId); // To prevent flakiness
+    await tapById(this.recipientContinueEnabledButtonId);
     if (memoTag == "noTag") {
       await waitForElementById(this.memoTagDrawerTitleId);
       await tapById(this.memoTagIgnoreButtonId);
@@ -101,13 +102,13 @@ export default class SendPage {
 
   @Step("Expect Continue button disabled")
   async expectContinueButtonDisabled() {
-    await expect(getElementById(this.recipientContinueButtonId)).toBeVisible();
-    await tapById(this.recipientContinueButtonId);
+    await expect(getElementById(this.recipientContinueDisabledButtonId)).toBeVisible();
   }
 
   @Step("Expect Continue button not visible")
   async expectContinueButtonNotVisible() {
-    await expect(getElementById(this.recipientContinueButtonId)).not.toBeVisible();
+    await expect(getElementById(this.recipientContinueEnabledButtonId)).not.toBeVisible();
+    await expect(getElementById(this.recipientContinueDisabledButtonId)).not.toBeVisible();
   }
 
   @Step("Expect sender to have error title")

--- a/apps/ledger-live-mobile/e2e/page/trade/stake.page.ts
+++ b/apps/ledger-live-mobile/e2e/page/trade/stake.page.ts
@@ -12,8 +12,9 @@ export default class StakePage {
   delegatedRatioId = (currencyId: string, delegatedPercent: number) =>
     `${currencyId}-delegate-ratio-${delegatedPercent}%`;
   allAssetsUsedText = (currencyId: string) => `${currencyId}-all-assets-used-text`;
-  summaryContinueButtonId = (currencyId: string) => `${currencyId}-summary-continue-button`;
-  delegationAmountContinueId = (currencyId: string) => `${currencyId}-delegation-amount-continue`;
+  summaryContinueButtonId = (currencyId: string) => `enabled-${currencyId}-summary-continue-button`;
+  delegationAmountContinueId = (currencyId: string) =>
+    `enabled-${currencyId}-delegation-amount-continue`;
   currencyRow = (currencyId: string) => `currency-row-${currencyId}`;
   zeroAssetText = "0\u00a0ATOM";
 

--- a/apps/ledger-live-mobile/src/components/Button.tsx
+++ b/apps/ledger-live-mobile/src/components/Button.tsx
@@ -89,7 +89,8 @@ export function BaseButton({
 
   function getTestID() {
     if (!otherProps.isFocused) return undefined;
-    if (otherProps.testID) return otherProps.testID;
+    const prefix = isDisabled ? "disabled-" : "enabled-";
+    if (otherProps.testID) return `${prefix}${otherProps.testID}`;
     if (isDisabled) return undefined;
 
     switch (type) {

--- a/apps/ledger-live-mobile/src/components/DeviceAction/deviceAction.test.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/deviceAction.test.tsx
@@ -64,7 +64,7 @@ describe("DeviceAction - Deprecation", () => {
     ).toBeVisible();
     expect(screen.getByText("Continue")).toBeVisible();
 
-    const continueButton = screen.getByTestId("warning-deprecation-continue");
+    const continueButton = screen.getByTestId("enabled-warning-deprecation-continue");
     await user.press(continueButton);
 
     expect(screen.getByText("Ledger Nano S™ can not Clear Sign this transaction")).toBeVisible();
@@ -120,7 +120,7 @@ describe("DeviceAction - Deprecation", () => {
     ).toBeVisible();
     expect(screen.getByText("Continue")).toBeVisible();
 
-    const continueButton = screen.getByTestId("warning-deprecation-continue");
+    const continueButton = screen.getByTestId("enabled-warning-deprecation-continue");
     await user.press(continueButton);
     expect(mockOnContinue).toHaveBeenCalled();
   });
@@ -167,7 +167,7 @@ describe("DeviceAction - Deprecation", () => {
     expect(screen.getByText("Ledger Nano S™ can not Clear Sign this transaction")).toBeVisible();
     expect(screen.getByText("Proceed at your own risk")).toBeVisible();
 
-    const continueButton = screen.getByTestId("warning-deprecation-continue");
+    const continueButton = screen.getByTestId("enabled-warning-deprecation-continue");
     await user.press(continueButton);
     expect(mockOnContinue).toHaveBeenCalled();
   });

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/__integrations__/openSuccessiveDrawers.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawer/__integrations__/openSuccessiveDrawers.test.tsx
@@ -17,11 +17,13 @@ describe("QueuedDrawer", () => {
     jest.useFakeTimers();
   });
 
-  const mainTestIds = testIds(TestIdPrefix.Main);
-  const inDrawer1TestIds = testIds(TestIdPrefix.InDrawer1);
-  const inDrawer4TestIds = testIds(TestIdPrefix.InDrawer4);
+  const withEnabledPrefix = <T extends Record<string, string>>(ids: T): T =>
+    Object.fromEntries(Object.entries(ids).map(([k, v]) => [k, `enabled-${v}`])) as T;
+  const mainTestIds = withEnabledPrefix(testIds(TestIdPrefix.Main));
+  const inDrawer1TestIds = withEnabledPrefix(testIds(TestIdPrefix.InDrawer1));
+  const inDrawer4TestIds = withEnabledPrefix(testIds(TestIdPrefix.InDrawer4));
   const modalCloseButtonId = "modal-close-button";
-  const navigateBackButtonId = "navigate-back-button";
+  const navigateBackButtonId = "enabled-navigate-back-button";
 
   const drawer1Text = "Drawer 1";
   const drawer2Text = "Drawer 2";

--- a/apps/ledger-live-mobile/src/screens/AnalyticsOptInPrompt/__tests__/AnalyticsOptInPrompt.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/AnalyticsOptInPrompt/__tests__/AnalyticsOptInPrompt.test.tsx
@@ -51,7 +51,7 @@ describe("AnalyticsOptInPrompt", () => {
   it("navigates to onboarding device selection when lazy onboarding is disabled", async () => {
     const { user } = renderAnalyticsOptInMain({ wallet40Enabled: true, lazyOnboarding: false });
 
-    await user.press(screen.getByTestId("accept-analytics-button"));
+    await user.press(screen.getByTestId("enabled-accept-analytics-button"));
 
     expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.BaseOnboarding, {
       screen: NavigatorName.Onboarding,
@@ -70,7 +70,7 @@ describe("AnalyticsOptInPrompt", () => {
       lazyOnboarding: true,
     });
 
-    await user.press(screen.getByTestId("accept-analytics-button"));
+    await user.press(screen.getByTestId("enabled-accept-analytics-button"));
 
     expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Base, {
       screen: NavigatorName.Main,
@@ -89,7 +89,7 @@ describe("AnalyticsOptInPrompt", () => {
       lazyOnboarding: true,
     });
 
-    await user.press(screen.getByTestId("accept-analytics-button"));
+    await user.press(screen.getByTestId("enabled-accept-analytics-button"));
 
     expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.BaseOnboarding, {
       screen: NavigatorName.Onboarding,

--- a/e2e/mobile/page/accounts/addAccount.drawer.ts
+++ b/e2e/mobile/page/accounts/addAccount.drawer.ts
@@ -8,7 +8,7 @@ export default class AddAccountDrawer extends CommonPage {
   baseLink = "add-account";
   deselectAllButtonId = "add-accounts-deselect-all";
   modalButtonId = "add-accounts-modal-add-button";
-  continueButtonId = "add-accounts-continue-button";
+  continueButtonId = "enabled-add-accounts-continue-button";
   closeAddAccountButtonId = "button-close-add-account";
   addFundsButtonId = "button-add-funds";
   actionDrawerReceiveButtonId = "action-drawer-receive-button";

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -8,7 +8,7 @@ import ErrorPage from "./error.page";
 export default class CommonPage {
   assetScreenFlatlistId = "asset-screen-flatlist";
   searchBarId = "common-search-field";
-  successViewDetailsButtonId = "success-view-details-button";
+  successViewDetailsButtonId = "enabled-success-view-details-button";
   validateSuccessScreenId = "validate-success-screen";
   proceedButtonId = "proceed-button";
   accountCardPrefix = "account-card-";
@@ -21,8 +21,7 @@ export default class CommonPage {
   errorPage = new ErrorPage();
 
   searchBar = () => getElementById(this.searchBarId);
-  closeButtonTestId = "NavigationHeaderCloseButton";
-  closeButton = () => getElementById(this.closeButtonTestId);
+  closeButton = () => getElementById("NavigationHeaderCloseButton");
   backButton = () => getElementById("navigation-header-back-button");
   accountCardRegExp = (id = ".*") => new RegExp(this.accountCardPrefix + id);
   accountItemRegExp = (id = ".*(?<!-name)$") => new RegExp(`${this.accountItemId}${id}`);

--- a/e2e/mobile/page/onboarding/onboardingSteps.page.ts
+++ b/e2e/mobile/page/onboarding/onboardingSteps.page.ts
@@ -3,7 +3,7 @@ import { isIos } from "../../helpers/commonHelpers";
 
 export default class OnboardingStepsPage {
   getStartedButtonId = "onboarding-getStarted-button";
-  acceptAnalyticsButtonId = "accept-analytics-button";
+  acceptAnalyticsButtonId = "enabled-accept-analytics-button";
   exploreWithoutDeviceButtonId = "discoverLive-exploreWithoutADevice";
   recoveryPhrase = "onboarding-useCase-recoveryPhrase";
   setupLedger = "onboarding-setupLedger";

--- a/e2e/mobile/page/trade/celoManageAssets.page.ts
+++ b/e2e/mobile/page/trade/celoManageAssets.page.ts
@@ -2,13 +2,13 @@ import { Step } from "jest-allure2-reporter/api";
 
 export default class CeloManageAssetsPage {
   titleId = "live-app-title";
-  celoLockButton = "celo-lock-button";
-  celoUnlockButton = "celo-unlock-button";
-  celoWithdrawButton = "celo-withdraw-button";
-  celoVoteButton = "celo-vote-button";
-  celoActivateVoteButton = "celo-activate-vote-button";
-  celoRevokeButton = "celo-revoke-button";
-  celoVoteStartButton = "celo-vote-start-button";
+  celoLockButton = "enabled-celo-lock-button";
+  celoUnlockButton = "enabled-celo-unlock-button";
+  celoWithdrawButton = "disabled-celo-withdraw-button";
+  celoVoteButton = "enabled-celo-vote-button";
+  celoActivateVoteButton = /^(enabled|disabled)-celo-activate-vote-button$/;
+  celoRevokeButton = /^(enabled|disabled)-celo-revoke-button$/;
+  celoVoteStartButton = "enabled-celo-vote-start-button";
 
   title = () => getElementById(this.titleId);
 

--- a/e2e/mobile/page/trade/earnV2Dashboard.page.ts
+++ b/e2e/mobile/page/trade/earnV2Dashboard.page.ts
@@ -17,10 +17,10 @@ export default class EarnV2DashboardPage {
   stakingProvider = (providerId: string) => `staking-provider-${providerId}-title`;
   earnMenuOption = (label: string) =>
     `earn-menu-option-${label.toLowerCase().replace(/\s+/g, "-")}`;
-  private static readonly stakingFlowTestIds: Record<string, string> = {
+  private static readonly stakingFlowTestIds: Record<string, string | RegExp> = {
     ETH: "staking-provider-modal-title",
-    ATOM: "cosmos-delegation-start-button",
-    SOL: "solana-delegation-start-button",
+    ATOM: /^(enabled-|disabled-)?cosmos-delegation-start-button$/,
+    SOL: /^(enabled-|disabled-)?solana-delegation-start-button$/,
   };
 
   // --- Ice Cold Start ---

--- a/e2e/mobile/page/trade/receive.page.ts
+++ b/e2e/mobile/page/trade/receive.page.ts
@@ -7,7 +7,7 @@ export default class ReceivePage {
   accountAddress = "receive-fresh-address";
   accountFreshAddress = "receive-verifyAddress-freshAdress";
   baseLink = "receive";
-  buttonContinueId = "add-accounts-continue-button";
+  buttonContinueId = "enabled-add-accounts-continue-button";
   buttonVerifyAddressId = "button-verify-my-address";
   networkBasedStep2HeaderTitleId = "addAccounts-header-step2-title";
   noVerifyAddressButton = "button-DontVerify-my-address";

--- a/e2e/mobile/page/trade/send.page.ts
+++ b/e2e/mobile/page/trade/send.page.ts
@@ -6,25 +6,30 @@ export default class SendPage {
   summaryAmountId = "send-summary-amount";
   summaryMemoTagId = "summary-memo-tag";
   validationEnsId = "device-validation-domain";
-  recipientContinueButtonId = "recipient-continue-button";
+  recipientContinueEnabledButtonId = "enabled-recipient-continue-button";
+  recipientContinueDisabledButtonId = "disabled-recipient-continue-button";
+  amountContinueEnabledButtonId = "enabled-amount-continue-button";
+  amountContinueDisabledButtonId = "disabled-amount-continue-button";
+  summaryContinueEnabledButtonId = "enabled-summary-continue-button";
+  summaryContinueDisabledButtonId = "disabled-summary-continue-button";
   recipientInputId = "recipient-input";
   recipientErrorId = "send-recipient-error";
   memoTagInputId = "memo-tag-input";
   memoTagDrawerTitleId = "memo-tag-drawer-title";
-  memoTagIgnoreButtonId = "memo-tag-ignore-button";
+  memoTagIgnoreButtonId = "enabled-memo-tag-ignore-button";
   amountInputId = "amount-input";
   amountErrorId = "send-amount-error";
   summaryErrorId = "insufficient-fee-error";
-  highFeeConfirmButtonID = "confirmation-modal-confirm-button";
+  highFeeConfirmButtonID = "enabled-confirmation-modal-confirm-button";
 
   summaryRecipient = () => getElementById("send-summary-recipient");
   summaryRecipientEns = () => getElementById("send-summary-recipient-ens");
   summaryMemoTag = () => getElementById(this.summaryMemoTagId);
   getStep1HeaderTitle = () => getElementById("send-header-step1-title");
   amountMaxSwitch = () => getElementById("send-amount-max-switch");
-  amountContinueButton = () => getElementById("amount-continue-button");
+  amountContinueButton = () => getElementById(this.amountContinueEnabledButtonId);
   summaryWarning = () => getElementById("send-summary-warning");
-  summaryContinueButton = () => getElementById("summary-continue-button");
+  summaryContinueButton = () => getElementById(this.summaryContinueEnabledButtonId);
   feeStrategy = (fee: string) => getElementByText(fee);
 
   @Step("Navigate to send screen")
@@ -62,8 +67,8 @@ export default class SendPage {
 
   @Step("Continue to next step and skip memo tag if needed")
   async recipientContinue(memoTag?: string) {
-    await waitForElementById(this.recipientContinueButtonId);
-    await tapById(this.recipientContinueButtonId);
+    await waitForElementById(this.recipientContinueEnabledButtonId);
+    await tapById(this.recipientContinueEnabledButtonId);
 
     if (memoTag === "noTag") {
       await waitForElementById(this.memoTagDrawerTitleId);
@@ -89,11 +94,13 @@ export default class SendPage {
       await detoxExpect(errElem).not.toBeVisible();
     }
 
-    const contBtn = getElementById(this.recipientContinueButtonId);
+    const enabledBtn = getElementById(this.recipientContinueEnabledButtonId);
+    const disabledBtn = getElementById(this.recipientContinueDisabledButtonId);
     if (continueButtonVisible) {
-      await detoxExpect(contBtn).toBeVisible();
+      await detoxExpect(enabledBtn).toBeVisible();
     } else {
-      await detoxExpect(contBtn).not.toBeVisible();
+      await detoxExpect(enabledBtn).not.toBeVisible();
+      await detoxExpect(disabledBtn).toBeVisible();
     }
   }
 
@@ -105,7 +112,7 @@ export default class SendPage {
     } else {
       await detoxExpect(errElem).toHaveText(expectedWarningMessage);
     }
-    const contBtn = getElementById(this.recipientContinueButtonId);
+    const contBtn = getElementById(this.recipientContinueEnabledButtonId);
     await detoxExpect(contBtn).toBeVisible();
   }
 
@@ -149,8 +156,10 @@ export default class SendPage {
   async expectSendAmountError(errorMessage: string) {
     const errElem = getElementById(this.amountErrorId);
     await detoxExpect(errElem).toHaveText(errorMessage);
-    const contBtn = this.amountContinueButton();
-    await detoxExpect(contBtn).not.toBeVisible();
+    const enabledBtn = this.amountContinueButton();
+    const disabledBtn = getElementById(this.amountContinueDisabledButtonId);
+    await detoxExpect(enabledBtn).not.toBeVisible();
+    await detoxExpect(disabledBtn).toBeVisible();
   }
 
   @Step("Set amount and continue")
@@ -193,8 +202,10 @@ export default class SendPage {
   async expectSendSummaryError(errorMessage: RegExp) {
     const err = await getTextOfElement(this.summaryErrorId);
     jestExpect(err).toMatch(errorMessage);
-    const btn = this.summaryContinueButton();
-    await detoxExpect(btn).not.toBeVisible();
+    const enabledBtn = this.summaryContinueButton();
+    const disabledBtn = getElementById(this.summaryContinueDisabledButtonId);
+    await detoxExpect(enabledBtn).not.toBeVisible();
+    await detoxExpect(disabledBtn).toBeVisible();
   }
 
   @Step("Expect warning in summary")

--- a/e2e/mobile/page/trade/stake.page.ts
+++ b/e2e/mobile/page/trade/stake.page.ts
@@ -23,7 +23,7 @@ export default class StakePage {
   delegationFees = (currencyId: string) => `${currencyId}-delegation-summary-fees`;
   summaryContinueButtonId = (currencyId: string) => `enabled-${currencyId}-summary-continue-button`;
   delegationStartId = (currencyId: string) =>
-    new RegExp(`^(enabled-)?${currencyId}-delegation-start-button$`);
+    new RegExp(`^((enabled|disabled)-)?${currencyId}-delegation-start-button$`);
   delegationAmountContinueId = (currencyId: string) =>
     `enabled-${currencyId}-delegation-amount-continue`;
   currencyRow = (currencyId: string) => `currency-row-${currencyId}`;

--- a/e2e/mobile/page/trade/stake.page.ts
+++ b/e2e/mobile/page/trade/stake.page.ts
@@ -5,8 +5,8 @@ export default class StakePage {
   celoLockAmountInput = "celo-lock-amount-input";
   celoVoteAmountId = "celo-vote-amount";
   celoVoteAmountInputId = "celo-vote-amount-input";
-  celoVoteAmountContinueId = "celo-vote-amount-continue";
-  celoVoteSummaryContinueId = "celo-vote-summary-continue";
+  celoVoteAmountContinueId = "enabled-celo-vote-amount-continue";
+  celoVoteSummaryContinueId = "enabled-celo-vote-summary-continue";
   searchPoolInput = "delegation-search-pool-input";
   selectAssetTitle = "select-asset-drawer-title";
 
@@ -21,9 +21,11 @@ export default class StakePage {
     `${currencyId}-delegate-ratio-${delegatedPercent}%`;
   delegationAmountInput = (currencyId: string) => `${currencyId}-delegation-amount-input`;
   delegationFees = (currencyId: string) => `${currencyId}-delegation-summary-fees`;
-  summaryContinueButtonId = (currencyId: string) => `${currencyId}-summary-continue-button`;
-  delegationStartId = (currencyId: string) => `${currencyId}-delegation-start-button`;
-  delegationAmountContinueId = (currencyId: string) => `${currencyId}-delegation-amount-continue`;
+  summaryContinueButtonId = (currencyId: string) => `enabled-${currencyId}-summary-continue-button`;
+  delegationStartId = (currencyId: string) =>
+    new RegExp(`^(enabled-)?${currencyId}-delegation-start-button$`);
+  delegationAmountContinueId = (currencyId: string) =>
+    `enabled-${currencyId}-delegation-amount-continue`;
   currencyRow = (currencyId: string) => `currency-row-${currencyId}`;
   providerRow = (providerTicker: string) => `provider-row-${providerTicker}`;
 

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -32,7 +32,7 @@ export default class SwapPage extends CommonPage {
   exportOperationsButton = "enabled-export-swap-operations-link";
   swapHistoryFeedbackLink = "swap-history-feedback-link";
   swapFormTabId = "swap-form-tab";
-  swapCloseButtonCompletedTestId = this.closeButtonTestId + "Completed";
+  swapCloseButtonCompletedTestId = "NavigationHeaderCloseButtonCompleted";
 
   operationDetails = {
     fromAccount: "swap-operation-details-fromAccount",

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -29,7 +29,7 @@ export default class SwapPage extends CommonPage {
   historyButton = "navigation-header-swap-history";
   topBarSwapHistoryButton = "topbar-swap-history";
   swapStatus = "swap-status";
-  exportOperationsButton = "export-swap-operations-link";
+  exportOperationsButton = "enabled-export-swap-operations-link";
   swapHistoryFeedbackLink = "swap-history-feedback-link";
   swapFormTabId = "swap-form-tab";
   swapCloseButtonCompletedTestId = this.closeButtonTestId + "Completed";


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile e2e test locator behavior for any `testID` rendered by `apps/ledger-live-mobile/src/components/Button.tsx`
  - Send, Receive, Add Account, Onboarding, CELO manage assets, Stake, Earn V2 Dashboard and Swap mobile e2e flows
  - Unit tests querying buttons by `testID` (DeviceAction, QueuedDrawer, AnalyticsOptInPrompt)

### Description

`apps/ledger-live-mobile/src/components/Button.tsx` now prefixes every explicit `testID` with `enabled-` or `disabled-` based on the button's state. This lets e2e tests differentiate a button that is rendered-but-disabled from a button that is missing from the tree, without introducing runtime attribute checks on every assertion.

All mobile e2e page objects and unit tests that reference those `testID`s have been updated to use the correct prefix. State-agnostic locators (CELO activate-vote and revoke) use a tight regex because their state depends on live account data.

### Related CI

- Latest Mobile E2E run - legacy: https://github.com/LedgerHQ/ledger-live/actions/runs/24585124379
- Latest Manual Mobile E2E run - Wallet4.0: https://github.com/LedgerHQ/ledger-live/actions/runs/24585181632

### Context

- **JIRA or GitHub link**: _(none provided)_

---

### Checklist for the PR Reviewers

- The code aligns with the requirements described in the linked JIRA or GitHub issue.
- The PR description clearly documents the changes made and explains any technical trade-offs or design decisions.
- There are no undocumented trade-offs, technical debt, or maintainability issues.
- The PR has been tested thoroughly, and any potential edge cases have been considered and handled.
- Any new dependencies have been justified and documented.
- Performance considerations have been taken into account.