### PR TITLE
[LWDM] feat(portfolio): scope balance sync display to countervalues phase

### DIFF
--- a/.changeset/calm-balance-cvs-phase.md
+++ b/.changeset/calm-balance-cvs-phase.md
@@ -4,4 +4,4 @@
 "live-mobile": minor
 ---
 
-Scope mobile portfolio balance loading to the countervalues phase and expose `cvPending` from sync sources
+Scope portfolio balance loading to the countervalues phase and expose `cvPending` from sync sources

--- a/.changeset/calm-balance-cvs-phase.md
+++ b/.changeset/calm-balance-cvs-phase.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Scope mobile portfolio balance loading to the countervalues phase and expose `cvPending` from sync sources

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
@@ -84,14 +84,24 @@ describe("useBalanceViewModel", () => {
     expect(mockUsePortfolioBalance).toHaveBeenCalledWith({ legacyRange: true });
   });
 
-  it("should return isLoading true when syncPhase is syncing", () => {
+  it("should return isLoading true while CVS is pending (iCvPending=true)", () => {
     mockUsePortfolioBalance.mockReturnValue(
-      makePortfolioBalanceReturn({ syncPhase: "syncing", isBalanceLoading: true }),
+      makePortfolioBalanceReturn({ syncPhase: "syncing", isBalanceLoading: true, isCvPending: true }),
     );
 
     const { result } = renderHook(() => useBalanceViewModel(), { initialState });
 
     expect(result.current.isLoading).toBe(true);
+  });
+
+  it("should return isLoading false once CVS settles (iCvPending=false), even mid bridge-sync", () => {
+    mockUsePortfolioBalance.mockReturnValue(
+      makePortfolioBalanceReturn({ syncPhase: "syncing", isCvPending: false }),
+    );
+
+    const { result } = renderHook(() => useBalanceViewModel(), { initialState });
+
+    expect(result.current.isLoading).toBe(false);
   });
 
   it("should return isLoading false when syncPhase is synced", () => {
@@ -108,11 +118,10 @@ describe("useBalanceViewModel", () => {
     expect(result.current.isLoading).toBe(false);
   });
 
-  it("should freeze balance during syncing and unfreeze when synced", () => {
+  it("should freeze balance while CVS is pending and animate once CVS settles", () => {
     mockUsePortfolioBalance.mockReturnValue(
       makePortfolioBalanceReturn({
         syncPhase: "synced",
-        isBalanceLoading: false,
         portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 1500 }] },
       }),
     );
@@ -120,106 +129,76 @@ describe("useBalanceViewModel", () => {
     const { result, rerender } = renderHook(() => useBalanceViewModel(), { initialState });
     expect(result.current.balance).toBe(1500);
 
+    // CVS fetch starts — balance frozen
     mockUsePortfolioBalance.mockReturnValue(
       makePortfolioBalanceReturn({
         syncPhase: "syncing",
-        isBalanceLoading: true,
+        isCvPending: true,
         portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 2000 }] },
       }),
     );
     rerender();
     expect(result.current.balance).toBe(1500);
 
+    // CVS settles — balance animates; bridge sync continues (syncPhase still syncing)
     mockUsePortfolioBalance.mockReturnValue(
       makePortfolioBalanceReturn({
-        syncPhase: "synced",
-        isBalanceLoading: false,
+        syncPhase: "syncing",
+        isCvPending: false,
         portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 2000 }] },
       }),
     );
     rerender();
     expect(result.current.balance).toBe(2000);
-  });
 
-  it("should keep balance frozen during settle guard period (isBalanceLoading false, syncPhase still syncing)", () => {
-    mockUsePortfolioBalance.mockReturnValue(
-      makePortfolioBalanceReturn({
-        syncPhase: "synced",
-        isBalanceLoading: false,
-        portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 1500 }] },
-      }),
-    );
-
-    const { result, rerender } = renderHook(() => useBalanceViewModel(), { initialState });
-    expect(result.current.balance).toBe(1500);
-
-    // Syncing starts
+    // Balance continues to update per-batch after CVS settles
     mockUsePortfolioBalance.mockReturnValue(
       makePortfolioBalanceReturn({
         syncPhase: "syncing",
-        isBalanceLoading: true,
-        portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 2500 }] },
+        isCvPending: false,
+        portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 2300 }] },
       }),
     );
     rerender();
-    expect(result.current.balance).toBe(1500);
-
-    // isBalanceLoading goes false but syncPhase stays syncing (settle guard)
-    mockUsePortfolioBalance.mockReturnValue(
-      makePortfolioBalanceReturn({
-        syncPhase: "syncing",
-        isBalanceLoading: false,
-        portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 2500 }] },
-      }),
-    );
-    rerender();
-    expect(result.current.balance).toBe(1500);
-
-    // Guard expires → syncPhase becomes synced → balance animates to new value
-    mockUsePortfolioBalance.mockReturnValue(
-      makePortfolioBalanceReturn({
-        syncPhase: "synced",
-        isBalanceLoading: false,
-        portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 2500 }] },
-      }),
-    );
-    rerender();
-    expect(result.current.balance).toBe(2500);
+    expect(result.current.balance).toBe(2300);
   });
 
-  it("should keep balanceAvailable false until sync settles (no shimmer gap after skeleton)", () => {
+  it("should keep balanceAvailable false until CVS settles (no shimmer gap after skeleton)", () => {
     mockUsePortfolioBalance.mockReturnValue(
       makePortfolioBalanceReturn({
         balanceAvailable: false,
         isColdStart: true,
         syncPhase: "syncing",
         isBalanceLoading: true,
+        isCvPending: true,
       }),
     );
 
     const { result, rerender } = renderHook(() => useBalanceViewModel(), { initialState });
     expect(result.current.balanceAvailable).toBe(false);
 
-    // CV data arrives: rawBalanceAvailable goes true, but sync is still settling
+    // Balance data available but CVS still pending — skeleton stays
     mockUsePortfolioBalance.mockReturnValue(
       makePortfolioBalanceReturn({
         balanceAvailable: true,
         isColdStart: false,
         syncPhase: "syncing",
-        isBalanceLoading: false,
+        isBalanceLoading: true,
+        isCvPending: true,
         portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 1200 }] },
       }),
     );
     rerender();
     expect(result.current.balanceAvailable).toBe(false);
 
-    // Sync settles → balanceAvailable becomes true, balance animates with no shimmer gap
+    // CVS settles → balance unlocks immediately, bridge sync continues
     mockUsePortfolioBalance.mockReturnValue(
       makePortfolioBalanceReturn({
         balanceAvailable: true,
         isColdStart: false,
-        syncPhase: "synced",
+        syncPhase: "syncing",
         isBalanceLoading: false,
+        isCvPending: false,
         portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 1200 }] },
       }),
     );

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/__tests__/useBalanceViewModel.test.ts
@@ -86,22 +86,16 @@ describe("useBalanceViewModel", () => {
 
   it("should return isLoading true while CVS is pending (iCvPending=true)", () => {
     mockUsePortfolioBalance.mockReturnValue(
-      makePortfolioBalanceReturn({ syncPhase: "syncing", isBalanceLoading: true, isCvPending: true }),
+      makePortfolioBalanceReturn({
+        syncPhase: "syncing",
+        isBalanceLoading: true,
+        isCvPending: true,
+      }),
     );
 
     const { result } = renderHook(() => useBalanceViewModel(), { initialState });
 
     expect(result.current.isLoading).toBe(true);
-  });
-
-  it("should return isLoading false once CVS settles (iCvPending=false), even mid bridge-sync", () => {
-    mockUsePortfolioBalance.mockReturnValue(
-      makePortfolioBalanceReturn({ syncPhase: "syncing", isCvPending: false }),
-    );
-
-    const { result } = renderHook(() => useBalanceViewModel(), { initialState });
-
-    expect(result.current.isLoading).toBe(false);
   });
 
   it("should return isLoading false when syncPhase is synced", () => {
@@ -204,7 +198,6 @@ describe("useBalanceViewModel", () => {
     );
     rerender();
     expect(result.current.balanceAvailable).toBe(true);
-    expect(result.current.isLoading).toBe(false);
   });
 
   it("should return shouldDisplayBalanceRefreshRework false when flag is disabled", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -41,17 +41,23 @@ export const useBalanceViewModel = (
     isColdStart,
     balanceAvailable: rawBalanceAvailable,
     syncPhase,
+    isCvPending,
   } = usePortfolioBalance({ legacyRange });
 
   const latestBalanceValue =
     portfolio.balanceHistory[portfolio.balanceHistory.length - 1]?.value ?? 0;
 
-  const { balanceAvailable, displayedBalance, isLoading } = useBalanceSyncState({
+  const { balanceAvailable, displayedBalance } = useBalanceSyncState({
     rawBalanceAvailable,
     syncPhase,
     latestBalance: latestBalanceValue,
     shouldFreezeOnSync: shouldDisplayBalanceRefreshRework,
+    cvPending: shouldDisplayBalanceRefreshRework ? isCvPending : undefined,
   });
+
+  // Shimmer is scoped to the CVS phase: disappears once countervalues settle,
+  // letting the balance animate to the fresh fiat value while account sync continues.
+  const isLoading = shouldDisplayBalanceRefreshRework ? isCvPending : syncPhase === "syncing";
 
   const unit = counterValue.units[0];
   const valueChange = portfolio.countervalueChange;

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -47,17 +47,13 @@ export const useBalanceViewModel = (
   const latestBalanceValue =
     portfolio.balanceHistory[portfolio.balanceHistory.length - 1]?.value ?? 0;
 
-  const { balanceAvailable, displayedBalance } = useBalanceSyncState({
+  const { balanceAvailable, displayedBalance, isLoading } = useBalanceSyncState({
     rawBalanceAvailable,
     syncPhase,
     latestBalance: latestBalanceValue,
     shouldFreezeOnSync: shouldDisplayBalanceRefreshRework,
     cvPending: shouldDisplayBalanceRefreshRework ? isCvPending : undefined,
   });
-
-  // Shimmer is scoped to the CVS phase: disappears once countervalues settle,
-  // letting the balance animate to the fresh fiat value while account sync continues.
-  const isLoading = shouldDisplayBalanceRefreshRework ? isCvPending : syncPhase === "syncing";
 
   const unit = counterValue.units[0];
   const valueChange = portfolio.countervalueChange;

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/fixtures.ts
@@ -60,6 +60,7 @@ function getDefault() {
     syncPhase: "synced" as SyncPhase,
     isBalanceLoading: false,
     isColdStart: false,
+    isCvPending: false,
     allAccounts: [] as never[],
     listOfErrorAccountNames: "",
     areAllAccountsUpToDate: true,

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/usePortfolioBalance.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/usePortfolioBalance.test.ts
@@ -24,6 +24,7 @@ const mockUseSyncSources = jest.fn().mockReturnValue({
   hasCvOrBridgeError: false,
   hasWalletSyncError: false,
   triggerRefresh: mockTriggerRefresh,
+  cvPending: false,
 });
 
 jest.mock("../useSyncSources", () => ({
@@ -52,6 +53,7 @@ const syncingState = {
   hasCvOrBridgeError: false,
   hasWalletSyncError: false,
   triggerRefresh: mockTriggerRefresh,
+  cvPending: true,
 };
 
 describe("usePortfolioBalance", () => {
@@ -67,6 +69,7 @@ describe("usePortfolioBalance", () => {
       hasCvOrBridgeError: false,
       hasWalletSyncError: false,
       triggerRefresh: mockTriggerRefresh,
+      cvPending: false,
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useSyncSources.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useSyncSources.test.ts
@@ -22,6 +22,7 @@ const fakeSyncSourcesReturn: liveCommon.SyncSourcesState = {
   hasCvOrBridgeError: false,
   hasWalletSyncError: false,
   triggerRefresh: jest.fn(),
+  cvPending: false,
 };
 
 describe("useSyncSources (desktop wrapper)", () => {

--- a/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalance.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalance.ts
@@ -121,6 +121,8 @@ export function usePortfolioBalance(options: UsePortfolioBalanceOptions = {}) {
     syncPhase,
     isBalanceLoading,
     isColdStart,
+    /** True while countervalues are being fetched within a user-triggered sync. */
+    isCvPending: syncPhase === "syncing" && syncSources.cvPending,
     allAccounts,
     listOfErrorAccountNames,
     areAllAccountsUpToDate,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
@@ -28,6 +28,7 @@ function makeReturn(
     balanceAvailable: boolean;
     syncPhase: SyncPhase;
     portfolio: typeof defaultPortfolio;
+    isCvPending: boolean;
   }> = {},
 ) {
   return {
@@ -37,6 +38,7 @@ function makeReturn(
     isBalanceLoading: false,
     isColdStart: false,
     isManualRefreshLoading: false,
+    isCvPending: false,
     allAccounts: [],
     accountsWithError: [],
     accountsImpactedByError: [],
@@ -54,7 +56,9 @@ function makeReturn(
 const defaultProps = { showAssets: true, isReadOnlyMode: false };
 
 const withFreezeFlag = {
-  overrideInitialState: withFlagOverrides({ lwmWallet40: { enabled: true, params: { balanceRefreshRework: true } } }),
+  overrideInitialState: withFlagOverrides({
+    lwmWallet40: { enabled: true, params: { balanceRefreshRework: true } },
+  }),
 };
 
 describe("usePortfolioBalanceSectionViewModel", () => {
@@ -97,7 +101,7 @@ describe("usePortfolioBalanceSectionViewModel", () => {
   });
 
   describe("balance freeze", () => {
-    it("freezes at pre-sync value and releases on settle", () => {
+    it("freezes while CVS is pending (iCvPending=true) and releases once CVS settles", () => {
       mockUsePortfolioBalance.mockReturnValue(
         makeReturn({
           portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 1500 }] },
@@ -110,22 +114,35 @@ describe("usePortfolioBalanceSectionViewModel", () => {
       );
       expect(result.current.balance).toBe(1500);
 
+      // Sync starts with CVS pending — balance must be frozen
       mockUsePortfolioBalance.mockReturnValue(
         makeReturn({
           syncPhase: "syncing",
+          isCvPending: true,
           portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 2000 }] },
         }),
       );
       rerender({});
       expect(result.current.balance).toBe(1500);
+    });
 
+    it("scopes isLoading to isCvPending when flag is enabled", () => {
+      // With feature flag on: isLoading = iCvPending (not full syncPhase)
       mockUsePortfolioBalance.mockReturnValue(
-        makeReturn({
-          portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 2000 }] },
-        }),
+        makeReturn({ syncPhase: "syncing", isCvPending: true }),
+      );
+      const { result, rerender } = renderHook(
+        () => usePortfolioBalanceSectionViewModel(defaultProps),
+        withFreezeFlag,
+      );
+      expect(result.current.isLoading).toBe(true);
+
+      // CVS settles — shimmer turns off even though bridge sync continues
+      mockUsePortfolioBalance.mockReturnValue(
+        makeReturn({ syncPhase: "syncing", isCvPending: false }),
       );
       rerender({});
-      expect(result.current.balance).toBe(2000);
+      expect(result.current.isLoading).toBe(false);
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
@@ -125,25 +125,6 @@ describe("usePortfolioBalanceSectionViewModel", () => {
       rerender({});
       expect(result.current.balance).toBe(1500);
     });
-
-    it("scopes isLoading to isCvPending when flag is enabled", () => {
-      // With feature flag on: isLoading = iCvPending (not full syncPhase)
-      mockUsePortfolioBalance.mockReturnValue(
-        makeReturn({ syncPhase: "syncing", isCvPending: true }),
-      );
-      const { result, rerender } = renderHook(
-        () => usePortfolioBalanceSectionViewModel(defaultProps),
-        withFreezeFlag,
-      );
-      expect(result.current.isLoading).toBe(true);
-
-      // CVS settles — shimmer turns off even though bridge sync continues
-      mockUsePortfolioBalance.mockReturnValue(
-        makeReturn({ syncPhase: "syncing", isCvPending: false }),
-      );
-      rerender({});
-      expect(result.current.isLoading).toBe(false);
-    });
   });
 
   describe("isBalanceAvailable", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
@@ -42,19 +42,17 @@ export const usePortfolioBalanceSectionViewModel = ({
   // immediately so the cached value is shown at cold start instead of a skeleton.
   const effectiveRawBalanceAvailable = rawBalanceAvailable || effectiveLatestBalance > 0;
 
-  const { balanceAvailable, displayedBalance } = useBalanceSyncState({
+  const {
+    balanceAvailable,
+    displayedBalance,
+    isLoading: effectiveIsLoading,
+  } = useBalanceSyncState({
     rawBalanceAvailable: effectiveRawBalanceAvailable,
     syncPhase,
     latestBalance: effectiveLatestBalance,
     shouldFreezeOnSync: shouldDisplayBalanceRefreshRework,
     cvPending: shouldDisplayBalanceRefreshRework ? isCvPending : undefined,
   });
-
-  // Shimmer is scoped to the CVS phase: disappears once countervalues settle,
-  // letting the balance animate to the fresh fiat value while account sync continues.
-  const effectiveIsLoading = shouldDisplayBalanceRefreshRework
-    ? isCvPending
-    : syncPhase === "syncing";
 
   const state: PortfolioBalanceState = useMemo(() => {
     if (isReadOnlyMode) {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
@@ -20,7 +20,12 @@ export const usePortfolioBalanceSectionViewModel = ({
   const { toggleDiscreetMode } = useToggleDiscreetMode();
   const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
 
-  const { portfolio, balanceAvailable: rawBalanceAvailable, syncPhase } = usePortfolioBalance();
+  const {
+    portfolio,
+    balanceAvailable: rawBalanceAvailable,
+    syncPhase,
+    isCvPending,
+  } = usePortfolioBalance();
 
   const { countervalueChange, balanceHistory } = portfolio;
   const lastItem = balanceHistory[balanceHistory.length - 1];
@@ -42,9 +47,14 @@ export const usePortfolioBalanceSectionViewModel = ({
     syncPhase,
     latestBalance: effectiveLatestBalance,
     shouldFreezeOnSync: shouldDisplayBalanceRefreshRework,
+    cvPending: shouldDisplayBalanceRefreshRework ? isCvPending : undefined,
   });
 
-  const effectiveIsLoading = syncPhase === "syncing";
+  // Shimmer is scoped to the CVS phase: disappears once countervalues settle,
+  // letting the balance animate to the fresh fiat value while account sync continues.
+  const effectiveIsLoading = shouldDisplayBalanceRefreshRework
+    ? isCvPending
+    : syncPhase === "syncing";
 
   const state: PortfolioBalanceState = useMemo(() => {
     if (isReadOnlyMode) {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/__tests__/PortfolioBalanceSync.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/__tests__/PortfolioBalanceSync.test.tsx
@@ -26,7 +26,13 @@ const defaultPortfolio = {
   countervalueSendSum: 0,
 };
 
-function makeReturn(overrides: Partial<{ balanceAvailable: boolean; syncPhase: SyncPhase }> = {}) {
+function makeReturn(
+  overrides: Partial<{
+    balanceAvailable: boolean;
+    syncPhase: SyncPhase;
+    isCvPending: boolean;
+  }> = {},
+) {
   return {
     portfolio: defaultPortfolio,
     balanceAvailable: true,
@@ -34,6 +40,7 @@ function makeReturn(overrides: Partial<{ balanceAvailable: boolean; syncPhase: S
     isBalanceLoading: false,
     isColdStart: false,
     isManualRefreshLoading: false,
+    isCvPending: false,
     allAccounts: [],
     accountsWithError: [],
     accountsImpactedByError: [],

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/index.tsx
@@ -44,17 +44,13 @@ export function PortfolioBalanceSync(): null {
 
   const effectiveRawBalanceAvailable = rawBalanceAvailable || effectiveLatestBalance > 0;
 
-  const { balanceAvailable, displayedBalance } = useBalanceSyncState({
+  const { balanceAvailable, displayedBalance, isLoading } = useBalanceSyncState({
     rawBalanceAvailable: effectiveRawBalanceAvailable,
     syncPhase,
     latestBalance: effectiveLatestBalance,
     shouldFreezeOnSync: shouldDisplayBalanceRefreshRework,
     cvPending: shouldDisplayBalanceRefreshRework ? isCvPending : undefined,
   });
-
-  // Shimmer is scoped to the CVS phase: disappears once countervalues settle,
-  // letting the balance animate to the fresh fiat value while account sync continues.
-  const isLoading = shouldDisplayBalanceRefreshRework ? isCvPending : syncPhase === "syncing";
 
   useEffect(() => {
     dispatch(

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/index.tsx
@@ -26,7 +26,12 @@ export function PortfolioBalanceSync(): null {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const { shouldDisplayBalanceRefreshRework } = useWalletFeaturesConfig("mobile");
 
-  const { portfolio, balanceAvailable: rawBalanceAvailable, syncPhase } = usePortfolioBalance();
+  const {
+    portfolio,
+    balanceAvailable: rawBalanceAvailable,
+    syncPhase,
+    isCvPending,
+  } = usePortfolioBalance();
 
   const lastItem = portfolio.balanceHistory[portfolio.balanceHistory.length - 1];
   const latestBalance = lastItem?.value ?? 0;
@@ -44,9 +49,12 @@ export function PortfolioBalanceSync(): null {
     syncPhase,
     latestBalance: effectiveLatestBalance,
     shouldFreezeOnSync: shouldDisplayBalanceRefreshRework,
+    cvPending: shouldDisplayBalanceRefreshRework ? isCvPending : undefined,
   });
 
-  const isLoading = syncPhase === "syncing";
+  // Shimmer is scoped to the CVS phase: disappears once countervalues settle,
+  // letting the balance animate to the fresh fiat value while account sync continues.
+  const isLoading = shouldDisplayBalanceRefreshRework ? isCvPending : syncPhase === "syncing";
 
   useEffect(() => {
     dispatch(

--- a/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalance.ts
@@ -127,6 +127,8 @@ export function usePortfolioBalance() {
     isColdStart,
     isManualRefreshLoading,
     isBridgeSyncPending: syncSources.stablePending,
+    /** True while countervalues are being fetched within a user-triggered sync. */
+    isCvPending: syncPhase === "syncing" && syncSources.cvPending,
     allAccounts,
     accountsWithError,
     accountsImpactedByError,

--- a/libs/ledger-live-common/src/bridge/react/__tests__/useBalanceSyncState.test.ts
+++ b/libs/ledger-live-common/src/bridge/react/__tests__/useBalanceSyncState.test.ts
@@ -11,6 +11,7 @@ interface Props {
   syncPhase: SyncPhase;
   latestBalance: number;
   shouldFreezeOnSync: boolean;
+  cvPending?: boolean;
 }
 
 const defaultProps: Props = {
@@ -132,6 +133,59 @@ describe("useBalanceSyncState", () => {
         shouldFreezeOnSync: false,
       });
       expect(result.current.displayedBalance).toBe(2000);
+    });
+  });
+
+  describe("cvPending override (mobile CVS-phase behaviour)", () => {
+    it("freezes while cvPending is true and releases once false, regardless of syncPhase", () => {
+      const { result, rerender } = renderBalanceSyncState({
+        syncPhase: "syncing",
+        latestBalance: 1000,
+        shouldFreezeOnSync: true,
+        cvPending: true,
+      });
+      expect(result.current.displayedBalance).toBe(1000);
+
+      // Balance updated by CVS — still frozen while cvPending
+      rerender({ ...defaultProps, syncPhase: "syncing", latestBalance: 1200, cvPending: true });
+      expect(result.current.displayedBalance).toBe(1000);
+
+      // CVS settles — balance animates even though bridge sync (syncPhase) is still active
+      rerender({ ...defaultProps, syncPhase: "syncing", latestBalance: 1200, cvPending: false });
+      expect(result.current.displayedBalance).toBe(1200);
+
+      // Balance continues to update per-batch after CVS settles
+      rerender({ ...defaultProps, syncPhase: "syncing", latestBalance: 1500, cvPending: false });
+      expect(result.current.displayedBalance).toBe(1500);
+    });
+
+    it("clears sticky balanceUnavailable once cvPending is false (no balance case)", () => {
+      const { result, rerender } = renderBalanceSyncState({
+        rawBalanceAvailable: false,
+        syncPhase: "syncing",
+        latestBalance: 0,
+        shouldFreezeOnSync: true,
+        cvPending: true,
+      });
+      expect(result.current.balanceAvailable).toBe(false);
+
+      // Balance becomes available mid-sync but CVS still pending — still blocked
+      rerender({
+        ...defaultProps,
+        rawBalanceAvailable: true,
+        syncPhase: "syncing",
+        cvPending: true,
+      });
+      expect(result.current.balanceAvailable).toBe(false);
+
+      // CVS settles — balance unlocks immediately even with bridge sync still running
+      rerender({
+        ...defaultProps,
+        rawBalanceAvailable: true,
+        syncPhase: "syncing",
+        cvPending: false,
+      });
+      expect(result.current.balanceAvailable).toBe(true);
     });
   });
 });

--- a/libs/ledger-live-common/src/bridge/react/__tests__/useBalanceSyncState.test.ts
+++ b/libs/ledger-live-common/src/bridge/react/__tests__/useBalanceSyncState.test.ts
@@ -32,9 +32,24 @@ describe("useBalanceSyncState", () => {
       { syncPhase: "syncing" as SyncPhase, expected: true },
       { syncPhase: "synced" as SyncPhase, expected: false },
       { syncPhase: "failed" as SyncPhase, expected: false },
-    ])("should be $expected when syncPhase is $syncPhase", ({ syncPhase, expected }) => {
-      const { result } = renderBalanceSyncState({ syncPhase });
-      expect(result.current.isLoading).toBe(expected);
+    ])(
+      "should be $expected when syncPhase is $syncPhase (no cvPending override)",
+      ({ syncPhase, expected }) => {
+        const { result } = renderBalanceSyncState({ syncPhase });
+        expect(result.current.isLoading).toBe(expected);
+      },
+    );
+
+    it("should be scoped to cvPending when provided: true while CVS pending, false once settled", () => {
+      const { result, rerender } = renderBalanceSyncState({
+        syncPhase: "syncing",
+        cvPending: true,
+      });
+      expect(result.current.isLoading).toBe(true);
+
+      // CVS settles — isLoading drops even though syncPhase stays syncing (bridge in progress)
+      rerender({ ...defaultProps, syncPhase: "syncing", cvPending: false });
+      expect(result.current.isLoading).toBe(false);
     });
   });
 

--- a/libs/ledger-live-common/src/bridge/react/__tests__/useSyncSources.test.ts
+++ b/libs/ledger-live-common/src/bridge/react/__tests__/useSyncSources.test.ts
@@ -135,6 +135,16 @@ describe("useSyncSources", () => {
     expect(result.current.hasWalletSyncError).toBe(true);
   });
 
+  it("should expose cvPending from countervalues polling", () => {
+    mockUseCountervaluesPolling.mockReturnValue({ ...defaultPollingReturn, pending: true });
+    const { result } = renderSyncSources();
+    expect(result.current.cvPending).toBe(true);
+
+    mockUseCountervaluesPolling.mockReturnValue({ ...defaultPollingReturn, pending: false });
+    const { result: result2 } = renderSyncSources();
+    expect(result2.current.cvPending).toBe(false);
+  });
+
   it("should call all three sync sources on triggerRefresh", () => {
     const { result } = renderSyncSources();
 

--- a/libs/ledger-live-common/src/bridge/react/useBalanceSyncState.ts
+++ b/libs/ledger-live-common/src/bridge/react/useBalanceSyncState.ts
@@ -6,6 +6,13 @@ interface UseBalanceSyncStateParams {
   readonly syncPhase: SyncPhase;
   readonly latestBalance: number;
   readonly shouldFreezeOnSync: boolean;
+  /**
+   * When provided, scopes the sticky-clear and freeze logic to the CVS phase
+   * instead of the full sync cycle. Use `syncPhase === "syncing" && cvPending`
+   * so that auto-polls never trigger the shimmer.
+   * When omitted, falls back to `syncPhase === "syncing"` (desktop behaviour).
+   */
+  readonly cvPending?: boolean;
 }
 
 interface BalanceSyncState {
@@ -17,10 +24,10 @@ interface BalanceSyncState {
 /**
  * Shared balance-display logic consumed by both desktop and mobile during sync.
  *
- * - **Sticky balanceAvailable**: stays `false` while syncing so the skeleton
- *   covers the entire cycle (Skeleton → Animate balance, no shimmer gap).
+ * - **Sticky balanceAvailable**: stays `false` while the active phase holds so
+ *   the skeleton covers the cycle (Skeleton → Animate balance, no shimmer gap).
  * - **Frozen balance**: holds the pre-sync value so `AmountDisplay` can
- *   animate the delta once the sync settles.
+ *   animate the delta once the phase settles.
  * - **isLoading**: true while `syncPhase` is `"syncing"`.
  */
 export function useBalanceSyncState({
@@ -28,24 +35,30 @@ export function useBalanceSyncState({
   syncPhase,
   latestBalance,
   shouldFreezeOnSync,
+  cvPending,
 }: UseBalanceSyncStateParams): BalanceSyncState {
+  // When cvPending is provided (mobile), the "active phase" ends when CVS settles
+  // rather than when the full bridge sync settles. This lets the balance animate
+  // to the new CVS value and continue updating per account batch.
+  const isPhaseActive = cvPending !== undefined ? cvPending : syncPhase === "syncing";
+
   const [balanceUnavailable, setBalanceUnavailable] = useState(!rawBalanceAvailable);
   useEffect(() => {
     if (!rawBalanceAvailable) {
       setBalanceUnavailable(true);
-    } else if (syncPhase !== "syncing") {
+    } else if (!isPhaseActive) {
       setBalanceUnavailable(false);
     }
-  }, [rawBalanceAvailable, syncPhase]);
+  }, [rawBalanceAvailable, isPhaseActive]);
 
   const frozenBalanceRef = useRef(latestBalance);
   useEffect(() => {
-    if (syncPhase !== "syncing") {
+    if (!isPhaseActive) {
       frozenBalanceRef.current = latestBalance;
     }
-  }, [syncPhase, latestBalance]);
+  }, [isPhaseActive, latestBalance]);
 
-  const shouldFreeze = shouldFreezeOnSync && syncPhase === "syncing";
+  const shouldFreeze = shouldFreezeOnSync && isPhaseActive;
 
   return {
     balanceAvailable: !balanceUnavailable,

--- a/libs/ledger-live-common/src/bridge/react/useBalanceSyncState.ts
+++ b/libs/ledger-live-common/src/bridge/react/useBalanceSyncState.ts
@@ -40,7 +40,7 @@ export function useBalanceSyncState({
   // When cvPending is provided (mobile), the "active phase" ends when CVS settles
   // rather than when the full bridge sync settles. This lets the balance animate
   // to the new CVS value and continue updating per account batch.
-  const isPhaseActive = cvPending !== undefined ? cvPending : syncPhase === "syncing";
+  const isPhaseActive = cvPending ?? syncPhase === "syncing";
 
   const [balanceUnavailable, setBalanceUnavailable] = useState(!rawBalanceAvailable);
   useEffect(() => {
@@ -63,6 +63,6 @@ export function useBalanceSyncState({
   return {
     balanceAvailable: !balanceUnavailable,
     displayedBalance: shouldFreeze ? frozenBalanceRef.current : latestBalance,
-    isLoading: syncPhase === "syncing",
+    isLoading: isPhaseActive,
   };
 }

--- a/libs/ledger-live-common/src/bridge/react/useSyncSources.ts
+++ b/libs/ledger-live-common/src/bridge/react/useSyncSources.ts
@@ -18,6 +18,8 @@ export interface SyncSourcesState {
   readonly hasCvOrBridgeError: boolean;
   readonly hasWalletSyncError: boolean;
   readonly triggerRefresh: () => void;
+  /** Raw countervalues polling pending flag — use to scope shimmer to the CVS phase only. */
+  readonly cvPending: boolean;
 }
 
 /**
@@ -58,5 +60,6 @@ export function useSyncSources(walletSyncState: WalletSyncUserState): SyncSource
     hasCvOrBridgeError,
     hasWalletSyncError,
     triggerRefresh,
+    cvPending: cvPolling.pending,
   };
 }

--- a/libs/ledger-live-common/src/bridge/react/useSyncSources.ts
+++ b/libs/ledger-live-common/src/bridge/react/useSyncSources.ts
@@ -18,7 +18,6 @@ export interface SyncSourcesState {
   readonly hasCvOrBridgeError: boolean;
   readonly hasWalletSyncError: boolean;
   readonly triggerRefresh: () => void;
-  /** Raw countervalues polling pending flag — use to scope shimmer to the CVS phase only. */
   readonly cvPending: boolean;
 }
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Portfolio total balance display while syncing (mobile and desktop hooks)
  - Countervalues vs bridge sync timing: loading skeleton, balance freeze, and shimmer should follow the same “active phase” (`isPhaseActive`) everywhere
  - Pull-to-refresh / user-triggered sync flows on mobile
  - `useSyncSources` consumers receive `cvPending` from countervalues polling

### 📝 Description

**Problem**: On mobile, portfolio balance loading and freeze behavior was tied to the full bridge sync cycle. That could retrigger shimmer or misalign loading with countervalues (CVS), and duplicating “when is shimmer on?” in each app was easy to drift from freeze/sticky behavior.

**Solution**:

- Expose **`cvPending`** from **`useSyncSources`** (raw countervalues polling pending flag).
- Extend **`useBalanceSyncState`** with optional **`cvPending`**. The hook derives a single **`isPhaseActive`** signal: if `cvPending` is passed, it tracks CVS; otherwise it follows `syncPhase === "syncing"` (desktop-style). Sticky `balanceAvailable`, frozen `displayedBalance`, and **`isLoading`** (shimmer) all use that same signal — **`isLoading`** is now **`isPhaseActive`**, not raw `syncPhase === "syncing"` alone.
- **Desktop** (`useBalanceViewModel`) and **mobile** (`usePortfolioBalanceSectionViewModel`, `PortfolioBalanceSync`) take **`isLoading`** from **`useBalanceSyncState`** instead of recomputing `shouldDisplayBalanceRefreshRework ? isCvPending : syncPhase === "syncing"` locally.
- **Tests**: `useBalanceSyncState` covers “CVS settles while `syncPhase` stays `syncing`”; redundant app-level tests for that case were removed so the contract lives in one place.

Demo sent in slack (you can ask me)


  ## Refresh lifecycle

  ### If local balance is available (MMKV cache on mobile / Redux store on desktop)

  User pulls to refresh
          │
          ▼
  [Phase 1 — CVS]
    • Show local balance + shimmer
    • Balance frozen (no visual jump while fiat rates update)
          │
          ▼  countervalues API returns
  [Transition]
    • Shimmer disappears
    • Balance animates from frozen → new CVS-updated fiat value
          │
          ▼
  [Phase 2 — Bridge sync, background]
    • No shimmer
    • As each batch of accounts syncs, balance re-animates to the new value
          │
          ▼  all accounts up to date
  [Done]

  ### If no local balance is available (cold start / first launch)

  App opens / user refreshes
          │
          ▼
  [Phase 1 — CVS]
    • Show skeleton with shimmer (Lumen Skeleton component)
    • Sticky keeps skeleton visible until CVS settles
          │
          ▼  countervalues settle + portfolio has balance data
  [Transition]
    • Skeleton replaced by AmountDisplay
    • Balance animates in
          │
          ▼
  [Phase 2 — Bridge sync, background]
    • Balance re-animates per account batch as operations arrive
          │
          ▼  all accounts up to date
  [Done]

  > **Note (LLD):** The top-right sync icon (`isRotating = syncPhase === "syncing"`) is unaffected — it continues to spin for the full CVS + bridge duration, as today.

  > **Note (LLM):** The entire lifecycle is gated behind `shouldDisplayBalanceRefreshRework` (`lwmWallet40.balanceRefreshRework`). When the flag is off, the old full-sync shimmer behaviour is preserved.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29314](https://ledgerhq.atlassian.net/browse/LIVE-29314) & [LIVE-29315](https://ledgerhq.atlassian.net/browse/LIVE-29315)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29314]: https://ledgerhq.atlassian.net/browse/LIVE-29314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ