### PR TITLE
[LWDM] fix(portfolio): reposition perps entry point above assets section

### DIFF
--- a/.changeset/bright-perps-position.md
+++ b/.changeset/bright-perps-position.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fix perps entry point position above assets section on portfolio screen

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/PortfolioView.tsx
@@ -66,8 +66,8 @@ export const PortfolioView = memo(function PortfolioView({
           <PortfolioBannerContent />
           {shouldDisplayMarketBanner && <MarketBanner />}
 
-          {shouldDisplayAssetSection ? <Assets /> : <AssetDistribution />}
           <PerpsEntryPoint />
+          {shouldDisplayAssetSection ? <Assets /> : <AssetDistribution />}
           {shouldDisplayAddAccountCta && <AddAccount />}
           {shouldDisplayAssetSection && <CryptoAddressesBanner />}
           {shouldDisplayBrazePlacement && <BottomCarouselContentCards />}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioPerpsEntryPoint/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioPerpsEntryPoint/index.tsx
@@ -35,7 +35,7 @@ export const PortfolioPerpsEntryPoint = () => {
 
   return (
     <FeatureToggle featureId="ptxPerpsLiveAppMobile">
-      <Box lx={{ marginTop: "s16", paddingHorizontal: "s16" }}>
+      <Box lx={{ marginBottom: "s16", paddingHorizontal: "s16" }}>
         <Subheader>
           <SubheaderRow onPress={handlePress} data-testid="portfolio-perps-subheader-row">
             <SubheaderTitle>{t("portfolio.perpsEntry.title")}</SubheaderTitle>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -131,6 +131,8 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
       );
     }
 
+    sections.push(<PortfolioPerpsEntryPoint key="perpsEntryPoint" />);
+
     if (shouldDisplayAssetSection) {
       sections.push(<WalletAssetsView key="categorizedAssets" />);
     } else {
@@ -145,8 +147,6 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
         />,
       );
     }
-
-    sections.push(<PortfolioPerpsEntryPoint key="perpsEntryPoint" />);
 
     if (isAWalletCardDisplayed) {
       sections.push(<PortfolioCarouselSection key="carousel" backgroundColor={backgroundColor} />);


### PR DESCRIPTION
Move the Perps entry point component before the assets/distribution section on both desktop and mobile portfolio screens. Also fix the spacing on mobile by switching from marginTop to marginBottom.

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->
<img width="383" height="372" alt="Screenshot 2026-04-20 at 11 26 26" src="https://github.com/user-attachments/assets/05c7820b-9c12-4ffd-bc94-39256af7e701" />

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

move back to the top position perps entry point

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->
https://ledgerhq.atlassian.net/browse/LIVE-26405


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
