### PR TITLE
[LWD] feat(desktop): Add MyWallet context menu with settings navigation

### DIFF
--- a/.changeset/pretty-rice-warn.md
+++ b/.changeset/pretty-rice-warn.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add settings in MyWallet context menu

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useSettings.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useSettings.test.ts
@@ -57,6 +57,19 @@ describe("useSettings", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/settings");
   });
 
+  it("uses the provided tracking source when navigating", () => {
+    mockUseLocation.mockReturnValue(createLocation("/accounts"));
+
+    const { result } = renderHook(() => useSettings("mywallet"));
+
+    act(() => {
+      result.current.handleSettings();
+    });
+
+    expect(mockSetTrackingSource).toHaveBeenCalledWith("mywallet");
+    expect(mockNavigate).toHaveBeenCalledWith("/settings");
+  });
+
   it("does not navigate when already on settings page", () => {
     mockUseLocation.mockReturnValue(createLocation("/settings"));
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
@@ -51,6 +51,7 @@ type SetupOptions = {
   experimentalVisible?: boolean;
   featureFlagsVisible?: boolean;
   operationsList?: boolean;
+  myWallet?: boolean;
   route?: string;
 };
 
@@ -60,6 +61,7 @@ const setup = ({
   experimentalVisible = false,
   featureFlagsVisible = false,
   operationsList = false,
+  myWallet = false,
   route,
 }: SetupOptions = {}) => {
   jest.mocked(useDiscreetMode).mockReturnValue(defaults.discreetMode);
@@ -79,8 +81,17 @@ const setup = ({
   });
   jest.mocked(useHistory).mockReturnValue(defaults.history);
 
-  const initialState = operationsList
-    ? withFlagOverrides({ lwdWallet40: { enabled: true, params: { operationsList: true } } })
+  const needsFlags = operationsList || myWallet;
+  const initialState = needsFlags
+    ? withFlagOverrides({
+        lwdWallet40: {
+          enabled: true,
+          params: {
+            ...(operationsList && { operationsList: true }),
+            ...(myWallet && { myWallet: true }),
+          },
+        },
+      })
     : undefined;
 
   const routeWrapper = route
@@ -127,9 +138,13 @@ describe("useTopBarViewModel", () => {
           "notification",
           "discreet",
           "history",
-          "settings",
           "my ledger",
         ],
+      ],
+      [
+        "myWallet enabled hides settings",
+        { myWallet: true },
+        ["synchronize", "notification", "discreet", "history", "my ledger"],
       ],
     ])("%s", (_name, options, expectedLabels) => {
       const { result } = setup(options);

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useSettings.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useSettings.ts
@@ -4,7 +4,11 @@ import { useTranslation } from "react-i18next";
 import { Settings } from "@ledgerhq/lumen-ui-react/symbols";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 
-export const useSettings = (): {
+export type SettingsTrackingSource = "topbar" | "mywallet";
+
+export const useSettings = (
+  source: SettingsTrackingSource = "topbar",
+): {
   handleSettings: () => void;
   settingsIcon: typeof Settings;
   tooltip: string;
@@ -16,10 +20,10 @@ export const useSettings = (): {
   const handleSettings = useCallback(() => {
     const url = "/settings";
     if (location.pathname !== url) {
-      setTrackingSource("topbar");
+      setTrackingSource(source);
       navigate(url);
     }
-  }, [navigate, location]);
+  }, [navigate, location, source]);
 
   return {
     handleSettings,

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
@@ -10,7 +10,7 @@ import { useSettings } from "./useSettings";
 import { useHistory } from "./useHistory";
 
 const useTopBarViewModel = () => {
-  const { shouldDisplayOperationsList } = useWalletFeaturesConfig("desktop");
+  const { shouldDisplayOperationsList, shouldDisplayMyWallet } = useWalletFeaturesConfig("desktop");
   const { handleDiscreet, discreetIcon, tooltip: discreetTooltip } = useDiscreetMode();
   const {
     hasAccounts,
@@ -112,16 +112,20 @@ const useTopBarViewModel = () => {
           },
         ]
       : []),
-    {
-      type: "action",
-      action: {
-        label: "settings",
-        tooltip: settingsTooltip,
-        icon: settingsIcon,
-        isInteractive: true,
-        onClick: handleSettings,
-      },
-    },
+    ...(!shouldDisplayMyWallet
+      ? [
+          {
+            type: "action" as const,
+            action: {
+              label: "settings",
+              tooltip: settingsTooltip,
+              icon: settingsIcon,
+              isInteractive: true,
+              onClick: handleSettings,
+            },
+          },
+        ]
+      : []),
     {
       type: "action",
       action: {

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/MyWalletTopBar.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/MyWalletTopBar.integration.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen, waitFor } from "tests/testSetup";
+import { useNavigate } from "react-router";
+import { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import { ContextMenu } from "../components/ContextMenu";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(() => mockNavigate),
+  useLocation: jest.fn(() => ({
+    pathname: "/",
+    state: null,
+    key: "default",
+    search: "",
+    hash: "",
+  })),
+}));
+
+jest.mock("~/renderer/analytics/TrackPage", () => ({
+  setTrackingSource: jest.fn(),
+}));
+
+const mockedUseNavigate = jest.mocked(useNavigate);
+const mockSetTrackingSource = jest.mocked(setTrackingSource);
+
+describe("MyWallet ContextMenu", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseNavigate.mockReturnValue(mockNavigate);
+  });
+
+  it("should render My Wallet trigger button", () => {
+    render(<ContextMenu />);
+
+    expect(screen.getByRole("button", { name: "Airplane" })).toBeVisible();
+  });
+
+  it("should show a settings button inside the popover when opened", async () => {
+    const { user } = render(<ContextMenu />);
+
+    await user.click(screen.getByRole("button", { name: "Airplane" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("topbar-action-button-settings")).toBeVisible();
+    });
+  });
+
+  it("should navigate to /settings with 'mywallet' tracking source when clicking settings", async () => {
+    const { user } = render(<ContextMenu />);
+
+    await user.click(screen.getByRole("button", { name: "Airplane" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("topbar-action-button-settings")).toBeVisible();
+    });
+
+    await user.click(screen.getByTestId("topbar-action-button-settings"));
+
+    expect(mockSetTrackingSource).toHaveBeenCalledWith("mywallet");
+    expect(mockNavigate).toHaveBeenCalledWith("/settings");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Popover, PopoverTrigger, PopoverContent, IconButton } from "@ledgerhq/lumen-ui-react";
 import { Airplane } from "@ledgerhq/lumen-ui-react/symbols";
 import { Explore } from "./Explore";
+import TopBar from "./TopBar";
 
 const side = "bottom";
 const align = "end";
@@ -11,7 +12,13 @@ export function ContextMenu() {
     <Popover>
       <PopoverTrigger render={<IconButton icon={Airplane} aria-label="Airplane" size="sm" />} />
 
-      <PopoverContent width="fixed" side={side} align={align} className="bg-surface">
+      <PopoverContent
+        width="fixed"
+        side={side}
+        align={align}
+        className="flex flex-col bg-surface gap-24"
+      >
+        <TopBar />
         <p className="body-2 text-base">
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos.
         </p>

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/TopBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/TopBarView.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { TopBarActionButton } from "LLD/components/TopBar/components/TopBarActionButton";
+import type { MyWalletTopBarViewProps } from "./types";
+
+const TopBarView = ({ settingsAction }: MyWalletTopBarViewProps) => (
+  <div className="flex justify-between items-center">
+    <p className="body-2 text-base">My Wallet</p>
+    <div className="flex gap-16">
+      <p className="body-2 text-base">Notifications</p>
+      <TopBarActionButton {...settingsAction} />
+    </div>
+  </div>
+);
+
+export default TopBarView;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/hooks/useTopBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/hooks/useTopBarViewModel.ts
@@ -1,0 +1,18 @@
+import { useSettings } from "LLD/components/TopBar/hooks/useSettings";
+import type { TopBarAction } from "LLD/components/TopBar/types";
+
+const useTopBarViewModel = () => {
+  const { handleSettings, settingsIcon, tooltip: settingsTooltip } = useSettings("mywallet");
+
+  const settingsAction: TopBarAction = {
+    label: "settings",
+    tooltip: settingsTooltip,
+    icon: settingsIcon,
+    isInteractive: true,
+    onClick: handleSettings,
+  };
+
+  return { settingsAction };
+};
+
+export default useTopBarViewModel;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import useTopBarViewModel from "./hooks/useTopBarViewModel";
+import TopBarView from "./TopBarView";
+
+const TopBar = () => {
+  const { settingsAction } = useTopBarViewModel();
+  return <TopBarView settingsAction={settingsAction} />;
+};
+
+export default TopBar;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/types.ts
@@ -1,0 +1,5 @@
+import type { TopBarAction } from "LLD/components/TopBar/types";
+
+export type MyWalletTopBarViewProps = {
+  settingsAction: TopBarAction;
+};


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Integration test added for ContextMenu settings navigation. Unit test added for useSettings tracking source parameter._
- [x] **Impact of the changes:**
      - MyWallet popover renders a settings button that navigates to `/settings`
      - Settings button in main TopBar conditionally hidden when MyWallet is enabled
      - Analytics tracking source correctly set to `mywallet` from the popover context

### 📝 Description

**Problem**: The MyWallet context menu needed a settings entry point with its own MVVM structure and distinct analytics tracking, separate from the main TopBar settings button.

**Solution**:
- Created the MyWallet TopBar following the MVVM pattern (View + ViewModel + types), consistent with the rest of the codebase
- Parameterized `useSettings` to accept a tracking source (`"topbar"` | `"mywallet"`) so analytics correctly distinguishes where the user clicked
- Conditionally hid the settings button from the main TopBar when `shouldDisplayMyWallet` is enabled (avoids duplication)
- Added integration test covering the ContextMenu → settings navigation flow
<img width="466" height="198" alt="Screenshot 2026-04-20 at 11 40 29" src="https://github.com/user-attachments/assets/b950aa70-8168-4574-80a8-04d0aa71248a" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26025](https://ledgerhq.atlassian.net/browse/LIVE-26025)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26025]: https://ledgerhq.atlassian.net/browse/LIVE-26025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ