### PR TITLE
fix(wallet-cli): resolve axios via live-common instead of coin-evm

### DIFF
--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -62,13 +62,13 @@ LiveConfig.setConfig(walletCliConfig);
 // and require() to lib/, creating separate LiveConfig.instance singletons.
 // Non-alpacaized families (solana, bitcoin) load their bridge via require() in
 // the lazy loaders above, so they read from the CJS instance.
-(require("@ledgerhq/live-config/LiveConfig") as typeof import("@ledgerhq/live-config/LiveConfig")).LiveConfig.setConfig(walletCliConfig);
+require("@ledgerhq/live-config/LiveConfig").LiveConfig.setConfig(walletCliConfig);
 // TODO: wallet-cli should own its Redux store setup (createRtkCryptoAssetsStore + RTK middleware)
 // instead of relying on setupCalClientStore from @ledgerhq/cryptoassets/cal-client (test-helpers).
 setupCalClientStore();
 // Also require() — the ESM import would set the flag on a different module instance
 // than the CJS setup.ts loaded by the lazy loaders above.
-(require("@ledgerhq/live-common/families/solana/setup") as typeof import("@ledgerhq/live-common/families/solana/setup")).setSolanaLdmkEnabled(true);
+require("@ledgerhq/live-common/families/solana/setup").setSolanaLdmkEnabled(true);
 registerWalletCliDmkTransport();
 
 setEnv("LEDGER_CLIENT_VERSION", "wallet-cli/0.1.0");

--- a/apps/wallet-cli/src/test/helpers/http-intercept.ts
+++ b/apps/wallet-cli/src/test/helpers/http-intercept.ts
@@ -8,8 +8,7 @@
  *
  * Axios uses node:http adapter by default in Bun (process is defined). We force it
  * onto the fetch adapter so its calls go through the globalThis.fetch patch below.
- * axios is not a direct dep of wallet-cli, so we resolve it via @ledgerhq/coin-evm
- * (which is) and patch both CJS and ESM instances.
+ * Axios is resolved via @ledgerhq/live-common (a direct dep of wallet-cli).
  */
 import path from "node:path";
 
@@ -21,14 +20,13 @@ if (!mockPort) {
 const mockBase = `http://localhost:${mockPort}`;
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const coinEvmDir = path.dirname(require.resolve("@ledgerhq/coin-evm/package.json"));
+const liveCommonDir = path.dirname(require.resolve("@ledgerhq/live-common/package.json"));
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const axiosPkgDir = path.dirname(require.resolve("axios/package.json", { paths: [coinEvmDir] }));
-
+const axiosPkgDir = path.dirname(require.resolve("axios/package.json", { paths: [liveCommonDir] }));
 // Patch CJS axios instance
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any
 (require(path.join(axiosPkgDir, "dist/node/axios.cjs")) as any).defaults.adapter = "fetch";
-// Patch ESM axios instance (coin-evm's `import axios from "axios"` resolves here)
+// Patch ESM axios instance
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ((await import(path.join(axiosPkgDir, "index.js"))) as any).default.defaults.adapter = "fetch";
 
@@ -68,14 +66,14 @@ const origFetch = globalThis.fetch;
 };
 
 // ---------------------------------------------------------------------------
-// Layer 2: node:http / node:https — fallback for non-fetch callers.
+// Layer 2: node:http / node:https — fallback for any remaining node:http callers.
 // HTTPS requests are redirected to the plain-HTTP mock server.
 // ---------------------------------------------------------------------------
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const http = require("node:http") as typeof import("node:http");
+const http = require("node:http");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const https = require("node:https") as typeof import("node:https");
+const https = require("node:https");
 
 const origHttpRequest = http.request.bind(http);
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 150 tests pass.
- [x] **Impact of the changes:**
  - No runtime behavior change.

### 📝 Description

Two small cleanup fixes in `wallet-cli`:

1. **`http-intercept.ts`** — resolve `axios` via `@ledgerhq/live-common` (a direct dep of wallet-cli) instead of `@ledgerhq/coin-evm` (which is not).
2. **`live-common-setup.ts`** — remove redundant `as typeof import(...)` casts on `require()` calls flagged by the linter (the type is already correctly inferred).

### ❓ Context

- **JIRA or GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/16470