### PR TITLE
docs: migrate to commands to skills

### DIFF
--- a/.cursor/agents/code-reviewer.md
+++ b/.cursor/agents/code-reviewer.md
@@ -10,8 +10,8 @@ You are a senior code reviewer for Ledger Wallet applications, specializing in m
 Follow all project rules in `.cursor/rules/`. Pay special attention to:
 
 - `react-mvvm.mdc` — MVVM compliance is a key review concern for code in `src/mvvm/`
-- `ldls-web.mdc` — Lumen UI for desktop (`src/mvvm/`)
-- `ldls-native.mdc` — Lumen UI for mobile (`src/mvvm/`)
+- `.cursor/skills/ldls-web/SKILL.md` — Lumen UI for desktop (`src/mvvm/`)
+- `.cursor/skills/ldls-native/SKILL.md` — Lumen UI for mobile (`src/mvvm/`)
 - `coin-families-contract.mdc` — No coin-specific branches (`if (family === "evm")` etc.) in generic UI; extend the families contract and implement in `families/<family>/` instead
 - `jest-mocks.mdc` — Jest mock patterns for test files (avoids flaky tests and mock conflicts)
 - `team-split-convention.mdc` — Multi-team files should be split into `[foo]/index.ts` and `[foo]/team-[team]/*.ts`; suggest this when a touched file clearly involves many teams

--- a/.cursor/skills/cleanup/SKILL.md
+++ b/.cursor/skills/cleanup/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: cleanup
+description: Run lint, format, and typecheck on modified files
+disable-model-invocation: true
+---
+
 # Cleanup
 
 Run lint, format, and typecheck on modified files.

--- a/.cursor/skills/client-ids/SKILL.md
+++ b/.cursor/skills/client-ids/SKILL.md
@@ -1,6 +1,6 @@
 ---
+name: client-ids
 description: Privacy-protected ID management with @ledgerhq/client-ids — DeviceId, UserId, DatadogId, export-rules.json
-alwaysApply: false
 ---
 
 # Client IDs Library (`@ledgerhq/client-ids`)

--- a/.cursor/skills/create-pr/SKILL.md
+++ b/.cursor/skills/create-pr/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: create-pr
+description: Create a pull request with proper description, changeset, and all required elements
+disable-model-invocation: true
+---
+
 # Create PR
 
 Create a pull request with proper description, changeset, and all required elements.

--- a/.cursor/skills/dialogs-slice/SKILL.md
+++ b/.cursor/skills/dialogs-slice/SKILL.md
@@ -1,6 +1,6 @@
 ---
+name: dialogs-slice
 description: Global dialogs Redux slice pattern for MVVM dialog state management
-alwaysApply: false
 ---
 
 # Global Dialogs Slice Pattern

--- a/.cursor/skills/e2e-desktop-onboard/SKILL.md
+++ b/.cursor/skills/e2e-desktop-onboard/SKILL.md
@@ -1,4 +1,10 @@
 ---
+name: e2e-desktop-onboard
+description: Interactive setup wizard for running desktop E2E (Playwright + Speculos) tests locally
+disable-model-invocation: true
+---
+
+---
 description: Interactive setup wizard for running desktop E2E (Playwright + Speculos) tests locally
 ---
 

--- a/.cursor/skills/e2e-mobile-onboard/SKILL.md
+++ b/.cursor/skills/e2e-mobile-onboard/SKILL.md
@@ -1,4 +1,10 @@
 ---
+name: e2e-mobile-onboard
+description: Interactive setup wizard for running mobile E2E (Detox) tests locally
+disable-model-invocation: true
+---
+
+---
 description: Interactive setup wizard for running mobile E2E (Detox) tests locally
 ---
 

--- a/.cursor/skills/feature-dev/SKILL.md
+++ b/.cursor/skills/feature-dev/SKILL.md
@@ -1,4 +1,10 @@
 ---
+name: feature-dev
+description: Guided feature development with codebase understanding and architecture focus
+disable-model-invocation: true
+---
+
+---
 description: Guided feature development with codebase understanding and architecture focus
 argument-hint: Optional feature description
 ---

--- a/.cursor/skills/ldls-native/SKILL.md
+++ b/.cursor/skills/ldls-native/SKILL.md
@@ -1,6 +1,6 @@
 ---
+name: ldls-native
 description: Lumen UI React Native design system rules
-alwaysApply: false
 ---
 
 @node_modules/@ledgerhq/lumen-ui-rnative/ai-rules/RULES.md

--- a/.cursor/skills/ldls-web/SKILL.md
+++ b/.cursor/skills/ldls-web/SKILL.md
@@ -1,6 +1,6 @@
 ---
+name: ldls-web
 description: LDLS UI React design system rules (@ledgerhq/lumen-ui-react)
-alwaysApply: false
 ---
 
 @node_modules/@ledgerhq/lumen-ui-react/ai-rules/RULES.md

--- a/.cursor/skills/pre-review/SKILL.md
+++ b/.cursor/skills/pre-review/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: pre-review
+description: Deep code review
+disable-model-invocation: true
+---
+
 # Pre-Review
 
 Deep code review

--- a/.cursor/skills/rebuild-to-fix-lib-import-errors/SKILL.md
+++ b/.cursor/skills/rebuild-to-fix-lib-import-errors/SKILL.md
@@ -1,6 +1,6 @@
 ---
+name: rebuild-to-fix-lib-import-errors
 description: When typecheck finds an error importing from a lib in the monorepo, rebuild the lib
-alwaysApply: false
 ---
 
 When typecheck finds an error importing from a lib in the monorepo rebuild the lib using the command below:

--- a/.cursor/skills/redux-slice/SKILL.md
+++ b/.cursor/skills/redux-slice/SKILL.md
@@ -1,6 +1,6 @@
 ---
+name: redux-slice
 description: Redux Toolkit createSlice best practices
-alwaysApply: false
 ---
 
 # Redux Toolkit - createSlice

--- a/.cursor/skills/rtk-query-api/SKILL.md
+++ b/.cursor/skills/rtk-query-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
+name: rtk-query-api
 description: RTK Query createApi best practices
-alwaysApply: false
 ---
 
 # RTK Query - createApi

--- a/.cursor/skills/test-coverage/SKILL.md
+++ b/.cursor/skills/test-coverage/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: test-coverage
+description: Increase test coverage to 90% on a target zone with iterative writing and refactoring
+disable-model-invocation: true
+---
+
 # Test Coverage
 
 Increase test coverage to 90% on a target zone with iterative writing and refactoring.

--- a/.cursor/skills/zod-schemas/SKILL.md
+++ b/.cursor/skills/zod-schemas/SKILL.md
@@ -1,6 +1,6 @@
 ---
+name: zod-schemas
 description: Zod schema validation patterns for API types
-alwaysApply: false
 ---
 
 # Zod Schema Validation

--- a/.github/instructions/mvvm-architecture.instructions.md
+++ b/.github/instructions/mvvm-architecture.instructions.md
@@ -2,7 +2,7 @@
 applyTo: "**/src/mvvm/**"
 ---
 
-<!-- Source: .cursor/rules/react-mvvm.mdc, .cursor/rules/ldls-web.mdc, .cursor/rules/ldls-native.mdc -->
+<!-- Source: .cursor/rules/react-mvvm.mdc, .cursor/skills/ldls-web/SKILL.md, .cursor/skills/ldls-native/SKILL.md -->
 <!-- Last synced: 2026-02-16 -->
 
 # MVVM Architecture

--- a/.github/instructions/typescript-react.instructions.md
+++ b/.github/instructions/typescript-react.instructions.md
@@ -2,7 +2,7 @@
 applyTo: "**/*.ts,**/*.tsx"
 ---
 
-<!-- Source: .cursor/rules/typescript.mdc, .cursor/rules/react-general.mdc, .cursor/rules/redux-slice.mdc, .cursor/rules/rtk-query-api.mdc, .cursor/rules/zod-schemas.mdc -->
+<!-- Source: .cursor/rules/typescript.mdc, .cursor/rules/react-general.mdc, .cursor/skills/redux-slice/SKILL.md, .cursor/skills/rtk-query-api/SKILL.md, .cursor/skills/zod-schemas/SKILL.md -->
 <!-- Last synced: 2026-02-13 -->
 
 # TypeScript & React


### PR DESCRIPTION
### 📝 Description

These changes are the result of applying Cursors `/migrate-to-skills` skill:
- All **commands** are migrated to **agent-skills** with `disable-model-invocation: true`
- All **rules** that were "applied intelligently" migrated to **agent-skills**

### ❓ Context

Jira: https://ledgerhq.atlassian.net/browse/LIVE-29279
ADR: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7035977860

