### PR TITLE
[LWD] feat(desktop): Add My Ledger item in MyWallet popover and hide topbar duplicate

### DIFF
--- a/.changeset/modern-icons-decide.md
+++ b/.changeset/modern-icons-decide.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add My Ledger item in the MyWallet popover and hide the duplicate top bar action when the popover is enabled.

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
@@ -131,20 +131,12 @@ describe("useTopBarViewModel", () => {
       [
         "all optional slots visible",
         { experimentalVisible: true, featureFlagsVisible: true, operationsList: true },
-        [
-          "experimental",
-          "feature flags",
-          "synchronize",
-          "notification",
-          "discreet",
-          "history",
-          "my ledger",
-        ],
+        ["experimental", "feature flags", "synchronize", "notification", "discreet", "history"],
       ],
       [
-        "myWallet enabled hides settings",
+        "myWallet enabled hides settings and my ledger",
         { myWallet: true },
-        ["synchronize", "notification", "discreet", "history", "my ledger"],
+        ["synchronize", "notification", "discreet", "history"],
       ],
     ])("%s", (_name, options, expectedLabels) => {
       const { result } = setup(options);

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
@@ -124,18 +124,18 @@ const useTopBarViewModel = () => {
               onClick: handleSettings,
             },
           },
+          {
+            type: "action" as const,
+            action: {
+              label: "my ledger",
+              tooltip: myLedgerTooltip,
+              icon: myLedgerIcon,
+              isInteractive: true,
+              onClick: handleMyLedger,
+            },
+          },
         ]
       : []),
-    {
-      type: "action",
-      action: {
-        label: "my ledger",
-        tooltip: myLedgerTooltip,
-        icon: myLedgerIcon,
-        isInteractive: true,
-        onClick: handleMyLedger,
-      },
-    },
   ];
 
   return {

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
@@ -4,6 +4,7 @@ import { Airplane } from "@ledgerhq/lumen-ui-react/symbols";
 import { Explore } from "./Explore";
 import TopBar from "./TopBar";
 import { ActionsList } from "./ActionsList";
+import { MyLedger } from "./MyLedger";
 
 const side = "bottom";
 const align = "end";
@@ -21,7 +22,10 @@ export function ContextMenu() {
       >
         <TopBar />
         <ActionsList />
-        <Explore />
+        <div className="flex flex-col gap-12">
+          <MyLedger />
+          <Explore />
+        </div>
       </PopoverContent>
     </Popover>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/MyLedgerView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/MyLedgerView.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import {
+  ListItem,
+  ListItemLeading,
+  ListItemContent,
+  ListItemTitle,
+  ListItemTrailing,
+  ListItemDescription,
+  Spot,
+} from "@ledgerhq/lumen-ui-react";
+import { ChevronRight } from "@ledgerhq/lumen-ui-react/symbols";
+import type { DeviceIconComponent } from "LLD/utils/getDeviceIcon";
+
+export type MyLedgerViewProps = {
+  title: string;
+  description: string;
+  icon: DeviceIconComponent;
+  onClick: () => void;
+};
+
+export function MyLedgerView({ title, description, icon, onClick }: MyLedgerViewProps) {
+  return (
+    <ListItem onClick={onClick} className="bg-muted">
+      <ListItemLeading>
+        <Spot icon={icon} appearance="icon" />
+        <ListItemContent>
+          <ListItemTitle>{title}</ListItemTitle>
+          <ListItemDescription>{description}</ListItemDescription>
+        </ListItemContent>
+      </ListItemLeading>
+      <ListItemTrailing>
+        <ChevronRight size={24} />
+      </ListItemTrailing>
+    </ListItem>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/hooks/useMyLedgerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/hooks/useMyLedgerViewModel.ts
@@ -1,0 +1,22 @@
+import { useTranslation } from "react-i18next";
+import { useMyLedger } from "LLD/components/TopBar/hooks/useMyLedger";
+import type { DeviceIconComponent } from "LLD/utils/getDeviceIcon";
+
+export type MyLedgerViewModel = {
+  title: string;
+  description: string;
+  icon: DeviceIconComponent;
+  handleClick: () => void;
+};
+
+export function useMyLedgerViewModel(): MyLedgerViewModel {
+  const { t } = useTranslation();
+  const { handleMyLedger, icon } = useMyLedger();
+
+  return {
+    title: t("myWallet.myLedger.title"),
+    description: t("myWallet.myLedger.description"),
+    icon,
+    handleClick: handleMyLedger,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/index.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { LedgerDevices } from "@ledgerhq/lumen-ui-react/symbols";
+import { render, screen } from "tests/testSetup";
+import * as UseMyLedgerViewModel from "./hooks/useMyLedgerViewModel";
+import { MyLedger } from "./index";
+
+jest.mock("./hooks/useMyLedgerViewModel", () => ({
+  useMyLedgerViewModel: jest.fn(),
+}));
+
+const handleClick = jest.fn();
+
+describe("MyLedger", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(UseMyLedgerViewModel, "useMyLedgerViewModel").mockReturnValue({
+      title: "My Ledger",
+      description: "Manage your Ledger device",
+      icon: LedgerDevices,
+      handleClick,
+    });
+  });
+
+  it("should display the my ledger item", () => {
+    render(<MyLedger />);
+
+    expect(screen.getByText("My Ledger")).toBeVisible();
+    expect(screen.getByText("Manage your Ledger device")).toBeVisible();
+  });
+
+  it("should trigger handleClick when clicked", async () => {
+    const { user } = render(<MyLedger />);
+
+    await user.click(screen.getByText("My Ledger"));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { MyLedgerView } from "./MyLedgerView";
+import { useMyLedgerViewModel } from "./hooks/useMyLedgerViewModel";
+
+export function MyLedger() {
+  const { title, description, icon, handleClick } = useMyLedgerViewModel();
+
+  return <MyLedgerView title={title} description={description} icon={icon} onClick={handleClick} />;
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8638,9 +8638,13 @@
     }
   },
   "myWallet": {
-    "explore": "Explore all Ledger devices",
     "actionsList": {
       "help": "Help"
-    }
+    },
+    "myLedger": {
+      "title": "My Ledger",
+      "description": "Manage your Ledger device"
+    },
+    "explore": "Explore all Ledger devices"
   }
 }


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - MyWallet popover now shows a "My Ledger" item alongside "Explore all Ledger devices"
  - Clicking "My Ledger" triggers the same navigation flow as the existing top bar button (navigates to `/manager` if onboarded, otherwise opens the Buy Device modal; also tracks `button_clicked`)
  - The standalone "My Ledger" top bar button is hidden when the MyWallet popover is enabled (`shouldDisplayMyWallet`), to avoid duplicated UI
  - Analytics tracking still fires via the existing `useMyLedger` hook

### Description

This PR adds a new "My Ledger" entry inside the MyWallet popover (`ContextMenu`). The component follows the MVVM pattern:

-  `MyLedger/index.tsx`: thin containers consuming the ViewModel and rendering the View
- `MyLedger/MyLedgerView.tsx`: pure presentational components
- `MyLedger/hooks/useMyLedgerViewModel.ts`: encapsulate all behavior (translations, URL resolution, click handling) and reuse the shared `useMyLedger` hook for the navigation logic

Because the popover now exposes "My Ledger", the standalone top bar action is hidden behind `!shouldDisplayMyWallet` in `useTopBarViewModel` to prevent duplicate entry points. The popover items are wrapped in a `flex flex-col gap-12` for proper spacing.

Unit tests cover both items:

- `MyLedger/index.test.tsx`: spies on the `useMyLedgerViewModel` hook and asserts title/description rendering + click delegation

> This PR is stacked on top of [#16502](https://github.com/LedgerHQ/ledger-live/pull/16502). Please review that one first.

### Before / After


https://github.com/user-attachments/assets/bba2b2be-dee6-47e1-9f42-9a6be0dc2809


### Context

- **JIRA link**: [LIVE-26137](https://ledgerhq.atlassian.net/browse/LIVE-26137)

---

### Checklist for the PR Reviewers

- The code aligns with the requirements described in the linked JIRA issue.
- The PR description clearly documents the changes made and explains any technical trade-offs or design decisions.
- There are no undocumented trade-offs, technical debt, or maintainability issues.
- The PR has been tested thoroughly, and any potential edge cases have been considered and handled.
- Any new dependencies have been justified and documented.
- Performance considerations have been taken into account.

[LIVE-26137]: https://ledgerhq.atlassian.net/browse/LIVE-26137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ