### PR TITLE
[LWDM] test(live-common): add coin-module eager-import non-regression tests

### DIFF
--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -345,6 +345,7 @@
     "**/fixtures/**"
   ],
   "ignoreUnimported": [
+    "src/coin-modules/non-regression-entry.ts",
     "src/bridge/generic-alpaca/alpaca/local/canton.ts",
     "src/bridge/generic-alpaca/alpaca/local/evm.ts",
     "src/bridge/generic-alpaca/alpaca/local/solana.ts",

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -358,6 +358,7 @@
     "camelcase": "^6.2.1",
     "cross-env": "^7.0.3",
     "env-cmd": "*",
+    "esbuild": "0.25.5",
     "fs": "^0.0.1-security",
     "glob": "^7.2.0",
     "jest": "catalog:",

--- a/libs/ledger-live-common/src/coin-modules/loaders.test.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.test.ts
@@ -1,0 +1,14 @@
+import { coinModuleLoaders } from "./loaders";
+
+describe("coinModuleLoaders smoke test", () => {
+  for (const loader of coinModuleLoaders) {
+    const entries = Object.entries(loader).flatMap(([k, fn]) =>
+      k !== "family" && typeof fn === "function" ? [[k, fn] as const] : [],
+    );
+    for (const [method, fn] of entries) {
+      it(`${loader.family}.${method}`, () => {
+        expect(() => fn()).not.toThrow();
+      });
+    }
+  }
+});

--- a/libs/ledger-live-common/src/coin-modules/no-coin-eager-imports.test.ts
+++ b/libs/ledger-live-common/src/coin-modules/no-coin-eager-imports.test.ts
@@ -1,0 +1,101 @@
+import * as esbuild from "esbuild";
+import * as path from "path";
+
+// Sources allowed to import coin-* packages or families/* directly.
+const ALLOWED_SOURCES = [
+  "ledger-live-common/src/families/",
+  "ledger-live-common/src/coin-modules/",
+  "ledger-live-common/src/bridge/generic-alpaca/", // LIVE-29339
+  "ledger-live-common/src/wallet-api/", // LIVE-29338
+];
+
+// Import paths with minimal bundle impact — types and error definitions only.
+const LOW_IMPACT_PATH = /\/(types|errors)(\/|$)/;
+
+let metafileInputs: esbuild.Metafile["inputs"];
+const root = path.resolve(__dirname, "../../..");
+const rel = (p: string) => path.relative(root, p).replace(/\\/g, "/");
+
+beforeAll(async () => {
+  const result = await esbuild.build({
+    entryPoints: [path.resolve(__dirname, "non-regression-entry.ts")],
+    bundle: true,
+    write: false,
+    packages: "external",
+    platform: "node",
+    format: "cjs",
+    metafile: true,
+  });
+  metafileInputs = result.metafile.inputs;
+}, 15000);
+
+function buildCausesMap(predicate: (pkg: string) => boolean): Record<string, string[]> {
+  const causes: Record<string, string[]> = {};
+  for (const [file, info] of Object.entries(metafileInputs)) {
+    for (const imp of info.imports) {
+      if (predicate(imp.path)) {
+        (causes[imp.path] ??= []).push(rel(file));
+      }
+    }
+  }
+  return Object.fromEntries(
+    Object.entries(causes)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => [k, v.sort()]),
+  );
+}
+
+test("coin-* eager imports — must be zero outside allowed zones", () => {
+  // Tracked exceptions not yet fixed — shrink this list as tickets close.
+  const KNOWN: Record<string, string> = {
+    "@ledgerhq/coin-bitcoin/operation": "LIVE-29326",
+    "@ledgerhq/coin-canton": "LIVE-29326",
+    "@ledgerhq/coin-cosmos/helpers": "LIVE-29326",
+    "@ledgerhq/coin-evm/config": "LIVE-29326",
+    "@ledgerhq/coin-evm/operation": "LIVE-29326",
+    "@ledgerhq/coin-tron/index": "LIVE-29326",
+    "@ledgerhq/coin-vechain/index": "LIVE-29326",
+  };
+  const violations: Record<string, string[]> = {};
+  for (const [file, info] of Object.entries(metafileInputs)) {
+    const src = rel(file);
+    if (ALLOWED_SOURCES.some(p => src.includes(p))) continue;
+    for (const imp of info.imports) {
+      if (!imp.path.startsWith("@ledgerhq/coin-")) continue;
+      if (imp.path.startsWith("@ledgerhq/coin-module-framework")) continue;
+      if (LOW_IMPACT_PATH.test(imp.path)) continue;
+      if (KNOWN[imp.path]) continue;
+      (violations[imp.path] ??= []).push(src);
+    }
+  }
+  expect(violations).toEqual({});
+});
+
+test("families/* eager imports — must be zero outside allowed zones", () => {
+  // Tracked exceptions not yet fixed — shrink this list as tickets close.
+  const KNOWN: Record<string, string> = {
+    "ledger-live-common/src/families/bitcoin/ACRESetup.ts": "LIVE-29411",
+    "ledger-live-common/src/families/tezos/staking.ts": "LIVE-29326",
+  };
+  const violations: Record<string, string[]> = {};
+  for (const [file, info] of Object.entries(metafileInputs)) {
+    const src = rel(file);
+    if (ALLOWED_SOURCES.some(p => src.includes(p))) continue;
+    for (const imp of info.imports) {
+      const impRel = rel(imp.path);
+      if (!impRel.includes("ledger-live-common/src/families/")) continue;
+      if (KNOWN[impRel]) continue;
+      (violations[impRel] ??= []).push(src);
+    }
+  }
+  expect(violations).toEqual({});
+});
+
+test("known problematic heavy libs are not imported", () => {
+  // libs known to cause significant bundle bloat or supply-chain concerns
+  const KNOWN_PROBLEMATIC_LIBS = ["tronweb", "web3"];
+  const causes = buildCausesMap(pkg =>
+    KNOWN_PROBLEMATIC_LIBS.some(lib => pkg === lib || pkg.startsWith(`${lib}/`)),
+  );
+  expect(causes).toEqual({});
+});

--- a/libs/ledger-live-common/src/coin-modules/non-regression-entry.ts
+++ b/libs/ledger-live-common/src/coin-modules/non-regression-entry.ts
@@ -1,0 +1,21 @@
+/**
+ * Entrypoint for the "coin-* eager imports" non-regression test.
+ *
+ * Lists all shared files that use load*ForFamily from the registry.
+ * The bundle check verifies which @ledgerhq/coin-* packages are still directly imported
+ * against an explicit allowlist of known eager imports. As files are migrated, that
+ * allowlist should shrink — a regression re-adds an entry.
+ */
+export { isAccountEmpty, clearAccount, getVotesCount } from "../account/helpers";
+export { isEditableOperation, isStuckOperation, getStuckAccountAndOperation } from "../operation";
+export { getValidateAddress } from "../bridge/generic-alpaca/validateAddress";
+export { getCurrencyBridge, getAccountBridge } from "../bridge/impl";
+export { sync as mockSync } from "../bridge/mockHelpers";
+export { genAccount } from "../mock/account";
+export { getDeviceTransactionConfig } from "../transaction/deviceTransactionConfig";
+export { fromTransactionRaw } from "../transaction/index";
+export { default as getAddress } from "../hw/getAddress/index";
+export { createAction as createAppAction } from "../hw/actions/app";
+export { prepareMessageToSign } from "../hw/signMessage/index";
+export { accountToWalletAPIAccount } from "../wallet-api/converters";
+export { accountToPlatformAccount } from "../platform/converters";

--- a/libs/ledger-live-common/src/coin-modules/registry.test.ts
+++ b/libs/ledger-live-common/src/coin-modules/registry.test.ts
@@ -5,6 +5,9 @@ import {
   loadSetupForFamily,
   loadTransactionForFamily,
   loadDeviceTxConfigForFamily,
+  loadWalletApiAdapterForFamily,
+  loadPlatformAdapterForFamily,
+  loadAccountModuleForFamily,
   loadMockBridgeForFamily,
   loadMockAccountForFamily,
 } from "./registry";
@@ -26,70 +29,45 @@ const makeLoader = (family: string, overrides: Partial<CoinModuleLoader> = {}): 
 
 describe("registerCoinModules / getRegisteredFamilies", () => {
   it("registers loaders and returns their families", () => {
-    registerCoinModules([makeLoader("bitcoin"), makeLoader("evm")]);
-    expect(getRegisteredFamilies()).toEqual(expect.arrayContaining(["bitcoin", "evm"]));
+    registerCoinModules([makeLoader("__regtest_a__"), makeLoader("__regtest_b__")]);
+    expect(getRegisteredFamilies()).toEqual(expect.arrayContaining(["__regtest_a__", "__regtest_b__"]));
   });
 });
 
-describe("loadSetupForFamily", () => {
-  it("calls the loader's loadSetup", () => {
-    const setup = { bridge: { currencyBridge: {}, accountBridge: {} } } as any;
-    registerCoinModules([makeLoader("bitcoin", { loadSetup: () => setup })]);
-    expect(loadSetupForFamily("bitcoin")).toBe(setup);
-  });
+type LoaderEntry = {
+  loaderKey: keyof CoinModuleLoader;
+  fn: (family: string) => unknown;
+  required?: true;
+};
 
-  it("throws CurrencyNotSupported for unknown family", () => {
-    expect(() => loadSetupForFamily("unknown_family")).toThrow(CurrencyNotSupported);
-  });
-});
+const allLoaders: LoaderEntry[] = [
+  { loaderKey: "loadSetup", fn: loadSetupForFamily, required: true },
+  { loaderKey: "loadTransaction", fn: loadTransactionForFamily, required: true },
+  { loaderKey: "loadDeviceTxConfig", fn: loadDeviceTxConfigForFamily },
+  { loaderKey: "loadWalletApiAdapter", fn: loadWalletApiAdapterForFamily },
+  { loaderKey: "loadPlatformAdapter", fn: loadPlatformAdapterForFamily },
+  { loaderKey: "loadAccount", fn: loadAccountModuleForFamily },
+  { loaderKey: "loadMockBridge", fn: loadMockBridgeForFamily },
+  { loaderKey: "loadMockAccount", fn: loadMockAccountForFamily },
+];
 
-describe("loadTransactionForFamily", () => {
-  it("calls the loader's loadTransaction", () => {
-    const txModule = { fromTransactionRaw: jest.fn() } as any;
-    registerCoinModules([makeLoader("evm", { loadTransaction: () => txModule })]);
-    expect(loadTransactionForFamily("evm")).toBe(txModule);
+describe.each(allLoaders)("$fn.name", ({ loaderKey, fn, required }) => {
+  it("returns module when loader has it", () => {
+    const stub = jest.fn();
+    registerCoinModules([makeLoader("__test__", { [loaderKey]: () => stub })]);
+    expect(fn("__test__")).toBe(stub);
   });
-});
-
-describe("loadDeviceTxConfigForFamily", () => {
-  it("returns the fn when loader has loadDeviceTxConfig", () => {
-    const fn = jest.fn() as any;
-    registerCoinModules([makeLoader("bitcoin", { loadDeviceTxConfig: () => fn })]);
-    expect(loadDeviceTxConfigForFamily("bitcoin")).toBe(fn);
-  });
-
-  it("returns undefined when loader has no loadDeviceTxConfig", () => {
-    registerCoinModules([makeLoader("evm")]);
-    expect(loadDeviceTxConfigForFamily("evm")).toBeUndefined();
-  });
-
-  it("returns undefined for unknown family", () => {
-    expect(loadDeviceTxConfigForFamily("unknown_family")).toBeUndefined();
-  });
-});
-
-describe("loadMockBridgeForFamily / loadMockAccountForFamily", () => {
-  it("returns undefined for unknown family", () => {
-    expect(loadMockBridgeForFamily("unknown")).toBeUndefined();
-    expect(loadMockAccountForFamily("unknown")).toBeUndefined();
-  });
-
-  it("returns undefined when loader has no mock loaders", () => {
-    registerCoinModules([makeLoader("bitcoin")]);
-    expect(loadMockBridgeForFamily("bitcoin")).toBeUndefined();
-    expect(loadMockAccountForFamily("bitcoin")).toBeUndefined();
-  });
-
-  it("calls loadMockBridge and loadMockAccount when present", () => {
-    const mockBridge = { currencyBridge: {} as any, accountBridge: {} as any };
-    const mockAccount = {};
-    registerCoinModules([
-      makeLoader("evm", {
-        loadMockBridge: () => mockBridge,
-        loadMockAccount: () => mockAccount,
-      }),
-    ]);
-    expect(loadMockBridgeForFamily("evm")).toBe(mockBridge);
-    expect(loadMockAccountForFamily("evm")).toBe(mockAccount);
-  });
+  if (required) {
+    it("throws CurrencyNotSupported for unknown family", () => {
+      expect(() => fn("__none__")).toThrow(CurrencyNotSupported);
+    });
+  } else {
+    it("returns undefined for unknown family", () => {
+      expect(fn("__none__")).toBeUndefined();
+    });
+    it("returns undefined when loader exists but method is absent", () => {
+      registerCoinModules([makeLoader("__bare__")]);
+      expect(fn("__bare__")).toBeUndefined();
+    });
+  }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7663,6 +7663,9 @@ importers:
       env-cmd:
         specifier: '*'
         version: 10.1.0
+      esbuild:
+        specifier: 0.25.5
+        version: 0.25.5
       fs:
         specifier: ^0.0.1-security
         version: 0.0.1-security


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - New tests only — no runtime behaviour changed.

### 📝 Description

Adds a bundle-level non-regression test (`no-coin-eager-imports.test.ts`) that
uses esbuild's metafile to assert that `@ledgerhq/coin-*` packages (other than
`coin-module-framework`) are **not** eagerly imported outside the designated zones:
`families/`, `coin-modules/`, `bridge/generic-alpaca/`, `wallet-api/`.

A dedicated esbuild entry-point (`non-regression-entry.ts`) re-exports all shared
files that currently use `load*ForFamily` helpers, so the bundle graph is stable.

Known violations are listed with ticket references and will be removed as each
file is migrated (tracked under LIVE-29326).

Also adds `loaders.test.ts` — a smoke test that calls every method on every
`CoinModuleLoader` entry and asserts it does not throw.

Fixes `registry.test.ts` typecheck by importing the three existing but
unimported helpers and removing seven loader entries whose backing
`CoinModuleLoader` keys do not exist yet in the type.

### ❓ Context

- **JIRA or GitHub link**: preparing code for https://github.com/LedgerHQ/ledger-live/pull/16470