### PR TITLE
[LWDM] fix(LIVE-29316): support fromAccountId in swap deeplinks (LLD + LLM)

### DIFF
--- a/.changeset/kind-pets-shave.md
+++ b/.changeset/kind-pets-shave.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Added fromAccountId to deeplink parameters

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/swap.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/swap.handler.test.ts
@@ -1,9 +1,18 @@
 import { swapHandler } from "../swap.handler";
 import { createMockContext } from "./test-utils";
+import { getAccountIdFromWalletAccountId } from "@ledgerhq/live-common/wallet-api/converters";
+
+jest.mock("@ledgerhq/live-common/wallet-api/converters", () => ({
+  getAccountIdFromWalletAccountId: jest.fn(),
+}));
+
+const mockedGetAccountIdFromWalletAccountId =
+  getAccountIdFromWalletAccountId as jest.MockedFunction<typeof getAccountIdFromWalletAccountId>;
 
 describe("swap.handler", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedGetAccountIdFromWalletAccountId.mockReset();
   });
 
   describe("swapHandler", () => {
@@ -94,6 +103,101 @@ describe("swap.handler", () => {
         defaultAmountFrom: "1.5",
         affiliate: "partner",
         from: "/market",
+      });
+    });
+
+    describe("fromAccountId / toAccountId", () => {
+      const WAPI_FROM = "11111111-1111-1111-1111-111111111111";
+      const WAPI_TO = "22222222-2222-2222-2222-222222222222";
+      const INTERNAL_FROM = "js:2:bitcoin:xpub-from:segwit";
+      const INTERNAL_TO = "js:2:ethereum:0xabc:";
+
+      it("forwards the resolved internal id for toAccountId when the lookup succeeds", () => {
+        const context = createMockContext();
+        mockedGetAccountIdFromWalletAccountId.mockImplementation(id =>
+          id === WAPI_TO ? INTERNAL_TO : undefined,
+        );
+
+        swapHandler(
+          { type: "swap", fromToken: "usdc", toToken: "usdt", toAccountId: WAPI_TO },
+          context,
+        );
+
+        expect(context.navigate).toHaveBeenCalledWith("/swap", {
+          defaultToken: { fromTokenId: "usdc", toTokenId: "usdt" },
+          defaultAccountId: { toAccountId: INTERNAL_TO },
+        });
+      });
+
+      it("forwards the resolved internal id for fromAccountId when the lookup succeeds", () => {
+        const context = createMockContext();
+        mockedGetAccountIdFromWalletAccountId.mockImplementation(id =>
+          id === WAPI_FROM ? INTERNAL_FROM : undefined,
+        );
+
+        swapHandler(
+          { type: "swap", fromToken: "usdc", toToken: "usdt", fromAccountId: WAPI_FROM },
+          context,
+        );
+
+        expect(context.navigate).toHaveBeenCalledWith("/swap", {
+          defaultToken: { fromTokenId: "usdc", toTokenId: "usdt" },
+          defaultAccountId: { fromAccountId: INTERNAL_FROM },
+        });
+      });
+
+      it("forwards both fromAccountId and toAccountId converted to internal ids", () => {
+        const context = createMockContext();
+        mockedGetAccountIdFromWalletAccountId.mockImplementation(id => {
+          if (id === WAPI_FROM) return INTERNAL_FROM;
+          if (id === WAPI_TO) return INTERNAL_TO;
+          return undefined;
+        });
+
+        swapHandler(
+          {
+            type: "swap",
+            fromToken: "usdc",
+            toToken: "usdt",
+            fromAccountId: WAPI_FROM,
+            toAccountId: WAPI_TO,
+          },
+          context,
+        );
+
+        expect(mockedGetAccountIdFromWalletAccountId).toHaveBeenCalledWith(WAPI_FROM);
+        expect(mockedGetAccountIdFromWalletAccountId).toHaveBeenCalledWith(WAPI_TO);
+        expect(context.navigate).toHaveBeenCalledWith("/swap", {
+          defaultToken: { fromTokenId: "usdc", toTokenId: "usdt" },
+          defaultAccountId: {
+            fromAccountId: INTERNAL_FROM,
+            toAccountId: INTERNAL_TO,
+          },
+        });
+      });
+
+      it("falls back to the raw id when the wallet-api map is cold (cold-start deeplink)", () => {
+        const context = createMockContext();
+        mockedGetAccountIdFromWalletAccountId.mockReturnValue(undefined);
+
+        swapHandler(
+          {
+            type: "swap",
+            fromToken: "usdc",
+            toToken: "usdt",
+            fromAccountId: WAPI_FROM,
+            toAccountId: WAPI_TO,
+          },
+          context,
+        );
+
+        expect(context.navigate).toHaveBeenCalledWith("/swap", {
+          defaultToken: { fromTokenId: "usdc", toTokenId: "usdt" },
+          defaultAccountId: {
+            fromAccountId: WAPI_FROM,
+            toAccountId: WAPI_TO,
+          },
+        });
       });
     });
   });

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/swap.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/swap.handler.ts
@@ -4,6 +4,7 @@ import { DeeplinkHandler } from "../types";
 export const swapHandler: DeeplinkHandler<"swap"> = (route, { navigate }) => {
   const {
     amountFrom,
+    fromAccountId,
     fromToken,
     toToken,
     affiliate,
@@ -19,7 +20,7 @@ export const swapHandler: DeeplinkHandler<"swap"> = (route, { navigate }) => {
     defaultAmountFrom?: string;
     affiliate?: string;
     from?: string;
-    defaultAccountId?: string;
+    defaultAccountId?: { fromAccountId?: string; toAccountId?: string };
   } = {};
 
   if (fromToken) {
@@ -53,7 +54,14 @@ export const swapHandler: DeeplinkHandler<"swap"> = (route, { navigate }) => {
   if (toAccountId) {
     const internalId = getAccountIdFromWalletAccountId(toAccountId);
     if (internalId) {
-      state.defaultAccountId = internalId;
+      state.defaultAccountId = { toAccountId: internalId };
+    }
+  }
+
+  if (fromAccountId) {
+    const internalId = getAccountIdFromWalletAccountId(fromAccountId);
+    if (internalId) {
+      state.defaultAccountId = { ...state.defaultAccountId, fromAccountId: internalId };
     }
   }
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/swap.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/swap.handler.ts
@@ -51,18 +51,22 @@ export const swapHandler: DeeplinkHandler<"swap"> = (route, { navigate }) => {
     state.from = fromPath;
   }
 
+  // For deeplinks that arrive at cold start, the internal id map
+  // may not be populated yet. In that case we forward the raw id as-is so the
+  // swap screen can still attempt to resolve it (or pass it straight to the Live App).
   if (toAccountId) {
     const internalId = getAccountIdFromWalletAccountId(toAccountId);
-    if (internalId) {
-      state.defaultAccountId = { toAccountId: internalId };
-    }
+    state.defaultAccountId = {
+      toAccountId: internalId ?? toAccountId,
+    };
   }
 
   if (fromAccountId) {
     const internalId = getAccountIdFromWalletAccountId(fromAccountId);
-    if (internalId) {
-      state.defaultAccountId = { ...state.defaultAccountId, fromAccountId: internalId };
-    }
+    state.defaultAccountId = {
+      ...state.defaultAccountId,
+      fromAccountId: internalId ?? fromAccountId,
+    };
   }
 
   navigate("/swap", state);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/parseDeepLink.ts
@@ -161,6 +161,7 @@ export function createRoute(parsed: ParsedDeeplink): DeeplinkRoute {
       const route: SwapRoute = {
         type: "swap",
         amountFrom: query.amountFrom,
+        fromAccountId: query.fromAccountId,
         fromToken: query.fromToken,
         toToken: query.toToken,
         affiliate: query.affiliate,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
@@ -115,6 +115,7 @@ export interface ManagerRoute {
 export interface SwapRoute {
   type: "swap";
   amountFrom?: string;
+  fromAccountId?: string;
   fromToken: string;
   toToken: string;
   affiliate?: string;

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -164,26 +164,27 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
   const swapDefaultTrack = useGetSwapTrackingProperties();
   const location = useLocation();
   const state = isSwapLocationState(location.state) ? location.state : null;
+
+  const rawFromAccountId =
+    typeof state?.defaultAccountId === "object"
+      ? state?.defaultAccountId?.fromAccountId
+      : undefined;
+
+  const rawToAccountId =
+    typeof state?.defaultAccountId === "string"
+      ? state.defaultAccountId
+      : state?.defaultAccountId?.toAccountId;
+
   const resolvedDefaultToAccount = useMemo(() => {
-    if (state?.defaultAccount) {
-      return state.defaultAccount;
-    }
-    const idState = state?.defaultAccountId;
-    if (typeof idState === "string") {
-      return accounts.find(acc => acc.id === idState);
-    }
-    if (idState && typeof idState === "object" && idState.toAccountId) {
-      return accounts.find(acc => acc.id === idState.toAccountId);
-    }
-    return undefined;
-  }, [accounts, state?.defaultAccount, state?.defaultAccountId]);
-  const resolvedDefaultFromAccount = useMemo(() => {
-    const idState = state?.defaultAccountId;
-    if (idState && typeof idState === "object" && idState.fromAccountId) {
-      return accounts.find(acc => acc.id === idState.fromAccountId);
-    }
-    return undefined;
-  }, [accounts, state?.defaultAccountId]);
+    if (state?.defaultAccount) return state.defaultAccount;
+    return rawToAccountId ? accounts.find(acc => acc.id === rawToAccountId) : undefined;
+  }, [accounts, state?.defaultAccount, rawToAccountId]);
+
+  const resolvedDefaultFromAccount = useMemo(
+    () => (rawFromAccountId ? accounts.find(acc => acc.id === rawFromAccountId) : undefined),
+    [accounts, rawFromAccountId],
+  );
+
   const resolvedDefaultToParentAccount = useMemo(() => {
     if (state?.defaultParentAccount) {
       return state.defaultParentAccount;
@@ -507,24 +508,31 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
   );
 
   const hashString = useMemo(() => {
+    // Prefer recomputing the wallet-API id from the resolved account (this also
+    // warms the uuidToAccountId map used by later custom.* handlers). If the
+    // local account isn't available (e.g. cold-start deeplink), fall back to
+    // whatever raw id came in — typically already a wallet-API id.
+    const fromAccountIdForUrl = resolvedDefaultFromAccount
+      ? accountToWalletAPIAccount(
+          walletState,
+          resolvedDefaultFromAccount,
+          resolvedDefaultFromParentAccount,
+        ).id
+      : rawFromAccountId;
+    const toAccountIdForUrl = resolvedDefaultToAccount
+      ? accountToWalletAPIAccount(
+          walletState,
+          resolvedDefaultToAccount,
+          resolvedDefaultToParentAccount,
+        ).id
+      : rawToAccountId;
+
     const params = new URLSearchParams({
       ...(isOffline ? { isOffline: "true" } : {}),
-      ...(resolvedDefaultFromAccount
+      ...(fromAccountIdForUrl ? { fromAccountId: fromAccountIdForUrl } : {}),
+      ...(toAccountIdForUrl
         ? {
-            fromAccountId: accountToWalletAPIAccount(
-              walletState,
-              resolvedDefaultFromAccount,
-              resolvedDefaultFromParentAccount,
-            ).id,
-          }
-        : {}),
-      ...(resolvedDefaultToAccount
-        ? {
-            toAccountId: accountToWalletAPIAccount(
-              walletState,
-              resolvedDefaultToAccount,
-              resolvedDefaultToParentAccount,
-            ).id,
+            toAccountId: toAccountIdForUrl,
             amountFrom: state?.defaultAmountFrom || "",
           }
         : {}),
@@ -557,6 +565,8 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
     return params;
   }, [
     isOffline,
+    rawFromAccountId,
+    rawToAccountId,
     resolvedDefaultFromAccount,
     resolvedDefaultFromParentAccount,
     resolvedDefaultToAccount,

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -58,6 +58,7 @@ import {
   useRedirectToSwapHistory,
 } from "../utils/index";
 import FeesDrawerLiveApp from "./FeesDrawerLiveApp";
+import { useSwapDefaultAccounts } from "./useSwapDefaultAccounts";
 import WebviewErrorDrawer from "./WebviewErrorDrawer/index";
 import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
 import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
@@ -165,52 +166,14 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
   const location = useLocation();
   const state = isSwapLocationState(location.state) ? location.state : null;
 
-  const rawFromAccountId =
-    typeof state?.defaultAccountId === "object"
-      ? state?.defaultAccountId?.fromAccountId
-      : undefined;
-
-  const rawToAccountId =
-    typeof state?.defaultAccountId === "string"
-      ? state.defaultAccountId
-      : state?.defaultAccountId?.toAccountId;
-
-  const resolvedDefaultToAccount = useMemo(() => {
-    if (state?.defaultAccount) return state.defaultAccount;
-    return rawToAccountId ? accounts.find(acc => acc.id === rawToAccountId) : undefined;
-  }, [accounts, state?.defaultAccount, rawToAccountId]);
-
-  const resolvedDefaultFromAccount = useMemo(
-    () => (rawFromAccountId ? accounts.find(acc => acc.id === rawFromAccountId) : undefined),
-    [accounts, rawFromAccountId],
-  );
-
-  const resolvedDefaultToParentAccount = useMemo(() => {
-    if (state?.defaultParentAccount) {
-      return state.defaultParentAccount;
-    }
-    if (state?.defaultParentAccountId) {
-      const candidate = accounts.find(acc => acc.id === state.defaultParentAccountId);
-      return candidate?.type === "Account" ? candidate : undefined;
-    }
-    if (resolvedDefaultToAccount?.type === "TokenAccount") {
-      const candidate = accounts.find(acc => acc.id === resolvedDefaultToAccount.parentId);
-      return candidate?.type === "Account" ? candidate : undefined;
-    }
-    return undefined;
-  }, [
-    accounts,
-    state?.defaultParentAccount,
-    state?.defaultParentAccountId,
+  const {
+    rawFromAccountId,
+    rawToAccountId,
+    resolvedDefaultFromAccount,
+    resolvedDefaultFromParentAccount,
     resolvedDefaultToAccount,
-  ]);
-  const resolvedDefaultFromParentAccount = useMemo(() => {
-    if (resolvedDefaultFromAccount?.type === "TokenAccount") {
-      const candidate = accounts.find(acc => acc.id === resolvedDefaultFromAccount.parentId);
-      return candidate?.type === "Account" ? candidate : undefined;
-    }
-    return undefined;
-  }, [accounts, resolvedDefaultFromAccount]);
+    resolvedDefaultToParentAccount,
+  } = useSwapDefaultAccounts(state);
   const { networkStatus } = useNetworkStatus();
   const isOffline = networkStatus === NetworkStatus.OFFLINE;
   // Remove after KYC AB Testing
@@ -508,10 +471,7 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
   );
 
   const hashString = useMemo(() => {
-    // Prefer recomputing the wallet-API id from the resolved account (this also
-    // warms the uuidToAccountId map used by later custom.* handlers). If the
-    // local account isn't available (e.g. cold-start deeplink), fall back to
-    // whatever raw id came in — typically already a wallet-API id.
+    // Recompute wallet-API ids when possible; otherwise keep raw deeplink ids.
     const fromAccountIdForUrl = resolvedDefaultFromAccount
       ? accountToWalletAPIAccount(
           walletState,

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -112,7 +112,7 @@ type TokenParams = {
 type SwapLocationState = {
   defaultAccount?: AccountLike;
   defaultParentAccount?: Account;
-  defaultAccountId?: string;
+  defaultAccountId?: string | { fromAccountId?: string; toAccountId?: string };
   defaultParentAccountId?: string;
   defaultCurrency?: { id?: string; fromCurrencyId?: string; toCurrencyId?: string };
   defaultAmountFrom?: string;
@@ -164,16 +164,27 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
   const swapDefaultTrack = useGetSwapTrackingProperties();
   const location = useLocation();
   const state = isSwapLocationState(location.state) ? location.state : null;
-  const resolvedDefaultAccount = useMemo(() => {
+  const resolvedDefaultToAccount = useMemo(() => {
     if (state?.defaultAccount) {
       return state.defaultAccount;
     }
-    if (state?.defaultAccountId) {
-      return accounts.find(acc => acc.id === state.defaultAccountId);
+    const idState = state?.defaultAccountId;
+    if (typeof idState === "string") {
+      return accounts.find(acc => acc.id === idState);
+    }
+    if (idState && typeof idState === "object" && idState.toAccountId) {
+      return accounts.find(acc => acc.id === idState.toAccountId);
     }
     return undefined;
   }, [accounts, state?.defaultAccount, state?.defaultAccountId]);
-  const resolvedDefaultParentAccount = useMemo(() => {
+  const resolvedDefaultFromAccount = useMemo(() => {
+    const idState = state?.defaultAccountId;
+    if (idState && typeof idState === "object" && idState.fromAccountId) {
+      return accounts.find(acc => acc.id === idState.fromAccountId);
+    }
+    return undefined;
+  }, [accounts, state?.defaultAccountId]);
+  const resolvedDefaultToParentAccount = useMemo(() => {
     if (state?.defaultParentAccount) {
       return state.defaultParentAccount;
     }
@@ -181,8 +192,8 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
       const candidate = accounts.find(acc => acc.id === state.defaultParentAccountId);
       return candidate?.type === "Account" ? candidate : undefined;
     }
-    if (resolvedDefaultAccount?.type === "TokenAccount") {
-      const candidate = accounts.find(acc => acc.id === resolvedDefaultAccount.parentId);
+    if (resolvedDefaultToAccount?.type === "TokenAccount") {
+      const candidate = accounts.find(acc => acc.id === resolvedDefaultToAccount.parentId);
       return candidate?.type === "Account" ? candidate : undefined;
     }
     return undefined;
@@ -190,8 +201,15 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
     accounts,
     state?.defaultParentAccount,
     state?.defaultParentAccountId,
-    resolvedDefaultAccount,
+    resolvedDefaultToAccount,
   ]);
+  const resolvedDefaultFromParentAccount = useMemo(() => {
+    if (resolvedDefaultFromAccount?.type === "TokenAccount") {
+      const candidate = accounts.find(acc => acc.id === resolvedDefaultFromAccount.parentId);
+      return candidate?.type === "Account" ? candidate : undefined;
+    }
+    return undefined;
+  }, [accounts, resolvedDefaultFromAccount]);
   const { networkStatus } = useNetworkStatus();
   const isOffline = networkStatus === NetworkStatus.OFFLINE;
   // Remove after KYC AB Testing
@@ -491,12 +509,21 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
   const hashString = useMemo(() => {
     const params = new URLSearchParams({
       ...(isOffline ? { isOffline: "true" } : {}),
-      ...(resolvedDefaultAccount
+      ...(resolvedDefaultFromAccount
+        ? {
+            fromAccountId: accountToWalletAPIAccount(
+              walletState,
+              resolvedDefaultFromAccount,
+              resolvedDefaultFromParentAccount,
+            ).id,
+          }
+        : {}),
+      ...(resolvedDefaultToAccount
         ? {
             toAccountId: accountToWalletAPIAccount(
               walletState,
-              resolvedDefaultAccount,
-              resolvedDefaultParentAccount,
+              resolvedDefaultToAccount,
+              resolvedDefaultToParentAccount,
             ).id,
             amountFrom: state?.defaultAmountFrom || "",
           }
@@ -528,7 +555,15 @@ const SwapWebView = ({ manifest, isEmbedded = false, Loader = SwapLoader }: Swap
     }).toString();
 
     return params;
-  }, [isOffline, resolvedDefaultAccount, resolvedDefaultParentAccount, state, walletState]);
+  }, [
+    isOffline,
+    resolvedDefaultFromAccount,
+    resolvedDefaultFromParentAccount,
+    resolvedDefaultToAccount,
+    resolvedDefaultToParentAccount,
+    state,
+    walletState,
+  ]);
 
   const onSwapWebviewError = (error?: SwapLiveError) => {
     logger.critical(error);

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/useSwapDefaultAccounts.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/useSwapDefaultAccounts.test.ts
@@ -1,0 +1,132 @@
+import { renderHook } from "@testing-library/react";
+import { Account, AccountLike } from "@ledgerhq/types-live";
+import { useSelector } from "LLD/hooks/redux";
+import { useSwapDefaultAccounts } from "./useSwapDefaultAccounts";
+
+jest.mock("LLD/hooks/redux");
+
+const mockedUseSelector = jest.mocked(useSelector);
+
+const account = (id: string): Account => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return { id, type: "Account" } as Account;
+};
+
+const tokenAccount = (id: string, parentId: string): AccountLike => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return { id, parentId, type: "TokenAccount" } as AccountLike;
+};
+
+describe("useSwapDefaultAccounts", () => {
+  const fromParentAccount = account("from-parent");
+  const fromTokenAccount = tokenAccount("from-token", fromParentAccount.id);
+  const toParentAccount = account("to-parent");
+  const toTokenAccount = tokenAccount("to-token", toParentAccount.id);
+  const standaloneToAccount = account("to-account");
+  const accounts = [fromParentAccount, fromTokenAccount, toParentAccount, toTokenAccount, standaloneToAccount];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseSelector.mockReturnValue(accounts);
+  });
+
+  it("returns raw ids and resolves both accounts from object-shaped defaultAccountId", () => {
+    const { result } = renderHook(() =>
+      useSwapDefaultAccounts({
+        defaultAccountId: {
+          fromAccountId: fromTokenAccount.id,
+          toAccountId: toTokenAccount.id,
+        },
+      }),
+    );
+
+    expect(result.current).toEqual({
+      rawFromAccountId: fromTokenAccount.id,
+      rawToAccountId: toTokenAccount.id,
+      resolvedDefaultFromAccount: fromTokenAccount,
+      resolvedDefaultFromParentAccount: fromParentAccount,
+      resolvedDefaultToAccount: toTokenAccount,
+      resolvedDefaultToParentAccount: toParentAccount,
+    });
+  });
+
+  it("treats legacy string defaultAccountId as the to account id", () => {
+    const { result } = renderHook(() =>
+      useSwapDefaultAccounts({
+        defaultAccountId: standaloneToAccount.id,
+      }),
+    );
+
+    expect(result.current.rawFromAccountId).toBeUndefined();
+    expect(result.current.rawToAccountId).toBe(standaloneToAccount.id);
+    expect(result.current.resolvedDefaultFromAccount).toBeUndefined();
+    expect(result.current.resolvedDefaultToAccount).toBe(standaloneToAccount);
+  });
+
+  it("prefers provided defaultAccount and defaultParentAccount over id lookups for the to side", () => {
+    const explicitAccount = account("explicit-to");
+    const explicitParent = account("explicit-parent");
+
+    const { result } = renderHook(() =>
+      useSwapDefaultAccounts({
+        defaultAccount: explicitAccount,
+        defaultParentAccount: explicitParent,
+        defaultAccountId: {
+          fromAccountId: fromTokenAccount.id,
+          toAccountId: standaloneToAccount.id,
+        },
+        defaultParentAccountId: toParentAccount.id,
+      }),
+    );
+
+    expect(result.current.rawToAccountId).toBe(standaloneToAccount.id);
+    expect(result.current.resolvedDefaultToAccount).toBe(explicitAccount);
+    expect(result.current.resolvedDefaultToParentAccount).toBe(explicitParent);
+    expect(result.current.resolvedDefaultFromAccount).toBe(fromTokenAccount);
+  });
+
+  it("uses defaultParentAccountId when no explicit parent account is provided", () => {
+    const { result } = renderHook(() =>
+      useSwapDefaultAccounts({
+        defaultAccountId: standaloneToAccount.id,
+        defaultParentAccountId: toParentAccount.id,
+      }),
+    );
+
+    expect(result.current.resolvedDefaultToAccount).toBe(standaloneToAccount);
+    expect(result.current.resolvedDefaultToParentAccount).toBe(toParentAccount);
+  });
+
+  it("keeps raw deeplink ids when no local account matches", () => {
+    const { result } = renderHook(() =>
+      useSwapDefaultAccounts({
+        defaultAccountId: {
+          fromAccountId: "unknown-from-wallet-api-id",
+          toAccountId: "unknown-to-wallet-api-id",
+        },
+      }),
+    );
+
+    expect(result.current).toEqual({
+      rawFromAccountId: "unknown-from-wallet-api-id",
+      rawToAccountId: "unknown-to-wallet-api-id",
+      resolvedDefaultFromAccount: undefined,
+      resolvedDefaultFromParentAccount: undefined,
+      resolvedDefaultToAccount: undefined,
+      resolvedDefaultToParentAccount: undefined,
+    });
+  });
+
+  it("returns empty derivation for null state", () => {
+    const { result } = renderHook(() => useSwapDefaultAccounts(null));
+
+    expect(result.current).toEqual({
+      rawFromAccountId: undefined,
+      rawToAccountId: undefined,
+      resolvedDefaultFromAccount: undefined,
+      resolvedDefaultFromParentAccount: undefined,
+      resolvedDefaultToAccount: undefined,
+      resolvedDefaultToParentAccount: undefined,
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/useSwapDefaultAccounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/useSwapDefaultAccounts.ts
@@ -1,0 +1,81 @@
+import { useMemo } from "react";
+import { useSelector } from "LLD/hooks/redux";
+import { Account, AccountLike } from "@ledgerhq/types-live";
+import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
+
+export type SwapDefaultAccountsState = {
+  defaultAccount?: AccountLike;
+  defaultParentAccount?: Account;
+  defaultAccountId?: string | { fromAccountId?: string; toAccountId?: string };
+  defaultParentAccountId?: string;
+} | null;
+
+export type SwapDefaultAccounts = {
+  rawFromAccountId: string | undefined;
+  rawToAccountId: string | undefined;
+  resolvedDefaultFromAccount: AccountLike | undefined;
+  resolvedDefaultFromParentAccount: Account | undefined;
+  resolvedDefaultToAccount: AccountLike | undefined;
+  resolvedDefaultToParentAccount: Account | undefined;
+};
+
+const findParentAccount = (
+  accounts: AccountLike[],
+  child: AccountLike | undefined,
+): Account | undefined => {
+  if (child?.type !== "TokenAccount") return undefined;
+  const candidate = accounts.find(acc => acc.id === child.parentId);
+  return candidate?.type === "Account" ? candidate : undefined;
+};
+
+export const useSwapDefaultAccounts = (state: SwapDefaultAccountsState): SwapDefaultAccounts => {
+  const accounts = useSelector(flattenAccountsSelector);
+
+  const rawFromAccountId =
+    typeof state?.defaultAccountId === "object"
+      ? state?.defaultAccountId?.fromAccountId
+      : undefined;
+
+  const rawToAccountId =
+    typeof state?.defaultAccountId === "string"
+      ? state.defaultAccountId
+      : state?.defaultAccountId?.toAccountId;
+
+  const resolvedDefaultToAccount = useMemo(() => {
+    if (state?.defaultAccount) return state.defaultAccount;
+    return rawToAccountId ? accounts.find(acc => acc.id === rawToAccountId) : undefined;
+  }, [accounts, state?.defaultAccount, rawToAccountId]);
+
+  const resolvedDefaultFromAccount = useMemo(
+    () => (rawFromAccountId ? accounts.find(acc => acc.id === rawFromAccountId) : undefined),
+    [accounts, rawFromAccountId],
+  );
+
+  const resolvedDefaultToParentAccount = useMemo(() => {
+    if (state?.defaultParentAccount) return state.defaultParentAccount;
+    if (state?.defaultParentAccountId) {
+      const candidate = accounts.find(acc => acc.id === state.defaultParentAccountId);
+      return candidate?.type === "Account" ? candidate : undefined;
+    }
+    return findParentAccount(accounts, resolvedDefaultToAccount);
+  }, [
+    accounts,
+    state?.defaultParentAccount,
+    state?.defaultParentAccountId,
+    resolvedDefaultToAccount,
+  ]);
+
+  const resolvedDefaultFromParentAccount = useMemo(
+    () => findParentAccount(accounts, resolvedDefaultFromAccount),
+    [accounts, resolvedDefaultFromAccount],
+  );
+
+  return {
+    rawFromAccountId,
+    rawToAccountId,
+    resolvedDefaultFromAccount,
+    resolvedDefaultFromParentAccount,
+    resolvedDefaultToAccount,
+    resolvedDefaultToParentAccount,
+  };
+};

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -815,6 +815,7 @@ export const DeeplinksProvider = ({
             const fromCurrency = searchParams.get("fromCurrency");
             const toCurrency = searchParams.get("toCurrency");
             const toAccountId = searchParams.get("toAccountId");
+            const fromAccountId = searchParams.get("fromAccountId");
             if (fromPath) swapParams.set("fromPath", fromPath);
             if (fromToken) swapParams.set("fromTokenId", fromToken);
             if (toToken) swapParams.set("toTokenId", toToken);
@@ -823,6 +824,7 @@ export const DeeplinksProvider = ({
             if (amountFrom) swapParams.set("amountFrom", amountFrom);
             if (affiliate) swapParams.set("affiliate", affiliate);
             if (toAccountId) swapParams.set("toAccountId", toAccountId);
+            if (fromAccountId) swapParams.set("fromAccountId", fromAccountId);
             const swapSearch = swapParams.toString();
             const pathWithParams = swapSearch ? `swap?${swapSearch}` : "swap";
             return getStateFromPath(pathWithParams, config);

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapLiveAppState.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapLiveAppState.ts
@@ -30,6 +30,7 @@ const SWAP_PARAM_KEYS: string[] = [
   "toCurrencyId",
   "amountFrom",
   "toAccountId",
+  "fromAccountId",
 ];
 
 const isRecord = (data: unknown): data is Record<string, unknown> =>

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useTranslateToSwapAccount.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useTranslateToSwapAccount.ts
@@ -10,6 +10,7 @@ import { DefaultAccountSwapParamList } from "../../types";
 import type { AccountLike, TokenAccount } from "@ledgerhq/types-live";
 
 type SwapLiveUrlParams = {
+  fromAccountId?: string;
   toAccountId?: string;
   toTokenId?: string;
   fromTokenId?: string;
@@ -63,6 +64,10 @@ export const useTranslateToSwapAccount = (
 
     if (params.toAccountId) {
       newParams.toAccountId = params.toAccountId;
+    }
+
+    if (params.fromAccountId) {
+      newParams.fromAccountId = params.fromAccountId;
     }
 
     if (defaultCurrency) {

--- a/apps/ledger-live-mobile/src/screens/Swap/types.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/types.ts
@@ -59,6 +59,7 @@ export interface DefaultAccountSwapParamList extends SwapLiveAppNavigationParams
   toCurrencyId?: string;
   fromCurrencyId?: string;
   toAccountId?: string;
+  fromAccountId?: string;
 }
 
 export type SwapLiveAppNavigationParams = {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR adds `fromAccountId` as a first-class deeplink param on both Desktop and Mobile, and wires it through to the Swap Live App URL

_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._


After

https://github.com/user-attachments/assets/7e712991-bb4d-4b4e-b264-341cf311e8d8

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-29316
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
