### PR TITLE
feat(ci): add Renovate rules for e2e/desktop and e2e/mobile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -118,6 +118,22 @@
       "description": "Global npm minimum release age",
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "2 days"
+    },
+    {
+      "description": "E2E - version updates",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["e2e/desktop/**", "e2e/mobile/**"],
+      "commitMessagePrefix": "chore(e2e):",
+      "labels": ["dependencies", "e2e"],
+      "reviewers": ["team:qaa"],
+      "assignees": ["team:qaa"]
+    },
+    {
+      "description": "E2E - group major updates",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["e2e/desktop/**", "e2e/mobile/**"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "e2e major updates"
     }
   ],
   "prConcurrentLimit": 10,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Config-only change; validated locally via `renovate-config-validator`, `renovate --platform=local --dry-run=full`, and direct invocation of Renovate's `applyPackageRules()` against fixture data from `e2e/desktop/package.json` and `e2e/mobile/package.json` to confirm every rule resolves the expected commit prefix, labels, reviewers, and grouping._
- [x] **Impact of the changes:**
  - On the next Renovate run on `develop`, dependency PRs for files under `e2e/desktop/**` and `e2e/mobile/**` should use the commit message prefix `chore(e2e):`.
  - Those PRs should carry the labels `dependencies` and `e2e`, and request reviews from `@ledgerhq/qaa` (also set as assignees).
  - Major-version bumps for any e2e dependency should be grouped into a single PR titled with the group name `e2e major updates`, rather than one PR per dep.
  - No impact on non-e2e dependency PRs — the existing global rules (minimum release age, GitHub Actions pinning, etc.) are untouched.

### 📝 Description

QAA-468 asks for automated dependency updates for the `e2e/desktop` and `e2e/mobile` test suites, so they don't silently drift and break later. Renovate is already configured for the repo, so rather than introduce a second bot (Dependabot), this PR extends the existing `renovate.json` with two `packageRules` scoped via `matchFileNames` to the two e2e directories.

**The new rules:**

1. **`E2E - version updates`** — matches any npm dep under `e2e/desktop/**` or `e2e/mobile/**`. Applies the commit prefix `chore(e2e):`, labels `dependencies, e2e`, and sets `team:qaa` as both reviewers and assignees so the QAA team owns triage.
2. **`E2E - group major updates`** — for the same file scope, groups every major-version bump into a single PR via `groupName: "e2e major updates"`. Rationale: e2e deps tend to have coordinated majors (Playwright, Detox, Allure, etc.) that often need to land together and require code changes; batching them into one PR prevents a wave of conflicting individual PRs.

No custom `schedule` is set — these rules inherit the repo's global Renovate schedule (weekdays 22:00 UTC) and `automerge: false` default, so the QAA team is always the human gate.

### ❓ Context

- **JIRA or GitHub link**: [QAA-468](https://ledgerhq.atlassian.net/browse/QAA-468)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-468]: https://ledgerhq.atlassian.net/browse/QAA-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ