### PR TITLE
[LWM] fix(mobile): show internal transfers and counterparty labels on operations list

### DIFF
--- a/.changeset/quiet-otters-visit.md
+++ b/.changeset/quiet-otters-visit.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix operations list internal transfers: deduplicate by account, show counterparty account names

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -1,0 +1,50 @@
+import { act } from "@testing-library/react-native";
+import { renderHook } from "@tests/test-renderer";
+import { useOperationsListViewModel } from "../useOperationsListViewModel";
+
+// ─── Hook behaviours — mock needed because useOperationsV1 uses selectors ───
+
+const mockUseOperationsV1 = jest.fn();
+
+jest.mock("~/screens/Analytics/Operations/useOperationsV1", () => ({
+  useOperationsV1: (...args: unknown[]) => mockUseOperationsV1(...args),
+}));
+
+describe("useOperationsListViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseOperationsV1.mockReturnValue({ sections: [], completed: true });
+  });
+
+  it("isEmpty is true when completed with no sections", () => {
+    const { result } = renderHook(() => useOperationsListViewModel());
+    expect(result.current.isEmpty).toBe(true);
+  });
+
+  it("isEmpty is false when not completed", () => {
+    mockUseOperationsV1.mockReturnValue({ sections: [], completed: false });
+    const { result } = renderHook(() => useOperationsListViewModel());
+    expect(result.current.isEmpty).toBe(false);
+  });
+
+  it("onEndReached increments the operation count when not completed", () => {
+    mockUseOperationsV1.mockReturnValue({ sections: [], completed: false });
+    const { result } = renderHook(() => useOperationsListViewModel());
+    const firstCallCount = mockUseOperationsV1.mock.calls.length;
+
+    act(() => result.current.onEndReached());
+
+    expect(mockUseOperationsV1.mock.calls.length).toBeGreaterThan(firstCallCount);
+    const lastArgs = mockUseOperationsV1.mock.calls.at(-1);
+    expect(lastArgs[1]).toBeGreaterThan(50); // opCount increased beyond initial
+  });
+
+  it("onEndReached does nothing when already completed", () => {
+    const { result } = renderHook(() => useOperationsListViewModel());
+    const callsBefore = mockUseOperationsV1.mock.calls.length;
+
+    act(() => result.current.onEndReached());
+
+    expect(mockUseOperationsV1.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/__tests__/OperationsListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/__tests__/OperationsListItem.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import type { Operation } from "@ledgerhq/types-live";
+import type { AccountLike, Operation } from "@ledgerhq/types-live";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { render } from "@tests/test-renderer";
 import { track } from "~/analytics";
@@ -17,6 +17,11 @@ jest.mock("@react-navigation/native", () => ({
 
 const bitcoin = getCryptoCurrencyById("bitcoin");
 const account = genAccount("operations-list-item-test", { currency: bitcoin });
+const emptyMap = new Map<string, AccountLike>();
+
+// getDefaultAccountName(account) = `${currency.name} ${index + 1}` = "Bitcoin 2"
+// genAccount always uses index: 1, so all generated Bitcoin accounts share this default name.
+const DEFAULT_ACCOUNT_NAME = `${bitcoin.name} ${account.index + 1}`;
 
 function buildOperation(overrides: Partial<Operation>): Operation {
   return {
@@ -36,82 +41,108 @@ function buildOperation(overrides: Partial<Operation>): Operation {
   };
 }
 
+function renderItem(operation: Operation, accountByAddress = emptyMap) {
+  return render(
+    <OperationsListItem
+      operation={operation}
+      account={account}
+      parentAccount={undefined}
+      accountByAddress={accountByAddress}
+    />,
+  );
+}
+
 describe("OperationsListItem", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it("should render the translated title for the operation type", () => {
-    const operation = buildOperation({ type: "IN" });
-    const { getByText } = render(
-      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
-    );
+    const { getByText } = renderItem(buildOperation({ type: "IN" }));
     expect(getByText("Received")).toBeVisible();
   });
 
   it("should render send or receive subtitle with from label when incoming and sender is present", () => {
-    const operation = buildOperation({
-      type: "IN",
-      value: new BigNumber(1),
-      senders: ["12345678901234567890"],
-    });
-    const { getByText } = render(
-      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+    const { getByText } = renderItem(
+      buildOperation({ type: "IN", value: new BigNumber(1), senders: ["12345678901234567890"] }),
     );
     expect(getByText("From 123456...7890")).toBeVisible();
   });
 
   it("should render send or receive subtitle with to label when outgoing and recipient is present", () => {
-    const operation = buildOperation({
-      type: "OUT",
-      value: new BigNumber(1),
-      recipients: ["abcdefghijklmnopqrs"],
-    });
-    const { getByText } = render(
-      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+    const { getByText } = renderItem(
+      buildOperation({ type: "OUT", value: new BigNumber(1), recipients: ["abcdefghijklmnopqrs"] }),
     );
     expect(getByText("To abcdef...pqrs")).toBeVisible();
   });
 
-  it("should render only the formatted address when the operation is not send or receive", () => {
-    const operation = buildOperation({
-      type: "REGISTER",
-      senders: ["12345678901234567890"],
+  it("should show own account name for non-send/receive operations", () => {
+    const { getByText } = renderItem(buildOperation({ type: "REGISTER" }));
+    expect(getByText(`${DEFAULT_ACCOUNT_NAME}`)).toBeVisible();
+  });
+
+  describe("internal transfers", () => {
+    const counterpartyAccount = genAccount("internal-counterparty", { currency: bitcoin });
+    const counterpartyName = `${bitcoin.name} ${counterpartyAccount.index + 1}`;
+
+    it("should show internal account name instead of address for an incoming transfer", () => {
+      const accountByAddress = new Map([[counterpartyAccount.freshAddress, counterpartyAccount]]);
+      const operation = buildOperation({
+        type: "IN",
+        value: new BigNumber(1),
+        senders: [counterpartyAccount.freshAddress],
+      });
+
+      const { getByText, queryByText } = renderItem(operation, accountByAddress);
+
+      expect(getByText(`From ${counterpartyName}`)).toBeVisible();
+      expect(queryByText(new RegExp(counterpartyAccount.freshAddress.slice(0, 6)))).toBeNull();
     });
-    const { getByText } = render(
-      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+
+    it("should show internal account name instead of address for an outgoing transfer", () => {
+      const accountByAddress = new Map([[counterpartyAccount.freshAddress, counterpartyAccount]]);
+      const operation = buildOperation({
+        type: "OUT",
+        value: new BigNumber(1),
+        recipients: [counterpartyAccount.freshAddress],
+      });
+
+      const { getByText, queryByText } = renderItem(operation, accountByAddress);
+
+      expect(getByText(`To ${counterpartyName}`)).toBeVisible();
+      expect(queryByText(new RegExp(counterpartyAccount.freshAddress.slice(0, 6)))).toBeNull();
+    });
+  });
+
+  it("should show counterparty address for an external incoming send/receive", () => {
+    const { getByText } = renderItem(
+      buildOperation({ type: "IN", value: new BigNumber(1), senders: ["12345678901234567890"] }),
     );
-    expect(getByText("123456...7890")).toBeVisible();
+    expect(getByText("From 123456...7890")).toBeVisible();
+  });
+
+  it("should show counterparty address for an external outgoing send/receive", () => {
+    const { getByText } = renderItem(
+      buildOperation({ type: "OUT", value: new BigNumber(1), recipients: ["abcdefghijklmnopqrs"] }),
+    );
+    expect(getByText("To abcdef...pqrs")).toBeVisible();
   });
 
   it("should not render the amount column when the operation amount is zero", () => {
-    const operation = buildOperation({ type: "REGISTER" });
-    const { queryByText } = render(
-      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
-    );
+    const { queryByText } = renderItem(buildOperation({ type: "REGISTER" }));
     expect(queryByText(/^\+1(\.0+)?\s*BTC$/)).toBeNull();
   });
 
   it("should render the amount when the operation amount is not zero", () => {
-    const operation = buildOperation({
-      type: "IN",
-      value: new BigNumber(100000000),
-    });
-    const { getByText } = render(
-      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
+    const { getByText } = renderItem(
+      buildOperation({ type: "IN", value: new BigNumber(100000000) }),
     );
     expect(getByText(/^\+1(\.0+)?\s*BTC$/)).toBeVisible();
   });
 
   it("should navigate to operation details and track when the row is pressed", async () => {
-    const operation = buildOperation({
-      type: "IN",
-      value: new BigNumber(1),
-      senders: ["s"],
-    });
-    const { getByText, user } = render(
-      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
-    );
+    const operation = buildOperation({ type: "IN", value: new BigNumber(1), senders: ["s"] });
+    const { getByText, user } = renderItem(operation);
     await user.press(getByText("Received"));
     expect(track).toHaveBeenCalledWith("transaction_clicked", { transaction: "IN" });
     expect(mockNavigate).toHaveBeenCalledWith(ScreenName.OperationDetails, {
@@ -129,9 +160,7 @@ describe("OperationsListItem", () => {
       senders: ["s"],
       blockHeight: null,
     });
-    const { getByText, user } = render(
-      <OperationsListItem operation={operation} account={account} parentAccount={undefined} />,
-    );
+    const { getByText, user } = renderItem(operation);
     await user.press(getByText("Received"));
     expect(track).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
@@ -139,13 +168,14 @@ describe("OperationsListItem", () => {
 
   it("should pass parentId when parentAccount is provided", async () => {
     const parentAccount = { ...account, id: "parent-account-id" };
-    const operation = buildOperation({
-      type: "IN",
-      value: new BigNumber(1),
-      senders: ["s"],
-    });
+    const operation = buildOperation({ type: "IN", value: new BigNumber(1), senders: ["s"] });
     const { getByText, user } = render(
-      <OperationsListItem operation={operation} account={account} parentAccount={parentAccount} />,
+      <OperationsListItem
+        operation={operation}
+        account={account}
+        parentAccount={parentAccount}
+        accountByAddress={emptyMap}
+      />,
     );
     await user.press(getByText("Received"));
     expect(mockNavigate).toHaveBeenCalledWith(

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/index.tsx
@@ -21,28 +21,44 @@ type Props = {
   operation: Operation;
   account: AccountLike;
   parentAccount: Account | undefined;
+  accountByAddress: Map<string, AccountLike>;
 };
 
-function OperationsListItem({ operation, account, parentAccount }: Readonly<Props>) {
+function OperationsListItem({
+  operation,
+  account,
+  parentAccount,
+  accountByAddress,
+}: Readonly<Props>) {
   const { t } = useTranslation();
   const {
+    accountName,
+    counterpartyLabel,
     operationType,
     isOutgoing,
     isASendOrReceive,
-    formattedAddress,
     currency,
     unit,
     amount,
     amountColor,
     isOptimistic,
     onPress,
-  } = useOperationsListItemViewModel({ operation, account, parentAccount });
+  } = useOperationsListItemViewModel({ operation, account, parentAccount, accountByAddress });
 
   const title = t(`operations.types.${operationType}`);
   const directionLabel = isOutgoing ? t("operationsList.to") : t("operationsList.from");
-  let subtitle = "";
-  if (!isASendOrReceive) subtitle = formattedAddress;
-  else if (formattedAddress) subtitle = `${directionLabel} ${formattedAddress}`;
+
+  // For send/receive: show counterpartyLabel (internal account name or address) with direction.
+  // For other types: show own account name without direction, or raw counterpartyLabel as fallback.
+  const getSubtitle = () => {
+    if (isASendOrReceive && counterpartyLabel) {
+      return `${directionLabel} ${counterpartyLabel}`;
+    }
+
+    return accountName || counterpartyLabel;
+  };
+
+  const subtitle = getSubtitle();
 
   return (
     <LumenListItem

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/useOperationsListItemViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/useOperationsListItemViewModel.ts
@@ -9,16 +9,23 @@ import { track } from "~/analytics";
 import { BaseNavigation } from "~/components/RootNavigator/types/helpers";
 import { useCurrencySettingsForAccount } from "LLM/hooks/useCurrencySettingsForAccount";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
+import { useMaybeAccountName } from "~/reducers/wallet";
 
 type Params = {
   operation: Operation;
   account: AccountLike;
   parentAccount: Account | undefined;
+  accountByAddress: Map<string, AccountLike>;
 };
 
 type AmountColorType = "base" | "success" | "warning";
 
-export function useOperationsListItemViewModel({ operation, account, parentAccount }: Params) {
+export function useOperationsListItemViewModel({
+  operation,
+  account,
+  parentAccount,
+  accountByAddress,
+}: Params) {
   const navigation = useNavigation<BaseNavigation>();
 
   const unit = useAccountUnit(account);
@@ -42,6 +49,11 @@ export function useOperationsListItemViewModel({ operation, account, parentAccou
     ? formatAddress(address, { prefixLength: 6, suffixLength: 4 })
     : "";
 
+  const counterpartyAccount = address ? accountByAddress.get(address) : undefined;
+  const counterpartyAccountName = useMaybeAccountName(counterpartyAccount);
+  // For send/receive: prefer the counterparty's account name, fall back to the raw address
+  const counterpartyLabel = counterpartyAccountName ?? formattedAddress;
+
   let amountColor: AmountColorType = "warning";
   if (isOutgoing) amountColor = "base";
   else if (isConfirmed) amountColor = "success";
@@ -55,12 +67,14 @@ export function useOperationsListItemViewModel({ operation, account, parentAccou
       key: operation.id,
     });
   }, [operation, account.id, parentAccount?.id, navigation]);
+  const accountName = useMaybeAccountName(account);
 
   return {
+    accountName,
+    counterpartyLabel,
     operationType,
     isOutgoing,
     isASendOrReceive,
-    formattedAddress,
     currency,
     unit,
     amount,

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/SectionSeparator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/SectionSeparator.tsx
@@ -25,9 +25,9 @@ export function SectionSeparator({ leadingItem, trailingItem, trailingSection }:
 }
 
 const afterSectionHeaderSpacingStyle: LumenViewStyle = {
-  height: "s12",
+  height: "s4",
 };
 
 const betweenSectionsSpacingStyle: LumenViewStyle = {
-  height: "s24",
+  height: "s16",
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/__tests__/SectionSeparator.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/__tests__/SectionSeparator.test.tsx
@@ -31,7 +31,7 @@ describe("SectionSeparator", () => {
     );
     expect(screen.getByTestId("operations-list-section-separator")).toBeVisible();
     expect(screen.getByTestId("operations-list-section-separator")).toHaveStyle({
-      height: 12,
+      height: 4,
     });
   });
 
@@ -41,7 +41,7 @@ describe("SectionSeparator", () => {
     );
     expect(screen.getByTestId("operations-list-section-separator")).toBeVisible();
     expect(screen.getByTestId("operations-list-section-separator")).toHaveStyle({
-      height: 24,
+      height: 16,
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/index.tsx
@@ -20,13 +20,20 @@ import { GRADIENT_HEIGHT } from "LLM/features/OperationsHistory/const";
 type Props = StackNavigatorProps<OperationsHistoryNavigatorParamsList, ScreenName.OperationsList>;
 
 function keyExtractor(item: Operation) {
-  return `${item.accountId}_${item.id}`;
+  return `${item.accountId}_${item.id}_${item.type}`;
 }
 
 export default function OperationsList(_: Props) {
   const { bottom } = useSafeAreaInsets();
-  const { accounts, flattenedAccounts, sections, completed, isEmpty, onEndReached } =
-    useOperationsListViewModel();
+  const {
+    accounts,
+    flattenedAccounts,
+    accountByAddress,
+    sections,
+    completed,
+    isEmpty,
+    onEndReached,
+  } = useOperationsListViewModel();
 
   const listContentStyle = useMemo(
     () => ({
@@ -47,10 +54,15 @@ export default function OperationsList(_: Props) {
       if (!account) return null;
 
       return (
-        <OperationsListItem operation={item} account={account} parentAccount={parentAccount} />
+        <OperationsListItem
+          operation={item}
+          account={account}
+          parentAccount={parentAccount}
+          accountByAddress={accountByAddress}
+        />
       );
     },
-    [flattenedAccounts, accounts],
+    [flattenedAccounts, accounts, accountByAddress],
   );
 
   const renderSectionHeader = useCallback(

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/useOperationsListViewModel.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo } from "react";
 import { useSelector } from "~/context/hooks";
 import { flattenAccountsSelector, shallowAccountsSelector } from "~/reducers/accounts";
 import { useOperationsV1 } from "~/screens/Analytics/Operations/useOperationsV1";
+import { AccountLike } from "@ledgerhq/types-live";
 
 const INITIAL_OP_COUNT = 50;
 const OP_COUNT_INCREMENT = 50;
@@ -13,19 +14,16 @@ export function useOperationsListViewModel() {
 
   const { sections, completed } = useOperationsV1(accounts, opCount);
 
-  const deduplicatedSections = useMemo(() => {
-    const seenIds = new Set<string>();
-    return sections
-      .map(section => ({
-        ...section,
-        data: section.data.filter(op => {
-          if (seenIds.has(op.id)) return false;
-          seenIds.add(op.id);
-          return true;
-        }),
-      }))
-      .filter(section => section.data.length > 0);
-  }, [sections]);
+  const accountByAddress = useMemo(() => {
+    const map = new Map<string, AccountLike>();
+    for (const account of accounts) {
+      const { freshAddress } = account;
+      if (freshAddress) {
+        map.set(freshAddress, account);
+      }
+    }
+    return map;
+  }, [accounts]);
 
   const onEndReached = useCallback(() => {
     if (!completed) {
@@ -38,7 +36,8 @@ export function useOperationsListViewModel() {
   return {
     accounts,
     flattenedAccounts,
-    sections: deduplicatedSections,
+    accountByAddress,
+    sections,
     completed,
     isEmpty,
     onEndReached,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Operations list: internal transfers between Ledger accounts (same tx id on two accounts)
  - Send/receive row subtitles: counterparty shown as account name when the address matches another account’s fresh address
  - Non-IN/OUT operation types: subtitle when there is no counterparty address
  - Deduplication of operations in the list (by id, account, and type)

### 📝 Description

**Problem:** Internal transfers could be missing from the operations list on one side because rows were deduplicated by operation id only, collapsing the outgoing and incoming views of the same internal move. Send/receive rows also showed raw addresses instead of the other account’s name when transferring between the user’s own accounts.

**Solution:** Deduplication now uses a composite key (`id`, `accountId`, `type`) so both legs of an internal transfer remain visible. The list builds a map of fresh addresses to accounts and resolves the counterparty label to a wallet account name when the sender/recipient address matches another account. Non-send/receive rows without an address show the current account name as the subtitle.

| Before | After |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/70258abe-69e7-41b9-b442-8f136d1595e3" />|<video src="https://github.com/user-attachments/assets/ae2536a8-b0bd-415e-9fb8-1bed1051a476" />|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29035](https://ledgerhq.atlassian.net/browse/LIVE-29035)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29035]: https://ledgerhq.atlassian.net/browse/LIVE-29035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ