### PR TITLE
[LWDM] fix(live-common): defer coin bridge loading via async import() in generic-alpaca (LIVE-29339)

### DIFF
--- a/.changeset/alpaca-async-bridge-import.md
+++ b/.changeset/alpaca-async-bridge-import.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Defer coin bridge loading in generic-alpaca via async import() instead of static imports to avoid eagerly pulling heavy SDKs (ethers/viem, stellar-sdk, solana web3.js, taquito) for all alpaca users

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/bridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/bridge.ts
@@ -1,20 +1,24 @@
 import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import evmBridge from "./families/evm/bridge";
-import stellarBridge from "./families/stellar/bridge";
-import solanaBridge from "./families/solana/bridge";
-import tezosBridge from "./families/tezos/bridge";
 
-export function getBridgeApi(currency: CryptoCurrency, network: string): BridgeApi {
+export async function getBridgeApi(currency: CryptoCurrency, network: string): Promise<BridgeApi> {
   switch (network) {
-    case "evm":
+    case "evm": {
+      const { evmBridge } = await import("./families/evm/bridge.js");
       return evmBridge(currency);
-    case "solana":
+    }
+    case "solana": {
+      const { solanaBridge } = await import("./families/solana/bridge.js");
       return solanaBridge(currency);
-    case "stellar":
+    }
+    case "stellar": {
+      const { stellarBridge } = await import("./families/stellar/bridge.js");
       return stellarBridge;
-    case "tezos":
+    }
+    case "tezos": {
+      const { tezosBridge } = await import("./families/tezos/bridge.js");
       return tezosBridge;
+    }
     default:
       return {};
   }

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/estimateMaxSpendable.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/estimateMaxSpendable.ts
@@ -17,7 +17,7 @@ export function genericEstimateMaxSpendable(
     }
     const mainAccount = getMainAccount(account, parentAccount);
     const alpacaApi = await getAlpacaApi(mainAccount.currency.id, kind);
-    const bridgeApi = getBridgeApi(mainAccount.currency, network);
+    const bridgeApi = await getBridgeApi(mainAccount.currency, network);
     const draftTransaction = {
       ...createTransaction(account),
       ...transaction,

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/evm/bridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/evm/bridge.ts
@@ -66,7 +66,7 @@ function getBalanceOptions(currency: CryptoCurrency): BalanceOptions {
   };
 }
 
-export default function evmBridge(currency: CryptoCurrency): BridgeApi {
+export function evmBridge(currency: CryptoCurrency): BridgeApi {
   return {
     getTokenFromAsset: async (asset: AssetInfo) => getTokenFromAsset(currency, asset),
     getAssetFromToken: (token: TokenCurrency, owner: string) =>

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/solana/bridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/solana/bridge.ts
@@ -43,7 +43,7 @@ export function computeIntentType(transaction: Record<string, unknown>): string 
   }
 }
 
-export default function solanaBridge(currency: CryptoCurrency): BridgeApi {
+export function solanaBridge(currency: CryptoCurrency): BridgeApi {
   return {
     getTokenFromAsset: async (asset: AssetInfo) => getTokenFromAsset(currency, asset),
     getAssetFromToken: (token: TokenCurrency, owner: string) => getAssetFromToken(token, owner),

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/stellar/bridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/stellar/bridge.ts
@@ -37,7 +37,7 @@ export function getAssetFromToken(token: TokenCurrency): AssetInfo {
   };
 }
 
-export default {
+export const stellarBridge = {
   getTokenFromAsset,
   getAssetFromToken,
   getChainSpecificRules,

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/tezos/bridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/tezos/bridge.ts
@@ -22,7 +22,7 @@ export function getAssetFromToken(token: TokenCurrency, owner: string): AssetInf
   };
 }
 
-export default {
+export const tezosBridge = {
   getTokenFromAsset,
   getAssetFromToken,
 } satisfies BridgeApi;

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/getAccountShape.ts
@@ -308,7 +308,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
   return async (info, syncConfig) => {
     const { address, initialAccount, currency, derivationMode } = info;
     const alpacaApi = await getAlpacaApi(currency.id, kind);
-    const bridgeApi = getBridgeApi(currency, network);
+    const bridgeApi = await getBridgeApi(currency, network);
 
     const chainSpecificValidation = bridgeApi.getChainSpecificRules?.();
     if (chainSpecificValidation) {

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/getTransactionStatus.ts
@@ -18,7 +18,7 @@ export function genericGetTransactionStatus(
 ): AccountBridge<GenericTransaction>["getTransactionStatus"] {
   return async (account, transaction) => {
     const alpacaApi = await getAlpacaApi(account.currency.id, kind);
-    const bridgeApi = getBridgeApi(account.currency, network);
+    const bridgeApi = await getBridgeApi(account.currency, network);
 
     const draftTransaction = {
       mode: transaction?.mode ?? "send",

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/prepareTransaction.ts
@@ -49,7 +49,7 @@ export function genericPrepareTransaction(
 ): AccountBridge<GenericTransaction>["prepareTransaction"] {
   return async (account, transaction) => {
     const alpacaApi = await getAlpacaApi(account.currency.id, kind);
-    const bridgeApi = getBridgeApi(account.currency, network);
+    const bridgeApi = await getBridgeApi(account.currency, network);
 
     const getAssetFromTokenForCurrency = bridgeApi.getAssetFromToken;
     const { assetReference, assetOwner } = getAssetFromTokenForCurrency

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/signOperation.ts
@@ -51,7 +51,7 @@ export const genericSignOperation =
     new Observable(o => {
       async function main() {
         const alpacaApi = await getAlpacaApi(account.currency.id, kind);
-        const bridgeApi = getBridgeApi(account.currency, network);
+        const bridgeApi = await getBridgeApi(account.currency, network);
         if (!transaction.fees) throw new FeeNotLoaded();
         const customFees = bigNumberToBigIntDeep({
           value: transaction.fees ?? new BigNumber(0),

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/tests/getAccountShape.test.ts
@@ -28,7 +28,7 @@ jest.mock("../alpaca", () => ({
   }),
 }));
 jest.mock("../bridge", () => ({
-  getBridgeApi: () => ({
+  getBridgeApi: () => Promise.resolve({
     getTokenFromAsset: getTokenFromAssetMock,
     getChainSpecificRules: () => ({
       getAccountShape: (...a: any[]) => chainSpecificGetAccountShapeMock(...a),

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/tests/prepareTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/tests/prepareTransaction.test.ts
@@ -48,7 +48,7 @@ describe("genericPrepareTransaction", () => {
       findTokenById: () => Promise.resolve(undefined),
     });
     (transactionToIntent as jest.Mock).mockReturnValue({ mock: "intent" });
-    (getBridgeApi as jest.Mock).mockReturnValue({
+    (getBridgeApi as jest.Mock).mockResolvedValue({
       getAssetFromToken: jest.fn().mockReturnValue(undefined),
     });
   });
@@ -210,7 +210,7 @@ describe("genericPrepareTransaction", () => {
     (getAlpacaApi as jest.Mock).mockReturnValue({
       estimateFees: () => Promise.resolve({ value: 0n }),
     });
-    (getBridgeApi as jest.Mock).mockReturnValue({
+    (getBridgeApi as jest.Mock).mockResolvedValue({
       getAssetFromToken: jest.fn().mockImplementation((token: TokenCurrency, owner: string) => ({
         assetOwner: owner,
         assetReference: token.id,

--- a/libs/ledger-live-common/src/coin-modules/no-coin-eager-imports.test.ts
+++ b/libs/ledger-live-common/src/coin-modules/no-coin-eager-imports.test.ts
@@ -5,7 +5,21 @@ import * as path from "path";
 const ALLOWED_SOURCES = [
   "ledger-live-common/src/families/",
   "ledger-live-common/src/coin-modules/",
-  "ledger-live-common/src/bridge/generic-alpaca/", // LIVE-29339
+  // Lazy leaf modules under generic-alpaca — only reachable via dynamic import() or conditional
+  // require() in their parent (alpaca/index.ts or signer.ts). esbuild traces through import()
+  // boundaries so these appear in the metafile, but they are NOT loaded at startup.
+  "ledger-live-common/src/bridge/generic-alpaca/alpaca/local/canton.ts",
+  "ledger-live-common/src/bridge/generic-alpaca/alpaca/local/evm.ts",
+  "ledger-live-common/src/bridge/generic-alpaca/alpaca/local/solana.ts",
+  "ledger-live-common/src/bridge/generic-alpaca/alpaca/local/stellar.ts",
+  "ledger-live-common/src/bridge/generic-alpaca/alpaca/local/tezos.ts",
+  "ledger-live-common/src/bridge/generic-alpaca/alpaca/local/tron.ts",
+  "ledger-live-common/src/bridge/generic-alpaca/alpaca/local/xrp.ts",
+  "ledger-live-common/src/bridge/generic-alpaca/families/evm/signer.ts",
+  "ledger-live-common/src/bridge/generic-alpaca/families/stellar/bridge.ts",
+  "ledger-live-common/src/bridge/generic-alpaca/families/stellar/signer.ts",
+  "ledger-live-common/src/bridge/generic-alpaca/families/tezos/signer.ts",
+  "ledger-live-common/src/bridge/generic-alpaca/families/xrp/signer.ts",
   "ledger-live-common/src/wallet-api/", // LIVE-29338
 ];
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** All 234 existing generic-alpaca tests pass.
- [x] **Impact of the changes:**
  - `getBridgeApi` is now `async` — call sites must `await` it (all 5 already in async functions).
  - Heavy coin SDKs (ethers/viem, stellar-sdk, solana web3.js, taquito) are no longer eagerly loaded at startup for every alpaca user.
  - No functional behavior change; only load timing.

### 📝 Description

`bridge/generic-alpaca/bridge.ts` statically imported the full coin bridges for evm, stellar, solana, and tezos, which pulled in heavy SDKs at startup for all alpaca users regardless of which chain they use.

This PR replaces the static imports with `async import()` in a switch statement, matching the existing pattern in `alpaca/index.ts`. The `getBridgeApi` function becomes `async`; the 5 call sites (`getAccountShape`, `prepareTransaction`, `estimateMaxSpendable`, `getTransactionStatus`, `signOperation`) were all already inside `async` functions so only needed `await` added. Test mocks updated accordingly.

```diff
-import evmBridge from "./families/evm/bridge";
-import stellarBridge from "./families/stellar/bridge";
-import solanaBridge from "./families/solana/bridge";
-import tezosBridge from "./families/tezos/bridge";

-export function getBridgeApi(currency, network): BridgeApi {
+export async function getBridgeApi(currency, network): Promise<BridgeApi> {
   switch (network) {
-    case "evm": return evmBridge(currency);
+    case "evm": return (await import("./families/evm/bridge")).default(currency);
     // ...
   }
 }
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29339](https://ledgerhq.atlassian.net/browse/LIVE-29339)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29339]: https://ledgerhq.atlassian.net/browse/LIVE-29339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ