### PR TITLE
[LWDM] fix(live-common): route ACRESetup messageSigner through coin-modules registry

### DIFF
--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -26,6 +26,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
   {
     family: "bitcoin",
     loadSetup: () => require("../families/bitcoin/setup"),
+    loadMessageSigner: () => require("../families/bitcoin/ACRESetup").messageSigner,
     loadTransaction: () => require("@ledgerhq/coin-bitcoin/transaction").default,
     loadDeviceTxConfig: () => require("@ledgerhq/coin-bitcoin/deviceTransactionConfig").default,
     loadWalletApiAdapter: () => require("../families/bitcoin/walletApiAdapter").default,

--- a/libs/ledger-live-common/src/coin-modules/registry.ts
+++ b/libs/ledger-live-common/src/coin-modules/registry.ts
@@ -7,6 +7,7 @@ import type {
   GetStuckAccountAndOperationFn,
   IsEditableOperationFn,
   IsStuckOperationFn,
+  MessageSignerModule,
   MockAccountModule,
   MockBridgeModule,
   PlatformAdapterModule,
@@ -43,6 +44,17 @@ export function getRegisteredFamilies(): string[] {
  */
 export const loadSetupForFamily = (family: string): FamilySetup =>
   getLoader(family).loadSetup();
+
+/**
+ * Loads the message signer for the given coin family.
+ * Uses the dedicated `loadMessageSigner` loader if available, otherwise falls
+ * back to `loadSetup().messageSigner`.
+ */
+export const loadMessageSignerForFamily = (family: string): MessageSignerModule | undefined => {
+  const loader = getLoader(family);
+  if (loader.loadMessageSigner) return loader.loadMessageSigner();
+  return loader.loadSetup().messageSigner;
+};
 
 export const loadTransactionForFamily = (family: string): TransactionModule =>
   getLoader(family).loadTransaction();

--- a/libs/ledger-live-common/src/coin-modules/types.ts
+++ b/libs/ledger-live-common/src/coin-modules/types.ts
@@ -19,6 +19,8 @@ import type { GetWalletAPITransactionSignFlowInfos } from "../wallet-api/types";
 export type MessageSignerModule = {
   signMessage: SignMessage;
   prepareMessageToSign?: (opts: { account: Account; message: string }) => AnyMessage;
+  signWithdraw?: SignMessage;
+  signIn?: SignMessage;
 };
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -103,6 +105,7 @@ export type GetStuckAccountAndOperationFn = (
 export type CoinModuleLoader = {
   family: string;
   loadSetup: () => FamilySetup;
+  loadMessageSigner?: () => MessageSignerModule;
   loadTransaction: () => TransactionModule;
   loadDeviceTxConfig?: () => DeviceTransactionConfigFn;
   loadWalletApiAdapter?: () => WalletApiAdapterModule;

--- a/libs/ledger-live-common/src/hw/signMessage/index.ts
+++ b/libs/ledger-live-common/src/hw/signMessage/index.ts
@@ -5,14 +5,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { firstValueFrom, from, Observable } from "rxjs";
 import { AcreMessageType } from "@ledgerhq/wallet-api-acre-module";
 import { Account, AnyMessage } from "@ledgerhq/types-live";
-import { loadSetupForFamily } from "../../coin-modules/registry";
+import { loadSetupForFamily, loadMessageSignerForFamily } from "../../coin-modules/registry";
 import type { AppRequest, AppState } from "../actions/app";
 import { createAction as createAppAction } from "../actions/app";
 import type { Device } from "../actions/types";
 import type { ConnectAppEvent, Input as ConnectAppInput } from "../connectApp";
 import { withDevice } from "../deviceAccess";
 import type { SignMessage, Result } from "./types";
-import { messageSigner as ACREMessageSigner } from "../../families/bitcoin/ACRESetup";
 import { decodeAccountId } from "../../account";
 
 export const prepareMessageToSign = async (account: Account, message: string): Promise<AnyMessage> => {
@@ -36,15 +35,16 @@ const signMessage: SignMessage = (transport, account, opts) => {
   const setup = loadSetupForFamily(currency.family);
   let signMessage = setup.messageSigner?.signMessage;
   if ("type" in opts) {
+    const messageSigner = loadMessageSignerForFamily(currency.family);
     switch (opts.type) {
       case AcreMessageType.Withdraw:
-        signMessage = ACREMessageSigner.signWithdraw;
+        signMessage = messageSigner?.signWithdraw;
         break;
       case AcreMessageType.SignIn:
-        signMessage = ACREMessageSigner.signIn;
+        signMessage = messageSigner?.signIn;
         break;
       default:
-        signMessage = ACREMessageSigner.signMessage;
+        signMessage = messageSigner?.signMessage;
         break;
     }
   }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- typecheck passes; the no-coin-eager-imports test (future, LIVE-29411) will assert toEqual({}) once merged -->
- [x] **Impact of the changes:**
  - `signMessage/index.ts` no longer eagerly loads `families/bitcoin/ACRESetup` at module init time
  - Bitcoin ACRE signing (Withdraw / SignIn) now resolves through the coin-modules registry

### 📝 Description

`hw/signMessage/index.ts` was directly importing `messageSigner` from `families/bitcoin/ACRESetup`, bypassing the coin-modules registry and preventing deferred loading of the bitcoin module.

This PR:
1. Extends `MessageSignerModule` in `types.ts` with optional `signWithdraw?` / `signIn?` for ACRE-specific signing
2. Adds optional `loadMessageSigner?` to `CoinModuleLoader` so a family can expose a dedicated message signer independently of its main setup
3. Wires bitcoin's loader to `ACRESetup.messageSigner` via `loadMessageSigner`
4. Exposes `loadMessageSignerForFamily()` in the registry (falls back to `loadSetup().messageSigner` when `loadMessageSigner` is absent)
5. Rewrites `signMessage/index.ts` to use `loadMessageSignerForFamily()`, removing the direct `families/` import

**Consumer diff (no API change for callers of `signMessage`):**
```diff
- import { messageSigner as ACREMessageSigner } from "../../families/bitcoin/ACRESetup";
+ import { loadMessageSignerForFamily } from "../../coin-modules/registry";
  // signWithdraw / signIn now resolved lazily through the registry
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29411](https://ledgerhq.atlassian.net/browse/LIVE-29411)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29411]: https://ledgerhq.atlassian.net/browse/LIVE-29411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ