### PR TITLE
[LWM] fix(LIVE-27313): avoid hedera erc20 token association

### DIFF
--- a/.changeset/hot-flies-lick.md
+++ b/.changeset/hot-flies-lick.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: avoid hedera erc20 association

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/01-SelectToken.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/01-SelectToken.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { useTokensData } from "@ledgerhq/cryptoassets/cal-client/hooks/useTokensData";
+import { NavigatorName, ScreenName } from "~/const";
+import type { State } from "~/reducers/types";
+import SelectToken, { type Props } from "./01-SelectToken";
+import { HEDERA_ACCOUNT_1, HEDERA_ASSOCIATED_SUBACCOUNT } from "../__mocks__/account.mock";
+import { htsToken, erc20Token } from "../__mocks__/currency.mock";
+
+jest.mock("@ledgerhq/cryptoassets/cal-client/hooks/useTokensData");
+
+const mockedUseTokensData = jest.mocked(useTokensData);
+const mockNavigate = jest.fn();
+
+const mockNavigation = {
+  navigate: mockNavigate,
+} as unknown as Props["navigation"];
+
+const mockRoute = {
+  key: "test",
+  name: ScreenName.HederaAssociateTokenSelectToken,
+  params: { accountId: HEDERA_ACCOUNT_1.id },
+} as unknown as Props["route"];
+
+const buildRowTestId = (tokenId: string) => `big-currency-row-${tokenId}`;
+
+describe("AssociateTokenFlow - select token", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseTokensData.mockReturnValue({
+      data: { tokens: [htsToken, erc20Token], pagination: { nextCursor: "" } },
+      isLoading: false,
+      isSuccess: true,
+      error: undefined,
+      isError: false,
+      loadNext: jest.fn(),
+      refetch: jest.fn(),
+    });
+  });
+
+  it("should render the token list", () => {
+    render(<SelectToken navigation={mockNavigation} route={mockRoute} />, {
+      overrideInitialState: (state: State): State => ({
+        ...state,
+        accounts: { ...state.accounts, active: [HEDERA_ACCOUNT_1] },
+      }),
+    });
+
+    expect(screen.getByTestId(buildRowTestId(htsToken.id))).toBeVisible();
+    expect(screen.getByTestId(buildRowTestId(erc20Token.id))).toBeVisible();
+  });
+
+  it("should navigate to HederaAssociateTokenSummary when tapping an unassociated HTS token", async () => {
+    const { user } = render(<SelectToken navigation={mockNavigation} route={mockRoute} />, {
+      overrideInitialState: (state: State): State => ({
+        ...state,
+        accounts: { ...state.accounts, active: [HEDERA_ACCOUNT_1] },
+      }),
+    });
+
+    await user.press(screen.getByTestId(buildRowTestId(htsToken.id)));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.HederaAssociateTokenSummary, {
+      accountId: HEDERA_ACCOUNT_1.id,
+      token: htsToken,
+    });
+  });
+
+  it("should navigate to ReceiveConfirmation with mainAccount.id when tapping an ERC-20 token", async () => {
+    const { user } = render(<SelectToken navigation={mockNavigation} route={mockRoute} />, {
+      overrideInitialState: (state: State): State => ({
+        ...state,
+        accounts: { ...state.accounts, active: [HEDERA_ACCOUNT_1] },
+      }),
+    });
+
+    await user.press(screen.getByTestId(buildRowTestId(erc20Token.id)));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.ReceiveFunds, {
+      screen: ScreenName.ReceiveConfirmation,
+      params: {
+        currency: erc20Token,
+        accountId: HEDERA_ACCOUNT_1.id,
+      },
+    });
+  });
+
+  it("should navigate to ReceiveConfirmation with subAccount ids when tapping an already-associated HTS token", async () => {
+    const { user } = render(<SelectToken navigation={mockNavigation} route={mockRoute} />, {
+      overrideInitialState: (state: State): State => ({
+        ...state,
+        accounts: {
+          ...state.accounts,
+          active: [{ ...HEDERA_ACCOUNT_1, subAccounts: [HEDERA_ASSOCIATED_SUBACCOUNT] }],
+        },
+      }),
+    });
+
+    await user.press(screen.getByTestId(buildRowTestId(htsToken.id)));
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.ReceiveFunds, {
+      screen: ScreenName.ReceiveConfirmation,
+      params: {
+        currency: htsToken,
+        accountId: HEDERA_ASSOCIATED_SUBACCOUNT.id,
+        parentId: HEDERA_ASSOCIATED_SUBACCOUNT.parentId,
+      },
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/01-SelectToken.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/01-SelectToken.tsx
@@ -71,6 +71,14 @@ export default function SelectToken({ navigation, route }: Props) {
             parentId: subAccount.parentId,
           },
         });
+      } else if (currency.tokenType !== "hts") {
+        navigation.navigate(NavigatorName.ReceiveFunds, {
+          screen: ScreenName.ReceiveConfirmation,
+          params: {
+            currency,
+            accountId: mainAccount.id,
+          },
+        });
       } else {
         navigation.navigate(ScreenName.HederaAssociateTokenSummary, {
           accountId: mainAccount.id,

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/01-SelectToken.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/01-SelectToken.tsx
@@ -17,7 +17,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import type { HederaAssociateTokenFlowParamList } from "~/families/hedera/AssociateTokenFlow/types";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
-type Props = BaseComposite<
+export type Props = BaseComposite<
   StackNavigatorProps<HederaAssociateTokenFlowParamList, ScreenName.HederaAssociateTokenSelectToken>
 >;
 

--- a/apps/ledger-live-mobile/src/families/hedera/__mocks__/account.mock.ts
+++ b/apps/ledger-live-mobile/src/families/hedera/__mocks__/account.mock.ts
@@ -1,0 +1,12 @@
+import {
+  createFixtureAccount,
+  createFixtureTokenAccount,
+} from "@ledgerhq/live-common/mock/fixtures/cryptoCurrencies";
+import { hederaCurrency, htsToken } from "./currency.mock";
+
+export const HEDERA_ACCOUNT_1 = createFixtureAccount("01", hederaCurrency);
+
+export const HEDERA_ASSOCIATED_SUBACCOUNT = {
+  ...createFixtureTokenAccount("01", htsToken),
+  parentId: HEDERA_ACCOUNT_1.id,
+};

--- a/apps/ledger-live-mobile/src/families/hedera/__mocks__/currency.mock.ts
+++ b/apps/ledger-live-mobile/src/families/hedera/__mocks__/currency.mock.ts
@@ -1,0 +1,26 @@
+import { cryptocurrenciesById } from "@ledgerhq/cryptoassets";
+import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+
+export const hederaCurrency = cryptocurrenciesById["hedera"];
+
+export const htsToken: TokenCurrency = {
+  type: "TokenCurrency",
+  id: "hedera/hts/0.0.123456",
+  name: "My HTS Token",
+  ticker: "MHTS",
+  units: [{ name: "My HTS Token", code: "MHTS", magnitude: 8 }],
+  contractAddress: "0.0.123456",
+  parentCurrency: hederaCurrency,
+  tokenType: "hts",
+};
+
+export const erc20Token: TokenCurrency = {
+  type: "TokenCurrency",
+  id: "hedera/erc20/0x1234",
+  name: "My ERC-20 Token",
+  ticker: "MERC",
+  units: [{ name: "My ERC-20 Token", code: "MERC", magnitude: 18 }],
+  contractAddress: "0x1234",
+  parentCurrency: hederaCurrency,
+  tokenType: "erc20",
+};


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Clicking on the Hedera ERC20 token shouldn't redirect to the association flow

### 📝 Description

This PR fixes invalid redirect when Hedera ERC20 token is clicked in "AssociateTokenFlow" in mobile app.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-27313


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
