### PR TITLE
[LWM] fix(mobile): adjust Wallet 4.0 portfolio spacing

### DIFF
--- a/.changeset/live-29473-wallet-spacing.md
+++ b/.changeset/live-29473-wallet-spacing.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Adjust Wallet 4.0 portfolio, assets, and related screen spacing

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/CryptoAddressesFooter.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/CryptoAddressesFooter.tsx
@@ -9,7 +9,7 @@ type Props = Readonly<{
   onPress: () => void;
 }>;
 
-const PADDING_BOTTOM = 32;
+const PADDING_BOTTOM = 16;
 
 export const FOOTER_HEIGHT = 80;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MarketBanner/components/MarketBannerView/index.tsx
@@ -50,7 +50,7 @@ const MarketBannerView = ({
   );
 
   return (
-    <Box testID={testID} lx={{ marginBottom: "s32" }}>
+    <Box testID={testID} lx={{ marginBottom: "s24" }}>
       <Subheader testID="market-banner-title">
         <SubheaderRow
           onPress={onSectionTitlePress}

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/Portfolio/index.tsx
@@ -125,7 +125,7 @@ export const PortfolioScreen = ({ navigation }: NavigationProps) => {
 
     if (shouldDisplayMarketBanner) {
       sections.push(
-        <Box key="marketBanner" px={6} pt={6}>
+        <Box key="marketBanner" px={6}>
           <MarketBanner />
         </Box>,
       );

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/AssetsSections/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/AssetsSections/index.tsx
@@ -15,7 +15,7 @@ export const AssetsSections: React.FC<AssetsSectionsProps> = ({
 }) => {
   if (shouldDisplayAssetSection) {
     return (
-      <Box lx={{ gap: "s24" }}>
+      <Box lx={{ gap: "s16" }}>
         <PortfolioCryptosSection variant={variant} />
         <PortfolioStablecoinsSection variant={variant} />
       </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/CryptosSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/CryptosSection/index.tsx
@@ -31,7 +31,7 @@ const PortfolioCryptosSectionComponent: React.FC<PortfolioCryptosSectionProps> =
         <SubheaderRow
           onPress={hasMore ? onPressShowAll : undefined}
           accessibilityRole={hasMore ? "button" : undefined}
-          lx={{ marginBottom: "s12" }}
+          lx={{ marginBottom: "s4" }}
         >
           <SubheaderTitle>{t("wallet.tabs.crypto")}</SubheaderTitle>
           {hasMore && (

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StablecoinsSection/index.tsx
@@ -33,7 +33,7 @@ const PortfolioStablecoinsSectionComponent: React.FC<PortfolioStablecoinsSection
         <SubheaderRow
           onPress={hasMore ? onPressShowAll : undefined}
           accessibilityRole={hasMore ? "button" : undefined}
-          lx={{ marginBottom: "s12" }}
+          lx={{ marginBottom: "s4" }}
         >
           <SubheaderTitle>{t("wallet.tabs.stablecoins")}</SubheaderTitle>
           {hasMore && (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Spacing-only UI tweaks; not covered by automated tests._
- [x] **Impact of the changes:**
      - Portfolio screen: market banner container and spacing below the banner
      - Wallet assets: vertical gaps between Cryptos and Stablecoins sections, subheader spacing
      - Market banner: margin below the section
      - Crypto addresses screen: footer bottom padding

### 📝 Description

**Problem**: Wallet 4.0 portfolio and related surfaces had spacing that did not match the intended design for [LIVE-29473](https://ledgerhq.atlassian.net/browse/LIVE-29473) ([W4.0] LWM - Spacing).

**Solution**: Tightened layout tokens consistently:

- Portfolio: removed extra top padding on the market banner wrapper; reduced market banner bottom margin (`s32` → `s24`).
- Wallet assets: reduced gap between asset sections (`s24` → `s16`) and subheader row bottom margin for Cryptos and Stablecoins (`s12` → `s4`).
- Crypto addresses: reduced footer bottom padding (32 → 16) to align with the updated vertical rhythm.


https://github.com/user-attachments/assets/84de3e0f-965e-4dd3-9622-15842b79771a


READONLY MODE:


https://github.com/user-attachments/assets/ada58c56-ce39-4ef1-8ec1-2c6a226ef6b9



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29473](https://ledgerhq.atlassian.net/browse/LIVE-29473)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29473]: https://ledgerhq.atlassian.net/browse/LIVE-29473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-29473]: https://ledgerhq.atlassian.net/browse/LIVE-29473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ