### PR TITLE
test(ci): set explicitly to avoid unexpected behaviour

### DIFF
--- a/tools/actions/composites/run-e2e-playwright-tests/action.yml
+++ b/tools/actions/composites/run-e2e-playwright-tests/action.yml
@@ -91,6 +91,9 @@ runs:
         if [[ "${{ inputs.enable_wallet40 }}" = "false" ]]; then
           export E2E_ENABLE_WALLET40=0
           echo "Wallet 4.0 disabled!"
+        else
+          export E2E_ENABLE_WALLET40=1
+          echo "Wallet 4.0 enabled!"
         fi
 
         set +e


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Always set the toggle on CI to avoid unexpected behaviour.

tested on release:
4.0 enabled: [build](https://github.com/LedgerHQ/ledger-live/actions/runs/24715589132) and [report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/91ce1b3f-339a-414c-9e39-c97e90284c8e/).
legacy: [build](https://github.com/LedgerHQ/ledger-live/actions/runs/24715623393) and [report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/3e7d0093-3428-42fe-901a-ee8facbad897/).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: N/A


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
