### PR TITLE
[LWD] feat(desktop): add recover action to my wallet and hide sidebar entry

### DIFF
--- a/.changeset/shiny-adults-invent.md
+++ b/.changeset/shiny-adults-invent.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add recover action to my wallet actions list and hide sidebar recover when my wallet is enabled

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
@@ -91,14 +91,16 @@ export function SideBarView({ viewModel }: SideBarViewProps) {
             <FeatureToggle featureId="referralProgramDesktopSidebar">
               <SideBarItem value="refer" icon={Gift} activeIcon={Gift} label={t("sidebar.refer")} />
             </FeatureToggle>
-            <FeatureToggle featureId="protectServicesDesktop">
-              <SideBarItem
-                value="recover"
-                icon={ShieldCheck}
-                activeIcon={ShieldCheck}
-                label={t("sidebar.recover")}
-              />
-            </FeatureToggle>
+            {viewModel.isMyWalletEnabled ? null : (
+              <FeatureToggle featureId="protectServicesDesktop">
+                <SideBarItem
+                  value="recover"
+                  icon={ShieldCheck}
+                  activeIcon={ShieldCheck}
+                  label={t("sidebar.recover")}
+                />
+              </FeatureToggle>
+            )}
             <SideBarCollapseToggle />
           </SideBarTrailing>
         </SideBar>

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
@@ -90,6 +90,18 @@ describe("SideBar", () => {
       expect(screen.queryByText("[L] Recover")).not.toBeInTheDocument();
     });
 
+    it("should hide Recover when My Wallet is enabled", () => {
+      renderSideBarWithRoute(
+        "/",
+        withFeatureFlags({
+          lwdWallet40: { enabled: true, params: { myWallet: true } },
+          protectServicesDesktop: { enabled: true },
+        }),
+      );
+
+      expect(screen.queryByText("[L] Recover")).not.toBeInTheDocument();
+    });
+
     it("should disable Card item when card manifest is unavailable", () => {
       renderSideBarWithRoute("/");
 

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
@@ -70,7 +70,18 @@ describe("useSideBarViewModel", () => {
       noAccounts: false,
       totalStarredAccounts: 0,
       active: "home",
+      isMyWalletEnabled: false,
     });
+  });
+
+  it("should expose My Wallet state when enabled", () => {
+    const { result } = renderViewModel(
+      withFeatureFlags({
+        lwdWallet40: { enabled: true, params: { myWallet: true } },
+      }),
+    );
+
+    expect(result.current.isMyWalletEnabled).toBe(true);
   });
 
   describe("collapse", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/types.ts
@@ -37,6 +37,7 @@ export interface SideBarViewModel {
   readonly isMarketBannerEnabled: boolean;
   readonly isQuickActionCtasEnabled: boolean;
   readonly isWallet40MainNavEnabled: boolean;
+  readonly isMyWalletEnabled: boolean;
   readonly referralProgramConfig: ReferralProgramConfig | null;
   readonly recoverFeature: RecoverFeatureConfig | null;
   readonly recoverHomePath: string | undefined;

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
@@ -131,6 +131,7 @@ export function useSideBarViewModel(): SideBarViewModel {
     shouldDisplayQuickActionCtas: isQuickActionCtasEnabled,
     shouldDisplayWallet40MainNav: isWallet40MainNavEnabled,
     shouldDisplayAssetSection,
+    shouldDisplayMyWallet: isMyWalletEnabled,
     isEnabled: isWallet40Enabled,
   } = useWalletFeaturesConfig("desktop");
 
@@ -325,6 +326,7 @@ export function useSideBarViewModel(): SideBarViewModel {
     isMarketBannerEnabled,
     isQuickActionCtasEnabled,
     isWallet40MainNavEnabled,
+    isMyWalletEnabled,
     referralProgramConfig,
     recoverFeature,
     recoverHomePath,

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/ActionsListView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/ActionsListView.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { TileButton } from "@ledgerhq/lumen-ui-react";
+import type { Action } from "./types";
+
+export type ActionsListViewProps = {
+  actions: Action[];
+};
+
+export function ActionsListView({ actions }: ActionsListViewProps) {
+  return (
+    <div className="flex gap-8 justify-between" data-testid="my-wallet-actions-list">
+      {actions.map(({ icon, label, onClick, id }) => (
+        <TileButton
+          key={id}
+          icon={icon}
+          onClick={onClick}
+          data-testid={`my-wallet-action-${id}`}
+          isFull
+        >
+          {label}
+        </TileButton>
+      ))}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/__tests__/ActionsList.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/__tests__/ActionsList.test.tsx
@@ -1,42 +1,122 @@
-import { t } from "i18next";
+import { useAccountPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 import React from "react";
-import { render, screen } from "tests/testSetup";
-import { track } from "~/renderer/analytics/segment";
+import { render, screen, withFlagOverrides } from "tests/testSetup";
+import * as segment from "~/renderer/analytics/segment";
 import { ActionsList } from "..";
 
+const HELP_LABEL = "Help";
+const RECOVER_LABEL = "[L] Recover";
+const MY_WALLET_ROUTE = "/my-wallet";
+const RECOVER_HOME_PATH = "/recover";
+
 const mockNavigate = jest.fn();
+
+jest.mock("@ledgerhq/live-common/hooks/recoverFeatureFlag", () => ({
+  useAccountPath: jest.fn(),
+}));
 
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
   useNavigate: () => mockNavigate,
 }));
 
-const mockTrack = jest.mocked(track);
+const mockUseAccountPath = jest.mocked(useAccountPath);
+const renderActionsList = (options?: Parameters<typeof render>[1]) =>
+  render(<ActionsList />, options);
+const getHelpButton = () => screen.getByRole("button", { name: HELP_LABEL });
+const getRecoverButton = () => screen.getByRole("button", { name: RECOVER_LABEL });
+const queryRecoverButton = () => screen.queryByRole("button", { name: RECOVER_LABEL });
 
 describe("ActionsList", () => {
   beforeEach(() => {
+    mockUseAccountPath.mockReturnValue(undefined);
+  });
+  afterAll(() => {
     jest.clearAllMocks();
   });
 
-  it("should render the list with the help action", () => {
-    render(<ActionsList />);
+  it("shows help and hides recover by default", () => {
+    renderActionsList();
 
     expect(screen.getByTestId("my-wallet-actions-list")).toBeVisible();
-    expect(screen.getByRole("button", { name: t("myWallet.actionsList.help") })).toBeVisible();
+    expect(getHelpButton()).toBeVisible();
+    expect(queryRecoverButton()).not.toBeInTheDocument();
   });
 
-  it("should navigate to the help settings and track the click when the help action is pressed", async () => {
-    const { user } = render(<ActionsList />, { initialRoute: "/my-wallet" });
+  it("shows recover when the feature is enabled", () => {
+    renderActionsList({
+      initialState: withFlagOverrides({
+        protectServicesDesktop: {
+          enabled: true,
+          params: { protectId: "protect-id" },
+        },
+      }),
+    });
 
-    await user.click(screen.getByRole("button", { name: t("myWallet.actionsList.help") }));
+    expect(getRecoverButton()).toBeVisible();
+  });
 
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
+  it("navigates to help settings and tracks the click", async () => {
+    const trackSpy = jest.spyOn(segment, "track");
+    const { user } = renderActionsList({ initialRoute: MY_WALLET_ROUTE });
+
+    await user.click(getHelpButton());
+
     expect(mockNavigate).toHaveBeenCalledWith("/settings/help");
-    expect(mockTrack).toHaveBeenCalledTimes(1);
-    expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
+    expect(trackSpy).toHaveBeenCalledWith("button_clicked", {
       button: "Help",
-      page: "/my-wallet",
+      page: MY_WALLET_ROUTE,
       entry: "my_wallet_actions_list",
     });
+  });
+
+  it("navigates to the recover home and tracks the click", async () => {
+    const trackSpy = jest.spyOn(segment, "track");
+    mockUseAccountPath.mockReturnValue(RECOVER_HOME_PATH);
+
+    const { user } = renderActionsList({
+      initialRoute: MY_WALLET_ROUTE,
+      initialState: withFlagOverrides({
+        protectServicesDesktop: {
+          enabled: true,
+          params: {
+            openRecoverFromSidebar: true,
+            protectId: "protect-id",
+          },
+        },
+      }),
+    });
+
+    await user.click(getRecoverButton());
+
+    expect(mockNavigate).toHaveBeenCalledWith(RECOVER_HOME_PATH);
+    expect(trackSpy).toHaveBeenCalledWith("button_clicked", {
+      button: "Recover",
+      page: MY_WALLET_ROUTE,
+      entry: "my_wallet_actions_list",
+    });
+  });
+
+  it("persists hasClickedRecover in the store after the first recover click", async () => {
+    mockUseAccountPath.mockReturnValue(RECOVER_HOME_PATH);
+
+    const { user, store } = renderActionsList({
+      initialRoute: MY_WALLET_ROUTE,
+      initialState: withFlagOverrides({
+        protectServicesDesktop: {
+          enabled: true,
+          params: {
+            openRecoverFromSidebar: true,
+            protectId: "protect-id",
+          },
+        },
+      }),
+    });
+
+    expect(store.getState().settings.hasClickedRecover).toBe(false);
+
+    await user.click(getRecoverButton());
+
+    expect(store.getState().settings.hasClickedRecover).toBe(true);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/index.tsx
@@ -1,16 +1,9 @@
 import React from "react";
-import { TileButton } from "@ledgerhq/lumen-ui-react";
+import { ActionsListView } from "./ActionsListView";
 import { useActionsListViewModel } from "./useActionsListViewModel";
 
 export function ActionsList() {
   const { actions } = useActionsListViewModel();
-  return (
-    <div className="flex gap-8 justify-between" data-testid="my-wallet-actions-list">
-      {actions.map(({ icon, label, onClick, id }) => (
-        <TileButton key={id} icon={icon} className="flex-1" onClick={onClick}>
-          {label}
-        </TileButton>
-      ))}
-    </div>
-  );
+
+  return <ActionsListView actions={actions} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/useActionsListViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/useActionsListViewModel.ts
@@ -1,14 +1,30 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router";
-import { LifeRing } from "@ledgerhq/lumen-ui-react/symbols";
+import { LifeRing, ShieldCheck, ShieldCheckNotification } from "@ledgerhq/lumen-ui-react/symbols";
 import { track } from "~/renderer/analytics/segment";
 import type { Action } from "./types";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useAccountPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { openModal } from "~/renderer/actions/modals";
+import { hasClickedRecoverSelector } from "~/renderer/reducers/settings";
+import { setHasClickedRecover } from "~/renderer/actions/settings";
 
-export function useActionsListViewModel() {
+export type ActionsListViewModel = {
+  actions: Action[];
+};
+
+export function useActionsListViewModel(): ActionsListViewModel {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
+
+  const recoverFeature = useFeature("protectServicesDesktop");
+  const recoverHomePath = useAccountPath(recoverFeature);
+  const dispatch = useDispatch();
+  const hasClickedRecover = useSelector(hasClickedRecoverSelector);
+  const recoverIcon = hasClickedRecover ? ShieldCheck : ShieldCheckNotification;
 
   const openHelp = useCallback(() => {
     track("button_clicked", {
@@ -19,27 +35,54 @@ export function useActionsListViewModel() {
     navigate("/settings/help");
   }, [location.pathname, navigate]);
 
-  const actions = useMemo<Action[]>(
-    () => [
-      {
-        icon: LifeRing,
-        label: "1",
-        id: "1",
-      },
-      {
-        icon: LifeRing,
-        label: t("myWallet.actionsList.help"),
-        onClick: openHelp,
-        id: "help",
-      },
-      {
-        icon: LifeRing,
-        label: "3",
-        id: "3",
-      },
-    ],
-    [openHelp, t],
-  );
+  const handleClickRecover = useCallback(() => {
+    const enabled = recoverFeature?.enabled;
+    const openRecoverFromSidebar = recoverFeature?.params?.openRecoverFromSidebar;
+    const liveAppId = recoverFeature?.params?.protectId;
+
+    if (!hasClickedRecover) {
+      dispatch(setHasClickedRecover(true));
+    }
+
+    if (enabled && openRecoverFromSidebar && liveAppId && recoverHomePath) {
+      navigate(recoverHomePath);
+    } else if (enabled) {
+      dispatch(openModal("MODAL_PROTECT_DISCOVER", undefined));
+    }
+    track("button_clicked", {
+      button: "Recover",
+      page: location.pathname,
+      entry: "my_wallet_actions_list",
+    });
+  }, [
+    recoverFeature?.enabled,
+    recoverFeature?.params?.openRecoverFromSidebar,
+    recoverFeature?.params?.protectId,
+    recoverHomePath,
+    hasClickedRecover,
+    navigate,
+    dispatch,
+    location.pathname,
+  ]);
+
+  const actions: Action[] = [
+    ...(recoverFeature?.enabled
+      ? [
+          {
+            icon: recoverIcon,
+            label: t("myWallet.actionsList.recover"),
+            onClick: handleClickRecover,
+            id: "recover",
+          },
+        ]
+      : []),
+    {
+      icon: LifeRing,
+      label: t("myWallet.actionsList.help"),
+      onClick: openHelp,
+      id: "help",
+    },
+  ];
 
   return { actions };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
@@ -11,15 +11,10 @@ const align = "end";
 
 export function ContextMenu() {
   return (
-    <Popover>
+    <Popover overlay>
       <PopoverTrigger render={<IconButton icon={Airplane} aria-label="Airplane" size="sm" />} />
 
-      <PopoverContent
-        width="fixed"
-        side={side}
-        align={align}
-        className="flex flex-col bg-surface gap-24"
-      >
+      <PopoverContent width="fixed" side={side} align={align} className="flex flex-col gap-24">
         <TopBar />
         <ActionsList />
         <div className="flex flex-col gap-12">

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/ExploreView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/ExploreView.tsx
@@ -17,7 +17,7 @@ export type ExploreViewProps = {
 
 export function ExploreView({ title, onClick }: ExploreViewProps) {
   return (
-    <ListItem onClick={onClick} className="bg-muted">
+    <ListItem onClick={onClick} className="bg-surface">
       <ListItemLeading>
         <Image resource={ExploreImage} alt="Explore" className="w-48 h-48" />
         <ListItemContent>

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/MyLedgerView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/MyLedgerView.tsx
@@ -20,7 +20,7 @@ export type MyLedgerViewProps = {
 
 export function MyLedgerView({ title, description, icon, onClick }: MyLedgerViewProps) {
   return (
-    <ListItem onClick={onClick} className="bg-muted">
+    <ListItem onClick={onClick} className="bg-surface">
       <ListItemLeading>
         <Spot icon={icon} appearance="icon" />
         <ListItemContent>

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -403,3 +403,8 @@ export const setHasSeenWalletV4Tour = (hasSeenWalletV4Tour: boolean) => ({
   type: "SET_HAS_SEEN_WALLET_V4_TOUR",
   payload: hasSeenWalletV4Tour,
 });
+
+export const setHasClickedRecover = (hasClickedRecover: boolean) => ({
+  type: "SET_HAS_CLICKED_RECOVER",
+  payload: hasClickedRecover,
+});

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -132,6 +132,7 @@ export type SettingsState = {
   alwaysShowMemoTagInfo: boolean;
   anonymousUserNotifications: { LNSUpsell?: number } & Record<string, number>;
   hasSeenWalletV4Tour: boolean;
+  hasClickedRecover: boolean;
   doNotAskAgainSkipMemo: boolean;
   deprecationDoNotRemind: string[];
   lastAnalyticsConsentDate: string | null;
@@ -235,6 +236,7 @@ export const INITIAL_STATE: SettingsState = {
   alwaysShowMemoTagInfo: true,
   anonymousUserNotifications: {},
   hasSeenWalletV4Tour: false,
+  hasClickedRecover: false,
   doNotAskAgainSkipMemo: false,
   deprecationDoNotRemind: [],
   lastAnalyticsConsentDate: null,
@@ -299,6 +301,7 @@ type HandlersPayloads = {
     notifications: Record<string, number>;
   };
   SET_HAS_SEEN_WALLET_V4_TOUR: boolean;
+  SET_HAS_CLICKED_RECOVER: boolean;
 };
 type SettingsHandlers<PreciseKey = true> = Handlers<SettingsState, HandlersPayloads, PreciseKey>;
 
@@ -527,6 +530,10 @@ const handlers: SettingsHandlers = {
   SET_HAS_SEEN_WALLET_V4_TOUR: (state: SettingsState, { payload }) => ({
     ...state,
     hasSeenWalletV4Tour: payload,
+  }),
+  SET_HAS_CLICKED_RECOVER: (state: SettingsState, { payload }) => ({
+    ...state,
+    hasClickedRecover: payload,
   }),
 };
 
@@ -841,6 +848,7 @@ export const alwaysShowMemoTagInfoSelector = (state: State) => state.settings.al
 export const anonymousUserNotificationsSelector = (state: State) =>
   state.settings.anonymousUserNotifications;
 export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasSeenWalletV4Tour;
+export const hasClickedRecoverSelector = (state: State) => state.settings.hasClickedRecover;
 
 // Last onboarded device is the device set when a user goes through the onboarding flow.
 // Last seen device is the device set when a user performs a device action (e.g. pairing, firmware update, etc.).

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8639,7 +8639,8 @@
   },
   "myWallet": {
     "actionsList": {
-      "help": "Help"
+      "help": "Help",
+      "recover": "[L] Recover"
     },
     "myLedger": {
       "title": "My Ledger",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - My Wallet actions list rendering (recover action visibility)
      - Sidebar recover entry conditional display
      - Recover navigation and tracking analytics
      - Popover and list item UI styling

### 📝 Description

When My Wallet is enabled, the Recover entry in the sidebar becomes redundant since users access Recover directly from the My Wallet context menu. This PR consolidates the Recover access point.

**Changes:**
- Added Recover action to the My Wallet `ActionsList` with proper navigation, feature flag gating, and analytics tracking
- Extracted `ActionsListView` as a dedicated view component following MVVM pattern
- Hidden the sidebar Recover entry when My Wallet is enabled to avoid duplication
- Added `hasClickedRecover` state in Redux settings to track notification badge dismissal
- Updated UI: popover overlay, `bg-surface` for list items
- Updated and expanded unit + integration tests


https://github.com/user-attachments/assets/12ef2bc3-575f-4d68-ae71-b941e515f323



### ❓ Context

- **JIRA or GitHub link**: [LIVE-26047](https://ledgerhq.atlassian.net/browse/LIVE-26047)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26047]: https://ledgerhq.atlassian.net/browse/LIVE-26047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ