### PR TITLE
[LWD] feat(desktop): add refer action to my wallet and hide sidebar entry

### DIFF
--- a/.changeset/shy-seahorses-cough.md
+++ b/.changeset/shy-seahorses-cough.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add refer action to my wallet actions list and hide sidebar refer when my wallet is enabled

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
@@ -88,18 +88,25 @@ export function SideBarView({ viewModel }: SideBarViewProps) {
             />
           </SideBarLeading>
           <SideBarTrailing>
-            <FeatureToggle featureId="referralProgramDesktopSidebar">
-              <SideBarItem value="refer" icon={Gift} activeIcon={Gift} label={t("sidebar.refer")} />
-            </FeatureToggle>
             {viewModel.isMyWalletEnabled ? null : (
-              <FeatureToggle featureId="protectServicesDesktop">
-                <SideBarItem
-                  value="recover"
-                  icon={ShieldCheck}
-                  activeIcon={ShieldCheck}
-                  label={t("sidebar.recover")}
-                />
-              </FeatureToggle>
+              <>
+                <FeatureToggle featureId="referralProgramDesktopSidebar">
+                  <SideBarItem
+                    value="refer"
+                    icon={Gift}
+                    activeIcon={Gift}
+                    label={t("sidebar.refer")}
+                  />
+                </FeatureToggle>
+                <FeatureToggle featureId="protectServicesDesktop">
+                  <SideBarItem
+                    value="recover"
+                    icon={ShieldCheck}
+                    activeIcon={ShieldCheck}
+                    label={t("sidebar.recover")}
+                  />
+                </FeatureToggle>
+              </>
             )}
             <SideBarCollapseToggle />
           </SideBarTrailing>

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
@@ -90,16 +90,18 @@ describe("SideBar", () => {
       expect(screen.queryByText("[L] Recover")).not.toBeInTheDocument();
     });
 
-    it("should hide Recover when My Wallet is enabled", () => {
+    it("should hide Recover and Refer a friend when My Wallet is enabled", () => {
       renderSideBarWithRoute(
         "/",
         withFeatureFlags({
           lwdWallet40: { enabled: true, params: { myWallet: true } },
           protectServicesDesktop: { enabled: true },
+          referralProgramDesktopSidebar: { enabled: true, params: { path: "/refer" } },
         }),
       );
 
       expect(screen.queryByText("[L] Recover")).not.toBeInTheDocument();
+      expect(screen.queryByText("Refer a friend")).not.toBeInTheDocument();
     });
 
     it("should disable Card item when card manifest is unavailable", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/__tests__/ActionsList.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/__tests__/ActionsList.test.tsx
@@ -1,13 +1,15 @@
 import { useAccountPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
-import * as segment from "~/renderer/analytics/segment";
+import { track } from "~/renderer/analytics/segment";
 import { ActionsList } from "..";
 
 const HELP_LABEL = "Help";
 const RECOVER_LABEL = "[L] Recover";
+const REFER_LABEL = "Referral";
 const MY_WALLET_ROUTE = "/my-wallet";
 const RECOVER_HOME_PATH = "/recover";
+const REFER_PATH = "/refer-a-friend";
 
 const mockNavigate = jest.fn();
 
@@ -21,11 +23,10 @@ jest.mock("react-router", () => ({
 }));
 
 const mockUseAccountPath = jest.mocked(useAccountPath);
+const mockTrack = jest.mocked(track);
 const renderActionsList = (options?: Parameters<typeof render>[1]) =>
   render(<ActionsList />, options);
-const getHelpButton = () => screen.getByRole("button", { name: HELP_LABEL });
-const getRecoverButton = () => screen.getByRole("button", { name: RECOVER_LABEL });
-const queryRecoverButton = () => screen.queryByRole("button", { name: RECOVER_LABEL });
+const getButton = (name: string) => screen.getByRole("button", { name });
 
 describe("ActionsList", () => {
   beforeEach(() => {
@@ -35,12 +36,11 @@ describe("ActionsList", () => {
     jest.clearAllMocks();
   });
 
-  it("shows help and hides recover by default", () => {
+  it("shows only help by default", () => {
     renderActionsList();
 
     expect(screen.getByTestId("my-wallet-actions-list")).toBeVisible();
-    expect(getHelpButton()).toBeVisible();
-    expect(queryRecoverButton()).not.toBeInTheDocument();
+    expect(getButton(HELP_LABEL)).toBeVisible();
   });
 
   it("shows recover when the feature is enabled", () => {
@@ -53,17 +53,16 @@ describe("ActionsList", () => {
       }),
     });
 
-    expect(getRecoverButton()).toBeVisible();
+    expect(getButton(RECOVER_LABEL)).toBeVisible();
   });
 
   it("navigates to help settings and tracks the click", async () => {
-    const trackSpy = jest.spyOn(segment, "track");
     const { user } = renderActionsList({ initialRoute: MY_WALLET_ROUTE });
 
-    await user.click(getHelpButton());
+    await user.click(getButton(HELP_LABEL));
 
     expect(mockNavigate).toHaveBeenCalledWith("/settings/help");
-    expect(trackSpy).toHaveBeenCalledWith("button_clicked", {
+    expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
       button: "Help",
       page: MY_WALLET_ROUTE,
       entry: "my_wallet_actions_list",
@@ -71,7 +70,6 @@ describe("ActionsList", () => {
   });
 
   it("navigates to the recover home and tracks the click", async () => {
-    const trackSpy = jest.spyOn(segment, "track");
     mockUseAccountPath.mockReturnValue(RECOVER_HOME_PATH);
 
     const { user } = renderActionsList({
@@ -87,10 +85,10 @@ describe("ActionsList", () => {
       }),
     });
 
-    await user.click(getRecoverButton());
+    await user.click(getButton(RECOVER_LABEL));
 
     expect(mockNavigate).toHaveBeenCalledWith(RECOVER_HOME_PATH);
-    expect(trackSpy).toHaveBeenCalledWith("button_clicked", {
+    expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
       button: "Recover",
       page: MY_WALLET_ROUTE,
       entry: "my_wallet_actions_list",
@@ -115,8 +113,42 @@ describe("ActionsList", () => {
 
     expect(store.getState().settings.hasClickedRecover).toBe(false);
 
-    await user.click(getRecoverButton());
+    await user.click(getButton(RECOVER_LABEL));
 
     expect(store.getState().settings.hasClickedRecover).toBe(true);
+  });
+
+  it("shows refer when the feature is enabled", () => {
+    renderActionsList({
+      initialState: withFlagOverrides({
+        referralProgramDesktopSidebar: {
+          enabled: true,
+          params: { path: REFER_PATH },
+        },
+      }),
+    });
+
+    expect(getButton(REFER_LABEL)).toBeVisible();
+  });
+
+  it("navigates to the refer path and tracks the click", async () => {
+    const { user } = renderActionsList({
+      initialRoute: MY_WALLET_ROUTE,
+      initialState: withFlagOverrides({
+        referralProgramDesktopSidebar: {
+          enabled: true,
+          params: { path: REFER_PATH },
+        },
+      }),
+    });
+
+    await user.click(getButton(REFER_LABEL));
+
+    expect(mockNavigate).toHaveBeenCalledWith(REFER_PATH);
+    expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
+      button: "Refer",
+      page: MY_WALLET_ROUTE,
+      entry: "my_wallet_actions_list",
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/useActionsListViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/useActionsListViewModel.ts
@@ -1,7 +1,12 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router";
-import { LifeRing, ShieldCheck, ShieldCheckNotification } from "@ledgerhq/lumen-ui-react/symbols";
+import {
+  Gift,
+  LifeRing,
+  ShieldCheck,
+  ShieldCheckNotification,
+} from "@ledgerhq/lumen-ui-react/symbols";
 import { track } from "~/renderer/analytics/segment";
 import type { Action } from "./types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
@@ -20,6 +25,7 @@ export function useActionsListViewModel(): ActionsListViewModel {
   const navigate = useNavigate();
   const location = useLocation();
 
+  const referralProgramConfig = useFeature("referralProgramDesktopSidebar");
   const recoverFeature = useFeature("protectServicesDesktop");
   const recoverHomePath = useAccountPath(recoverFeature);
   const dispatch = useDispatch();
@@ -65,6 +71,17 @@ export function useActionsListViewModel(): ActionsListViewModel {
     location.pathname,
   ]);
 
+  const handleClickRefer = useCallback(() => {
+    if (referralProgramConfig?.enabled && referralProgramConfig?.params?.path) {
+      navigate(referralProgramConfig.params.path);
+      track("button_clicked", {
+        button: "Refer",
+        page: location.pathname,
+        entry: "my_wallet_actions_list",
+      });
+    }
+  }, [referralProgramConfig, navigate, location.pathname]);
+
   const actions: Action[] = [
     ...(recoverFeature?.enabled
       ? [
@@ -82,6 +99,16 @@ export function useActionsListViewModel(): ActionsListViewModel {
       onClick: openHelp,
       id: "help",
     },
+    ...(referralProgramConfig?.enabled
+      ? [
+          {
+            icon: Gift,
+            label: t("myWallet.actionsList.refer"),
+            onClick: handleClickRefer,
+            id: "refer",
+          },
+        ]
+      : []),
   ];
 
   return { actions };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8640,7 +8640,8 @@
   "myWallet": {
     "actionsList": {
       "help": "Help",
-      "recover": "[L] Recover"
+      "recover": "[L] Recover",
+      "refer": "Referral"
     },
     "myLedger": {
       "title": "My Ledger",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - My Wallet actions list rendering (referral action visibility)
      - Sidebar refer entry conditional display when My Wallet is enabled
      - Refer navigation and tracking analytics

### 📝 Description

When My Wallet is enabled, the "Refer a friend" entry in the sidebar becomes redundant since users can access it directly from the My Wallet context menu. This PR consolidates the referral access point, following the same pattern used for Recover.

**Changes:**
- Added Referral action to the My Wallet `ActionsList` with proper navigation, feature flag gating (`referralProgramDesktopSidebar`), and analytics tracking
- Hidden the sidebar "Refer a friend" entry when My Wallet is enabled, grouped with Recover in a single conditional block
- Updated SideBar integration test to verify both Refer and Recover are hidden when My Wallet is enabled
- Added ActionsList unit tests for the referral action (visibility and navigation)
- Refactored test helpers: replaced `jest.spyOn(segment, "track")` with `jest.mocked(track)` to avoid stacking spies on the global mock

https://github.com/user-attachments/assets/8b0cc2de-aca1-48ae-b9a5-f81a088f0557


### ❓ Context

- **JIRA or GitHub link**: [LIVE-26043](https://ledgerhq.atlassian.net/browse/LIVE-26043)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26043]: https://ledgerhq.atlassian.net/browse/LIVE-26043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ