### PR TITLE
[LWDM] feat(LIVE-28106): use mirror consensus timestamp for Hedera tx start

### DIFF
--- a/.changeset/giant-bobcats-change.md
+++ b/.changeset/giant-bobcats-change.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-hedera": minor
+"@ledgerhq/live-common": minor
+---
+
+Add an optional mirror-node timestamp path for Hedera transaction creation to reduce INVALID_TRANSACTION_START failures caused by local clock drift, with safe fallback to system time behind a feature flag.

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -20,7 +20,7 @@ import { rpcClient } from "../network/rpc";
 import { MAINNET_TEST_ACCOUNTS } from "../test/fixtures/account.fixture";
 
 describe("createApi", () => {
-  const api = createApi({ useHgraphForErc20: true }, "hedera");
+  const api = createApi({ useHgraphForErc20: true, useNetworkTimestamp: true }, "hedera");
 
   beforeAll(() => {
     // Setup CAL client store (automatically set as global store)

--- a/libs/coin-modules/coin-hedera/src/api/index.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.ts
@@ -63,7 +63,11 @@ export function createApi(
     combine,
     craftTransaction: async (txIntent, customFees) => {
       invariant(!txIntent.useAllAmount, "useAllAmount is not supported");
-      const { serializedTx } = await craftTransaction(txIntent, customFees);
+      const { serializedTx } = await craftTransaction({
+        txIntent,
+        ...(customFees && { customFees }),
+        config,
+      });
 
       return {
         transaction: serializedTx,

--- a/libs/coin-modules/coin-hedera/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/signOperation.test.ts
@@ -1,0 +1,70 @@
+import hederaCoinConfig from "../config";
+import { craftTransaction } from "../logic/craftTransaction";
+import { combine } from "../logic/combine";
+import { getMockedAccount } from "../test/fixtures/account.fixture";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
+import { getMockedTransaction } from "../test/fixtures/transaction.fixture";
+import { buildSignOperation } from "./signOperation";
+
+jest.mock("../logic/craftTransaction", () => ({
+  craftTransaction: jest.fn(),
+}));
+
+jest.mock("../logic/combine", () => ({
+  combine: jest.fn(),
+}));
+
+jest.mock("../logic/utils", () => ({
+  serializeSignature: jest.fn(() => "serialized-signature"),
+  serializeTransaction: jest.fn(() => "serialized-transaction"),
+  getHederaTransactionBodyBytes: jest.fn(() => new Uint8Array([1, 2, 3])),
+  isTokenAssociateTransaction: jest.fn(() => false),
+  isStakingTransaction: jest.fn(() => false),
+  safeParseAccountId: jest.fn(async (value: string) => [undefined, { accountId: value }]),
+}));
+
+describe("signOperation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("passes hedera coin config to craftTransaction", async () => {
+    const account = getMockedAccount();
+    const transaction = getMockedTransaction();
+    const config = getMockedConfig();
+
+    jest.spyOn(hederaCoinConfig, "getCoinConfig").mockReturnValue(config);
+    jest
+      .mocked(craftTransaction)
+      .mockResolvedValue({ tx: {} as never, serializedTx: "serialized-tx" });
+    jest.mocked(combine).mockReturnValue("combined-signature");
+
+    const signerContext = jest.fn(
+      async (_deviceId: string, fn: (signer: any) => Promise<string>) => {
+        const signer = {
+          signTransaction: jest.fn(async () => new Uint8Array([9, 9, 9])),
+        };
+
+        return await fn(signer);
+      },
+    );
+
+    const signOperation = buildSignOperation(signerContext as never);
+
+    await new Promise<void>((resolve, reject) => {
+      signOperation({ account, transaction, deviceId: "test-device" }).subscribe({
+        complete: () => resolve(),
+        error: err => reject(err),
+      });
+    });
+
+    expect(hederaCoinConfig.getCoinConfig).toHaveBeenCalledTimes(1);
+    expect(hederaCoinConfig.getCoinConfig).toHaveBeenCalledWith(account.currency.id);
+    expect(craftTransaction).toHaveBeenCalledTimes(1);
+    expect(craftTransaction).toHaveBeenCalledWith({
+      txIntent: expect.any(Object),
+      config,
+    });
+    expect(combine).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/signOperation.ts
@@ -3,6 +3,7 @@ import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/he
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { Observable } from "rxjs";
+import hederaCoinConfig from "../config";
 import { DEFAULT_GAS_LIMIT, HEDERA_TRANSACTION_MODES } from "../constants";
 import { combine } from "../logic/combine";
 import { craftTransaction } from "../logic/craftTransaction";
@@ -33,6 +34,7 @@ export const buildSignOperation =
           let data: HederaTxData | undefined;
           const accountAddress = account.freshAddress;
           const accountPublicKey = account.seedIdentifier;
+          const coinConfig = hederaCoinConfig.getCoinConfig(account.currency.id);
           const subAccount = findSubAccountById(account, transaction.subAccountId || "");
           const isHTSTokenTransaction =
             transaction.mode === HEDERA_TRANSACTION_MODES.Send &&
@@ -86,8 +88,8 @@ export const buildSignOperation =
             : undefined;
 
           const signedTx = await signerContext(deviceId, async signer => {
-            const { tx } = await craftTransaction(
-              {
+            const { tx } = await craftTransaction({
+              txIntent: {
                 intentType: "transaction",
                 type,
                 asset,
@@ -101,8 +103,9 @@ export const buildSignOperation =
                 },
                 ...(data && { data }),
               },
-              customFees,
-            );
+              ...(customFees && { customFees }),
+              config: coinConfig,
+            });
 
             const txBodyBytes = getHederaTransactionBodyBytes(tx);
             const signatureBytes = await signer.signTransaction(txBodyBytes);

--- a/libs/coin-modules/coin-hedera/src/config.ts
+++ b/libs/coin-modules/coin-hedera/src/config.ts
@@ -5,6 +5,11 @@ import buildCoinConfig, {
 
 export type HederaConfig = {
   useHgraphForErc20: boolean;
+  /**
+   * When true, the transaction valid-start time is sourced from the latest
+   * network block instead of the local machine clock.
+   */
+  useNetworkTimestamp: boolean;
 };
 
 export type HederaCoinConfig = CurrencyConfig & HederaConfig;

--- a/libs/coin-modules/coin-hedera/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/craftTransaction.integ.test.ts
@@ -2,10 +2,13 @@ import * as sdk from "@hashgraph/sdk";
 import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
 import invariant from "invariant";
 import { HEDERA_TRANSACTION_MODES } from "../constants";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
 import type { HederaMemo, HederaTxData } from "../types";
 import { craftTransaction } from "./craftTransaction";
 
 describe("craftTransaction", () => {
+  const defaultConfig = getMockedConfig();
+
   it("should accept account id or long zero EVM address when crafting ERC20 token transfer transaction", async () => {
     // recipient account has no EVM alias, long-zero EVM address is used
 
@@ -42,8 +45,14 @@ describe("craftTransaction", () => {
       recipient: "0x0000000000000000000000000000000000003039",
     } satisfies TransactionIntent<HederaMemo, HederaTxData>;
 
-    const resultAccountId = await craftTransaction(txIntentAccountId);
-    const resultEVMAddress = await craftTransaction(txIntentEVMAddress);
+    const resultAccountId = await craftTransaction({
+      txIntent: txIntentAccountId,
+      config: defaultConfig,
+    });
+    const resultEVMAddress = await craftTransaction({
+      txIntent: txIntentEVMAddress,
+      config: defaultConfig,
+    });
 
     expect(resultAccountId.tx).toBeInstanceOf(sdk.ContractExecuteTransaction);
     expect(resultEVMAddress.tx).toBeInstanceOf(sdk.ContractExecuteTransaction);
@@ -95,8 +104,14 @@ describe("craftTransaction", () => {
       recipient: "0xcf15538fa293ab04cdd7ce45bcdac8b6e2dc7ebc",
     } satisfies TransactionIntent<HederaMemo, HederaTxData>;
 
-    const resultAccountId = await craftTransaction(txIntentAccountId);
-    const resultEVMAddress = await craftTransaction(txIntentEVMAddress);
+    const resultAccountId = await craftTransaction({
+      txIntent: txIntentAccountId,
+      config: defaultConfig,
+    });
+    const resultEVMAddress = await craftTransaction({
+      txIntent: txIntentEVMAddress,
+      config: defaultConfig,
+    });
 
     expect(resultAccountId.tx).toBeInstanceOf(sdk.ContractExecuteTransaction);
     expect(resultEVMAddress.tx).toBeInstanceOf(sdk.ContractExecuteTransaction);

--- a/libs/coin-modules/coin-hedera/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/craftTransaction.test.ts
@@ -1,11 +1,13 @@
 import * as sdk from "@hashgraph/sdk";
 import type { FeeEstimation, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
 import invariant from "invariant";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
 import {
   HEDERA_TRANSACTION_MODES,
   TINYBAR_SCALE,
   TRANSACTION_VALID_DURATION_SECONDS,
 } from "../constants";
+import { apiClient } from "../network/api";
 import { rpcClient } from "../network/rpc";
 import type { HederaMemo, HederaTxData } from "../types";
 import { craftTransaction } from "./craftTransaction";
@@ -14,6 +16,8 @@ import { serializeTransaction, toEVMAddress } from "./utils";
 jest.mock("./utils");
 
 describe("craftTransaction", () => {
+  const defaultConfig = getMockedConfig();
+
   beforeEach(() => {
     jest.clearAllMocks();
     (serializeTransaction as jest.Mock).mockReturnValue("serialized-transaction");
@@ -21,6 +25,10 @@ describe("craftTransaction", () => {
 
   afterAll(async () => {
     await rpcClient._resetInstance();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it("should craft a native HBAR transfer transaction", async () => {
@@ -40,7 +48,7 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    const result = await craftTransaction(txIntent);
+    const result = await craftTransaction({ txIntent, config: defaultConfig });
 
     expect(result.tx).toBeInstanceOf(sdk.TransferTransaction);
     invariant(result.tx instanceof sdk.TransferTransaction, "TransferTransaction type guard");
@@ -77,7 +85,7 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    const result = await craftTransaction(txIntent);
+    const result = await craftTransaction({ txIntent, config: defaultConfig });
 
     expect(result.tx).toBeInstanceOf(sdk.TransferTransaction);
     invariant(result.tx instanceof sdk.TransferTransaction, "TransferTransaction type guard");
@@ -120,7 +128,7 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo, HederaTxData>;
 
-    const result = await craftTransaction(txIntent);
+    const result = await craftTransaction({ txIntent, config: defaultConfig });
 
     expect(result.tx).toBeInstanceOf(sdk.ContractExecuteTransaction);
     invariant(
@@ -158,7 +166,7 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    const result = await craftTransaction(txIntent);
+    const result = await craftTransaction({ txIntent, config: defaultConfig });
 
     expect(result.tx).toBeInstanceOf(sdk.TokenAssociateTransaction);
     invariant(
@@ -181,8 +189,8 @@ describe("craftTransaction", () => {
       value: BigInt(50000),
     };
 
-    const result = await craftTransaction(
-      {
+    const result = await craftTransaction({
+      txIntent: {
         intentType: "transaction",
         type: HEDERA_TRANSACTION_MODES.Send,
         amount: BigInt(1000000),
@@ -198,7 +206,8 @@ describe("craftTransaction", () => {
         },
       },
       customFees,
-    );
+      config: defaultConfig,
+    });
 
     expect(result.tx).toBeInstanceOf(sdk.TransferTransaction);
     invariant(result.tx instanceof sdk.TransferTransaction, "TransferTransaction type guard");
@@ -222,7 +231,9 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    await expect(craftTransaction(txIntent)).rejects.toThrow();
+    await expect(craftTransaction({ txIntent, config: defaultConfig })).rejects.toThrow(
+      "hedera: invalid asset type",
+    );
   });
 
   it("should throw error when token associate transaction has missing assetReference", async () => {
@@ -242,7 +253,9 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    await expect(craftTransaction(txIntent)).rejects.toThrow();
+    await expect(craftTransaction({ txIntent, config: defaultConfig })).rejects.toThrow(
+      "hedera: assetReference is missing",
+    );
   });
 
   it("should throw error when token transfer transaction has missing assetReference", async () => {
@@ -262,6 +275,122 @@ describe("craftTransaction", () => {
       },
     } satisfies TransactionIntent<HederaMemo>;
 
-    await expect(craftTransaction(txIntent)).rejects.toThrow();
+    await expect(craftTransaction({ txIntent, config: defaultConfig })).rejects.toThrow(
+      "hedera: no assetReference in token transfer",
+    );
+  });
+
+  it("should use mirror node timestamp when feature flag is enabled", async () => {
+    const mockGetLatestBlock = jest.spyOn(apiClient, "getLatestBlock");
+    mockGetLatestBlock.mockResolvedValue({
+      timestamp: { from: "1758733200.632122898", to: null },
+    });
+
+    const txIntent = {
+      intentType: "transaction",
+      type: HEDERA_TRANSACTION_MODES.Send,
+      amount: BigInt(1 * 10 ** TINYBAR_SCALE),
+      recipient: "0.0.12345",
+      sender: "0.0.54321",
+      asset: {
+        type: "native",
+      },
+      memo: {
+        kind: "text",
+        type: "string",
+        value: "Hbar transfer",
+      },
+    } satisfies TransactionIntent<HederaMemo>;
+
+    const result = await craftTransaction({
+      txIntent,
+      config: {
+        ...defaultConfig,
+        useNetworkTimestamp: true,
+      },
+    });
+
+    expect(mockGetLatestBlock).toHaveBeenCalledTimes(1);
+    expect(result.tx).toBeInstanceOf(sdk.TransferTransaction);
+  });
+
+  it("should fallback to system timestamp when latest block cannot be fetched", async () => {
+    const mockGetLatestBlock = jest.spyOn(apiClient, "getLatestBlock");
+    mockGetLatestBlock.mockRejectedValue(new Error("mirror unavailable"));
+
+    const txIntent = {
+      intentType: "transaction",
+      type: HEDERA_TRANSACTION_MODES.Send,
+      amount: BigInt(1 * 10 ** TINYBAR_SCALE),
+      recipient: "0.0.12345",
+      sender: "0.0.54321",
+      asset: {
+        type: "native",
+      },
+      memo: {
+        kind: "text",
+        type: "string",
+        value: "Hbar transfer",
+      },
+    } satisfies TransactionIntent<HederaMemo>;
+
+    const result = await craftTransaction({
+      txIntent,
+      config: {
+        ...defaultConfig,
+        useNetworkTimestamp: true,
+      },
+    });
+
+    expect(mockGetLatestBlock).toHaveBeenCalledTimes(1);
+    expect(result.tx).toBeInstanceOf(sdk.TransferTransaction);
+  });
+
+  it("should use mirror timestamp when system clock is skewed", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2000-01-01T00:00:00.000Z"));
+    const mockGetLatestBlock = jest.spyOn(apiClient, "getLatestBlock");
+    mockGetLatestBlock.mockResolvedValue({
+      timestamp: { from: "1758733200.632122898", to: null },
+    });
+
+    const txIntent = {
+      intentType: "transaction",
+      type: HEDERA_TRANSACTION_MODES.Send,
+      amount: BigInt(1 * 10 ** TINYBAR_SCALE),
+      recipient: "0.0.12345",
+      sender: "0.0.54321",
+      asset: {
+        type: "native",
+      },
+      memo: {
+        kind: "text",
+        type: "string",
+        value: "Hbar transfer",
+      },
+    } satisfies TransactionIntent<HederaMemo>;
+
+    const [withoutMirror, withMirror] = await Promise.all([
+      craftTransaction({
+        txIntent,
+        config: {
+          ...defaultConfig,
+          useNetworkTimestamp: false,
+        },
+      }),
+      craftTransaction({
+        txIntent,
+        config: {
+          ...defaultConfig,
+          useNetworkTimestamp: true,
+        },
+      }),
+    ]);
+
+    const localSkewSeconds = Number(withoutMirror.tx.transactionId?.validStart?.seconds.toString());
+    expect(localSkewSeconds).toBeGreaterThanOrEqual(946684700);
+    expect(localSkewSeconds).toBeLessThanOrEqual(946684800);
+    expect(mockGetLatestBlock).toHaveBeenCalledTimes(1);
+    expect(withMirror.tx).toBeInstanceOf(sdk.TransferTransaction);
   });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/craftTransaction.ts
@@ -1,5 +1,4 @@
 import {
-  AccountId,
   AccountUpdateTransaction,
   ContractExecuteTransaction,
   ContractFunctionParameters,
@@ -12,12 +11,14 @@ import {
 import type { FeeEstimation, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
+import type { HederaConfig } from "../config";
 import {
   DEFAULT_GAS_LIMIT,
   HEDERA_TRANSACTION_MODES,
   TRANSACTION_VALID_DURATION_SECONDS,
 } from "../constants";
 import { rpcClient } from "../network/rpc";
+import { createTransactionId } from "../network/utils";
 import type { HederaMemo, HederaTxData } from "../types";
 import { hasSpecificIntentData, serializeTransaction, toEVMAddress } from "./utils";
 
@@ -26,6 +27,7 @@ interface BuilderOperator {
 }
 
 interface BuilderCommonTransactionFields {
+  transactionId: TransactionId;
   maxFee: BigNumber | undefined;
   memo: string;
 }
@@ -76,7 +78,7 @@ async function buildUnsignedCoinTransaction({
 
   const tx = new TransferTransaction()
     .setTransactionValidDuration(TRANSACTION_VALID_DURATION_SECONDS)
-    .setTransactionId(TransactionId.generate(accountId))
+    .setTransactionId(transaction.transactionId)
     .setTransactionMemo(transaction.memo)
     .addHbarTransfer(accountId, hbarAmount.negated())
     .addHbarTransfer(transaction.recipient, hbarAmount);
@@ -100,7 +102,7 @@ async function buildUnsignedHTSTokenTransaction({
 
   const tx = new TransferTransaction()
     .setTransactionValidDuration(TRANSACTION_VALID_DURATION_SECONDS)
-    .setTransactionId(TransactionId.generate(accountId))
+    .setTransactionId(transaction.transactionId)
     .setTransactionMemo(transaction.memo)
     .addTokenTransfer(tokenId, accountId, transaction.amount.negated().toNumber())
     .addTokenTransfer(tokenId, transaction.recipient, transaction.amount.toNumber());
@@ -113,13 +115,10 @@ async function buildUnsignedHTSTokenTransaction({
 }
 
 async function buildUnsignedERC20TokenTransaction({
-  account,
   transaction,
 }: {
-  account: BuilderOperator;
   transaction: BuilderERC20TokenTransferTransaction;
 }): Promise<ContractExecuteTransaction> {
-  const accountId = AccountId.fromString(account.accountId);
   const contractId = ContractId.fromEvmAddress(0, 0, transaction.tokenAddress);
   const recipientEvmAddress = await toEVMAddress(transaction.recipient);
   invariant(recipientEvmAddress, `hedera: EVM address is missing ${transaction.recipient}`);
@@ -133,7 +132,7 @@ async function buildUnsignedERC20TokenTransaction({
 
   const tx = new ContractExecuteTransaction()
     .setTransactionValidDuration(TRANSACTION_VALID_DURATION_SECONDS)
-    .setTransactionId(TransactionId.generate(accountId))
+    .setTransactionId(transaction.transactionId)
     .setTransactionMemo(transaction.memo ?? "")
     .setContractId(contractId)
     .setGas(gas)
@@ -157,7 +156,7 @@ async function buildTokenAssociateTransaction({
 
   const tx = new TokenAssociateTransaction()
     .setTransactionValidDuration(TRANSACTION_VALID_DURATION_SECONDS)
-    .setTransactionId(TransactionId.generate(accountId))
+    .setTransactionId(transaction.transactionId)
     .setTransactionMemo(transaction.memo)
     .setAccountId(accountId)
     .setTokenIds([transaction.tokenId]);
@@ -180,7 +179,7 @@ async function buildUnsignedUpdateAccountTransaction({
 
   const tx = new AccountUpdateTransaction()
     .setTransactionValidDuration(TRANSACTION_VALID_DURATION_SECONDS)
-    .setTransactionId(TransactionId.generate(accountId))
+    .setTransactionId(transaction.transactionId)
     .setTransactionMemo(transaction.memo ?? "")
     .setAccountId(accountId);
 
@@ -199,12 +198,27 @@ async function buildUnsignedUpdateAccountTransaction({
   return tx.freezeWith(await rpcClient.getInstance());
 }
 
-export async function craftTransaction(
-  txIntent: TransactionIntent<HederaMemo, HederaTxData>,
-  customFees?: FeeEstimation,
-) {
+function isStakingMode(type: string): type is BuilderUpdateAccountTransaction["type"] {
+  return (
+    type === HEDERA_TRANSACTION_MODES.Redelegate ||
+    type === HEDERA_TRANSACTION_MODES.Undelegate ||
+    type === HEDERA_TRANSACTION_MODES.Delegate
+  );
+}
+
+export async function craftTransaction({
+  txIntent,
+  customFees,
+  config,
+}: {
+  txIntent: TransactionIntent<HederaMemo, HederaTxData>;
+  customFees?: FeeEstimation;
+  config: HederaConfig;
+}) {
   const account = { accountId: txIntent.sender };
   const maxFee = customFees ? new BigNumber(customFees.value.toString()) : undefined;
+
+  const transactionId = await createTransactionId(account.accountId, config);
 
   let tx;
 
@@ -216,6 +230,7 @@ export async function craftTransaction(
       account,
       transaction: {
         type: txIntent.type,
+        transactionId,
         tokenId: txIntent.asset.assetReference,
         memo: txIntent.memo.value,
         maxFee,
@@ -230,6 +245,7 @@ export async function craftTransaction(
       account,
       transaction: {
         type: txIntent.type,
+        transactionId,
         tokenAddress: txIntent.asset.assetReference,
         amount,
         recipient: txIntent.recipient,
@@ -246,9 +262,9 @@ export async function craftTransaction(
       : DEFAULT_GAS_LIMIT;
 
     tx = await buildUnsignedERC20TokenTransaction({
-      account,
       transaction: {
         type: txIntent.type,
+        transactionId,
         tokenAddress: txIntent.asset.assetReference,
         amount,
         recipient: txIntent.recipient,
@@ -257,11 +273,7 @@ export async function craftTransaction(
         gasLimit,
       },
     });
-  } else if (
-    txIntent.type === HEDERA_TRANSACTION_MODES.Redelegate ||
-    txIntent.type === HEDERA_TRANSACTION_MODES.Undelegate ||
-    txIntent.type === HEDERA_TRANSACTION_MODES.Delegate
-  ) {
+  } else if (isStakingMode(txIntent.type)) {
     const stakingNodeId = hasSpecificIntentData(txIntent, "staking")
       ? txIntent.data.stakingNodeId
       : undefined;
@@ -270,6 +282,7 @@ export async function craftTransaction(
       account,
       transaction: {
         type: txIntent.type,
+        transactionId,
         memo: txIntent.memo.value,
         maxFee,
         stakingNodeId,
@@ -284,6 +297,7 @@ export async function craftTransaction(
       account,
       transaction: {
         type: HEDERA_TRANSACTION_MODES.Send,
+        transactionId,
         amount,
         recipient: txIntent.recipient,
         memo: txIntent.memo.value,

--- a/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
@@ -87,6 +87,7 @@ import {
   millisToSeconds,
   nanosToSeconds,
   secondsToNanos,
+  toTimestamp,
   createStakingRewardOperationHash,
 } from "./utils";
 
@@ -812,6 +813,22 @@ describe("logic utils", () => {
 
       expect(result.start.getMilliseconds()).toEqual(0);
       expect(result.end.getMilliseconds()).toEqual(0);
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("should parse seconds and nanos from consensus timestamp", () => {
+      const result = toTimestamp("1758733200.632122898");
+
+      expect(result.seconds.toString()).toBe("1758733200");
+      expect(result.nanos.toString()).toBe("632122898");
+    });
+
+    it("should support nanos shorter than 9 digits", () => {
+      const result = toTimestamp("1758733200.6");
+
+      expect(result.seconds.toString()).toBe("1758733200");
+      expect(result.nanos.toString()).toBe("600000000");
     });
   });
 

--- a/libs/coin-modules/coin-hedera/src/logic/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.ts
@@ -2,6 +2,7 @@ import { createHash } from "crypto";
 import {
   AccountId,
   EntityIdHelper,
+  Timestamp,
   Transaction as HederaSDKTransaction,
   TransactionId,
 } from "@hashgraph/sdk";
@@ -820,6 +821,17 @@ export function secondsToNanos(seconds: number | BigNumber): BigNumber {
 
 export function nanosToSeconds(nanos: number | BigNumber): BigNumber {
   return new BigNumber(nanos).dividedBy(10 ** 9);
+}
+
+export function toTimestamp(consensusTimestamp: string): Timestamp {
+  const [secondsPart, nanosPart] = consensusTimestamp.split(".");
+
+  invariant(
+    typeof secondsPart === "string" && typeof nanosPart === "string",
+    `invalid consensus timestamp format: ${consensusTimestamp}`,
+  );
+
+  return new Timestamp(Number(secondsPart), Number(nanosPart.padEnd(9, "0")));
 }
 
 export function createStakingRewardOperationHash(hash: string): string {

--- a/libs/coin-modules/coin-hedera/src/network/api.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.test.ts
@@ -237,6 +237,47 @@ describe("getNetworkFees", () => {
   });
 });
 
+describe("getLatestBlock", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return latest block", async () => {
+    const latestBlock = {
+      timestamp: { from: "1758733199.000000000", to: "1758733200.632122898" },
+    };
+
+    mockedNetwork.mockResolvedValueOnce(
+      getMockResponse({
+        blocks: [latestBlock],
+        links: { next: null },
+      }),
+    );
+
+    const result = await apiClient.getLatestBlock();
+
+    expect(result).toEqual(latestBlock);
+    expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    expect(mockedNetwork.mock.calls[0][0].url).toContain("/api/v1/blocks");
+    expect(mockedNetwork.mock.calls[0][0].url).toContain("limit=1");
+    expect(mockedNetwork.mock.calls[0][0].url).toContain("order=desc");
+  });
+
+  it("should throw when no blocks are returned", async () => {
+    mockedNetwork.mockResolvedValueOnce(
+      getMockResponse({
+        blocks: [],
+        links: { next: null },
+      }),
+    );
+
+    await expect(apiClient.getLatestBlock()).rejects.toThrow(
+      "No blocks found on the Hedera network",
+    );
+    expect(mockedNetwork).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("getContractCallResult", () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/libs/coin-modules/coin-hedera/src/network/api.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.ts
@@ -8,9 +8,11 @@ import { HEDERA_TRANSACTION_NAMES } from "../constants";
 import { HederaAddAccountError } from "../errors";
 import type {
   HederaMirrorAccountTokensResponse,
+  HederaMirrorBlocksResponse,
   HederaMirrorTransactionsResponse,
   HederaMirrorAccount,
   HederaMirrorAccountsResponse,
+  HederaMirrorBlock,
   HederaMirrorToken,
   HederaMirrorTransaction,
   HederaMirrorNetworkFees,
@@ -179,6 +181,25 @@ async function getLatestTransaction(before: Date): Promise<HederaMirrorTransacti
   }
 
   return transaction;
+}
+
+async function getLatestBlock(): Promise<HederaMirrorBlock> {
+  const params = new URLSearchParams({
+    limit: "1",
+    order: "desc",
+  });
+
+  const res = await network<HederaMirrorBlocksResponse>({
+    method: "GET",
+    url: `${API_URL}/api/v1/blocks?${params.toString()}`,
+  });
+  const block = res.data.blocks[0];
+
+  if (!block) {
+    throw new Error("No blocks found on the Hedera network");
+  }
+
+  return block;
 }
 
 async function getNetworkFees(): Promise<HederaMirrorNetworkFees> {
@@ -410,6 +431,7 @@ export const apiClient = {
   getAccount,
   getAccountTokens,
   getAccountTransactions,
+  getLatestBlock,
   getLatestTransaction,
   getNetworkFees,
   getContractCallResult,

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -14,11 +14,13 @@ import {
   getMockedMirrorTransaction,
   getMockedMirrorContractCallResult,
 } from "../test/fixtures/mirror.fixture";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
 import { getMockedThirdwebTransaction } from "../test/fixtures/thirdweb.fixture";
 import type { HederaMirrorCoinTransfer } from "../types";
 import { apiClient } from "./api";
 import { hgraphClient } from "./hgraph";
 import {
+  createTransactionId,
   enrichERC20Transfers,
   getERC20BalancesForAccount,
   getERC20BalancesForAccountV2,
@@ -31,8 +33,62 @@ jest.mock("./api");
 jest.mock("./hgraph");
 
 describe("network utils", () => {
+  const defaultConfig = getMockedConfig();
+
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("createTransactionId", () => {
+    it("should use mirror node timestamp when feature flag is enabled", async () => {
+      (apiClient.getLatestBlock as jest.Mock).mockResolvedValue({
+        timestamp: { from: "1758733200.632122898", to: null },
+      });
+
+      const result = await createTransactionId("0.0.54321", {
+        ...defaultConfig,
+        useNetworkTimestamp: true,
+      });
+
+      expect(apiClient.getLatestBlock).toHaveBeenCalledTimes(1);
+      expect(result.validStart?.seconds.toString()).toEqual("1758733200");
+      expect(result.validStart?.nanos.toString()).toEqual("632122898");
+    });
+
+    it("should fallback to system timestamp when latest block fetch fails", async () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2000-01-01T00:00:00.000Z"));
+      (apiClient.getLatestBlock as jest.Mock).mockRejectedValue(new Error("network unavailable"));
+
+      const result = await createTransactionId("0.0.54321", {
+        ...defaultConfig,
+        useNetworkTimestamp: true,
+      });
+
+      const localSkewSeconds = Number(result.validStart?.seconds.toString());
+      expect(apiClient.getLatestBlock).toHaveBeenCalledTimes(1);
+      expect(localSkewSeconds).toBeGreaterThanOrEqual(946684700);
+      expect(localSkewSeconds).toBeLessThanOrEqual(946684800);
+    });
+
+    it("should use system timestamp when feature flag is disabled", async () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2000-01-01T00:00:00.000Z"));
+
+      const result = await createTransactionId("0.0.54321", {
+        ...defaultConfig,
+        useNetworkTimestamp: false,
+      });
+
+      const localSkewSeconds = Number(result.validStart?.seconds.toString());
+      expect(apiClient.getLatestBlock).not.toHaveBeenCalled();
+      expect(localSkewSeconds).toBeGreaterThanOrEqual(946684700);
+      expect(localSkewSeconds).toBeLessThanOrEqual(946684800);
+    });
   });
 
   describe("parseTransfers", () => {
@@ -314,20 +370,20 @@ describe("network utils", () => {
           },
         },
       });
-      const mockContractCallResult = {
+      const mockContractCallResult = getMockedMirrorContractCallResult({
         timestamp: "1234567890.000000000",
         contract_id: mockTokenERC20.contractAddress,
         gas_consumed: 50000,
         gas_limit: 100000,
         gas_used: 50000,
-      };
-      const mockMirrorTransaction = {
+      });
+      const mockMirrorTransaction = getMockedMirrorTransaction({
         consensus_timestamp: mockContractCallResult.timestamp,
         transaction_hash: "BASE64HASH",
         transaction_id: "0.0.123@1234567890.000",
         charged_tx_fee: 100000,
         memo_base64: "",
-      };
+      });
 
       (apiClient.getContractCallResult as jest.Mock).mockResolvedValue(mockContractCallResult);
       (apiClient.findTransactionByContractCall as jest.Mock).mockResolvedValue(
@@ -383,17 +439,12 @@ describe("network utils", () => {
         transactionHash: "0xTXHASH1",
         address: mockTokenERC20.contractAddress,
       });
-      const mockContractCallResult = {
+      const mockContractCallResult = getMockedMirrorContractCallResult({
         timestamp: "1234567890.000000000",
         contract_id: mockTokenERC20.contractAddress,
-        gas_consumed: 50000,
-        gas_limit: 100000,
-        gas_used: 50000,
-      };
+      });
 
-      (apiClient.getContractCallResult as jest.Mock).mockResolvedValue(
-        mockContractCallResult as any,
-      );
+      (apiClient.getContractCallResult as jest.Mock).mockResolvedValue(mockContractCallResult);
       (apiClient.findTransactionByContractCall as jest.Mock).mockResolvedValue(null);
       setupMockCryptoAssetsStore({
         findTokenByAddressInCurrency: jest.fn().mockReturnValue(mockTokenERC20),

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -1,11 +1,12 @@
-import { AccountId } from "@hashgraph/sdk";
+import { AccountId, TransactionId } from "@hashgraph/sdk";
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets/state";
 import { getEnv } from "@ledgerhq/live-env";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
+import type { HederaConfig } from "../config";
 import { SUPPORTED_ERC20_TOKENS } from "../constants";
-import { nanosToSeconds, toEntityId } from "../logic/utils";
+import { nanosToSeconds, toEntityId, toTimestamp } from "../logic/utils";
 import type {
   HederaMirrorTokenTransfer,
   HederaMirrorCoinTransfer,
@@ -18,6 +19,24 @@ import type {
 } from "../types";
 import { apiClient } from "./api";
 import { hgraphClient } from "./hgraph";
+
+export async function createTransactionId(
+  accountId: string,
+  config: HederaConfig,
+): Promise<TransactionId> {
+  if (!config.useNetworkTimestamp) {
+    return TransactionId.generate(accountId);
+  }
+
+  try {
+    const lastBlock = await apiClient.getLatestBlock();
+    const validStart = toTimestamp(lastBlock.timestamp.to ?? lastBlock.timestamp.from);
+
+    return TransactionId.withValidStart(AccountId.fromString(accountId), validStart);
+  } catch {
+    return TransactionId.generate(accountId);
+  }
+}
 
 function isValidRecipient(accountId: AccountId, recipients: string[]): boolean {
   if (accountId.shard.eq(0) && accountId.realm.eq(0)) {

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/config.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/config.fixture.ts
@@ -4,5 +4,6 @@ export const getMockedConfig = (): HederaCoinConfig => {
   return {
     status: { type: "active" },
     useHgraphForErc20: false,
+    useNetworkTimestamp: false,
   };
 };

--- a/libs/coin-modules/coin-hedera/src/types/mirror.ts
+++ b/libs/coin-modules/coin-hedera/src/types/mirror.ts
@@ -81,6 +81,20 @@ export interface HederaMirrorTransactionsResponse {
   };
 }
 
+export interface HederaMirrorBlock {
+  timestamp: {
+    from: string;
+    to: string | null;
+  };
+}
+
+export interface HederaMirrorBlocksResponse {
+  blocks: HederaMirrorBlock[];
+  links: {
+    next: string | null;
+  };
+}
+
 export interface HederaMirrorNetworkFees {
   fees: {
     gas: number;

--- a/libs/ledger-live-common/src/families/hedera/config.ts
+++ b/libs/ledger-live-common/src/families/hedera/config.ts
@@ -9,6 +9,7 @@ export const hederaConfig: Record<string, ConfigInfo> = {
         features: [{ id: "blockchain_txs", status: "active" }],
       },
       useHgraphForErc20: true,
+      useNetworkTimestamp: true,
     },
   },
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add an optional mirror-node timestamp path for Hedera transaction creation to reduce INVALID_TRANSACTION_START failures caused by local clock drift, with safe fallback to system time behind a feature flag.

### 📝 Description

This PR adds an optional mirror-node timestamp path for Hedera transaction creation to reduce INVALID_TRANSACTION_START failures caused by local clock drift, with safe fallback to system time behind a feature flag.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-28106

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
