### PR TITLE
[LWD] Fix Recover webview not reloading when the same deeplink is opened while already on Recover

### DIFF
--- a/.changeset/calm-foxes-remount.md
+++ b/.changeset/calm-foxes-remount.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Recover webview not reloading when the same deeplink is opened while already on Recover

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/recover.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/recover.handler.test.ts
@@ -37,6 +37,33 @@ describe("recover.handler", () => {
       expect(context.navigate).toHaveBeenCalledWith("/recover/platform", undefined, "?step=2");
     });
 
+    it("merges location state and bumps recoverDeeplinkAt when already on the same recover URL", () => {
+      const context = createMockContext({
+        currentPathname: "/recover/platform",
+        currentSearch: "?step=2",
+        currentLocationState: { deviceId: "device-1", fromOnboarding: true },
+      });
+
+      recoverHandler(
+        {
+          type: "recover",
+          path: "platform",
+          search: "?step=2",
+        },
+        context,
+      );
+
+      expect(context.navigate).toHaveBeenCalledWith(
+        "/recover/platform",
+        expect.objectContaining({
+          deviceId: "device-1",
+          fromOnboarding: true,
+          recoverDeeplinkAt: expect.any(String),
+        }),
+        "?step=2",
+      );
+    });
+
     it("handles empty path by navigating to /recover/ when no recoverAppId in context", () => {
       const context = createMockContext();
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/test-utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/test-utils.ts
@@ -12,6 +12,8 @@ export const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
   accountsPath: "/accounts",
   ...overrides,
 });

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/recover.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/recover.handler.ts
@@ -1,10 +1,35 @@
+import type { RecoverState } from "~/renderer/screens/recover/Player";
 import { DeeplinkHandler } from "../types";
 
-export const recoverHandler: DeeplinkHandler<"recover"> = (route, { navigate, recoverAppId }) => {
+export const recoverHandler: DeeplinkHandler<"recover"> = (route, context) => {
   const { path, search } = route;
+  const { navigate, recoverAppId, currentPathname, currentSearch, currentLocationState } = context;
   // When no path (e.g. ledgerwallet://recover), use default Ledger Recover app id from feature flag
   const appId = path || recoverAppId || "";
-  navigate(`/recover/${appId}`, undefined, search);
+  const targetPath = `/recover/${appId}`;
+  const isSameRecoverRoute = targetPath === currentPathname && search === currentSearch;
+
+  /**
+   * useDeepLinkHandler.navigate skips routerNavigate when pathname + search + state are unchanged.
+   * Recover email links often repeat the same URL while the user already has Recover open; we still
+   * need a navigation + webview remount so the embedded app can advance (see RecoverPlayer key).
+   */
+  let navigationState: RecoverState | undefined;
+  if (isSameRecoverRoute) {
+    const prev =
+      currentLocationState !== null &&
+      currentLocationState !== undefined &&
+      typeof currentLocationState === "object" &&
+      !Array.isArray(currentLocationState)
+        ? { ...currentLocationState }
+        : {};
+    navigationState = {
+      ...prev,
+      recoverDeeplinkAt: String(Date.now()),
+    };
+  }
+
+  navigate(targetPath, navigationState, search);
 };
 
 export const recoverRestoreFlowHandler: DeeplinkHandler<"recover-restore-flow"> = (

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
@@ -4,7 +4,7 @@ import type { AppDispatch } from "~/state-manager/configureStore";
 
 export type NavigateFn = (
   pathname: string,
-  state?: { [k: string]: string | object },
+  state?: { [k: string]: string | number | boolean | object | null | undefined },
   search?: string,
 ) => void;
 
@@ -37,6 +37,10 @@ export interface DeeplinkHandlerContext {
   postOnboardingDeeplinkHandler: PostOnboardingDeeplinkHandlerFn;
   tryRedirectToPostOnboardingOrRecover: TryRedirectToPostOnboardingOrRecoverFn;
   currentPathname: string;
+  /** Current URL search (e.g. `?foo=bar`), used to detect repeated Recover deeplinks. */
+  currentSearch: string;
+  /** Current React Router location state (used to preserve fields when forcing Recover navigation). */
+  currentLocationState: unknown;
   /** Feature-flag-aware path to the accounts list screen (`/cryptos` or `/accounts`). */
   accountsPath: string;
   /** Default Ledger Recover app id (from feature flag) for recover deeplink when no path is given */

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
@@ -43,7 +43,7 @@ export function useDeepLinkHandler() {
   const accountsPath = getAccountsSidebarPath(shouldDisplayAssetSection);
 
   const navigate: NavigateFn = useCallback(
-    (pathname: string, state?: { [k: string]: string | object }, search?: string) => {
+    (pathname: string, state?: Parameters<NavigateFn>[1], search?: string) => {
       const hasNewPathname = pathname !== location.pathname;
       const hasNewSearch = typeof search === "string" && search !== location.search;
       const hasNewState = JSON.stringify(state) !== JSON.stringify(location.state);
@@ -71,6 +71,8 @@ export function useDeepLinkHandler() {
       postOnboardingDeeplinkHandler,
       tryRedirectToPostOnboardingOrRecover,
       currentPathname: location.pathname,
+      currentSearch: location.search,
+      currentLocationState: location.state,
       accountsPath,
       recoverAppId,
     }),
@@ -84,6 +86,8 @@ export function useDeepLinkHandler() {
       postOnboardingDeeplinkHandler,
       tryRedirectToPostOnboardingOrRecover,
       location.pathname,
+      location.search,
+      location.state,
       accountsPath,
       recoverAppId,
     ],

--- a/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
@@ -31,6 +31,8 @@ export type RecoverState = {
   fromOnboarding?: boolean;
   deviceId?: string;
   seedConfiguration?: SeedOriginType;
+  /** Bumped on repeated same-URL Recover deeplinks so the webview remounts with a fresh load. */
+  recoverDeeplinkAt?: string;
 };
 
 const FullscreenWrapper = styled.div`
@@ -125,7 +127,12 @@ export default function RecoverPlayer() {
 
   return manifest ? (
     <FullscreenWrapper>
-      <WebRecoverPlayer manifest={manifest} inputs={inputs} onClose={onClose} />
+      <WebRecoverPlayer
+        key={`${manifest.id}-${search}-${state?.recoverDeeplinkAt ?? ""}`}
+        manifest={manifest}
+        inputs={inputs}
+        onClose={onClose}
+      />
     </FullscreenWrapper>
   ) : null; // TODO: display an error component instead of `null`
 }


### PR DESCRIPTION
Ensure that clicking a Recover deeplink (e.g. from an email) triggers a refresh even if the user is already on the same screen. This is achieved by bumping a `recoverDeeplinkAt` timestamp in the navigation state and using it as a React key to force the webview to remount.

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request addresses an issue where the Recover webview was not reloading when the same deeplink was opened repeatedly while already on the Recover screen. The changes ensure that repeated deeplinks to the same Recover URL will now force a remount of the webview, allowing the embedded app to advance as expected. Additional improvements were made to deeplink handler context and navigation state management to support this fix.

https://github.com/user-attachments/assets/908881b8-acc1-44f8-8f3b-00126ebe6ab2

### ❓ Context

[LIVE-29487](https://ledgerhq.atlassian.net/browse/LIVE-29487)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29487]: https://ledgerhq.atlassian.net/browse/LIVE-29487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ