### PR TITLE
[LWD] fix(desktop): normalize sync onboarding genuine check errors

### DIFF
--- a/.changeset/quiet-mice-jog.md
+++ b/.changeset/quiet-mice-jog.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Normalize SyncOnboarding genuine check errors on desktop

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
@@ -26,6 +26,7 @@ import { useNavigate } from "react-router";
 import { NetworkDown } from "@ledgerhq/errors";
 import { NetworkStatus, useNetworkStatus } from "~/renderer/hooks/useNetworkStatus";
 import { urls } from "~/config/urls";
+import { normalizeGenuineCheckError } from "./normalizeGenuineCheckError";
 
 export type Props = {
   onComplete: () => void;
@@ -271,7 +272,7 @@ const EarlySecurityChecks = ({
             resetGenuineCheckState();
             setGenuineCheckStatus(SoftwareCheckStatus.active);
           },
-          error: genuineCheckError,
+          error: normalizeGenuineCheckError(genuineCheckError),
         },
         commonDrawerProps,
       );
@@ -303,7 +304,7 @@ const EarlySecurityChecks = ({
             resetGenuineCheckState();
             setGenuineCheckStatus(SoftwareCheckStatus.active);
           },
-          error: new NetworkDown(),
+          error: normalizeGenuineCheckError(new NetworkDown()),
         },
         commonDrawerProps,
       );

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/normalizeGenuineCheckError.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/normalizeGenuineCheckError.test.ts
@@ -1,0 +1,22 @@
+import { GenuineCheckFailed, NetworkDown } from "@ledgerhq/errors";
+import { normalizeGenuineCheckError } from "./normalizeGenuineCheckError";
+
+describe("normalizeGenuineCheckError", () => {
+  it("should wrap the original error as GenuineCheckFailed", () => {
+    const originalError = new Error("spoofed error");
+
+    const normalizedError = normalizeGenuineCheckError(originalError);
+
+    expect(normalizedError).toBeInstanceOf(GenuineCheckFailed);
+    expect(normalizedError.cause).toBe(originalError);
+  });
+
+  it("should preserve a network error as the cause", () => {
+    const originalError = new NetworkDown();
+
+    const normalizedError = normalizeGenuineCheckError(originalError);
+
+    expect(normalizedError).toBeInstanceOf(GenuineCheckFailed);
+    expect(normalizedError.cause).toBe(originalError);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/normalizeGenuineCheckError.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/normalizeGenuineCheckError.ts
@@ -1,0 +1,6 @@
+import { GenuineCheckFailed } from "@ledgerhq/errors";
+import { DmkError } from "@ledgerhq/live-dmk-desktop";
+
+export function normalizeGenuineCheckError(error: Error | DmkError) {
+  return new GenuineCheckFailed("", undefined, { cause: error });
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - SyncOnboarding desktop Early Security Checks error presentation
  - Genuine check retry flow on desktop for touchscreen devices
  - Regression coverage for normalized genuine check failures

### 📝 Description

This PR aligns the SyncOnboarding desktop genuine check flow with the existing desktop onboarding behavior by standardizing the error shown when the genuine check fails during Early Security Checks.

Instead of surfacing raw underlying errors in that step, the desktop flow now routes those failures through a single generic failed genuine check error while preserving the original cause for debugging. The change is scoped to desktop SyncOnboarding, keeps the existing drawer UX, and adds focused test coverage for the normalization helper.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
