### PR TITLE
[LWM] fix(mobile): align native launch screen background to black

### DIFF
--- a/.changeset/calm-splash-screens-match.md
+++ b/.changeset/calm-splash-screens-match.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Set native launch screen background to pure black on iOS and Android

--- a/apps/ledger-live-mobile/android/app/src/main/res/layout/launch_screen.xml
+++ b/apps/ledger-live-mobile/android/app/src/main/res/layout/launch_screen.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     android:gravity="center"
     android:orientation="vertical"
-    android:background="#131214">
+    android:background="#000000">
     <ImageView
         android:id="@+id/imageView"
         android:layout_width="match_parent"

--- a/apps/ledger-live-mobile/android/app/src/main/res/values-v31/styles.xml
+++ b/apps/ledger-live-mobile/android/app/src/main/res/values-v31/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="AppTheme.Splash" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <item name="windowSplashScreenBackground">#131214</item>
+        <item name="windowSplashScreenBackground">#000000</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_logo</item>
         <item name="android:windowActionBar">false</item>
         <item name="postSplashScreenTheme">@style/AppTheme</item>

--- a/apps/ledger-live-mobile/android/app/src/main/res/values/styles.xml
+++ b/apps/ledger-live-mobile/android/app/src/main/res/values/styles.xml
@@ -12,11 +12,11 @@
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowActionBar">false</item>
         <item name="android:forceDarkAllowed">false</item>
-        <item name="android:windowBackground">#131214</item>
+        <item name="android:windowBackground">#000000</item>
     </style>
 
     <!-- Fallback splash for pre-Android 12 -->
     <style name="AppTheme.Splash" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <item name="android:windowBackground">#131214</item>
+        <item name="android:windowBackground">#000000</item>
     </style>
 </resources>

--- a/apps/ledger-live-mobile/ios/LaunchScreen.storyboard
+++ b/apps/ledger-live-mobile/ios/LaunchScreen.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24128" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,7 +21,7 @@
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
-                        <color key="backgroundColor" red="0.074509803921568626" green="0.070588235294117646" blue="0.078431372549019607" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0" green="0" blue="0" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="2tu-j2-iR2" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="centerX"/>
                             <constraint firstItem="2tu-j2-iR2" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" id="centerY"/>
@@ -35,7 +35,8 @@
             <point key="canvasLocation" x="-170.22900763358777" y="93.661971830985919"/>
         </scene>
     </scenes>
+    <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
     <resources>
-        <image name="splash_logo.png" width="640" height="640"/>
+        <image name="splash_logo.png" width="1920" height="1920"/>
     </resources>
 </document>

--- a/apps/ledger-live-mobile/src/mvvm/features/LaunchScreen/components/LottieLauncher.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LaunchScreen/components/LottieLauncher.tsx
@@ -35,6 +35,6 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "#131214",
+    backgroundColor: "#000000",
   },
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/LaunchScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LaunchScreen/index.tsx
@@ -62,7 +62,7 @@ export const AppLoadingManager: React.FC<AppLoadingManagerProps> = ({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#131214",
+    backgroundColor: "#000000",
   },
   absoluteFill: {
     position: "absolute",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Native launch screen XML/storyboard only; not covered by Jest._
- [x] **Impact of the changes:**
      - Cold start splash screen on iOS and Android (native launch screen before JS loads)
      - Visual consistency of background color with pure black (#000000)

### 📝 Description

**Problem:** The native splash screen used a dark gray background (`#131214` on Android, equivalent gray on iOS) instead of pure black, which could look inconsistent with the app shell and design intent.

**Solution:** Updated the Android `launch_screen.xml` background to `#000000` and the iOS `LaunchScreen.storyboard` view background to pure black (`RGB 0,0,0`). Saving the storyboard also refreshed Interface Builder metadata (tools/plugin versions), splash image dimensions in resources, and added a document-level tint color.

| IOS | ANDROID |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/c5fd0d70-0fa1-48a5-bd3b-8c11d89791f3" />|<video src="https://github.com/user-attachments/assets/e3c18be2-1f98-4e33-8c78-2b0f2ab59e66" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29492](https://ledgerhq.atlassian.net/browse/LIVE-29492)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29492]: https://ledgerhq.atlassian.net/browse/LIVE-29492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ