### PR TITLE
[LWM] feat(mobile): add Help Support section to MyWallet

### DIFF
--- a/.changeset/brave-foxes-learn.md
+++ b/.changeset/brave-foxes-learn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add Support and Learning section with Ledger Support and Ledger Academy rows to MyWallet Help screen

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8865,6 +8865,16 @@
       "sections": {
         "supportAndLearning": "Support and learning",
         "more": "More"
+      },
+      "rows": {
+        "ledgerSupport": {
+          "title": "Ledger Support",
+          "description": "Get help with our FAQs or chat"
+        },
+        "ledgerAcademy": {
+          "title": "Ledger Academy",
+          "description": "Learn crypto"
+        }
       }
     },
     "deviceSection": {

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/__tests__/MyWalletHelpScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/__tests__/MyWalletHelpScreen.test.tsx
@@ -1,23 +1,34 @@
 import React from "react";
-import { render, screen } from "@tests/test-renderer";
+import { Linking } from "react-native";
+import { render, screen, fireEvent } from "@tests/test-renderer";
 import { MyWalletHelpScreen } from "../index";
+import { urls } from "~/utils/urls";
 
-jest.mock("~/analytics", () => ({
-  ...jest.requireActual("~/analytics"),
-  TrackScreen: () => null,
+jest.mock("LLM/hooks/useLocalizedUrls", () => ({
+  useLocalizedUrl: (url: string) => url,
 }));
 
 describe("MyWalletHelpScreen", () => {
-  it("should render both section headers", () => {
-    render(<MyWalletHelpScreen />);
-
-    expect(screen.getByText("Support and learning")).toBeVisible();
-    expect(screen.getByText("More")).toBeVisible();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
   });
 
-  it("should render the scrollable container", () => {
+  it("should render all sections and rows, and open correct URLs on press", () => {
     render(<MyWalletHelpScreen />);
 
     expect(screen.getByTestId("my-wallet-help-screen")).toBeVisible();
+    expect(screen.getByText(/support and learning/i)).toBeVisible();
+    expect(screen.getByText(/more/i)).toBeVisible();
+    expect(screen.getByText(/ledger support/i)).toBeVisible();
+    expect(screen.getByText(/get help with our faqs or chat/i)).toBeVisible();
+    expect(screen.getByText(/ledger academy/i)).toBeVisible();
+    expect(screen.getByText(/learn crypto/i)).toBeVisible();
+
+    fireEvent.press(screen.getByTestId("help-ledger-support-row"));
+    expect(Linking.openURL).toHaveBeenCalledWith(urls.faq);
+
+    fireEvent.press(screen.getByTestId("help-ledger-academy-row"));
+    expect(Linking.openURL).toHaveBeenCalledWith(urls.resources.ledgerAcademy);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/components/HelpListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/components/HelpListItem.tsx
@@ -1,0 +1,41 @@
+import React, { ComponentType, memo } from "react";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+  type IconProps,
+} from "@ledgerhq/lumen-ui-rnative";
+import { ChevronRight, ExternalLink } from "@ledgerhq/lumen-ui-rnative/symbols";
+
+type Props = {
+  onPress: () => void;
+  title: string;
+  description: string;
+  icon: ComponentType<IconProps>;
+  trailing?: "externalLink" | "chevron";
+  testID?: string;
+};
+
+export const HelpListItem = memo(
+  ({ onPress, title, description, icon: Icon, trailing = "externalLink", testID }: Props) => (
+    <ListItem onPress={onPress} testID={testID} lx={{ marginHorizontal: "-s8" }}>
+      <ListItemLeading>
+        <Icon size={24} />
+        <ListItemContent>
+          <ListItemTitle>{title}</ListItemTitle>
+          <ListItemDescription>{description}</ListItemDescription>
+        </ListItemContent>
+      </ListItemLeading>
+      <ListItemTrailing>
+        {trailing === "externalLink" ? (
+          <ExternalLink size={24} color="base" />
+        ) : (
+          <ChevronRight size={24} color="base" />
+        )}
+      </ListItemTrailing>
+    </ListItem>
+  ),
+);

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/index.tsx
@@ -1,21 +1,45 @@
 import React from "react";
 import { ScrollView } from "react-native";
 import { Box, Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-rnative";
+import { LifeRing, Information } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useTranslation } from "~/context/Locale";
 import { TrackScreen } from "~/analytics";
+import { useMyWalletHelpViewModel } from "./useMyWalletHelpViewModel";
+import { HelpListItem } from "./components/HelpListItem";
 
 export function MyWalletHelpScreen() {
   const { t } = useTranslation();
+  const { isChatbotEnabled, onLedgerSupportPress, onLedgerAcademyPress } =
+    useMyWalletHelpViewModel();
 
   return (
     <ScrollView testID="my-wallet-help-screen">
       <TrackScreen category="MyWallet" name="Help" />
       <Box lx={{ paddingHorizontal: "s16", paddingTop: "s24", gap: "s24" }}>
-        <Subheader>
-          <SubheaderRow testID="my-wallet-help-section-support">
-            <SubheaderTitle>{t("myWallet.help.sections.supportAndLearning")}</SubheaderTitle>
-          </SubheaderRow>
-        </Subheader>
+        <Box lx={{ gap: "s8" }}>
+          <Subheader>
+            <SubheaderRow testID="my-wallet-help-section-support">
+              <SubheaderTitle>{t("myWallet.help.sections.supportAndLearning")}</SubheaderTitle>
+            </SubheaderRow>
+          </Subheader>
+          <HelpListItem
+            onPress={onLedgerSupportPress}
+            testID="help-ledger-support-row"
+            icon={LifeRing}
+            title={
+              isChatbotEnabled ? t("help.chatbot") : t("myWallet.help.rows.ledgerSupport.title")
+            }
+            description={t("myWallet.help.rows.ledgerSupport.description")}
+          />
+          <HelpListItem
+            onPress={onLedgerAcademyPress}
+            testID="help-ledger-academy-row"
+            icon={Information}
+            title={t("myWallet.help.rows.ledgerAcademy.title")}
+            description={t("myWallet.help.rows.ledgerAcademy.description")}
+          />
+        </Box>
+
         <Subheader>
           <SubheaderRow testID="my-wallet-help-section-more">
             <SubheaderTitle>{t("myWallet.help.sections.more")}</SubheaderTitle>

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/useMyWalletHelpViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/useMyWalletHelpViewModel.ts
@@ -1,0 +1,32 @@
+import { useCallback } from "react";
+import { Linking } from "react-native";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
+import { urls } from "~/utils/urls";
+import { track } from "~/analytics";
+import { ScreenName } from "~/const";
+
+export function useMyWalletHelpViewModel() {
+  const chatbotSupportFeature = useFeature("llmChatbotSupport");
+  const isChatbotEnabled = chatbotSupportFeature?.enabled ?? false;
+
+  const localizedFaqUrl = useLocalizedUrl(urls.faq);
+  const localizedChatbotUrl = useLocalizedUrl(urls.chatbot);
+  const localizedAcademyUrl = useLocalizedUrl(urls.resources.ledgerAcademy);
+
+  const onLedgerSupportPress = useCallback(() => {
+    track("button_clicked", { button: "LedgerSupport", page: ScreenName.MyWalletHelp });
+    Linking.openURL(isChatbotEnabled ? localizedChatbotUrl : localizedFaqUrl);
+  }, [isChatbotEnabled, localizedChatbotUrl, localizedFaqUrl]);
+
+  const onLedgerAcademyPress = useCallback(() => {
+    track("button_clicked", { button: "LedgerAcademy", page: ScreenName.MyWalletHelp });
+    Linking.openURL(localizedAcademyUrl);
+  }, [localizedAcademyUrl]);
+
+  return {
+    isChatbotEnabled,
+    onLedgerSupportPress,
+    onLedgerAcademyPress,
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit tests for the Help screen rows and interactions.
- [x] **Impact of the changes:**
      - MyWallet Help screen: new Support and Learning section with Ledger Support and Ledger Academy rows

### 📝 Description

Add the "Support and learning" section to the new Wallet 4.0 MyWallet Help screen:
- **Ledger Support** row: opens Ledger support URL (or chatbot if `llmChatbotSupport` feature flag is enabled)
- **Ledger Academy** row: opens Ledger Academy URL in the browser

Both rows use Lumen UI `ListItem` components following the MVVM pattern with a dedicated `useMyWalletHelpViewModel` hook.

### ❓ Context
<img width="350" height="750" alt="Simulator Screenshot - Test Ios - 2026-04-22 at 09 40 10" src="https://github.com/user-attachments/assets/9904245f-9684-41b3-8c0d-9bb2116ef718" />

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-26559

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.