### PR TITLE
[LWM] feat(mobile): add Help More section to MyWallet

### DIFF
--- a/.changeset/gentle-doors-clear.md
+++ b/.changeset/gentle-doors-clear.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add More section with Save logs, Ledger Status and Clear cache rows to MyWallet Help screen

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8886,6 +8886,18 @@
         "ledgerAcademy": {
           "title": "Ledger Academy",
           "description": "Learn crypto"
+        },
+        "saveLogs": {
+          "title": "Save logs",
+          "description": "Save Ledger Wallet logs for troubleshooting"
+        },
+        "ledgerStatus": {
+          "title": "Ledger Status",
+          "description": "Check our system status"
+        },
+        "clearCache": {
+          "title": "Clear cache",
+          "description": "Scan transactions and recalculate balances"
         }
       }
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/__tests__/MyWalletHelpScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/__tests__/MyWalletHelpScreen.test.tsx
@@ -1,11 +1,45 @@
 import React from "react";
 import { Linking } from "react-native";
-import { render, screen, fireEvent } from "@tests/test-renderer";
+import { render, screen } from "@tests/test-renderer";
 import { MyWalletHelpScreen } from "../index";
 import { urls } from "~/utils/urls";
 
 jest.mock("LLM/hooks/useLocalizedUrls", () => ({
   useLocalizedUrl: (url: string) => url,
+}));
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const RN = require("react-native");
+  const actual = jest.requireActual("@ledgerhq/lumen-ui-rnative");
+  return {
+    ...actual,
+    BottomSheetView: ({ children }: { children: React.ReactNode }) => <RN.View>{children}</RN.View>,
+    BottomSheetHeader: () => <RN.View testID="bottom-sheet-header" />,
+  };
+});
+
+jest.mock("LLM/components/QueuedDrawer/QueuedDrawerBottomSheet", () => {
+  const { View } = require("react-native");
+  return function MockQueuedDrawerBottomSheet({
+    children,
+    isRequestingToBeOpened,
+  }: {
+    children: React.ReactNode;
+    isRequestingToBeOpened: boolean;
+  }) {
+    if (!isRequestingToBeOpened) return null;
+    return <View testID="queued-drawer-bottom-sheet">{children}</View>;
+  };
+});
+
+const mockExportLogs = jest.fn();
+jest.mock("~/components/useExportLogs", () => ({
+  __esModule: true,
+  default: () => mockExportLogs,
+}));
+
+jest.mock("~/actions/general", () => ({
+  useCleanCache: jest.fn(() => jest.fn()),
 }));
 
 describe("MyWalletHelpScreen", () => {
@@ -14,8 +48,15 @@ describe("MyWalletHelpScreen", () => {
     jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
   });
 
-  it("should render all sections and rows, and open correct URLs on press", () => {
+  it("should render both section headers", () => {
     render(<MyWalletHelpScreen />);
+
+    expect(screen.getByText("Support and learning")).toBeVisible();
+    expect(screen.getByText("More")).toBeVisible();
+  });
+
+  it("should render all sections and rows, and open correct URLs on press", async () => {
+    const { user } = render(<MyWalletHelpScreen />);
 
     expect(screen.getByTestId("my-wallet-help-screen")).toBeVisible();
     expect(screen.getByText(/support and learning/i)).toBeVisible();
@@ -25,10 +66,55 @@ describe("MyWalletHelpScreen", () => {
     expect(screen.getByText(/ledger academy/i)).toBeVisible();
     expect(screen.getByText(/learn crypto/i)).toBeVisible();
 
-    fireEvent.press(screen.getByTestId("help-ledger-support-row"));
+    await user.press(screen.getByTestId("help-ledger-support-row"));
     expect(Linking.openURL).toHaveBeenCalledWith(urls.faq);
 
-    fireEvent.press(screen.getByTestId("help-ledger-academy-row"));
+    await user.press(screen.getByTestId("help-ledger-academy-row"));
     expect(Linking.openURL).toHaveBeenCalledWith(urls.resources.ledgerAcademy);
+  });
+
+  it("should render Save logs row", () => {
+    render(<MyWalletHelpScreen />);
+
+    expect(screen.getByText("Save logs")).toBeVisible();
+    expect(screen.getByText("Save Ledger Wallet logs for troubleshooting")).toBeVisible();
+  });
+
+  it("should render Ledger Status row", () => {
+    render(<MyWalletHelpScreen />);
+
+    expect(screen.getByText("Ledger Status")).toBeVisible();
+    expect(screen.getByText("Check our system status")).toBeVisible();
+  });
+
+  it("should render Clear cache row", () => {
+    render(<MyWalletHelpScreen />);
+
+    expect(screen.getByText("Clear cache")).toBeVisible();
+    expect(screen.getByText("Scan transactions and recalculate balances")).toBeVisible();
+  });
+
+  it("should call export logs when Save logs is pressed", async () => {
+    const { user } = render(<MyWalletHelpScreen />);
+
+    await user.press(screen.getByTestId("help-save-logs-row"));
+
+    expect(mockExportLogs).toHaveBeenCalled();
+  });
+
+  it("should open status URL when Ledger Status is pressed", async () => {
+    const { user } = render(<MyWalletHelpScreen />);
+
+    await user.press(screen.getByTestId("help-ledger-status-row"));
+
+    expect(Linking.openURL).toHaveBeenCalledWith("https://status.ledger.com");
+  });
+
+  it("should open clear cache drawer when Clear cache is pressed", async () => {
+    const { user } = render(<MyWalletHelpScreen />);
+
+    await user.press(screen.getByTestId("help-clear-cache-row"));
+
+    expect(screen.getByText("Clear")).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/index.tsx
@@ -1,51 +1,132 @@
 import React from "react";
 import { ScrollView } from "react-native";
-import { Box, Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-rnative";
-import { LifeRing, Information } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  Box,
+  BottomSheetHeader,
+  BottomSheetView,
+  Button,
+  Subheader,
+  SubheaderRow,
+  SubheaderTitle,
+  Text,
+  Spot,
+} from "@ledgerhq/lumen-ui-rnative";
+import { Download, Information, LifeRing, Trash } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useTranslation } from "~/context/Locale";
 import { TrackScreen } from "~/analytics";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import { useMyWalletHelpViewModel } from "./useMyWalletHelpViewModel";
 import { HelpListItem } from "./components/HelpListItem";
 
 export function MyWalletHelpScreen() {
   const { t } = useTranslation();
-  const { isChatbotEnabled, onLedgerSupportPress, onLedgerAcademyPress } =
-    useMyWalletHelpViewModel();
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const {
+    isChatbotEnabled,
+    onLedgerSupportPress,
+    onLedgerAcademyPress,
+    onSaveLogsPress,
+    onLedgerStatusPress,
+    onClearCachePress,
+    onClearCacheConfirm,
+    isClearCacheDrawerOpen,
+    onClearCacheDrawerClose,
+  } = useMyWalletHelpViewModel();
 
   return (
-    <ScrollView testID="my-wallet-help-screen">
-      <TrackScreen category="MyWallet" name="Help" />
-      <Box lx={{ paddingHorizontal: "s16", paddingTop: "s24", gap: "s24" }}>
-        <Box lx={{ gap: "s8" }}>
-          <Subheader>
-            <SubheaderRow testID="my-wallet-help-section-support">
-              <SubheaderTitle>{t("myWallet.help.sections.supportAndLearning")}</SubheaderTitle>
-            </SubheaderRow>
-          </Subheader>
-          <HelpListItem
-            onPress={onLedgerSupportPress}
-            testID="help-ledger-support-row"
-            icon={LifeRing}
-            title={
-              isChatbotEnabled ? t("help.chatbot") : t("myWallet.help.rows.ledgerSupport.title")
-            }
-            description={t("myWallet.help.rows.ledgerSupport.description")}
-          />
-          <HelpListItem
-            onPress={onLedgerAcademyPress}
-            testID="help-ledger-academy-row"
-            icon={Information}
-            title={t("myWallet.help.rows.ledgerAcademy.title")}
-            description={t("myWallet.help.rows.ledgerAcademy.description")}
-          />
-        </Box>
+    <>
+      <ScrollView testID="my-wallet-help-screen">
+        <TrackScreen category="MyWallet" name="Help" />
+        <Box lx={{ paddingHorizontal: "s16", paddingTop: "s24", gap: "s24" }}>
+          <Box lx={{ gap: "s8" }}>
+            <Subheader>
+              <SubheaderRow testID="my-wallet-help-section-support">
+                <SubheaderTitle>{t("myWallet.help.sections.supportAndLearning")}</SubheaderTitle>
+              </SubheaderRow>
+            </Subheader>
+            <HelpListItem
+              onPress={onLedgerSupportPress}
+              testID="help-ledger-support-row"
+              icon={LifeRing}
+              title={
+                isChatbotEnabled ? t("help.chatbot") : t("myWallet.help.rows.ledgerSupport.title")
+              }
+              description={t("myWallet.help.rows.ledgerSupport.description")}
+            />
+            <HelpListItem
+              onPress={onLedgerAcademyPress}
+              testID="help-ledger-academy-row"
+              icon={Information}
+              title={t("myWallet.help.rows.ledgerAcademy.title")}
+              description={t("myWallet.help.rows.ledgerAcademy.description")}
+            />
+          </Box>
 
-        <Subheader>
-          <SubheaderRow testID="my-wallet-help-section-more">
-            <SubheaderTitle>{t("myWallet.help.sections.more")}</SubheaderTitle>
-          </SubheaderRow>
-        </Subheader>
-      </Box>
-    </ScrollView>
+          <Box lx={{ gap: "s8" }}>
+            <Subheader>
+              <SubheaderRow testID="my-wallet-help-section-more">
+                <SubheaderTitle>{t("myWallet.help.sections.more")}</SubheaderTitle>
+              </SubheaderRow>
+            </Subheader>
+            <HelpListItem
+              onPress={onSaveLogsPress}
+              testID="help-save-logs-row"
+              icon={Download}
+              title={t("myWallet.help.rows.saveLogs.title")}
+              description={t("myWallet.help.rows.saveLogs.description")}
+              trailing="chevron"
+            />
+            <HelpListItem
+              onPress={onLedgerStatusPress}
+              testID="help-ledger-status-row"
+              icon={Information}
+              title={t("myWallet.help.rows.ledgerStatus.title")}
+              description={t("myWallet.help.rows.ledgerStatus.description")}
+            />
+            <HelpListItem
+              onPress={onClearCachePress}
+              testID="help-clear-cache-row"
+              icon={Trash}
+              title={t("myWallet.help.rows.clearCache.title")}
+              description={t("myWallet.help.rows.clearCache.description")}
+              trailing="chevron"
+            />
+          </Box>
+        </Box>
+      </ScrollView>
+
+      <QueuedDrawerBottomSheet
+        isRequestingToBeOpened={isClearCacheDrawerOpen}
+        onClose={onClearCacheDrawerClose}
+        enableDynamicSizing
+      >
+        <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
+          <BottomSheetHeader />
+          <Box lx={{ alignItems: "center", gap: "s16", paddingHorizontal: "s16" }}>
+            <Spot appearance="info" size={72} />
+            <Text typography="heading5SemiBold" lx={{ textAlign: "center", color: "base" }}>
+              {t("settings.help.clearCache")}
+            </Text>
+            <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+              {t("settings.help.clearCacheModalDesc")}
+            </Text>
+          </Box>
+          <Box lx={{ paddingHorizontal: "s16", paddingTop: "s24", gap: "s8" }}>
+            <Button
+              appearance="base"
+              size="lg"
+              onPress={onClearCacheConfirm}
+              testID="clear-cache-button"
+            >
+              {t("settings.help.clearCacheButton")}
+            </Button>
+            <Button appearance="transparent" size="lg" onPress={onClearCacheDrawerClose}>
+              {t("common.cancel")}
+            </Button>
+          </Box>
+        </BottomSheetView>
+      </QueuedDrawerBottomSheet>
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/useMyWalletHelpViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/screens/Help/useMyWalletHelpViewModel.ts
@@ -1,7 +1,11 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { Linking } from "react-native";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
+import { useCleanCache } from "~/actions/general";
+import { reboot } from "~/actions/appstate";
+import { useDispatch } from "~/context/hooks";
+import useExportLogs from "~/components/useExportLogs";
 import { urls } from "~/utils/urls";
 import { track } from "~/analytics";
 import { ScreenName } from "~/const";
@@ -14,6 +18,12 @@ export function useMyWalletHelpViewModel() {
   const localizedChatbotUrl = useLocalizedUrl(urls.chatbot);
   const localizedAcademyUrl = useLocalizedUrl(urls.resources.ledgerAcademy);
 
+  const exportLogs = useExportLogs();
+  const cleanCache = useCleanCache();
+  const dispatch = useDispatch();
+
+  const [isClearCacheDrawerOpen, setIsClearCacheDrawerOpen] = useState(false);
+
   const onLedgerSupportPress = useCallback(() => {
     track("button_clicked", { button: "LedgerSupport", page: ScreenName.MyWalletHelp });
     Linking.openURL(isChatbotEnabled ? localizedChatbotUrl : localizedFaqUrl);
@@ -24,9 +34,39 @@ export function useMyWalletHelpViewModel() {
     Linking.openURL(localizedAcademyUrl);
   }, [localizedAcademyUrl]);
 
+  const onSaveLogsPress = useCallback(() => {
+    track("button_clicked", { button: "SaveLogs", page: ScreenName.MyWalletHelp });
+    exportLogs();
+  }, [exportLogs]);
+
+  const onLedgerStatusPress = useCallback(() => {
+    track("button_clicked", { button: "LedgerStatus", page: ScreenName.MyWalletHelp });
+    Linking.openURL(urls.resources.status);
+  }, []);
+
+  const onClearCachePress = useCallback(() => {
+    track("button_clicked", { button: "ClearCache", page: ScreenName.MyWalletHelp });
+    setIsClearCacheDrawerOpen(true);
+  }, []);
+
+  const onClearCacheConfirm = useCallback(async () => {
+    await cleanCache();
+    dispatch(reboot());
+  }, [cleanCache, dispatch]);
+
+  const onClearCacheDrawerClose = useCallback(() => {
+    setIsClearCacheDrawerOpen(false);
+  }, []);
+
   return {
     isChatbotEnabled,
     onLedgerSupportPress,
     onLedgerAcademyPress,
+    onSaveLogsPress,
+    onLedgerStatusPress,
+    onClearCachePress,
+    onClearCacheConfirm,
+    isClearCacheDrawerOpen,
+    onClearCacheDrawerClose,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit tests for all More section rows and interactions.
- [x] **Impact of the changes:**
      - MyWallet Help screen: new More section with Save logs, Ledger Status and Clear cache rows

### 📝 Description

Add the "More" section to the new Wallet 4.0 MyWallet Help screen:
- **Save logs** row: triggers native log export via `useExportLogs` hook
- **Ledger Status** row: opens Ledger status page URL in browser
- **Clear cache** row: shows confirmation drawer before clearing cache and rebooting

All rows use Lumen UI `ListItem` components following the MVVM pattern with a dedicated `useMyWalletHelpViewModel` hook.

### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-26560

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.