### PR TITLE
[LWM] feat(mobile): add no-device state CTA in My Wallet device section

### DIFF
--- a/.changeset/gentle-device-appear.md
+++ b/.changeset/gentle-device-appear.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add "Add a Ledger device" CTA in My Wallet when no BLE devices are paired

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8870,6 +8870,7 @@
     "deviceSection": {
       "title": "My devices",
       "add": "Add",
+      "addDevice": "Add a Ledger device",
       "exploreAllDevices": "Explore all Ledger devices",
       "available": "Available",
       "unavailable": "Not connected"

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/DeviceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/DeviceSectionView.tsx
@@ -1,16 +1,17 @@
 import React from "react";
-import { Box, Link, Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-rnative";
-import { PlusCircleFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { Box, Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-rnative";
 import { useTranslation } from "~/context/Locale";
 import { type DeviceSectionDevice } from "./useDeviceSectionViewModel";
-import { DeviceListItem } from "./components/DeviceListItem";
-import { ExploreDevicesItem } from "./components/ExploreDevicesItem";
+import { AddDeviceLink } from "./components/AddDeviceLink";
+import { DeviceListContent } from "./components/DeviceListContent";
 
 interface DeviceSectionViewProps {
   readonly devices: readonly DeviceSectionDevice[];
+  readonly hasDevices: boolean;
+  readonly onAddDevice: () => void;
 }
 
-export function DeviceSectionView({ devices }: DeviceSectionViewProps) {
+export function DeviceSectionView({ devices, hasDevices, onAddDevice }: DeviceSectionViewProps) {
   const { t } = useTranslation();
 
   return (
@@ -21,25 +22,12 @@ export function DeviceSectionView({ devices }: DeviceSectionViewProps) {
             {t("myWallet.deviceSection.title")}
           </SubheaderTitle>
           <Box lx={{ flex: 1 }} />
-          <Box
-            lx={{ flexDirection: "row", alignItems: "center", gap: "s8" }}
-            testID="my-wallet-device-section-add"
-          >
-            <Link appearance="accent" size="md" underline={false}>
-              {t("myWallet.deviceSection.add")}
-            </Link>
-            <PlusCircleFill size={20} color="interactive" />
-          </Box>
+          {hasDevices && <AddDeviceLink onPress={onAddDevice} />}
         </SubheaderRow>
       </Subheader>
 
       <Box lx={{ gap: "s16" }}>
-        <Box lx={{ backgroundColor: "surface", borderRadius: "md" }}>
-          {devices.map(device => (
-            <DeviceListItem key={device.id} device={device} />
-          ))}
-        </Box>
-        <ExploreDevicesItem />
+        <DeviceListContent devices={devices} onAddDevice={onAddDevice} />
       </Box>
     </Box>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__integrations__/DeviceSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__integrations__/DeviceSection.integration.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@tests/test-renderer";
+import { render, screen, fireEvent } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { DeviceSectionView } from "../DeviceSectionView";
 import { type DeviceSectionDevice } from "../useDeviceSectionViewModel";
@@ -10,10 +10,13 @@ const mockDevices: DeviceSectionDevice[] = [
   { id: "device-3", name: "Flex 3294", modelId: DeviceModelId.europa, available: false },
 ];
 
+const mockOnAddDevice = jest.fn();
+
 describe("DeviceSection", () => {
   describe("with no devices", () => {
     beforeEach(() => {
-      render(<DeviceSectionView devices={[]} />);
+      mockOnAddDevice.mockClear();
+      render(<DeviceSectionView devices={[]} hasDevices={false} onAddDevice={mockOnAddDevice} />);
     });
 
     it("renders the section container", () => {
@@ -25,16 +28,26 @@ describe("DeviceSection", () => {
       expect(screen.getByTestId("my-wallet-device-section-title")).toHaveTextContent("My devices");
     });
 
-    it("renders the Add button", () => {
-      expect(screen.getByTestId("my-wallet-device-section-add")).toBeVisible();
+    it("does not render the Add header link", () => {
+      expect(screen.queryByTestId("my-wallet-device-section-add")).toBeNull();
     });
 
-    it('renders the "Explore all Ledger devices" item', () => {
-      expect(screen.getByTestId("my-wallet-device-section-explore")).toBeVisible();
+    it('renders the "Add a Ledger device" CTA', () => {
+      expect(screen.getByTestId("my-wallet-device-section-add-device")).toBeVisible();
+      expect(screen.getByText("Add a Ledger device")).toBeVisible();
+    });
+
+    it('does not render the "Explore all Ledger devices" item', () => {
+      expect(screen.queryByTestId("my-wallet-device-section-explore")).toBeNull();
     });
 
     it("does not render any device item", () => {
       expect(screen.queryByTestId("my-wallet-device-item-device-1")).toBeNull();
+    });
+
+    it("calls onAddDevice when the CTA is pressed", () => {
+      fireEvent.press(screen.getByTestId("my-wallet-device-section-add-device"));
+      expect(mockOnAddDevice).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -42,7 +55,13 @@ describe("DeviceSection", () => {
     const singleDevice: DeviceSectionDevice[] = [mockDevices[0]];
 
     beforeEach(() => {
-      render(<DeviceSectionView devices={singleDevice} />);
+      render(
+        <DeviceSectionView
+          devices={singleDevice}
+          hasDevices={true}
+          onAddDevice={mockOnAddDevice}
+        />,
+      );
     });
 
     it("renders the device item", () => {
@@ -57,6 +76,14 @@ describe("DeviceSection", () => {
       expect(screen.getByText("Not connected")).toBeVisible();
     });
 
+    it("renders the Add header link", () => {
+      expect(screen.getByTestId("my-wallet-device-section-add")).toBeVisible();
+    });
+
+    it('does not render the "Add a Ledger device" CTA', () => {
+      expect(screen.queryByTestId("my-wallet-device-section-add-device")).toBeNull();
+    });
+
     it('renders the "Explore all Ledger devices" item', () => {
       expect(screen.getByTestId("my-wallet-device-section-explore")).toBeVisible();
     });
@@ -68,7 +95,13 @@ describe("DeviceSection", () => {
     ];
 
     beforeEach(() => {
-      render(<DeviceSectionView devices={availableDevice} />);
+      render(
+        <DeviceSectionView
+          devices={availableDevice}
+          hasDevices={true}
+          onAddDevice={mockOnAddDevice}
+        />,
+      );
     });
 
     it('renders "Available" status', () => {
@@ -78,7 +111,9 @@ describe("DeviceSection", () => {
 
   describe("with multiple devices", () => {
     beforeEach(() => {
-      render(<DeviceSectionView devices={mockDevices} />);
+      render(
+        <DeviceSectionView devices={mockDevices} hasDevices={true} onAddDevice={mockOnAddDevice} />,
+      );
     });
 
     it("renders all device items", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/AddDeviceItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/AddDeviceItem.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import {
+  Box,
+  ListItem,
+  ListItemContent,
+  ListItemLeading,
+  ListItemTitle,
+} from "@ledgerhq/lumen-ui-rnative";
+import { Plus } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
+
+type AddDeviceItemProps = {
+  readonly onPress: () => void;
+};
+
+export function AddDeviceItem({ onPress }: AddDeviceItemProps) {
+  const { t } = useTranslation();
+
+  return (
+    <ListItem
+      lx={{ backgroundColor: "surface", borderRadius: "md" }}
+      testID="my-wallet-device-section-add-device"
+      onPress={onPress}
+    >
+      <ListItemLeading>
+        <Box
+          lx={{
+            backgroundColor: "muted",
+            borderRadius: "full",
+            width: "s48",
+            height: "s48",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Plus size={20} color="base" />
+        </Box>
+        <ListItemContent>
+          <ListItemTitle>{t("myWallet.deviceSection.addDevice")}</ListItemTitle>
+        </ListItemContent>
+      </ListItemLeading>
+    </ListItem>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/AddDeviceLink.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/AddDeviceLink.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Box, Link } from "@ledgerhq/lumen-ui-rnative";
+import { PlusCircleFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
+
+type AddDeviceLinkProps = {
+  readonly onPress: () => void;
+};
+
+export function AddDeviceLink({ onPress }: AddDeviceLinkProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Box
+      lx={{ flexDirection: "row", alignItems: "center", gap: "s8" }}
+      testID="my-wallet-device-section-add"
+    >
+      <Link appearance="accent" size="md" underline={false} onPress={onPress}>
+        {t("myWallet.deviceSection.add")}
+      </Link>
+      <PlusCircleFill size={20} color="interactive" />
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListContent.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { type DeviceSectionDevice } from "../useDeviceSectionViewModel";
+import { DeviceListItem } from "./DeviceListItem";
+import { ExploreDevicesItem } from "./ExploreDevicesItem";
+import { AddDeviceItem } from "./AddDeviceItem";
+
+type DeviceListContentProps = {
+  readonly devices: readonly DeviceSectionDevice[];
+  readonly onAddDevice: () => void;
+};
+
+export function DeviceListContent({ devices, onAddDevice }: DeviceListContentProps) {
+  if (devices.length === 0) {
+    return <AddDeviceItem onPress={onAddDevice} />;
+  }
+
+  return (
+    <>
+      <Box lx={{ backgroundColor: "surface", borderRadius: "md" }}>
+        {devices.map(device => (
+          <DeviceListItem key={device.id} device={device} />
+        ))}
+      </Box>
+      <ExploreDevicesItem />
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/index.tsx
@@ -3,7 +3,7 @@ import { useDeviceSectionViewModel } from "./useDeviceSectionViewModel";
 import { DeviceSectionView } from "./DeviceSectionView";
 
 export function DeviceSection() {
-  const { devices } = useDeviceSectionViewModel();
+  const { devices, hasDevices, onAddDevice } = useDeviceSectionViewModel();
 
-  return <DeviceSectionView devices={devices} />;
+  return <DeviceSectionView devices={devices} hasDevices={hasDevices} onAddDevice={onAddDevice} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
@@ -1,7 +1,10 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { DeviceModelId } from "@ledgerhq/devices";
 import { useSelector } from "~/context/hooks";
 import { bleDevicesSelector } from "~/reducers/ble";
+import { ScreenName } from "~/const";
 
 export interface DeviceSectionDevice {
   readonly id: string;
@@ -12,9 +15,13 @@ export interface DeviceSectionDevice {
 
 interface DeviceSectionViewModel {
   readonly devices: readonly DeviceSectionDevice[];
+  readonly hasDevices: boolean;
+  readonly onAddDevice: () => void;
 }
 
 export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<{ [key: string]: object | undefined }>>();
   const knownDevices = useSelector(bleDevicesSelector);
 
   const devices = useMemo(
@@ -25,5 +32,11 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
     [knownDevices],
   );
 
-  return { devices };
+  const hasDevices = devices.length > 0;
+
+  const onAddDevice = useCallback(() => {
+    navigation.navigate(ScreenName.BleDevicePairingFlow);
+  }, [navigation]);
+
+  return { devices, hasDevices, onAddDevice };
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - My Wallet screen → "My devices" section behavior when no BLE devices are paired
      - Navigation to BLE pairing flow from the new CTA
      - Device list rendering when devices are present (should remain unchanged)

### 📝 Description

When no BLE devices are paired, the My Wallet "My devices" section shows an empty surface with no actionable guidance for the user.

This PR adds an "Add a Ledger device" CTA (`ListItem` with a circular "+" icon) that replaces the empty device list when no known BLE devices exist. Tapping the CTA navigates to `BleDevicePairingFlow`. The "Add" header link and "Explore all Ledger devices" row are hidden in the no-device state and remain visible when devices are present.

**Changes:**
- `useDeviceSectionViewModel` — added `hasDevices` boolean and `onAddDevice` navigation callback
- `DeviceSectionView` — conditional rendering via extracted `DeviceListContent` component
- New components: `AddDeviceItem` (CTA row), `AddDeviceLink` (header link), `DeviceListContent` (content switcher)
- Integration tests updated with 17 assertions covering both states
<img width="350" height="750" alt="Simulator Screenshot - Test Ios - 2026-04-21 at 14 53 58" src="https://github.com/user-attachments/assets/5b0d3783-7812-4c70-95be-b21a5ffb07b2" />

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26538](https://ledgerhq.atlassian.net/browse/LIVE-26538)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26538]: https://ledgerhq.atlassian.net/browse/LIVE-26538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ