### PR TITLE
[LWD] feat(desktop): move notification indicator into mywallet context menu

### DIFF
--- a/.changeset/chatty-dancers-hear.md
+++ b/.changeset/chatty-dancers-hear.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Move NotificationIndicator into MyWallet ContextMenu and fix popover not closing on action click

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/TopBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/TopBarView.tsx
@@ -8,21 +8,33 @@ import { TopBarActionsList } from "./components/ActionsList";
 import FirmwareUpdateBanner from "~/renderer/components/FirmwareUpdateBanner";
 import Updater from "LLD/features/Updater";
 import { MyWallet } from "LLD/features/MyWallet";
+import { InformationDrawer } from "~/renderer/components/TopBar/NotificationIndicator/InformationDrawer";
 
-const TopBarView = ({ slots, shouldShowFirmwareUpdateBanner }: TopBarViewProps) => {
+const TopBarView = ({
+  slots,
+  shouldShowFirmwareUpdateBanner,
+  isInformationCenterOpen,
+  onInformationCenterClose,
+}: TopBarViewProps) => {
   return (
-    <NavBar className="w-full min-w-0 items-center px-32 pt-32 pb-24">
-      <NavBarTitle className="h-48">
-        <Breadcrumb />
-      </NavBarTitle>
-      <NavBarTrailing className="h-48 gap-12">
-        <LiveAppDrawer />
-        {shouldShowFirmwareUpdateBanner && <FirmwareUpdateBanner />}
-        <Updater />
-        <TopBarActionsList slots={slots} />
-        <MyWallet />
-      </NavBarTrailing>
-    </NavBar>
+    <>
+      <InformationDrawer
+        isOpen={isInformationCenterOpen}
+        onRequestClose={onInformationCenterClose}
+      />
+      <NavBar className="w-full min-w-0 items-center px-32 pt-32 pb-24">
+        <NavBarTitle className="h-48">
+          <Breadcrumb />
+        </NavBarTitle>
+        <NavBarTrailing className="h-48 gap-12">
+          <LiveAppDrawer />
+          {shouldShowFirmwareUpdateBanner && <FirmwareUpdateBanner />}
+          <Updater />
+          <TopBarActionsList slots={slots} />
+          <MyWallet />
+        </NavBarTrailing>
+      </NavBar>
+    </>
   );
 };
 export default TopBarView;

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/TopBarView.test.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { render, screen } from "tests/testSetup";
+import { getBrazeWebSdkJestMock as mockGetBrazeWebSdkJestMock } from "tests/mocks/brazeWebSdk";
 import TopBarView from "../TopBarView";
 import { TopBarSlot } from "../types";
+
+jest.mock("@braze/web-sdk", () => mockGetBrazeWebSdkJestMock());
 
 jest.mock("../components/ActionsList", () => ({
   TopBarActionsList: () => null,
@@ -14,15 +17,20 @@ jest.mock("~/renderer/components/FirmwareUpdateBanner", () => ({
 
 describe("TopBarView", () => {
   const defaultSlots: TopBarSlot[] = [];
+  const defaultProps = {
+    slots: defaultSlots,
+    isInformationCenterOpen: false,
+    onInformationCenterClose: jest.fn(),
+  };
 
   it("should render updater when not in manager", () => {
-    render(<TopBarView slots={defaultSlots} shouldShowFirmwareUpdateBanner={true} />);
+    render(<TopBarView {...defaultProps} shouldShowFirmwareUpdateBanner={true} />);
 
     expect(screen.getByTestId("firmware-update-banner")).toBeInTheDocument();
   });
 
   it("should not render updater when in manager", () => {
-    render(<TopBarView slots={defaultSlots} shouldShowFirmwareUpdateBanner={false} />);
+    render(<TopBarView {...defaultProps} shouldShowFirmwareUpdateBanner={false} />);
 
     expect(screen.queryByTestId("firmware-update-banner")).not.toBeInTheDocument();
   });

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/__tests__/index.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen } from "tests/testSetup";
 import userEvent from "@testing-library/user-event";
+import { getBrazeWebSdkJestMock as mockGetBrazeWebSdkJestMock } from "tests/mocks/brazeWebSdk";
 import TopBar from "../index";
 import { BTC_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
 
@@ -8,17 +9,7 @@ jest.mock("~/renderer/families", () => ({
   getLLDCoinFamily: () => ({}),
 }));
 
-jest.mock("@braze/web-sdk", () => ({
-  getCachedContentCards: () => ({ cards: [] }),
-  initialize: () => true,
-  changeUser: () => {},
-  requestContentCardsRefresh: () => {},
-  subscribeToContentCardsUpdates: () => () => {},
-  automaticallyShowInAppMessages: () => {},
-  openSession: () => {},
-  logCardDismissal: () => {},
-  logContentCardClick: () => {},
-}));
+jest.mock("@braze/web-sdk", () => mockGetBrazeWebSdkJestMock());
 
 describe("TopBar", () => {
   const getDefaultInitialState = (overrides = {}) => ({

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/NotificationIndicator.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/components/NotificationIndicator.tsx
@@ -1,11 +1,8 @@
 import React from "react";
-import { InformationDrawer } from "~/renderer/components/TopBar/NotificationIndicator/InformationDrawer";
-import { useInformationCenter } from "../hooks/useInformationCenter";
 import { useNotificationIndicator } from "../hooks/useNotificationIndicator";
 import { TopBarActionButton } from "./TopBarActionButton";
 
 export function NotificationIndicator() {
-  const { isOpen, onRequestClose } = useInformationCenter();
   const {
     tooltip,
     icon,
@@ -14,15 +11,12 @@ export function NotificationIndicator() {
   } = useNotificationIndicator();
 
   return (
-    <>
-      <InformationDrawer isOpen={isOpen} onRequestClose={onRequestClose} />
-      <TopBarActionButton
-        label="notifications"
-        tooltip={tooltip}
-        isInteractive={isInteractive}
-        onClick={handleOpenNotificationCenter}
-        icon={icon}
-      />
-    </>
+    <TopBarActionButton
+      label="notifications"
+      tooltip={tooltip}
+      isInteractive={isInteractive}
+      onClick={handleOpenNotificationCenter}
+      icon={icon}
+    />
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/__tests__/useTopBarViewModel.test.ts
@@ -131,12 +131,12 @@ describe("useTopBarViewModel", () => {
       [
         "all optional slots visible",
         { experimentalVisible: true, featureFlagsVisible: true, operationsList: true },
-        ["experimental", "feature flags", "synchronize", "notification", "discreet", "history"],
+        ["experimental", "feature flags", "synchronize", "discreet", "history"],
       ],
       [
-        "myWallet enabled hides settings and my ledger",
+        "myWallet enabled hides settings, my ledger, and notification",
         { myWallet: true },
-        ["synchronize", "notification", "discreet", "history"],
+        ["synchronize", "discreet", "history"],
       ],
     ])("%s", (_name, options, expectedLabels) => {
       const { result } = setup(options);

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/hooks/useTopBarViewModel.ts
@@ -8,9 +8,12 @@ import { useFeatureFlags } from "./useFeatureFlags";
 import { useMyLedger } from "./useMyLedger";
 import { useSettings } from "./useSettings";
 import { useHistory } from "./useHistory";
+import { useInformationCenter } from "./useInformationCenter";
 
 const useTopBarViewModel = () => {
   const { shouldDisplayOperationsList, shouldDisplayMyWallet } = useWalletFeaturesConfig("desktop");
+  const { isOpen: isInformationCenterOpen, onRequestClose: onInformationCenterClose } =
+    useInformationCenter();
   const { handleDiscreet, discreetIcon, tooltip: discreetTooltip } = useDiscreetMode();
   const {
     hasAccounts,
@@ -86,7 +89,7 @@ const useTopBarViewModel = () => {
           },
         ]
       : []),
-    { type: "notification" },
+    ...(shouldDisplayMyWallet ? [] : [{ type: "notification" as const }]),
     {
       type: "action",
       action: {
@@ -112,8 +115,9 @@ const useTopBarViewModel = () => {
           },
         ]
       : []),
-    ...(!shouldDisplayMyWallet
-      ? [
+    ...(shouldDisplayMyWallet
+      ? []
+      : [
           {
             type: "action" as const,
             action: {
@@ -134,13 +138,14 @@ const useTopBarViewModel = () => {
               onClick: handleMyLedger,
             },
           },
-        ]
-      : []),
+        ]),
   ];
 
   return {
     topBarSlots,
     inManager,
+    isInformationCenterOpen,
+    onInformationCenterClose,
   };
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/index.tsx
@@ -3,8 +3,16 @@ import useTopBarViewModel from "./hooks/useTopBarViewModel";
 import TopBarView from "./TopBarView";
 
 const TopBar = () => {
-  const { topBarSlots, inManager } = useTopBarViewModel();
+  const { topBarSlots, inManager, isInformationCenterOpen, onInformationCenterClose } =
+    useTopBarViewModel();
 
-  return <TopBarView slots={topBarSlots} shouldShowFirmwareUpdateBanner={!inManager} />;
+  return (
+    <TopBarView
+      slots={topBarSlots}
+      shouldShowFirmwareUpdateBanner={!inManager}
+      isInformationCenterOpen={isInformationCenterOpen}
+      onInformationCenterClose={onInformationCenterClose}
+    />
+  );
 };
 export default TopBar;

--- a/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/TopBar/types.ts
@@ -47,6 +47,8 @@ type TopBarSlot = { type: "action"; action: TopBarAction } | { type: "notificati
 type TopBarViewProps = {
   slots: TopBarSlot[];
   shouldShowFirmwareUpdateBanner: boolean;
+  isInformationCenterOpen: boolean;
+  onInformationCenterClose: () => void;
 };
 
 export type { TopBarAction, TopBarActionAppearance, TopBarSlot, TopBarViewProps };

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/MyWalletTopBar.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/MyWalletTopBar.integration.test.tsx
@@ -37,13 +37,14 @@ describe("MyWallet ContextMenu", () => {
     expect(screen.getByRole("button", { name: "Airplane" })).toBeVisible();
   });
 
-  it("should show a settings button inside the popover when opened", async () => {
+  it("should show settings and notifications buttons inside the popover when opened", async () => {
     const { user } = render(<ContextMenu />);
 
     await user.click(screen.getByRole("button", { name: "Airplane" }));
 
     await waitFor(() => {
       expect(screen.getByTestId("topbar-action-button-settings")).toBeVisible();
+      expect(screen.getByTestId("topbar-action-button-notifications")).toBeVisible();
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/__tests__/ActionsList.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/__tests__/ActionsList.test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { render, screen, withFlagOverrides } from "tests/testSetup";
 import { track } from "~/renderer/analytics/segment";
 import { ActionsList } from "..";
+import ContextMenuContext from "../../ContextMenuContext";
 
 const HELP_LABEL = "Help";
 const RECOVER_LABEL = "[L] Recover";
@@ -12,6 +13,7 @@ const RECOVER_HOME_PATH = "/recover";
 const REFER_PATH = "/refer-a-friend";
 
 const mockNavigate = jest.fn();
+const mockClose = jest.fn();
 
 jest.mock("@ledgerhq/live-common/hooks/recoverFeatureFlag", () => ({
   useAccountPath: jest.fn(),
@@ -25,7 +27,12 @@ jest.mock("react-router", () => ({
 const mockUseAccountPath = jest.mocked(useAccountPath);
 const mockTrack = jest.mocked(track);
 const renderActionsList = (options?: Parameters<typeof render>[1]) =>
-  render(<ActionsList />, options);
+  render(
+    <ContextMenuContext.Provider value={{ close: mockClose }}>
+      <ActionsList />
+    </ContextMenuContext.Provider>,
+    options,
+  );
 const getButton = (name: string) => screen.getByRole("button", { name });
 
 describe("ActionsList", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/useActionsListViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/useActionsListViewModel.ts
@@ -15,12 +15,14 @@ import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { openModal } from "~/renderer/actions/modals";
 import { hasClickedRecoverSelector } from "~/renderer/reducers/settings";
 import { setHasClickedRecover } from "~/renderer/actions/settings";
+import { useContextMenuClose } from "../ContextMenuContext";
 
 export type ActionsListViewModel = {
   actions: Action[];
 };
 
 export function useActionsListViewModel(): ActionsListViewModel {
+  const close = useContextMenuClose();
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
@@ -39,7 +41,8 @@ export function useActionsListViewModel(): ActionsListViewModel {
       entry: "my_wallet_actions_list",
     });
     navigate("/settings/help");
-  }, [location.pathname, navigate]);
+    close();
+  }, [location.pathname, navigate, close]);
 
   const handleClickRecover = useCallback(() => {
     const enabled = recoverFeature?.enabled;
@@ -60,6 +63,7 @@ export function useActionsListViewModel(): ActionsListViewModel {
       page: location.pathname,
       entry: "my_wallet_actions_list",
     });
+    close();
   }, [
     recoverFeature?.enabled,
     recoverFeature?.params?.openRecoverFromSidebar,
@@ -69,6 +73,7 @@ export function useActionsListViewModel(): ActionsListViewModel {
     navigate,
     dispatch,
     location.pathname,
+    close,
   ]);
 
   const handleClickRefer = useCallback(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
@@ -1,26 +1,33 @@
-import React from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Popover, PopoverTrigger, PopoverContent, IconButton } from "@ledgerhq/lumen-ui-react";
 import { Airplane } from "@ledgerhq/lumen-ui-react/symbols";
 import { Explore } from "./Explore";
 import TopBar from "./TopBar";
 import { ActionsList } from "./ActionsList";
 import { MyLedger } from "./MyLedger";
+import ContextMenuContext from "./ContextMenuContext";
 
 const side = "bottom";
 const align = "end";
 
 export function ContextMenu() {
+  const [open, setOpen] = useState(false);
+  const close = useCallback(() => setOpen(false), []);
+  const contextValue = useMemo(() => ({ close }), [close]);
+
   return (
-    <Popover overlay>
+    <Popover overlay open={open} onOpenChange={setOpen}>
       <PopoverTrigger render={<IconButton icon={Airplane} aria-label="Airplane" size="sm" />} />
 
       <PopoverContent width="fixed" side={side} align={align} className="flex flex-col gap-24">
-        <TopBar />
-        <ActionsList />
-        <div className="flex flex-col gap-12">
-          <MyLedger />
-          <Explore />
-        </div>
+        <ContextMenuContext.Provider value={contextValue}>
+          <TopBar />
+          <ActionsList />
+          <div className="flex flex-col gap-12">
+            <MyLedger />
+            <Explore />
+          </div>
+        </ContextMenuContext.Provider>
       </PopoverContent>
     </Popover>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenuContext.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenuContext.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from "react";
+
+type ContextMenuContextValue = {
+  close: () => void;
+};
+
+const ContextMenuContext = createContext<ContextMenuContextValue | null>(null);
+
+/**
+ * Returns the `close` function from the nearest ContextMenu provider.
+ * Call it from any child inside the popover to dismiss the menu after an action.
+ */
+export function useContextMenuClose() {
+  const ctx = useContext(ContextMenuContext);
+  if (!ctx) {
+    throw new Error("useContextMenuClose must be used within a ContextMenu");
+  }
+  return ctx.close;
+}
+
+export default ContextMenuContext;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/hooks/useMyLedgerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/MyLedger/hooks/useMyLedgerViewModel.ts
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useMyLedger } from "LLD/components/TopBar/hooks/useMyLedger";
 import type { DeviceIconComponent } from "LLD/utils/getDeviceIcon";
+import { useContextMenuClose } from "../../ContextMenuContext";
 
 export type MyLedgerViewModel = {
   title: string;
@@ -10,13 +11,19 @@ export type MyLedgerViewModel = {
 };
 
 export function useMyLedgerViewModel(): MyLedgerViewModel {
+  const close = useContextMenuClose();
   const { t } = useTranslation();
   const { handleMyLedger, icon } = useMyLedger();
+
+  const handleClick = () => {
+    handleMyLedger();
+    close();
+  };
 
   return {
     title: t("myWallet.myLedger.title"),
     description: t("myWallet.myLedger.description"),
     icon,
-    handleClick: handleMyLedger,
+    handleClick,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/TopBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/TopBarView.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import { TopBarActionButton } from "LLD/components/TopBar/components/TopBarActionButton";
 import type { MyWalletTopBarViewProps } from "./types";
 
-const TopBarView = ({ settingsAction }: MyWalletTopBarViewProps) => (
+const TopBarView = ({ settingsAction, notificationAction }: MyWalletTopBarViewProps) => (
   <div className="flex justify-between items-center">
     <p className="body-2 text-base">My Wallet</p>
     <div className="flex gap-16">
-      <p className="body-2 text-base">Notifications</p>
+      <TopBarActionButton {...notificationAction} />
       <TopBarActionButton {...settingsAction} />
     </div>
   </div>

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/hooks/useTopBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/hooks/useTopBarViewModel.ts
@@ -1,18 +1,45 @@
 import { useSettings } from "LLD/components/TopBar/hooks/useSettings";
+import { useNotificationIndicator } from "LLD/components/TopBar/hooks/useNotificationIndicator";
 import type { TopBarAction } from "LLD/components/TopBar/types";
+import { useContextMenuClose } from "../../ContextMenuContext";
 
 const useTopBarViewModel = () => {
+  const close = useContextMenuClose();
   const { handleSettings, settingsIcon, tooltip: settingsTooltip } = useSettings("mywallet");
+  const {
+    tooltip: notificationTooltip,
+    icon: notificationIcon,
+    isInteractive: notificationIsInteractive,
+    onClick: handleOpenNotificationCenter,
+  } = useNotificationIndicator();
+
+  const onSettingsClick = () => {
+    handleSettings();
+    close();
+  };
+
+  const onNotificationClick = () => {
+    handleOpenNotificationCenter();
+    close();
+  };
 
   const settingsAction: TopBarAction = {
     label: "settings",
     tooltip: settingsTooltip,
     icon: settingsIcon,
     isInteractive: true,
-    onClick: handleSettings,
+    onClick: onSettingsClick,
   };
 
-  return { settingsAction };
+  const notificationAction: TopBarAction = {
+    label: "notifications",
+    tooltip: notificationTooltip,
+    icon: notificationIcon,
+    isInteractive: notificationIsInteractive,
+    onClick: onNotificationClick,
+  };
+
+  return { settingsAction, notificationAction };
 };
 
 export default useTopBarViewModel;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/index.tsx
@@ -3,8 +3,8 @@ import useTopBarViewModel from "./hooks/useTopBarViewModel";
 import TopBarView from "./TopBarView";
 
 const TopBar = () => {
-  const { settingsAction } = useTopBarViewModel();
-  return <TopBarView settingsAction={settingsAction} />;
+  const { settingsAction, notificationAction } = useTopBarViewModel();
+  return <TopBarView settingsAction={settingsAction} notificationAction={notificationAction} />;
 };
 
 export default TopBar;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/types.ts
@@ -2,4 +2,5 @@ import type { TopBarAction } from "LLD/components/TopBar/types";
 
 export type MyWalletTopBarViewProps = {
   settingsAction: TopBarAction;
+  notificationAction: TopBarAction;
 };

--- a/apps/ledger-live-desktop/tests/mocks/brazeWebSdk.ts
+++ b/apps/ledger-live-desktop/tests/mocks/brazeWebSdk.ts
@@ -1,0 +1,21 @@
+/**
+ * Stub for @braze/web-sdk in Jest — the real package is ESM-only and cannot be parsed by Jest
+ * without transform exceptions. Use with:
+ * `jest.mock("@braze/web-sdk", () => require("tests/mocks/brazeWebSdk").getBrazeWebSdkJestMock());`
+ */
+export function getBrazeWebSdkJestMock(): Record<string, unknown> {
+  class ClassicCard {}
+  return {
+    ClassicCard,
+    getCachedContentCards: () => ({ cards: [] }),
+    initialize: () => true,
+    changeUser: () => {},
+    requestContentCardsRefresh: () => {},
+    subscribeToContentCardsUpdates: () => () => {},
+    automaticallyShowInAppMessages: () => {},
+    openSession: () => {},
+    logCardDismissal: () => {},
+    logContentCardClick: () => {},
+    logContentCardImpressions: () => {},
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing tests updated, but no new end-to-end tests added._
- [x] **Impact of the changes:**
      - NotificationIndicator button now appears inside the MyWallet popover instead of the global TopBar when the MyWallet feature flag is enabled
      - Clicking any action inside the ContextMenu popover now properly closes the popover
      - InformationDrawer (notification panel) remains always mounted in the global TopBar

### 📝 Description

When the MyWallet feature flag (`shouldDisplayMyWallet`) is enabled, the NotificationIndicator button was still rendered in the global TopBar while Settings and My Ledger had already moved into the MyWallet ContextMenu popover. Additionally, clicking a button inside the popover when already on the target page would not close the popover.

**Changes:**
- Move the notification slot from the global TopBar into the MyWallet ContextMenu TopBar (like Settings), conditionally keeping it in the global TopBar only when `shouldDisplayMyWallet` is false
- Extract `InformationDrawer` from `NotificationIndicator` component up to the global `TopBarView` so the drawer stays mounted regardless of the feature flag
- Make the ContextMenu `Popover` controlled (`open`/`onOpenChange`) and expose a `close()` function via `ContextMenuContext` so all child components can dismiss the popover after an action
- Update tests for slot ordering, context provider wrapping, and new view props


https://github.com/user-attachments/assets/6cfef275-49d6-4306-bdd3-0aad1fc15ce3




### ❓ Context

- **JIRA or GitHub link**: [LIVE-26020](https://ledgerhq.atlassian.net/browse/LIVE-26020)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26020]: https://ledgerhq.atlassian.net/browse/LIVE-26020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ