### PR TITLE
[LWDM] feat(coin-evm): stop staking feature

### DIFF
--- a/.changeset/selfish-shirts-dream.md
+++ b/.changeset/selfish-shirts-dream.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(staking-evm): undelegate native staking evm

--- a/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/index.tsx
@@ -3,7 +3,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
-import type { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import {
   mapDelegations,
   mapUnbondings,
@@ -11,6 +10,7 @@ import {
   canDelegate,
   getValidatorExplorerUrl,
   prefetchValidators,
+  hasUnbondingPeriod,
 } from "@ledgerhq/live-common/families/evm/staking/logic";
 import { isStakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
 import type { StakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
@@ -41,8 +41,7 @@ const Wrapper = styled(Box).attrs(() => ({
 const Delegation = ({ account }: { account: StakingAccount }) => {
   const dispatch = useDispatch();
   const { enabled: isEvmNativeStakingEnabled, params } = useFeature("evmNativeStaking") ?? {};
-  const isCurrencySupported =
-    params?.supportedCurrencyIds?.includes(account.currency.id as CryptoCurrencyId) || false;
+  const isCurrencySupported = params?.supportedCurrencyIds?.includes(account.currency.id) || false;
 
   const unit = useAccountUnit(account);
   const currencyId = account.currency.id;
@@ -77,6 +76,14 @@ const Delegation = ({ account }: { account: StakingAccount }) => {
     () => dispatch(openModal("MODAL_EVM_DELEGATE", { account })),
     [account, dispatch],
   );
+  const onRedirect = useCallback(
+    (validatorAddress: string, modalName: string) => {
+      if (modalName === "MODAL_EVM_UNDELEGATE") {
+        dispatch(openModal("MODAL_EVM_UNDELEGATE", { account, validatorAddress }));
+      }
+    },
+    [account, dispatch],
+  );
 
   if (!isCurrencySupported || !isEvmNativeStakingEnabled) return null;
 
@@ -90,10 +97,12 @@ const Delegation = ({ account }: { account: StakingAccount }) => {
   const mappedUnbondings = mapUnbondings(unbondings, validators, unit);
   const mappedRedelegations = mapRedelegations(redelegations, validators, unit);
   const onClaimRewards = () => {};
-  const onRedirect = () => {};
 
   const hasDelegations = delegations.length > 0;
-  const hasUnbondings = unbondings.length > 0;
+  // Only surface the "Pending undelegation" section when the chain enforces an unbonding
+  // period (Acceptance Criteria: Tracking). Instant-withdrawal chains never have pending
+  // unbondings so showing the header would be misleading.
+  const hasUnbondings = unbondings.length > 0 && hasUnbondingPeriod(account.currency.id);
   const hasRedelegations = redelegations.length > 0;
   const hasRewards = pendingRewardsBalance.gt(0);
 

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
@@ -1,0 +1,192 @@
+import invariant from "invariant";
+import React, { useCallback, useState } from "react";
+import { compose } from "redux";
+import { connect } from "react-redux";
+import { useDispatch } from "LLD/hooks/redux";
+import { Trans, withTranslation } from "react-i18next";
+import { TFunction } from "i18next";
+import { createStructuredSelector } from "reselect";
+import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
+import Track from "~/renderer/analytics/Track";
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { StepId, StepProps, St } from "./types";
+import { Account, Operation } from "@ledgerhq/types-live";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { addPendingOperation } from "@ledgerhq/live-common/account/index";
+import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
+import { getCurrentDevice } from "~/renderer/reducers/devices";
+import { OpenModal, openModal } from "~/renderer/actions/modals";
+import Stepper from "~/renderer/components/Stepper";
+import StepAmount, { StepAmountFooter } from "./steps/StepAmount";
+import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
+import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
+import logger from "~/renderer/logger";
+import type { StakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
+import { isStakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
+
+export type Data = {
+  account: StakingAccount;
+  validatorAddress: string;
+  source?: string;
+};
+
+type OwnProps = {
+  stepId: StepId;
+  onClose: () => void;
+  onChangeStepId: (a: StepId) => void;
+  params: Data;
+};
+type StateProps = {
+  t: TFunction;
+  device: Device | undefined | null;
+  accounts: Account[];
+  openModal: OpenModal;
+};
+type Props = OwnProps & StateProps;
+
+const steps: Array<St> = [
+  {
+    id: "amount",
+    label: <Trans i18nKey="ethereum.evmStaking.undelegation.flow.steps.amount.title" />,
+    component: StepAmount,
+    noScroll: true,
+    footer: StepAmountFooter,
+  },
+  {
+    id: "connectDevice",
+    label: <Trans i18nKey="ethereum.evmStaking.undelegation.flow.steps.connectDevice.title" />,
+    component: GenericStepConnectDevice as unknown as React.ComponentType<StepProps>,
+    onBack: ({ transitionTo }: StepProps) => transitionTo("amount"),
+  },
+  {
+    id: "confirmation",
+    label: <Trans i18nKey="ethereum.evmStaking.undelegation.flow.steps.confirmation.title" />,
+    component: StepConfirmation,
+    footer: StepConfirmationFooter,
+  },
+];
+
+const mapStateToProps = createStructuredSelector({
+  device: getCurrentDevice,
+});
+const mapDispatchToProps = {
+  openModal,
+};
+
+const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }: Props) => {
+  const [optimisticOperation, setOptimisticOperation] = useState<Operation | null>(null);
+  const [transactionError, setTransactionError] = useState<Error | null>(null);
+  const [signed, setSigned] = useState(false);
+  const dispatch = useDispatch();
+  const { account, validatorAddress, source = "Account Page" } = params;
+
+  const {
+    transaction,
+    setTransaction,
+    updateTransaction,
+    parentAccount,
+    status,
+    bridgeError,
+    bridgePending,
+  } = useBridgeTransaction(() => {
+    invariant(isStakingAccount(account), "evm: account with staking resources required");
+    // Pre-populate the transaction with the existing delegation amount so the user starts
+    // on a valid "undelegate all" intent. The amount field lets them reduce it afterwards.
+    const delegation = account.stakingResources.delegations.find(
+      d => d.validatorAddress === validatorAddress,
+    );
+    const bridge = getAccountBridge(account, undefined);
+    const baseTransaction = bridge.createTransaction(account);
+    const transaction = bridge.updateTransaction(baseTransaction, {
+      mode: "undelegate",
+      valAddress: validatorAddress,
+      recipient: account.freshAddress,
+      amount: delegation?.amount,
+      useAllAmount: false,
+    });
+    return {
+      account,
+      parentAccount: undefined,
+      transaction,
+    };
+  });
+
+  const handleStepChange = useCallback((e: St) => onChangeStepId(e.id), [onChangeStepId]);
+  const handleRetry = useCallback(() => {
+    setTransactionError(null);
+    onChangeStepId("amount");
+  }, [onChangeStepId]);
+  const handleTransactionError = useCallback((error: Error) => {
+    if (!(error instanceof UserRefusedOnDevice)) {
+      logger.critical(error);
+    }
+    setTransactionError(error);
+  }, []);
+  const handleOperationBroadcasted = useCallback(
+    (optimisticOperation: Operation) => {
+      if (!account) return;
+      dispatch(
+        updateAccountWithUpdater(account.id, account =>
+          addPendingOperation(account, optimisticOperation),
+        ),
+      );
+      setOptimisticOperation(optimisticOperation);
+      setTransactionError(null);
+    },
+    [account, dispatch],
+  );
+
+  const error = transactionError || bridgeError;
+  const errorSteps = [];
+  if (transactionError) {
+    errorSteps.push(2);
+  } else if (bridgeError) {
+    errorSteps.push(0);
+  }
+
+  const stepperProps = {
+    title: t("ethereum.evmStaking.undelegation.flow.title"),
+    device,
+    account,
+    parentAccount,
+    transaction,
+    signed,
+    stepId,
+    steps,
+    errorSteps,
+    disabledSteps: [],
+    hideBreadcrumb: !!error && ["amount"].includes(stepId),
+    onRetry: handleRetry,
+    onStepChange: handleStepChange,
+    onClose,
+    error,
+    status,
+    optimisticOperation,
+    openModal,
+    setSigned,
+    onChangeTransaction: setTransaction,
+    onUpdateTransaction: updateTransaction,
+    onOperationBroadcasted: handleOperationBroadcasted,
+    onTransactionError: handleTransactionError,
+    t,
+    bridgePending,
+    source,
+    validatorAddress,
+  };
+
+  return (
+    <Stepper {...stepperProps}>
+      <SyncSkipUnderPriority priority={100} />
+      <Track onUnmount event="CloseModalUndelegation" />
+    </Stepper>
+  );
+};
+
+const C = compose<React.ComponentType<OwnProps>>(
+  connect(mapStateToProps, mapDispatchToProps),
+  withTranslation(),
+)(Body);
+
+export default C;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/fields/AmountField.tsx
@@ -1,0 +1,133 @@
+import React, { useMemo, useState } from "react";
+import { BigNumber } from "bignumber.js";
+import styled from "styled-components";
+import type { StakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
+import type { TransactionStatusCommon } from "@ledgerhq/types-live";
+import Box from "~/renderer/components/Box";
+import InputCurrency from "~/renderer/components/InputCurrency";
+import Label from "~/renderer/components/Label";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+
+type Props = Readonly<{
+  amount: BigNumber;
+  delegatedAmount: BigNumber;
+  account: StakingAccount;
+  status: TransactionStatusCommon;
+  onChange: (amount: BigNumber) => void;
+  label: React.ReactNode;
+}>;
+
+export default function AmountField({
+  amount,
+  delegatedAmount,
+  account,
+  onChange,
+  status: { errors, warnings },
+  label,
+}: Props) {
+  const unit = useAccountUnit(account);
+  const [focused, setFocused] = useState(false);
+
+  const options = useMemo(
+    () => [
+      { label: "25%", value: delegatedAmount.multipliedBy(0.25).integerValue() },
+      { label: "50%", value: delegatedAmount.multipliedBy(0.5).integerValue() },
+      { label: "75%", value: delegatedAmount.multipliedBy(0.75).integerValue() },
+      { label: "100%", value: delegatedAmount },
+    ],
+    [delegatedAmount],
+  );
+
+  // Forward only errors that make sense here: `amount` and the generic-alpaca `unbonding` bucket,
+  // while skipping validator-level (`valAddress`) which is surfaced at the row selection step.
+  const error = errors?.amount || errors?.unbonding;
+  const warning = useMemo(() => focused && Object.values(warnings || {})[0], [focused, warnings]);
+
+  return (
+    <Box my={2}>
+      <Label>{label}</Label>
+      <InputCurrency
+        autoFocus={false}
+        error={error}
+        warning={warning}
+        containerProps={{
+          grow: true,
+        }}
+        unit={unit}
+        value={amount}
+        onChange={onChange}
+        onChangeFocus={() => setFocused(true)}
+        renderLeft={<InputLeft>{unit.code}</InputLeft>}
+        renderRight={
+          <InputRight>
+            {options.map(({ label, value }) => (
+              <AmountButton
+                active={value.eq(amount)}
+                key={label}
+                error={!!error}
+                onClick={() => onChange(value)}
+              >
+                {label}
+              </AmountButton>
+            ))}
+          </InputRight>
+        }
+      />
+    </Box>
+  );
+}
+
+const InputLeft = styled(Box).attrs(() => ({
+  ff: "Inter|Medium",
+  color: "neutral.c70",
+  fontSize: 4,
+  justifyContent: "center",
+  horizontal: true,
+  pl: 3,
+}))``;
+
+const InputRight = styled(Box).attrs(() => ({
+  ff: "Inter|Medium",
+  color: "neutral.c70",
+  fontSize: 4,
+  justifyContent: "center",
+  horizontal: true,
+}))`
+  padding: ${p => p.theme.space[2]}px;
+`;
+
+const AmountButton = styled.button.attrs<{
+  error: boolean;
+  active: boolean;
+}>(() => ({
+  type: "button",
+}))<{
+  error: boolean;
+  active: boolean;
+}>`
+  background-color: ${p =>
+    p.error
+      ? p.theme.colors.lightRed
+      : p.active
+        ? p.theme.colors.primary.c80
+        : p.theme.colors.opacityDefault.c10};
+  color: ${p =>
+    p.error
+      ? p.theme.colors.alertRed
+      : p.active
+        ? p.theme.colors.neutral.c00
+        : p.theme.colors.primary.c80}!important;
+  border: none;
+  border-radius: 4px;
+  padding: 0px ${p => p.theme.space[2]}px;
+  margin: 0 2.5px;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 200ms ease-out;
+  &:hover {
+    filter: contrast(2);
+  }
+`;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/fields/ValidatorField.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import type { StakingMappedDelegation } from "@ledgerhq/live-common/families/evm/staking/types";
+import Box from "~/renderer/components/Box";
+import Label from "~/renderer/components/Label";
+import Text from "~/renderer/components/Text";
+import EvmValidatorIcon from "~/renderer/families/evm/shared/components/EvmValidatorIcon";
+
+type Props = Readonly<{
+  delegation: StakingMappedDelegation;
+}>;
+
+/**
+ * Read-only display of the validator the user is undelegating from.
+ * The validator is picked upstream via the "Stop staking" CTA on the delegation row,
+ * so there is no search/select experience in the undelegation modal (contrary to the
+ * delegation flow where the user picks a validator).
+ */
+export default function ValidatorField({ delegation }: Props) {
+  const { t } = useTranslation();
+  const { validator, validatorAddress, formattedAmount } = delegation;
+  const name = validator?.name ?? validatorAddress;
+  return (
+    <Box mb={4}>
+      <Label>{t("ethereum.evmStaking.undelegation.flow.steps.amount.fields.validator")}</Label>
+      <Container horizontal alignItems="center" justifyContent="space-between" p={3}>
+        <Box horizontal alignItems="center">
+          <EvmValidatorIcon
+            validator={
+              validator ?? {
+                validatorAddress,
+                name: validatorAddress,
+              }
+            }
+          />
+          <Text ml={2} ff="Inter|Medium" fontSize={4} color="neutral.c100">
+            {name}
+          </Text>
+        </Box>
+        <Text ff="Inter|Regular" fontSize={4} color="neutral.c80">
+          {formattedAmount}
+        </Text>
+      </Container>
+    </Box>
+  );
+}
+
+const Container = styled(Box)`
+  border: 1px solid ${p => p.theme.colors.neutral.c40};
+  border-radius: 4px;
+`;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/fields/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/fields/index.ts
@@ -1,0 +1,2 @@
+export { default as ValidatorField } from "./ValidatorField";
+export { default as AmountField } from "./AmountField";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/index.tsx
@@ -1,0 +1,44 @@
+import React, { PureComponent } from "react";
+import Modal from "~/renderer/components/Modal";
+import Body, { Data } from "./Body";
+import { StepId } from "./types";
+
+type State = {
+  stepId: StepId;
+};
+
+const INITIAL_STATE: State = {
+  stepId: "amount",
+};
+
+class UndelegationModal extends PureComponent<Data, State> {
+  state: State = INITIAL_STATE;
+
+  handleReset = () => this.setState({ ...INITIAL_STATE });
+
+  handleStepChange = (stepId: StepId) => this.setState({ stepId });
+
+  render() {
+    const { stepId } = this.state;
+    const isModalLocked = ["connectDevice", "confirmation"].includes(stepId);
+    return (
+      <Modal
+        name="MODAL_EVM_UNDELEGATE"
+        centered
+        onHide={this.handleReset}
+        preventBackdropClick={isModalLocked}
+        width={550}
+        render={({ onClose, data }) => (
+          <Body
+            stepId={stepId}
+            onClose={onClose}
+            onChangeStepId={this.handleStepChange}
+            params={data || {}}
+          />
+        )}
+      />
+    );
+  }
+}
+
+export default UndelegationModal;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/steps/StepAmount.tsx
@@ -1,0 +1,169 @@
+import { BigNumber } from "bignumber.js";
+import invariant from "invariant";
+import React, { useCallback, useMemo } from "react";
+import { useTranslation, Trans } from "react-i18next";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import type { AccountBridge } from "@ledgerhq/types-live";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-alpaca/types";
+import {
+  mapDelegations,
+  getUnbondingPeriodDays,
+  hasUnbondingPeriod,
+} from "@ledgerhq/live-common/families/evm/staking/logic";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import Text from "~/renderer/components/Text";
+import Alert from "~/renderer/components/Alert";
+import ErrorBanner from "~/renderer/components/ErrorBanner";
+import AccountFooter from "~/renderer/modals/Send/AccountFooter";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { ValidatorField, AmountField } from "../fields";
+import { StepProps } from "../types";
+
+export default function StepAmount({
+  account,
+  parentAccount,
+  transaction,
+  onUpdateTransaction,
+  status,
+  error,
+  validatorAddress,
+}: Readonly<StepProps>) {
+  invariant(account && transaction, "account and transaction required");
+  const unit = useAccountUnit(account);
+
+  const bridge = getAccountBridge(account, parentAccount) as AccountBridge<GenericTransaction>;
+
+  // Rely on the authoritative mapping (same as the delegation table) to keep the validator
+  // metadata (name, icon) consistent across the whole flow.
+  const mappedDelegation = useMemo(() => {
+    const [mapped] = mapDelegations(
+      account.stakingResources.delegations.filter(d => d.validatorAddress === validatorAddress),
+      account.stakingResources.validators ?? [],
+      unit,
+    );
+    return mapped;
+  }, [
+    account.stakingResources.delegations,
+    account.stakingResources.validators,
+    unit,
+    validatorAddress,
+  ]);
+
+  const delegatedAmount = mappedDelegation?.amount ?? new BigNumber(0);
+
+  const onChangeAmount = useCallback(
+    (amount: BigNumber) => {
+      onUpdateTransaction(tx => bridge.updateTransaction(tx, { amount }));
+    },
+    [onUpdateTransaction, bridge],
+  );
+
+  const unbondingDays = getUnbondingPeriodDays(account.currency.id);
+  const showLockup = hasUnbondingPeriod(account.currency.id);
+
+  // Surface any bridge validation error that is NOT shown inside the AmountField
+  // (e.g. errors.fees when the account has no free balance for gas).
+  // Must be called before the conditional return to respect rules of hooks.
+  const hiddenError = useMemo(() => {
+    const { amount: _a, unbonding: _u, ...rest } = status.errors ?? {};
+    return Object.values(rest)[0] ?? null;
+  }, [status.errors]);
+
+  if (!mappedDelegation) {
+    return (
+      <Box flow={1}>
+        <ErrorBanner error={new Error("No delegation found for the requested validator")} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box flow={1}>
+      <TrackPage
+        category="Undelegation Flow EVM"
+        name="Step 1"
+        flow="stake"
+        action="undelegation"
+        currency={account.currency.id}
+      />
+      {error && <ErrorBanner error={error} />}
+      {!error && hiddenError && <ErrorBanner error={hiddenError} />}
+      {showLockup && unbondingDays ? (
+        <Box horizontal justifyContent="center" mb={2}>
+          <Text ff="Inter|Medium" fontSize={4}>
+            <Trans
+              i18nKey="ethereum.evmStaking.undelegation.flow.steps.amount.subtitle"
+              values={{ numberOfDays: unbondingDays }}
+            >
+              <b></b>
+            </Trans>
+          </Text>
+        </Box>
+      ) : null}
+      <ValidatorField delegation={mappedDelegation} />
+      <AmountField
+        amount={transaction.amount ?? new BigNumber(0)}
+        delegatedAmount={delegatedAmount}
+        account={account}
+        status={status}
+        onChange={onChangeAmount}
+        label={<Trans i18nKey="ethereum.evmStaking.undelegation.flow.steps.amount.fields.amount" />}
+      />
+      <Box mb={1} />
+      <Alert type="primary" mt={2}>
+        {showLockup && unbondingDays ? (
+          <Trans
+            i18nKey="ethereum.evmStaking.undelegation.flow.steps.amount.warningWithTimelock"
+            values={{ numberOfDays: unbondingDays }}
+          >
+            <b></b>
+          </Trans>
+        ) : (
+          // Instant withdrawals — no unbonding period. We only surface the auto-claim notice.
+          <Trans i18nKey="ethereum.evmStaking.undelegation.flow.steps.amount.warningInstant">
+            <b></b>
+          </Trans>
+        )}
+      </Alert>
+    </Box>
+  );
+}
+
+export function StepAmountFooter({
+  transitionTo,
+  account,
+  parentAccount,
+  onClose,
+  status,
+  bridgePending,
+  transaction,
+}: Readonly<StepProps>) {
+  const { t } = useTranslation();
+  const { errors } = status;
+  const hasErrors = Object.keys(errors).length;
+  // Pre-populated from the delegation row — amount must be positive to proceed.
+  // bridgePending is handled via isLoading on the button (spinner), not by disabling outright,
+  // so the user gets visual feedback instead of a silently-grayed button.
+  const hasAmount = !!transaction && new BigNumber(transaction.amount ?? 0).gt(0);
+  const canNext = !hasErrors && hasAmount;
+  return (
+    <>
+      <AccountFooter parentAccount={parentAccount} account={account} status={status} />
+      <Box horizontal>
+        <Button mr={1} onClick={onClose}>
+          {t("common.cancel")}
+        </Button>
+        <Button
+          isLoading={bridgePending}
+          disabled={!canNext}
+          primary
+          onClick={() => transitionTo("connectDevice")}
+        >
+          {t("common.continue")}
+        </Button>
+      </Box>
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/steps/StepConfirmation.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useMemo } from "react";
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import { BigNumber } from "bignumber.js";
+import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { track } from "~/renderer/analytics/segment";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import RetryButton from "~/renderer/components/RetryButton";
+import ErrorDisplay from "~/renderer/components/ErrorDisplay";
+import SuccessDisplay from "~/renderer/components/SuccessDisplay";
+import BroadcastErrorDisclaimer from "~/renderer/components/BroadcastErrorDisclaimer";
+import { OperationDetails } from "~/renderer/drawers/OperationDetails";
+import { setDrawer } from "~/renderer/drawers/Provider";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import type { Operation } from "@ledgerhq/types-live";
+import { StepProps } from "../types";
+
+const Container = styled(Box).attrs(() => ({
+  alignItems: "center",
+  grow: true,
+  color: "neutral.c100",
+}))<{
+  shouldSpace?: boolean;
+}>`
+  justify-content: ${p => (p.shouldSpace ? "space-between" : "center")};
+`;
+
+function StepConfirmation({
+  optimisticOperation,
+  error,
+  signed,
+  transaction,
+  source,
+  account,
+  validatorAddress,
+}: Readonly<StepProps>) {
+  const currencyId = account.currency.id;
+  const unit = useAccountUnit(account);
+
+  useEffect(() => {
+    if (optimisticOperation && validatorAddress) {
+      track("staking_completed", {
+        currency: currencyId.toUpperCase(),
+        validator: validatorAddress,
+        delegation: "undelegation",
+        flow: "stake",
+        source,
+      });
+    }
+  }, [currencyId, optimisticOperation, validatorAddress, source]);
+
+  const validatorName = useMemo(() => {
+    const validator = account.stakingResources.validators?.find(
+      v => v.validatorAddress === validatorAddress,
+    );
+    return validator?.name ?? validatorAddress;
+  }, [account.stakingResources.validators, validatorAddress]);
+
+  if (optimisticOperation) {
+    const amount = transaction?.amount
+      ? formatCurrencyUnit(unit, new BigNumber(transaction.amount), { showCode: true })
+      : "";
+    return (
+      <Container>
+        <TrackPage
+          category="Undelegation Flow EVM"
+          name="Step Confirmed"
+          flow="stake"
+          action="undelegation"
+          currency={currencyId}
+        />
+        <SyncOneAccountOnMount
+          reason="transaction-flow-confirmation"
+          priority={10}
+          accountId={optimisticOperation.accountId}
+        />
+        <SuccessDisplay
+          title={
+            <Trans i18nKey="ethereum.evmStaking.undelegation.flow.steps.confirmation.success.title" />
+          }
+          description={
+            <div>
+              <Trans
+                i18nKey="ethereum.evmStaking.undelegation.flow.steps.confirmation.success.description"
+                values={{ amount, validator: validatorName }}
+              >
+                <b></b>
+              </Trans>
+            </div>
+          }
+        />
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container shouldSpace={signed}>
+        <TrackPage
+          category="Undelegation Flow EVM"
+          name="Step Confirmation Error"
+          flow="stake"
+          action="undelegation"
+          currency={currencyId}
+        />
+        {signed ? (
+          <BroadcastErrorDisclaimer
+            title={
+              <Trans i18nKey="ethereum.evmStaking.undelegation.flow.steps.confirmation.broadcastError" />
+            }
+          />
+        ) : null}
+        <ErrorDisplay error={error} withExportLogs />
+      </Container>
+    );
+  }
+
+  return null;
+}
+
+export function StepConfirmationFooter({
+  account,
+  onRetry,
+  error,
+  onClose,
+  optimisticOperation,
+}: Readonly<StepProps>) {
+  let concernedOperation: Operation | null = null;
+  if (optimisticOperation) {
+    const firstSubOperation = optimisticOperation.subOperations?.[0];
+    concernedOperation = firstSubOperation ?? optimisticOperation;
+  }
+
+  let footerSecondaryAction: React.ReactNode = null;
+  if (concernedOperation) {
+    footerSecondaryAction = (
+      <Button
+        primary
+        ml={2}
+        event="Undelegation EVM Step 3 View OpD Clicked"
+        onClick={() => {
+          onClose();
+          if (account && concernedOperation) {
+            setDrawer(OperationDetails, {
+              operationId: concernedOperation.id,
+              accountId: account.id,
+            });
+          }
+        }}
+      >
+        <Trans i18nKey="ethereum.evmStaking.undelegation.flow.steps.confirmation.success.cta" />
+      </Button>
+    );
+  } else if (error) {
+    footerSecondaryAction = <RetryButton primary ml={2} onClick={onRetry} />;
+  }
+
+  return (
+    <Box horizontal alignItems="right">
+      <Button data-testid="modal-close-button" ml={2} onClick={onClose}>
+        <Trans i18nKey="common.close" />
+      </Button>
+      {footerSecondaryAction}
+    </Box>
+  );
+}
+
+export default StepConfirmation;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/types.ts
@@ -1,0 +1,35 @@
+import { TFunction } from "i18next";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { Step } from "~/renderer/components/Stepper";
+import type { StakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-alpaca/types";
+import { TransactionStatusCommon, Operation } from "@ledgerhq/types-live";
+import { OpenModal } from "~/renderer/actions/modals";
+
+export type StepId = "amount" | "connectDevice" | "confirmation";
+
+export type StepProps = {
+  t: TFunction;
+  transitionTo: (a: string) => void;
+  device: Device | undefined | null;
+  account: StakingAccount;
+  parentAccount: never;
+  onRetry: (a: void) => void;
+  onClose: () => void;
+  openModal: OpenModal;
+  optimisticOperation: Operation | undefined;
+  error: Error | undefined;
+  signed: boolean;
+  transaction: GenericTransaction | undefined | null;
+  status: TransactionStatusCommon;
+  onChangeTransaction: (a: GenericTransaction) => void;
+  onUpdateTransaction: (a: (a: GenericTransaction) => GenericTransaction) => void;
+  onTransactionError: (a: Error) => void;
+  onOperationBroadcasted: (a: Operation) => void;
+  setSigned: (a: boolean) => void;
+  bridgePending: boolean;
+  source?: string;
+  validatorAddress: string;
+};
+
+export type St = Step<StepId, StepProps>;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/modals.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/modals.ts
@@ -5,6 +5,8 @@ import { AccountLike } from "@ledgerhq/types-live";
 import MODAL_EVM_DELEGATE from "./DelegationFlowModal";
 import { Data as DelegationProps } from "./DelegationFlowModal/Body";
 import MODAL_EVM_REWARDS_INFO, { Props as RewardsInfoProps } from "./DelegationFlowModal/Info";
+import MODAL_EVM_UNDELEGATE from "./UndelegationFlowModal";
+import { Data as UndelegationProps } from "./UndelegationFlowModal/Body";
 
 export type ModalsData = {
   MODAL_EVM_STAKE: {
@@ -16,6 +18,7 @@ export type ModalsData = {
   MODAL_EVM_EDIT_TRANSACTION: EditTransactionModalProps;
   MODAL_EVM_DELEGATE: DelegationProps;
   MODAL_EVM_REWARDS_INFO: RewardsInfoProps;
+  MODAL_EVM_UNDELEGATE: UndelegationProps;
 };
 
 const modals: MakeModalsType<ModalsData> = {
@@ -23,6 +26,7 @@ const modals: MakeModalsType<ModalsData> = {
   MODAL_EVM_EDIT_TRANSACTION: EditTransactionModal,
   MODAL_EVM_DELEGATE,
   MODAL_EVM_REWARDS_INFO,
+  MODAL_EVM_UNDELEGATE,
 };
 
 export default modals;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4275,7 +4275,35 @@
       },
       "undelegation": {
         "header": "Undelegation(s)",
-        "inactiveTooltip": "Undelegated amounts do not generate rewards."
+        "headerTooltip": "Available after the {{numberOfDays}}-day timelock",
+        "inactiveTooltip": "Undelegated amounts do not generate rewards.",
+        "flow": {
+          "title": "Stop staking",
+          "steps": {
+            "amount": {
+              "title": "Amount",
+              "subtitle": "The undelegation process takes <0>{{numberOfDays}} days</0> to finalize.",
+              "warningWithTimelock": "Rewards will be automatically claimed. The undelegated amount will be back in the available balance after the <0>{{numberOfDays}}-day timelock</0>.",
+              "warningInstant": "Rewards will be automatically claimed. The undelegated amount will be immediately available in your balance.",
+              "fields": {
+                "validator": "Validator",
+                "amount": "Amount to undelegate"
+              }
+            },
+            "connectDevice": {
+              "title": "Device"
+            },
+            "confirmation": {
+              "title": "Confirmation",
+              "success": {
+                "title": "You have successfully undelegated your assets.",
+                "description": "<0>{{amount}}</0> were undelegated from <0>{{validator}}</0>",
+                "cta": "View details"
+              },
+              "broadcastError": "Your transaction may have failed. Please wait a moment then check the transaction history before trying again."
+            }
+          }
+        }
       }
     }
   },

--- a/libs/coin-modules/coin-evm/src/staking/validators.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators.test.ts
@@ -202,11 +202,23 @@ describe("staking/validators", () => {
       expect(getUnbondingPeriodDays("sei_evm")).toBe(21);
     });
 
-    it("hasUnbondingPeriod is true for Sei and false without config", () => {
+    it.each(["celo", "__unknown__"])(
+      "getUnbondingPeriodDays returns undefined without config (%s)",
+      currencyId => {
+        expect(getUnbondingPeriodDays(currencyId)).toBeUndefined();
+      },
+    );
+
+    it("hasUnbondingPeriod is true for Sei", () => {
       expect(hasUnbondingPeriod("sei_evm")).toBe(true);
-      expect(hasUnbondingPeriod("celo")).toBe(false);
-      expect(hasUnbondingPeriod("unknown")).toBe(false);
     });
+
+    it.each(["celo", "__unknown__"])(
+      "hasUnbondingPeriod is false without configured unbonding (%s)",
+      currencyId => {
+        expect(hasUnbondingPeriod(currencyId)).toBe(false);
+      },
+    );
   });
 
   describe("getValidatorsPage", () => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Add support for EVM staking undelegation.
- Implement the desktop flow to let users stop staking from an existing delegation.
- Wire the new flow to the EVM staking transaction logic.
- Add validation and tests for undelegation handling, including SEI-specific amount conversion.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-28032)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
