### PR TITLE
[LWDM] refactor(common): [LIVE-29430] add connect-app initialization input helpers

### DIFF
--- a/.changeset/odd-goats-extract.md
+++ b/.changeset/odd-goats-extract.md
@@ -1,0 +1,4 @@
+"@ledgerhq/live-common": patch
+---
+
+Extract connect-app AppRequest resolution helpers for device initialization

--- a/.changeset/odd-goats-extract.md
+++ b/.changeset/odd-goats-extract.md
@@ -1,4 +1,5 @@
+---
 "@ledgerhq/live-common": patch
 ---
 
-Extract connect-app AppRequest resolution helpers for device initialization
+Add shared connect-app device-initialization input helpers for DIE migrations

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -550,6 +550,8 @@
     "src/hooks/useAppVersionBlockCheck.ts",
     "src/hooks/useHtmlLinkSegments.ts",
     "src/hw/actions/uninstallAllApps.ts",
+    "src/hw/deviceInitialization/buildConnectAppInitializationInput.ts",
+    "src/hw/deviceInitialization/deprecationPresentation.ts",
     "src/hw/getBitcoinLikeInfo.ts",
     "src/jest.d.ts",
     "src/market/api/countervalues.ts",

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -223,6 +223,7 @@
     "@ledgerhq/coin-xrp": "catalog:",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/device-core": "workspace:^",
+    "@ledgerhq/device-intent": "workspace:^",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/errors": "workspace:^",

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -1,6 +1,6 @@
 import { interval, Observable, of } from "rxjs";
 import { scan, debounce, tap, takeWhile } from "rxjs/operators";
-import { useEffect, useCallback, useState, useRef } from "react";
+import { useEffect, useCallback, useState, useMemo, useRef } from "react";
 import { log } from "@ledgerhq/logs";
 import type {
   AppAndVersion,
@@ -17,12 +17,15 @@ import type { Account, DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types
 import { DeviceId } from "@ledgerhq/client-ids/ids";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getImplementation, ImplementationType } from "./implementations";
-import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import {
   resolveAppRequestRequirements,
   toConnectAppRequest,
 } from "../deviceInitialization/resolveAppRequestRequirements";
 import type { AppRequestInput } from "../deviceInitialization/types";
+import {
+  buildExpectedAccountIdentity,
+  validateDerivedAddress,
+} from "../deviceInitialization/wrongDeviceValidation";
 
 export type State = {
   isLoading: boolean;
@@ -474,16 +477,23 @@ export const createAction = (
         displayUpgradeWarning: false,
       }));
     }, []);
+
+    const wrongDeviceCheck = useMemo(
+      () =>
+        validateDerivedAddress(
+          appRequest.account ? buildExpectedAccountIdentity(appRequest.account) : undefined,
+          state.derivation?.address,
+        ),
+      [appRequest.account, state.derivation?.address],
+    );
+
     return {
       ...state,
       inWrongDeviceForAccount:
-        state.derivation && appRequest.account
-          ? state.derivation.address !== appRequest.account.freshAddress &&
-            state.derivation.address !== appRequest.account.seedIdentifier // Use-case added for Hedera
-            ? {
-                accountName: getDefaultAccountName(appRequest.account),
-              }
-            : null
+        wrongDeviceCheck.status === "mismatch"
+          ? {
+              accountName: wrongDeviceCheck.accountName,
+            }
           : null,
       onRetry,
       passWarning,

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -1,13 +1,7 @@
-import invariant from "invariant";
 import { interval, Observable, of } from "rxjs";
 import { scan, debounce, tap, takeWhile } from "rxjs/operators";
 import { useEffect, useCallback, useState, useRef } from "react";
 import { log } from "@ledgerhq/logs";
-import {
-  getDerivationScheme,
-  getDerivationModesForCurrency,
-  runDerivationScheme,
-} from "@ledgerhq/ledger-wallet-framework/derivation";
 import type {
   AppAndVersion,
   ConnectAppEvent,
@@ -19,12 +13,16 @@ import { useReplaySubject } from "../../observable";
 import type { Device, Action } from "./types";
 import { shouldUpgrade } from "../../apps";
 import { AppOp, SkippedAppOp } from "../../apps/types";
-import { loadAccountModuleForFamily } from "../../coin-modules/registry";
 import type { Account, DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 import { DeviceId } from "@ledgerhq/client-ids/ids";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getImplementation, ImplementationType } from "./implementations";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import {
+  resolveAppRequestRequirements,
+  toConnectAppRequest,
+} from "../deviceInitialization/resolveAppRequestRequirements";
+import type { AppRequestInput } from "../deviceInitialization/types";
 
 export type State = {
   isLoading: boolean;
@@ -81,16 +79,7 @@ export type AppState = State & {
     | undefined;
 };
 
-export type AppRequest = {
-  appName?: string;
-  currency?: CryptoCurrency | null;
-  account?: Account;
-  tokenCurrency?: TokenCurrency;
-  dependencies?: AppRequest[];
-  withInlineInstallProgress?: boolean;
-  requireLatestFirmware?: boolean;
-  allowPartialDependencies?: boolean;
-};
+export type AppRequest = AppRequestInput;
 
 export type AppResult = {
   device: Device;
@@ -379,85 +368,6 @@ const reducer = (state: State, e: Event): State => {
   return state;
 };
 
-/**
- * Map between an AppRequest and a ConnectAppRequest, allowing us to
- * specify an account or a currency without resolving manually the actual
- * applications we depend on in order to access the flow.
- */
-async function inferCommandParams(appRequest: AppRequest): Promise<ConnectAppRequest> {
-  let derivationMode;
-  let derivationPath;
-
-  const {
-    account,
-    requireLatestFirmware,
-    allowPartialDependencies = false,
-    dependencies: appDependencies,
-  } = appRequest;
-  let { appName, currency } = appRequest;
-
-  if (!currency && account) {
-    currency = account.currency;
-  }
-
-  if (!appName && currency) {
-    appName = currency.managerAppName;
-  }
-
-  invariant(appName, "appName or currency or account is missing");
-
-  let dependencies: string[] | undefined = undefined;
-  if (appDependencies) {
-    dependencies = (await Promise.all(appDependencies.map(d => inferCommandParams(d)))).map(
-      p => p.appName,
-    );
-  }
-
-  if (!currency) {
-    return {
-      appName,
-      dependencies,
-      requireLatestFirmware,
-      allowPartialDependencies,
-    };
-  }
-
-  let extra;
-
-  if (account) {
-    derivationMode = account.derivationMode;
-    derivationPath = account.freshAddressPath;
-    const m = await loadAccountModuleForFamily(account.currency.family);
-
-    if (m && m.injectGetAddressParams) {
-      extra = m.injectGetAddressParams(account);
-    }
-  } else {
-    const modes = getDerivationModesForCurrency(currency);
-    derivationMode = modes[modes.length - 1];
-    derivationPath = runDerivationScheme(
-      getDerivationScheme({
-        currency,
-        derivationMode,
-      }),
-      currency,
-    );
-  }
-
-  return {
-    appName,
-    dependencies,
-    requireLatestFirmware,
-    requiresDerivation: {
-      derivationMode,
-      path: derivationPath,
-      currencyId: currency.id,
-      ...extra,
-    },
-    allowPartialDependencies,
-  };
-}
-
 export let currentMode: keyof typeof ImplementationType = "event";
 export function setDeviceMode(mode: keyof typeof ImplementationType): void {
   currentMode = mode;
@@ -475,7 +385,14 @@ export const createAction = (
     const [request, setRequest] = useState<ConnectAppRequest | null>(null);
     // oxlint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => {
-      inferCommandParams(appRequest).then(setRequest);
+      let dead = false;
+      resolveAppRequestRequirements(appRequest).then(requirements => {
+        if (dead) return;
+        setRequest(toConnectAppRequest(requirements));
+      });
+      return () => {
+        dead = true;
+      };
     }, [
       appRequest.appName,
       appRequest.account?.id,

--- a/libs/ledger-live-common/src/hw/deviceInitialization/buildConnectAppInitializationInput.test.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/buildConnectAppInitializationInput.test.ts
@@ -1,0 +1,156 @@
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import {
+  createFixtureAccount,
+  createFixtureTokenAccount,
+} from "../../mock/fixtures/cryptoCurrencies";
+import { FlowName } from "../../device-action/utils";
+
+jest.mock("@ledgerhq/ledger-wallet-framework/derivation", () => ({
+  getDerivationScheme: jest.fn(() => "mock-scheme"),
+  getDerivationModesForCurrency: jest.fn(() => ["ethM", ""]),
+  runDerivationScheme: jest.fn(() => "44'/60'/0'/0/0"),
+}));
+
+jest.mock("../../coin-modules/registry", () => ({
+  loadAccountModuleForFamily: jest.fn(() => undefined),
+}));
+
+import {
+  getDerivationModesForCurrency,
+  getDerivationScheme,
+  runDerivationScheme,
+} from "@ledgerhq/ledger-wallet-framework/derivation";
+import { loadAccountModuleForFamily } from "../../coin-modules/registry";
+import { buildConnectAppInitializationInput } from "./buildConnectAppInitializationInput";
+
+const mockGetDerivationModesForCurrency = jest.mocked(getDerivationModesForCurrency);
+const mockGetDerivationScheme = jest.mocked(getDerivationScheme);
+const mockRunDerivationScheme = jest.mocked(runDerivationScheme);
+const mockLoadAccountModuleForFamily = jest.mocked(loadAccountModuleForFamily);
+
+const ethereumCurrency = getCryptoCurrencyById("ethereum");
+
+describe("deviceInitialization buildConnectAppInitializationInput", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDerivationModesForCurrency.mockReturnValue(["ethM", ""]);
+    mockGetDerivationScheme.mockReturnValue("mock-scheme");
+    mockRunDerivationScheme.mockReturnValue("44'/60'/0'/0/0");
+    mockLoadAccountModuleForFamily.mockReturnValue(undefined);
+  });
+
+  it("builds the initialization input from account data and flow metadata", async () => {
+    const account = createFixtureAccount("01", ethereumCurrency);
+    account.derivationMode = "ethM";
+    account.freshAddress = "0xfresh";
+    account.seedIdentifier = "0xseed";
+    account.freshAddressPath = "44'/60'/1'/0/0";
+
+    expect(
+      await buildConnectAppInitializationInput({
+        appRequest: { account },
+        flow: FlowName.send,
+      }),
+    ).toEqual({
+      appName: "Ethereum",
+      dependencies: [],
+      requireLatestFirmware: false,
+      allowPartialDependencies: false,
+      requiresDerivation: {
+        currencyId: "ethereum",
+        derivationMode: "ethM",
+        path: "44'/60'/1'/0/0",
+      },
+      expectedAccount: {
+        accountName: getDefaultAccountName(account),
+        acceptableDerivedAddresses: ["0xfresh", "0xseed"],
+      },
+      deprecation: {
+        flow: FlowName.send,
+        currencyName: "Ethereum",
+      },
+    });
+  });
+
+  it("keeps account-derived requirements while skipping wrong-device validation when requested", async () => {
+    const account = createFixtureAccount("02", ethereumCurrency);
+    account.derivationMode = "ethM";
+    account.freshAddressPath = "44'/60'/2'/0/0";
+
+    expect(
+      await buildConnectAppInitializationInput({
+        appRequest: { account },
+        skipWrongDeviceCheck: true,
+      }),
+    ).toEqual({
+      appName: "Ethereum",
+      dependencies: [],
+      requireLatestFirmware: false,
+      allowPartialDependencies: false,
+      requiresDerivation: {
+        currencyId: "ethereum",
+        derivationMode: "ethM",
+        path: "44'/60'/2'/0/0",
+      },
+      expectedAccount: undefined,
+      deprecation: undefined,
+    });
+  });
+
+  it("uses an explicit currency name override over request fallbacks", async () => {
+    const tokenCurrency = createFixtureTokenAccount("11").token;
+
+    expect(
+      await buildConnectAppInitializationInput({
+        appRequest: {
+          appName: "Exchange",
+          tokenCurrency,
+        },
+        flow: FlowName.swap,
+        currencyName: "Custom Coin",
+      }),
+    ).toMatchObject({
+      appName: "Exchange",
+      deprecation: {
+        flow: FlowName.swap,
+        currencyName: "Custom Coin",
+      },
+    });
+  });
+
+  it("falls back from token currency to account currency to currency for deprecation naming", async () => {
+    const account = createFixtureAccount("03", ethereumCurrency);
+    const tokenCurrency = createFixtureTokenAccount("12").token;
+    const tokenInput = await buildConnectAppInitializationInput({
+      appRequest: {
+        appName: "Exchange",
+        tokenCurrency,
+      },
+      flow: FlowName.swap,
+    });
+    const accountInput = await buildConnectAppInitializationInput({
+      appRequest: { account },
+      flow: FlowName.receive,
+    });
+    const currencyInput = await buildConnectAppInitializationInput({
+      appRequest: { currency: ethereumCurrency },
+      flow: FlowName.addAccount,
+    });
+
+    expect(tokenInput.deprecation).toEqual({
+      flow: FlowName.swap,
+      currencyName: tokenCurrency.name,
+    });
+
+    expect(accountInput.deprecation).toEqual({
+      flow: FlowName.receive,
+      currencyName: "Ethereum",
+    });
+
+    expect(currencyInput.deprecation).toEqual({
+      flow: FlowName.addAccount,
+      currencyName: "Ethereum",
+    });
+  });
+});

--- a/libs/ledger-live-common/src/hw/deviceInitialization/buildConnectAppInitializationInput.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/buildConnectAppInitializationInput.ts
@@ -1,0 +1,63 @@
+import type { FlowName } from "../../device-action/utils";
+import {
+  resolveAppRequestRequirements,
+  toConnectAppInitializationInput,
+  toConnectAppRequest,
+} from "./resolveAppRequestRequirements";
+import type { AppRequestInput, ConnectAppInitializationInput } from "./types";
+import { buildExpectedAccountIdentity } from "./wrongDeviceValidation";
+
+export type BuildConnectAppInitializationParams = {
+  appRequest: AppRequestInput;
+  flow?: FlowName;
+  currencyName?: string;
+  skipWrongDeviceCheck?: boolean;
+};
+
+/**
+ * Build the connect-app `deviceInitializationInput` consumed by DIE from the
+ * same `AppRequestInput` shape historically passed to legacy connect-app flows.
+ *
+ * Use this when migrating a flow from `hw/actions/app` / `connectApp` to
+ * `DeviceIntentExecutor`:
+ * - keep building the same `AppRequestInput`
+ * - pass it to `buildConnectAppInitializationInput(...)`
+ * - pass the returned object unchanged as `deviceInitializationInput`
+ *
+ * Callers should not manually derive `appName`, `dependencies`,
+ * `requiresDerivation`, `expectedAccount`, or `deprecation`. This builder is
+ * the canonical translation boundary from rich domain input to DIE init input.
+ */
+export async function buildConnectAppInitializationInput(
+  params: BuildConnectAppInitializationParams,
+): Promise<ConnectAppInitializationInput> {
+  const resolved = await resolveAppRequestRequirements(params.appRequest);
+  const baseInput = toConnectAppInitializationInput(resolved);
+
+  const expectedAccount =
+    !params.skipWrongDeviceCheck && params.appRequest.account
+      ? buildExpectedAccountIdentity(params.appRequest.account)
+      : undefined;
+
+  const derivedCurrencyName =
+    params.currencyName ??
+    params.appRequest.tokenCurrency?.name ??
+    params.appRequest.account?.currency?.name ??
+    params.appRequest.currency?.name;
+
+  const deprecation =
+    params.flow && derivedCurrencyName
+      ? {
+          flow: params.flow,
+          currencyName: derivedCurrencyName,
+        }
+      : undefined;
+
+  return {
+    ...baseInput,
+    expectedAccount,
+    deprecation,
+  };
+}
+
+export { resolveAppRequestRequirements, toConnectAppInitializationInput, toConnectAppRequest };

--- a/libs/ledger-live-common/src/hw/deviceInitialization/deprecationPresentation.test.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/deprecationPresentation.test.ts
@@ -1,0 +1,221 @@
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import type { DeviceDeprecationRules } from "../connectApp";
+import { FlowName } from "../../device-action/utils";
+import { decideDeprecationPresentation } from "./deprecationPresentation";
+
+const defaultDate = new Date("2023-12-31");
+
+function createRules(overrides: Partial<DeviceDeprecationRules> = {}): DeviceDeprecationRules {
+  return {
+    warningScreenVisible: false,
+    clearSigningScreenVisible: false,
+    errorScreenVisible: false,
+    modelId: DeviceModelId.nanoS,
+    date: defaultDate,
+    warningScreenRules: { exception: [], deprecatedFlow: [] },
+    clearSigningScreenRules: { exception: [], deprecatedFlow: [] },
+    errorScreenRules: { exception: [], deprecatedFlow: [] },
+    onContinue: jest.fn(),
+    ...overrides,
+  };
+}
+
+// These tests define the deprecation semantics expected by the shared DIE
+// initializer: dismissing a currency only skips the generic warning screen,
+// while clear-signing remains an independent gate.
+describe("deviceInitialization deprecationPresentation", () => {
+  it("returns block when the blocking screen applies", () => {
+    expect(
+      decideDeprecationPresentation({
+        rules: createRules({
+          errorScreenVisible: true,
+          errorScreenRules: {
+            exception: [],
+            deprecatedFlow: [FlowName.send],
+          },
+        }),
+        flow: FlowName.send,
+        currencyName: "Ethereum",
+        deprecationDismissedCurrencyNames: ["Ethereum"],
+      }),
+    ).toEqual({
+      status: "block",
+      currencyName: "Ethereum",
+      deviceModelId: DeviceModelId.nanoS,
+      supportEndDate: defaultDate,
+    });
+  });
+
+  it("returns warning and clear-signing screens when both apply", () => {
+    expect(
+      decideDeprecationPresentation({
+        rules: createRules({
+          warningScreenVisible: true,
+          clearSigningScreenVisible: true,
+          warningScreenRules: {
+            exception: [],
+            deprecatedFlow: [FlowName.send],
+          },
+          clearSigningScreenRules: {
+            exception: [],
+            deprecatedFlow: [FlowName.send],
+          },
+        }),
+        flow: FlowName.send,
+        currencyName: "Ethereum",
+        deprecationDismissedCurrencyNames: [],
+      }),
+    ).toEqual({
+      status: "show",
+      screenSequence: ["warning", "clearSigning"],
+      currencyName: "Ethereum",
+      deviceModelId: DeviceModelId.nanoS,
+      supportEndDate: defaultDate,
+    });
+  });
+
+  it("returns only the warning screen when clear-signing does not apply", () => {
+    expect(
+      decideDeprecationPresentation({
+        rules: createRules({
+          warningScreenVisible: true,
+          clearSigningScreenVisible: true,
+          warningScreenRules: {
+            exception: [],
+            deprecatedFlow: [FlowName.send],
+          },
+          clearSigningScreenRules: {
+            exception: [],
+            deprecatedFlow: [FlowName.receive],
+          },
+        }),
+        flow: FlowName.send,
+        currencyName: "Ethereum",
+        deprecationDismissedCurrencyNames: [],
+      }),
+    ).toEqual({
+      status: "show",
+      screenSequence: ["warning"],
+      currencyName: "Ethereum",
+      deviceModelId: DeviceModelId.nanoS,
+      supportEndDate: defaultDate,
+    });
+  });
+
+  it("returns the clear-signing screen on its own when only it applies", () => {
+    expect(
+      decideDeprecationPresentation({
+        rules: createRules({
+          clearSigningScreenVisible: true,
+          clearSigningScreenRules: {
+            exception: [],
+            deprecatedFlow: [FlowName.receive],
+          },
+        }),
+        flow: FlowName.receive,
+        currencyName: "Ethereum",
+        deprecationDismissedCurrencyNames: [],
+      }),
+    ).toEqual({
+      status: "show",
+      screenSequence: ["clearSigning"],
+      currencyName: "Ethereum",
+      deviceModelId: DeviceModelId.nanoS,
+      supportEndDate: defaultDate,
+    });
+  });
+
+  it("skips the warning but still shows clear-signing when the currency was dismissed", () => {
+    expect(
+      decideDeprecationPresentation({
+        rules: createRules({
+          warningScreenVisible: true,
+          clearSigningScreenVisible: true,
+          warningScreenRules: {
+            exception: [],
+            deprecatedFlow: [FlowName.send],
+          },
+          clearSigningScreenRules: {
+            exception: [],
+            deprecatedFlow: [FlowName.send],
+          },
+        }),
+        flow: FlowName.send,
+        currencyName: "Ethereum",
+        deprecationDismissedCurrencyNames: ["Ethereum"],
+      }),
+    ).toEqual({
+      status: "show",
+      screenSequence: ["clearSigning"],
+      currencyName: "Ethereum",
+      deviceModelId: DeviceModelId.nanoS,
+      supportEndDate: defaultDate,
+    });
+  });
+
+  it("skips the warning when it was dismissed and no clear-signing screen applies", () => {
+    expect(
+      decideDeprecationPresentation({
+        rules: createRules({
+          warningScreenVisible: true,
+          warningScreenRules: {
+            exception: [],
+            deprecatedFlow: [FlowName.send],
+          },
+        }),
+        flow: FlowName.send,
+        currencyName: "Ethereum",
+        deprecationDismissedCurrencyNames: ["Ethereum"],
+      }),
+    ).toEqual({ status: "skipped" });
+  });
+
+  it("skips when the flow is unknown or not covered by the rules", () => {
+    expect(
+      decideDeprecationPresentation({
+        rules: createRules({
+          warningScreenVisible: true,
+          warningScreenRules: {
+            exception: [],
+            deprecatedFlow: [FlowName.send],
+          },
+        }),
+        flow: FlowName.unknown,
+        currencyName: "Ethereum",
+        deprecationDismissedCurrencyNames: [],
+      }),
+    ).toEqual({ status: "skipped" });
+
+    expect(
+      decideDeprecationPresentation({
+        rules: createRules({
+          warningScreenVisible: true,
+          warningScreenRules: {
+            exception: [],
+            deprecatedFlow: [FlowName.receive],
+          },
+        }),
+        flow: FlowName.send,
+        currencyName: "Ethereum",
+        deprecationDismissedCurrencyNames: [],
+      }),
+    ).toEqual({ status: "skipped" });
+  });
+
+  it("skips when the currency is explicitly excluded", () => {
+    expect(
+      decideDeprecationPresentation({
+        rules: createRules({
+          warningScreenVisible: true,
+          warningScreenRules: {
+            exception: ["Ethereum"],
+            deprecatedFlow: [FlowName.send],
+          },
+        }),
+        flow: FlowName.send,
+        currencyName: "Ethereum",
+        deprecationDismissedCurrencyNames: [],
+      }),
+    ).toEqual({ status: "skipped" });
+  });
+});

--- a/libs/ledger-live-common/src/hw/deviceInitialization/deprecationPresentation.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/deprecationPresentation.ts
@@ -1,0 +1,103 @@
+import type { DeviceDeprecationRules, DeviceDeprecationScreenRules } from "../connectApp";
+import { FlowName } from "../../device-action/utils";
+import type { DeprecationPresentationDecision, DeprecationScreenKind } from "./types";
+
+function doesScreenApply(params: {
+  rules: DeviceDeprecationScreenRules | undefined;
+  flow: FlowName;
+  currencyName: string;
+}): boolean {
+  const { rules, flow, currencyName } = params;
+
+  if (flow === FlowName.unknown) {
+    return false;
+  }
+
+  if (!rules?.deprecatedFlow?.includes(flow)) {
+    return false;
+  }
+
+  if (rules.exception?.includes(currencyName)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Decide how the new DIE connect-app initializer should present device deprecation.
+ *
+ * Dismissing a currency only suppresses the generic deprecation warning. It does
+ * not suppress a clear-signing warning, which remains eligible when its own
+ * rules apply. Blocking deprecation remains blocking.
+ */
+export function decideDeprecationPresentation(params: {
+  rules: DeviceDeprecationRules;
+  flow: FlowName;
+  currencyName: string;
+  deprecationDismissedCurrencyNames: string[];
+}): DeprecationPresentationDecision {
+  const { rules, flow, currencyName, deprecationDismissedCurrencyNames } = params;
+
+  const errorApplies =
+    rules.errorScreenVisible &&
+    doesScreenApply({
+      rules: rules.errorScreenRules,
+      flow,
+      currencyName,
+    });
+
+  if (errorApplies) {
+    return {
+      status: "block",
+      currencyName,
+      deviceModelId: rules.modelId,
+      supportEndDate: rules.date,
+    };
+  }
+
+  const warningApplies =
+    rules.warningScreenVisible &&
+    doesScreenApply({
+      rules: rules.warningScreenRules,
+      flow,
+      currencyName,
+    });
+
+  const clearSigningApplies =
+    rules.clearSigningScreenVisible &&
+    doesScreenApply({
+      rules: rules.clearSigningScreenRules,
+      flow,
+      currencyName,
+    });
+
+  const warningDismissed = deprecationDismissedCurrencyNames.includes(currencyName);
+
+  if (warningApplies && !warningDismissed) {
+    const screenSequence: Array<DeprecationScreenKind> = ["warning"];
+    if (clearSigningApplies) {
+      screenSequence.push("clearSigning");
+    }
+
+    return {
+      status: "show",
+      screenSequence,
+      currencyName,
+      deviceModelId: rules.modelId,
+      supportEndDate: rules.date,
+    };
+  }
+
+  if (clearSigningApplies) {
+    return {
+      status: "show",
+      screenSequence: ["clearSigning"],
+      currencyName,
+      deviceModelId: rules.modelId,
+      supportEndDate: rules.date,
+    };
+  }
+
+  return { status: "skipped" };
+}

--- a/libs/ledger-live-common/src/hw/deviceInitialization/resolveAppRequestRequirements.test.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/resolveAppRequestRequirements.test.ts
@@ -1,0 +1,174 @@
+import {
+  resolveAppRequestRequirements,
+  toConnectAppInitializationInput,
+  toConnectAppRequest,
+} from "./resolveAppRequestRequirements";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { createFixtureAccount } from "../../mock/fixtures/cryptoCurrencies";
+
+jest.mock("@ledgerhq/ledger-wallet-framework/derivation", () => ({
+  getDerivationScheme: jest.fn(() => "mock-scheme"),
+  getDerivationModesForCurrency: jest.fn(() => ["ethM", ""]),
+  runDerivationScheme: jest.fn(() => "44'/60'/0'/0/0"),
+}));
+
+jest.mock("../../coin-modules/registry", () => ({
+  loadAccountModuleForFamily: jest.fn(() => undefined),
+}));
+
+import {
+  getDerivationModesForCurrency,
+  getDerivationScheme,
+  runDerivationScheme,
+} from "@ledgerhq/ledger-wallet-framework/derivation";
+import { loadAccountModuleForFamily } from "../../coin-modules/registry";
+
+const mockGetDerivationModesForCurrency = jest.mocked(getDerivationModesForCurrency);
+const mockGetDerivationScheme = jest.mocked(getDerivationScheme);
+const mockRunDerivationScheme = jest.mocked(runDerivationScheme);
+const mockLoadAccountModuleForFamily = jest.mocked(loadAccountModuleForFamily);
+
+const ethereumCurrency = getCryptoCurrencyById("ethereum");
+const bitcoinCashCurrency = getCryptoCurrencyById("bitcoin_cash");
+
+describe("deviceInitialization requirements", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDerivationModesForCurrency.mockReturnValue(["ethM", ""]);
+    mockGetDerivationScheme.mockReturnValue("mock-scheme");
+    mockRunDerivationScheme.mockReturnValue("44'/60'/0'/0/0");
+    mockLoadAccountModuleForFamily.mockReturnValue(undefined);
+  });
+
+  it("resolves account-only input from account data", async () => {
+    const account = createFixtureAccount("01", ethereumCurrency);
+    account.derivationMode = "ethM";
+    account.freshAddressPath = "44'/60'/1'/0/0";
+
+    await expect(resolveAppRequestRequirements({ account })).resolves.toEqual({
+      appName: "Ethereum",
+      dependencies: undefined,
+      requireLatestFirmware: undefined,
+      allowPartialDependencies: false,
+      requiresDerivation: {
+        currencyId: "ethereum",
+        derivationMode: "ethM",
+        path: "44'/60'/1'/0/0",
+      },
+    });
+    expect(mockLoadAccountModuleForFamily).toHaveBeenCalledWith("evm");
+    expect(mockGetDerivationModesForCurrency).not.toHaveBeenCalled();
+  });
+
+  it("resolves currency-only input with the default derivation path", async () => {
+    await expect(resolveAppRequestRequirements({ currency: ethereumCurrency })).resolves.toEqual({
+      appName: "Ethereum",
+      dependencies: undefined,
+      requireLatestFirmware: undefined,
+      allowPartialDependencies: false,
+      requiresDerivation: {
+        currencyId: "ethereum",
+        derivationMode: "",
+        path: "44'/60'/0'/0/0",
+      },
+    });
+    expect(mockGetDerivationModesForCurrency).toHaveBeenCalledWith(ethereumCurrency);
+    expect(mockGetDerivationScheme).toHaveBeenCalledWith({
+      currency: ethereumCurrency,
+      derivationMode: "",
+    });
+    expect(mockRunDerivationScheme).toHaveBeenCalledWith("mock-scheme", ethereumCurrency);
+  });
+
+  it("resolves appName-only input without derivation", async () => {
+    await expect(resolveAppRequestRequirements({ appName: "Ethereum" })).resolves.toEqual({
+      appName: "Ethereum",
+      dependencies: undefined,
+      requireLatestFirmware: undefined,
+      allowPartialDependencies: false,
+    });
+  });
+
+  it("resolves nested dependencies recursively", async () => {
+    const account = createFixtureAccount("02", ethereumCurrency);
+    account.derivationMode = "ethM";
+    account.freshAddressPath = "44'/60'/0'/0/0";
+
+    await expect(
+      resolveAppRequestRequirements({
+        account,
+        dependencies: [{ appName: "BOLOS" }, { currency: ethereumCurrency }],
+      }),
+    ).resolves.toEqual({
+      appName: "Ethereum",
+      dependencies: ["BOLOS", "Ethereum"],
+      requireLatestFirmware: undefined,
+      allowPartialDependencies: false,
+      requiresDerivation: {
+        currencyId: "ethereum",
+        derivationMode: "ethM",
+        path: "44'/60'/0'/0/0",
+      },
+    });
+  });
+
+  it("preserves allowPartialDependencies and requireLatestFirmware", async () => {
+    await expect(
+      resolveAppRequestRequirements({
+        appName: "Exchange",
+        allowPartialDependencies: true,
+        requireLatestFirmware: true,
+      }),
+    ).resolves.toEqual({
+      appName: "Exchange",
+      dependencies: undefined,
+      requireLatestFirmware: true,
+      allowPartialDependencies: true,
+    });
+  });
+
+  it("includes family-specific injected address params", async () => {
+    mockLoadAccountModuleForFamily.mockReturnValue({
+      injectGetAddressParams: jest.fn(() => ({ forceFormat: "cashaddr" })),
+    });
+
+    const account = createFixtureAccount("03", bitcoinCashCurrency);
+    account.derivationMode = "unsplit";
+    account.freshAddressPath = "44'/145'/0'/0/0";
+
+    await expect(resolveAppRequestRequirements({ account })).resolves.toEqual({
+      appName: "Bitcoin Cash",
+      dependencies: undefined,
+      requireLatestFirmware: undefined,
+      allowPartialDependencies: false,
+      requiresDerivation: {
+        currencyId: "bitcoin_cash",
+        derivationMode: "unsplit",
+        forceFormat: "cashaddr",
+        path: "44'/145'/0'/0/0",
+      },
+    });
+  });
+
+  it("keeps legacy request optionality while normalizing the DIE input", async () => {
+    const resolved = await resolveAppRequestRequirements({
+      appName: "Ethereum",
+    });
+
+    expect(toConnectAppRequest(resolved)).toEqual({
+      appName: "Ethereum",
+      dependencies: undefined,
+      requireLatestFirmware: undefined,
+      allowPartialDependencies: false,
+      requiresDerivation: undefined,
+    });
+
+    expect(toConnectAppInitializationInput(resolved)).toEqual({
+      appName: "Ethereum",
+      dependencies: [],
+      requireLatestFirmware: false,
+      allowPartialDependencies: false,
+      requiresDerivation: undefined,
+    });
+  });
+});

--- a/libs/ledger-live-common/src/hw/deviceInitialization/resolveAppRequestRequirements.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/resolveAppRequestRequirements.ts
@@ -1,0 +1,120 @@
+import invariant from "invariant";
+import {
+  getDerivationScheme,
+  getDerivationModesForCurrency,
+  runDerivationScheme,
+} from "@ledgerhq/ledger-wallet-framework/derivation";
+import { loadAccountModuleForFamily } from "../../coin-modules/registry";
+import type { ConnectAppRequest } from "../connectApp";
+import type { AppRequestInput, ConnectAppInitializationInput, RequiresDerivation } from "./types";
+
+export type ResolvedAppRequirements = {
+  appName: string;
+  dependencies?: string[];
+  requireLatestFirmware?: boolean;
+  allowPartialDependencies: boolean;
+  requiresDerivation?: RequiresDerivation;
+};
+
+/**
+ * Map between an AppRequest and a ConnectAppRequest, allowing us to
+ * specify an account or a currency without resolving manually the actual
+ * applications we depend on in order to access the flow.
+ */
+export async function resolveAppRequestRequirements(
+  appRequest: AppRequestInput,
+): Promise<ResolvedAppRequirements> {
+  let derivationMode;
+  let derivationPath;
+
+  const {
+    account,
+    requireLatestFirmware,
+    allowPartialDependencies = false,
+    dependencies: appDependencies,
+  } = appRequest;
+  let { appName, currency } = appRequest;
+
+  if (!currency && account) {
+    currency = account.currency;
+  }
+
+  if (!appName && currency) {
+    appName = currency.managerAppName;
+  }
+
+  invariant(appName, "appName or currency or account is missing");
+
+  let dependencies: string[] | undefined = undefined;
+  if (appDependencies) {
+    dependencies = (await Promise.all(appDependencies.map(resolveAppRequestRequirements))).map(
+      requirements => requirements.appName,
+    );
+  }
+
+  if (!currency) {
+    return {
+      appName,
+      dependencies,
+      requireLatestFirmware,
+      allowPartialDependencies,
+    };
+  }
+
+  let extra;
+
+  if (account) {
+    derivationMode = account.derivationMode;
+    derivationPath = account.freshAddressPath;
+    const m = await loadAccountModuleForFamily(account.currency.family);
+
+    if (m && m.injectGetAddressParams) {
+      extra = m.injectGetAddressParams(account);
+    }
+  } else {
+    const modes = getDerivationModesForCurrency(currency);
+    derivationMode = modes[modes.length - 1];
+    derivationPath = runDerivationScheme(
+      getDerivationScheme({
+        currency,
+        derivationMode,
+      }),
+      currency,
+    );
+  }
+
+  return {
+    appName,
+    dependencies,
+    requireLatestFirmware,
+    requiresDerivation: {
+      derivationMode,
+      path: derivationPath,
+      currencyId: currency.id,
+      ...extra,
+    },
+    allowPartialDependencies,
+  };
+}
+
+export function toConnectAppRequest(requirements: ResolvedAppRequirements): ConnectAppRequest {
+  return {
+    appName: requirements.appName,
+    dependencies: requirements.dependencies,
+    requireLatestFirmware: requirements.requireLatestFirmware,
+    allowPartialDependencies: requirements.allowPartialDependencies,
+    requiresDerivation: requirements.requiresDerivation,
+  };
+}
+
+export function toConnectAppInitializationInput(
+  requirements: ResolvedAppRequirements,
+): Omit<ConnectAppInitializationInput, "expectedAccount" | "deprecation"> {
+  return {
+    appName: requirements.appName,
+    dependencies: requirements.dependencies ?? [],
+    requireLatestFirmware: requirements.requireLatestFirmware ?? false,
+    allowPartialDependencies: requirements.allowPartialDependencies,
+    requiresDerivation: requirements.requiresDerivation,
+  };
+}

--- a/libs/ledger-live-common/src/hw/deviceInitialization/resolveAppRequestRequirements.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/resolveAppRequestRequirements.ts
@@ -5,8 +5,8 @@ import {
   runDerivationScheme,
 } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { loadAccountModuleForFamily } from "../../coin-modules/registry";
-import type { ConnectAppRequest } from "../connectApp";
-import type { AppRequestInput, ConnectAppInitializationInput, RequiresDerivation } from "./types";
+import type { ConnectAppRequest, RequiresDerivation } from "../connectApp";
+import type { AppRequestInput, ConnectAppInitializationInput } from "./types";
 
 export type ResolvedAppRequirements = {
   appName: string;
@@ -17,7 +17,7 @@ export type ResolvedAppRequirements = {
 };
 
 /**
- * Map between an AppRequest and a ConnectAppRequest, allowing us to
+ * Map between an AppRequest and a ResolvedAppRequirements, allowing us to
  * specify an account or a currency without resolving manually the actual
  * applications we depend on in order to access the flow.
  */

--- a/libs/ledger-live-common/src/hw/deviceInitialization/types.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/types.ts
@@ -1,0 +1,41 @@
+import type { Account, DerivationMode } from "@ledgerhq/types-live";
+import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { FlowName } from "../../device-action/utils";
+
+export type RequiresDerivation = {
+  currencyId: string;
+  path: string;
+  derivationMode: DerivationMode;
+  forceFormat?: string;
+};
+
+export type ExpectedAccountIdentity = {
+  accountName: string;
+  acceptableDerivedAddresses: string[];
+};
+
+export type DeprecationPresentationInput = {
+  flow: FlowName;
+  currencyName: string;
+};
+
+export type AppRequestInput = {
+  appName?: string;
+  currency?: CryptoCurrency | null;
+  account?: Account;
+  tokenCurrency?: TokenCurrency;
+  dependencies?: AppRequestInput[];
+  withInlineInstallProgress?: boolean;
+  requireLatestFirmware?: boolean;
+  allowPartialDependencies?: boolean;
+};
+
+export type ConnectAppInitializationInput = {
+  appName: string;
+  dependencies: string[];
+  requireLatestFirmware: boolean;
+  allowPartialDependencies: boolean;
+  requiresDerivation?: RequiresDerivation;
+  expectedAccount?: ExpectedAccountIdentity;
+  deprecation?: DeprecationPresentationInput;
+};

--- a/libs/ledger-live-common/src/hw/deviceInitialization/types.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/types.ts
@@ -1,23 +1,89 @@
-import type { Account, DerivationMode } from "@ledgerhq/types-live";
+import type { DeviceId } from "@ledgerhq/client-ids/ids";
+import type { DeviceExtractedContext } from "@ledgerhq/device-intent";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+import type { Account, DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 import type { FlowName } from "../../device-action/utils";
-
-export type RequiresDerivation = {
-  currencyId: string;
-  path: string;
-  derivationMode: DerivationMode;
-  forceFormat?: string;
-};
+import type { RequiresDerivation } from "../connectApp";
 
 export type ExpectedAccountIdentity = {
   accountName: string;
   acceptableDerivedAddresses: string[];
 };
 
+/**
+ * Caller-provided context used to decide whether a deprecation screen applies
+ * for the current connect-app flow.
+ */
 export type DeprecationPresentationInput = {
+  /** Flow in which connect-app is currently running. */
   flow: FlowName;
+  /**
+   * User-facing main currency or token name.
+   *
+   * This value is used for policy exception matching, persisted warning
+   * dismissal matching, and deprecation screen copy.
+   */
   currencyName: string;
 };
+
+/** Ordered, non-blocking deprecation screens that the UI may need to display. */
+export type DeprecationScreenKind = "warning" | "clearSigning";
+
+/** No deprecation UI should be shown and initialization can continue immediately. */
+export type SkippedDeprecationPresentationDecision = {
+  status: "skipped";
+};
+
+/**
+ * Non-blocking deprecation UI must be shown before initialization can continue.
+ */
+export type ShownDeprecationPresentationDecision = {
+  status: "show";
+  /**
+   * Ordered list of non-blocking screens to show to the user.
+   *
+   * The UI should preserve this order when walking through the sequence.
+   */
+  screenSequence: DeprecationScreenKind[];
+  /** User-facing currency or token name the decision applies to. */
+  currencyName: string;
+  /** Device model affected by the deprecation policy. */
+  deviceModelId: DeviceModelId;
+  /**
+   * Date shown in deprecation copy for when support for this currency on this
+   * device model ends.
+   */
+  supportEndDate: Date;
+};
+
+/**
+ * The flow is blocked by deprecation policy and must not continue.
+ */
+export type BlockingDeprecationPresentationDecision = {
+  status: "block";
+  /** User-facing currency or token name the decision applies to. */
+  currencyName: string;
+  /** Device model affected by the deprecation policy. */
+  deviceModelId: DeviceModelId;
+  /**
+   * Date shown in deprecation copy for when support for this currency on this
+   * device model ends.
+   */
+  supportEndDate: Date;
+};
+
+/**
+ * UI-ready result of evaluating device deprecation for a specific flow and
+ * currency.
+ *
+ * This folds together remote-config applicability, flow/currency matching, and
+ * warning dismissal state so rendering code does not need to recompute them.
+ */
+export type DeprecationPresentationDecision =
+  | SkippedDeprecationPresentationDecision
+  | ShownDeprecationPresentationDecision
+  | BlockingDeprecationPresentationDecision;
 
 export type AppRequestInput = {
   appName?: string;
@@ -39,3 +105,54 @@ export type ConnectAppInitializationInput = {
   expectedAccount?: ExpectedAccountIdentity;
   deprecation?: DeprecationPresentationInput;
 };
+
+export type ConnectAppInitSideEffects = {
+  onDeviceIdObserved: (deviceId: DeviceId) => void;
+  onLastSeenDeviceInfoObserved: (params: {
+    modelId: DeviceModelId;
+    deviceInfo: DeviceInfo;
+    latestFirmware: FirmwareUpdateContext | null;
+  }) => void;
+};
+
+export type ConnectAppInitJobState =
+  | { type: "connect-device" }
+  | { type: "unlock-device" }
+  | { type: "locked-device" }
+  | { type: "request-manager-permission" }
+  | { type: "listing-apps" }
+  | {
+      type: "installing-app";
+      appName: string;
+      progress: number;
+      index: number;
+      total: number;
+    }
+  | {
+      type: "requires-app-installation";
+      appName: string;
+      appNames: string[];
+    }
+  | { type: "request-quit-app" }
+  | { type: "request-open-app"; appName: string }
+  | {
+      type: "deprecation-show";
+      decision: Extract<DeprecationPresentationDecision, { status: "show" }>;
+      onContinue: () => void;
+    }
+  | {
+      type: "deprecation-block";
+      decision: Extract<DeprecationPresentationDecision, { status: "block" }>;
+    }
+  | {
+      type: "wrong-device";
+      accountName: string;
+    }
+  | {
+      type: "outdated-app-warning";
+      appName: string;
+      onContinue: () => void;
+    }
+  | { type: "loading" }
+  | { type: "error"; error: unknown }
+  | { type: "done"; extractedContext: DeviceExtractedContext };

--- a/libs/ledger-live-common/src/hw/deviceInitialization/wrongDeviceValidation.test.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/wrongDeviceValidation.test.ts
@@ -1,0 +1,70 @@
+import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { createFixtureAccount } from "../../mock/fixtures/cryptoCurrencies";
+import {
+  buildExpectedAccountIdentity,
+  validateDerivedAddress,
+} from "./wrongDeviceValidation";
+
+const ethereumCurrency = getCryptoCurrencyById("ethereum");
+
+describe("deviceInitialization wrongDeviceValidation", () => {
+  it("builds the expected account identity with fresh and seed addresses", () => {
+    const account = createFixtureAccount("01", ethereumCurrency);
+    account.freshAddress = "0xfresh";
+    account.seedIdentifier = "0xseed";
+
+    expect(buildExpectedAccountIdentity(account)).toEqual({
+      accountName: getDefaultAccountName(account),
+      acceptableDerivedAddresses: ["0xfresh", "0xseed"],
+    });
+  });
+
+  it("omits the seed identifier when it is missing", () => {
+    const account = createFixtureAccount("02", ethereumCurrency);
+    account.freshAddress = "0xfresh";
+    Object.defineProperty(account, "seedIdentifier", { value: undefined, configurable: true });
+
+    expect(buildExpectedAccountIdentity(account)).toEqual({
+      accountName: getDefaultAccountName(account),
+      acceptableDerivedAddresses: ["0xfresh"],
+    });
+  });
+
+  it("returns a match when the derived address is acceptable", () => {
+    expect(
+      validateDerivedAddress(
+        {
+          accountName: "Ethereum 1",
+          acceptableDerivedAddresses: ["0xfresh", "0xseed"],
+        },
+        "0xseed",
+      ),
+    ).toEqual({ status: "match" });
+  });
+
+  it("returns a mismatch when the derived address does not match", () => {
+    expect(
+      validateDerivedAddress(
+        {
+          accountName: "Ethereum 1",
+          acceptableDerivedAddresses: ["0xfresh", "0xseed"],
+        },
+        "0xother",
+      ),
+    ).toEqual({ status: "mismatch", accountName: "Ethereum 1" });
+  });
+
+  it("returns skipped when validation input is incomplete", () => {
+    expect(validateDerivedAddress(undefined, "0xseed")).toEqual({ status: "skipped" });
+    expect(
+      validateDerivedAddress(
+        {
+          accountName: "Ethereum 1",
+          acceptableDerivedAddresses: ["0xfresh"],
+        },
+        undefined,
+      ),
+    ).toEqual({ status: "skipped" });
+  });
+});

--- a/libs/ledger-live-common/src/hw/deviceInitialization/wrongDeviceValidation.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/wrongDeviceValidation.ts
@@ -1,0 +1,28 @@
+import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import type { Account } from "@ledgerhq/types-live";
+import type { ExpectedAccountIdentity } from "./types";
+
+export function buildExpectedAccountIdentity(account: Account): ExpectedAccountIdentity {
+  return {
+    accountName: getDefaultAccountName(account),
+    acceptableDerivedAddresses: [
+      account.freshAddress,
+      ...(account.seedIdentifier ? [account.seedIdentifier] : []),
+    ],
+  };
+}
+
+export function validateDerivedAddress(
+  expectedAccount: ExpectedAccountIdentity | undefined,
+  derivedAddress: string | undefined,
+): { status: "match" } | { status: "skipped" } | { status: "mismatch"; accountName: string } {
+  if (!expectedAccount || !derivedAddress) {
+    return { status: "skipped" };
+  }
+
+  if (expectedAccount.acceptableDerivedAddresses.includes(derivedAddress)) {
+    return { status: "match" };
+  }
+
+  return { status: "mismatch", accountName: expectedAccount.accountName };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7300,6 +7300,9 @@ importers:
       '@ledgerhq/device-core':
         specifier: workspace:^
         version: link:../device-core
+      '@ledgerhq/device-intent':
+        specifier: workspace:^
+        version: link:../device-intent
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.2.0(rxjs@7.8.2)


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - introduces a shared connect-app initialization layer for both legacy flows and `DeviceIntentExecutor (DIE)` migrations
  - centralizes the rules that determine which app the flow expects, whether the connected device matches the target account, and whether deprecation screens should be shown or block the flow
  - removes one duplicated account/device validation path from `hw/actions/app` by reusing the shared helper

### 📝 Description

Ledger Wallet is moving connect-app flows to `DeviceIntentExecutor (DIE)`. Before those flows can run, the app needs a consistent way to answer a few connect-app questions:
- which Ledger app should be opened or installed
- whether derivation is required for the requested account
- whether the connected device appears to be the wrong one for that account
- whether the current device/currency/flow combination should show a deprecation warning or block the flow entirely. 

Today, those decisions are partly scattered across legacy connect-app code. This PR pulls them into reusable `live-common` helpers so new `DeviceIntentExecutor` flows can rely on one shared source of truth instead of re-implementing the same behavior.

Concretely, this PR:
- introduces `buildConnectAppInitializationInput()` as the adapter from `AppRequestInput` to the `DeviceIntentExecutor` initialization payload
- keeps the logic that turns an `AppRequestInput` (which contains an input etc.) into the expected app/dependency/derivation requirements in one shared place, instead of having each flow figure it out again on its own
- adds a shared helper to detect a "wrong device" situation by comparing the address derived from the connected Ledger with the expected account addresses
- adds a shared helper to decide deprecation-screen behavior, i.e. whether initialization should skip, show, or block on device deprecation messaging such as warning or clear-signing screens
- updates the legacy `hw/actions/app` flow to reuse the shared helpers
- adds focused unit coverage

Overall, this PR makes connect-app initialization easier to share across old and new flows, and reduces the amount of flow-specific wiring needed when migrating a connect-app flow to `DeviceIntentExecutor`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29430]
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29430]: https://ledgerhq.atlassian.net/browse/LIVE-29430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ