### PR TITLE
[LWM] fix(live-mobile): prevent frozen overlay on iOS resume after long background

### DIFF
--- a/apps/ledger-live-mobile/ios/AppDelegate.swift
+++ b/apps/ledger-live-mobile/ios/AppDelegate.swift
@@ -21,8 +21,10 @@ import ExpoModulesCore
 
 @main
 class AppDelegate: RCTAppDelegate, UNUserNotificationCenterDelegate {
-
   private var launchedFromPush = false
+
+  var overlayBlurView: UIVisualEffectView?
+  var overlayLogoView: UIImageView?
 
   override func application(
     _ application: UIApplication,

--- a/apps/ledger-live-mobile/ios/Overlay.swift
+++ b/apps/ledger-live-mobile/ios/Overlay.swift
@@ -10,6 +10,8 @@ import UIKit
 
 extension AppDelegate {
   func showOverlay() {
+    guard overlayBlurView == nil else { return }
+
     let blurEffect = UIBlurEffect(style: .regular)
     let blurEffectView = UIVisualEffectView(effect: blurEffect)
     let logoView = UIImageView(image: UIImage(named: "Blurry_nocache1"))
@@ -17,9 +19,6 @@ extension AppDelegate {
 
     let window = self.window
     blurEffectView.frame = window.bounds
-    blurEffectView.tag = 12345
-    logoView.tag = 12346
-
     blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     window.addSubview(blurEffectView)
     window.addSubview(logoView)
@@ -29,19 +28,22 @@ extension AppDelegate {
     logoView.setContentHuggingPriority(UILayoutPriority(251), for: .vertical)
     logoView.frame = CGRect(x: 0, y: 0, width: 128, height: 128)
     logoView.center = CGPoint(x: window.frame.size.width / 2, y: window.frame.size.height / 2)
+
+    overlayBlurView = blurEffectView
+    overlayLogoView = logoView
   }
 
   func hideOverlay() {
-    let window = self.window
-    let blurEffectView = window.viewWithTag(12345)
-    let logoView = window.viewWithTag(12346)
+    guard let blurEffectView = overlayBlurView, let logoView = overlayLogoView else { return }
+    overlayBlurView = nil
+    overlayLogoView = nil
 
     UIView.animate(withDuration: 0.5, animations: {
-      blurEffectView?.alpha = 0
-      logoView?.alpha = 0
+      blurEffectView.alpha = 0
+      logoView.alpha = 0
     }, completion: { _ in
-      blurEffectView?.removeFromSuperview()
-      logoView?.removeFromSuperview()
+      blurEffectView.removeFromSuperview()
+      logoView.removeFromSuperview()
     })
   }
 }

--- a/apps/ledger-live-mobile/src/components/useIsAppInBackground.tsx
+++ b/apps/ledger-live-mobile/src/components/useIsAppInBackground.tsx
@@ -11,6 +11,6 @@ export default function useIsAppInBackground() {
     return () => {
       listener.remove();
     };
-  });
+  }, []);
   return isInBackground;
 }

--- a/apps/ledger-live-mobile/src/context/AuthPass/auth.hooks.ts
+++ b/apps/ledger-live-mobile/src/context/AuthPass/auth.hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
 import { AppState, Platform, Vibration } from "react-native";
 import type { Privacy } from "~/reducers/types";
 import * as Keychain from "react-native-keychain";
@@ -30,7 +30,7 @@ interface UseAppStateHandlerProps {
 }
 
 export function useAppStateHandler({ isPasswordLockBlocked, lock }: UseAppStateHandlerProps) {
-  const [appState, setAppState] = useState<string>(AppState.currentState || "");
+  const appStateRef = useRef<string>(AppState.currentState || "");
   const timeRef = useRef<number>(0);
 
   // The state lifecycle differs between iOS and Android. This is to prevent FaceId from triggering an inactive state and looping.
@@ -43,7 +43,7 @@ export function useAppStateHandler({ isPasswordLockBlocked, lock }: UseAppStateH
   // If the app reopened from the background, lock the app
   const handleAppStateChange = useCallback(
     (nextAppState: string) => {
-      const wasBackgrounded = isBackgrounded(appState);
+      const wasBackgrounded = isBackgrounded(appStateRef.current);
       const isNowActive = nextAppState === "active";
 
       if (nextAppState === "background") {
@@ -68,9 +68,9 @@ export function useAppStateHandler({ isPasswordLockBlocked, lock }: UseAppStateH
           lock();
         }
       }
-      setAppState(nextAppState);
+      appStateRef.current = nextAppState;
     },
-    [appState, isPasswordLockBlocked, lock],
+    [isPasswordLockBlocked, lock],
   );
 
   return { handleAppStateChange };


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- Manual testing steps described below; unit test for useAppStateHandler recommended as follow-up -->
- [ ] **Impact of the changes:**
  - iOS only — no Android changes
  - Affects the secure overlay shown when app is backgrounded
  - Affects the auth lock triggered on app resume
  - QA should focus on: background/foreground cycling with and without biometrics, long background periods (1h+), rapid home button presses

### 📝 Description

**Problem:** After putting the app in background for a long time (reported: ~1 day), on resume the secure overlay (blur screen) would remain stuck forever. Datadog RUM showed frozen frames on the `Background` view on resume.

Three root causes were identified:

**1. `Overlay.swift` — stacked overlays via `viewWithTag` (the "forever" bug)**

`showOverlay()` unconditionally added blur/logo subviews to the window without checking if an overlay already existed. `hideOverlay()` used `window.viewWithTag()` to locate views, which returns only the *first* matching view. Rapid background/foreground cycling could stack two overlay layers with the same tag — `hideOverlay()` would remove only one, leaving the second permanently stuck.

Fixed by storing the overlay views as instance properties (`overlayBlurView`, `overlayLogoView`) on `AppDelegate`. `showOverlay()` now no-ops if an overlay is already present. `hideOverlay()` nils the refs immediately and uses the captured references in the animation — idempotent and race-condition-free.

**2. `auth.hooks.ts` — `handleAppStateChange` recreated on every transition**

`appState` was in `useState`, so every `setAppState(nextAppState)` recreated `handleAppStateChange` (it was in its dependency array). This cascaded: `setupComponent` was recreated → `useEffect` re-ran → AppState listener was torn down and re-registered (dropping events in that window) → `auth()` was called again (opening duplicate biometric prompts).

Fixed by replacing `useState` with `useRef` for `appState`. The ref is mutated directly, so `handleAppStateChange` is now stable — its deps are only `[isPasswordLockBlocked, lock]`.

**3. `useIsAppInBackground.tsx` — missing `[]` dependency array**

The `useEffect` had no dependency array, causing the AppState listener to be removed and re-added on every render. Same missed-event window as above.

Fixed by adding `[]`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28296](https://ledgerhq.atlassian.net/browse/LIVE-28296)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28296]: https://ledgerhq.atlassian.net/browse/LIVE-28296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ