### PR TITLE
chore(wallet-cli): add bunli generation checks

### DIFF
--- a/.github/workflows/build-wallet-cli-reusable.yml
+++ b/.github/workflows/build-wallet-cli-reusable.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Install dependencies
         run: pnpm i --filter "@ledgerhq/wallet-cli..." --filter "ledger-live"
 
+      - name: Check wallet-cli generated commands
+        run: pnpm exec nx run "@ledgerhq/wallet-cli:generate:check"
+
       - name: Build wallet-cli
         run: pnpm exec nx run @ledgerhq/wallet-cli:build
 

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "start": "bun run ./src/cli.ts",
     "dev": "bunli dev",
+    "generate": "bunli generate",
+    "generate:check": "bunli generate && git diff --exit-code -- .bunli/commands.gen.ts",
     "build": "bunli build",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "bun test src/",

--- a/apps/wallet-cli/project.json
+++ b/apps/wallet-cli/project.json
@@ -6,6 +6,12 @@
     "coverage": {
       "outputs": ["{projectRoot}/coverage/**"]
     },
+    "generate": {
+      "outputs": ["{projectRoot}/.bunli/commands.gen.ts"]
+    },
+    "generate:check": {
+      "cache": false
+    },
     "build": {
       "cache": false
     }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - CI checks

### 📝 Description

Add explicit generate and generate:check scripts for wallet-cli so Bunli command metadata can be regenerated and verified in CI.
Declare the corresponding Nx target outputs and disable caching for the drift check target.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
