### PR TITLE
[LWM] fix(mobile): save mock accounts before reboot

### DIFF
--- a/.changeset/calm-mocks-persist.md
+++ b/.changeset/calm-mocks-persist.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Persist generated mock accounts to storage before reboot so they survive app restart

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccounts.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccounts.tsx
@@ -7,8 +7,10 @@ import { genAccount } from "@ledgerhq/live-common/mock/account";
 import { listSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
 import SettingsRow from "~/components/SettingsRow";
 import { reboot } from "~/actions/appstate";
-import { useDispatch } from "~/context/hooks";
+import { useDispatch, useStore } from "~/context/hooks";
 import { replaceAccounts } from "~/actions/accounts";
+import { exportSelector } from "~/reducers/accounts";
+import { saveAccounts } from "~/db";
 
 const generateMockAccounts = (count: number) =>
   Array(count)
@@ -29,6 +31,7 @@ export default function GenerateMockAccountsButton({
   count: number;
 }) {
   const dispatch = useDispatch();
+  const store = useStore();
 
   return (
     <SettingsRow
@@ -46,10 +49,10 @@ export default function GenerateMockAccountsButton({
             },
             {
               text: "Ok",
-              onPress: () => {
+              onPress: async () => {
                 const mockAccounts = generateMockAccounts(count);
-
                 dispatch(replaceAccounts(mockAccounts));
+                await saveAccounts(await exportSelector(store.getState()));
                 dispatch(reboot());
               },
             },

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsSelect.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateMockAccountsSelect.tsx
@@ -10,8 +10,10 @@ import { CryptoCurrency, CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account } from "@ledgerhq/types-live";
 import SettingsRow from "~/components/SettingsRow";
 import { reboot } from "~/actions/appstate";
-import { useDispatch } from "~/context/hooks";
+import { useDispatch, useStore } from "~/context/hooks";
 import { replaceAccounts } from "~/actions/accounts";
+import { exportSelector } from "~/reducers/accounts";
+import { saveAccounts } from "~/db";
 import { ScreenName } from "~/const";
 import CurrencyIcon from "~/components/CurrencyIcon";
 import { SettingsNavigatorStackParamList } from "~/components/RootNavigator/types/SettingsNavigator";
@@ -41,6 +43,7 @@ const currencies = listSupportedCurrencies().sort((a, b) => a.name.localeCompare
 
 export const GenerateMockAccountSelectScreen = () => {
   const dispatch = useDispatch();
+  const store = useStore();
   const [tokens, setTokens] = useState<string>("");
 
   const [checkedCurrencies, setCheckedCurrencies] = useState<Record<string, boolean>>({});
@@ -58,11 +61,10 @@ export const GenerateMockAccountSelectScreen = () => {
   const handlePressContinue = useCallback(() => {
     const selectedCurrencies = currencies.filter(({ id }) => checkedCurrencies[id]);
 
-    const onPress = () => {
+    const onPress = async () => {
       const mockAccounts = generateMockAccounts(selectedCurrencies, tokens);
-
       dispatch(replaceAccounts(mockAccounts));
-
+      await saveAccounts(await exportSelector(store.getState()));
       dispatch(reboot());
     };
 
@@ -79,7 +81,7 @@ export const GenerateMockAccountSelectScreen = () => {
       ],
       { cancelable: true },
     );
-  }, [checkedCurrencies, dispatch, tokens]);
+  }, [checkedCurrencies, dispatch, tokens, store]);
 
   const insets = useSafeAreaInsets();
   return (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Debug-only mock account generators; no automated tests added._
- [x] **Impact of the changes:**
      - Settings → Debug → Generators: generate mock accounts (fixed count and per-currency flows), then force-close and reopen the app — mock accounts should still be present
      - Confirm normal account sync and storage are unchanged outside this debug path

### 📝 Description

**Problem:** Mock accounts created from the developer “Generate mock accounts” flows updated Redux but were not written to local storage before the app rebooted, so they disappeared after the next launch.

**Solution:** After `replaceAccounts`, the app now exports the accounts slice and calls `saveAccounts` before `reboot()`, matching how persisted accounts are saved elsewhere so mock data survives restarts.


https://github.com/user-attachments/assets/ceae3b57-4a17-463d-911b-df511cbe2acc




### ❓ Context

- **JIRA or GitHub link**: [LIVE-29510](https://ledgerhq.atlassian.net/browse/LIVE-29510)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29510]: https://ledgerhq.atlassian.net/browse/LIVE-29510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ