### PR TITLE
fix(e2e): wait for swap readiness on trending assets

### DIFF
--- a/.changeset/gentle-assets-wait.md
+++ b/.changeset/gentle-assets-wait.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+---
+
+Fix swap E2E readiness wait for the Trending Assets screen

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -485,8 +485,10 @@ export class SwapPage extends WebViewAppPage {
         this._webviewPage = undefined;
         const remaining = overallTimeout - (Date.now() - startTime);
         const webview = await this.getWebView(remaining);
-        await webview.waitForSelector(`[data-testid="${this.executeButtonDisabled}"]`, {
-          timeout: Math.min(15_000, overallTimeout - (Date.now() - startTime)),
+        const readyStateTimeout = Math.min(15_000, overallTimeout - (Date.now() - startTime));
+        await webview.getByRole("heading", { name: "Trending Assets" }).waitFor({
+          state: "visible",
+          timeout: readyStateTimeout,
         });
         return;
       } catch {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop swap entrypoints that rely on `goAndWaitForSwapToBeReady()`
  - Readiness detection when the swap webview reloads or is replaced
  - Initial swap landing state detection through the current `Trending Assets` screen

### 📝 Description

The desktop swap E2E readiness helper was still waiting for the old disabled execute button before considering the swap live app ready. After the swap entry screen changed, that signal was no longer a stable marker and could make the readiness wait flaky.

This PR updates `goAndWaitForSwapToBeReady()` to wait for the visible `Trending Assets` heading instead. The existing retry loop remains in place, so the helper still tolerates webview reloads while aligning with the current swap landing UI.

### ❓ Context

- **JIRA or GitHub link**: No ticket provided

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)