### PR TITLE
[LWD] Merge pull request #16561 from LedgerHQ/fix/LIVE-29487_email

### DIFF
--- a/.changeset/calm-foxes-remount.md
+++ b/.changeset/calm-foxes-remount.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Recover webview not reloading when the same deeplink is opened while already on Recover

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/accounts.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/accounts.handler.test.ts
@@ -29,6 +29,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/addAccount.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/addAccount.handler.test.ts
@@ -21,6 +21,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/bridge.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/bridge.handler.test.ts
@@ -22,6 +22,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/buy.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/buy.handler.test.ts
@@ -13,6 +13,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/default.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/default.handler.test.ts
@@ -13,6 +13,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/discover.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/discover.handler.test.ts
@@ -26,6 +26,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/earn.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/earn.handler.test.ts
@@ -13,6 +13,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/ledgerSync.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/ledgerSync.handler.test.ts
@@ -20,6 +20,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/manager.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/manager.handler.test.ts
@@ -13,6 +13,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/market.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/market.handler.test.ts
@@ -13,6 +13,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/postOnboarding.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/postOnboarding.handler.test.ts
@@ -13,6 +13,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/recover.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/recover.handler.test.ts
@@ -13,6 +13,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 
@@ -50,6 +53,33 @@ describe("recover.handler", () => {
       );
 
       expect(context.navigate).toHaveBeenCalledWith("/recover/platform", undefined, "?step=2");
+    });
+
+    it("merges location state and bumps recoverDeeplinkAt when already on the same recover URL", () => {
+      const context = createMockContext({
+        currentPathname: "/recover/platform",
+        currentSearch: "?step=2",
+        currentLocationState: { deviceId: "device-1", fromOnboarding: true },
+      });
+
+      recoverHandler(
+        {
+          type: "recover",
+          path: "platform",
+          search: "?step=2",
+        },
+        context,
+      );
+
+      expect(context.navigate).toHaveBeenCalledWith(
+        "/recover/platform",
+        expect.objectContaining({
+          deviceId: "device-1",
+          fromOnboarding: true,
+          recoverDeeplinkAt: expect.any(String),
+        }),
+        "?step=2",
+      );
     });
 
     it("handles empty path by navigating to /recover/ when no recoverAppId in context", () => {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/settings.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/settings.handler.test.ts
@@ -13,6 +13,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/swap.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/swap.handler.test.ts
@@ -13,6 +13,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/transactionFlow.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/transactionFlow.handler.test.ts
@@ -50,6 +50,9 @@ const createMockContext = (
   postOnboardingDeeplinkHandler: jest.fn(),
   tryRedirectToPostOnboardingOrRecover: jest.fn(() => false),
   currentPathname: "/",
+  currentSearch: "",
+  currentLocationState: undefined,
+  accountsPath: "/accounts",
   ...overrides,
 });
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/recover.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/recover.handler.ts
@@ -1,10 +1,35 @@
+import type { RecoverState } from "~/renderer/screens/recover/Player";
 import { DeeplinkHandler } from "../types";
 
-export const recoverHandler: DeeplinkHandler<"recover"> = (route, { navigate, recoverAppId }) => {
+export const recoverHandler: DeeplinkHandler<"recover"> = (route, context) => {
   const { path, search } = route;
+  const { navigate, recoverAppId, currentPathname, currentSearch, currentLocationState } = context;
   // When no path (e.g. ledgerwallet://recover), use default Ledger Recover app id from feature flag
   const appId = path || recoverAppId || "";
-  navigate(`/recover/${appId}`, undefined, search);
+  const targetPath = `/recover/${appId}`;
+  const isSameRecoverRoute = targetPath === currentPathname && search === currentSearch;
+
+  /**
+   * useDeepLinkHandler.navigate skips routerNavigate when pathname + search + state are unchanged.
+   * Recover email links often repeat the same URL while the user already has Recover open; we still
+   * need a navigation + webview remount so the embedded app can advance (see RecoverPlayer key).
+   */
+  let navigationState: RecoverState | undefined;
+  if (isSameRecoverRoute) {
+    const prev =
+      currentLocationState !== null &&
+      currentLocationState !== undefined &&
+      typeof currentLocationState === "object" &&
+      !Array.isArray(currentLocationState)
+        ? { ...currentLocationState }
+        : {};
+    navigationState = {
+      ...prev,
+      recoverDeeplinkAt: String(Date.now()),
+    };
+  }
+
+  navigate(targetPath, navigationState, search);
 };
 
 export const recoverRestoreFlowHandler: DeeplinkHandler<"recover-restore-flow"> = (

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/types.ts
@@ -4,7 +4,7 @@ import type { AppDispatch } from "~/state-manager/configureStore";
 
 export type NavigateFn = (
   pathname: string,
-  state?: { [k: string]: string | object },
+  state?: { [k: string]: string | number | boolean | object | null | undefined },
   search?: string,
 ) => void;
 
@@ -37,6 +37,12 @@ export interface DeeplinkHandlerContext {
   postOnboardingDeeplinkHandler: PostOnboardingDeeplinkHandlerFn;
   tryRedirectToPostOnboardingOrRecover: TryRedirectToPostOnboardingOrRecoverFn;
   currentPathname: string;
+  /** Current URL search (e.g. `?foo=bar`), used to detect repeated Recover deeplinks. */
+  currentSearch: string;
+  /** Current React Router location state (used to preserve fields when forcing Recover navigation). */
+  currentLocationState: unknown;
+  /** Feature-flag-aware path to the accounts list screen (`/cryptos` or `/accounts`). */
+  accountsPath: string;
   /** Default Ledger Recover app id (from feature flag) for recover deeplink when no path is given */
   recoverAppId?: string;
 }

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useSelector, useDispatch } from "LLD/hooks/redux";
 import { useLocation, useNavigate } from "react-router";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useFeature, useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
@@ -16,6 +16,7 @@ import { trackDeeplinkingEvent } from "./utils";
 import { parseDeepLink, createRoute } from "./parseDeepLink";
 import { executeHandler } from "./registry";
 import { DeeplinkHandlerContext, NavigateFn } from "./types";
+import { getAccountsSidebarPath } from "LLD/components/SideBar/utils";
 
 export function useDeepLinkHandler() {
   const dispatch = useDispatch();
@@ -38,9 +39,11 @@ export function useDeepLinkHandler() {
   const openSendFlow = useOpenSendFlow();
   const recoverFF = useFeature("protectServicesDesktop");
   const recoverAppId = recoverFF?.params?.protectId;
+  const { shouldDisplayAssetSection } = useWalletFeaturesConfig("desktop");
+  const accountsPath = getAccountsSidebarPath(shouldDisplayAssetSection);
 
   const navigate: NavigateFn = useCallback(
-    (pathname: string, state?: { [k: string]: string | object }, search?: string) => {
+    (pathname: string, state?: Parameters<NavigateFn>[1], search?: string) => {
       const hasNewPathname = pathname !== location.pathname;
       const hasNewSearch = typeof search === "string" && search !== location.search;
       const hasNewState = JSON.stringify(state) !== JSON.stringify(location.state);
@@ -68,6 +71,9 @@ export function useDeepLinkHandler() {
       postOnboardingDeeplinkHandler,
       tryRedirectToPostOnboardingOrRecover,
       currentPathname: location.pathname,
+      currentSearch: location.search,
+      currentLocationState: location.state,
+      accountsPath,
       recoverAppId,
     }),
     [
@@ -80,6 +86,9 @@ export function useDeepLinkHandler() {
       postOnboardingDeeplinkHandler,
       tryRedirectToPostOnboardingOrRecover,
       location.pathname,
+      location.search,
+      location.state,
+      accountsPath,
       recoverAppId,
     ],
   );

--- a/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
@@ -31,6 +31,8 @@ export type RecoverState = {
   fromOnboarding?: boolean;
   deviceId?: string;
   seedConfiguration?: SeedOriginType;
+  /** Bumped on repeated same-URL Recover deeplinks so the webview remounts with a fresh load. */
+  recoverDeeplinkAt?: string;
 };
 
 const FullscreenWrapper = styled.div`
@@ -125,7 +127,12 @@ export default function RecoverPlayer() {
 
   return manifest ? (
     <FullscreenWrapper>
-      <WebRecoverPlayer manifest={manifest} inputs={inputs} onClose={onClose} />
+      <WebRecoverPlayer
+        key={`${manifest.id}-${search}-${state?.recoverDeeplinkAt ?? ""}`}
+        manifest={manifest}
+        inputs={inputs}
+        onClose={onClose}
+      />
     </FullscreenWrapper>
   ) : null; // TODO: display an error component instead of `null`
 }


### PR DESCRIPTION
[LWD] Fix Recover webview not reloading when the same deeplink is opened while already on Recover

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request addresses an issue where the Recover webview in Ledger Live Desktop was not reloading when the same deeplink was opened while already on the Recover screen. It introduces logic to force a remount of the webview on repeated deeplinks, ensures that navigation state is properly updated, and enhances test coverage for this scenario. Additionally, it improves the deeplinking handler context to provide more comprehensive routing information.
