### PR TITLE
ci(renovate): split e2e tooling update groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -120,20 +120,34 @@
       "minimumReleaseAge": "2 days"
     },
     {
-      "description": "E2E - version updates",
+      "description": "E2E Playwright and Allure linked updates",
       "matchManagers": ["npm"],
-      "matchFileNames": ["e2e/desktop/**", "e2e/mobile/**"],
+      "groupName": "e2e playwright and allure",
+      "matchPackageNames": [
+        "@playwright/test",
+        "playwright",
+        "allure-js-commons",
+        "allure-playwright",
+        "allure-commandline"
+      ],
       "commitMessagePrefix": "chore(e2e):",
       "labels": ["dependencies", "e2e"],
       "reviewers": ["team:qaa"],
       "assignees": ["team:qaa"]
     },
     {
-      "description": "E2E - group major updates",
+      "description": "E2E Detox and Allure linked updates",
       "matchManagers": ["npm"],
-      "matchFileNames": ["e2e/desktop/**", "e2e/mobile/**"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "e2e major updates"
+      "groupName": "e2e detox and allure",
+      "matchPackageNames": [
+        "detox",
+        "detox-allure2-adapter",
+        "jest-allure2-reporter"
+      ],
+      "commitMessagePrefix": "chore(e2e):",
+      "labels": ["dependencies", "e2e"],
+      "reviewers": ["team:qaa"],
+      "assignees": ["team:qaa"]
     }
   ],
   "prConcurrentLimit": 10,


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not applicable for a repo-level Renovate configuration change with no package release impact._
- [ ] **Covered by automatic tests.** _No focused automated test covers Renovate grouping rules; correctness will be validated by the resulting Renovate PR grouping and CI behavior._
- [x] **Impact of the changes:**
      - Renovate grouping for Playwright and Allure dependency updates
      - Renovate grouping for Detox and Allure dependency updates
      - Labels, reviewers, assignees, and `chore(e2e):` commit prefix on generated dependency PRs

### 📝 Description

This PR refines the Renovate configuration for E2E tooling updates so unrelated dependency bumps are no longer grouped together under one broad E2E rule.

Previously, the E2E Renovate rules matched by file path, which could mix Playwright-related and Detox-related upgrades into the same dependency update flow. This change switches those rules to explicit package-name groups: one for Playwright and Allure packages, and one for Detox and its related reporting packages, while preserving the existing labels, reviewers, assignees, and commit prefix.

### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)