### PR TITLE
[LWDM] refactor(live-common): suspend-ready useBridgeTransaction and useAccountBridge hook

### DIFF
--- a/.changeset/live-29193-suspense-ready-bridge-hooks.md
+++ b/.changeset/live-29193-suspense-ready-bridge-hooks.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add `useAccountBridge` hook leveraging React `use()` to suspend while the bridge
+module loads asynchronously. Refactor `useBridgeTransaction` so its init callback
+can be async and the initial state is resolved via `use()` before first render,
+removing the synchronous `getAccountBridge` call from the reducer. All call sites
+updated to `async` init with `await getAccountBridge()`.
+
+Requires a `<Suspense>` boundary in the parent tree (LIVE-29193).

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -12,7 +12,9 @@ const PtxInfoDialog = lazy(() => import("LLD/features/PtxInfoDialog"));
 const GlobalDialogs = () => (
   <>
     <ModularDialogRoot />
-    <SendFlowRoot />
+    <Suspense fallback={null}>
+      <SendFlowRoot />
+    </Suspense>
     <PerpsSignRoot />
     <ActionConfirmationDialog />
     <Suspense fallback={null}>

--- a/apps/ledger-live-desktop/src/renderer/ModalsLayer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/ModalsLayer.tsx
@@ -60,7 +60,7 @@ const ModalsLayer = ({ modalsState }: { modalsState: ModalsState }) => {
     >
       {state => (
         <BackDrop ref={nodeRef} state={state}>
-          {first || null}
+          <React.Suspense fallback={null}>{first || null}</React.Suspense>
         </BackDrop>
       )}
     </Transition>

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/Body.tsx
@@ -84,10 +84,10 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const { account } = params;
     invariant(account, "algorand: account required");
-    const bridge = getAccountBridge(account);
+    const bridge = await getAccountBridge(account);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "optIn",

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.tsx
@@ -84,10 +84,10 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const { account } = params;
     invariant(account, "algorand: account required");
-    const bridge = getAccountBridge(account, undefined);
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "claimReward",

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/Body.tsx
@@ -77,10 +77,10 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     invariant(accountProp.aptosResources, "aptos: account and aptos resources required");
 
-    const bridge = getAccountBridge(accountProp, undefined);
+    const bridge = await getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const mode = "restake";
     const recipient = validatorAddress;

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/Body.tsx
@@ -77,10 +77,10 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     invariant(accountProp.aptosResources, "aptos: account and aptos resources required");
 
-    const bridge = getAccountBridge(accountProp, undefined);
+    const bridge = await getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const mode = "unstake";
     const recipient = validatorAddress;

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/Body.tsx
@@ -77,10 +77,10 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     invariant(accountProp.aptosResources, "aptos: account and aptos resources required");
 
-    const bridge = getAccountBridge(accountProp, undefined);
+    const bridge = await getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const mode = "withdraw";
     const recipient = validatorAddress;

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/Body.tsx
@@ -108,13 +108,13 @@ const Body = ({
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const { account } = params;
     invariant(
       account && account.cardanoResources,
       "cardano: account and cardano resources required",
     );
-    const bridge = getAccountBridge(account, undefined);
+    const bridge = await getAccountBridge(account, undefined);
     let transaction = bridge.createTransaction(account);
     transaction = bridge.updateTransaction(transaction, { mode: "delegate" });
 

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/Body.tsx
@@ -94,13 +94,13 @@ const Body = ({
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const { account } = params;
     invariant(
       account && account.cardanoResources,
       "cardano: account and cardano resources required",
     );
-    const bridge = getAccountBridge(account, undefined);
+    const bridge = await getAccountBridge(account, undefined);
     const transaction = bridge.createTransaction(account);
     const updatedTransaction = bridge.updateTransaction(transaction, {
       mode: "undelegate",

--- a/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/Body.tsx
@@ -78,8 +78,8 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const dispatch = useDispatch();
   const { account, parentAccount, vote, source } = params;
   const { transaction, setTransaction, status, bridgeError, bridgePending } = useBridgeTransaction(
-    () => {
-      const bridge = getAccountBridge(account, parentAccount);
+    async () => {
+      const bridge = await getAccountBridge(account, parentAccount);
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "activate",

--- a/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/Body.tsx
@@ -76,8 +76,8 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const dispatch = useDispatch();
   const { account, parentAccount, source } = params;
   const { transaction, setTransaction, status, bridgeError, bridgePending } = useBridgeTransaction(
-    () => {
-      const bridge = getAccountBridge(account, parentAccount);
+    async () => {
+      const bridge = await getAccountBridge(account, parentAccount);
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "lock",

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SimpleOperationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SimpleOperationFlowModal/Body.tsx
@@ -93,10 +93,10 @@ const Body = ({ t, stepId, device, openModal, onClose, onChangeStepId, params, m
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const { account } = params;
     invariant(account, "celo: account required");
-    const bridge = getAccountBridge(account, undefined);
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode,

--- a/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/Body.tsx
@@ -81,9 +81,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const { account, parentAccount } = params;
-    const bridge = getAccountBridge(account, parentAccount);
+    const bridge = await getAccountBridge(account, parentAccount);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "unlock",

--- a/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/Body.tsx
@@ -82,9 +82,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const { account, parentAccount } = params;
-    const bridge = getAccountBridge(account, parentAccount);
+    const bridge = await getAccountBridge(account, parentAccount);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "withdraw",

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.tsx
@@ -84,7 +84,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const { account, validatorAddress } = params;
     invariant(account && account.cosmosResources, "cosmos: account and cosmos resources required");
 
@@ -98,7 +98,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
         address: validatorAddress,
         amount: pendingRewards,
       }));
-    const bridge = getAccountBridge(account, undefined);
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "claimReward",

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Body.tsx
@@ -96,9 +96,9 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     invariant(account && account.cosmosResources, "cosmos: account and cosmos resources required");
-    const bridge = getAccountBridge(account, undefined);
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "delegate",

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/Body.tsx
@@ -103,12 +103,12 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     invariant(account && account.cosmosResources, "cosmos: account and cosmos resources required");
     const source = account.cosmosResources?.delegations.find(
       d => d.validatorAddress === validatorAddress,
     );
-    const bridge = getAccountBridge(account, undefined);
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "redelegate",

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/Body.tsx
@@ -70,10 +70,10 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     invariant(accountProp.cosmosResources, "cosmos: account and cosmos resources required");
     const delegations = accountProp.cosmosResources.delegations || [];
-    const bridge = getAccountBridge(accountProp, undefined);
+    const bridge = await getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const newTx = {
       mode: "undelegate",

--- a/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/Body.tsx
@@ -98,9 +98,9 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     invariant(isStakingAccount(account), "evm: account with staking resources required");
-    const bridge = getAccountBridge(account, undefined);
+    const bridge = await getAccountBridge(account, undefined);
     const baseTransaction = bridge.createTransaction(account);
     // NB: `mode` is intentionally not set here. It is set later together with `valAddress`
     // (see StepDelegation → updateValidator) once the user has picked a validator.

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/Body.tsx
@@ -85,8 +85,8 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
-      const bridge = getAccountBridge(account);
+    useBridgeTransaction(async () => {
+      const bridge = await getAccountBridge(account);
       const t = bridge.createTransaction(account);
 
       const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
@@ -153,10 +153,10 @@ const Body = ({
     bridgePending,
     updateTransaction,
     setAccount: updateTransactionAccount,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     invariant(account, "hedera: account is required");
 
-    const bridge = getAccountBridge(account, parentAccount);
+    const bridge = await getAccountBridge(account, parentAccount);
     const transaction = bridge.createTransaction(account);
 
     return {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
@@ -85,8 +85,8 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
-      const bridge = getAccountBridge(account);
+    useBridgeTransaction(async () => {
+      const bridge = await getAccountBridge(account);
       const t = bridge.createTransaction(account);
 
       const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/Body.tsx
@@ -72,9 +72,9 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     invariant(accountProp.nearResources, "near: account and near resources required");
-    const bridge = getAccountBridge(accountProp, undefined);
+    const bridge = await getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const mode = "unstake";
     const recipient = validatorAddress;

--- a/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/Body.tsx
@@ -72,9 +72,9 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     invariant(accountProp.nearResources, "near: account and near resources required");
-    const bridge = getAccountBridge(accountProp, undefined);
+    const bridge = await getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const mode = "withdraw";
     const recipient = validatorAddress;

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/Body.tsx
@@ -73,9 +73,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { transaction, setTransaction, account, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(async () => {
       const { account } = params;
-      const bridge = getAccountBridge(account);
+      const bridge = await getAccountBridge(account);
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "bond",

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/Body.tsx
@@ -86,13 +86,13 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const { account } = params;
     invariant(
       account && account.polkadotResources,
       "polkadot: account and polkadot resources required",
     );
-    const bridge = getAccountBridge(account, undefined);
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const initialValidators = (account?.polkadotResources?.nominations || [])
       .filter(nomination => !!nomination.status)

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/Body.tsx
@@ -74,9 +74,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { transaction, setTransaction, account, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(async () => {
       const { account } = params;
-      const bridge = getAccountBridge(account);
+      const bridge = await getAccountBridge(account);
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "rebond",

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/Body.tsx
@@ -94,10 +94,10 @@ const Body = ({ t, stepId, device, openModal, onChangeStepId, params, onClose, m
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const { account } = params;
     invariant(account, "polkadot: account required");
-    const bridge = getAccountBridge(account, undefined);
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode,

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/Body.tsx
@@ -75,9 +75,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { transaction, setTransaction, account, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(async () => {
       const { account } = params;
-      const bridge = getAccountBridge(account);
+      const bridge = await getAccountBridge(account);
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "unbond",

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/Body.tsx
@@ -83,10 +83,10 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const { account } = params;
     invariant(account, "stellar: account required");
-    const bridge = getAccountBridge(account, undefined);
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "changeTrust",

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
@@ -131,10 +131,10 @@ export default function Body({ onChangeStepId, onClose, setError, stepId, params
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
     const parentAccount = params && params.parentAccount;
     const account = params && params.account;
-    const bridge = getAccountBridge(account, parentAccount);
+    const bridge = await getAccountBridge(account, parentAccount);
     const tx = bridge.createTransaction(account);
     const { recipient, ...txData } = transactionData;
     const tx2 = bridge.updateTransaction(tx, {

--- a/apps/ledger-live-desktop/tests/specs/families/polkadot.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/families/polkadot.spec.ts
@@ -13,7 +13,7 @@ test("Nomination flow", async ({ page }) => {
     await page.locator('[data-testid="account-component-Polkadot 1"]').click();
     await page.getByRole("button", { name: "Nominate" }).scrollIntoViewIfNeeded();
     await page.getByRole("button", { name: "Nominate" }).click();
-    expect(await page.getByText("Validators (8)").isVisible()).toBeTruthy();
+    await expect(page.getByText("Validators (8)")).toBeVisible();
     await expect
       .soft(page.locator('[data-testid="modal-content"]'))
       .toHaveScreenshot("nominate-modal-dot-nominator-row.png");

--- a/apps/ledger-live-mobile/src/components/RootNavigator/FreezeNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/FreezeNavigator.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "styled-components/native";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import Info from "~/screens/FreezeFunds/01-Info";
 import Amount from "~/screens/FreezeFunds/02-Amount";
 import SelectDevice from "~/screens/SelectDevice";
@@ -21,7 +21,10 @@ export default function FreezeNavigator() {
   const { t } = useTranslation();
   const stackNavConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
-    <Stack.Navigator screenOptions={stackNavConfig}>
+    <Stack.Navigator
+      screenOptions={stackNavConfig}
+      screenLayout={bridgeSuspenseScreenLayout}
+    >
       <Stack.Screen
         name={ScreenName.FreezeInfo}
         component={Info}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SendFundsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SendFundsNavigator.tsx
@@ -13,7 +13,7 @@ import SendConnectDevice from "~/screens/ConnectDevice";
 import SendValidationSuccess from "~/screens/SendFunds/07-ValidationSuccess";
 import SendBroadcastError from "~/screens/SendFunds/07-SendBroadcastError";
 import SendValidationError from "~/screens/SendFunds/07-ValidationError";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "../StepHeader";
 import type { SendFundsNavigatorStackParamList } from "./types/SendFundsNavigator";
 
@@ -28,7 +28,10 @@ export default function SendFundsNavigator() {
 
   return (
     <DomainServiceProvider>
-      <Stack.Navigator screenOptions={stackNavigationConfig}>
+      <Stack.Navigator
+        screenOptions={stackNavigationConfig}
+        screenLayout={bridgeSuspenseScreenLayout}
+      >
         <Stack.Screen
           name={ScreenName.SendCoin}
           component={SendCoin}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SignTransactionNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SignTransactionNavigator.tsx
@@ -8,7 +8,7 @@ import SignTransactionSummary from "~/screens/SendFunds/04-Summary";
 import SelectDevice from "~/screens/SelectDevice";
 import SignTransactionConnectDevice from "~/screens/SignTransaction/02-ConnectDevice";
 import SignTransactionValidationError from "~/screens/SignTransaction/03-ValidationError";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "../StepHeader";
 import { SignTransactionNavigatorParamList } from "./types/SignTransactionNavigator";
 
@@ -22,7 +22,10 @@ export default function SignTransactionNavigator() {
 
   return (
     <DomainServiceProvider>
-      <Stack.Navigator screenOptions={stackNavigationConfig}>
+      <Stack.Navigator
+        screenOptions={stackNavigationConfig}
+        screenLayout={bridgeSuspenseScreenLayout}
+      >
         <Stack.Screen
           name={ScreenName.SignTransactionSummary}
           component={SignTransactionSummary}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/UnfreezeNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/UnfreezeNavigator.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "styled-components/native";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import Amount from "~/screens/UnfreezeFunds/01-Amount";
 import SelectDevice from "~/screens/SelectDevice";
 import ConnectDevice from "~/screens/ConnectDevice";
@@ -18,7 +18,10 @@ export default function UnfreezeNavigator() {
   const { colors } = useTheme();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
-    <Stack.Navigator screenOptions={stackNavigationConfig}>
+    <Stack.Navigator
+      screenOptions={stackNavigationConfig}
+      screenLayout={bridgeSuspenseScreenLayout}
+    >
       <Stack.Screen
         name={ScreenName.UnfreezeAmount}
         component={Amount}

--- a/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/01-Started.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/01-Started.tsx
@@ -37,11 +37,11 @@ export default function DelegationStarted({ navigation, route }: Props) {
   const { locale } = useSettings();
   invariant(account, "Account required");
   const mainAccount = getMainAccount(account, undefined) as AlgorandAccount;
-  const bridge = getAccountBridge(mainAccount, undefined);
   invariant(mainAccount && mainAccount.algorandResources, "algorand Account required");
   const { rewards } = mainAccount.algorandResources;
   const unit = useAccountUnit(mainAccount);
-  const { transaction, status } = useBridgeTransaction(() => {
+  const { transaction, status } = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(mainAccount, undefined);
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/index.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "@react-navigation/native";
 import {
   getStackNavigatorConfig,
   defaultNavigationOptions,
+  bridgeSuspenseScreenLayout,
 } from "../../../../navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
@@ -28,6 +29,7 @@ function ClaimRewardsFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.AlgorandClaimRewardsStarted}

--- a/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/01-Started.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/01-Started.tsx
@@ -26,9 +26,9 @@ export default function RegisterAccountStarted({ navigation, route }: Props) {
   invariant(account, "account needed");
 
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, parentAccount);
 
-  const { transaction, status } = useBridgeTransaction(() => {
+  const { transaction, status } = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(account, parentAccount);
     const t = bridge.createTransaction(mainAccount);
 
     const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 
 import RegisterAccountStarted from "./01-Started";
@@ -22,7 +22,10 @@ function RegisterAccountFlow() {
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (
-    <Stack.Navigator screenOptions={stackNavigatorConfig}>
+    <Stack.Navigator
+      screenOptions={stackNavigatorConfig}
+      screenLayout={bridgeSuspenseScreenLayout}
+    >
       <Stack.Screen
         name={ScreenName.CeloRegistrationStarted}
         component={RegisterAccountStarted}

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/01-Summary.tsx
@@ -1,5 +1,5 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useValidatorGroups } from "@ledgerhq/live-common/families/celo/react";
@@ -42,7 +42,7 @@ export default function RevokeSummary({ navigation, route }: Props) {
   const validators = useValidatorGroups();
   const votes = revokableVotes(account as CeloAccount);
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge(account, undefined);
 
   const chosenValidator = useMemo(() => {
     if (validator !== undefined) {

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import ConnectDevice from "~/screens/ConnectDevice";
 import SelectDevice from "~/screens/SelectDevice";
 import VoteAmount from "./VoteAmount";
@@ -27,6 +27,7 @@ function RevokeFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CeloRevokeSummary}

--- a/apps/ledger-live-mobile/src/families/celo/UnlockFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/UnlockFlow/01-Amount.tsx
@@ -15,7 +15,7 @@ import { useTheme } from "@react-navigation/native";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
 import LText from "~/components/LText";
@@ -41,7 +41,7 @@ export default function UnlockAmount({ navigation, route }: Props) {
   const { account, parentAccount } = useAccountScreen(route);
   invariant(account, "account is required");
 
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
 
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);

--- a/apps/ledger-live-mobile/src/families/celo/UnlockFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/UnlockFlow/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 
 import UnlockAmount from "./01-Amount";
@@ -22,7 +22,10 @@ function UnlockFlow() {
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (
-    <Stack.Navigator screenOptions={stackNavigatorConfig}>
+    <Stack.Navigator
+      screenOptions={stackNavigatorConfig}
+      screenLayout={bridgeSuspenseScreenLayout}
+    >
       <Stack.Screen
         name={ScreenName.CeloUnlockAmount}
         component={UnlockAmount}

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/02-Summary.tsx
@@ -1,5 +1,5 @@
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { useValidatorGroups } from "@ledgerhq/live-common/families/celo/react";
@@ -45,7 +45,7 @@ export default function VoteSummary({ navigation, route }: Props) {
 
   const validators = useValidatorGroups();
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge(account, undefined);
 
   const chosenValidator = useMemo(() => {
     if (validator !== undefined) {

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/VoteAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/VoteAmount.tsx
@@ -12,7 +12,7 @@ import {
 import { Trans } from "~/context/Locale";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
 import LText from "~/components/LText";
@@ -38,7 +38,7 @@ export default function VoteAmount({ navigation, route }: Props) {
 
   const [maxSpendable, setMaxSpendable] = useState(0);
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge(account);
 
   const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction(() => {
     return {

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import ConnectDevice from "~/screens/ConnectDevice";
 import SelectDevice from "~/screens/SelectDevice";
 import VoteAmount from "./VoteAmount";
@@ -28,6 +28,7 @@ function VoteFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CeloVoteStarted}

--- a/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
@@ -6,7 +6,7 @@ import { Trans } from "~/context/Locale";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { rgba, Text, Icons } from "@ledgerhq/native-ui";
@@ -42,7 +42,7 @@ export default function WithdrawAmount({ navigation, route }: Props) {
   const { account, parentAccount } = useAccountScreen(route);
   invariant(account, "account is required");
 
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
 
   const { transaction, setTransaction, status, bridgeError, bridgePending } = useBridgeTransaction(

--- a/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import ConnectDevice from "~/screens/ConnectDevice";
 import SelectDevice from "~/screens/SelectDevice";
 import WithdrawAmount from "./WithdrawAmount";
@@ -25,6 +25,7 @@ function WithdrawFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CeloWithdrawAmount}

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/01-SelectValidator.tsx
@@ -7,7 +7,7 @@ import type {
   CosmosValidatorItem,
   Transaction,
 } from "@ledgerhq/live-common/families/cosmos/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useCosmosFamilyMappedDelegations } from "@ledgerhq/live-common/families/cosmos/react";
@@ -30,7 +30,7 @@ function ClaimRewardsSelectValidator({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
   const mainAccount = getMainAccount(account, undefined) as CosmosAccount;
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge(account, undefined);
   const { cosmosResources } = mainAccount;
   invariant(cosmosResources, "cosmosResources required");
   const transaction = useBridgeTransaction(() => {

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.tsx
@@ -4,7 +4,7 @@ import { View, StyleSheet, TouchableOpacity } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans } from "~/context/Locale";
 import type { CosmosAccount, Transaction } from "@ledgerhq/live-common/families/cosmos/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useTheme } from "@react-navigation/native";
@@ -56,7 +56,7 @@ function ClaimRewardsAmount({ navigation, route }: Props) {
   const { colors } = useTheme();
   const account = useAccountScreen(route).account as CosmosAccount;
   invariant(account && account.cosmosResources, "account and cosmos transaction required");
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const unit = useAccountUnit(mainAccount);
   const currency = getAccountCurrency(mainAccount);

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig, defaultNavigationOptions } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, defaultNavigationOptions, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import ClaimRewardsSelectValidator from "./01-SelectValidator";
@@ -27,6 +27,7 @@ function ClaimRewardsFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CosmosClaimRewardsValidator}

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
@@ -1,5 +1,5 @@
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { getMaxDelegationAvailable } from "@ledgerhq/live-common/families/cosmos/logic";
@@ -48,7 +48,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
 
   const mainAccount = getMainAccount(account, parentAccount);
   const validators = useLedgerFirstShuffledValidatorsCosmosFamily(mainAccount.currency.id);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge(account, undefined);
 
   const chosenValidator = useMemo(() => {
     if (validator !== undefined) {

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import ConnectDevice from "~/screens/ConnectDevice";
 import SelectDevice from "~/screens/SelectDevice";
 import DelegationAmount from "../shared/02-SelectAmount";
@@ -28,6 +28,7 @@ function DelegationFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CosmosDelegationStarted}

--- a/apps/ledger-live-mobile/src/families/cosmos/Delegations/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/Delegations/index.tsx
@@ -85,8 +85,8 @@ function Delegations({ account }: Props) {
     cosmosResources &&
     cosmosResources.unbondings &&
     mapUnbondings(cosmosResources.unbondings, validators, unit);
-  const bridge = getAccountBridge(account, undefined);
-  const { transaction } = useBridgeTransaction(() => {
+  const { transaction } = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(mainAccount);
     const { validatorSrcAddress } = { ...banner };
     return {

--- a/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/01-SelectValidator.tsx
@@ -39,11 +39,11 @@ function RedelegationSelectValidator({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
   const mainAccount = getMainAccount(account, undefined) as CosmosAccount;
-  const bridge = getAccountBridge(account, undefined);
   const { cosmosResources } = mainAccount;
   invariant(cosmosResources, "cosmosResources required");
   const delegations = cosmosResources.delegations;
-  const bridgeTransaction = useBridgeTransaction(() => {
+  const bridgeTransaction = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig, defaultNavigationOptions } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, defaultNavigationOptions, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import RedelegationSelectValidator from "./01-SelectValidator";
@@ -27,6 +27,7 @@ function RedelegationFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CosmosRedelegationValidator}

--- a/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/01-Amount.tsx
@@ -19,11 +19,11 @@ type Props = StackNavigatorProps<
 function UndelegationAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = getAccountBridge(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const validator = route.params.delegation.validator;
   const amount = route.params.delegation.amount;
-  const { transaction } = useBridgeTransaction(() => {
+  const { transaction } = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import UndelegationAmount from "./01-Amount";
@@ -26,6 +26,7 @@ function UndelegationFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.CosmosUndelegationAmount}

--- a/apps/ledger-live-mobile/src/families/cosmos/shared/03-BridgeTransaction.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/shared/03-BridgeTransaction.tsx
@@ -28,10 +28,10 @@ export default function CosmosBridgeTransaction({ navigation, route }: Props) {
   invariant(account, "account required");
 
   const mainAccount = getMainAccount(account) as CosmosAccount;
-  const bridge = getAccountBridge(account);
   const { transaction: initialTx, mode } = route.params;
 
-  const { transaction, bridgePending, status } = useBridgeTransaction(() => {
+  const { transaction, bridgePending, status } = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(account);
     if (!initialTx) {
       const t = bridge.createTransaction(mainAccount);
 

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/02-Summary.tsx
@@ -35,8 +35,8 @@ export default function Summary({ navigation, route }: Props) {
   invariant(account, "hedera: account is required");
   const mainAccount = getMainAccount(account, parentAccount);
 
-  const { transaction, status, bridgeError, bridgePending } = useBridgeTransaction(() => {
-    const bridge = getAccountBridge(account, parentAccount);
+  const { transaction, status, bridgeError, bridgePending } = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(account, parentAccount);
     const transaction = bridge.createTransaction(account);
     const updatedTransaction = bridge.updateTransaction(transaction, {
       mode: HEDERA_TRANSACTION_MODES.TokenAssociate,

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/index.tsx
@@ -12,7 +12,7 @@ import type { HederaAssociateTokenFlowParamList } from "./types";
 import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
 import { NavigationHeaderCloseButtonAdvanced } from "~/components/NavigationHeaderCloseButton";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import SelectDevice from "~/screens/SelectDevice";
 import ConnectDevice from "~/screens/ConnectDevice";
 
@@ -27,6 +27,7 @@ function AssociateTokenFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.HederaAssociateTokenSelectToken}

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/Claim.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/Claim.tsx
@@ -7,7 +7,7 @@ import { useTheme } from "@react-navigation/native";
 import StepHeader from "~/components/StepHeader";
 import ClaimRewardsSelectDevice from "~/screens/SelectDevice";
 import ClaimRewardsConnectDevice from "~/screens/ConnectDevice";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import styles from "~/navigation/styles";
 import { ScreenName } from "~/const";
 
@@ -44,6 +44,7 @@ const Claim = () => {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.MultiversXClaimRewardsValidator}

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickMethod/PickMethod.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickMethod/PickMethod.tsx
@@ -3,7 +3,7 @@ import { View, TouchableOpacity } from "react-native";
 import { useTheme } from "@react-navigation/native";
 import { Trans } from "~/context/Locale";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { handleTransactionStatus } from "@ledgerhq/live-common/families/multiversx/helpers";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/ledger-wallet-framework/account";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -43,7 +43,7 @@ const PickMethod = (props: PickMethodPropsType) => {
 
   const mainAccount = getMainAccount(account, undefined);
   const currency = getAccountCurrency(mainAccount);
-  const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+  const bridge: AccountBridge<Transaction> = useAccountBridge(account);
   const unit = useAccountUnit(mainAccount);
   const methods = [TransactionMethodEnum.claimRewards, TransactionMethodEnum.reDelegateRewards];
 

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickValidator/PickValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickValidator/PickValidator.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useCallback } from "react";
 import { View, FlatList } from "react-native";
 import { useTheme } from "@react-navigation/native";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account";
 
 import BigNumber from "bignumber.js";
@@ -25,7 +25,7 @@ const PickValidator = (props: PickValidatorPropsType) => {
   const { colors } = useTheme();
 
   const mainAccount = getMainAccount(account, undefined);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge(account, undefined);
   const unit = useAccountUnit(account);
 
   /*

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/Delegate.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/Delegate.tsx
@@ -5,7 +5,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
 
 import StepHeader from "~/components/StepHeader";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import { ScreenName } from "~/const";
 
 import EarnRewards from "./components/EarnRewards";
@@ -47,6 +47,7 @@ const Delegate = () => {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.MultiversXDelegationStarted}

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/SetDelegation/SetDelegation.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/SetDelegation/SetDelegation.tsx
@@ -45,7 +45,6 @@ const SetDelegation = (props: SetDelegationPropsType) => {
 
   const currency = getAccountCurrency(account);
   const color = getCurrencyColor(currency);
-  const bridge = getAccountBridge(account);
   const mainAccount = getMainAccount(account, undefined);
   const unit = useAccountUnit(account);
 
@@ -62,14 +61,17 @@ const SetDelegation = (props: SetDelegationPropsType) => {
    * Instantiate the transaction when opening the flow. Only gets runned once.
    */
 
-  const { transaction, updateTransaction, status, bridgeError } = useBridgeTransaction(() => ({
-    account,
-    transaction: bridge.updateTransaction(bridge.createTransaction(mainAccount), {
-      amount: new BigNumber(0),
-      recipient: defaultValidator ? defaultValidator.contract : "",
-      mode: "delegate",
-    }),
-  }));
+  const { transaction, updateTransaction, status, bridgeError } = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(account);
+    return {
+      account,
+      transaction: bridge.updateTransaction(bridge.createTransaction(mainAccount), {
+        amount: new BigNumber(0),
+        recipient: defaultValidator ? defaultValidator.contract : "",
+        mode: "delegate",
+      }),
+    };
+  });
 
   /*
    * Use the transaction recipient to find the chosen validator and access more data about it..

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/Undelegate.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/Undelegate.tsx
@@ -5,7 +5,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
 
 import StepHeader from "~/components/StepHeader";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import { ScreenName } from "~/const";
 
 import PickAmount from "./components/PickAmount";
@@ -43,6 +43,7 @@ const Undelegate = () => {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.MultiversXUndelegationAmount}

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/components/PickAmount/PickAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/components/PickAmount/PickAmount.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { View, Keyboard, TouchableOpacity, TouchableWithoutFeedback, Platform } from "react-native";
 import { Trans } from "~/context/Locale";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { denominate } from "@ledgerhq/live-common/families/multiversx/helpers";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useTheme } from "styled-components/native";
@@ -33,7 +33,7 @@ const PickAmount = (props: PickAmountPropsType) => {
   const { amount, account, validator } = route.params;
 
   const unit = useAccountUnit(account);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge(account, undefined);
   const { locale } = useSettings();
 
   const [value, setValue] = useState(new BigNumber(amount));

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/Withdraw.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/Withdraw.tsx
@@ -8,7 +8,7 @@ import StepHeader from "~/components/StepHeader";
 import WithdrawSelectDevice from "~/screens/SelectDevice";
 import WithdrawConnectDevice from "~/screens/ConnectDevice";
 
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import { ScreenName } from "~/const";
 
 import WithdrawFunds from "./components/WithdrawFunds";
@@ -43,6 +43,7 @@ const Withdraw = () => {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.MultiversXWithdrawFunds}

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/components/WithdrawFunds/WithdrawFunds.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/components/WithdrawFunds/WithdrawFunds.tsx
@@ -34,7 +34,6 @@ const WithdrawFunds = (props: WithdrawFundsPropsType) => {
 
   const mainAccount = getMainAccount(account, undefined);
   const currency = getAccountCurrency(mainAccount);
-  const bridge = getAccountBridge(account);
   const unit = useAccountUnit(mainAccount);
   const name = validator.identity.name || validator.contract;
 
@@ -42,14 +41,17 @@ const WithdrawFunds = (props: WithdrawFundsPropsType) => {
    * Instantiate a new transaction with the given arguments.
    */
 
-  const { transaction, status } = useBridgeTransaction(() => ({
-    account,
-    transaction: bridge.updateTransaction(bridge.createTransaction(mainAccount), {
-      mode: "withdraw",
-      recipient: validator.contract,
-      amount,
-    }),
-  }));
+  const { transaction, status } = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(account);
+    return {
+      account,
+      transaction: bridge.updateTransaction(bridge.createTransaction(mainAccount), {
+        mode: "withdraw",
+        recipient: validator.contract,
+        amount,
+      }),
+    };
+  });
 
   /*
    * Callback called when navigating to the next screen of the current flow.

--- a/apps/ledger-live-mobile/src/families/near/StakingFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/near/StakingFlow/02-Summary.tsx
@@ -1,5 +1,5 @@
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { useLedgerFirstShuffledValidatorsNear } from "@ledgerhq/live-common/families/near/react";
@@ -46,7 +46,7 @@ export default function StakingSummary({ navigation, route }: Props) {
 
   const validators = useLedgerFirstShuffledValidatorsNear("");
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge(account, undefined);
 
   const chosenValidator = useMemo(() => {
     if (validator !== undefined) {

--- a/apps/ledger-live-mobile/src/families/near/StakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/near/StakingFlow/index.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import ConnectDevice from "~/screens/ConnectDevice";
 import SelectDevice from "~/screens/SelectDevice";
 import StakingAmount from "../shared/02-SelectAmount";
@@ -29,6 +29,7 @@ function StakingFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.NearStakingStarted}

--- a/apps/ledger-live-mobile/src/families/near/UnstakingFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/near/UnstakingFlow/01-Amount.tsx
@@ -19,7 +19,6 @@ type Props = BaseComposite<
 function UnstakingAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = getAccountBridge(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const { validatorId } = route.params.stakingPosition;
   const {
@@ -27,7 +26,8 @@ function UnstakingAmount({ navigation, route }: Props) {
     updateTransaction,
     status,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/near/UnstakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/near/UnstakingFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import UnstakingAmount from "./01-Amount";
@@ -25,6 +25,7 @@ function UnstakingFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.NearUnstakingAmount}

--- a/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/01-Amount.tsx
@@ -19,7 +19,6 @@ type Props = BaseComposite<
 function WithdrawingAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = getAccountBridge(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const { validatorId } = route.params.stakingPosition;
   const {
@@ -27,7 +26,8 @@ function WithdrawingAmount({ navigation, route }: Props) {
     updateTransaction,
     status,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import WithdrawingAmount from "./01-Amount";
@@ -25,6 +25,7 @@ function WithdrawingFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.NearWithdrawingAmount}

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectAmount.tsx
@@ -1,5 +1,5 @@
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { SOLANA_DELEGATION_RESERVE } from "@ledgerhq/live-common/families/solana/staking";
 import { useTheme } from "@react-navigation/native";
@@ -48,7 +48,7 @@ export default function DelegationSelectAmount({ navigation, route }: Props) {
 
   const [maxSpendable, setMaxSpendable] = useState(0);
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge(account);
 
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
     () => ({

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { Platform } from "react-native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import DelegationConnectDevice from "~/screens/ConnectDevice";
 import DelegationSelectDevice from "~/screens/SelectDevice";
 import DelegationSelectValidator from "./SelectValidator";
@@ -28,6 +28,7 @@ function DelegationFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.SolanaDelegationStarted}

--- a/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/01-SelectAsset.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/01-SelectAsset.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { View, StyleSheet, SafeAreaView, FlatList, TouchableOpacity } from "react-native";
 import { Trans } from "~/context/Locale";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import type { Transaction as StellarTransaction } from "@ledgerhq/live-common/families/stellar/types";
 import type { TokenAccount } from "@ledgerhq/types-live";
@@ -93,7 +93,7 @@ export default function DelegationStarted({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "Account required");
   const mainAccount = getMainAccount(account);
-  const bridge = getAccountBridge(mainAccount);
+  const bridge = useAccountBridge(mainAccount);
   invariant(mainAccount, "stellar Account required");
   const { transaction, status } = useBridgeTransaction(() => {
     const t = bridge.createTransaction(mainAccount);

--- a/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import styles from "~/navigation/styles";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
@@ -25,6 +25,7 @@ function AddAssetFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.StellarAddAssetSelectAsset}

--- a/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/01-Amount.tsx
@@ -18,7 +18,6 @@ type Props = BaseComposite<
 function UnstakingAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = getAccountBridge(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const { stakedSuiId, principal } = route.params.stakingPosition;
   const {
@@ -26,7 +25,8 @@ function UnstakingAmount({ navigation, route }: Props) {
     updateTransaction,
     status,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(async () => {
+    const bridge = await getAccountBridge(account, undefined);
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/index.tsx
@@ -3,7 +3,7 @@ import { Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "@react-navigation/native";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
 import UnstakingAmount from "./01-Amount";
@@ -25,6 +25,7 @@ function UnstakingFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.SuiUnstakingAmount}

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
@@ -159,8 +159,8 @@ export default function SelectValidator({ navigation, route }: Props) {
 
   invariant(account, "account is undefined");
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
-    () => {
-      const bridge = getAccountBridge(account, parentAccount);
+    async () => {
+      const bridge = await getAccountBridge(account, parentAccount);
       return {
         account,
         parentAccount,

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import { useTheme } from "@react-navigation/native";
 import StepHeader from "~/components/StepHeader";
 import { ScreenName } from "~/const";
-import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import DelegationStarted from "./Started";
 import DelegationSummary from "./Summary";
 import DelegationSelectValidator from "./SelectValidator";
@@ -27,6 +27,7 @@ function DelegationFlow() {
         ...stackNavigationConfig,
         gestureEnabled: Platform.OS === "ios",
       }}
+      screenLayout={bridgeSuspenseScreenLayout}
     >
       <Stack.Screen
         name={ScreenName.DelegationStarted}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/index.tsx
@@ -80,12 +80,14 @@ export default function SendWorkflow() {
 
   return (
     <DomainServiceProvider>
+      <React.Suspense fallback={null}>
       <SendFlowOrchestrator
         initParams={initParams}
         onClose={handleClose}
         stepRegistry={stepRegistry}
         flowConfig={SEND_FLOW_CONFIG}
       />
+      </React.Suspense>
     </DomainServiceProvider>
   );
 }

--- a/apps/ledger-live-mobile/src/navigation/navigatorConfig.tsx
+++ b/apps/ledger-live-mobile/src/navigation/navigatorConfig.tsx
@@ -22,6 +22,12 @@ export const defaultNavigationOptions: Partial<NativeStackNavigationOptions> = {
 type ColorV2 = Theme["colors"];
 type ColorV3 = DefaultTheme["colors"];
 
+export const bridgeSuspenseScreenLayout = ({
+  children,
+}: {
+  children: React.ReactElement;
+}): React.ReactElement => <React.Suspense fallback={null}>{children}</React.Suspense>;
+
 export const getStackNavigatorConfig = (
   c: ColorV2 | ColorV3,
   closable = false,

--- a/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
@@ -233,7 +233,11 @@ export function useListHeaderComponents({
           ]
         : []),
       ...(!empty && AccountBodyHeaderRendered
-        ? [<SectionContainer key="AccountBody">{AccountBodyHeaderRendered}</SectionContainer>]
+        ? [
+            <SectionContainer key="AccountBody">
+              <React.Suspense fallback={null}>{AccountBodyHeaderRendered}</React.Suspense>
+            </SectionContainer>,
+          ]
         : []),
       ...(!empty && account.type === "Account" && account.subAccounts
         ? [

--- a/apps/ledger-live-mobile/src/screens/FreezeFunds/02-Amount.tsx
+++ b/apps/ledger-live-mobile/src/screens/FreezeFunds/02-Amount.tsx
@@ -11,7 +11,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans, useTranslation } from "~/context/Locale";
 import invariant from "invariant";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import { GraphTabs, Text, IconsLegacy } from "@ledgerhq/native-ui";
 import { Transaction } from "@ledgerhq/live-common/families/tron/types";
@@ -63,7 +63,7 @@ export default function FreezeAmount({ navigation, route }: NavigatorProps) {
 
   invariant(account && account.type === "Account", "account is required");
 
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge(account, undefined);
 
   const defaultUnit = useAccountUnit(account);
   const { spendableBalance } = account;

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -28,6 +28,7 @@
     "src/bridge/impl.ts",
     "src/bridge/index.ts",
     "src/bridge/react/index.ts",
+    "src/bridge/useAccountBridge.ts",
     "src/bridge/useBridgeTransaction.ts",
     "src/counterValues/state-manager/api.ts",
     "src/counterValues/state-manager/onSchemaFailure.ts",

--- a/libs/ledger-live-common/src/bridge/useAccountBridge.test.ts
+++ b/libs/ledger-live-common/src/bridge/useAccountBridge.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+import "../__tests__/test-helpers/dom-polyfill";
+import React from "react";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { renderHook, act } from "@testing-library/react";
+import { genAccount } from "../mock/account";
+import { setSupportedCurrencies } from "../currencies";
+import { useAccountBridge } from "./useAccountBridge";
+
+const BTC = getCryptoCurrencyById("bitcoin");
+setSupportedCurrencies(["bitcoin"]);
+
+const suspenseWrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(React.Suspense, { fallback: null }, children);
+
+describe("useAccountBridge", () => {
+  test("returns a bridge with createTransaction for a BTC account", async () => {
+    const account = genAccount("mocked-account-1", { currency: BTC });
+
+    let result: ReturnType<typeof renderHook<ReturnType<typeof useAccountBridge>, void>>["result"];
+    await act(async () => {
+      ({ result } = renderHook(() => useAccountBridge(account), { wrapper: suspenseWrapper }));
+      // Two microtask ticks: one for "await getAccountBridge", one for React's wakeUp to fire.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(typeof result!.current.createTransaction).toBe("function");
+    expect(typeof result!.current.updateTransaction).toBe("function");
+    expect(typeof result!.current.prepareTransaction).toBe("function");
+  });
+});

--- a/libs/ledger-live-common/src/bridge/useAccountBridge.ts
+++ b/libs/ledger-live-common/src/bridge/useAccountBridge.ts
@@ -1,0 +1,16 @@
+import { use, useMemo } from "react";
+import { getAccountBridge } from ".";
+import type { Account, AccountBridge, AccountLike, TransactionCommon } from "@ledgerhq/types-live";
+
+// Requires a <Suspense> boundary in the parent tree.
+export function useAccountBridge<T extends TransactionCommon>(
+  account: AccountLike,
+  parentAccount?: Account | null,
+): AccountBridge<T> {
+  const promise = useMemo(
+    async () => await getAccountBridge(account, parentAccount),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [account.id, parentAccount?.id],
+  );
+  return use(promise);
+}

--- a/libs/ledger-live-common/src/bridge/useBridgeTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/useBridgeTransaction.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import "../__tests__/test-helpers/dom-polyfill";
+import React from "react";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { genAccount } from "../mock/account";
@@ -13,10 +14,12 @@ import useBridgeTransaction, {
 } from "./useBridgeTransaction";
 import { setSupportedCurrencies } from "../currencies";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import { setEnv } from "@ledgerhq/live-env";
 
 const BTC = getCryptoCurrencyById("bitcoin");
 
 setSupportedCurrencies(["bitcoin"]);
+setEnv("MOCK", "1");
 
 LiveConfig.setConfig({
   config_currency_bitcoin: {
@@ -34,35 +37,62 @@ jest.mock("@ledgerhq/live-config/LiveConfig", () => ({
   },
 }));
 
+// Prevent real network calls from bitcoin's prepareTransaction (getFeeItems).
+jest.mock("../families/bitcoin/bridge/api", () => ({
+  getFeeItems: jest.fn().mockResolvedValue({ items: [], defaultFeePerByte: null }),
+}));
+
+const suspenseWrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(React.Suspense, { fallback: null }, children);
+
 describe("useBridgeTransaction", () => {
   test("initialize with a BTC account settles the transaction", async () => {
     const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-    const { result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })));
+    let result: ReturnType<typeof renderHook<ReturnType<typeof useBridgeTransaction>, void>>["result"];
+    await act(async () => {
+      ({ result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })), {
+        wrapper: suspenseWrapper,
+      }));
+      // Four microtask ticks: two for makeInit awaits, two for React's Suspense wakeUp.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
 
     await waitFor(
       () => {
-        expect(result.current.bridgePending).toBeFalsy();
-        expect(result.current.bridgeError).toBeFalsy();
-        expect(result.current.transaction).not.toBeFalsy();
-        expect(result.current.account).not.toBeFalsy();
+        expect(result!.current.bridgePending).toBeFalsy();
+        expect(result!.current.bridgeError).toBeFalsy();
+        expect(result!.current.transaction).not.toBeFalsy();
+        expect(result!.current.account).not.toBeFalsy();
       },
       { timeout: 10000 },
     );
-  });
+  }, 30000);
 
   test("bridgeError go through", async () => {
     const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-    const { result } = renderHook(() =>
-      useBridgeTransaction(() => {
-        const bridge = getAccountBridge(mainAccount);
-        const transaction = bridge.updateTransaction(bridge.createTransaction(mainAccount), {
-          recipient: "criticalcrash",
-        });
-        return { account: mainAccount, transaction };
-      }),
-    );
-    await waitFor(() => expect(result.current.bridgeError).not.toBeFalsy());
-  });
+    let result: ReturnType<typeof renderHook<ReturnType<typeof useBridgeTransaction>, void>>["result"];
+    await act(async () => {
+      ({ result } = renderHook(
+        () =>
+          useBridgeTransaction(() => {
+            const bridge = getAccountBridge(mainAccount);
+            const transaction = bridge.updateTransaction(bridge.createTransaction(mainAccount), {
+              recipient: "criticalcrash",
+            });
+            return { account: mainAccount, transaction };
+          }),
+        { wrapper: suspenseWrapper },
+      ));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result!.current.bridgeError).not.toBeFalsy(), { timeout: 10000 });
+  }, 30000);
 
   test("bridgeError can be caught with globalOnBridgeError", async () => {
     const before = getGlobalOnBridgeError();
@@ -70,22 +100,30 @@ describe("useBridgeTransaction", () => {
       const errors: Array<any> = [];
       setGlobalOnBridgeError(error => errors.push(error));
       const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-      renderHook(() =>
-        useBridgeTransaction(() => {
-          const bridge = getAccountBridge(mainAccount);
-          const transaction = bridge.updateTransaction(bridge.createTransaction(mainAccount), {
-            recipient: "criticalcrash",
-          });
-          return { account: mainAccount, transaction };
-        }),
-      );
+      await act(async () => {
+        renderHook(
+          () =>
+            useBridgeTransaction(() => {
+              const bridge = getAccountBridge(mainAccount);
+              const transaction = bridge.updateTransaction(bridge.createTransaction(mainAccount), {
+                recipient: "criticalcrash",
+              });
+              return { account: mainAccount, transaction };
+            }),
+          { wrapper: suspenseWrapper },
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
 
-      await waitFor(() => expect(errors.length).toBe(1));
+      await waitFor(() => expect(errors.length).toBe(1), { timeout: 10000 });
       expect(errors[0]).toMatchObject(new Error("isInvalidRecipient_mock_criticalcrash"));
     } finally {
       setGlobalOnBridgeError(before);
     }
-  });
+  }, 30000);
 
   describe("shouldSyncBeforeTx", () => {
     const mockCurrency = { id: "btc" } as any;
@@ -146,49 +184,76 @@ describe("useBridgeTransaction", () => {
   describe("updateAccount", () => {
     test("updates account reference without resetting the transaction", async () => {
       const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-      const { result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })));
+      let result: ReturnType<typeof renderHook<ReturnType<typeof useBridgeTransaction>, void>>["result"];
+      await act(async () => {
+        ({ result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })), {
+          wrapper: suspenseWrapper,
+        }));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
 
-      await waitFor(() => expect(result.current.transaction).not.toBeFalsy(), { timeout: 10000 });
+      await waitFor(() => expect(result!.current.transaction).not.toBeFalsy(), { timeout: 10000 });
 
-      const transactionBefore = result.current.transaction;
+      const transactionBefore = result!.current.transaction;
 
       const updatedAccount = { ...mainAccount, blockHeight: (mainAccount.blockHeight ?? 0) + 1 };
       act(() => {
-        result.current.updateAccount(updatedAccount);
+        result!.current.updateAccount(updatedAccount);
       });
 
-      expect(result.current.account).toBe(updatedAccount);
-      expect(result.current.account).not.toBe(mainAccount);
+      expect(result!.current.account).toBe(updatedAccount);
+      expect(result!.current.account).not.toBe(mainAccount);
       // transaction must not be reset
-      expect(result.current.transaction).toBe(transactionBefore);
-    });
+      expect(result!.current.transaction).toBe(transactionBefore);
+    }, 30000);
 
     test("is a no-op when the account id does not match", async () => {
       const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-      const { result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })));
+      let result: ReturnType<typeof renderHook<ReturnType<typeof useBridgeTransaction>, void>>["result"];
+      await act(async () => {
+        ({ result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })), {
+          wrapper: suspenseWrapper,
+        }));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
 
-      await waitFor(() => expect(result.current.account).not.toBeFalsy(), { timeout: 10000 });
+      await waitFor(() => expect(result!.current.account).not.toBeFalsy(), { timeout: 10000 });
 
       const differentAccount = genAccount("mocked-account-2", { currency: BTC });
       act(() => {
-        result.current.updateAccount(differentAccount);
+        result!.current.updateAccount(differentAccount);
       });
 
-      expect(result.current.account).toBe(mainAccount);
-    });
+      expect(result!.current.account).toBe(mainAccount);
+    }, 30000);
 
     test("is a no-op when the account reference is identical", async () => {
       const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-      const { result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })));
-
-      await waitFor(() => expect(result.current.account).not.toBeFalsy(), { timeout: 10000 });
-
-      const accountBefore = result.current.account;
-      act(() => {
-        result.current.updateAccount(mainAccount);
+      let result: ReturnType<typeof renderHook<ReturnType<typeof useBridgeTransaction>, void>>["result"];
+      await act(async () => {
+        ({ result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })), {
+          wrapper: suspenseWrapper,
+        }));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
       });
 
-      expect(result.current.account).toBe(accountBefore);
-    });
+      await waitFor(() => expect(result!.current.account).not.toBeFalsy(), { timeout: 10000 });
+
+      const accountBefore = result!.current.account;
+      act(() => {
+        result!.current.updateAccount(mainAccount);
+      });
+
+      expect(result!.current.account).toBe(accountBefore);
+    }, 30000);
   });
 });

--- a/libs/ledger-live-common/src/bridge/useBridgeTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/useBridgeTransaction.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import { useEffect, useReducer, useCallback, useRef } from "react";
+import { useEffect, useReducer, useCallback, useRef, use, useMemo } from "react";
 import { log } from "@ledgerhq/logs";
 import { getAccountBridge } from ".";
 import { getMainAccount } from "../account";
@@ -39,6 +39,7 @@ type Actions<T extends Transaction = Transaction> =
       type: "setAccount";
       account: AccountLike;
       parentAccount: Account | null | undefined;
+      bridge: AccountBridge<any>;
     }
   | {
       type: "setTransaction";
@@ -107,20 +108,22 @@ export const shouldSyncBeforeTx = (currency: CryptoCurrency): boolean => {
 
 const makeInit =
   <T extends Transaction = Transaction>(
-    optionalInit: (() => Partial<State<T>>) | null | undefined,
+    optionalInit: (() => Partial<State<T>> | Promise<Partial<State<T>>>) | null | undefined,
   ) =>
-  (): State<T> => {
+  async (): Promise<State<T>> => {
     let s = initial as State<T>;
 
     if (optionalInit) {
-      const patch = optionalInit();
+      const patch = await optionalInit();
       const { account, parentAccount, transaction } = patch;
 
       if (account) {
+        const bridge = await getAccountBridge(account, parentAccount);
         s = (reducer as Reducer<T>)(s, {
           type: "setAccount",
           account,
           parentAccount,
+          bridge,
         });
       }
 
@@ -141,11 +144,10 @@ const reducer = <T extends Transaction = Transaction>(
 ): State<T> => {
   switch (action.type) {
     case "setAccount": {
-      const { account, parentAccount } = action;
+      const { account, parentAccount, bridge } = action;
 
       try {
         const mainAccount = getMainAccount(account, parentAccount);
-        const bridge = getAccountBridge(account, parentAccount) as AccountBridge<T>;
         const subAccountId = account.type !== "Account" && account.id;
         let t = bridge.createTransaction(mainAccount);
 
@@ -234,8 +236,11 @@ const ERROR_RETRY_DELAY_MULTIPLIER = 1.5;
 const DEBOUNCE_STATUS_DELAY = 300;
 
 const useBridgeTransaction = <T extends Transaction = Transaction>(
-  optionalInit?: (() => Partial<State<T>>) | null | undefined,
+  optionalInit?: (() => Partial<State<T>> | Promise<Partial<State<T>>>) | null | undefined,
 ): Result<T> => {
+  const optionalInitRef = useRef(optionalInit);
+  const initialStatePromise = useMemo(() => makeInit(optionalInitRef.current)(), []);
+  const initialState = use(initialStatePromise);
   const [
     {
       account,
@@ -249,14 +254,18 @@ const useBridgeTransaction = <T extends Transaction = Transaction>(
       errorStatus,
     },
     dispatch,
-  ] = useReducer(reducer as Reducer<T>, undefined, makeInit<T>(optionalInit));
+  ] = useReducer(reducer, initialState);
+
   const setAccount = useCallback(
-    (account, parentAccount) =>
+    async (account, parentAccount) => {
+      const bridge = await getAccountBridge(account, parentAccount);
       dispatch({
         type: "setAccount",
         account,
         parentAccount,
-      }),
+        bridge,
+      });
+    },
     [dispatch],
   );
 

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useFromState.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useFromState.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import "../../../__tests__/test-helpers/dom-polyfill";
+import React from "react";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { Account } from "@ledgerhq/types-live";
 import { renderHook, act } from "@testing-library/react";
@@ -12,9 +13,11 @@ import { genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account
 import { genAccount } from "../../../mock/account";
 import { useFromState } from "./useFromState";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import { setSupportedCurrencies } from "../../../currencies";
 
 const BTC = getCryptoCurrencyById("bitcoin");
 const ETH = getCryptoCurrencyById("ethereum");
+setSupportedCurrencies(["bitcoin", "ethereum"]);
 LiveConfig.setConfig({
   config_currency_bitcoin: {
     type: "object",
@@ -55,28 +58,40 @@ const mockedAccounts: Account[] = [
 const mockedTokenAccount = genTokenAccount(1, mockedAccounts[1], USDT);
 const allAccounts = [...mockedAccounts, mockedTokenAccount] as Account[];
 
+const suspenseWrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(React.Suspense, { fallback: null }, children);
+
+// Settle useBridgeTransaction's async init inside a Suspense boundary.
+// Four microtask ticks: one for the async makeInit return, three for React Suspense wakeUp.
+async function initHook<T>(fn: () => T) {
+  let result!: { current: T };
+  await act(async () => {
+    ({ result } = renderHook(fn, { wrapper: suspenseWrapper }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return result;
+}
+
 describe("useFromState", () => {
-  test("call hook without arguments", () => {
-    const { result } = renderHook(() => {
+  test("call hook without arguments", async () => {
+    const result = await initHook(() => {
       const bridgeTransaction = useBridgeTransaction();
-      return useFromState({
-        bridgeTransaction,
-      });
+      return useFromState({ bridgeTransaction });
     });
     expect(result.current).toMatchObject({
       fromState: selectorStateDefaultValues,
     });
   });
 
-  test("call hook with default currency", () => {
+  test("call hook with default currency", async () => {
     const defaultCurrency = BTC;
 
-    const { result } = renderHook(() => {
+    const result = await initHook(() => {
       const bridgeTransaction = useBridgeTransaction();
-      return useFromState({
-        defaultCurrency,
-        bridgeTransaction,
-      });
+      return useFromState({ defaultCurrency, bridgeTransaction });
     });
     expect(result.current).toMatchObject({
       fromState: {
@@ -86,17 +101,13 @@ describe("useFromState", () => {
     });
   });
 
-  test("call hook with default accounts", () => {
+  test("call hook with default accounts", async () => {
     const defaultAccount = mockedTokenAccount;
     const defaultParentAccount = mockedAccounts[1];
 
-    const { result } = renderHook(() => {
+    const result = await initHook(() => {
       const bridgeTransaction = useBridgeTransaction();
-      return useFromState({
-        defaultAccount,
-        defaultParentAccount,
-        bridgeTransaction,
-      });
+      return useFromState({ defaultAccount, defaultParentAccount, bridgeTransaction });
     });
     expect(result.current).toMatchObject({
       fromState: {
@@ -107,14 +118,11 @@ describe("useFromState", () => {
     });
   });
 
-  test("call hook and set the account and all the related properties", () => {
-    const { result } = renderHook(() => {
+  test("call hook and set the account and all the related properties", async () => {
+    const result = await initHook(() => {
       const bridgeTransaction = useBridgeTransaction();
       return {
-        ...useFromState({
-          accounts: allAccounts,
-          bridgeTransaction,
-        }),
+        ...useFromState({ accounts: allAccounts, bridgeTransaction }),
         bridgeTransaction,
       };
     });
@@ -123,8 +131,11 @@ describe("useFromState", () => {
       fromState: selectorStateDefaultValues,
     });
 
-    act(() => {
+    // setAccount is async (awaits getAccountBridge); use await act to flush the microtask.
+    await act(async () => {
       result.current.setFromAccount(mockedTokenAccount);
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
     expect(result.current).toMatchObject({
@@ -142,13 +153,10 @@ describe("useFromState", () => {
     });
   });
 
-  test("call hook and set the amount after 400ms", () => {
-    const { result } = renderHook(() => {
+  test("call hook and set the amount after 400ms", async () => {
+    const result = await initHook(() => {
       const bridgeTransaction = useBridgeTransaction();
-      return useFromState({
-        accounts: allAccounts,
-        bridgeTransaction,
-      });
+      return useFromState({ accounts: allAccounts, bridgeTransaction });
     });
 
     expect(result.current).toMatchObject({
@@ -178,13 +186,10 @@ describe("useFromState", () => {
     });
   });
 
-  test("call hook and set the the most recent amount input after 400ms", () => {
-    const { result } = renderHook(() => {
+  test("call hook and set the the most recent amount input after 400ms", async () => {
+    const result = await initHook(() => {
       const bridgeTransaction = useBridgeTransaction();
-      return useFromState({
-        accounts: allAccounts,
-        bridgeTransaction,
-      });
+      return useFromState({ accounts: allAccounts, bridgeTransaction });
     });
 
     expect(result.current).toMatchObject({


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** — `useAccountBridge.test.ts` added
- [ ] **Impact of the changes:**
  - All `useBridgeTransaction` callers must be wrapped in a `<Suspense>` boundary
  - Init callbacks that call `getAccountBridge` must become `async`

### 📝 Description

Adds `useAccountBridge` (React `use()` + Suspense) and refactors `useBridgeTransaction`
so its init can be async. Initial state is resolved via `use()` before first render,
removing synchronous `getAccountBridge` from the reducer.

**Consumer change:**
```diff
- } = useBridgeTransaction(() => {
-   const bridge = getAccountBridge(account, parentAccount);
+ } = useBridgeTransaction(async () => {
+   const bridge = await getAccountBridge(account, parentAccount);
    return { account, parentAccount, transaction: bridge.createTransaction(account) };
  });
```

New hook for direct bridge access (requires `<Suspense>` in parent tree):
```ts
const bridge = useAccountBridge(account, parentAccount);
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29193](https://ledgerhq.atlassian.net/browse/LIVE-29193)
- **ADR link (if any)**: N/A

[LIVE-29193]: https://ledgerhq.atlassian.net/browse/LIVE-29193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ