### PR TITLE
[LWM] feat(mobile): hide network badge in wallet assets sections

### DIFF
--- a/.changeset/quiet-icons-hide.md
+++ b/.changeset/quiet-icons-hide.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Hide network badge on currency icons in wallet assets section lists

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/components/AssetListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/components/AssetListItem.tsx
@@ -20,41 +20,44 @@ interface AssetListItemProps {
   onPress: (asset: Asset) => void;
   precomputed: AssetListItemViewModelResult;
   lx?: LumenViewStyle;
+  hideNetwork?: boolean;
 }
 
-const AssetListItem: React.FC<AssetListItemProps> = memo(({ asset, onPress, precomputed, lx }) => {
-  const handlePress = useCallback(() => onPress(asset), [asset, onPress]);
-  const { formattedBalance, formattedCounterValue, countervalueChange } = precomputed;
+const AssetListItem: React.FC<AssetListItemProps> = memo(
+  ({ asset, onPress, precomputed, lx, hideNetwork }) => {
+    const handlePress = useCallback(() => onPress(asset), [asset, onPress]);
+    const { formattedBalance, formattedCounterValue, countervalueChange } = precomputed;
 
-  return (
-    <LumenListItem onPress={handlePress} testID={`assetItem-${asset.currency.name}`} lx={lx}>
-      <ListItemLeading>
-        <CurrencyIcon currency={asset.currency} size={48} />
-        <ListItemContent style={{ flex: 1, minWidth: 0 }}>
-          <ListItemTitle numberOfLines={1}>{asset.currency.name}</ListItemTitle>
-          <ListItemDescription numberOfLines={1}>{formattedBalance}</ListItemDescription>
-        </ListItemContent>
-      </ListItemLeading>
-      <ListItemTrailing>
-        <Box lx={{ flexDirection: "column", alignItems: "flex-end", gap: "s4" }}>
-          {formattedCounterValue != null && (
-            <Text typography="body2SemiBold" lx={{ color: "base" }}>
-              {formattedCounterValue}
-            </Text>
-          )}
-          {countervalueChange && (
-            <Delta
-              valueChange={countervalueChange}
-              percent
-              fallbackToPercentPlaceholder
-              isArrowDisplayed
-            />
-          )}
-        </Box>
-      </ListItemTrailing>
-    </LumenListItem>
-  );
-});
+    return (
+      <LumenListItem onPress={handlePress} testID={`assetItem-${asset.currency.name}`} lx={lx}>
+        <ListItemLeading>
+          <CurrencyIcon currency={asset.currency} size={48} hideNetwork={hideNetwork} />
+          <ListItemContent style={{ flex: 1, minWidth: 0 }}>
+            <ListItemTitle numberOfLines={1}>{asset.currency.name}</ListItemTitle>
+            <ListItemDescription numberOfLines={1}>{formattedBalance}</ListItemDescription>
+          </ListItemContent>
+        </ListItemLeading>
+        <ListItemTrailing>
+          <Box lx={{ flexDirection: "column", alignItems: "flex-end", gap: "s4" }}>
+            {formattedCounterValue != null && (
+              <Text typography="body2SemiBold" lx={{ color: "base" }}>
+                {formattedCounterValue}
+              </Text>
+            )}
+            {countervalueChange && (
+              <Delta
+                valueChange={countervalueChange}
+                percent
+                fallbackToPercentPlaceholder
+                isArrowDisplayed
+              />
+            )}
+          </Box>
+        </ListItemTrailing>
+      </LumenListItem>
+    );
+  },
+);
 AssetListItem.displayName = "AssetListItem";
 
 export default AssetListItem;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/SectionListContent/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/SectionListContent/index.tsx
@@ -39,6 +39,7 @@ export const SectionListContent = ({
       onPress={onItemPress}
       precomputed={precomputedData.get(item.currency.id)!}
       lx={NEGATIVE_MARGIN_OFFSET}
+      hideNetwork
     />
   ));
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing `AssetListItem` tests still apply; the `hideNetwork` branch is not asserted separately._
- [x] **Impact of the changes:**
      - Wallet Assets tab: section lists that use `SectionListContent` (e.g. cryptos / stablecoins rows)
      - Currency row icons: network badge should be hidden where `hideNetwork` is passed
      - Other `AssetListItem` usages (default `hideNetwork` omitted) should look unchanged

### 📝 Description

**Problem:** In wallet assets section lists, showing the network badge on each currency icon can be redundant or visually noisy when the section context already makes the network clear.

**Solution:** `AssetListItem` accepts an optional `hideNetwork` flag and forwards it to `CurrencyIcon`. `SectionListContent` passes `hideNetwork` so rows in those section lists hide the network badge while other asset lists keep the previous behavior.

| Before | After |
| ------ | ----- |
|<img width="452" height="900" alt="Screenshot 2026-04-22 at 12 22 13 PM" src="https://github.com/user-attachments/assets/295976c2-5597-4348-b34c-4a5acfdefd57" />|<img width="452" height="900" alt="Screenshot 2026-04-22 at 12 22 21 PM" src="https://github.com/user-attachments/assets/800b7a12-07ba-426a-9ca9-66a6bcd339b7" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28368](https://ledgerhq.atlassian.net/browse/LIVE-28368)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28368]: https://ledgerhq.atlassian.net/browse/LIVE-28368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ