### PR TITLE
[LWDM] fix(BACK-11168): fix Hedera getBalance/getStakes performance

### DIFF
--- a/.changeset/tall-turkeys-allow.md
+++ b/.changeset/tall-turkeys-allow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix(BACK-11168): fix Hedera getBalance/getStakes performance

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
@@ -39,7 +39,6 @@ describe("getBalance", () => {
   it("should return native balance when only HBAR is present", async () => {
     (apiClient.getAccount as jest.Mock).mockResolvedValue(mockMirrorAccount);
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue([]);
-    (apiClient.getNodes as jest.Mock).mockResolvedValue({ nodes: [] });
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue([]);
 
     const result = await getBalance(mockCurrency, address);
@@ -48,6 +47,9 @@ describe("getBalance", () => {
     expect(apiClient.getAccount).toHaveBeenCalledWith(address);
     expect(apiClient.getAccountTokens).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccountTokens).toHaveBeenCalledWith(address);
+    // non-staking account: no node lookup should happen
+    expect(apiClient.getNode).not.toHaveBeenCalled();
+    expect(apiClient.getNodes).not.toHaveBeenCalled();
     expect(result).toEqual([
       {
         asset: { type: "native" },
@@ -88,7 +90,6 @@ describe("getBalance", () => {
 
     (apiClient.getAccount as jest.Mock).mockResolvedValue(mockMirrorAccount);
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue(mockMirrorTokens);
-    (apiClient.getNodes as jest.Mock).mockResolvedValue({ nodes: [] });
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue(mockERC20Balances);
 
     const result = await getBalance(mockCurrency, address);
@@ -151,14 +152,16 @@ describe("getBalance", () => {
 
     (apiClient.getAccount as jest.Mock).mockResolvedValue(mockMirrorAccount);
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue([]);
-    (apiClient.getNodes as jest.Mock).mockResolvedValue({ nodes: [mockMirrorNode] });
+    (apiClient.getNode as jest.Mock).mockResolvedValue(mockMirrorNode);
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue([]);
 
     const result = await getBalance(mockCurrency, address);
 
     expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
     expect(apiClient.getAccount).toHaveBeenCalledWith(address);
-    expect(apiClient.getNodes).toHaveBeenCalledTimes(1);
+    expect(apiClient.getNode).toHaveBeenCalledTimes(1);
+    expect(apiClient.getNode).toHaveBeenCalledWith(mockMirrorAccount.staked_node_id);
+    expect(apiClient.getNodes).not.toHaveBeenCalled();
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       asset: { type: "native" },
@@ -240,7 +243,6 @@ describe("getBalance", () => {
 
     (apiClient.getAccount as jest.Mock).mockResolvedValue(mockMirrorAccount);
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue(mockMirrorTokens);
-    (apiClient.getNodes as jest.Mock).mockResolvedValue({ nodes: [] });
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue(mockERC20Balances);
 
     const result = await getBalance(mockCurrency, address);
@@ -278,7 +280,6 @@ describe("getBalance", () => {
 
     (apiClient.getAccount as jest.Mock).mockRejectedValue(error);
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue([]);
-    (apiClient.getNodes as jest.Mock).mockResolvedValue({ nodes: [] });
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue([]);
 
     await expect(getBalance(mockCurrency, address)).rejects.toThrow(error);
@@ -289,7 +290,6 @@ describe("getBalance", () => {
 
     (apiClient.getAccount as jest.Mock).mockResolvedValue(mockMirrorAccount);
     (apiClient.getAccountTokens as jest.Mock).mockRejectedValue(error);
-    (apiClient.getNodes as jest.Mock).mockResolvedValue({ nodes: [] });
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue([]);
 
     await expect(getBalance(mockCurrency, address)).rejects.toThrow(error);
@@ -300,7 +300,6 @@ describe("getBalance", () => {
 
     (apiClient.getAccount as jest.Mock).mockResolvedValue(mockMirrorAccount);
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue([]);
-    (apiClient.getNodes as jest.Mock).mockResolvedValue({ nodes: [] });
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockRejectedValue(error);
 
     await expect(getBalance(mockCurrency, address)).rejects.toThrow(error);
@@ -320,7 +319,6 @@ describe("getBalance", () => {
 
     (apiClient.getAccount as jest.Mock).mockRejectedValue(error);
     (apiClient.getAccountTokens as jest.Mock).mockResolvedValue([]);
-    (apiClient.getNodes as jest.Mock).mockResolvedValue({ nodes: [] });
     (networkUtils.getERC20BalancesForAccountV2 as jest.Mock).mockResolvedValue([]);
 
     const result = await getBalance(mockCurrency, address);

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
@@ -12,15 +12,24 @@ import { getERC20BalancesForAccountV2 } from "../network/utils";
 export async function getBalance(currency: CryptoCurrency, address: string): Promise<Balance[]> {
   try {
     const coinConfig = hederaCoinConfig.getCoinConfig(currency.id);
-    const [mirrorAccount, mirrorTokens, mirrorNodes, erc20TokenBalances] = await Promise.all([
-      apiClient.getAccount(address),
+    // Fetch only the specific staked node (or nothing at all for non-staking
+    // accounts) instead of paginating the full /network/nodes list. The
+    // validator lookup is chained on the account promise so it still runs
+    // concurrently with the token fetches.
+    const mirrorAccountPromise = apiClient.getAccount(address);
+    const validatorPromise = mirrorAccountPromise.then(account =>
+      typeof account.staked_node_id === "number" && account.staked_node_id >= 0
+        ? apiClient.getNode(account.staked_node_id)
+        : null,
+    );
+    const [mirrorAccount, mirrorTokens, erc20TokenBalances, validator] = await Promise.all([
+      mirrorAccountPromise,
       apiClient.getAccountTokens(address),
-      apiClient.getNodes({ fetchAllPages: true }),
       coinConfig.useHgraphForErc20 ? getERC20BalancesForAccountV2(address) : Promise.resolve([]),
+      validatorPromise,
     ]);
 
     const mixedTokens = [...mirrorTokens, ...erc20TokenBalances];
-    const validator = mirrorNodes.nodes.find(v => v.node_id === mirrorAccount.staked_node_id);
 
     const nativeBalance: Balance = {
       asset: { type: "native" },

--- a/libs/coin-modules/coin-hedera/src/logic/getStakes.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getStakes.test.ts
@@ -4,6 +4,7 @@ import { getStakes } from "./getStakes";
 describe("getStakes", () => {
   const mockAddress = "0.0.123456";
   const mockGetAccount = jest.spyOn(apiClient, "getAccount");
+  const mockGetNode = jest.spyOn(apiClient, "getNode");
   const mockGetNodes = jest.spyOn(apiClient, "getNodes");
 
   beforeEach(() => {
@@ -20,29 +21,48 @@ describe("getStakes", () => {
       staked_node_id: null,
     });
 
-    mockGetNodes.mockResolvedValue({
-      nodes: [
-        {
-          node_id: 1,
-          node_account_id: "0.0.3",
-          description: "",
-          stake: 100000000000,
-          max_stake: 500000000000,
-          min_stake: 0,
-          stake_rewarded: 0,
-          reward_rate_start: 0,
-        },
-      ],
-      nextCursor: null,
-    });
-
     const result = await getStakes(mockAddress);
 
     expect(result.items).toEqual([]);
     expect(mockGetAccount).toHaveBeenCalledTimes(1);
     expect(mockGetAccount).toHaveBeenCalledWith(mockAddress);
-    expect(mockGetNodes).toHaveBeenCalledTimes(1);
-    expect(mockGetNodes).toHaveBeenCalledWith({ fetchAllPages: true });
+    // when there's no staked_node_id we must not hit the nodes endpoint at all
+    expect(mockGetNode).not.toHaveBeenCalled();
+    expect(mockGetNodes).not.toHaveBeenCalled();
+  });
+
+  it("should return inactive stake and skip node lookup when staked_node_id is -1", async () => {
+    const balance = 1000000000;
+    const pendingReward = 100000000;
+
+    mockGetAccount.mockResolvedValue({
+      account: mockAddress,
+      max_automatic_token_associations: 0,
+      evm_address: "",
+      balance: { balance, timestamp: "0", tokens: [] },
+      pending_reward: pendingReward,
+      staked_node_id: -1,
+    });
+
+    const result = await getStakes(mockAddress);
+
+    expect(result.items).toEqual([
+      {
+        uid: mockAddress,
+        address: mockAddress,
+        asset: { type: "native" },
+        state: "inactive",
+        amount: BigInt(balance) + BigInt(pendingReward),
+        amountDeposited: BigInt(balance),
+        amountRewarded: BigInt(pendingReward),
+        details: {
+          stakedNodeId: -1,
+          overstaked: null,
+        },
+      },
+    ]);
+    expect(mockGetNode).not.toHaveBeenCalled();
+    expect(mockGetNodes).not.toHaveBeenCalled();
   });
 
   it("should return inactive stake when delegated node is not found", async () => {
@@ -59,24 +79,12 @@ describe("getStakes", () => {
       staked_node_id: stakedNodeId,
     });
 
-    mockGetNodes.mockResolvedValue({
-      nodes: [
-        {
-          node_id: 1,
-          node_account_id: "0.0.3",
-          description: "",
-          stake: 100000000000,
-          max_stake: 500000000000,
-          min_stake: 0,
-          stake_rewarded: 0,
-          reward_rate_start: 0,
-        },
-      ],
-      nextCursor: null,
-    });
+    mockGetNode.mockResolvedValue(null);
 
     const result = await getStakes(mockAddress);
 
+    expect(mockGetNode).toHaveBeenCalledTimes(1);
+    expect(mockGetNode).toHaveBeenCalledWith(stakedNodeId);
     expect(result.items).toEqual([
       {
         uid: mockAddress,
@@ -109,24 +117,20 @@ describe("getStakes", () => {
       staked_node_id: nodeId,
     });
 
-    mockGetNodes.mockResolvedValue({
-      nodes: [
-        {
-          node_id: nodeId,
-          node_account_id: nodeAccountId,
-          description: "",
-          stake: 100000000000,
-          max_stake: 500000000000,
-          min_stake: 0,
-          stake_rewarded: 0,
-          reward_rate_start: 0,
-        },
-      ],
-      nextCursor: null,
+    mockGetNode.mockResolvedValue({
+      node_id: nodeId,
+      node_account_id: nodeAccountId,
+      description: "",
+      stake: 100000000000,
+      max_stake: 500000000000,
+      min_stake: 0,
+      stake_rewarded: 0,
+      reward_rate_start: 0,
     });
 
     const result = await getStakes(mockAddress);
 
+    expect(mockGetNode).toHaveBeenCalledWith(nodeId);
     expect(result.items).toEqual([
       {
         uid: mockAddress,
@@ -157,20 +161,15 @@ describe("getStakes", () => {
       staked_node_id: nodeId,
     });
 
-    mockGetNodes.mockResolvedValue({
-      nodes: [
-        {
-          node_id: nodeId,
-          node_account_id: "0.0.3",
-          description: "",
-          stake: 500000000000,
-          max_stake: 500000000000,
-          min_stake: 0,
-          stake_rewarded: 0,
-          reward_rate_start: 0,
-        },
-      ],
-      nextCursor: null,
+    mockGetNode.mockResolvedValue({
+      node_id: nodeId,
+      node_account_id: "0.0.3",
+      description: "",
+      stake: 500000000000,
+      max_stake: 500000000000,
+      min_stake: 0,
+      stake_rewarded: 0,
+      reward_rate_start: 0,
     });
 
     const result = await getStakes(mockAddress);

--- a/libs/coin-modules/coin-hedera/src/logic/getStakes.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getStakes.ts
@@ -5,18 +5,16 @@ import { apiClient } from "../network/api";
  * Fetch stakes for a given Hedera account.
  */
 export async function getStakes(address: string): Promise<Page<Stake>> {
-  const [mirrorAccount, mirrorNodes] = await Promise.all([
-    apiClient.getAccount(address),
-    apiClient.getNodes({ fetchAllPages: true }),
-  ]);
-
+  const mirrorAccount = await apiClient.getAccount(address);
   const stakedNodeId = mirrorAccount.staked_node_id;
 
   if (typeof stakedNodeId !== "number") {
     return { items: [] };
   }
 
-  const delegatedNode = mirrorNodes.nodes.find(node => node.node_id === stakedNodeId);
+  // -1 is used by the mirror node to indicate the account is no longer delegated
+  // to any node (e.g. after an undelegation). In that case we skip the node lookup.
+  const delegatedNode = stakedNodeId >= 0 ? await apiClient.getNode(stakedNodeId) : null;
   const balance = BigInt(mirrorAccount.balance.balance);
   const pendingReward = BigInt(mirrorAccount.pending_reward);
 

--- a/libs/coin-modules/coin-hedera/src/network/api.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.ts
@@ -339,6 +339,19 @@ async function getTransactionsByTimestampRange({
   return transactions;
 }
 
+async function getNode(nodeId: number): Promise<HederaMirrorNode | null> {
+  const params = new URLSearchParams({
+    "node.id": `eq:${nodeId}`,
+    limit: "1",
+  });
+
+  const res = await network<HederaMirrorNodesResponse>({
+    method: "GET",
+    url: `${API_URL}/api/v1/network/nodes?${params.toString()}`,
+  });
+  return res.data.nodes[0] ?? null;
+}
+
 async function getNodes({
   cursor,
   limit = 100,
@@ -405,5 +418,6 @@ export const apiClient = {
   getERC20Balance,
   estimateContractCallGas,
   getTransactionsByTimestampRange,
+  getNode,
   getNodes,
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - coin-hedera

### 📝 Description

`getBalance`/`getStakes` takes 1m30s at the moment, this PR optimizes performance:
 - nodes API is not used if account is not staked
 - instead of fetching all nodes, only fetch the one we need

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/BACK-11168


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
