### PR TITLE
[LWD] fix: shrink crypto addresses search in narrow layouts

### DIFF
--- a/.changeset/narrow-mangos-shine.md
+++ b/.changeset/narrow-mangos-shine.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix(desktop): shrink crypto addresses search in narrow layouts so the add address action stays visible

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAddressesView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/CryptoAddressesView.tsx
@@ -37,8 +37,8 @@ export function CryptoAddressesView({
       <PageHeader title={t("cryptoAddresses.title")} />
       <div data-testid="crypto-page-content" className="flex min-h-0 flex-1 flex-col gap-16">
         <TableActionBar>
-          <TableActionBarLeading>
-            <div className="w-[400px] flex-auto pt-4">
+          <TableActionBarLeading className="flex-1 min-w-0">
+            <div className="w-full max-w-[400px] min-w-0 pt-4">
               <SearchInput
                 value={searchValue}
                 placeholder={t("cryptoAddresses.tableActions.searchAddress")}
@@ -46,7 +46,7 @@ export function CryptoAddressesView({
               />
             </div>
           </TableActionBarLeading>
-          <TableActionBarTrailing>
+          <TableActionBarTrailing className="shrink-0">
             <Button
               appearance="base"
               size="md"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request addresses a UI issue in the crypto addresses page of Ledger Live Desktop, specifically improving the layout in narrow viewports so that the "add address" action remains visible and accessible. The main changes involve updating the search input and action bar styling for better responsiveness.

https://github.com/user-attachments/assets/10dac266-8213-4af1-9c8a-ca82823cd448


### ❓ Context

[LIVE-29202](https://ledgerhq.atlassian.net/browse/LIVE-29202)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29202]: https://ledgerhq.atlassian.net/browse/LIVE-29202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ