### PR TITLE
[LWDM] feat(desktop): add product tour developer controls

### DIFF
--- a/.changeset/clean-masks-shave.md
+++ b/.changeset/clean-masks-shave.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add developer controls for the product tour completion state

--- a/apps/ledger-live-desktop/src/renderer/actions/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/constants.ts
@@ -3,6 +3,7 @@
 /** Settings --------- */
 export const PURGE_EXPIRED_ANONYMOUS_USER_NOTIFICATIONS =
   "settings/purgeExpiredAnonymousUserNotifications";
+export const SET_PRODUCT_TOUR_COMPLETED = "settings/setProductTourCompleted";
 export const TOGGLE_MEMOTAG_INFO = "settings/toggleShouldDisplayMemoTagInfo";
 export const TOGGLE_MEV = "settings/toggleMEV";
 export const UPDATE_ANONYMOUS_USER_NOTIFICATIONS = "settings/updateAnonymousUserNotifications";

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -21,6 +21,7 @@ import { useRefreshAccountsOrdering } from "~/renderer/actions/general";
 import { Language, Locale } from "~/config/languages";
 import {
   PURGE_EXPIRED_ANONYMOUS_USER_NOTIFICATIONS,
+  SET_PRODUCT_TOUR_COMPLETED,
   TOGGLE_MEMOTAG_INFO,
   TOGGLE_MEV,
   UPDATE_ANONYMOUS_USER_NOTIFICATIONS,
@@ -402,6 +403,11 @@ export const updateAnonymousUserNotifications = (payload: {
 export const setHasSeenWalletV4Tour = (hasSeenWalletV4Tour: boolean) => ({
   type: "SET_HAS_SEEN_WALLET_V4_TOUR",
   payload: hasSeenWalletV4Tour,
+});
+
+export const setProductTourCompleted = (productTourCompleted: boolean) => ({
+  type: SET_PRODUCT_TOUR_COMPLETED,
+  payload: productTourCompleted,
 });
 
 export const setHasClickedRecover = (hasClickedRecover: boolean) => ({

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -33,6 +33,7 @@ import regionsByKey from "~/renderer/screens/settings/sections/General/regions.j
 import { State } from ".";
 import {
   PURGE_EXPIRED_ANONYMOUS_USER_NOTIFICATIONS,
+  SET_PRODUCT_TOUR_COMPLETED,
   TOGGLE_MEMOTAG_INFO,
   TOGGLE_MEV,
   UPDATE_ANONYMOUS_USER_NOTIFICATIONS,
@@ -132,6 +133,7 @@ export type SettingsState = {
   alwaysShowMemoTagInfo: boolean;
   anonymousUserNotifications: { LNSUpsell?: number } & Record<string, number>;
   hasSeenWalletV4Tour: boolean;
+  productTourCompleted: boolean;
   hasClickedRecover: boolean;
   doNotAskAgainSkipMemo: boolean;
   deprecationDoNotRemind: string[];
@@ -236,6 +238,7 @@ export const INITIAL_STATE: SettingsState = {
   alwaysShowMemoTagInfo: true,
   anonymousUserNotifications: {},
   hasSeenWalletV4Tour: false,
+  productTourCompleted: false,
   hasClickedRecover: false,
   doNotAskAgainSkipMemo: false,
   deprecationDoNotRemind: [],
@@ -301,6 +304,7 @@ type HandlersPayloads = {
     notifications: Record<string, number>;
   };
   SET_HAS_SEEN_WALLET_V4_TOUR: boolean;
+  [SET_PRODUCT_TOUR_COMPLETED]: boolean;
   SET_HAS_CLICKED_RECOVER: boolean;
 };
 type SettingsHandlers<PreciseKey = true> = Handlers<SettingsState, HandlersPayloads, PreciseKey>;
@@ -530,6 +534,10 @@ const handlers: SettingsHandlers = {
   SET_HAS_SEEN_WALLET_V4_TOUR: (state: SettingsState, { payload }) => ({
     ...state,
     hasSeenWalletV4Tour: payload,
+  }),
+  [SET_PRODUCT_TOUR_COMPLETED]: (state: SettingsState, { payload }) => ({
+    ...state,
+    productTourCompleted: payload,
   }),
   SET_HAS_CLICKED_RECOVER: (state: SettingsState, { payload }) => ({
     ...state,
@@ -848,6 +856,7 @@ export const alwaysShowMemoTagInfoSelector = (state: State) => state.settings.al
 export const anonymousUserNotificationsSelector = (state: State) =>
   state.settings.anonymousUserNotifications;
 export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasSeenWalletV4Tour;
+export const productTourCompletedSelector = (state: State) => state.settings.productTourCompleted;
 export const hasClickedRecoverSelector = (state: State) => state.settings.hasClickedRecover;
 
 // Last onboarded device is the device set when a user goes through the onboarding flow.

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeaturesAndFlowsDevTool/ProductTourSection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeaturesAndFlowsDevTool/ProductTourSection.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Button, Divider } from "@ledgerhq/lumen-ui-react";
+import { DeveloperToggleRow } from "../components/DeveloperToggleRow";
+
+interface ProductTourSectionProps {
+  readonly productTourCompleted: boolean;
+  readonly onToggleProductTourCompleted: () => void;
+}
+
+export const ProductTourSection = ({
+  productTourCompleted,
+  onToggleProductTourCompleted,
+}: ProductTourSectionProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <span className="body-2-semi-bold text-muted">
+        {t("settings.developer.featuresAndFlowsDevTool.productTour.title")}
+      </span>
+      <Divider />
+      <DeveloperToggleRow
+        name="wallet-feature-product-tour"
+        label={t("settings.developer.featuresAndFlowsDevTool.productTour.label")}
+        selected={productTourCompleted}
+        onChange={onToggleProductTourCompleted}
+        description={
+          productTourCompleted
+            ? t("settings.developer.featuresAndFlowsDevTool.productTour.completed")
+            : t("settings.developer.featuresAndFlowsDevTool.productTour.notCompleted")
+        }
+      />
+      <Button appearance="accent" size="sm" onClick={() => undefined}>
+        {t("settings.developer.featuresAndFlowsDevTool.productTour.open")}
+      </Button>
+    </div>
+  );
+};

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeaturesAndFlowsDevTool/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeaturesAndFlowsDevTool/index.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+import { useSelector, useDispatch } from "LLD/hooks/redux";
+import { productTourCompletedSelector } from "~/renderer/reducers/settings";
+import { setProductTourCompleted } from "~/renderer/actions/settings";
+import { SettingsSectionRow as Row } from "../../../SettingsSection";
+import { ProductTourSection } from "./ProductTourSection";
+
+const FeaturesAndFlowsDevTool = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const productTourCompleted = useSelector(productTourCompletedSelector);
+  const [contentExpanded, setContentExpanded] = useState(false);
+
+  const toggleContentVisibility = () => {
+    setContentExpanded(prev => !prev);
+  };
+
+  const handleToggleProductTourCompleted = () => {
+    dispatch(setProductTourCompleted(!productTourCompleted));
+  };
+
+  return (
+    <Row
+      title={t("settings.developer.featuresAndFlowsDevTool.title")}
+      descContainerStyle={{ maxWidth: undefined }}
+      contentContainerStyle={{ marginRight: 0 }}
+      childrenContainerStyle={{ alignSelf: "flex-start" }}
+      desc={
+        <div className="flex flex-col gap-2 pt-2">
+          <p className="text-muted">
+            {t("settings.developer.featuresAndFlowsDevTool.description")}
+          </p>
+
+          {contentExpanded ? (
+            <div className="mt-4 flex flex-col gap-12">
+              <ProductTourSection
+                productTourCompleted={productTourCompleted}
+                onToggleProductTourCompleted={handleToggleProductTourCompleted}
+              />
+            </div>
+          ) : null}
+        </div>
+      }
+    >
+      <Button appearance="accent" size="sm" onClick={toggleContentVisibility}>
+        {contentExpanded ? t("settings.developer.hide") : t("settings.developer.show")}
+      </Button>
+    </Row>
+  );
+};
+
+export default FeaturesAndFlowsDevTool;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/components/TourSection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/components/TourSection.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Divider } from "@ledgerhq/lumen-ui-react";
-import { ToggleRow } from "./ToggleRow";
+import { DeveloperToggleRow } from "../../components/DeveloperToggleRow";
 
 interface TourSectionProps {
   readonly hasSeenTour: boolean;
@@ -22,7 +22,7 @@ export const TourSection = ({
         {t("settings.developer.walletFeaturesDevTool.tourState")}
       </span>
       <Divider />
-      <ToggleRow
+      <DeveloperToggleRow
         name="wallet-feature-has-seen-tour"
         label="Has Seen Wallet V4 Tour"
         selected={hasSeenTour}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/components/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletFeaturesDevTool/components/index.ts
@@ -2,5 +2,4 @@ export { QuickActions } from "./QuickActions";
 export { FeatureParamRow } from "./FeatureParamRow";
 export { FeatureFlagPreview } from "./FeatureFlagPreview";
 export { MainFeatureToggle } from "./MainFeatureToggle";
-export { ToggleRow } from "./ToggleRow";
 export { TourSection } from "./TourSection";

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/components/DeveloperToggleRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/components/DeveloperToggleRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Switch } from "@ledgerhq/lumen-ui-react";
 
-interface ToggleRowProps {
+interface DeveloperToggleRowProps {
   readonly name: string;
   readonly label: string;
   readonly selected: boolean;
@@ -9,11 +9,17 @@ interface ToggleRowProps {
   readonly description?: string;
 }
 
-export const ToggleRow = ({ name, label, selected, onChange, description }: ToggleRowProps) => (
+export const DeveloperToggleRow = ({
+  name,
+  label,
+  selected,
+  onChange,
+  description,
+}: DeveloperToggleRowProps) => (
   <div className="flex items-center justify-between rounded-md bg-surface p-4">
     <div className="flex flex-col gap-1">
       <span className="body-3">{label}</span>
-      {description && <span className="body-3 text-muted">{description}</span>}
+      {description ? <span className="body-3 text-muted">{description}</span> : null}
     </div>
     <Switch name={name} selected={selected} onChange={onChange} />
   </div>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
@@ -36,6 +36,7 @@ import { MockAccountGeneratorSection } from "./GenerateMockAccounts";
 import AppJsonImporter from "./AppJsonImporter";
 import CustomLockScreenTester from "./CustomLockScreenTester";
 import WalletFeaturesDevTool from "./WalletFeaturesDevTool";
+import FeaturesAndFlowsDevTool from "./FeaturesAndFlowsDevTool";
 import AnalyticsConsentOptInDevTool from "./AnalyticsConsentOptInDevTool";
 import { AnalyticsConsentOptInDevScreen } from "./AnalyticsConsentOptInDevTool/AnalyticsConsentOptInDevScreen";
 
@@ -139,6 +140,7 @@ const Default = () => {
         </Row>
       )}
       <WalletFeaturesDevTool />
+      <FeaturesAndFlowsDevTool />
       <AnalyticsConsentOptInDevTool />
       <ModularDrawerDevTool />
       <CryptoAssetsListDevTool />

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4862,6 +4862,17 @@
         "debugDialog": "Debug Dialog",
         "debugDuplicates": "Debug Duplicates"
       },
+      "featuresAndFlowsDevTool": {
+        "title": "Features & Flows",
+        "description": "Developer tools for feature-related flows.",
+        "productTour": {
+          "title": "Product Tour",
+          "label": "Product Tour",
+          "completed": "Product tour is marked as completed.",
+          "notCompleted": "Product tour is not completed yet.",
+          "open": "Open"
+        }
+      },
       "walletFeaturesDevTool": {
         "title": "Wallet Features Dev Tool",
         "description": "Toggle Wallet 4.0 features for desktop (lwdWallet40 feature flag).",

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -641,6 +641,7 @@ export const DEFAULT_FEATURES: Features = {
   },
   lwmLedgerSyncOptimisation: DEFAULT_FEATURE,
   lwdLedgerSyncOptimisation: DEFAULT_FEATURE,
+  lwdProductTour: DEFAULT_FEATURE,
   lwmNewWordingOptInNotificationsDrawer: {
     ...DEFAULT_FEATURE,
     params: { variant: ABTestingVariants.variantA },

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -250,6 +250,7 @@ export type Features = CurrencyFeatures & {
   lldLedgerSyncEntryPoints: Feature_LldLedgerSyncEntryPoints;
   lwmLedgerSyncOptimisation: DefaultFeature;
   lwdLedgerSyncOptimisation: DefaultFeature;
+  lwdProductTour: DefaultFeature;
   lwmNewWordingOptInNotificationsDrawer: Feature_LwmNewWordingOptInNotificationsDrawer;
   lldNanoSUpsellBanners: Feature_LldNanoSUpsellBanners;
   llmNanoSUpsellBanners: Feature_LlmNanoSUpsellBanners;

--- a/shared/feature-flags/src/flags/team-engagement/index.ts
+++ b/shared/feature-flags/src/flags/team-engagement/index.ts
@@ -5,6 +5,7 @@ export * from "./lldActionCarousel";
 export * from "./lldAnalyticsOptInPrompt";
 export * from "./lldNanoSUpsellBanners";
 export * from "./lldOnboardingEnableSync";
+export * from "./lwdProductTour";
 export * from "./lldRebornABtest";
 export * from "./lldSyncOnboardingIncr1";
 export * from "./llmAnalyticsOptInPrompt";

--- a/shared/feature-flags/src/flags/team-engagement/lwdProductTour.ts
+++ b/shared/feature-flags/src/flags/team-engagement/lwdProductTour.ts
@@ -1,0 +1,3 @@
+import { flag } from "../../define";
+
+export const lwdProductTour = flag();


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No targeted automated tests were added for this developer-only desktop settings flow._
- [x] **Impact of the changes:**
      - Desktop Developer settings entry and copy for the new `Features & Flows` tool
      - Product tour completion state wiring in desktop settings actions and reducer
      - Shared feature flag registration for `lwdProductTour`
      - Shared `DeveloperToggleRow` reuse across developer tools

### 📝 Description

This PR adds a dedicated desktop developer tool for product-tour debugging so the flow state can be inspected and toggled without overloading the existing Wallet Features dev tool.

The change introduces the `lwdProductTour` feature flag, stores the product tour completion state in desktop settings, adds a new `Features & Flows` row in Developer settings, extracts a reusable `DeveloperToggleRow` component shared by dev tools, and wires English i18n copy for the new entry.

<img width="1386" height="330" alt="image" src="https://github.com/user-attachments/assets/6f2fc57b-0053-4695-8a4e-efbb71fb7f01" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28132](https://ledgerhq.atlassian.net/browse/LIVE-28132)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-28132]: https://ledgerhq.atlassian.net/browse/LIVE-28132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ