### PR TITLE
[LWM] feat(lwm): device tap navigates to My Ledger

### DIFF
--- a/.changeset/gentle-device-tap.md
+++ b/.changeset/gentle-device-tap.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Make device cards tappable to navigate to My Ledger screen (LIVE-26537).

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/DeviceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/DeviceSectionView.tsx
@@ -10,6 +10,7 @@ interface DeviceSectionViewProps {
   readonly hasDevices: boolean;
   readonly onAddDevice: () => void;
   readonly onExploreDevices: () => void;
+  readonly onDevicePress: (device: DeviceSectionDevice) => void;
 }
 
 export function DeviceSectionView({
@@ -17,6 +18,7 @@ export function DeviceSectionView({
   hasDevices,
   onAddDevice,
   onExploreDevices,
+  onDevicePress,
 }: DeviceSectionViewProps) {
   const { t } = useTranslation();
 
@@ -37,6 +39,7 @@ export function DeviceSectionView({
           devices={devices}
           onAddDevice={onAddDevice}
           onExploreDevices={onExploreDevices}
+          onDevicePress={onDevicePress}
         />
       </Box>
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__integrations__/DeviceSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__integrations__/DeviceSection.integration.test.tsx
@@ -12,6 +12,7 @@ const mockDevices: DeviceSectionDevice[] = [
 
 const mockOnAddDevice = jest.fn();
 const mockOnExploreDevices = jest.fn();
+const mockOnDevicePress = jest.fn();
 
 const renderView = (devices: readonly DeviceSectionDevice[]) =>
   render(
@@ -20,12 +21,24 @@ const renderView = (devices: readonly DeviceSectionDevice[]) =>
       hasDevices={devices.length > 0}
       onAddDevice={mockOnAddDevice}
       onExploreDevices={mockOnExploreDevices}
+      onDevicePress={mockOnDevicePress}
     />,
   );
 
 describe("DeviceSection", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe("device card press", () => {
+    beforeEach(() => {
+      renderView([mockDevices[0]]);
+    });
+
+    it("calls onDevicePress with the device when tapped", async () => {
+      fireEvent.press(screen.getByTestId("my-wallet-device-item-device-1"));
+      await waitFor(() => expect(mockOnDevicePress).toHaveBeenCalledWith(mockDevices[0]));
+    });
   });
 
   describe("with no devices", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListContent.tsx
@@ -9,12 +9,14 @@ type DeviceListContentProps = {
   readonly devices: readonly DeviceSectionDevice[];
   readonly onAddDevice: () => void;
   readonly onExploreDevices: () => void;
+  readonly onDevicePress: (device: DeviceSectionDevice) => void;
 };
 
 export function DeviceListContent({
   devices,
   onAddDevice,
   onExploreDevices,
+  onDevicePress,
 }: DeviceListContentProps) {
   if (devices.length === 0) {
     return <AddDeviceItem onPress={onAddDevice} />;
@@ -24,7 +26,7 @@ export function DeviceListContent({
     <>
       <Box lx={{ backgroundColor: "surface", borderRadius: "md" }}>
         {devices.map(device => (
-          <DeviceListItem key={device.id} device={device} />
+          <DeviceListItem key={device.id} device={device} onPress={onDevicePress} />
         ))}
       </Box>
       <ExploreDevicesItem onPress={onExploreDevices} />

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListItem.tsx
@@ -29,11 +29,14 @@ const deviceSources: Record<DeviceModelId, ImageSourcePropType> = {
 
 type DeviceListItemProps = {
   readonly device: DeviceSectionDevice;
+  readonly onPress: (device: DeviceSectionDevice) => void;
 };
 
-export function DeviceListItem({ device }: DeviceListItemProps) {
+export function DeviceListItem({ device, onPress }: DeviceListItemProps) {
+  const handlePress = () => onPress(device);
+
   return (
-    <ListItem testID={`my-wallet-device-item-${device.id}`}>
+    <ListItem testID={`my-wallet-device-item-${device.id}`} onPress={handlePress}>
       <ListItemLeading>
         <Image
           source={deviceSources[device.modelId]}

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/index.tsx
@@ -3,7 +3,8 @@ import { useDeviceSectionViewModel } from "./useDeviceSectionViewModel";
 import { DeviceSectionView } from "./DeviceSectionView";
 
 export function DeviceSection() {
-  const { devices, hasDevices, onAddDevice, onExploreDevices } = useDeviceSectionViewModel();
+  const { devices, hasDevices, onAddDevice, onExploreDevices, onDevicePress } =
+    useDeviceSectionViewModel();
 
   return (
     <DeviceSectionView
@@ -11,6 +12,7 @@ export function DeviceSection() {
       hasDevices={hasDevices}
       onAddDevice={onAddDevice}
       onExploreDevices={onExploreDevices}
+      onDevicePress={onDevicePress}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
@@ -6,7 +6,7 @@ import type { DeviceModelId } from "@ledgerhq/devices";
 import { findMatchingNewDevice, useBleDevicesScanning } from "@ledgerhq/live-dmk-mobile";
 import { useSelector } from "~/context/hooks";
 import { bleDevicesSelector } from "~/reducers/ble";
-import { ScreenName } from "~/const";
+import { NavigatorName, ScreenName } from "~/const";
 import { urls } from "~/utils/urls";
 import { track } from "~/analytics";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
@@ -23,6 +23,7 @@ interface DeviceSectionViewModel {
   readonly hasDevices: boolean;
   readonly onAddDevice: () => void;
   readonly onExploreDevices: () => void;
+  readonly onDevicePress: (device: DeviceSectionDevice) => void;
 }
 
 export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
@@ -58,5 +59,27 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
     Linking.openURL(exploreDevicesUrl);
   }, [exploreDevicesUrl]);
 
-  return { devices, onAddDevice, onExploreDevices, hasDevices };
+  const onDevicePress = useCallback(
+    (device: DeviceSectionDevice) => {
+      track("button_clicked", {
+        button: "Device",
+        page: ScreenName.MyWallet,
+        deviceModelId: device.modelId,
+      });
+      navigation.navigate(NavigatorName.MyLedger, {
+        screen: ScreenName.MyLedgerChooseDevice,
+        params: {
+          device: {
+            deviceId: device.id,
+            deviceName: device.name,
+            modelId: device.modelId,
+            wired: false,
+          },
+        },
+      });
+    },
+    [navigation],
+  );
+
+  return { devices, onAddDevice, onExploreDevices, hasDevices, onDevicePress };
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Integration test verifies `onDevicePress` is called with the correct device when a card is tapped.
- [x] **Impact of the changes:**
      - Device cards in My Wallet → Devices section are now tappable
      - Tapping navigates to My Ledger → Choose Device screen
      - 3-dot icon area is excluded from the tap target (trailing `ListItemTrailing` intercepts its own events via the responder chain)

### 📝 Description

Makes device cards in the My Wallet Devices section pressable. Tapping any card triggers `onDevicePress` in the VM, which tracks the event and navigates to `NavigatorName.MyLedger → ScreenName.MyLedgerChooseDevice`. The trailing icon area (3-dot menu, added by LIVE-26536) remains independently pressable.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26537