### PR TITLE
[LWM] feat(lwm): device remove menu

### DIFF
--- a/.changeset/brave-cards-remove.md
+++ b/.changeset/brave-cards-remove.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add 3-dot menu on device cards with Remove confirmation drawer (LIVE-26536).

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8907,7 +8907,8 @@
       "addDevice": "Add a Ledger device",
       "exploreAllDevices": "Explore all Ledger devices",
       "available": "Available",
-      "unavailable": "Not connected"
+      "unavailable": "Not connected",
+      "menuAccessibilityLabel": "Device options"
     }
   }
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/DeviceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/DeviceSectionView.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "~/context/Locale";
 import { type DeviceSectionDevice } from "./useDeviceSectionViewModel";
 import { AddDeviceLink } from "./components/AddDeviceLink";
 import { DeviceListContent } from "./components/DeviceListContent";
+import { DeviceRemoveDrawer } from "./components/DeviceRemoveDrawer";
 
 interface DeviceSectionViewProps {
   readonly devices: readonly DeviceSectionDevice[];
@@ -11,6 +12,11 @@ interface DeviceSectionViewProps {
   readonly onAddDevice: () => void;
   readonly onExploreDevices: () => void;
   readonly onDevicePress: (device: DeviceSectionDevice) => void;
+  readonly onOpenMenu: (device: DeviceSectionDevice) => void;
+  readonly selectedDevice: DeviceSectionDevice | null;
+  readonly isRemoveDrawerOpen: boolean;
+  readonly onCloseRemoveMenu: () => void;
+  readonly onRemoveDevice: () => void;
 }
 
 export function DeviceSectionView({
@@ -19,6 +25,11 @@ export function DeviceSectionView({
   onAddDevice,
   onExploreDevices,
   onDevicePress,
+  onOpenMenu,
+  selectedDevice,
+  isRemoveDrawerOpen,
+  onCloseRemoveMenu,
+  onRemoveDevice,
 }: DeviceSectionViewProps) {
   const { t } = useTranslation();
 
@@ -40,8 +51,16 @@ export function DeviceSectionView({
           onAddDevice={onAddDevice}
           onExploreDevices={onExploreDevices}
           onDevicePress={onDevicePress}
+          onOpenMenu={onOpenMenu}
         />
       </Box>
+
+      <DeviceRemoveDrawer
+        device={selectedDevice}
+        isOpen={isRemoveDrawerOpen}
+        onClose={onCloseRemoveMenu}
+        onRemove={onRemoveDevice}
+      />
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__integrations__/DeviceSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__integrations__/DeviceSection.integration.test.tsx
@@ -13,8 +13,17 @@ const mockDevices: DeviceSectionDevice[] = [
 const mockOnAddDevice = jest.fn();
 const mockOnExploreDevices = jest.fn();
 const mockOnDevicePress = jest.fn();
+const mockOnOpenMenu = jest.fn();
+const mockOnCloseRemoveMenu = jest.fn();
+const mockOnRemoveDevice = jest.fn();
 
-const renderView = (devices: readonly DeviceSectionDevice[]) =>
+const renderView = (
+  devices: readonly DeviceSectionDevice[],
+  overrides: Partial<{
+    selectedDevice: DeviceSectionDevice | null;
+    isRemoveDrawerOpen: boolean;
+  }> = {},
+) =>
   render(
     <DeviceSectionView
       devices={devices}
@@ -22,6 +31,11 @@ const renderView = (devices: readonly DeviceSectionDevice[]) =>
       onAddDevice={mockOnAddDevice}
       onExploreDevices={mockOnExploreDevices}
       onDevicePress={mockOnDevicePress}
+      onOpenMenu={mockOnOpenMenu}
+      selectedDevice={overrides.selectedDevice ?? null}
+      isRemoveDrawerOpen={overrides.isRemoveDrawerOpen ?? false}
+      onCloseRemoveMenu={mockOnCloseRemoveMenu}
+      onRemoveDevice={mockOnRemoveDevice}
     />,
   );
 
@@ -100,6 +114,11 @@ describe("DeviceSection", () => {
     it('renders the "Explore all Ledger devices" item', () => {
       expect(screen.getByTestId("my-wallet-device-section-explore")).toBeVisible();
     });
+
+    it("calls onOpenMenu with the device when the 3-dot menu icon is pressed", async () => {
+      fireEvent.press(screen.getByTestId("my-wallet-device-item-device-1-menu"));
+      await waitFor(() => expect(mockOnOpenMenu).toHaveBeenCalledWith(mockDevices[0]));
+    });
   });
 
   describe("with an available device", () => {
@@ -135,6 +154,12 @@ describe("DeviceSection", () => {
 
     it('renders the "Explore all Ledger devices" item', () => {
       expect(screen.getByTestId("my-wallet-device-section-explore")).toBeVisible();
+    });
+
+    it("renders a menu icon for each device", () => {
+      expect(screen.getByTestId("my-wallet-device-item-device-1-menu")).toBeVisible();
+      expect(screen.getByTestId("my-wallet-device-item-device-2-menu")).toBeVisible();
+      expect(screen.getByTestId("my-wallet-device-item-device-3-menu")).toBeVisible();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
@@ -1,9 +1,12 @@
 import { Linking } from "react-native";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { disconnect } from "@ledgerhq/live-common/hw/index";
 import { act, renderHook } from "@tests/test-renderer";
 import { ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { urls } from "~/utils/urls";
-import { useDeviceSectionViewModel } from "../useDeviceSectionViewModel";
+import { useDeviceSectionViewModel, type DeviceSectionDevice } from "../useDeviceSectionViewModel";
+import type { State } from "~/reducers/types";
 
 const mockNavigate = jest.fn();
 
@@ -16,6 +19,25 @@ jest.mock("@ledgerhq/live-dmk-mobile", () => ({
   findMatchingNewDevice: jest.fn(() => null),
   useBleDevicesScanning: jest.fn(() => ({ scannedDevices: [] })),
 }));
+
+jest.mock("@ledgerhq/live-common/hw/index", () => ({
+  disconnect: jest.fn(() => Promise.resolve()),
+}));
+
+const mockDevice: DeviceSectionDevice = {
+  id: "device-1",
+  name: "Flex Pro",
+  modelId: DeviceModelId.europa,
+  available: false,
+};
+
+const withKnownDevice = (state: State): State => ({
+  ...state,
+  ble: {
+    ...state.ble,
+    knownDevices: [{ id: "device-1", name: "Flex Pro", modelId: DeviceModelId.europa }],
+  },
+});
 
 describe("useDeviceSectionViewModel", () => {
   beforeEach(() => {
@@ -47,6 +69,78 @@ describe("useDeviceSectionViewModel", () => {
         button: "ExploreDevices",
         page: ScreenName.MyWallet,
       });
+    });
+  });
+
+  describe("onOpenRemoveMenu", () => {
+    it("should set selectedDevice and open the drawer", () => {
+      const { result } = renderHook(() => useDeviceSectionViewModel());
+
+      expect(result.current.selectedDevice).toBeNull();
+      expect(result.current.isRemoveDrawerOpen).toBe(false);
+
+      act(() => result.current.onOpenRemoveMenu(mockDevice));
+
+      expect(result.current.selectedDevice).toEqual(mockDevice);
+      expect(result.current.isRemoveDrawerOpen).toBe(true);
+    });
+  });
+
+  describe("onCloseRemoveMenu", () => {
+    it("should close the drawer", () => {
+      const { result } = renderHook(() => useDeviceSectionViewModel());
+
+      act(() => result.current.onOpenRemoveMenu(mockDevice));
+      expect(result.current.isRemoveDrawerOpen).toBe(true);
+
+      act(() => result.current.onCloseRemoveMenu());
+      expect(result.current.isRemoveDrawerOpen).toBe(false);
+    });
+  });
+
+  describe("onRemoveDevice", () => {
+    it("should dispatch removeKnownDevice, disconnect, close drawer, and clear selection", async () => {
+      const { result, store } = renderHook(() => useDeviceSectionViewModel(), {
+        overrideInitialState: withKnownDevice,
+      });
+
+      act(() => result.current.onOpenRemoveMenu(mockDevice));
+
+      await act(async () => {
+        await result.current.onRemoveDevice();
+      });
+
+      expect(disconnect).toHaveBeenCalledWith("device-1");
+      expect(result.current.isRemoveDrawerOpen).toBe(false);
+      expect(result.current.selectedDevice).toBeNull();
+      expect(store.getState().ble.knownDevices).toEqual([]);
+    });
+
+    it("should do nothing when no device is selected", async () => {
+      const { result } = renderHook(() => useDeviceSectionViewModel());
+
+      await act(async () => {
+        await result.current.onRemoveDevice();
+      });
+
+      expect(disconnect).not.toHaveBeenCalled();
+    });
+
+    it("should still clear selection when disconnect fails", async () => {
+      jest.mocked(disconnect).mockRejectedValueOnce(new Error("BLE error"));
+
+      const { result } = renderHook(() => useDeviceSectionViewModel(), {
+        overrideInitialState: withKnownDevice,
+      });
+
+      act(() => result.current.onOpenRemoveMenu(mockDevice));
+
+      await act(async () => {
+        await result.current.onRemoveDevice();
+      });
+
+      expect(result.current.selectedDevice).toBeNull();
+      expect(result.current.isRemoveDrawerOpen).toBe(false);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListContent.tsx
@@ -10,6 +10,7 @@ type DeviceListContentProps = {
   readonly onAddDevice: () => void;
   readonly onExploreDevices: () => void;
   readonly onDevicePress: (device: DeviceSectionDevice) => void;
+  readonly onOpenMenu: (device: DeviceSectionDevice) => void;
 };
 
 export function DeviceListContent({
@@ -17,6 +18,7 @@ export function DeviceListContent({
   onAddDevice,
   onExploreDevices,
   onDevicePress,
+  onOpenMenu,
 }: DeviceListContentProps) {
   if (devices.length === 0) {
     return <AddDeviceItem onPress={onAddDevice} />;
@@ -26,7 +28,7 @@ export function DeviceListContent({
     <>
       <Box lx={{ backgroundColor: "surface", borderRadius: "md" }}>
         {devices.map(device => (
-          <DeviceListItem key={device.id} device={device} onPress={onDevicePress} />
+          <DeviceListItem key={device.id} device={device} onPress={onDevicePress} onOpenMenu={onOpenMenu} />
         ))}
       </Box>
       <ExploreDevicesItem onPress={onExploreDevices} />

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListItem.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback } from "react";
-import { Image, Pressable, type ImageSourcePropType } from "react-native";
+import { Image, type ImageSourcePropType } from "react-native";
 import { DeviceModelId } from "@ledgerhq/devices";
 import {
   Box,
+  IconButton,
   ListItem,
   ListItemContent,
   ListItemLeading,
@@ -10,6 +11,7 @@ import {
   ListItemTrailing,
 } from "@ledgerhq/lumen-ui-rnative";
 import { MoreVertical } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
 import { type DeviceSectionDevice } from "../useDeviceSectionViewModel";
 import { DeviceStatusTag } from "./DeviceStatusTag";
 
@@ -34,6 +36,7 @@ type DeviceListItemProps = {
 };
 
 export function DeviceListItem({ device, onPress, onOpenMenu }: DeviceListItemProps) {
+  const { t } = useTranslation();
   const handlePress = useCallback(() => onPress(device), [device, onPress]);
   const handleMenuPress = useCallback(() => onOpenMenu(device), [device, onOpenMenu]);
 
@@ -53,13 +56,14 @@ export function DeviceListItem({ device, onPress, onOpenMenu }: DeviceListItemPr
         </ListItemContent>
       </ListItemLeading>
       <ListItemTrailing>
-        <Pressable
+        <IconButton
+          appearance="no-background"
+          size="md"
+          icon={MoreVertical}
           onPress={handleMenuPress}
           testID={`my-wallet-device-item-${device.id}-menu`}
-          hitSlop={8}
-        >
-          <MoreVertical size={24} color="muted" />
-        </Pressable>
+          accessibilityLabel={t("myWallet.deviceSection.menuAccessibilityLabel")}
+        />
       </ListItemTrailing>
     </ListItem>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListItem.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Image, type ImageSourcePropType } from "react-native";
+import React, { useCallback } from "react";
+import { Image, Pressable, type ImageSourcePropType } from "react-native";
 import { DeviceModelId } from "@ledgerhq/devices";
 import {
   Box,
@@ -30,10 +30,12 @@ const deviceSources: Record<DeviceModelId, ImageSourcePropType> = {
 type DeviceListItemProps = {
   readonly device: DeviceSectionDevice;
   readonly onPress: (device: DeviceSectionDevice) => void;
+  readonly onOpenMenu: (device: DeviceSectionDevice) => void;
 };
 
-export function DeviceListItem({ device, onPress }: DeviceListItemProps) {
-  const handlePress = () => onPress(device);
+export function DeviceListItem({ device, onPress, onOpenMenu }: DeviceListItemProps) {
+  const handlePress = useCallback(() => onPress(device), [device, onPress]);
+  const handleMenuPress = useCallback(() => onOpenMenu(device), [device, onOpenMenu]);
 
   return (
     <ListItem testID={`my-wallet-device-item-${device.id}`} onPress={handlePress}>
@@ -51,7 +53,13 @@ export function DeviceListItem({ device, onPress }: DeviceListItemProps) {
         </ListItemContent>
       </ListItemLeading>
       <ListItemTrailing>
-        <MoreVertical size={24} color="muted" />
+        <Pressable
+          onPress={handleMenuPress}
+          testID={`my-wallet-device-item-${device.id}-menu`}
+          hitSlop={8}
+        >
+          <MoreVertical size={24} color="muted" />
+        </Pressable>
       </ListItemTrailing>
     </ListItem>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceRemoveDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceRemoveDrawer.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Flex } from "@ledgerhq/native-ui";
+import { Trans } from "~/context/Locale";
+import Button from "~/components/Button";
+import Trash from "~/icons/Trash";
+import QueuedDrawer from "~/components/QueuedDrawer";
+import { DeviceIllustration } from "~/components/DeviceIllustration";
+import { type DeviceSectionDevice } from "../useDeviceSectionViewModel";
+
+type DeviceRemoveDrawerProps = {
+  readonly device: DeviceSectionDevice | null;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly onRemove: () => void;
+};
+
+export function DeviceRemoveDrawer({ device, isOpen, onClose, onRemove }: DeviceRemoveDrawerProps) {
+  return (
+    <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={onClose}>
+      {device ? (
+        <Flex alignItems="center" mb={8}>
+          <DeviceIllustration deviceModelId={device.modelId} />
+        </Flex>
+      ) : null}
+      <Button
+        event="DeviceRemoveAction"
+        type="alert"
+        IconLeft={Trash}
+        title={<Trans i18nKey="common.forgetDevice" />}
+        onPress={onRemove}
+      />
+    </QueuedDrawer>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceRemoveDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceRemoveDrawer.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import { Flex } from "@ledgerhq/native-ui";
-import { Trans } from "~/context/Locale";
-import Button from "~/components/Button";
-import Trash from "~/icons/Trash";
-import QueuedDrawer from "~/components/QueuedDrawer";
+import { Box, Button } from "@ledgerhq/lumen-ui-rnative";
+import { Trash } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import { DeviceIllustration } from "~/components/DeviceIllustration";
 import { type DeviceSectionDevice } from "../useDeviceSectionViewModel";
 
@@ -15,20 +14,18 @@ type DeviceRemoveDrawerProps = {
 };
 
 export function DeviceRemoveDrawer({ device, isOpen, onClose, onRemove }: DeviceRemoveDrawerProps) {
+  const { t } = useTranslation();
+
   return (
-    <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={onClose}>
+    <QueuedDrawerBottomSheet isRequestingToBeOpened={isOpen} onClose={onClose} enableDynamicSizing>
       {device ? (
-        <Flex alignItems="center" mb={8}>
+        <Box lx={{ alignItems: "center", marginBottom: "s32" }}>
           <DeviceIllustration deviceModelId={device.modelId} />
-        </Flex>
+        </Box>
       ) : null}
-      <Button
-        event="DeviceRemoveAction"
-        type="alert"
-        IconLeft={Trash}
-        title={<Trans i18nKey="common.forgetDevice" />}
-        onPress={onRemove}
-      />
-    </QueuedDrawer>
+      <Button appearance="red" size="lg" icon={Trash} onPress={onRemove}>
+        {t("common.forgetDevice")}
+      </Button>
+    </QueuedDrawerBottomSheet>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/index.tsx
@@ -3,8 +3,18 @@ import { useDeviceSectionViewModel } from "./useDeviceSectionViewModel";
 import { DeviceSectionView } from "./DeviceSectionView";
 
 export function DeviceSection() {
-  const { devices, hasDevices, onAddDevice, onExploreDevices, onDevicePress } =
-    useDeviceSectionViewModel();
+  const {
+    devices,
+    hasDevices,
+    onAddDevice,
+    onExploreDevices,
+    onDevicePress,
+    selectedDevice,
+    isRemoveDrawerOpen,
+    onOpenRemoveMenu,
+    onCloseRemoveMenu,
+    onRemoveDevice,
+  } = useDeviceSectionViewModel();
 
   return (
     <DeviceSectionView
@@ -13,6 +23,11 @@ export function DeviceSection() {
       onAddDevice={onAddDevice}
       onExploreDevices={onExploreDevices}
       onDevicePress={onDevicePress}
+      onOpenMenu={onOpenRemoveMenu}
+      selectedDevice={selectedDevice}
+      isRemoveDrawerOpen={isRemoveDrawerOpen}
+      onCloseRemoveMenu={onCloseRemoveMenu}
+      onRemoveDevice={onRemoveDevice}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
@@ -1,11 +1,13 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Linking } from "react-native";
 import type { DeviceModelId } from "@ledgerhq/devices";
+import { disconnect } from "@ledgerhq/live-common/hw/index";
 import { findMatchingNewDevice, useBleDevicesScanning } from "@ledgerhq/live-dmk-mobile";
-import { useSelector } from "~/context/hooks";
+import { useDispatch, useSelector } from "~/context/hooks";
 import { bleDevicesSelector } from "~/reducers/ble";
+import { removeKnownDevice } from "~/actions/ble";
 import { NavigatorName, ScreenName } from "~/const";
 import { urls } from "~/utils/urls";
 import { track } from "~/analytics";
@@ -24,12 +26,20 @@ interface DeviceSectionViewModel {
   readonly onAddDevice: () => void;
   readonly onExploreDevices: () => void;
   readonly onDevicePress: (device: DeviceSectionDevice) => void;
+  readonly selectedDevice: DeviceSectionDevice | null;
+  readonly isRemoveDrawerOpen: boolean;
+  readonly onOpenRemoveMenu: (device: DeviceSectionDevice) => void;
+  readonly onCloseRemoveMenu: () => void;
+  readonly onRemoveDevice: () => void;
 }
 
 export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
   const navigation =
     useNavigation<NativeStackNavigationProp<{ [key: string]: object | undefined }>>();
+  const dispatch = useDispatch();
   const knownDevices = useSelector(bleDevicesSelector);
+  const [selectedDevice, setSelectedDevice] = useState<DeviceSectionDevice | null>(null);
+  const [isRemoveDrawerOpen, setIsRemoveDrawerOpen] = useState(false);
   const { scannedDevices } = useBleDevicesScanning(true);
 
   const devices = useMemo(
@@ -81,5 +91,33 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
     [navigation],
   );
 
-  return { devices, onAddDevice, onExploreDevices, hasDevices, onDevicePress };
+  const onOpenRemoveMenu = useCallback((device: DeviceSectionDevice) => {
+    setSelectedDevice(device);
+    setIsRemoveDrawerOpen(true);
+  }, []);
+
+  const onCloseRemoveMenu = useCallback(() => {
+    setIsRemoveDrawerOpen(false);
+  }, []);
+
+  const onRemoveDevice = useCallback(async () => {
+    if (!selectedDevice) return;
+    dispatch(removeKnownDevice(selectedDevice.id));
+    setIsRemoveDrawerOpen(false);
+    await disconnect(selectedDevice.id).catch(() => {});
+    setSelectedDevice(null);
+  }, [selectedDevice, dispatch]);
+
+  return {
+    devices,
+    hasDevices,
+    onAddDevice,
+    onExploreDevices,
+    onDevicePress,
+    selectedDevice,
+    isRemoveDrawerOpen,
+    onOpenRemoveMenu,
+    onCloseRemoveMenu,
+    onRemoveDevice,
+  };
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
@@ -91,20 +91,25 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
     [navigation],
   );
 
-  const onOpenRemoveMenu = useCallback((device: DeviceSectionDevice) => {
+  const onOpenRemoveMenu = (device: DeviceSectionDevice) => {
     setSelectedDevice(device);
     setIsRemoveDrawerOpen(true);
-  }, []);
+  };
 
-  const onCloseRemoveMenu = useCallback(() => {
+  const onCloseRemoveMenu = () => {
     setIsRemoveDrawerOpen(false);
-  }, []);
+  };
 
   const onRemoveDevice = useCallback(async () => {
     if (!selectedDevice) return;
     dispatch(removeKnownDevice(selectedDevice.id));
     setIsRemoveDrawerOpen(false);
-    await disconnect(selectedDevice.id).catch(() => {});
+    try {
+      await disconnect(selectedDevice.id);
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+    } catch {
+      /* empty */
+    }
     setSelectedDevice(null);
   }, [selectedDevice, dispatch]);
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Integration tests verify the 3-dot menu icon is rendered per device and calls `onOpenMenu` with the correct device when pressed.
- [x] **Impact of the changes:**
      - Each device card in My Wallet → Devices section now has a tappable 3-dot icon in the trailing area
      - Tapping the icon opens a bottom drawer showing the device illustration and a red "Forget device" button
      - Confirming dispatches `removeKnownDevice` and disconnects the device
      - The device list updates immediately (redux state drives the list)

### 📝 Description

Wires the existing `MoreVertical` icon on device cards into a `Pressable` that opens a `QueuedDrawer` confirmation sheet. The drawer shows the device illustration (via `DeviceIllustration`) and a destructive button. On confirm, `removeKnownDevice(device.id)` is dispatched and `disconnect(device.id)` is called (swallowing errors). State is managed in `useDeviceSectionViewModel` with `selectedDevice` and `isRemoveDrawerOpen`.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26536