### PR TITLE
docs: introduce AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Project Context
+
+## Overview
+
+- "Ledger Wallet" (formerly "ledger-live") is a crypto wallet
+- This pnpm and turborepo monorepo provides frontend apps
+
+## Common Commands
+
+- Use pnpm commands for build, dev, linting and testing.
+- See [/docs/common-commands.md](/docs/common-commands.md)
+
+## Validate Before Finishing
+
+- Before finishing any agentic code change, run static checks for the affected scope
+- See [/docs/dev/validate-before-finishing.md](/docs/dev/validate-before-finishing.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,1 @@
-# Project Context
-
-## Overview
-
-- "Ledger Wallet" (formerly "ledger-live") is a crypto wallet
-- This pnpm and turborepo monorepo provides frontend apps
-
-## Common Commands
-
-- Use pnpm commands for build, dev, linting and testing.
-- See [/docs/common-commands.md](/docs/common-commands.md)
-
-## Validate Before Finishing
-
-- Before finishing any agentic code change, run static checks for the affected scope
-- See [/docs/dev/validate-before-finishing.md](/docs/dev/validate-before-finishing.md)
+[Prefer](/AGENTS.md)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -390,6 +390,10 @@ tools/actions/composites/merge-e2e-detox-timings/                           @led
 /turbo.json                                           @ledgerhq/platform @ledgerhq/wallet-ci
 /nx.json                                              @ledgerhq/platform @ledgerhq/wallet-ci
 
+# Platform — Agent files
+AGENTS.md                         @ledgerhq/platform
+/CLAUDE.md                        @ledgerhq/platform
+
 # Cross-team generic files can be opted out (no strict ownership when it concerns everyone)
 .github/copilot-instructions.md
 libs/ledger-live-common/src/featureFlags/defaultFeatures.ts


### PR DESCRIPTION
### 📝 Description

Initially just introducing an `AGENTS.md` in place of `CLAUDE.md`

### ❓ Context

- Jira: https://ledgerhq.atlassian.net/browse/LIVE-29290
- ADR: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7035977860

This is a step towards migrating Cursor and Copilot specific context to a shared location:

- 🟢 Create AGENTS.md (these changes)
- 🟠 Move **Copilot Instructions** and **Cursor rules** to `AGENTS.md` and `.agents/skills`