### PR TITLE
ci: Adjust release bot permissions

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 2
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup git user
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop


### PR DESCRIPTION
Adjust back to utilising live-github-bot following permission elevation to fix release issues