### PR TITLE
[LWDM] feat(dmk): add blind signing tracking context

### DIFF
--- a/.changeset/quiet-pandas-wander.md
+++ b/.changeset/quiet-pandas-wander.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-dmk-shared": minor
+"@ledgerhq/live-signer-evm": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add blind-signing tracking context for dmk signer ethereum

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -89,6 +89,7 @@
     "@ledgerhq/live-countervalues": "workspace:^",
     "@ledgerhq/live-countervalues-react": "workspace:^",
     "@ledgerhq/live-dmk-desktop": "workspace:^",
+    "@ledgerhq/live-dmk-shared": "workspace:^",
     "@ledgerhq/live-dmk-speculos": "workspace:^",
     "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/live-network": "workspace:^",

--- a/apps/ledger-live-desktop/src/live-common-setup-base.ts
+++ b/apps/ledger-live-desktop/src/live-common-setup-base.ts
@@ -1,5 +1,7 @@
+import os from "os";
 import { setEnv, getEnv } from "@ledgerhq/live-env";
 import { setResolutionConfig } from "@shared/feature-flags";
+import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import BigNumber from "bignumber.js";
 
 let ledgerClientVersion = `lld/${__APP_VERSION__}`;
@@ -15,6 +17,13 @@ process.env.LEDGER_CLIENT_VERSION = ledgerClientVersion;
 setResolutionConfig({
   platform: "desktop",
   appVersion: __APP_VERSION__,
+});
+
+liveBlindSigningReporter.setContext({
+  platform: "desktop",
+  appVersion: __APP_VERSION__,
+  platformOS: process.platform,
+  platformVersion: os.release(),
 });
 
 BigNumber.set({ DECIMAL_PLACES: getEnv("BIG_NUMBER_DECIMAL_PLACES") });

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -38,7 +38,7 @@ import { lock, setOSDarkMode } from "~/renderer/actions/application";
 import {
   languageSelector,
   sentryLogsSelector,
-  shareAnalyticsSelector,
+  trackingEnabledSelector,
   hideEmptyTokenAccountsSelector,
   filterTokenOperationsZeroAmountSelector,
 } from "~/renderer/reducers/settings";
@@ -175,7 +175,7 @@ async function init() {
   const initialSettings = (await getKey("app", "settings")) || {};
   startAnalytics(store);
 
-  liveBlindSigningReporter.setConsentSource(() => shareAnalyticsSelector(store.getState()));
+  liveBlindSigningReporter.setConsentSource(() => trackingEnabledSelector(store.getState()));
 
   // Build settings to load, ensuring hasCompletedOnboarding is false after a hard reset
   const settingsToLoad = { ...initialSettings };

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -38,9 +38,11 @@ import { lock, setOSDarkMode } from "~/renderer/actions/application";
 import {
   languageSelector,
   sentryLogsSelector,
+  shareAnalyticsSelector,
   hideEmptyTokenAccountsSelector,
   filterTokenOperationsZeroAmountSelector,
 } from "~/renderer/reducers/settings";
+import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import ReactRoot from "~/renderer/ReactRoot";
 import AppError from "~/renderer/AppError";
 import { expectOperatingSystemSupportStatus } from "~/support/os";
@@ -172,6 +174,8 @@ async function init() {
   });
   const initialSettings = (await getKey("app", "settings")) || {};
   startAnalytics(store);
+
+  liveBlindSigningReporter.setConsentSource(() => shareAnalyticsSelector(store.getState()));
 
   // Build settings to load, ensuring hasCompletedOnboarding is false after a hard reset
   const settingsToLoad = { ...initialSettings };

--- a/apps/ledger-live-mobile/src/analytics/SegmentSetup.tsx
+++ b/apps/ledger-live-mobile/src/analytics/SegmentSetup.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from "react";
+import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import { useStore } from "~/context/hooks";
+import { analyticsEnabledSelector } from "~/reducers/settings";
 import { start } from "./segment";
 import useFlushInBackground from "./useFlushInBackground";
 
@@ -10,6 +12,10 @@ const SegmentSetup = (): null => {
     start(store).catch(error => console.error(`Failed to initialize Segment with error: ${error}`));
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    liveBlindSigningReporter.setConsentSource(() => analyticsEnabledSelector(store.getState()));
+  }, [store]);
 
   useFlushInBackground();
 

--- a/apps/ledger-live-mobile/src/analytics/SegmentSetup.tsx
+++ b/apps/ledger-live-mobile/src/analytics/SegmentSetup.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import { useStore } from "~/context/hooks";
-import { analyticsEnabledSelector } from "~/reducers/settings";
+import { trackingEnabledSelector } from "~/reducers/settings";
 import { start } from "./segment";
 import useFlushInBackground from "./useFlushInBackground";
 
@@ -14,7 +14,7 @@ const SegmentSetup = (): null => {
   }, []);
 
   useEffect(() => {
-    liveBlindSigningReporter.setConsentSource(() => analyticsEnabledSelector(store.getState()));
+    liveBlindSigningReporter.setConsentSource(() => trackingEnabledSelector(store.getState()));
   }, [store]);
 
   useFlushInBackground();

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -11,6 +11,7 @@ import { Platform } from "react-native";
 import { setSecp256k1Instance } from "@ledgerhq/live-common/families/bitcoin/logic";
 import { setGlobalOnBridgeError } from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { setResolutionConfig } from "@shared/feature-flags";
+import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import "./experimental";
 import logger, { ConsoleLogger } from "./logger";
 import BigNumber from "bignumber.js";
@@ -28,6 +29,12 @@ setWalletAPIVersion(WALLET_API_VERSION);
 setResolutionConfig({
   platform: Platform.OS === "ios" ? "ios" : "android",
   appVersion: VersionNumber.appVersion ?? undefined,
+});
+liveBlindSigningReporter.setContext({
+  platform: "mobile",
+  appVersion: VersionNumber.appVersion ?? undefined,
+  platformOS: Platform.OS,
+  platformVersion: String(Platform.Version),
 });
 
 setSupportedCurrencies([

--- a/libs/live-dmk-shared/package.json
+++ b/libs/live-dmk-shared/package.json
@@ -32,6 +32,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@ledgerhq/context-module": "catalog:",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/logs": "workspace:^",
     "@ledgerhq/types-devices": "workspace:^",

--- a/libs/live-dmk-shared/src/index.ts
+++ b/libs/live-dmk-shared/src/index.ts
@@ -3,6 +3,12 @@ export { activeDeviceSessionSubject } from "./config/activeDeviceSession";
 export { dmkToLedgerDeviceIdMap, ledgerToDmkDeviceIdMap } from "./config/dmkToLedgerDeviceIdMap";
 export { LedgerLiveLogger } from "./services/LedgerLiveLogger";
 export { UserHashService } from "./services/UserHashService";
+export {
+  LiveBlindSigningReporter,
+  liveBlindSigningReporter,
+  buildDefaultHttpBlindSigningReporter,
+} from "./services/LiveBlindSigningReporter";
+export type { LiveBlindSigningContext } from "./services/LiveBlindSigningReporter";
 
 export { ConnectAppDeviceAction } from "./device-action/ConnectApp/ConnectAppDeviceAction";
 export type {

--- a/libs/live-dmk-shared/src/services/LiveBlindSigningReporter.test.ts
+++ b/libs/live-dmk-shared/src/services/LiveBlindSigningReporter.test.ts
@@ -1,0 +1,181 @@
+import { Left, Right } from "purify-ts";
+import {
+  type BlindSigningReporter,
+  type BlindSigningReportParams,
+} from "@ledgerhq/context-module";
+import {
+  LiveBlindSigningReporter,
+  buildDefaultHttpBlindSigningReporter,
+  liveBlindSigningReporter,
+} from "./LiveBlindSigningReporter";
+
+const makeParams = (
+  overrides: Partial<BlindSigningReportParams> = {},
+): BlindSigningReportParams =>
+  ({
+    signatureId: "sig-1",
+    signingMethod: "eth_signTransaction",
+    isBlindSign: true,
+    chainId: 1,
+    targetAddress: "0xabc",
+    blindSignReason: null,
+    modelId: "nanoX",
+    signerAppVersion: "1.0.0",
+    deviceVersion: "2.0.0",
+    ethContext: null,
+    ...overrides,
+  }) as unknown as BlindSigningReportParams;
+
+const makeFakeInner = (
+  result: Awaited<ReturnType<BlindSigningReporter["report"]>> = Right<void, Error>(undefined),
+): BlindSigningReporter & { report: jest.Mock } => ({
+  report: jest.fn().mockResolvedValue(result),
+});
+
+describe("LiveBlindSigningReporter", () => {
+  const reporter = LiveBlindSigningReporter.getInstance();
+
+  beforeEach(() => {
+    reporter.clearContext();
+    reporter.setConsent(false);
+    // Reset inner: no public clear method exists; cast to satisfy the setter.
+    reporter.setInner(undefined as unknown as BlindSigningReporter);
+  });
+
+  describe("singleton", () => {
+    it("returns the same instance from getInstance", () => {
+      expect(LiveBlindSigningReporter.getInstance()).toBe(
+        LiveBlindSigningReporter.getInstance(),
+      );
+    });
+
+    it("exposes the same singleton via the liveBlindSigningReporter export", () => {
+      expect(liveBlindSigningReporter).toBe(LiveBlindSigningReporter.getInstance());
+    });
+  });
+
+  describe("context", () => {
+    it("merges partial updates, preserving earlier keys", () => {
+      reporter.setContext({ platform: "desktop", appVersion: "1.0.0" });
+      reporter.setContext({ appVersion: "2.0.0", platformOS: "darwin" });
+
+      expect(reporter.getContext()).toEqual({
+        platform: "desktop",
+        appVersion: "2.0.0",
+        platformOS: "darwin",
+      });
+    });
+
+    it("clears the context", () => {
+      reporter.setContext({ platform: "mobile", sessionId: "abc" });
+      reporter.clearContext();
+      expect(reporter.getContext()).toEqual({});
+    });
+  });
+
+  describe("consent", () => {
+    it("defaults to false", () => {
+      expect(reporter.hasConsent()).toBe(false);
+    });
+
+    it("reflects setConsent updates", () => {
+      reporter.setConsent(true);
+      expect(reporter.hasConsent()).toBe(true);
+      reporter.setConsent(false);
+      expect(reporter.hasConsent()).toBe(false);
+    });
+
+    it("reads consent lazily from setConsentSource on each call", () => {
+      let flag = false;
+      reporter.setConsentSource(() => flag);
+      expect(reporter.hasConsent()).toBe(false);
+      flag = true;
+      expect(reporter.hasConsent()).toBe(true);
+      flag = false;
+      expect(reporter.hasConsent()).toBe(false);
+    });
+  });
+
+  describe("report", () => {
+    it("resolves to Right(undefined) and does not call any inner when no inner is set", async () => {
+      const result = await reporter.report(makeParams());
+      expect(result.isRight()).toBe(true);
+      expect(result.extract()).toBeUndefined();
+    });
+
+    it("forwards params unchanged when consent is false", async () => {
+      const inner = makeFakeInner();
+      reporter.setInner(inner);
+      reporter.setContext({ platform: "desktop", appVersion: "9.9.9" });
+
+      const params = makeParams({ signatureId: "sig-no-consent" });
+      await reporter.report(params);
+
+      expect(inner.report).toHaveBeenCalledTimes(1);
+      expect(inner.report).toHaveBeenCalledWith(params);
+      const forwarded = inner.report.mock.calls[0][0];
+      expect(forwarded).not.toHaveProperty("platform");
+      expect(forwarded).not.toHaveProperty("appVersion");
+    });
+
+    it("merges context into params when consent is true", async () => {
+      const inner = makeFakeInner();
+      reporter.setInner(inner);
+      reporter.setContext({
+        platform: "mobile",
+        appVersion: "1.2.3",
+        platformOS: "ios",
+        platformVersion: "18.0",
+        sessionId: "session-42",
+      });
+      reporter.setConsent(true);
+
+      const params = makeParams({ signatureId: "sig-consent" });
+      await reporter.report(params);
+
+      expect(inner.report).toHaveBeenCalledTimes(1);
+      expect(inner.report).toHaveBeenCalledWith({
+        ...params,
+        platform: "mobile",
+        appVersion: "1.2.3",
+        platformOS: "ios",
+        platformVersion: "18.0",
+        sessionId: "session-42",
+      });
+    });
+
+    it("propagates a Right result returned by the inner reporter", async () => {
+      const inner = makeFakeInner(Right<void, Error>(undefined));
+      reporter.setInner(inner);
+
+      const result = await reporter.report(makeParams());
+
+      expect(result.isRight()).toBe(true);
+    });
+
+    it("propagates a Left result returned by the inner reporter", async () => {
+      const err = new Error("boom");
+      const inner = makeFakeInner(Left<Error, void>(err));
+      reporter.setInner(inner);
+
+      const result = await reporter.report(makeParams());
+
+      expect(result.isLeft()).toBe(true);
+      expect(result.extract()).toBe(err);
+    });
+  });
+});
+
+describe("buildDefaultHttpBlindSigningReporter", () => {
+  it("returns an object implementing BlindSigningReporter", () => {
+    const built = buildDefaultHttpBlindSigningReporter("origin-token");
+    expect(built).toBeTruthy();
+    expect(typeof built.report).toBe("function");
+  });
+
+  it("accepts a custom appSource without throwing", () => {
+    expect(() =>
+      buildDefaultHttpBlindSigningReporter("origin-token", "custom-source"),
+    ).not.toThrow();
+  });
+});

--- a/libs/live-dmk-shared/src/services/LiveBlindSigningReporter.ts
+++ b/libs/live-dmk-shared/src/services/LiveBlindSigningReporter.ts
@@ -1,0 +1,91 @@
+import { type Either, Right } from "purify-ts";
+import { noopLoggerFactory } from "@ledgerhq/device-management-kit";
+import {
+  type BlindSigningPlatform,
+  type BlindSigningReporter,
+  type BlindSigningReportParams,
+  DEFAULT_CONFIG,
+  DefaultBlindSigningReporter,
+  HttpBlindSigningReporterDatasource,
+} from "@ledgerhq/context-module";
+
+export type LiveBlindSigningContext = {
+  platform?: BlindSigningPlatform;
+  appVersion?: string;
+  platformOS?: string;
+  platformVersion?: string;
+  liveAppContext?: string | null;
+  sessionId?: string | null;
+};
+
+export class LiveBlindSigningReporter implements BlindSigningReporter {
+  private static _instance: LiveBlindSigningReporter | null = null;
+
+  private context: LiveBlindSigningContext = {};
+  private inner: BlindSigningReporter | null = null;
+  private consentGetter: () => boolean = () => false;
+
+  private constructor() {}
+
+  static getInstance(): LiveBlindSigningReporter {
+    if (!LiveBlindSigningReporter._instance) {
+      LiveBlindSigningReporter._instance = new LiveBlindSigningReporter();
+    }
+    return LiveBlindSigningReporter._instance;
+  }
+
+  setInner(inner: BlindSigningReporter) {
+    this.inner = inner;
+  }
+
+  setContext(ctx: Partial<LiveBlindSigningContext>) {
+    this.context = { ...this.context, ...ctx };
+  }
+
+  getContext(): Readonly<LiveBlindSigningContext> {
+    return this.context;
+  }
+
+  clearContext() {
+    this.context = {};
+  }
+
+  setConsentSource(getConsent: () => boolean) {
+    this.consentGetter = getConsent;
+  }
+
+  setConsent(consent: boolean) {
+    this.consentGetter = () => consent;
+  }
+
+  hasConsent(): boolean {
+    return this.consentGetter();
+  }
+
+  async report(params: BlindSigningReportParams): Promise<Either<Error, void>> {
+    if (!this.inner) return Right<void, Error>(undefined);
+    if (!this.consentGetter()) {
+      return this.inner.report(params);
+    }
+    return this.inner.report({
+      ...params,
+      ...this.context,
+    } as BlindSigningReportParams);
+  }
+}
+
+export const liveBlindSigningReporter = LiveBlindSigningReporter.getInstance();
+
+export function buildDefaultHttpBlindSigningReporter(
+  originToken: string,
+  appSource = "ledger-wallet",
+): BlindSigningReporter {
+  return new DefaultBlindSigningReporter(
+    new HttpBlindSigningReporterDatasource({
+      ...DEFAULT_CONFIG,
+      appSource,
+      originToken,
+      loggerFactory: noopLoggerFactory,
+    }),
+  );
+}

--- a/libs/live-signer-evm/jest.config.js
+++ b/libs/live-signer-evm/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   testEnvironment: "node",
+  testEnvironmentOptions: {
+    customExportConditions: ["@ledgerhq/source"],
+  },
   testPathIgnorePatterns: ["lib/", "lib-es/"],
   transform: {
     "^.+\\.(ts|tsx)?$": [

--- a/libs/live-signer-evm/package.json
+++ b/libs/live-signer-evm/package.json
@@ -33,6 +33,7 @@
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-eth": "workspace:^",
+    "@ledgerhq/live-dmk-shared": "workspace:^",
     "rxjs": "catalog:"
   },
   "scripts": {

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -25,6 +25,10 @@ import {
 } from "@ledgerhq/errors";
 import { EvmAddress, EvmSigner, EvmSignerEvent } from "@ledgerhq/coin-evm/types/signer";
 import type { LoadConfig, ResolutionConfig } from "@ledgerhq/hw-app-eth/services/types";
+import {
+  buildDefaultHttpBlindSigningReporter,
+  liveBlindSigningReporter,
+} from "@ledgerhq/live-dmk-shared";
 
 export type DAError =
   | GetAddressDAError
@@ -39,8 +43,13 @@ export class DmkSignerEth implements EvmSigner {
     readonly sessionId: string,
   ) {
     const originToken = "1e55ba3959f4543af24809d9066a2120bd2ac9246e626e26a1ff77eb109ca0e5"; // gitleaks:allow
+    liveBlindSigningReporter.setInner(
+      buildDefaultHttpBlindSigningReporter(originToken, "ledger-wallet"),
+    );
+    liveBlindSigningReporter.setContext({ sessionId });
     const contextModule = new ContextModuleBuilder({ originToken })
       .setAppSource("ledger-wallet")
+      .setBlindSigningReporter(liveBlindSigningReporter)
       .build();
     this.signer = new SignerEthBuilder({
       dmk,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -969,6 +969,9 @@ importers:
       '@ledgerhq/live-dmk-desktop':
         specifier: workspace:^
         version: link:../../libs/live-dmk-desktop
+      '@ledgerhq/live-dmk-shared':
+        specifier: workspace:^
+        version: link:../../libs/live-dmk-shared
       '@ledgerhq/live-dmk-speculos':
         specifier: workspace:^
         version: link:../../libs/live-dmk-speculos
@@ -10569,6 +10572,9 @@ importers:
 
   libs/live-dmk-shared:
     dependencies:
+      '@ledgerhq/context-module':
+        specifier: 1.16.0
+        version: 1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -11033,6 +11039,9 @@ importers:
       '@ledgerhq/hw-app-eth':
         specifier: workspace:^
         version: link:../ledgerjs/packages/hw-app-eth
+      '@ledgerhq/live-dmk-shared':
+        specifier: workspace:^
+        version: link:../live-dmk-shared
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Analytics consent behavior: no blind-signing reports should leak any platform/session context when analytics is disabled in settings on either Desktop or Mobile.
  - Toggling the "Share analytics" / `shareAnalytics` (desktop) and `analyticsEnabled` (mobile) settings takes effect immediately because the reporter reads consent lazily from a getter each time it reports.

### Description

Adds a shared blind-signing tracking context so the Device Management Kit's `BlindSigningReporter` can enrich reports with platform metadata only when the user has consented to analytics.

**Problem**: The EVM DMK signer produced blind-signing reports without a centralized way to attach platform-level context (platform, app version, OS, session id) nor to gate that context behind the user's analytics consent. This made it impossible to safely correlate reports across apps while respecting the user's privacy preference.

**Solution**:

- New shared singleton `LiveBlindSigningReporter` in `@ledgerhq/live-dmk-shared` that:
  - wraps an inner `BlindSigningReporter` (set by the signer),
  - stores a mutable `LiveBlindSigningContext` (`platform`, `appVersion`, `platformOS`, `platformVersion`, `liveAppContext`, `sessionId`),
  - exposes `setConsentSource(() => boolean)` so apps plug in their own consent selector; `hasConsent()` and `report()` call the getter lazily on every read, so no subscribe/dedup plumbing is needed on the app side,
  - keeps `setConsent(boolean)` as a thin shim around `setConsentSource` for callers that just want to force a static value,
  - when consent is `false`, reports are forwarded with the original params only (no context leak).
- `buildDefaultHttpBlindSigningReporter(originToken, appSource?)` factory exposing the default HTTP datasource using the DMK `noopLoggerFactory`.
- Wiring:
  - `apps/ledger-live-desktop/src/live-common-setup-base.ts` and `apps/ledger-live-mobile/src/live-common-setup.ts` initialize `platform`, `appVersion`, `platformOS`, `platformVersion` at startup.
  - `apps/ledger-live-desktop/src/renderer/init.tsx` calls `liveBlindSigningReporter.setConsentSource(() => shareAnalyticsSelector(store.getState()))` once the Redux store is ready.
  - `apps/ledger-live-mobile/src/analytics/SegmentSetup.tsx` calls `liveBlindSigningReporter.setConsentSource(() => analyticsEnabledSelector(store.getState()))` in a `useEffect` once the store is in scope.
  - `libs/live-signer-evm/src/DmkSignerEth.ts` installs the default HTTP inner reporter, sets the `sessionId` context, and passes the singleton to `ContextModuleBuilder.setBlindSigningReporter(...)`.
- Jest config: `libs/live-signer-evm/jest.config.js` adds `testEnvironmentOptions.customExportConditions: ["@ledgerhq/source"]` so the test runner resolves workspace packages from their TS sources via the `@ledgerhq/source` export condition (fixes an ESM/CJS parse error when pulling in `@ledgerhq/live-dmk-shared`).
- Unit tests: `libs/live-dmk-shared/src/services/LiveBlindSigningReporter.test.ts` covers singleton identity, context merge/clear, consent toggling via both `setConsent` and `setConsentSource` (including the lazy-read behavior), report forwarding (no inner, no consent, with consent, Right/Left propagation) and the HTTP factory.

### Context

- **JIRA or GitHub link**: [DSDK-1078](https://ledgerhq.atlassian.net/browse/DSDK-1078)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.


[DSDK-1078]: https://ledgerhq.atlassian.net/browse/DSDK-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
