### PR TITLE
[LWD] fix(desktop): restore discover carousel scrolling

### DIFF
--- a/.changeset/brave-turtle-scroll.md
+++ b/.changeset/brave-turtle-scroll.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Restore Discover carousel scrolling after removing the global flex-shrink reset

--- a/apps/ledger-live-desktop/src/renderer/screens/platform/v2/Catalog/LocalLiveAppSection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/platform/v2/Catalog/LocalLiveAppSection.tsx
@@ -30,7 +30,15 @@ export function LocalLiveAppSection({ localLiveApps }: { localLiveApps: LiveAppM
   );
 }
 
-const Scroll = styled(Flex).attrs({ overflowX: "scroll" })`
+const Scroll = styled(Flex).attrs({
+  flexDirection: "row",
+  overflowX: "scroll",
+  overflowY: "hidden",
+})`
+  > * {
+    flex-shrink: 0;
+  }
+
   &::-webkit-scrollbar {
     display: none;
   }

--- a/apps/ledger-live-desktop/src/renderer/screens/platform/v2/Catalog/RecentlyUsed.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/platform/v2/Catalog/RecentlyUsed.tsx
@@ -33,7 +33,15 @@ export function RecentlyUsed({
   );
 }
 
-const Scroll = styled(Flex).attrs({ overflowX: "scroll" })`
+const Scroll = styled(Flex).attrs({
+  flexDirection: "row",
+  overflowX: "scroll",
+  overflowY: "hidden",
+})`
+  > * {
+    flex-shrink: 0;
+  }
+
   &::-webkit-scrollbar {
     display: none;
   }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Not sure we should cover the scroll in e2e but we could
- [x] **Impact of the changes:**
  - Desktop discover section scroll for recently used

### 📝 Description

Keep Discover live app cards from shrinking inside horizontal scroll rows so the Recently Used and Locally Loaded sections overflow and scroll correctly again after the global flex-shrink reset was removed.

### ❓ Context

- **JIRA or GitHub link**: 
- **ADR link (if any)**: 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
