### PR TITLE
[LWM] feat(mobile): add notification indicator to MyWallet avatar [LIVE-26547]

### DIFF
--- a/.changeset/warm-foxes-blink.md
+++ b/.changeset/warm-foxes-blink.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add notification indicator to MyWallet avatar in top bar

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/TopBarView/index.tsx
@@ -50,7 +50,7 @@ export function TopBarView({
   const myLedgerAction = useMyLedgerTopBarAction(onMyLedgerPress);
 
   const leadingElement = shouldDisplayMyWallet ? (
-    <MyWalletTopBarAction onPress={onMyWalletPress} />
+    <MyWalletTopBarAction onPress={onMyWalletPress} showNotification={hasUnreadNotifications} />
   ) : undefined;
 
   const notificationIcon = useCallback<IconButtonProps["icon"]>(

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/MyWalletTopBarAction.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/MyWalletTopBarAction.tsx
@@ -6,9 +6,10 @@ import { useTheme, LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 
 type Props = {
   onPress: () => void;
+  showNotification: boolean;
 };
 
-export function MyWalletTopBarAction({ onPress }: Readonly<Props>) {
+export function MyWalletTopBarAction({ onPress, showNotification }: Readonly<Props>) {
   const { theme } = useTheme();
   const isAndroid = Platform.OS === "android";
   const backgroundColor: LumenViewStyle["backgroundColor"] = isAndroid
@@ -29,7 +30,7 @@ export function MyWalletTopBarAction({ onPress }: Readonly<Props>) {
         backgroundColor: pressed ? theme.colors.bg[pressedBackgroundColor] : undefined,
       })}
     >
-      <UserAvatar size="md" lx={{ backgroundColor }} />
+      <UserAvatar size="md" lx={{ backgroundColor }} showNotification={showNotification} />
     </Pressable>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/components/UserAvatar/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/components/UserAvatar/index.tsx
@@ -4,8 +4,17 @@ import { Avatar, type AvatarProps } from "@ledgerhq/lumen-ui-rnative";
 type Props = {
   size?: AvatarProps["size"];
   lx?: AvatarProps["lx"];
+  showNotification?: AvatarProps["showNotification"];
 };
 
-export function UserAvatar({ size = "lg", lx }: Readonly<Props>) {
-  return <Avatar size={size} alt="My wallet avatar" testID="my-wallet-avatar" lx={lx} />;
+export function UserAvatar({ size = "lg", lx, showNotification }: Readonly<Props>) {
+  return (
+    <Avatar
+      size={size}
+      alt="My wallet avatar"
+      testID="my-wallet-avatar"
+      lx={lx}
+      showNotification={showNotification}
+    />
+  );
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 
- [x] **Impact of the changes:**
      -  Notification dot now appears on the MyWallet avatar when there are unread notifications

### 📝 Description 
Thread `hasUnreadNotifications` through `TopBarView` → `MyWalletTopBarAction` → `UserAvatar` so the lumen `Avatar` `showNotification` dot reflects unread notification state.

https://github.com/user-attachments/assets/f03a4dfe-fa79-4592-977a-890be18fb1cd


### ❓ Context

- **JIRA or GitHub link**: [LIVE-26547](https://ledgerhq.atlassian.net/browse/LIVE-26547)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26547]: https://ledgerhq.atlassian.net/browse/LIVE-26547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ