### PR TITLE
[LWDM] feat(LIVE-29150): improvement to private sync progress for Aleo

### DIFF
--- a/.changeset/fuzzy-guests-wink.md
+++ b/.changeset/fuzzy-guests-wink.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-aleo": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+extended private sync progress tracking for Aleo

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.test.tsx
@@ -1,36 +1,26 @@
 import BigNumber from "bignumber.js";
 import React from "react";
-import { Subject } from "rxjs";
 import { act, fireEvent, render, screen } from "tests/testSetup";
 import * as currencies from "@ledgerhq/live-common/currencies/index";
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
 import { PRIVATE_BALANCE_PLACEHOLDER } from "./constants";
+import { useAleoPrivateSync } from "./hooks/useAleoPrivateSync";
 import { ALEO_ACCOUNT_1 } from "./__mocks__/account.mock";
 
 jest.mock("~/renderer/hooks/useAccountUnit");
 jest.mock("@ledgerhq/live-common/currencies/index");
-jest.mock("@ledgerhq/live-common/bridge/impl");
-jest.mock("~/renderer/actions/accounts", () => ({
-  ...jest.requireActual("~/renderer/actions/accounts"),
-  updateAccountWithUpdater: jest
-    .fn()
-    .mockImplementation((accountId: string, updater: (a: unknown) => unknown) => ({
-      type: "UPDATE_ACCOUNT",
-      payload: { accountId, updater },
-    })),
-}));
-
-const { getAccountBridge } = jest.requireMock("@ledgerhq/live-common/bridge/impl");
+jest.mock("./hooks/useAleoPrivateSync");
 
 const mockUseAccountUnit = jest.mocked(useAccountUnit);
+const mockUseAleoPrivateSync = jest.mocked(useAleoPrivateSync);
 
 describe("AccountBalanceSummaryFooter", () => {
   const mockSpendableBalance = BigNumber(100);
   const mockTransparentBalance = BigNumber(60);
-  let syncSubject: Subject<(acc: AleoAccount) => AleoAccount>;
-  let mockSync: jest.Mock;
+  let mockStart: jest.Mock;
+  let mockStop: jest.Mock;
   const mockAccount: AleoAccount = {
     ...ALEO_ACCOUNT_1,
     spendableBalance: mockSpendableBalance,
@@ -46,6 +36,17 @@ describe("AccountBalanceSummaryFooter", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    mockStart = jest.fn();
+    mockStop = jest.fn();
+
+    mockUseAleoPrivateSync.mockReturnValue({
+      isSyncing: false,
+      progress: 0,
+      error: null,
+      start: mockStart,
+      stop: mockStop,
+    });
+
     mockUseAccountUnit.mockReturnValue({
       code: "ALEO",
       name: "Aleo",
@@ -57,14 +58,9 @@ describe("AccountBalanceSummaryFooter", () => {
       .mockImplementation((_unit, value, _formatConfig) => {
         return value ? `formatted: ${value.toString()}` : PRIVATE_BALANCE_PLACEHOLDER;
       });
-
-    syncSubject = new Subject();
-    mockSync = jest.fn().mockReturnValue(syncSubject.asObservable());
-    getAccountBridge.mockReturnValue({ sync: mockSync });
   });
 
   afterEach(() => {
-    if (!syncSubject.closed) syncSubject.complete();
     jest.useRealTimers();
   });
 
@@ -102,10 +98,37 @@ describe("AccountBalanceSummaryFooter", () => {
   });
 
   describe("sync button", () => {
-    it("should show 'Start sync' button when account is not yet synced", () => {
+    it("should show 'Start sync' button when account is not yet synced and hook is idle", () => {
       render(<AccountBalanceSummaryFooter account={mockAccount} />);
 
       expect(screen.getByRole("button", { name: "Start sync" })).toBeInTheDocument();
+    });
+
+    it("should pass autoStart: true to the hook for an unsynced account", () => {
+      render(<AccountBalanceSummaryFooter account={mockAccount} />);
+
+      expect(mockUseAleoPrivateSync).toHaveBeenCalledWith(
+        expect.objectContaining({ autoStart: true }),
+      );
+    });
+
+    it("should pass autoStart: false to the hook for an already-synced account", () => {
+      const syncedAccount: AleoAccount = {
+        ...mockAccount,
+        aleoResources: {
+          transparentBalance: mockTransparentBalance,
+          privateBalance: null,
+          unspentPrivateRecords: [],
+          lastPrivateSyncDate: new Date(),
+          provableApi: { scannerStatus: { synced: true, percentage: 100 } },
+        },
+      };
+
+      render(<AccountBalanceSummaryFooter account={syncedAccount} />);
+
+      expect(mockUseAleoPrivateSync).toHaveBeenCalledWith(
+        expect.objectContaining({ autoStart: false }),
+      );
     });
 
     it("should show 'Sync again' button when account is already synced", () => {
@@ -125,49 +148,58 @@ describe("AccountBalanceSummaryFooter", () => {
       expect(screen.getByRole("button", { name: "Sync again" })).toBeInTheDocument();
     });
 
-    it("should show 'Stop sync' button after clicking 'Start sync'", async () => {
-      render(<AccountBalanceSummaryFooter account={mockAccount} />);
-
-      await act(async () => {
-        fireEvent.click(screen.getByRole("button", { name: "Start sync" }));
+    it("should show 'Stop sync' button when the hook reports isSyncing: true", () => {
+      mockUseAleoPrivateSync.mockReturnValue({
+        isSyncing: true,
+        progress: 0,
+        error: null,
+        start: mockStart,
+        stop: mockStop,
       });
+
+      render(<AccountBalanceSummaryFooter account={mockAccount} />);
 
       expect(screen.getByRole("button", { name: "Stop sync" })).toBeInTheDocument();
     });
 
-    it("should return to 'Start sync' button after clicking 'Stop sync'", async () => {
+    it("should call start() when the sync button is clicked in idle state", async () => {
       render(<AccountBalanceSummaryFooter account={mockAccount} />);
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Start sync" }));
       });
+
+      expect(mockStart).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call stop() when Stop sync is clicked", async () => {
+      mockUseAleoPrivateSync.mockReturnValue({
+        isSyncing: true,
+        progress: 0,
+        error: null,
+        start: mockStart,
+        stop: mockStop,
+      });
+
+      render(<AccountBalanceSummaryFooter account={mockAccount} />);
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Stop sync" }));
       });
 
-      expect(screen.getByRole("button", { name: "Start sync" })).toBeInTheDocument();
+      expect(mockStop).toHaveBeenCalledTimes(1);
     });
 
-    it("should display sync progress percentage while syncing", async () => {
+    it("should display sync progress percentage while syncing", () => {
+      mockUseAleoPrivateSync.mockReturnValue({
+        isSyncing: true,
+        progress: 37,
+        error: null,
+        start: mockStart,
+        stop: mockStop,
+      });
+
       render(<AccountBalanceSummaryFooter account={mockAccount} />);
-
-      await act(async () => {
-        fireEvent.click(screen.getByRole("button", { name: "Start sync" }));
-      });
-
-      await act(async () => {
-        syncSubject.next(() => ({
-          ...mockAccount,
-          aleoResources: {
-            transparentBalance: mockTransparentBalance,
-            privateBalance: null,
-            unspentPrivateRecords: [],
-            lastPrivateSyncDate: null,
-            provableApi: { scannerStatus: { synced: false, percentage: 37 } },
-          },
-        }));
-      });
 
       expect(screen.getByText("37%")).toBeInTheDocument();
     });
@@ -185,37 +217,60 @@ describe("AccountBalanceSummaryFooter", () => {
         provableApi: { scannerStatus: { synced: true, percentage: 100 } },
       },
     };
-    const completeUpdater = () => completedAccount;
 
     it("should still show 'Stop sync' and progress immediately after sync completes at 100%", () => {
       jest.useFakeTimers();
-      render(<AccountBalanceSummaryFooter account={mockAccount} />);
 
+      // Start with sync running at 100%
+      mockUseAleoPrivateSync.mockReturnValue({
+        isSyncing: true,
+        progress: 100,
+        error: null,
+        start: mockStart,
+        stop: mockStop,
+      });
+      const { rerender } = render(<AccountBalanceSummaryFooter account={mockAccount} />);
+
+      // Simulate sync completion: hook transitions to isSyncing: false
+      mockUseAleoPrivateSync.mockReturnValue({
+        isSyncing: false,
+        progress: 100,
+        error: null,
+        start: mockStart,
+        stop: mockStop,
+      });
       act(() => {
-        fireEvent.click(screen.getByRole("button", { name: "Start sync" }));
+        rerender(<AccountBalanceSummaryFooter account={mockAccount} />);
       });
 
-      act(() => {
-        syncSubject.next(completeUpdater);
-        syncSubject.complete();
-      });
-
-      // delay hasn't elapsed yet — still showing running state with 100%
+      // Delay hasn't elapsed yet — still showing running state with 100%
       expect(screen.getByRole("button", { name: "Stop sync" })).toBeInTheDocument();
       expect(screen.getByText("100%")).toBeInTheDocument();
     });
 
     it("should transition to 'Sync again' after the 200ms finish delay elapses", () => {
       jest.useFakeTimers();
+
+      // Start with sync running at 100%
+      mockUseAleoPrivateSync.mockReturnValue({
+        isSyncing: true,
+        progress: 100,
+        error: null,
+        start: mockStart,
+        stop: mockStop,
+      });
       const { rerender } = render(<AccountBalanceSummaryFooter account={mockAccount} />);
 
-      act(() => {
-        fireEvent.click(screen.getByRole("button", { name: "Start sync" }));
+      // Simulate sync completion
+      mockUseAleoPrivateSync.mockReturnValue({
+        isSyncing: false,
+        progress: 100,
+        error: null,
+        start: mockStart,
+        stop: mockStop,
       });
-
       act(() => {
-        syncSubject.next(completeUpdater);
-        syncSubject.complete();
+        rerender(<AccountBalanceSummaryFooter account={mockAccount} />);
       });
 
       // Simulate the Redux store updating the account prop after the sync completed

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/AccountBalanceSummaryFooter.tsx
@@ -123,7 +123,11 @@ const AccountBalanceSummaryFooter = ({ account }: Readonly<Props>) => {
     progress: hookProgress,
     start: handleStart,
     stop: handleStop,
-  } = useAleoPrivateSync({ account });
+  } = useAleoPrivateSync({
+    account,
+    autoStart: account.type === "Account" && !account.aleoResources?.lastPrivateSyncDate,
+    keepAliveOnUnmount: true,
+  });
 
   const [displaySyncing, setDisplaySyncing] = useState(isSyncing);
   const finishDelayRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/constants.ts
@@ -5,3 +5,6 @@ export enum AleoCustomModal {
 }
 
 export const MANDATORY_SYNC_POLLING_DELAY = 3000;
+
+/** Minimum time (ms) between progress state updates in the hook to avoid flooding React renders. */
+export const PROGRESS_THROTTLE_INTERVAL_MS = 500;

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.test.ts
@@ -816,4 +816,99 @@ describe("useAleoPrivateSync", () => {
       expect(onAccountUpdated).not.toHaveBeenCalled();
     });
   });
+
+  describe("external completion via aleoPrivateSyncProgress$", () => {
+    it("should call onAccountUpdated immediately when Redux has already flushed lastPrivateSyncDate", () => {
+      jest.useFakeTimers();
+      const onAccountUpdated = jest.fn();
+      const syncDate = new Date();
+      const baseAccount = makeAleoAccount(100, true);
+      const syncedAccount: AleoAccount = {
+        ...baseAccount,
+        aleoResources: {
+          ...baseAccount.aleoResources!,
+          lastPrivateSyncDate: syncDate,
+        },
+      };
+
+      const { result } = renderHook(
+        () => useAleoPrivateSync({ account: syncedAccount, onAccountUpdated }),
+        { initialState: { accounts: [syncedAccount] } },
+      );
+
+      act(() => {
+        result.current.start();
+      });
+
+      // Complete without a result — subscriptionRef becomes null, retry timer pending
+      act(() => {
+        syncSubject.complete();
+      });
+
+      // A keepAlive instance emits progress=100; liveAccount already has lastPrivateSyncDate
+      act(() => {
+        aleoPrivateSyncProgress$.next({ accountId: syncedAccount.id, progress: 100 });
+        jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
+      });
+
+      expect(result.current.isSyncing).toBe(false);
+      expect(onAccountUpdated).toHaveBeenCalledTimes(1);
+      expect(onAccountUpdated).toHaveBeenCalledWith(syncedAccount);
+    });
+
+    it("should defer onAccountUpdated via the liveAccount effect when Redux has not yet flushed", () => {
+      jest.useFakeTimers();
+      const onAccountUpdated = jest.fn();
+      const account = makeAleoAccount();
+
+      const { result, store } = renderHook(
+        () => useAleoPrivateSync({ account, onAccountUpdated }),
+        { initialState: { accounts: [account] } },
+      );
+
+      act(() => {
+        result.current.start();
+      });
+
+      // Complete without a result — subscriptionRef becomes null, retry timer pending
+      act(() => {
+        syncSubject.complete();
+      });
+
+      // External progress=100 arrives; liveAccount still lacks lastPrivateSyncDate
+      act(() => {
+        aleoPrivateSyncProgress$.next({ accountId: account.id, progress: 100 });
+        jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
+      });
+
+      // pendingExternalCompletionRef is now true, but onAccountUpdated not yet fired
+      expect(onAccountUpdated).not.toHaveBeenCalled();
+      expect(result.current.isSyncing).toBe(false);
+
+      // Simulate Redux catching up: dispatch UPDATE_ACCOUNT with lastPrivateSyncDate set
+      const syncDate = new Date();
+      act(() => {
+        store.dispatch({
+          type: "UPDATE_ACCOUNT",
+          payload: {
+            accountId: account.id,
+            updater: (acc: AleoAccount): AleoAccount => ({
+              ...acc,
+              aleoResources: {
+                ...acc.aleoResources!,
+                lastPrivateSyncDate: syncDate,
+              },
+            }),
+          },
+        });
+      });
+
+      expect(onAccountUpdated).toHaveBeenCalledTimes(1);
+      expect(onAccountUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aleoResources: expect.objectContaining({ lastPrivateSyncDate: syncDate }),
+        }),
+      );
+    });
+  });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.test.ts
@@ -3,9 +3,10 @@ import { Subject } from "rxjs";
 import { act } from "react";
 import { renderHook } from "tests/testSetup";
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
+import { aleoPrivateSyncProgress$ } from "@ledgerhq/live-common/families/aleo/privateSyncProgress";
 import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
 import { useAleoPrivateSync } from "./useAleoPrivateSync";
-import { MANDATORY_SYNC_POLLING_DELAY } from "../constants";
+import { MANDATORY_SYNC_POLLING_DELAY, PROGRESS_THROTTLE_INTERVAL_MS } from "../constants";
 
 jest.mock("@ledgerhq/live-common/bridge/impl");
 jest.mock("~/renderer/actions/accounts", () => ({
@@ -72,7 +73,7 @@ describe("useAleoPrivateSync", () => {
       expect(result.current.isSyncing).toBe(true);
     });
 
-    it("should update progress on next emissions", async () => {
+    it("should set progress to 100 when next is emitted from the bridge observable", async () => {
       const { result } = renderHook(() => useAleoPrivateSync({ account: makeAleoAccount() }));
 
       await act(async () => {
@@ -80,7 +81,24 @@ describe("useAleoPrivateSync", () => {
       });
 
       await act(async () => {
-        syncSubject.next(() => makeAleoAccount(42));
+        syncSubject.next(() => makeAleoAccount(100, true));
+      });
+
+      expect(result.current.progress).toBe(100);
+    });
+
+    it("should update progress via aleoPrivateSyncProgress$ emissions", () => {
+      jest.useFakeTimers();
+      const account = makeAleoAccount();
+      const { result } = renderHook(() => useAleoPrivateSync({ account }));
+
+      act(() => {
+        result.current.start();
+      });
+
+      act(() => {
+        aleoPrivateSyncProgress$.next({ accountId: account.id, progress: 42 });
+        jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
       });
 
       expect(result.current.progress).toBe(42);
@@ -154,7 +172,7 @@ describe("useAleoPrivateSync", () => {
       expect(result.current.progress).toBe(100);
     });
 
-    it("should retry when percentage is 100 but synced is false (scanner not yet ready)", () => {
+    it("should retry when complete fires without any result (scanner not yet ready)", () => {
       jest.useFakeTimers();
       const firstSubject = new Subject<(acc: AleoAccount) => AleoAccount>();
       const secondSubject = new Subject<(acc: AleoAccount) => AleoAccount>();
@@ -168,9 +186,8 @@ describe("useAleoPrivateSync", () => {
         result.current.start();
       });
 
-      // Emit percentage=100 but synced=false — this is the bug scenario
+      // Complete without emitting next — scanner returned null, retry expected
       act(() => {
-        firstSubject.next(() => makeAleoAccount(100, false));
         firstSubject.complete();
       });
 
@@ -191,7 +208,7 @@ describe("useAleoPrivateSync", () => {
       expect(result.current.isSyncing).toBe(false);
     });
 
-    it("should retry after polling delay when complete fires with synced=false", () => {
+    it("should retry after polling delay when complete fires without any result", () => {
       jest.useFakeTimers();
       const firstSubject = new Subject<(acc: AleoAccount) => AleoAccount>();
       const secondSubject = new Subject<(acc: AleoAccount) => AleoAccount>();
@@ -205,8 +222,8 @@ describe("useAleoPrivateSync", () => {
         result.current.start();
       });
 
+      // Complete without any next emission — triggers retry after delay
       act(() => {
-        firstSubject.next(() => makeAleoAccount(50));
         firstSubject.complete();
       });
 
@@ -219,7 +236,8 @@ describe("useAleoPrivateSync", () => {
       expect(mockSync).toHaveBeenCalledTimes(2);
 
       act(() => {
-        secondSubject.complete();
+        // Second observable also completes without result — stop manually to avoid infinite retry
+        result.current.stop();
       });
     });
 
@@ -349,7 +367,7 @@ describe("useAleoPrivateSync", () => {
     });
 
     it("should not call onAccountUpdated when not provided", async () => {
-      // No onAccountUpdated — just confirm it doesn't throw
+      // No onAccountUpdated — just confirm it doesn't throw and progress reaches 100
       const { result } = renderHook(() => useAleoPrivateSync({ account: makeAleoAccount() }));
 
       await act(async () => {
@@ -357,10 +375,10 @@ describe("useAleoPrivateSync", () => {
       });
 
       await act(async () => {
-        syncSubject.next(() => makeAleoAccount(50));
+        syncSubject.next(() => makeAleoAccount(100, true));
       });
 
-      expect(result.current.progress).toBe(50);
+      expect(result.current.progress).toBe(100);
     });
 
     it("should use the latest onAccountUpdated ref without restarting sync", async () => {
@@ -386,6 +404,416 @@ describe("useAleoPrivateSync", () => {
 
       expect(first).not.toHaveBeenCalled();
       expect(second).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("aleoPrivateSyncProgress$ edge cases", () => {
+    it("should ignore progress events for a different accountId", () => {
+      jest.useFakeTimers();
+      const account = makeAleoAccount();
+      const { result } = renderHook(() => useAleoPrivateSync({ account }));
+
+      act(() => {
+        result.current.start();
+      });
+
+      act(() => {
+        aleoPrivateSyncProgress$.next({ accountId: "different-account-id", progress: 60 });
+        jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
+      });
+
+      expect(result.current.progress).toBe(0);
+    });
+
+    it("should ignore progress events with null progress", () => {
+      jest.useFakeTimers();
+      const account = makeAleoAccount();
+      const { result } = renderHook(() => useAleoPrivateSync({ account }));
+
+      act(() => {
+        result.current.start();
+      });
+
+      act(() => {
+        aleoPrivateSyncProgress$.next({ accountId: account.id, progress: null });
+        jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
+      });
+
+      expect(result.current.progress).toBe(0);
+    });
+
+    it("should not decrease progress (Math.max behaviour)", () => {
+      jest.useFakeTimers();
+      const account = makeAleoAccount();
+      const { result } = renderHook(() => useAleoPrivateSync({ account }));
+
+      act(() => {
+        result.current.start();
+      });
+
+      act(() => {
+        aleoPrivateSyncProgress$.next({ accountId: account.id, progress: 70 });
+        jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
+      });
+
+      act(() => {
+        aleoPrivateSyncProgress$.next({ accountId: account.id, progress: 30 });
+        jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
+      });
+
+      expect(result.current.progress).toBe(70);
+    });
+
+    it("should ignore progress events when not syncing", () => {
+      jest.useFakeTimers();
+      const account = makeAleoAccount();
+      const { result } = renderHook(() => useAleoPrivateSync({ account }));
+
+      // Do not call start() — isSyncing is false
+      act(() => {
+        aleoPrivateSyncProgress$.next({ accountId: account.id, progress: 55 });
+        jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
+      });
+
+      expect(result.current.progress).toBe(0);
+    });
+  });
+
+  describe("start() called while already syncing", () => {
+    it("should reset progress to 0 and re-subscribe when start() is called again", async () => {
+      const firstSubject = new Subject<(acc: AleoAccount) => AleoAccount>();
+      const secondSubject = new Subject<(acc: AleoAccount) => AleoAccount>();
+      mockSync
+        .mockReturnValueOnce(firstSubject.asObservable())
+        .mockReturnValueOnce(secondSubject.asObservable());
+
+      const { result } = renderHook(() => useAleoPrivateSync({ account: makeAleoAccount() }));
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      // Advance partial progress
+      await act(async () => {
+        firstSubject.next(() => makeAleoAccount(50));
+      });
+
+      expect(result.current.progress).toBe(100);
+
+      // Calling start() again should reset
+      await act(async () => {
+        result.current.start();
+      });
+
+      expect(result.current.progress).toBe(0);
+      expect(result.current.isSyncing).toBe(true);
+      expect(mockSync).toHaveBeenCalledTimes(2);
+    });
+
+    it("should clear a previous error when start() is called while an error is set", async () => {
+      const { result } = renderHook(() => useAleoPrivateSync({ account: makeAleoAccount() }));
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      await act(async () => {
+        syncSubject.error(new Error("first error"));
+      });
+
+      expect(result.current.error).not.toBeNull();
+
+      syncSubject = new Subject();
+      mockSync.mockReturnValue(syncSubject.asObservable());
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("dispatch behaviour", () => {
+    it("should dispatch updateAccountWithUpdater on each sync emission", async () => {
+      const { updateAccountWithUpdater } = jest.requireMock("~/renderer/actions/accounts");
+      const { result } = renderHook(() => useAleoPrivateSync({ account: makeAleoAccount() }));
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      await act(async () => {
+        syncSubject.next(() => makeAleoAccount(50));
+      });
+
+      expect(updateAccountWithUpdater).toHaveBeenCalledTimes(1);
+      expect(updateAccountWithUpdater).toHaveBeenCalledWith(
+        ALEO_ACCOUNT_1.id,
+        expect.any(Function),
+      );
+    });
+
+    it("should dispatch once per emission when multiple next values arrive", async () => {
+      const { updateAccountWithUpdater } = jest.requireMock("~/renderer/actions/accounts");
+      const { result } = renderHook(() => useAleoPrivateSync({ account: makeAleoAccount() }));
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      await act(async () => {
+        syncSubject.next(() => makeAleoAccount(33));
+        syncSubject.next(() => makeAleoAccount(66));
+      });
+
+      expect(updateAccountWithUpdater).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("account: null / undefined", () => {
+    it("should not call sync when account is null", async () => {
+      const { result } = renderHook(() => useAleoPrivateSync({ account: null }));
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      expect(mockSync).not.toHaveBeenCalled();
+    });
+
+    it("should return isSyncing=false and progress=0 when account is null", () => {
+      const { result } = renderHook(() => useAleoPrivateSync({ account: null }));
+
+      expect(result.current.isSyncing).toBe(false);
+      expect(result.current.progress).toBe(0);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("keepAliveOnUnmount: true", () => {
+    it("should keep the sync running after unmount (bridge subscription not cancelled)", async () => {
+      const onAccountUpdated = jest.fn();
+      const account = makeAleoAccount();
+      const { result, unmount } = renderHook(
+        () => useAleoPrivateSync({ account, keepAliveOnUnmount: true, onAccountUpdated }),
+        { initialState: { accounts: [account] } },
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      unmount();
+
+      // Emitting after unmount should still call onAccountUpdated (sync is alive)
+      await act(async () => {
+        syncSubject.next(() => makeAleoAccount(100, true));
+      });
+
+      expect(onAccountUpdated).toHaveBeenCalledTimes(1);
+    });
+
+    it("should adopt registry state when component remounts while sync is running", async () => {
+      jest.useFakeTimers();
+      const account = makeAleoAccount();
+      const initialState = { accounts: [account] };
+
+      const { result: first, unmount } = renderHook(
+        () => useAleoPrivateSync({ account, keepAliveOnUnmount: true, autoStart: true }),
+        { initialState },
+      );
+
+      // Advance some progress via the progress subject
+      act(() => {
+        aleoPrivateSyncProgress$.next({ accountId: account.id, progress: 55 });
+        jest.advanceTimersByTime(PROGRESS_THROTTLE_INTERVAL_MS + 100);
+      });
+
+      expect(first.current.progress).toBe(55);
+
+      unmount();
+
+      // Remount — should pick up isSyncing=true and progress=55 from registry
+      const { result: second } = renderHook(
+        () => useAleoPrivateSync({ account, keepAliveOnUnmount: true, autoStart: true }),
+        { initialState },
+      );
+
+      expect(second.current.isSyncing).toBe(true);
+      expect(second.current.progress).toBe(55);
+      // Should NOT have started a second bridge sync
+      expect(mockSync).toHaveBeenCalledTimes(1);
+    });
+
+    it("should dispatch to Redux and call onAccountUpdated after unmount (isMountedRef only guards state setters)", async () => {
+      const { updateAccountWithUpdater } = jest.requireMock("~/renderer/actions/accounts");
+      const onAccountUpdated = jest.fn();
+      const account = makeAleoAccount();
+      const { result, unmount } = renderHook(
+        () => useAleoPrivateSync({ account, keepAliveOnUnmount: true, onAccountUpdated }),
+        { initialState: { accounts: [account] } },
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      unmount();
+
+      await act(async () => {
+        syncSubject.next(() => makeAleoAccount(100, true));
+      });
+
+      // Non-state side-effects are NOT guarded by isMountedRef
+      expect(updateAccountWithUpdater).toHaveBeenCalledTimes(1);
+      expect(onAccountUpdated).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not crash and not set error state when the keepAlive sync errors after unmount", async () => {
+      const account = makeAleoAccount();
+      const { result, unmount } = renderHook(
+        () => useAleoPrivateSync({ account, keepAliveOnUnmount: true }),
+        { initialState: { accounts: [account] } },
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      unmount();
+
+      // Error fires after unmount — isMountedRef prevents setError/setIsSyncing
+      await act(async () => {
+        syncSubject.error(new Error("post-unmount error"));
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+
+    it("should clear the registry after sync completes so a remounted hook starts a fresh sync", async () => {
+      const account = makeAleoAccount();
+      const initialState = { accounts: [account] };
+
+      const { result, unmount } = renderHook(
+        () => useAleoPrivateSync({ account, keepAliveOnUnmount: true }),
+        { initialState },
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      // Sync completes — keepAliveOnUnmountRef branch clears the registry entry
+      await act(async () => {
+        syncSubject.next(() => makeAleoAccount(100, true));
+        syncSubject.complete();
+      });
+
+      unmount();
+
+      syncSubject = new Subject();
+      mockSync.mockReturnValue(syncSubject.asObservable());
+
+      // Remount with autoStart: no live registry entry, so a fresh sync is started
+      const { result: second } = renderHook(
+        () => useAleoPrivateSync({ account, keepAliveOnUnmount: true, autoStart: true }),
+        { initialState },
+      );
+
+      expect(mockSync).toHaveBeenCalledTimes(2);
+      expect(second.current.isSyncing).toBe(true);
+    });
+
+    it("should clear the registry after sync errors so a remounted hook starts a fresh sync", async () => {
+      const account = makeAleoAccount();
+      const initialState = { accounts: [account] };
+
+      const { result, unmount } = renderHook(
+        () => useAleoPrivateSync({ account, keepAliveOnUnmount: true }),
+        { initialState },
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      unmount();
+
+      // Error fires after unmount — keepAliveOnUnmountRef branch clears the registry entry
+      await act(async () => {
+        syncSubject.error(new Error("sync error"));
+      });
+
+      syncSubject = new Subject();
+      mockSync.mockReturnValue(syncSubject.asObservable());
+
+      // Remount with autoStart: no live registry entry, so a fresh sync is started
+      const { result: second } = renderHook(
+        () => useAleoPrivateSync({ account, keepAliveOnUnmount: true, autoStart: true }),
+        { initialState },
+      );
+
+      expect(mockSync).toHaveBeenCalledTimes(2);
+      expect(second.current.isSyncing).toBe(true);
+    });
+
+    it("should store the RxJS subscription in the registry so stop() can cancel it after unmount", async () => {
+      const account = makeAleoAccount();
+      const { result, unmount } = renderHook(
+        () => useAleoPrivateSync({ account, keepAliveOnUnmount: true }),
+        { initialState: { accounts: [account] } },
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      const stopFn = result.current.stop;
+      unmount();
+
+      // stop() retrieves entry.sub from the registry and unsubscribes it
+      await act(async () => {
+        stopFn();
+      });
+
+      const onAccountUpdated = jest.fn();
+      // Bind a fresh callback — original hook is gone, but the subscription should be dead
+      await act(async () => {
+        syncSubject.next(() => makeAleoAccount(100, true));
+      });
+
+      // No callback wired here, but the key assertion is that dispatch was NOT called
+      const { updateAccountWithUpdater } = jest.requireMock("~/renderer/actions/accounts");
+      expect(updateAccountWithUpdater).not.toHaveBeenCalled();
+      expect(onAccountUpdated).not.toHaveBeenCalled();
+    });
+
+    it("should cancel the keep-alive subscription when stop() is called after unmount", async () => {
+      const onAccountUpdated = jest.fn();
+      const account = makeAleoAccount();
+      const { result, unmount } = renderHook(
+        () => useAleoPrivateSync({ account, keepAliveOnUnmount: true, onAccountUpdated }),
+        { initialState: { accounts: [account] } },
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      const stopFn = result.current.stop;
+      unmount();
+
+      await act(async () => {
+        stopFn();
+      });
+
+      // Emitting now should be ignored — subscription was cancelled
+      await act(async () => {
+        syncSubject.next(() => makeAleoAccount(100, true));
+      });
+
+      expect(onAccountUpdated).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/hooks/useAleoPrivateSync.ts
@@ -2,10 +2,33 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { SYNC_TYPE_SHIELDED } from "@ledgerhq/types-live";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
-import { useDispatch } from "LLD/hooks/redux";
+import { useDispatch, useSelector, useStore } from "LLD/hooks/redux";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
-import { MANDATORY_SYNC_POLLING_DELAY } from "../constants";
+import { accountSelector } from "~/renderer/reducers/accounts";
+import type { State } from "~/renderer/reducers";
+import { aleoPrivateSyncProgress$ } from "@ledgerhq/live-common/families/aleo/privateSyncProgress";
+import { asyncScheduler, throttleTime } from "rxjs";
+import { MANDATORY_SYNC_POLLING_DELAY, PROGRESS_THROTTLE_INTERVAL_MS } from "../constants";
 import { isAleoAccount } from "../modals/send/steps/utils";
+
+/**
+ * Module-level registry that keeps track of sync subscriptions that should
+ * survive component unmount (when keepAliveOnUnmount is true).
+ *
+ * Keyed by accountId so any remounting hook instance can adopt the running sync
+ * instead of starting a duplicate.
+ */
+interface KeepAliveEntry {
+  isSyncing: boolean;
+  progress: number;
+  /** The underlying RxJS subscription — held here so stop() can cancel it even
+   *  after the originating component has unmounted. */
+  sub: { unsubscribe(): void } | null;
+  /** Unsubscribes from the Redux store watcher that detects account deletion. */
+  storeUnsubscribe: (() => void) | null;
+}
+
+const keepAliveRegistry = new Map<string, KeepAliveEntry>();
 
 interface UseAleoPrivateSyncOptions {
   account: Account | TokenAccount | null | undefined;
@@ -13,6 +36,12 @@ interface UseAleoPrivateSyncOptions {
   autoStart?: boolean;
   /** Called with the locally-computed updated account after each sync emission. */
   onAccountUpdated?: (account: Account) => void;
+  /**
+   * If true the sync subscription is NOT cancelled when the component unmounts.
+   * The sync continues in the background, dispatching results to Redux. When the
+   * component remounts it automatically adopts the running sync from the registry.
+   */
+  keepAliveOnUnmount?: boolean;
 }
 
 interface UseAleoPrivateSyncResult {
@@ -27,8 +56,15 @@ export const useAleoPrivateSync = ({
   account,
   autoStart = false,
   onAccountUpdated,
+  keepAliveOnUnmount = false,
 }: UseAleoPrivateSyncOptions): UseAleoPrivateSyncResult => {
   const dispatch = useDispatch();
+  const store = useStore();
+
+  const accountId = account?.type === "Account" ? account.id : undefined;
+  const liveAccount = useSelector((state: State) =>
+    accountId ? accountSelector(state, { accountId }) : undefined,
+  );
 
   const onAccountUpdatedRef = useRef(onAccountUpdated);
   onAccountUpdatedRef.current = onAccountUpdated;
@@ -36,58 +72,98 @@ export const useAleoPrivateSync = ({
   const accountRef = useRef(account);
   accountRef.current = account;
 
-  const isSyncingRef = useRef(false);
+  const liveAccountRef = useRef(liveAccount);
+  liveAccountRef.current = liveAccount;
+
+  // Read registry once on mount so a remounting hook adopts the running sync.
+  const keepAliveEntry =
+    keepAliveOnUnmount && accountId ? keepAliveRegistry.get(accountId) : undefined;
+
+  const keepAliveOnUnmountRef = useRef(keepAliveOnUnmount);
+  keepAliveOnUnmountRef.current = keepAliveOnUnmount;
+
+  const isSyncingRef = useRef(keepAliveEntry?.isSyncing ?? false);
   const subscriptionRef = useRef<{ unsubscribe(): void } | null>(null);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Set when we adopt an external completion so the liveAccount effect can
+  // call onAccountUpdated once Redux has caught up with the dispatch.
+  const pendingExternalCompletionRef = useRef(false);
+  // Tracks whether the component is currently mounted. Used to skip React
+  // state updates and callbacks when the subscription fires after unmount
+  // (only relevant for keepAliveOnUnmount=true, where the RxJS subscription
+  // outlives the component).
+  const isMountedRef = useRef(true);
 
-  const [isSyncing, setIsSyncing] = useState(false);
-  const [progress, setProgress] = useState(0);
+  const [isSyncing, setIsSyncing] = useState(keepAliveEntry?.isSyncing ?? false);
+  const [progress, setProgress] = useState(keepAliveEntry?.progress ?? 0);
   const [error, setError] = useState<Error | null>(null);
 
   const runSync = useCallback(() => {
     const acc = accountRef.current;
     if (!isSyncingRef.current || acc?.type !== "Account" || !isAleoAccount(acc)) return;
 
-    let latestPercentage = 0;
-    let latestSynced = false;
+    const currentAccountId = acc.id;
+    let receivedFinalResult = false;
     const bridge = getAccountBridge(acc);
-    subscriptionRef.current = bridge
-      .sync(acc, { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED })
-      .subscribe({
-        next: updater => {
-          const currentAcc = accountRef.current;
-          if (currentAcc?.type !== "Account" || !isAleoAccount(currentAcc)) return;
-          dispatch(updateAccountWithUpdater(currentAcc.id, updater));
-          const updatedAccount = updater(currentAcc);
-          if (!isAleoAccount(updatedAccount)) return;
-          latestPercentage =
-            updatedAccount.aleoResources?.provableApi?.scannerStatus?.percentage ?? 0;
-          latestSynced = updatedAccount.aleoResources?.provableApi?.scannerStatus?.synced ?? false;
-          setProgress(latestPercentage);
-          onAccountUpdatedRef.current?.(updatedAccount);
-          // Scanner is done — mark syncing complete immediately so the
-          // component can react without waiting for the observable to complete.
-          if (latestSynced) {
-            isSyncingRef.current = false;
-            setIsSyncing(false);
-          }
-        },
-        error: (err: Error) => {
-          subscriptionRef.current = null;
-          isSyncingRef.current = false;
+    const sub = bridge.sync(acc, { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED }).subscribe({
+      next: updater => {
+        const currentAcc = accountRef.current;
+        if (currentAcc?.type !== "Account" || !isAleoAccount(currentAcc)) return;
+        dispatch(updateAccountWithUpdater(currentAcc.id, updater));
+        const updatedAccount = updater(currentAcc);
+        if (!isAleoAccount(updatedAccount)) return;
+        receivedFinalResult = true;
+        if (keepAliveOnUnmountRef.current) {
+          const entry = keepAliveRegistry.get(currentAccountId);
+          entry?.storeUnsubscribe?.();
+          keepAliveRegistry.delete(currentAccountId);
+        }
+        onAccountUpdatedRef.current?.(updatedAccount);
+        isSyncingRef.current = false;
+        if (isMountedRef.current) {
+          setIsSyncing(false);
+          setProgress(100);
+        }
+      },
+      error: (err: Error) => {
+        subscriptionRef.current = null;
+        if (keepAliveOnUnmountRef.current) {
+          const entry = keepAliveRegistry.get(currentAccountId);
+          entry?.storeUnsubscribe?.();
+          keepAliveRegistry.delete(currentAccountId);
+        }
+        isSyncingRef.current = false;
+        if (isMountedRef.current) {
           setIsSyncing(false);
           setError(err);
-        },
-        complete: () => {
-          subscriptionRef.current = null;
-          if (isSyncingRef.current && !latestSynced) {
-            retryTimerRef.current = setTimeout(runSync, MANDATORY_SYNC_POLLING_DELAY);
-          } else if (isSyncingRef.current) {
-            isSyncingRef.current = false;
+        }
+      },
+      complete: () => {
+        subscriptionRef.current = null;
+        if (isSyncingRef.current && !receivedFinalResult) {
+          retryTimerRef.current = setTimeout(runSync, MANDATORY_SYNC_POLLING_DELAY);
+        } else if (isSyncingRef.current) {
+          if (keepAliveOnUnmountRef.current) {
+            const entry = keepAliveRegistry.get(currentAccountId);
+            entry?.storeUnsubscribe?.();
+            keepAliveRegistry.delete(currentAccountId);
+          }
+          isSyncingRef.current = false;
+          if (isMountedRef.current) {
             setIsSyncing(false);
           }
-        },
-      });
+        }
+      },
+    });
+    if (!sub.closed) {
+      subscriptionRef.current = sub;
+      // Store the live subscription in the registry so stop() can cancel it
+      // even after this component instance has unmounted.
+      if (keepAliveOnUnmountRef.current) {
+        const entry = keepAliveRegistry.get(currentAccountId);
+        if (entry) entry.sub = sub;
+      }
+    }
   }, [dispatch]);
 
   const start = useCallback(() => {
@@ -98,31 +174,138 @@ export const useAleoPrivateSync = ({
     setProgress(0);
     isSyncingRef.current = true;
     setIsSyncing(true);
+    if (keepAliveOnUnmountRef.current) {
+      const id = accountRef.current?.type === "Account" ? accountRef.current.id : undefined;
+      if (id) {
+        // Subscribe to the Redux store so we can cancel the sync if the account
+        // is deleted while the component is unmounted.
+        const storeUnsubscribe = store.subscribe(() => {
+          const found = accountSelector(store.getState(), { accountId: id });
+          if (!found) {
+            const entry = keepAliveRegistry.get(id);
+            if (entry) {
+              entry.sub?.unsubscribe();
+              entry.storeUnsubscribe?.();
+              keepAliveRegistry.delete(id);
+            }
+          }
+        });
+        keepAliveRegistry.set(id, { isSyncing: true, progress: 0, sub: null, storeUnsubscribe });
+      }
+    }
     runSync();
-  }, [runSync]);
+  }, [runSync, store]);
 
   const stop = useCallback(() => {
     isSyncingRef.current = false;
     if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
     subscriptionRef.current?.unsubscribe();
     subscriptionRef.current = null;
-    setIsSyncing(false);
+    // Also cancel and remove any keep-alive subscription for this account
+    if (keepAliveOnUnmountRef.current) {
+      const id = accountRef.current?.type === "Account" ? accountRef.current.id : undefined;
+      if (id) {
+        const entry = keepAliveRegistry.get(id);
+        entry?.sub?.unsubscribe();
+        entry?.storeUnsubscribe?.();
+        keepAliveRegistry.delete(id);
+      }
+    }
+    if (isMountedRef.current) {
+      setIsSyncing(false);
+    }
+  }, []);
+
+  // Track component mount state so subscription handlers can skip React state
+  // updates after unmount (keepAliveOnUnmount keeps the RxJS sub alive).
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
   }, []);
 
   // Auto-start: kick off on mount; cleanup always runs on unmount.
   useEffect(() => {
     if (autoStart) {
-      isSyncingRef.current = true;
-      setIsSyncing(true);
-      runSync();
+      const registryEntry =
+        keepAliveOnUnmount && accountId ? keepAliveRegistry.get(accountId) : undefined;
+      if (registryEntry?.isSyncing) {
+        // Adopt the already-running keep-alive sync: just observe via
+        // aleoPrivateSyncProgress$ — no new subscription needed.
+        isSyncingRef.current = true;
+        setIsSyncing(true);
+        setProgress(registryEntry.progress);
+      } else {
+        start();
+      }
     }
     return () => {
-      isSyncingRef.current = false;
-      if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
-      subscriptionRef.current?.unsubscribe();
-      subscriptionRef.current = null;
+      if (!keepAliveOnUnmount) stop();
+      // When keepAliveOnUnmount is true we intentionally leave the subscription
+      // alive so the sync can complete in the background.
     };
-  }, [autoStart, runSync]);
+  }, [autoStart, keepAliveOnUnmount, accountId, start, stop]);
+
+  // Subscribe to progress events emitted by the sync observable via the subject.
+  useEffect(() => {
+    if (!accountId) return;
+    const sub = aleoPrivateSyncProgress$
+      .pipe(
+        throttleTime(PROGRESS_THROTTLE_INTERVAL_MS, asyncScheduler, {
+          leading: true,
+          trailing: true,
+        }),
+      )
+      .subscribe(event => {
+        if (event.accountId !== accountId || !isSyncingRef.current || event.progress === null)
+          return;
+        const progress = event.progress;
+        setProgress(prev => Math.max(prev, progress));
+        // Keep registry progress current so a remounting component adopts accurate state.
+        if (keepAliveOnUnmountRef.current) {
+          const entry = keepAliveRegistry.get(accountId);
+          if (entry) entry.progress = Math.max(entry.progress, progress);
+        }
+        // Another hook instance completed the full sync while we were blocked/retrying.
+        // Adopt it as done so we don't fire a redundant second sync.
+        if (event.progress >= 100 && subscriptionRef.current === null) {
+          if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+          isSyncingRef.current = false;
+          setIsSyncing(false);
+          if (keepAliveOnUnmountRef.current) {
+            const entry = keepAliveRegistry.get(accountId);
+            entry?.storeUnsubscribe?.();
+            keepAliveRegistry.delete(accountId);
+          }
+          // By the time this throttled event arrives Redux has already been
+          // updated by the keepAlive instance. Read the ref directly so we
+          // don't depend on a liveAccount re-render that has already fired.
+          const currentLiveAccount = liveAccountRef.current;
+          if (
+            currentLiveAccount &&
+            isAleoAccount(currentLiveAccount) &&
+            currentLiveAccount.aleoResources?.lastPrivateSyncDate
+          ) {
+            onAccountUpdatedRef.current?.(currentLiveAccount);
+          } else {
+            // Rare: Redux hasn't flushed yet — fall back to the liveAccount effect.
+            pendingExternalCompletionRef.current = true;
+          }
+        }
+      });
+    return () => sub.unsubscribe();
+  }, [accountId]);
+
+  // Once Redux reflects the externally-completed sync, propagate the fresh
+  // account to the caller (e.g. the modal's updateAccount).
+  useEffect(() => {
+    if (!pendingExternalCompletionRef.current) return;
+    if (!liveAccount || !isAleoAccount(liveAccount)) return;
+    if (!liveAccount.aleoResources?.lastPrivateSyncDate) return;
+    pendingExternalCompletionRef.current = false;
+    onAccountUpdatedRef.current?.(liveAccount);
+  }, [liveAccount]);
 
   return { isSyncing, progress, error, start, stop };
 };

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepMandatoryPrivateSync.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/modals/send/steps/StepMandatoryPrivateSync.test.tsx
@@ -162,7 +162,7 @@ describe("StepMandatoryPrivateSync", () => {
       });
 
       // No crash — updateAccount being optional is handled gracefully
-      expect(screen.getByText(/30%/)).toBeInTheDocument();
+      expect(screen.getByText(/Syncing your private balance/)).toBeInTheDocument();
     });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/bridge/privateSyncProgress.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/privateSyncProgress.ts
@@ -1,0 +1,13 @@
+// This module defines a Subject that emits events related to the progress of private synchronization for Aleo accounts.
+// Each event includes the account ID and the current progress percentage (or null if progress is not available).
+// This allows different parts of the application to subscribe to these events and react accordingly,
+// such as updating UI components or triggering other actions based on the synchronization status of Aleo accounts.
+
+import { Subject } from "rxjs";
+
+export interface AleoPrivateSyncProgressEvent {
+  accountId: string;
+  progress: number | null;
+}
+
+export const aleoPrivateSyncProgress$ = new Subject<AleoPrivateSyncProgressEvent>();

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
@@ -1067,7 +1067,7 @@ describe("sync.ts", () => {
       expect(emissions[0].aleoResources?.provableApi).toBeNull();
     });
 
-    it("private-only sync (SYNC_TYPE_SHIELDED) emits a progress update when scanner is configured but not fully synced", async () => {
+    it("private-only sync (SYNC_TYPE_SHIELDED) emits zero values when scanner is configured but not fully synced", async () => {
       // Account with provableApi already configured (has aleoResources)
       const accountWithProvableApi: AleoAccount = {
         ...getMockedAccount(),
@@ -1094,13 +1094,8 @@ describe("sync.ts", () => {
 
       expect(syncs).toHaveLength(1);
       const emissions = await collectAll(syncs[0]);
-      // Should emit exactly one partial update carrying the refreshed provableApi
-      expect(emissions).toHaveLength(1);
-      expect(emissions[0].aleoResources?.provableApi?.scannerStatus?.percentage).toBe(75);
-      expect(emissions[0].aleoResources?.provableApi?.scannerStatus?.synced).toBe(false);
-      // operations are preserved so makeSync (shouldMergeOps: false) does not wipe them
-      expect(emissions[0].operations).toEqual(accountWithProvableApi.operations);
-      expect(emissions[0].balance).toBeUndefined();
+      // performPrivateSync returns null when scanner is not ready → no subscriber.next call
+      expect(emissions).toHaveLength(0);
     });
 
     it("combined sync (SYNC_TYPE_TRANSPARENT | SYNC_TYPE_SHIELDED) does NOT emit progress when scanner is not ready", async () => {
@@ -1147,6 +1142,11 @@ describe("sync.ts", () => {
     it("should handle undefined operations in private-only sync path", async () => {
       const accountWithNoOps = { ...mockInitialAccount, operations: undefined as any };
 
+      mockAccessProvableApi.mockResolvedValue({
+        ...mockAleoResources.provableApi!,
+        scannerStatus: { percentage: 100, synced: true },
+      });
+
       const { syncs } = buildSyncObservables(
         { ...baseInfo, initialAccount: accountWithNoOps },
         { paginationConfig: {}, syncType: SYNC_TYPE_SHIELDED },
@@ -1168,7 +1168,19 @@ describe("sync.ts", () => {
         unspentRecords: [],
       });
 
-      const { syncs } = buildSyncObservables(baseInfo, {
+      // Combined sync only runs private when account has been synced before (lastPrivateSyncDate set)
+      const syncedBaseInfo = {
+        ...baseInfo,
+        initialAccount: {
+          ...mockInitialAccount,
+          aleoResources: {
+            ...mockInitialAccount.aleoResources!,
+            lastPrivateSyncDate: new Date("2024-01-01"),
+          },
+        },
+      };
+
+      const { syncs } = buildSyncObservables(syncedBaseInfo, {
         paginationConfig: {},
         syncType: SYNC_TYPE_TRANSPARENT | SYNC_TYPE_SHIELDED,
       });
@@ -1176,8 +1188,7 @@ describe("sync.ts", () => {
       expect(syncs).toHaveLength(1);
       const [first, second] = await collectAll(syncs[0]);
 
-      // first emission: public result (no lastPrivateSyncDate yet)
-      expect(first.aleoResources?.lastPrivateSyncDate).toBeNull();
+      // first emission: public result
       expect(first.blockHeight).toBe(100);
 
       // second emission: private result (has lastPrivateSyncDate, updated balance)
@@ -1218,10 +1229,22 @@ describe("sync.ts", () => {
       // Make one of the private sub-calls throw
       mockFetchAllOwnedRecords.mockRejectedValue(new Error("Scanner unavailable"));
 
-      const shape$ = makeGetAccountShape()(
-        { ...baseInfo },
-        { paginationConfig: {}, syncType: SYNC_TYPE_TRANSPARENT | SYNC_TYPE_SHIELDED },
-      );
+      // Combined sync only runs private when account has been privately synced before
+      const infoWithSyncedAccount = {
+        ...baseInfo,
+        initialAccount: {
+          ...mockInitialAccount,
+          aleoResources: {
+            ...mockInitialAccount.aleoResources!,
+            lastPrivateSyncDate: new Date("2024-01-01"),
+          },
+        },
+      };
+
+      const shape$ = makeGetAccountShape()(infoWithSyncedAccount, {
+        paginationConfig: {},
+        syncType: SYNC_TYPE_TRANSPARENT | SYNC_TYPE_SHIELDED,
+      });
 
       const emissions: Partial<AleoAccount>[] = [];
       await expect(

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -19,7 +19,14 @@ import {
   isRecordScannerReady,
   splitPrivateAndPublicOperations,
 } from "../logic/utils";
+import { aleoPrivateSyncProgress$ } from "./privateSyncProgress";
 import { accessProvableApi, fetchAllOwnedRecords, patchPublicOperations } from "../network/utils";
+import {
+  PROGRESS_AFTER_SCANNER,
+  PROGRESS_AFTER_LIST_OPS,
+  PROGRESS_AFTER_PARSING_RECORDS,
+  PROGRESS_DONE,
+} from "../constants";
 import type {
   AleoAccount,
   AleoOperation,
@@ -28,6 +35,8 @@ import type {
 } from "../types";
 import { getPrivateBalance } from "../logic/getPrivateBalance";
 import { listPrivateOperations } from "../logic/listPrivateOperations";
+
+const privateSyncInFlight = new Set<string>();
 
 /**
  * Performs the public (transparent) portion of the Aleo account sync.
@@ -62,12 +71,12 @@ export async function performPublicSync(
   const transparentBalance = new BigNumber(nativeBalance.toString());
 
   const shouldSyncFromScratch = !initialAccount;
-  const allOldOperations = shouldSyncFromScratch ? [] : (initialAccount?.operations ?? []);
+  const allOldOperations = shouldSyncFromScratch ? [] : initialAccount?.operations ?? [];
 
   // Keep public and private ops separate so each cursor is derived from the correct op type.
   // Mixing them risks using a private op's blockHeight as the public sync cursor.
   const [oldPrivateOps, oldPublicOps] = splitPrivateAndPublicOperations(allOldOperations);
-  const lastBlockHeight = shouldSyncFromScratch ? 0 : (oldPublicOps[0]?.blockHeight ?? 0);
+  const lastBlockHeight = shouldSyncFromScratch ? 0 : oldPublicOps[0]?.blockHeight ?? 0;
 
   const latestAccountPublicOperations = await listOperations({
     currency,
@@ -158,7 +167,8 @@ export async function performPrivateSync(
   _syncConfig: SyncConfig,
   currentPublicOps: AleoOperation[],
   freshTransparentBalance?: BigNumber,
-  emitProgressUpdates?: boolean,
+  onProgress?: (progress: number) => void,
+  signal?: AbortSignal,
 ): Promise<Partial<AleoAccount> | null> {
   const { initialAccount, address, derivationMode, currency } = info;
   invariant(initialAccount, "aleo: performPrivateSync requires initialAccount");
@@ -190,20 +200,18 @@ export async function performPrivateSync(
     throw err;
   });
 
+  const freshScannerStatus = provableApi?.scannerStatus;
+
   if (!isProvableApiConfigured(provableApi)) {
     throw new AleoApiConfigurationResetError();
   }
 
+  signal?.throwIfAborted();
+
   if (!isRecordScannerReady(provableApi)) {
-    if (emitProgressUpdates && initialAccount.aleoResources) {
-      return {
-        operations: initialAccount.operations,
-        operationsCount: initialAccount.operationsCount,
-        aleoResources: {
-          ...initialAccount.aleoResources,
-          provableApi,
-        },
-      };
+    if (onProgress) {
+      const scannerPct = freshScannerStatus?.percentage ?? 0;
+      onProgress(Math.round(scannerPct * (PROGRESS_AFTER_SCANNER / 100)));
     }
     return null;
   }
@@ -229,13 +237,20 @@ export async function performPrivateSync(
       currency,
       uuid: provableApi.uuid,
       start: lastPrivateBlockHeight,
+      ...(signal && { signal }),
     }),
     fetchAllOwnedRecords({
       currency,
       uuid: provableApi.uuid,
       unspent: true,
+      ...(signal && { signal }),
     }),
   ]);
+
+  signal?.throwIfAborted();
+
+  // Emits PROGRESS_AFTER_SCANNER% progress when all records are fetched
+  onProgress?.(PROGRESS_AFTER_SCANNER);
 
   const [latestAccountPrivateOperations, patchedPublicOperations] = await Promise.all([
     listPrivateOperations({
@@ -244,6 +259,18 @@ export async function performPrivateSync(
       address,
       ledgerAccountId,
       privateRecords: rawNewPrivateRecords,
+      ...(onProgress
+        ? {
+            onProgress: (completed: number, total: number) =>
+              onProgress(
+                PROGRESS_AFTER_SCANNER +
+                  Math.round(
+                    (completed / total) * (PROGRESS_AFTER_LIST_OPS - PROGRESS_AFTER_SCANNER),
+                  ),
+              ),
+          }
+        : {}),
+      ...(signal && { signal }),
     }),
     patchPublicOperations({
       currency,
@@ -263,11 +290,23 @@ export async function performPrivateSync(
     record => !latestAccountPrivateOperations.consumedRecordTags.has(record.tag),
   );
 
+  signal?.throwIfAborted();
+
   const privateBalanceResult = await getPrivateBalance({
     currency,
     viewKey,
     privateRecords: filteredUnspentRecords,
     oldUnspentRecords: initialAccount.aleoResources?.unspentPrivateRecords ?? [],
+    ...(onProgress
+      ? {
+          onProgress: (completed: number, total: number) =>
+            onProgress(
+              PROGRESS_AFTER_LIST_OPS +
+                Math.round((completed / total) * PROGRESS_AFTER_PARSING_RECORDS),
+            ),
+        }
+      : {}),
+    ...(signal && { signal }),
   });
   const privateBalance = privateBalanceResult.balance;
   const unspentPrivateRecords: AleoUnspentRecord[] = privateBalanceResult.unspentRecords;
@@ -293,6 +332,8 @@ export async function performPrivateSync(
     privateBalance: privateBalance.toString(),
   });
 
+  onProgress?.(PROGRESS_DONE);
+
   return {
     type: "Account",
     id: ledgerAccountId,
@@ -317,14 +358,42 @@ export function createPrivateSyncObservable(
   syncConfig: SyncConfig,
   publicOps: AleoOperation[],
   freshTransparentBalance?: BigNumber,
-  emitProgressUpdates?: boolean,
 ): Observable<Partial<AleoAccount>> {
   const { initialAccount } = info;
   const currencyId = info.currency.id;
+  const lockKey = `${info.currency.id}:${info.address}`;
   log("aleo/createPrivateSyncObservable", `Initiating private sync for ${currencyId}`);
   return new Observable<Partial<AleoAccount>>(subscriber => {
-    performPrivateSync(info, syncConfig, publicOps, freshTransparentBalance, emitProgressUpdates)
+    if (privateSyncInFlight.has(lockKey)) {
+      log(
+        "aleo/createPrivateSyncObservable",
+        `Private sync already in flight for ${currencyId}, skipping duplicate`,
+      );
+      subscriber.complete();
+      return;
+    }
+    privateSyncInFlight.add(lockKey);
+    const releaseLock = () => privateSyncInFlight.delete(lockKey);
+
+    const controller = new AbortController();
+
+    const accountId = initialAccount?.id;
+    const onProgress = accountId
+      ? (progress: number) => {
+          aleoPrivateSyncProgress$.next({ accountId, progress });
+        }
+      : undefined;
+
+    performPrivateSync(
+      info,
+      syncConfig,
+      publicOps,
+      freshTransparentBalance,
+      onProgress,
+      controller.signal,
+    )
       .then(result => {
+        releaseLock();
         if (result) {
           log("aleo/createPrivateSyncObservable", `Private sync completed for ${currencyId}`, {
             operationsCount: result.operationsCount,
@@ -339,6 +408,8 @@ export function createPrivateSyncObservable(
         subscriber.complete();
       })
       .catch(err => {
+        releaseLock();
+
         if (err instanceof AleoApiConfigurationResetError && initialAccount?.aleoResources) {
           // set `provableApi` to null before surfacing the error so the next sync cycle starts fresh re-registration
           subscriber.next({
@@ -351,11 +422,21 @@ export function createPrivateSyncObservable(
           });
         }
 
+        if (err instanceof Error && err.name === "AbortError") {
+          log("aleo/createPrivateSyncObservable", `Private sync aborted for ${currencyId}`);
+          subscriber.complete();
+          return;
+        }
         log("aleo/createPrivateSyncObservable", `Private sync error for ${currencyId}`, {
           error: err.message,
         });
         subscriber.error(err);
       });
+
+    return () => {
+      controller.abort();
+      releaseLock();
+    };
   });
 }
 
@@ -368,6 +449,10 @@ export function createPrivateSyncObservable(
  *
  * When only one sync type is requested a single observable is returned for
  * that type.
+ *
+ * Background combined syncs (public + private) only include the private step
+ * if the account has been privately synced at least once before
+ * (`lastPrivateSyncDate` is set).
  */
 export function buildSyncObservables(
   info: AccountShapeInfo<AleoAccount>,
@@ -382,9 +467,12 @@ export function buildSyncObservables(
   const isPublicSync = !!(syncType & SYNC_TYPE_TRANSPARENT);
   const isPrivateSync = !!(syncType & SYNC_TYPE_SHIELDED) && privateEnabled;
 
+  const hasPrivateSyncedBefore = !!initialAccount?.aleoResources?.lastPrivateSyncDate;
+  const shouldRunPrivate = isPrivateSync && (hasPrivateSyncedBefore || !isPublicSync);
+
   const syncs: Observable<Partial<AleoAccount>>[] = [];
 
-  if (isPublicSync && isPrivateSync) {
+  if (isPublicSync && shouldRunPrivate) {
     syncs.push(
       createPublicSyncObservable(info, syncConfig).pipe(
         concatMap(publicResult =>
@@ -405,17 +493,9 @@ export function buildSyncObservables(
     );
   } else if (isPublicSync) {
     syncs.push(createPublicSyncObservable(info, syncConfig));
-  } else if (isPrivateSync) {
+  } else if (shouldRunPrivate) {
     const [, initialPublicOps] = splitPrivateAndPublicOperations(initialAccount?.operations ?? []);
-    syncs.push(
-      createPrivateSyncObservable(
-        info,
-        syncConfig,
-        initialPublicOps as AleoOperation[],
-        undefined,
-        true,
-      ),
-    );
+    syncs.push(createPrivateSyncObservable(info, syncConfig, initialPublicOps as AleoOperation[]));
   }
 
   return { syncs, syncType };

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -23,3 +23,17 @@ export const AMOUNT_ARG_INDEX = 2;
 
 // The maximum amount of records to fetch in a single API call when fetching owned records. This is not a limit on the total number of records that can be fetched, but rather a pagination parameter for the API calls.
 export const DEFAULT_RECORDS_PAGE_SIZE = 1000;
+
+/**
+ * Progress phase boundaries for private sync.
+ *
+ * Phase 1 (PROGRESS_AFTER_SCANNER):          0 → 30   — record scanner / fetch stage
+ * Phase 2 (PROGRESS_AFTER_LIST_OPS):        30 → 65   — listing / decoding private operations (35 pts)
+ * Phase 3 (PROGRESS_AFTER_PARSING_RECORDS): 65 → 95   — parsing records / computing private balance (30 pts)
+ * Done:                                        100
+ */
+export const PROGRESS_AFTER_SCANNER = 30;
+export const PROGRESS_AFTER_LIST_OPS = PROGRESS_AFTER_SCANNER + 35; // 65
+export const PROGRESS_AFTER_PARSING_RECORDS = 30; // 65 → 95
+export const PROGRESS_DONE = 100;
+export const PROGRESS_THROTTLE_MIN_STEP = 5;

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.test.ts
@@ -240,4 +240,49 @@ describe("getPrivateBalance", () => {
     expect(balance).toEqual(new BigNumber(0));
     expect(unspentRecords).toEqual([]);
   });
+
+  it("should call onProgress after each decrypted record", async () => {
+    const record1 = { ...testnetPrivateRecord, commitment: "c1" };
+    const record2 = { ...testnetPrivateRecord, commitment: "c2" };
+
+    jest
+      .mocked(sdkClient.decryptRecord)
+      .mockResolvedValueOnce({
+        ...mockDecryptedRecord,
+        data: { microcredits: "100000u64.private" },
+      })
+      .mockResolvedValueOnce({
+        ...mockDecryptedRecord,
+        data: { microcredits: "200000u64.private" },
+      });
+
+    const onProgress = jest.fn();
+
+    await getPrivateBalance({
+      currency: mockCurrency,
+      viewKey: mockViewKey,
+      privateRecords: [record1, record2],
+      oldUnspentRecords: [],
+      onProgress,
+    });
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenNthCalledWith(1, 1, 2);
+    expect(onProgress).toHaveBeenNthCalledWith(2, 2, 2);
+  });
+
+  it("should throw AbortError when signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      getPrivateBalance({
+        currency: mockCurrency,
+        viewKey: mockViewKey,
+        privateRecords: [testnetPrivateRecord],
+        oldUnspentRecords: [],
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+  });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.test.ts
@@ -283,6 +283,6 @@ describe("getPrivateBalance", () => {
         oldUnspentRecords: [],
         signal: controller.signal,
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ name: "AbortError" });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.ts
@@ -11,11 +11,15 @@ export async function getPrivateBalance({
   viewKey,
   privateRecords,
   oldUnspentRecords,
+  onProgress,
+  signal,
 }: {
   currency: CryptoCurrency;
   viewKey: string;
   privateRecords: AleoPrivateRecord[];
   oldUnspentRecords: AleoUnspentRecord[];
+  onProgress?: (completed: number, total: number) => void;
+  signal?: AbortSignal;
 }): Promise<{
   balance: BigNumber;
   unspentRecords: AleoUnspentRecord[];
@@ -25,31 +29,37 @@ export async function getPrivateBalance({
     record => record.program_name === PROGRAM_ID.CREDITS && !record.spent,
   );
 
+  let completed = 0;
   const decryptedResults = await promiseAllBatched(2, unspentCreditsRecords, async record => {
+    signal?.throwIfAborted();
     const cachedRecord = recordByCiphertext.get(record.record_ciphertext);
 
+    let result: { microcredits: string; unspentRecord: AleoUnspentRecord };
     if (cachedRecord) {
-      return {
+      result = {
         microcredits: cachedRecord.microcredits,
         unspentRecord: cachedRecord,
       };
+    } else {
+      const decryptedRecord = await sdkClient.decryptRecord({
+        currency,
+        viewKey,
+        ciphertext: record.record_ciphertext,
+      });
+      const microcredits = parseMicrocredits(decryptedRecord.data.microcredits);
+
+      result = {
+        microcredits,
+        unspentRecord: {
+          ...record,
+          microcredits,
+          decryptedData: decryptedRecord,
+        },
+      };
     }
 
-    const decryptedRecord = await sdkClient.decryptRecord({
-      currency,
-      viewKey,
-      ciphertext: record.record_ciphertext,
-    });
-    const microcredits = parseMicrocredits(decryptedRecord.data.microcredits);
-
-    return {
-      microcredits,
-      unspentRecord: {
-        ...record,
-        microcredits,
-        decryptedData: decryptedRecord,
-      },
-    };
+    onProgress?.(++completed, unspentCreditsRecords.length);
+    return result;
   });
 
   const balance = decryptedResults.reduce((acc, { microcredits }) => {

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
@@ -398,4 +398,60 @@ describe("listPrivateOperations", () => {
 
     expect(result.consumedRecordTags).toEqual(new Set());
   });
+
+  it("should call onProgress after each enriched record", async () => {
+    const records = [
+      getMockedRecord({
+        transaction_id: "tx1",
+        program_name: PROGRAM_ID.CREDITS,
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+      }),
+      getMockedRecord({
+        transaction_id: "tx2",
+        program_name: PROGRAM_ID.CREDITS,
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+      }),
+    ];
+
+    mockEnrichPrivateRecord
+      .mockResolvedValueOnce(getMockedEnrichedPrivateRecord({ rawRecord: records[0] }))
+      .mockResolvedValueOnce(getMockedEnrichedPrivateRecord({ rawRecord: records[1] }));
+    mockToPrivateBridgeOperation.mockReturnValue(getMockedOperation());
+
+    const onProgress = jest.fn();
+
+    await listPrivateOperations({
+      currency: mockCurrency,
+      viewKey: mockViewKey,
+      address: mockAddress,
+      ledgerAccountId: mockLedgerAccountId,
+      privateRecords: records,
+      onProgress,
+    });
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenNthCalledWith(1, 1, 2);
+    expect(onProgress).toHaveBeenNthCalledWith(2, 2, 2);
+  });
+
+  it("should throw AbortError when signal is already aborted before processing", async () => {
+    const record = getMockedRecord({
+      program_name: PROGRAM_ID.CREDITS,
+      function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      listPrivateOperations({
+        currency: mockCurrency,
+        viewKey: mockViewKey,
+        address: mockAddress,
+        ledgerAccountId: mockLedgerAccountId,
+        privateRecords: [record],
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+  });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
@@ -452,6 +452,6 @@ describe("listPrivateOperations", () => {
         privateRecords: [record],
         signal: controller.signal,
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ name: "AbortError" });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
@@ -21,20 +21,29 @@ export async function listPrivateOperations({
   address,
   ledgerAccountId,
   privateRecords,
+  onProgress,
+  signal,
 }: {
   currency: CryptoCurrency;
   viewKey: string;
   address: string;
   ledgerAccountId: string;
   privateRecords: AleoPrivateRecord[];
+  onProgress?: (completed: number, total: number) => void;
+  signal?: AbortSignal;
 }): Promise<{
   operations: AleoOperation[];
   consumedRecordTags: Set<string>;
 }> {
   const consumedRecordTags = new Set<string>();
-  const enrichedRecords = await promiseAllBatched(2, privateRecords, rawRecord =>
-    enrichPrivateRecord({ currency, rawRecord, address, viewKey }),
-  );
+
+  let completed = 0;
+  const enrichedRecords = await promiseAllBatched(2, privateRecords, async rawRecord => {
+    signal?.throwIfAborted();
+    const result = await enrichPrivateRecord({ currency, rawRecord, address, viewKey });
+    onProgress?.(++completed, privateRecords.length);
+    return result;
+  });
 
   // Build the set of record tags consumed as inputs in outgoing transactions.
   // This is used to compensate for the record scanner returning already-spent records as unspent.

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -279,7 +279,7 @@ export function calculateAmount({
 
 export const isProvableApiConfigured = (
   provableApi: ProvableApi | null,
-): provableApi is Required<Pick<ProvableApi, "uuid">> => {
+): provableApi is ProvableApi & { uuid: string } => {
   return !!provableApi?.uuid;
 };
 

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -1690,7 +1690,7 @@ describe("network/utils", () => {
           uuid: mockUUID,
           signal: controller.signal,
         }),
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({ name: "AbortError" });
 
       expect(mockGetAccountOwnedRecords).not.toHaveBeenCalled();
     });

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -1679,5 +1679,20 @@ describe("network/utils", () => {
         }),
       ).rejects.toThrow("Scanner unavailable");
     });
+
+    it("should throw AbortError when signal is aborted before the first page request", async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        fetchAllOwnedRecords({
+          currency: mockCurrency,
+          uuid: mockUUID,
+          signal: controller.signal,
+        }),
+      ).rejects.toThrow();
+
+      expect(mockGetAccountOwnedRecords).not.toHaveBeenCalled();
+    });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -133,18 +133,21 @@ export async function fetchAllOwnedRecords({
   unspent,
   start,
   resultsPerPage = DEFAULT_RECORDS_PAGE_SIZE,
+  signal,
 }: {
   currency: CryptoCurrency;
   uuid: string;
   unspent?: boolean;
   start?: number;
   resultsPerPage?: number;
+  signal?: AbortSignal;
 }): Promise<AleoPrivateRecord[]> {
   const allRecords: AleoPrivateRecord[] = [];
   let page = 0;
   let hasMore = true;
 
   while (hasMore) {
+    signal?.throwIfAborted();
     const records = await apiClient.getAccountOwnedRecords({
       currency,
       uuid,

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -437,6 +437,7 @@
     "src/families/aleo/hw/getViewKey/index.ts",
     "src/families/aleo/types.ts",
     "src/families/aleo/utils.ts",
+    "src/families/aleo/privateSyncProgress.ts",
     "src/families/algorand/descriptor/index.ts",
     "src/families/algorand/descriptor/memo.ts",
     "src/families/aptos/config.ts",

--- a/libs/ledger-live-common/src/families/aleo/privateSyncProgress.ts
+++ b/libs/ledger-live-common/src/families/aleo/privateSyncProgress.ts
@@ -1,0 +1,1 @@
+export * from "@ledgerhq/coin-aleo/bridge/privateSyncProgress";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - improvement to private sync progress

### 📝 Description

- Background sync no longer triggers private sync for an account if the user hasn’t performed a private sync after entering that account. If the user hasn’t opened the account yet, background sync (triggered via the “Synchronize” button at the top or at intervals) will only start performing private sync once the account has already been synchronized at least once. This prevents situations where the user sees a spinning button immediately after adding an Aleo account, even though they haven’t opened it yet and sync was triggered for another account. It also significantly reduces app load right after adding Aleo to the account list.

- When a newly added account is opened for the first time, private sync for that account starts automatically.

- Exiting an account while private sync is in progress does not stop the sync. Stopping the sync is only possible by pressing the “Stop Sync” button or if sync has been synchronized at least one, by closing self transfer / send modals before mandatory private sync step ends. 

- The sync button and the mandatory private sync step now display the current sync progress percentage according to the following scheme:

  1. Phase 1 (PROGRESS_AFTER_SCANNER): 0 → 30 - record scanner / fetch stage
  2. Phase 2 (PROGRESS_AFTER_LIST_OPS): 30 → 65 - listing / decoding private operations (35 pts)
  3. Phase 3 (PROGRESS_AFTER_PARSING_RECORDS): 65 → 95 - parsing records / computing private balance (30 pts)
  4. Done: 100

- If the user manually starts a sync, or if it is automatically triggered for them via the autostart in button, then upon entering the send or self-transfer process, the mandatory private sync step will show the progress of the already running sync.

- Stopping the sync via the button stops its execution in the background; requests are aborted.

- Stopping the sync by closing the modal during mandatory private sync step stops its execution in the background; requests are aborted (only if there is no private sync already in progress triggered by pressing the button).

- Sync progress is now throttled to improve application performance for accounts with a very large number of records; the update interval is 500 ms.

- It is no longer possible to run private sync concurrently across multiple processes, which prevents additional load on the application.

- Deleting an account interrupts the private sync for that account; no unnecessary requests are executed.

Auto start: 
<img width="1228" height="832" alt="Screenshot from 2026-04-22 13-44-12" src="https://github.com/user-attachments/assets/ae92e692-f545-45b7-9da6-2fc2c83c7013" />

Shared progress: 

<img width="1229" height="848" alt="Screenshot from 2026-04-22 13-44-48" src="https://github.com/user-attachments/assets/15fd9809-7125-4d0c-83fe-67f5f0780a5e" />

<img width="1229" height="848" alt="Screenshot from 2026-04-22 13-44-52" src="https://github.com/user-attachments/assets/c8211efa-b9bc-4fd0-8d8f-176573675c89" />


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [https://ledgerhq.atlassian.net/browse/LIVE-29150](https://ledgerhq.atlassian.net/browse/LIVE-29150)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
