### PR TITLE
fix(wallet-cli): normalize device state handling across commands [LIVE-28257]

### DIFF
--- a/.changeset/steady-devices-classify.md
+++ b/.changeset/steady-devices-classify.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Improve wallet-cli device state handling and output consistency

--- a/apps/wallet-cli/.bunli/commands.gen.ts
+++ b/apps/wallet-cli/.bunli/commands.gen.ts
@@ -46,7 +46,8 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
           description: 'Discover accounts for a network on the connected device',
           options: {
             'network': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Network to scan, e.g. "bitcoin", "ethereum", "ethereum:goerli" (or first positional arg). No env = mainnet.', short: 'n', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-            'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+            'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+            'device-timeout': { type: 'z.coerce.number.int.positive.default', required: true, hasDefault: true, default: 60000, schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1480,"end":1486,"loc":{"start":{"line":36,"column":85,"index":1480},"end":{"line":36,"column":91,"index":1486}},"extra":{"rawValue":60000,"raw":"60_000"},"value":60000}}]}, validator: '(val) => true' }
           },
           path: './src/commands/account/discover'
         },
@@ -55,7 +56,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
           description: 'Resolve the fresh receive address for an account descriptor (no device required)',
           options: {
             'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor or session label (e.g. ethereum-1). Can also be the first positional arg.', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-            'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+            'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' }
           },
           path: './src/commands/account/fresh-address'
         }
@@ -67,7 +68,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       description: 'Fetch native and token balances for an account descriptor (no device required)',
       options: {
         'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor or session label (e.g. ethereum-1). Can also be the first positional arg.', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-        'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+        'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' }
       },
       path: './src/commands/balances'
     },
@@ -76,7 +77,8 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       description: 'Discover accounts for a network on the connected device',
       options: {
         'network': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Network to scan, e.g. "bitcoin", "ethereum", "ethereum:goerli" (or first positional arg). No env = mainnet.', short: 'n', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-        'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+        'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+        'device-timeout': { type: 'z.coerce.number.int.positive.default', required: true, hasDefault: true, default: 60000, schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1480,"end":1486,"loc":{"start":{"line":36,"column":85,"index":1480},"end":{"line":36,"column":91,"index":1486}},"extra":{"rawValue":60000,"raw":"60_000"},"value":60000}}]}, validator: '(val) => true' }
       },
       path: './src/commands/account/discover'
     },
@@ -85,7 +87,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       description: 'Resolve the fresh receive address for an account descriptor (no device required)',
       options: {
         'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor or session label (e.g. ethereum-1). Can also be the first positional arg.', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-        'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+        'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' }
       },
       path: './src/commands/account/fresh-address'
     },
@@ -96,7 +98,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
         'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor or session label (e.g. ethereum-1). Can also be the first positional arg.', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'limit': { type: 'z.coerce.number.int.min.optional', required: false, hasDefault: false, description: 'Max number of operations to return (Alpaca families only)', short: 'l', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'cursor': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Pagination cursor from a previous call\'s nextCursor (Alpaca families only)', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-        'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+        'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' }
       },
       path: './src/commands/operations'
     },
@@ -104,12 +106,12 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       name: 'quote',
       description: 'Fetch swap quotes',
       options: {
-        'from': { type: 'z.string.min', required: true, hasDefault: false, description: 'Source currency ID', short: 'f', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":571,"end":572,"loc":{"start":{"line":15,"column":32,"index":571},"end":{"line":15,"column":33,"index":572}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Source currency is required"}]}, validator: '(val) => true' },
-        'to': { type: 'z.string.min', required: true, hasDefault: false, description: 'Destination currency ID', short: 't', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":705,"end":706,"loc":{"start":{"line":19,"column":30,"index":705},"end":{"line":19,"column":31,"index":706}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Destination currency is required"}]}, validator: '(val) => true' },
-        'from-fresh-address': { type: 'z.string.min', required: true, hasDefault: false, description: 'Source account fresh receive address is required', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":867,"end":868,"loc":{"start":{"line":23,"column":48,"index":867},"end":{"line":23,"column":49,"index":868}},"extra":{"rawValue":1,"raw":"1"},"value":1}}]}, validator: '(val) => true' },
-        'to-fresh-address': { type: 'z.string.min', required: true, hasDefault: false, description: 'Destination account fresh receive address is required', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":998,"end":999,"loc":{"start":{"line":26,"column":46,"index":998},"end":{"line":26,"column":47,"index":999}},"extra":{"rawValue":1,"raw":"1"},"value":1}}]}, validator: '(val) => true' },
-        'amount': { type: 'z.string.min', required: true, hasDefault: false, description: 'Amount to swap in source currency', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1122,"end":1123,"loc":{"start":{"line":29,"column":34,"index":1122},"end":{"line":29,"column":35,"index":1123}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Amount is required"}]}, validator: '(val) => true' },
-        'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+        'from': { type: 'z.string.min', required: true, hasDefault: false, description: 'Source currency ID', short: 'f', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":592,"end":593,"loc":{"start":{"line":15,"column":32,"index":592},"end":{"line":15,"column":33,"index":593}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Source currency is required"}]}, validator: '(val) => true' },
+        'to': { type: 'z.string.min', required: true, hasDefault: false, description: 'Destination currency ID', short: 't', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":726,"end":727,"loc":{"start":{"line":19,"column":30,"index":726},"end":{"line":19,"column":31,"index":727}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Destination currency is required"}]}, validator: '(val) => true' },
+        'from-fresh-address': { type: 'z.string.min', required: true, hasDefault: false, description: 'Source account fresh receive address is required', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":888,"end":889,"loc":{"start":{"line":23,"column":48,"index":888},"end":{"line":23,"column":49,"index":889}},"extra":{"rawValue":1,"raw":"1"},"value":1}}]}, validator: '(val) => true' },
+        'to-fresh-address': { type: 'z.string.min', required: true, hasDefault: false, description: 'Destination account fresh receive address is required', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1019,"end":1020,"loc":{"start":{"line":26,"column":46,"index":1019},"end":{"line":26,"column":47,"index":1020}},"extra":{"rawValue":1,"raw":"1"},"value":1}}]}, validator: '(val) => true' },
+        'amount': { type: 'z.string.min', required: true, hasDefault: false, description: 'Amount to swap in source currency', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1143,"end":1144,"loc":{"start":{"line":29,"column":34,"index":1143},"end":{"line":29,"column":35,"index":1144}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Amount is required"}]}, validator: '(val) => true' },
+        'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' }
       },
       path: './src/commands/swap/quote'
     },
@@ -118,8 +120,9 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       description: 'Get receive address for an account (optionally verify on device)',
       options: {
         'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor or session label (e.g. ethereum-1). Can also be the first positional arg.', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-        'verify': { type: 'z.boolean.default', required: true, hasDefault: true, default: true, description: 'Verify address on device screen (default: true). Use --verify=false to skip device.', short: 'v', schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"BooleanLiteral","start":754,"end":758,"loc":{"start":{"line":16,"column":39,"index":754},"end":{"line":16,"column":43,"index":758}},"value":true}}]}, validator: '(val) => true' },
-        'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+        'verify': { type: 'z.boolean.default', required: true, hasDefault: true, default: true, description: 'Verify address on device screen (default: true). Use --verify=false to skip device.', short: 'v', schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"BooleanLiteral","start":920,"end":924,"loc":{"start":{"line":27,"column":39,"index":920},"end":{"line":27,"column":43,"index":924}},"value":true}}]}, validator: '(val) => true' },
+        'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+        'device-timeout': { type: 'z.coerce.number.int.positive.default', required: true, hasDefault: true, default: 60000, schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1480,"end":1486,"loc":{"start":{"line":36,"column":85,"index":1480},"end":{"line":36,"column":91,"index":1486}},"extra":{"rawValue":60000,"raw":"60_000"},"value":60000}}]}, validator: '(val) => true' }
       },
       path: './src/commands/receive'
     },
@@ -127,7 +130,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       name: 'reset',
       description: 'Wipe all accounts from the current session',
       options: {
-        'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+        'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' }
       },
       path: './src/commands/session/reset'
     },
@@ -136,8 +139,8 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       description: 'Sign and broadcast a transaction (bridge only, no Alpaca)',
       options: {
         'account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Account descriptor or session label (e.g. ethereum-1). Can also be the first positional arg.', short: 'a', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-        'to': { type: 'z.string.min', required: true, hasDefault: false, description: 'Recipient address', short: 't', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1861,"end":1862,"loc":{"start":{"line":62,"column":30,"index":1861},"end":{"line":62,"column":31,"index":1862}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Recipient address is required (--to <address>)"}]}, validator: '(val) => true' },
-        'amount': { type: 'z.string.min', required: true, hasDefault: false, description: 'Amount including ticker, e.g. \'0.001 BTC\', \'0.01 ETH\', \'0.4 USDT\'', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":2024,"end":2025,"loc":{"start":{"line":67,"column":21,"index":2024},"end":{"line":67,"column":22,"index":2025}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Amount is required (--amount '<value> <TICKER>', e.g. '0.01 ETH')"}]}, validator: '(val) => true' },
+        'to': { type: 'z.string.min', required: true, hasDefault: false, description: 'Recipient address', short: 't', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":4273,"end":4274,"loc":{"start":{"line":151,"column":30,"index":4273},"end":{"line":151,"column":31,"index":4274}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Recipient address is required (--to <address>)"}]}, validator: '(val) => true' },
+        'amount': { type: 'z.string.min', required: true, hasDefault: false, description: 'Amount including ticker, e.g. \'0.001 BTC\', \'0.01 ETH\', \'0.4 USDT\'', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":4436,"end":4437,"loc":{"start":{"line":156,"column":21,"index":4436},"end":{"line":156,"column":22,"index":4437}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Amount is required (--amount '<value> <TICKER>', e.g. '0.01 ETH')"}]}, validator: '(val) => true' },
         'fee-per-byte': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Fee per byte in satoshis (Bitcoin only)', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'rbf': { type: 'z.boolean.optional', required: false, hasDefault: false, description: 'Enable Replace-By-Fee (Bitcoin only)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'mode': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Transaction mode for Solana: send, stake.createAccount, stake.delegate, stake.undelegate, stake.withdraw', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
@@ -145,8 +148,9 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
         'stake-account': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Stake account address (Solana staking only)', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'memo': { type: 'z.string.min.optional', required: false, hasDefault: false, description: 'Memo/tag (Solana only)', min: 1, minLength: 1, schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
         'data': { type: 'z.string.regex.optional', required: false, hasDefault: false, description: 'EVM calldata as 0x-prefixed hex (e.g. 0xd0e30db0)', pattern: '^0x([0-9a-fA-F]{2})*$', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
-        'dry-run': { type: 'z.boolean.default', required: true, hasDefault: true, default: false, description: 'Prepare and validate transaction but do not sign or broadcast', schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"BooleanLiteral","start":3367,"end":3372,"loc":{"start":{"line":104,"column":42,"index":3367},"end":{"line":104,"column":47,"index":3372}},"value":false}}]}, validator: '(val) => true' },
-        'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+        'dry-run': { type: 'z.boolean.default', required: true, hasDefault: true, default: false, description: 'Prepare and validate transaction but do not sign or broadcast', schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"BooleanLiteral","start":5779,"end":5784,"loc":{"start":{"line":193,"column":42,"index":5779},"end":{"line":193,"column":47,"index":5784}},"value":false}}]}, validator: '(val) => true' },
+        'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' },
+        'device-timeout': { type: 'z.coerce.number.int.positive.default', required: true, hasDefault: true, default: 60000, schema: {"type":"zod","method":"default","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1480,"end":1486,"loc":{"start":{"line":36,"column":85,"index":1480},"end":{"line":36,"column":91,"index":1486}},"extra":{"rawValue":60000,"raw":"60_000"},"value":60000}}]}, validator: '(val) => true' }
       },
       path: './src/commands/send'
     },
@@ -158,7 +162,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
           name: 'view',
           description: 'Display all accounts stored in the current session',
           options: {
-            'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+            'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' }
           },
           path: './src/commands/session/view'
         },
@@ -166,7 +170,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
           name: 'reset',
           description: 'Wipe all accounts from the current session',
           options: {
-            'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+            'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' }
           },
           path: './src/commands/session/reset'
         }
@@ -181,12 +185,12 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
           name: 'quote',
           description: 'Fetch swap quotes',
           options: {
-            'from': { type: 'z.string.min', required: true, hasDefault: false, description: 'Source currency ID', short: 'f', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":571,"end":572,"loc":{"start":{"line":15,"column":32,"index":571},"end":{"line":15,"column":33,"index":572}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Source currency is required"}]}, validator: '(val) => true' },
-            'to': { type: 'z.string.min', required: true, hasDefault: false, description: 'Destination currency ID', short: 't', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":705,"end":706,"loc":{"start":{"line":19,"column":30,"index":705},"end":{"line":19,"column":31,"index":706}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Destination currency is required"}]}, validator: '(val) => true' },
-            'from-fresh-address': { type: 'z.string.min', required: true, hasDefault: false, description: 'Source account fresh receive address is required', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":867,"end":868,"loc":{"start":{"line":23,"column":48,"index":867},"end":{"line":23,"column":49,"index":868}},"extra":{"rawValue":1,"raw":"1"},"value":1}}]}, validator: '(val) => true' },
-            'to-fresh-address': { type: 'z.string.min', required: true, hasDefault: false, description: 'Destination account fresh receive address is required', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":998,"end":999,"loc":{"start":{"line":26,"column":46,"index":998},"end":{"line":26,"column":47,"index":999}},"extra":{"rawValue":1,"raw":"1"},"value":1}}]}, validator: '(val) => true' },
-            'amount': { type: 'z.string.min', required: true, hasDefault: false, description: 'Amount to swap in source currency', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1122,"end":1123,"loc":{"start":{"line":29,"column":34,"index":1122},"end":{"line":29,"column":35,"index":1123}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Amount is required"}]}, validator: '(val) => true' },
-            'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+            'from': { type: 'z.string.min', required: true, hasDefault: false, description: 'Source currency ID', short: 'f', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":592,"end":593,"loc":{"start":{"line":15,"column":32,"index":592},"end":{"line":15,"column":33,"index":593}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Source currency is required"}]}, validator: '(val) => true' },
+            'to': { type: 'z.string.min', required: true, hasDefault: false, description: 'Destination currency ID', short: 't', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":726,"end":727,"loc":{"start":{"line":19,"column":30,"index":726},"end":{"line":19,"column":31,"index":727}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Destination currency is required"}]}, validator: '(val) => true' },
+            'from-fresh-address': { type: 'z.string.min', required: true, hasDefault: false, description: 'Source account fresh receive address is required', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":888,"end":889,"loc":{"start":{"line":23,"column":48,"index":888},"end":{"line":23,"column":49,"index":889}},"extra":{"rawValue":1,"raw":"1"},"value":1}}]}, validator: '(val) => true' },
+            'to-fresh-address': { type: 'z.string.min', required: true, hasDefault: false, description: 'Destination account fresh receive address is required', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1019,"end":1020,"loc":{"start":{"line":26,"column":46,"index":1019},"end":{"line":26,"column":47,"index":1020}},"extra":{"rawValue":1,"raw":"1"},"value":1}}]}, validator: '(val) => true' },
+            'amount': { type: 'z.string.min', required: true, hasDefault: false, description: 'Amount to swap in source currency', min: 1, minLength: 1, schema: {"type":"zod","method":"min","args":[{"type":"unknown","raw":{"type":"NumericLiteral","start":1143,"end":1144,"loc":{"start":{"line":29,"column":34,"index":1143},"end":{"line":29,"column":35,"index":1144}},"extra":{"rawValue":1,"raw":"1"},"value":1}},{"type":"literal","value":"Amount is required"}]}, validator: '(val) => true' },
+            'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' }
           },
           path: './src/commands/swap/quote'
         }
@@ -197,7 +201,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       name: 'view',
       description: 'Display all accounts stored in the current session',
       options: {
-        'output': { type: 'OutputFormatSchema.default', required: true, hasDefault: true, default: "human", description: 'Output format: human (default) or json', schema: {"type":"zod","method":"default","args":[{"type":"literal","value":"human"}]}, validator: '(val) => true' }
+        'output': { type: 'OutputFormatSchema.optional', required: false, hasDefault: false, description: 'Output format: human or json (default: human)', schema: {"type":"zod","method":"optional","args":[]}, validator: '(val) => true' }
       },
       path: './src/commands/session/view'
     }

--- a/apps/wallet-cli/src/commands/account/discover.ts
+++ b/apps/wallet-cli/src/commands/account/discover.ts
@@ -2,14 +2,55 @@ import { defineCommand, option } from "@bunli/core";
 import { z } from "zod";
 import { WalletAdapter } from "../../wallet";
 import { WALLET_CLI_DMK_DEVICE_ID } from "../../device/register-dmk-transport";
-import { withCurrencyDeviceSession } from "../../session/bridge-device-session";
+import { WalletCliDeviceError } from "../../device/wallet-cli-device-error";
+import {
+  getManagerAppNameForCurrencyId,
+  withCurrencyDeviceSession,
+} from "../../session/bridge-device-session";
 import { walletCliDebug } from "../../shared/log";
 import { colors } from "../../shared/ui";
 import { parseNetworkArg, currencyIdFromNetwork } from "../../shared/accountDescriptor";
 import type { AccountDescriptorV1 } from "../../shared/accountDescriptor";
 import { createCommandOutput } from "../../output";
-import { outputOption } from "../inputs";
 import { Session } from "../../session/session-store";
+import { runObservable } from "../run-observable";
+import { deviceTimeoutOption, outputOption, resolveOutputFormat } from "../inputs";
+
+type DiscoverAccountsParams = {
+  wallet: WalletAdapter;
+  network: ReturnType<typeof parseNetworkArg>;
+  managerAppName: string;
+  out: ReturnType<typeof createCommandOutput>;
+};
+
+async function discoverAccounts({
+  wallet,
+  network,
+  managerAppName,
+  out,
+}: DiscoverAccountsParams): Promise<AccountDescriptorV1[]> {
+  const scanSpin = out.spin(`Scanning for ${colors.bold(network.name)} accounts…`);
+  let count = 0;
+  const discoveredDescriptors: AccountDescriptorV1[] = [];
+
+  await runObservable({
+    source$: wallet.discoverAccounts(network, WALLET_CLI_DMK_DEVICE_ID),
+    onNext: discoveredAccount => {
+      out.discoveredAccount(discoveredAccount);
+      discoveredDescriptors.push(discoveredAccount.descriptor);
+      count++;
+      if (scanSpin) scanSpin.text = `Scanning… (${count} found so far)`;
+    },
+    mapError: err =>
+      WalletCliDeviceError.fromUnknown(err, {
+        expectedApp: managerAppName,
+      }),
+  });
+
+  scanSpin?.success(`Found ${count} account${count === 1 ? "" : "s"}`);
+  out.flushDiscovery();
+  return discoveredDescriptors;
+}
 
 export default defineCommand({
   name: "discover",
@@ -21,8 +62,10 @@ export default defineCommand({
       short: "n",
     }),
     output: outputOption,
+    "device-timeout": deviceTimeoutOption,
   },
   handler: async ({ flags, positional }) => {
+    const output = resolveOutputFormat(flags.output);
     const networkArg = flags.network ?? positional[0];
     if (!networkArg) {
       throw new Error(
@@ -32,57 +75,44 @@ export default defineCommand({
 
     const network = parseNetworkArg(networkArg);
     const currencyId = currencyIdFromNetwork(network);
+    const managerAppName = getManagerAppNameForCurrencyId(currencyId);
     const networkStr = `${network.name}:${network.env}`;
-    walletCliDebug(`account discover: network=${networkStr}, output=${flags.output}`);
+    walletCliDebug(`account discover: network=${networkStr}, output=${output}`);
 
-    const out = createCommandOutput(flags.output, {
+    const out = createCommandOutput(output, {
       command: "account discover",
       network: networkStr,
     });
 
     await out.run(async () => {
-      const spin = out.spin(`Connect device and open ${colors.bold(network.name)} app…`);
-      const discoveredDescriptors: AccountDescriptorV1[] = [];
-
-      await withCurrencyDeviceSession(currencyId, async () => {
-        spin?.success("Device session established");
-
-        const wallet = new WalletAdapter();
-        const scanSpin = out.spin(`Scanning for ${colors.bold(network.name)} accounts…`);
-        let count = 0;
-
-        await new Promise<void>((resolve, reject) => {
-          wallet.discoverAccounts(network, WALLET_CLI_DMK_DEVICE_ID).subscribe({
-            next: d => {
-              out.discoveredAccount(d);
-              discoveredDescriptors.push(d.descriptor);
-              count++;
-              if (scanSpin) scanSpin.text = `Scanning… (${count} found so far)`;
-            },
-            error: err => {
-              scanSpin?.error("Scan failed");
-              reject(err);
-            },
-            complete: () => {
-              scanSpin?.success(`Found ${count} account${count === 1 ? "" : "s"}`);
-              resolve();
-            },
+      out.spin(`Connect device and open ${colors.bold(managerAppName)} app…`);
+      await withCurrencyDeviceSession(
+        currencyId,
+        async () => {
+          const wallet = new WalletAdapter();
+          const discoveredDescriptors = await discoverAccounts({
+            wallet,
+            network,
+            managerAppName,
+            out,
           });
-        });
 
-        out.flushDiscovery();
+          let added = 0;
+          try {
+            const session = await Session.read();
+            added = session.addDescriptors(discoveredDescriptors);
+            if (added > 0) await session.write();
+          } catch {
+            // Session persistence failure is non-fatal; discovery output is already flushed.
+          }
 
-        let added = 0;
-        try {
-          const session = await Session.read();
-          added = session.addDescriptors(discoveredDescriptors);
-          if (added > 0) await session.write();
-        } catch {
-          // Session persistence failure is non-fatal; discovery output is already flushed
-        }
-
-        if (added > 0) out.sessionSaved(added);
-      });
+          if (added > 0) out.sessionSaved(added);
+        },
+        {
+          deviceTimeoutMs: flags["device-timeout"],
+          onStateChange: state => out.deviceState(state),
+        },
+      );
     });
   },
 });

--- a/apps/wallet-cli/src/commands/account/fresh-address.ts
+++ b/apps/wallet-cli/src/commands/account/fresh-address.ts
@@ -2,7 +2,13 @@ import { defineCommand } from "@bunli/core";
 import { WalletAdapter } from "../../wallet";
 import { toV0, serializeNetwork, serializeV1 } from "../../shared/accountDescriptor";
 import { createCommandOutput } from "../../output";
-import { accountOption, outputOption, resolveAccountArg, resolveAccountDescriptorV1 } from "../inputs";
+import {
+  accountOption,
+  outputOption,
+  resolveAccountArg,
+  resolveAccountDescriptorV1,
+  resolveOutputFormat,
+} from "../inputs";
 
 export default defineCommand({
   name: "fresh-address",
@@ -13,9 +19,9 @@ export default defineCommand({
   },
   handler: async ({ flags, positional }) => {
     const ctx = { command: "account fresh-address", network: "", account: "" };
-    const out = createCommandOutput(flags.output, ctx);
+    const output = resolveOutputFormat(flags.output);
     const wallet = new WalletAdapter();
-
+    const out = createCommandOutput(output, ctx);
 
     await out.run(async () => {
       const v1 = await resolveAccountDescriptorV1(resolveAccountArg(flags.account, positional));

--- a/apps/wallet-cli/src/commands/balances.ts
+++ b/apps/wallet-cli/src/commands/balances.ts
@@ -3,7 +3,13 @@ import { WalletAdapter } from "../wallet";
 import { networkStringFromCurrencyId } from "../shared/accountDescriptor";
 import { walletCliDebug } from "../shared/log";
 import { createCommandOutput } from "../output";
-import { accountOption, outputOption, resolveAccountArg, resolveAccountDescriptor } from "./inputs";
+import {
+  accountOption,
+  outputOption,
+  resolveAccountArg,
+  resolveAccountDescriptor,
+  resolveOutputFormat,
+} from "./inputs";
 
 export default defineCommand({
   name: "balances",
@@ -13,14 +19,17 @@ export default defineCommand({
     output: outputOption,
   },
   handler: async ({ flags, positional }) => {
+    const output = resolveOutputFormat(flags.output);
     const ctx = { command: "balances", network: "", account: "" };
-    const out = createCommandOutput(flags.output, ctx);
+    const out = createCommandOutput(output, ctx);
 
     await out.run(async () => {
-      const descriptor = await resolveAccountDescriptor(resolveAccountArg(flags.account, positional));
+      const descriptor = await resolveAccountDescriptor(
+        resolveAccountArg(flags.account, positional),
+      );
       ctx.network = networkStringFromCurrencyId(descriptor.currencyId);
       ctx.account = descriptor.id;
-      walletCliDebug(`balances: account=${descriptor.id}, output=${flags.output}`);
+      walletCliDebug(`balances: account=${descriptor.id}, output=${output}`);
       const wallet = new WalletAdapter();
 
       const balances = await out.withActivity(

--- a/apps/wallet-cli/src/commands/inputs.test.ts
+++ b/apps/wallet-cli/src/commands/inputs.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "bun:test";
-import { resolveAccountArg } from "./inputs";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { resolveAccountArg, resolveOutputFormat } from "./inputs";
 import { XPUB } from "../shared/accountDescriptor/test-fixtures";
 
 const SHORT = `js:2:bitcoin:${XPUB}:native_segwit:0`;
@@ -15,5 +15,33 @@ describe("resolveAccountArg", () => {
 
   it("throws when both are missing", () => {
     expect(() => resolveAccountArg(undefined, [])).toThrow(/Missing account/);
+  });
+});
+
+describe("resolveOutputFormat", () => {
+  let savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of ["AGENT"]) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("defaults to human when no agent environment is detected", () => {
+    expect(resolveOutputFormat(undefined)).toBe("human");
+  });
+
+  it("preserves an explicitly requested output format", () => {
+    expect(resolveOutputFormat("human")).toBe("human");
+    expect(resolveOutputFormat("json")).toBe("json");
   });
 });

--- a/apps/wallet-cli/src/commands/inputs.ts
+++ b/apps/wallet-cli/src/commands/inputs.ts
@@ -1,5 +1,6 @@
 import { option } from "@bunli/core";
 import { z } from "zod";
+import { DEFAULT_DEVICE_TIMEOUT_MS } from "../device/connect-ledger-app";
 import { OutputFormatSchema, parseAccountDescriptor } from "../wallet/models";
 import type { AccountDescriptor } from "../wallet/models";
 import { parseV1 } from "../shared/accountDescriptor";
@@ -7,12 +8,33 @@ import type { AccountDescriptorV1 } from "../shared/accountDescriptor";
 import { Session } from "../session/session-store";
 
 export const accountOption = option(z.string().min(1).optional(), {
-  description: "Account descriptor or session label (e.g. ethereum-1). Can also be the first positional arg.",
+  description:
+    "Account descriptor or session label (e.g. ethereum-1). Can also be the first positional arg.",
   short: "a",
 });
 
-export const outputOption = option(OutputFormatSchema.default("human"), {
-  description: "Output format: human (default) or json",
+/**
+ * Shared --output option used by all commands. If omitted, the CLI keeps
+ * human-readable output.
+ */
+export const outputOption = option(OutputFormatSchema.optional(), {
+  description: "Output format: human or json (default: human)",
+});
+
+export function resolveOutputFormat(
+  output: z.infer<typeof OutputFormatSchema> | undefined,
+): z.infer<typeof OutputFormatSchema> {
+  return output ?? "human";
+}
+
+/**
+ * Shared --device-timeout option for every command that requires the device. Overrides the
+ * time (ms) ConnectApp waits for the user to unlock / confirm before giving up.
+ * Keep the literal Zod default in sync with DEFAULT_DEVICE_TIMEOUT_MS so Bunli can generate
+ * the concrete numeric default in command metadata.
+ */
+export const deviceTimeoutOption = option(z.coerce.number().int().positive().default(60_000), {
+  description: `Max time (ms) to wait for the device to unlock / confirm. Default: ${DEFAULT_DEVICE_TIMEOUT_MS}.`,
 });
 
 export function resolveAccountArg(

--- a/apps/wallet-cli/src/commands/operations.ts
+++ b/apps/wallet-cli/src/commands/operations.ts
@@ -4,7 +4,13 @@ import { WalletAdapter } from "../wallet";
 import { toV1, serializeV1, networkStringFromCurrencyId } from "../shared/accountDescriptor";
 import { walletCliDebug } from "../shared/log";
 import { createCommandOutput } from "../output";
-import { accountOption, outputOption, resolveAccountArg, resolveAccountDescriptor } from "./inputs";
+import {
+  accountOption,
+  outputOption,
+  resolveAccountArg,
+  resolveAccountDescriptor,
+  resolveOutputFormat,
+} from "./inputs";
 
 export default defineCommand({
   name: "operations",
@@ -22,17 +28,19 @@ export default defineCommand({
   },
   handler: async ({ flags, positional }) => {
     const ctx = { command: "operations", network: "", account: "" };
-    const out = createCommandOutput(flags.output, ctx);
+    const output = resolveOutputFormat(flags.output);
     const wallet = new WalletAdapter();
-
+    const out = createCommandOutput(output, ctx);
 
     await out.run(async () => {
-      const descriptor = await resolveAccountDescriptor(resolveAccountArg(flags.account, positional));
+      const descriptor = await resolveAccountDescriptor(
+        resolveAccountArg(flags.account, positional),
+      );
       ctx.network = networkStringFromCurrencyId(descriptor.currencyId);
       // accountId remapped to V1 descriptor — internal live-common id is intentionally dropped
       ctx.account = serializeV1(toV1(descriptor));
       walletCliDebug(
-        `operations: account=${descriptor.id}, limit=${flags.limit ?? "default"}, output=${flags.output}`,
+        `operations: account=${descriptor.id}, limit=${flags.limit ?? "default"}, output=${output}`,
       );
       const page = await out.withActivity(
         `Fetching operations for ${ctx.network}…`,

--- a/apps/wallet-cli/src/commands/receive.ts
+++ b/apps/wallet-cli/src/commands/receive.ts
@@ -3,10 +3,21 @@ import { z } from "zod";
 import { WalletAdapter } from "../wallet";
 import { networkStringFromCurrencyId } from "../shared/accountDescriptor";
 import { WALLET_CLI_DMK_DEVICE_ID } from "../device/register-dmk-transport";
-import { withCurrencyDeviceSession } from "../session/bridge-device-session";
+import { WalletCliDeviceError } from "../device/wallet-cli-device-error";
+import {
+  getManagerAppNameForCurrencyId,
+  withCurrencyDeviceSession,
+} from "../session/bridge-device-session";
 import { colors } from "../shared/ui";
 import { createCommandOutput } from "../output";
-import { accountOption, outputOption, resolveAccountArg, resolveAccountDescriptor } from "./inputs";
+import {
+  accountOption,
+  deviceTimeoutOption,
+  outputOption,
+  resolveAccountArg,
+  resolveAccountDescriptor,
+  resolveOutputFormat,
+} from "./inputs";
 
 export default defineCommand({
   name: "receive",
@@ -20,26 +31,43 @@ export default defineCommand({
       argumentKind: "flag",
     }),
     output: outputOption,
+    "device-timeout": deviceTimeoutOption,
   },
   handler: async ({ flags, positional }) => {
     const ctx = { command: "receive", network: "", account: "" };
-    const out = createCommandOutput(flags.output, ctx);
+    const output = resolveOutputFormat(flags.output);
     const wallet = new WalletAdapter();
-
+    const out = createCommandOutput(output, ctx);
 
     await out.run(async () => {
-      const descriptor = await resolveAccountDescriptor(resolveAccountArg(flags.account, positional));
+      const descriptor = await resolveAccountDescriptor(
+        resolveAccountArg(flags.account, positional),
+      );
       ctx.network = networkStringFromCurrencyId(descriptor.currencyId);
       ctx.account = descriptor.id;
+      const managerAppName = getManagerAppNameForCurrencyId(descriptor.currencyId);
       if (flags.verify) {
-        const spin = out.spin(`Connect device and open ${colors.bold(descriptor.currencyId)} app…`);
-        await withCurrencyDeviceSession(descriptor.currencyId, async () => {
-          spin?.success("Device session established");
-          const verifySpin = out.spin("Confirm address on your Ledger device…");
-          const address = await wallet.verifyAddress(descriptor, WALLET_CLI_DMK_DEVICE_ID);
-          verifySpin?.success("Address confirmed on device");
-          out.address(address);
-        });
+        const spin = out.spin(`Connect device and open ${colors.bold(managerAppName)} app…`);
+        await withCurrencyDeviceSession(
+          descriptor.currencyId,
+          async () => {
+            out.deviceState({ code: "awaiting_approval", reason: "verify_address" });
+            try {
+              const address = await wallet.verifyAddress(descriptor, WALLET_CLI_DMK_DEVICE_ID);
+              spin?.success("Address verified");
+              out.address(address);
+            } catch (e) {
+              throw WalletCliDeviceError.fromUnknown(e, {
+                expectedApp: managerAppName,
+                rejectedContext: "verify_address",
+              });
+            }
+          },
+          {
+            deviceTimeoutMs: flags["device-timeout"],
+            onStateChange: state => out.deviceState(state),
+          },
+        );
       } else {
         out.address(await wallet.getFreshAddress(descriptor));
       }

--- a/apps/wallet-cli/src/commands/run-observable.test.ts
+++ b/apps/wallet-cli/src/commands/run-observable.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { concat, of, throwError } from "rxjs";
+import { runObservable } from "./run-observable";
+
+describe("runObservable", () => {
+  it("consumes every emitted value before completing", async () => {
+    const seen: number[] = [];
+
+    await runObservable({
+      source$: of(1, 2, 3),
+      onNext: value => seen.push(value),
+    });
+
+    expect(seen).toEqual([1, 2, 3]);
+  });
+
+  it("maps observable errors before rethrowing", async () => {
+    const originalError = new Error("boom");
+    const mappedError = new Error("mapped");
+
+    await expect(
+      runObservable({
+        source$: concat(
+          of("before-error"),
+          throwError(() => originalError),
+        ),
+        mapError: error => {
+          expect(error).toBe(originalError);
+          return mappedError;
+        },
+      }),
+    ).rejects.toBe(mappedError);
+  });
+});

--- a/apps/wallet-cli/src/commands/run-observable.ts
+++ b/apps/wallet-cli/src/commands/run-observable.ts
@@ -1,0 +1,30 @@
+import {
+  lastValueFrom,
+  Observable,
+  catchError,
+  defaultIfEmpty,
+  ignoreElements,
+  tap,
+  throwError,
+} from "rxjs";
+
+type RunObservableOptions<T> = {
+  source$: Observable<T>;
+  onNext?: (value: T) => void;
+  mapError?: (error: unknown) => unknown;
+};
+
+export async function runObservable<T>({
+  source$,
+  onNext,
+  mapError,
+}: RunObservableOptions<T>): Promise<void> {
+  await lastValueFrom(
+    source$.pipe(
+      tap(value => onNext?.(value)),
+      catchError(error => throwError(() => (mapError ? mapError(error) : error))),
+      ignoreElements(),
+      defaultIfEmpty(undefined),
+    ),
+  );
+}

--- a/apps/wallet-cli/src/commands/send.ts
+++ b/apps/wallet-cli/src/commands/send.ts
@@ -1,16 +1,30 @@
 import { defineCommand, option } from "@bunli/core";
 import { z } from "zod";
-import { lastValueFrom } from "rxjs";
-import { tap } from "rxjs/operators";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { WalletAdapter } from "../wallet";
 import { TransactionIntentSchema } from "../wallet/intents";
-import { WALLET_CLI_DMK_DEVICE_ID, getWalletCliDeviceModelId } from "../device/register-dmk-transport";
-import { withCurrencyDeviceSession } from "../session/bridge-device-session";
+import type { AccountDescriptor } from "../wallet/models";
+import {
+  WALLET_CLI_DMK_DEVICE_ID,
+  getWalletCliDeviceModelId,
+} from "../device/register-dmk-transport";
+import { WalletCliDeviceError } from "../device/wallet-cli-device-error";
+import {
+  getManagerAppNameForCurrencyId,
+  withCurrencyDeviceSession,
+} from "../session/bridge-device-session";
 import { networkStringFromCurrencyId } from "../shared/accountDescriptor";
 import { colors } from "../shared/ui";
 import { createCommandOutput } from "../output";
-import { accountOption, outputOption, resolveAccountArg, resolveAccountDescriptor } from "./inputs";
+import { runObservable } from "./run-observable";
+import {
+  accountOption,
+  deviceTimeoutOption,
+  outputOption,
+  resolveAccountArg,
+  resolveAccountDescriptor,
+  resolveOutputFormat,
+} from "./inputs";
 
 type SendFlags = {
   account?: string;
@@ -24,7 +38,7 @@ type SendFlags = {
   memo?: string;
   data?: string;
   "dry-run": boolean;
-  output: "human" | "json";
+  output?: "human" | "json";
 };
 
 type IntentBuilder = (flags: SendFlags) => unknown;
@@ -53,6 +67,81 @@ const INTENT_BUILDERS: Record<string, IntentBuilder> = {
     memo: flags.memo,
   }),
 };
+
+function buildIntentData(currencyId: string, flags: SendFlags) {
+  const { family } = getCryptoCurrencyById(currencyId);
+  const builder = INTENT_BUILDERS[family];
+  if (!builder) {
+    throw new Error(
+      `Unsupported family: ${family}. Supported: ${Object.keys(INTENT_BUILDERS).join(", ")}`,
+    );
+  }
+  return builder(flags);
+}
+
+async function runDryRunSend(
+  wallet: WalletAdapter,
+  descriptor: AccountDescriptor,
+  intent: ReturnType<typeof TransactionIntentSchema.parse>,
+  out: ReturnType<typeof createCommandOutput>,
+): Promise<void> {
+  const spin = out.spin("Preparing transaction (dry run)…");
+  const prepared = await wallet.prepareSend(descriptor, intent);
+  spin?.success("Dry run complete (transaction not broadcasted)");
+  out.sendDryRun(prepared);
+}
+
+type RunLiveSendParams = {
+  wallet: WalletAdapter;
+  descriptor: AccountDescriptor;
+  intent: ReturnType<typeof TransactionIntentSchema.parse>;
+  managerAppName: string;
+  deviceTimeoutMs: number | undefined;
+  out: ReturnType<typeof createCommandOutput>;
+};
+
+async function runLiveSend({
+  wallet,
+  descriptor,
+  intent,
+  managerAppName,
+  deviceTimeoutMs,
+  out,
+}: RunLiveSendParams): Promise<void> {
+  out.spin(`Connect device and open ${colors.bold(managerAppName)} app…`);
+  await withCurrencyDeviceSession(
+    descriptor.currencyId,
+    async () => {
+      out.spin(`Preparing ${colors.bold(managerAppName)} transaction…`);
+
+      const deviceModelId = await getWalletCliDeviceModelId();
+      if (deviceModelId === undefined) {
+        throw new Error(
+          "Could not determine device model from the active session. Disconnect and reconnect the device.",
+        );
+      }
+
+      await runObservable({
+        source$: wallet.send(descriptor, intent, {
+          deviceId: WALLET_CLI_DMK_DEVICE_ID,
+          deviceModelId,
+        }),
+        onNext: event => out.sendEvent(event),
+        mapError: error =>
+          WalletCliDeviceError.fromKnownDeviceError(error, {
+            expectedApp: managerAppName,
+            rejectedContext: "sign",
+          }) ?? error,
+      });
+
+      out.sendComplete();
+    },
+    {
+      deviceTimeoutMs,
+      onStateChange: state => out.deviceState(state),
+    },
+  );
+}
 
 export default defineCommand({
   name: "send",
@@ -106,58 +195,40 @@ export default defineCommand({
       argumentKind: "flag",
     }),
     output: outputOption,
+    "device-timeout": deviceTimeoutOption,
   },
   handler: async ({ flags, positional }) => {
     const ctx = { command: "send", network: "", account: "" };
-    const out = createCommandOutput(flags.output, ctx);
+    const output = resolveOutputFormat(flags.output);
     const wallet = new WalletAdapter();
     const dryRun = flags["dry-run"];
+    const out = createCommandOutput(output, ctx);
 
     await out.run(async () => {
-      const descriptor = await resolveAccountDescriptor(resolveAccountArg(flags.account, positional));
+      const descriptor = await resolveAccountDescriptor(
+        resolveAccountArg(flags.account, positional),
+      );
       ctx.network = networkStringFromCurrencyId(descriptor.currencyId);
       ctx.account = descriptor.id;
+      const managerAppName = getManagerAppNameForCurrencyId(descriptor.currencyId);
 
       // Build the TransactionIntent based on the currency family
-      const { family } = getCryptoCurrencyById(descriptor.currencyId);
-      const builder = INTENT_BUILDERS[family];
-      if (!builder) {
-        throw new Error(
-          `Unsupported family: ${family}. Supported: ${Object.keys(INTENT_BUILDERS).join(", ")}`,
-        );
-      }
-      const intentData = builder(flags as SendFlags);
+      const intentData = buildIntentData(descriptor.currencyId, flags as SendFlags);
 
       // Intent schema parse may throw (ZodError) — out.run catches it in json mode
       const intent = TransactionIntentSchema.parse(intentData);
 
       if (dryRun) {
-        const spin = out.spin("Preparing transaction (dry run)…");
-        const prepared = await wallet.prepareSend(descriptor, intent);
-        spin?.clear();
-        out.sendDryRun(prepared);
-        spin?.success("Dry run complete (transaction not broadcasted)");
+        await runDryRunSend(wallet, descriptor, intent, out);
         return;
       }
-
-      const spin = out.spin(`Connect device and open ${colors.bold(descriptor.currencyId)} app…`);
-      await withCurrencyDeviceSession(descriptor.currencyId, async () => {
-        spin?.success("Device session established");
-        out.spin(`Preparing ${colors.bold(descriptor.currencyId)} transaction…`);
-
-        const deviceModelId = await getWalletCliDeviceModelId();
-        if (deviceModelId === undefined) {
-          throw new Error(
-            "Could not determine device model from the active session. Disconnect and reconnect the device.",
-          );
-        }
-        await lastValueFrom(
-          wallet
-            .send(descriptor, intent, { deviceId: WALLET_CLI_DMK_DEVICE_ID, deviceModelId })
-            .pipe(tap(event => out.sendEvent(event))),
-        );
-
-        out.sendComplete();
+      await runLiveSend({
+        wallet,
+        descriptor,
+        intent,
+        managerAppName,
+        deviceTimeoutMs: flags["device-timeout"],
+        out,
       });
     });
   },

--- a/apps/wallet-cli/src/commands/session/reset.test.ts
+++ b/apps/wallet-cli/src/commands/session/reset.test.ts
@@ -22,7 +22,10 @@ async function readSessionFile(xdgStateHome: string): Promise<unknown> {
 }
 
 let cleanup: (() => void) | undefined;
-afterEach(() => { cleanup?.(); cleanup = undefined; });
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
 
 describe("session reset — human", () => {
   it("reports empty when accounts list is already empty", async () => {

--- a/apps/wallet-cli/src/commands/session/reset.ts
+++ b/apps/wallet-cli/src/commands/session/reset.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from "@bunli/core";
 import { Session } from "../../session/session-store";
-import { outputOption } from "../inputs";
+import { outputOption, resolveOutputFormat } from "../inputs";
 import { createCommandOutput } from "../../output";
 
 export default defineCommand({
@@ -10,7 +10,10 @@ export default defineCommand({
     output: outputOption,
   },
   handler: async ({ flags }) => {
-    const out = createCommandOutput(flags.output, { command: "session reset", network: "all" });
+    const out = createCommandOutput(resolveOutputFormat(flags.output), {
+      command: "session reset",
+      network: "all",
+    });
 
     await out.run(async () => {
       let session: Session;

--- a/apps/wallet-cli/src/commands/session/view.test.ts
+++ b/apps/wallet-cli/src/commands/session/view.test.ts
@@ -15,7 +15,10 @@ const SAMPLE_ENTRIES = [
 ];
 
 let cleanup: (() => void) | undefined;
-afterEach(() => { cleanup?.(); cleanup = undefined; });
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
 
 describe("session view — human", () => {
   it("shows empty message when accounts list is empty", async () => {
@@ -51,10 +54,7 @@ describe("session view — json", () => {
   it("returns empty accounts array when session is empty", async () => {
     const fixture = makeSessionDir([]);
     cleanup = fixture.cleanup;
-    const { stdout, exitCode } = await runCli(
-      ["session", "view", "--output", "json"],
-      fixture.env,
-    );
+    const { stdout, exitCode } = await runCli(["session", "view", "--output", "json"], fixture.env);
     expect(exitCode).toBe(0);
     const data = JSON.parse(stdout);
     expect(data.command).toBe("session view");
@@ -64,10 +64,7 @@ describe("session view — json", () => {
   it("returns envelope with all account entries", async () => {
     const fixture = makeSessionDir(SAMPLE_ENTRIES);
     cleanup = fixture.cleanup;
-    const { stdout, exitCode } = await runCli(
-      ["session", "view", "--output", "json"],
-      fixture.env,
-    );
+    const { stdout, exitCode } = await runCli(["session", "view", "--output", "json"], fixture.env);
     expect(exitCode).toBe(0);
     const data = JSON.parse(stdout);
     expect(data.command).toBe("session view");
@@ -79,10 +76,7 @@ describe("session view — json", () => {
   it("includes timestamp in envelope", async () => {
     const fixture = makeSessionDir(SAMPLE_ENTRIES);
     cleanup = fixture.cleanup;
-    const { stdout } = await runCli(
-      ["session", "view", "--output", "json"],
-      fixture.env,
-    );
+    const { stdout } = await runCli(["session", "view", "--output", "json"], fixture.env);
     const data = JSON.parse(stdout);
     expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });

--- a/apps/wallet-cli/src/commands/session/view.ts
+++ b/apps/wallet-cli/src/commands/session/view.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from "@bunli/core";
 import { Session } from "../../session/session-store";
-import { outputOption } from "../inputs";
+import { outputOption, resolveOutputFormat } from "../inputs";
 import { createCommandOutput } from "../../output";
 
 export default defineCommand({
@@ -10,7 +10,10 @@ export default defineCommand({
     output: outputOption,
   },
   handler: async ({ flags }) => {
-    const out = createCommandOutput(flags.output, { command: "session view", network: "all" });
+    const out = createCommandOutput(resolveOutputFormat(flags.output), {
+      command: "session view",
+      network: "all",
+    });
 
     await out.run(async () => {
       const { accounts } = await Session.read();

--- a/apps/wallet-cli/src/commands/swap/quote.ts
+++ b/apps/wallet-cli/src/commands/swap/quote.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { getQuotes } from "@ledgerhq/live-common/wallet-api/Exchange/index";
 import { createCommandOutput } from "../../output";
 import { walletCliDebug } from "../../shared/log";
-import { outputOption } from "../inputs";
+import { outputOption, resolveOutputFormat } from "../inputs";
 import { mapSwapQuoteLine } from "./quote-shared";
 
 const DEFAULT_PROVIDERS = ["changelly_v2", "oneinch", "paraswap", "exodus", "swapsxyz"];
@@ -32,8 +32,9 @@ export default defineCommand({
     output: outputOption,
   },
   handler: async ({ flags }) => {
-    walletCliDebug(`quote: from=${flags.from} to=${flags.to} output=${flags.output}`);
-    const out = createCommandOutput(flags.output, { command: "swap quote", network: flags.from });
+    const output = resolveOutputFormat(flags.output);
+    walletCliDebug(`quote: from=${flags.from} to=${flags.to} output=${output}`);
+    const out = createCommandOutput(output, { command: "swap quote", network: flags.from });
 
     await out.run(async () => {
       const s = out.spin("Fetching swap quotes…");

--- a/apps/wallet-cli/src/device/classify-device-error.test.ts
+++ b/apps/wallet-cli/src/device/classify-device-error.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+import { SendApduTimeoutError } from "@ledgerhq/device-management-kit";
+import {
+  DisconnectedDevice,
+  DisconnectedDeviceDuringOperation,
+  LockedDeviceError,
+  ManagerDeviceLockedError,
+} from "@ledgerhq/errors";
+import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
+import { EmptyError } from "rxjs";
+import { classifyDeviceError } from "./classify-device-error";
+
+describe("classifyDeviceError", () => {
+  it("rxjs EmptyError → disconnected", () => {
+    expect(classifyDeviceError(new EmptyError())).toEqual({ code: "disconnected" });
+  });
+
+  it("DisconnectedDevice and DisconnectedDeviceDuringOperation → disconnected", () => {
+    expect(classifyDeviceError(new DisconnectedDevice())).toEqual({ code: "disconnected" });
+    expect(classifyDeviceError(new DisconnectedDeviceDuringOperation())).toEqual({
+      code: "disconnected",
+    });
+  });
+
+  it("LockedDeviceError and ManagerDeviceLockedError → locked", () => {
+    expect(classifyDeviceError(new LockedDeviceError())).toEqual({ code: "locked" });
+    expect(classifyDeviceError(new ManagerDeviceLockedError())).toEqual({ code: "locked" });
+  });
+
+  it("DMK-tagged DeviceLockedError → locked", () => {
+    expect(classifyDeviceError({ _tag: "DeviceLockedError" })).toEqual({ code: "locked" });
+  });
+
+  it("TransportStatusError LOCKED_DEVICE → locked", () => {
+    expect(classifyDeviceError(new TransportStatusError(StatusCodes.LOCKED_DEVICE))).toEqual({
+      code: "locked",
+    });
+  });
+
+  it("TransportStatusError SECURITY_STATUS_NOT_SATISFIED (0x6982) → locked", () => {
+    expect(classifyDeviceError(new TransportStatusError(0x6982))).toEqual({ code: "locked" });
+  });
+
+  it("TransportStatusError CONDITIONS_OF_USE_NOT_SATISFIED → rejected (sign by default)", () => {
+    expect(classifyDeviceError(new TransportStatusError(0x6985))).toEqual({
+      code: "rejected",
+      context: "sign",
+    });
+  });
+
+  it("TransportStatusError CONDITIONS_OF_USE_NOT_SATISFIED respects ctx.rejectedContext", () => {
+    expect(
+      classifyDeviceError(new TransportStatusError(0x6985), { rejectedContext: "verify_address" }),
+    ).toEqual({ code: "rejected", context: "verify_address" });
+  });
+
+  it("CLA_NOT_SUPPORTED / INS_NOT_SUPPORTED → wrong_app with expected-app from ctx", () => {
+    expect(
+      classifyDeviceError(new TransportStatusError(StatusCodes.CLA_NOT_SUPPORTED), {
+        expectedApp: "Ethereum",
+      }),
+    ).toEqual({ code: "wrong_app", expected: "Ethereum", found: undefined });
+    expect(
+      classifyDeviceError(new TransportStatusError(StatusCodes.INS_NOT_SUPPORTED), {
+        expectedApp: "Ethereum",
+        foundApp: "Bitcoin",
+      }),
+    ).toEqual({ code: "wrong_app", expected: "Ethereum", found: "Bitcoin" });
+  });
+
+  it("SendApduTimeoutError (both instance and tagged) → timeout", () => {
+    expect(classifyDeviceError(new SendApduTimeoutError("t"))).toEqual({ code: "timeout" });
+    expect(classifyDeviceError({ _tag: "SendApduTimeoutError" })).toEqual({ code: "timeout" });
+  });
+
+  it("transport framing tags → timeout", () => {
+    expect(classifyDeviceError({ _tag: "ReceiverApduError" })).toEqual({ code: "timeout" });
+    expect(classifyDeviceError({ _tag: "UnknownDeviceExchangeError" })).toEqual({
+      code: "timeout",
+    });
+  });
+
+  it("RefusedByUserDAError → rejected (open_app by default)", () => {
+    expect(classifyDeviceError({ _tag: "RefusedByUserDAError" })).toEqual({
+      code: "rejected",
+      context: "open_app",
+    });
+  });
+
+  it("OpenApp command error codes 670a / 6807 → app_not_installed", () => {
+    expect(
+      classifyDeviceError(
+        { _tag: "OpenAppCommandError", errorCode: "670a" },
+        { expectedApp: "Ethereum" },
+      ),
+    ).toEqual({ code: "app_not_installed", appName: "Ethereum" });
+    expect(
+      classifyDeviceError(
+        { _tag: "OpenAppCommandError", errorCode: "6807" },
+        { expectedApp: "Bitcoin" },
+      ),
+    ).toEqual({ code: "app_not_installed", appName: "Bitcoin" });
+  });
+
+  it("OpenApp error codes are case-insensitive", () => {
+    expect(classifyDeviceError({ errorCode: "670A" }, { expectedApp: "Ethereum" })).toEqual({
+      code: "app_not_installed",
+      appName: "Ethereum",
+    });
+  });
+
+  it("unrelated errors fall through to unknown with cause", () => {
+    const err = new Error("boom");
+    const state = classifyDeviceError(err);
+    expect(state.code).toBe("unknown");
+    if (state.code === "unknown") expect(state.cause).toBe(err);
+  });
+});

--- a/apps/wallet-cli/src/device/classify-device-error.ts
+++ b/apps/wallet-cli/src/device/classify-device-error.ts
@@ -1,0 +1,139 @@
+/**
+ * Single classifier that maps any thrown value from the device stack (DMK, @ledgerhq/errors,
+ * @ledgerhq/hw-transport, rxjs) to a canonical `DeviceState`.
+ *
+ * Kept deliberately free of rendering / I/O — callers use `renderDeviceState` or wrap the
+ * classified state in a `WalletCliDeviceError`.
+ */
+
+import { SendApduTimeoutError } from "@ledgerhq/device-management-kit";
+import {
+  DisconnectedDevice,
+  DisconnectedDeviceDuringOperation,
+  LockedDeviceError,
+  ManagerDeviceLockedError,
+} from "@ledgerhq/errors";
+import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
+import { EmptyError } from "rxjs";
+import type { DeviceState, RejectedContext } from "./device-state";
+
+export type ClassifyContext = {
+  /** App name we attempted to open/use. Used for `app_not_installed` / `wrong_app`. */
+  expectedApp?: string;
+  /** Currently open app (if known) — used for `wrong_app.found`. */
+  foundApp?: string;
+  /** Defaults the rejection context when we can't infer it from the error itself. */
+  rejectedContext?: RejectedContext;
+};
+
+const TRANSPORT_FRAMING_TAGS = new Set(["ReceiverApduError", "UnknownDeviceExchangeError"]);
+const APP_NOT_INSTALLED_OPEN_APP_CODES = new Set(["670a", "6807"]);
+
+function hasTag(error: unknown, tag: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "_tag" in error &&
+    (error as { _tag: unknown })._tag === tag
+  );
+}
+
+function hasAnyTag(error: unknown, tags: ReadonlySet<string>): boolean {
+  if (typeof error !== "object" || error === null || !("_tag" in error)) return false;
+  const tag = (error as { _tag: unknown })._tag;
+  return typeof tag === "string" && tags.has(tag);
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (typeof error === "object" && error !== null && "errorCode" in error) {
+    const code = (error as { errorCode: unknown }).errorCode;
+    if (typeof code === "string") return code.toLowerCase();
+  }
+  return undefined;
+}
+
+function isDisconnectedError(error: unknown): boolean {
+  return (
+    error instanceof EmptyError ||
+    error instanceof DisconnectedDevice ||
+    error instanceof DisconnectedDeviceDuringOperation
+  );
+}
+
+function isLockedError(error: unknown): boolean {
+  return (
+    error instanceof ManagerDeviceLockedError ||
+    error instanceof LockedDeviceError ||
+    hasTag(error, "DeviceLockedError")
+  );
+}
+
+function classifyTransportStatusError(
+  error: TransportStatusError,
+  ctx: ClassifyContext,
+): DeviceState | undefined {
+  switch (error.statusCode) {
+    case StatusCodes.LOCKED_DEVICE:
+    case StatusCodes.SECURITY_STATUS_NOT_SATISFIED:
+      return { code: "locked" };
+    case StatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED:
+      return { code: "rejected", context: ctx.rejectedContext ?? "sign" };
+    case StatusCodes.CLA_NOT_SUPPORTED:
+    case StatusCodes.INS_NOT_SUPPORTED:
+      return {
+        code: "wrong_app",
+        expected: ctx.expectedApp ?? "the correct app",
+        found: ctx.foundApp,
+      };
+    default:
+      return undefined;
+  }
+}
+
+export function classifyDeviceError(error: unknown, ctx: ClassifyContext = {}): DeviceState {
+  // Device-not-detected: rxjs EmptyError is thrown when lastValueFrom sees no emission,
+  // @ledgerhq/errors Disconnected* covers USB unplug / transport close.
+  if (isDisconnectedError(error)) {
+    return { code: "disconnected" };
+  }
+
+  // Device locked (multiple representations across stacks).
+  if (isLockedError(error)) {
+    return { code: "locked" };
+  }
+
+  // User-rejection / wrong-app / locked via legacy SW codes.
+  if (error instanceof TransportStatusError) {
+    const state = classifyTransportStatusError(error, ctx);
+    if (state) {
+      return state;
+    }
+  }
+
+  // Timeouts talking to the device — surface as a retriable timeout.
+  if (error instanceof SendApduTimeoutError || hasTag(error, "SendApduTimeoutError")) {
+    return { code: "timeout" };
+  }
+
+  // Transport framing errors (garbled APDU). Surfaced as timeout since root cause is
+  // typically lock / busy and the fix is the same: retry.
+  if (hasAnyTag(error, TRANSPORT_FRAMING_TAGS)) {
+    return { code: "timeout" };
+  }
+
+  // DMK refused-by-user (RefusedByUserDAError) happens when the user declines the OpenApp prompt.
+  if (hasTag(error, "RefusedByUserDAError")) {
+    return { code: "rejected", context: ctx.rejectedContext ?? "open_app" };
+  }
+
+  // OpenApp command error codes: 670a (app not found) / 6807 (app not installed).
+  const errorCode = getErrorCode(error);
+  if (errorCode !== undefined && APP_NOT_INSTALLED_OPEN_APP_CODES.has(errorCode)) {
+    return {
+      code: "app_not_installed",
+      appName: ctx.expectedApp ?? "The required",
+    };
+  }
+
+  return { code: "unknown", cause: error };
+}

--- a/apps/wallet-cli/src/device/connect-ledger-app.test.ts
+++ b/apps/wallet-cli/src/device/connect-ledger-app.test.ts
@@ -1,12 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
   DeviceActionStatus,
   UnknownDAError,
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 import { Observable } from "rxjs";
-import * as log from "../shared/log";
 import { connectLedgerApp } from "./connect-ledger-app";
+import type { DeviceState } from "./device-state";
+import { WalletCliDeviceError } from "./wallet-cli-device-error";
 
 function makeDmk(
   executeDeviceAction: () => { observable: Observable<unknown>; cancel: () => void },
@@ -43,17 +44,22 @@ describe("connectLedgerApp", () => {
     await expect(connectLedgerApp(dmk as never, "sess-1", "evm")).resolves.toBeUndefined();
   });
 
-  it("throws a proper Error when the device action ends with a tagged error object", async () => {
+  it("throws a WalletCliDeviceError when the device action ends with a tagged DMK error", async () => {
     const err = new UnknownDAError("test");
     const dmk = makeDmk(() => errorAction(err));
 
-    await expect(connectLedgerApp(dmk as never, "sess-1", "bitcoin")).rejects.toThrow(
-      "UnknownDAError",
-    );
+    try {
+      await connectLedgerApp(dmk as never, "sess-1", "bitcoin");
+      throw new Error("expected connectLedgerApp to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(WalletCliDeviceError);
+      const state = (e as WalletCliDeviceError).state;
+      expect(state.code).toBe("unknown");
+    }
   });
 
-  it("debug-logs pending UnlockDevice once when that interaction is required", async () => {
-    const spy = spyOn(log, "walletCliDebug").mockImplementation(() => {});
+  it("emits awaiting_approval.unlock when UnlockDevice interaction is required", async () => {
+    const states: DeviceState[] = [];
     const dmk = makeDmk(() => ({
       observable: new Observable(observer => {
         observer.next({
@@ -74,16 +80,37 @@ describe("connectLedgerApp", () => {
       cancel: () => {},
     }));
 
-    await connectLedgerApp(dmk as never, "sess-1", "evm");
+    await connectLedgerApp(dmk as never, "sess-1", "evm", {
+      onStateChange: s => states.push(s),
+    });
 
-    const pendingUnlock = spy.mock.calls.filter(
-      args =>
-        typeof args[0] === "string" &&
-        args[0].includes("ConnectApp pending") &&
-        args[1] === UserInteractionRequired.UnlockDevice,
+    const unlockStates = states.filter(
+      s => s.code === "awaiting_approval" && s.reason === "unlock",
     );
-    expect(pendingUnlock).toHaveLength(1);
-    spy.mockRestore();
+    expect(unlockStates).toHaveLength(1);
+  });
+
+  it("emits awaiting_approval.open_app when ConfirmOpenApp interaction is required", async () => {
+    const states: DeviceState[] = [];
+    const dmk = makeDmk(() => ({
+      observable: new Observable(observer => {
+        observer.next({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+        });
+        observer.next({ status: DeviceActionStatus.Completed, output: {} } as const);
+        observer.complete();
+      }),
+      cancel: () => {},
+    }));
+
+    await connectLedgerApp(dmk as never, "sess-1", "evm", {
+      onStateChange: s => states.push(s),
+    });
+
+    expect(states.some(s => s.code === "awaiting_approval" && s.reason === "open_app")).toBe(true);
   });
 
   describe("transport framing error retries", () => {
@@ -124,17 +151,21 @@ describe("connectLedgerApp", () => {
       expect(calls).toBe(2);
     });
 
-    it("throws a user-friendly error after exhausting retries on ReceiverApduError", async () => {
+    it("throws a WalletCliDeviceError (timeout) after exhausting retries on ReceiverApduError", async () => {
       let calls = 0;
       const dmk = makeDmk(() => {
         calls++;
         return errorAction({ _tag: "ReceiverApduError" as const });
       });
 
-      await expect(connectLedgerApp(dmk as never, "sess-1", "ethereum")).rejects.toThrow(
-        /could not communicate/i,
-      );
-      expect(calls).toBe(6); // 1 initial + 5 retries
+      try {
+        await connectLedgerApp(dmk as never, "sess-1", "ethereum");
+        throw new Error("expected to throw");
+      } catch (e) {
+        expect(e).toBeInstanceOf(WalletCliDeviceError);
+        expect((e as WalletCliDeviceError).state.code).toBe("timeout");
+      }
+      expect(calls).toBe(6);
     });
   });
 });

--- a/apps/wallet-cli/src/device/connect-ledger-app.ts
+++ b/apps/wallet-cli/src/device/connect-ledger-app.ts
@@ -10,8 +10,8 @@ import {
 import { EmptyError, lastValueFrom } from "rxjs";
 import { tap } from "rxjs/operators";
 import { walletCliDebug } from "../shared/log";
-import { writeStderr } from "../shared/ui";
-import { toWalletCliDeviceError } from "./wallet-cli-device-error";
+import type { DeviceState } from "./device-state";
+import { WalletCliDeviceError } from "./wallet-cli-device-error";
 
 type ConnectAppState = DeviceActionState<
   ConnectAppDAOutput,
@@ -20,26 +20,28 @@ type ConnectAppState = DeviceActionState<
 >;
 
 /**
- * Unlike Live's connectApp (unlockTimeout: 0), the CLI uses a positive timeout so users can
- * unlock the device after starting a command.
+ * Default unlock timeout: how long ConnectApp waits for the user to unlock the device
+ * before giving up. Overridable per-call via the `deviceTimeoutMs` option (CLI flag
+ * `--device-timeout`).
  */
-const CONNECT_APP_UNLOCK_TIMEOUT_MS = 60_000;
+export const DEFAULT_DEVICE_TIMEOUT_MS = 60_000;
 
 /**
- * Abort ConnectApp if it makes no progress. RxJS `timeout()` alone is insufficient when DMK/USB work
- * blocks without scheduling timers; we call `executeDeviceAction().cancel()` on a wall-clock timer (same
- * pattern as Live unsubscribing from the device action).
+ * Silence timeout: abort the device action if it makes no progress at all (e.g. USB is
+ * dead before any APDU comes back). Always >= deviceTimeoutMs + buffer.
  */
-const CONNECT_APP_SILENCE_TIMEOUT_MS = CONNECT_APP_UNLOCK_TIMEOUT_MS + 60_000;
+const SILENCE_TIMEOUT_EXTRA_MS = 60_000;
 
 /**
- * When the device is locked inside an app (e.g. Ethereum), the DMK's `waitForDeviceUnlock` polling
- * may receive an unparseable APDU response (`ReceiverApduError`) instead of error code 5515.
- * The polling misidentifies this as "unlocked" and the action fails immediately.
+ * When the device is locked inside an app (e.g. Ethereum), the DMK's `waitForDeviceUnlock`
+ * polling may receive an unparseable APDU response (`ReceiverApduError`) instead of error
+ * code 5515. The polling misidentifies this as "unlocked" and the action fails immediately.
  * We retry the whole device action so the user has time to unlock.
  */
 const MAX_TRANSPORT_ERROR_RETRIES = 5;
 const TRANSPORT_ERROR_RETRY_DELAY_MS = 3_000;
+
+const RETRIABLE_TRANSPORT_TAGS = new Set(["ReceiverApduError", "UnknownDeviceExchangeError"]);
 
 function summarizeConnectAppError(error: ConnectAppDAError): Record<string, unknown> {
   if (error instanceof Error) {
@@ -48,33 +50,12 @@ function summarizeConnectAppError(error: ConnectAppDAError): Record<string, unkn
   if (typeof error === "object" && error !== null) {
     const o = error as unknown as Record<string, unknown>;
     const summary: Record<string, unknown> = {};
-    if ("_tag" in o) {
-      summary._tag = o._tag;
-    }
-    if ("errorCode" in o) {
-      summary.errorCode = o.errorCode;
-    }
+    if ("_tag" in o) summary._tag = o._tag;
+    if ("errorCode" in o) summary.errorCode = o.errorCode;
     return summary;
   }
   return { value: String(error) };
 }
-
-function toError(error: ConnectAppDAError): Error {
-  if (error instanceof Error) {
-    return toWalletCliDeviceError(error);
-  }
-  if ("_tag" in error && error._tag === "SendApduTimeoutError") {
-    return toWalletCliDeviceError(error);
-  }
-  if (isTransportFramingError(error)) {
-    return toWalletCliDeviceError(error);
-  }
-  const tag = "_tag" in error ? error._tag : "UnknownError";
-  const code = "errorCode" in error ? ` (${error.errorCode})` : "";
-  return new Error(`${tag}${code}`);
-}
-
-const RETRIABLE_TRANSPORT_TAGS = new Set(["ReceiverApduError", "UnknownDeviceExchangeError"]);
 
 function isTransportFramingError(error: ConnectAppDAError): boolean {
   return (
@@ -85,16 +66,33 @@ function isTransportFramingError(error: ConnectAppDAError): boolean {
   );
 }
 
+export type ConnectLedgerAppOptions = {
+  /** Observer invoked for each intermediate device-state transition (unlock, approve open). */
+  onStateChange?: (state: DeviceState) => void;
+  /** Max time to wait for the device to be unlocked. Defaults to DEFAULT_DEVICE_TIMEOUT_MS. */
+  deviceTimeoutMs?: number;
+};
+
 /**
- * Open the Ledger Manager app by name on an existing DMK USB session (same device action as Live LDk connectApp).
+ * Open the Ledger Manager app by name on an existing DMK USB session (same device action
+ * as Live LDk connectApp). Emits intermediate `DeviceState`s via `options.onStateChange`
+ * and throws `WalletCliDeviceError` for every failure path.
  */
 export async function connectLedgerApp(
   dmk: DeviceManagementKit,
   sessionId: string,
   managerAppName: string,
+  options: ConnectLedgerAppOptions = {},
 ): Promise<void> {
+  const deviceTimeoutMs = options.deviceTimeoutMs ?? DEFAULT_DEVICE_TIMEOUT_MS;
+  const silenceTimeoutMs = deviceTimeoutMs + SILENCE_TIMEOUT_EXTRA_MS;
+
   for (let attempt = 0; ; attempt++) {
-    const result = await connectLedgerAppOnce(dmk, sessionId, managerAppName);
+    const result = await connectLedgerAppOnce(dmk, sessionId, managerAppName, {
+      onStateChange: options.onStateChange,
+      deviceTimeoutMs,
+      silenceTimeoutMs,
+    });
     if (!result) return;
 
     if (isTransportFramingError(result) && attempt < MAX_TRANSPORT_ERROR_RETRIES) {
@@ -107,7 +105,7 @@ export async function connectLedgerApp(
       continue;
     }
 
-    throw toError(result);
+    throw WalletCliDeviceError.fromUnknown(result, { expectedApp: managerAppName });
   }
 }
 
@@ -119,6 +117,15 @@ async function connectLedgerAppOnce(
   dmk: DeviceManagementKit,
   sessionId: string,
   managerAppName: string,
+  {
+    onStateChange,
+    deviceTimeoutMs,
+    silenceTimeoutMs,
+  }: {
+    onStateChange?: (state: DeviceState) => void;
+    deviceTimeoutMs: number;
+    silenceTimeoutMs: number;
+  },
 ): Promise<ConnectAppDAError | undefined> {
   const deviceAction = new ConnectAppDeviceAction({
     input: {
@@ -126,7 +133,7 @@ async function connectLedgerAppOnce(
       dependencies: [],
       requireLatestFirmware: false,
       allowMissingApplication: false,
-      unlockTimeout: CONNECT_APP_UNLOCK_TIMEOUT_MS,
+      unlockTimeout: deviceTimeoutMs,
     },
   });
 
@@ -134,16 +141,14 @@ async function connectLedgerAppOnce(
   const { observable, cancel } = dmk.executeDeviceAction({ sessionId, deviceAction });
   const stallTimer = globalThis.setTimeout(() => {
     cancel();
-  }, CONNECT_APP_SILENCE_TIMEOUT_MS);
+  }, silenceTimeoutMs);
 
   let lastRequiredInteraction: ConnectAppDARequiredInteraction | undefined;
   try {
     finalState = await lastValueFrom(
       observable.pipe(
         tap((state: ConnectAppState) => {
-          if (state.status !== DeviceActionStatus.Pending) {
-            return;
-          }
+          if (state.status !== DeviceActionStatus.Pending) return;
           const r = state.intermediateValue?.requiredUserInteraction;
           if (r == null || r === UserInteractionRequired.None || r === lastRequiredInteraction) {
             return;
@@ -155,27 +160,19 @@ async function connectLedgerAppOnce(
             managerAppName,
           );
 
-          // Write user-visible messages to stderr
           if (r === UserInteractionRequired.UnlockDevice) {
-            writeStderr(
-              `[~] Waiting: Ledger detected but locked. Enter your PIN on the device.\n`,
-            );
+            onStateChange?.({ code: "awaiting_approval", reason: "unlock" });
           } else if (r === UserInteractionRequired.ConfirmOpenApp) {
-            writeStderr(
-              `[i] Opening ${managerAppName} app on your Ledger... ACTION REQUIRED: Confirm on device screen.\n`,
-            );
+            onStateChange?.({ code: "awaiting_approval", reason: "open_app" });
           }
         }),
       ),
     );
   } catch (e) {
     if (e instanceof EmptyError) {
-      throw new Error(
-        `[x] Error: Ledger device not detected. Plug in your Ledger via USB, enter your PIN, then run the command again.`,
-        { cause: e },
-      );
+      throw new WalletCliDeviceError({ code: "disconnected" }, { cause: e });
     }
-    throw toWalletCliDeviceError(e);
+    throw WalletCliDeviceError.fromUnknown(e, { expectedApp: managerAppName });
   } finally {
     globalThis.clearTimeout(stallTimer);
   }
@@ -196,7 +193,10 @@ async function connectLedgerAppOnce(
     );
   }
   if (finalState.status !== DeviceActionStatus.Completed) {
-    throw new Error(`Connect app ended with status: ${finalState.status}`);
+    throw new WalletCliDeviceError({
+      code: "unknown",
+      cause: new Error(`Connect app ended with status: ${finalState.status}`),
+    });
   }
   return undefined;
 }

--- a/apps/wallet-cli/src/device/device-state.test.ts
+++ b/apps/wallet-cli/src/device/device-state.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "bun:test";
+import {
+  DEVICE_EXIT_CODES,
+  type DeviceState,
+  isTerminalDeviceState,
+  renderDeviceState,
+} from "./device-state";
+
+describe("renderDeviceState", () => {
+  it("renders disconnected with the [✖] glyph and exit code 3", () => {
+    const { glyph, message, exitCode } = renderDeviceState({ code: "disconnected" });
+    expect(glyph).toBe("[✖]");
+    expect(message).toBe("Ledger not detected. Plug in, unlock, retry.");
+    expect(exitCode).toBe(DEVICE_EXIT_CODES.disconnected);
+  });
+
+  it("renders wrong_app without found-app", () => {
+    const { glyph, message, exitCode } = renderDeviceState({
+      code: "wrong_app",
+      expected: "Ethereum",
+    });
+    expect(glyph).toBe("[✖]");
+    expect(message).toBe("Wrong app. Open Ethereum.");
+    expect(exitCode).toBe(DEVICE_EXIT_CODES.wrong_app);
+  });
+
+  it("renders wrong_app with found-app in parentheses", () => {
+    const { message } = renderDeviceState({
+      code: "wrong_app",
+      expected: "Ethereum",
+      found: "Bitcoin",
+    });
+    expect(message).toBe("Wrong app (found: Bitcoin). Open Ethereum.");
+  });
+
+  it("renders awaiting_approval.sign with [⧖] glyph and exit 0", () => {
+    const { glyph, message, exitCode } = renderDeviceState({
+      code: "awaiting_approval",
+      reason: "sign",
+    });
+    expect(glyph).toBe("[⧖]");
+    expect(message).toBe("Review on device. Approve or reject.");
+    expect(exitCode).toBe(DEVICE_EXIT_CODES.success);
+  });
+
+  it("renders awaiting_approval.verify_address", () => {
+    const { message } = renderDeviceState({ code: "awaiting_approval", reason: "verify_address" });
+    expect(message).toMatch(/Review address on device/);
+  });
+
+  it("renders awaiting_approval.open_app", () => {
+    const { message } = renderDeviceState({ code: "awaiting_approval", reason: "open_app" });
+    expect(message).toMatch(/Confirm on device to open the app/);
+  });
+
+  it("renders awaiting_approval.unlock", () => {
+    const { message } = renderDeviceState({ code: "awaiting_approval", reason: "unlock" });
+    expect(message).toMatch(/Ledger is locked.*PIN/);
+  });
+
+  it("renders rejected.sign with [✖] and exit code 2", () => {
+    const { glyph, message, exitCode } = renderDeviceState({
+      code: "rejected",
+      context: "sign",
+    });
+    expect(glyph).toBe("[✖]");
+    expect(message).toBe("Rejected on device. No action taken.");
+    expect(exitCode).toBe(DEVICE_EXIT_CODES.rejected);
+  });
+
+  it("renders rejected.verify_address", () => {
+    const { message } = renderDeviceState({ code: "rejected", context: "verify_address" });
+    expect(message).toMatch(/Address not confirmed/);
+  });
+
+  it("renders rejected.open_app", () => {
+    const { message } = renderDeviceState({ code: "rejected", context: "open_app" });
+    expect(message).toMatch(/App was not opened/);
+  });
+
+  it("renders exchange_app_needed with [ℹ] glyph and exit 0", () => {
+    const { glyph, message, exitCode } = renderDeviceState({ code: "exchange_app_needed" });
+    expect(glyph).toBe("[ℹ]");
+    expect(message).toBe("Open Exchange app.");
+    expect(exitCode).toBe(DEVICE_EXIT_CODES.success);
+  });
+
+  it("renders locked with [✖] and exit 6", () => {
+    const { glyph, message, exitCode } = renderDeviceState({ code: "locked" });
+    expect(glyph).toBe("[✖]");
+    expect(message).toMatch(/locked/i);
+    expect(exitCode).toBe(DEVICE_EXIT_CODES.timeout);
+  });
+
+  it("renders app_not_installed with the app name and exit 5", () => {
+    const { glyph, message, exitCode } = renderDeviceState({
+      code: "app_not_installed",
+      appName: "Ethereum",
+    });
+    expect(glyph).toBe("[✖]");
+    expect(message).toMatch(/Ethereum.*not installed/);
+    expect(exitCode).toBe(DEVICE_EXIT_CODES.app_not_installed);
+  });
+
+  it("renders timeout with exit 6", () => {
+    const { exitCode, message } = renderDeviceState({ code: "timeout" });
+    expect(message).toMatch(/Timed out/);
+    expect(exitCode).toBe(DEVICE_EXIT_CODES.timeout);
+  });
+
+  it("renders unknown from an Error cause using its message", () => {
+    const { message, exitCode } = renderDeviceState({
+      code: "unknown",
+      cause: new Error("boom"),
+    });
+    expect(message).toBe("boom");
+    expect(exitCode).toBe(DEVICE_EXIT_CODES.generic);
+  });
+
+  it("renders unknown from a string cause", () => {
+    const { message } = renderDeviceState({ code: "unknown", cause: "oops" });
+    expect(message).toBe("oops");
+  });
+
+  it("renders unknown fallback for null cause", () => {
+    const { message } = renderDeviceState({ code: "unknown", cause: null });
+    expect(message).toBe("An unknown error occurred talking to the Ledger.");
+  });
+});
+
+describe("isTerminalDeviceState", () => {
+  const terminalCodes: Array<[string, DeviceState]> = [
+    ["disconnected", { code: "disconnected" }],
+    ['wrong_app (expected "Ethereum")', { code: "wrong_app", expected: "Ethereum" }],
+    ["rejected (context: sign)", { code: "rejected", context: "sign" }],
+    ["locked", { code: "locked" }],
+    ['app_not_installed ("Ethereum")', { code: "app_not_installed", appName: "Ethereum" }],
+    ["timeout", { code: "timeout" }],
+    ["unknown (with Error cause)", { code: "unknown", cause: new Error("x") }],
+  ];
+  const intermediateCodes: Array<[string, DeviceState]> = [
+    ["awaiting_approval (sign)", { code: "awaiting_approval", reason: "sign" }],
+    ["exchange_app_needed", { code: "exchange_app_needed" }],
+  ];
+
+  it.each(terminalCodes)("is terminal for %s", (_, state) => {
+    expect(isTerminalDeviceState(state)).toBe(true);
+  });
+
+  it.each(intermediateCodes)("is non-terminal for %s", (_, state) => {
+    expect(isTerminalDeviceState(state)).toBe(false);
+  });
+});

--- a/apps/wallet-cli/src/device/device-state.ts
+++ b/apps/wallet-cli/src/device/device-state.ts
@@ -1,0 +1,166 @@
+/**
+ * Shared device-state union used by every device-requiring command (sync, receive, send,
+ * future swap execute). A single source of truth for:
+ *
+ *  - the canonical glyph + actionable message shown to the user,
+ *  - the exit code reported by the process,
+ *  - the `code` field included in JSON error envelopes for programmatic consumers.
+ *
+ * Terminal states (disconnected, wrong_app, rejected, locked, app_not_installed, timeout,
+ * unknown) are attached to `WalletCliDeviceError` and cause a non-zero exit.
+ * Non-terminal states (awaiting_approval, exchange_app_needed) are emitted via
+ * `CommandOutput.deviceState` as the user makes progress.
+ */
+
+export type DeviceStateCode =
+  | "disconnected"
+  | "wrong_app"
+  | "awaiting_approval"
+  | "rejected"
+  | "exchange_app_needed"
+  | "locked"
+  | "app_not_installed"
+  | "timeout"
+  | "unknown";
+
+export type AwaitingApprovalReason = "sign" | "verify_address" | "open_app" | "unlock";
+export type RejectedContext = "sign" | "verify_address" | "open_app";
+
+export type DeviceState =
+  | { code: "disconnected" }
+  | { code: "wrong_app"; expected: string; found?: string }
+  | { code: "awaiting_approval"; reason: AwaitingApprovalReason }
+  | { code: "rejected"; context: RejectedContext }
+  | { code: "exchange_app_needed" }
+  | { code: "locked" }
+  | { code: "app_not_installed"; appName: string }
+  | { code: "timeout" }
+  | { code: "unknown"; cause: unknown };
+
+export type DeviceStateGlyph = "[✖]" | "[⧖]" | "[ℹ]";
+
+export const DEVICE_EXIT_CODES = {
+  success: 0,
+  generic: 1,
+  rejected: 2,
+  disconnected: 3,
+  wrong_app: 4,
+  app_not_installed: 5,
+  timeout: 6,
+} as const;
+
+export type DeviceExitCode = (typeof DEVICE_EXIT_CODES)[keyof typeof DEVICE_EXIT_CODES];
+
+/**
+ * A terminal state causes the process to exit non-zero once rendered.
+ * Intermediate states only drive user-facing progress messages.
+ */
+export function isTerminalDeviceState(state: DeviceState): boolean {
+  switch (state.code) {
+    case "awaiting_approval":
+    case "exchange_app_needed":
+      return false;
+    default:
+      return true;
+  }
+}
+
+/**
+ * Pure mapping from a DeviceState to the glyph + actionable message + process exit code.
+ * Shared by the human renderer (spinner text) and the JSON error envelope (code + message).
+ */
+export function renderDeviceState(state: DeviceState): {
+  glyph: DeviceStateGlyph;
+  message: string;
+  exitCode: DeviceExitCode;
+} {
+  switch (state.code) {
+    case "disconnected":
+      return {
+        glyph: "[✖]",
+        message: "Ledger not detected. Plug in, unlock, retry.",
+        exitCode: DEVICE_EXIT_CODES.disconnected,
+      };
+    case "wrong_app": {
+      const found = state.found ? ` (found: ${state.found})` : "";
+      return {
+        glyph: "[✖]",
+        message: `Wrong app${found}. Open ${state.expected}.`,
+        exitCode: DEVICE_EXIT_CODES.wrong_app,
+      };
+    }
+    case "awaiting_approval":
+      return {
+        glyph: "[⧖]",
+        message: renderAwaitingApprovalMessage(state.reason),
+        exitCode: DEVICE_EXIT_CODES.success,
+      };
+    case "rejected":
+      return {
+        glyph: "[✖]",
+        message: renderRejectedMessage(state.context),
+        exitCode: DEVICE_EXIT_CODES.rejected,
+      };
+    case "exchange_app_needed":
+      return {
+        glyph: "[ℹ]",
+        message: "Open Exchange app.",
+        exitCode: DEVICE_EXIT_CODES.success,
+      };
+    case "locked":
+      return {
+        glyph: "[✖]",
+        message: "Ledger is locked. Unlock your device with your PIN and retry.",
+        exitCode: DEVICE_EXIT_CODES.timeout,
+      };
+    case "app_not_installed":
+      return {
+        glyph: "[✖]",
+        message: `${state.appName} app is not installed. Install it via Ledger Live and retry.`,
+        exitCode: DEVICE_EXIT_CODES.app_not_installed,
+      };
+    case "timeout":
+      return {
+        glyph: "[✖]",
+        message:
+          "Timed out talking to the Ledger over USB. The device may be busy or locked. Retry the command.",
+        exitCode: DEVICE_EXIT_CODES.timeout,
+      };
+    case "unknown":
+      return {
+        glyph: "[✖]",
+        message: unknownCauseMessage(state.cause),
+        exitCode: DEVICE_EXIT_CODES.generic,
+      };
+  }
+}
+
+function renderAwaitingApprovalMessage(reason: AwaitingApprovalReason): string {
+  switch (reason) {
+    case "sign":
+      return "Review on device. Approve or reject.";
+    case "verify_address":
+      return "Review address on device. Approve or reject.";
+    case "open_app":
+      return "Confirm on device to open the app.";
+    case "unlock":
+      return "Ledger is locked. Enter your PIN on the device.";
+  }
+}
+
+function renderRejectedMessage(context: RejectedContext): string {
+  switch (context) {
+    case "sign":
+      return "Rejected on device. No action taken.";
+    case "verify_address":
+      return "Rejected on device. Address not confirmed.";
+    case "open_app":
+      return "Rejected on device. App was not opened.";
+  }
+}
+
+function unknownCauseMessage(cause: unknown): string {
+  if (cause instanceof Error && cause.message) return cause.message;
+  if (typeof cause === "string" && cause.length > 0) return cause;
+  return "An unknown error occurred talking to the Ledger.";
+}

--- a/apps/wallet-cli/src/device/wallet-cli-device-error.test.ts
+++ b/apps/wallet-cli/src/device/wallet-cli-device-error.test.ts
@@ -2,76 +2,108 @@ import { describe, expect, it } from "bun:test";
 import { SendApduTimeoutError } from "@ledgerhq/device-management-kit";
 import { LockedDeviceError, ManagerDeviceLockedError } from "@ledgerhq/errors";
 import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
-import { toWalletCliDeviceError } from "./wallet-cli-device-error";
+import { DEVICE_EXIT_CODES } from "./device-state";
+import { toWalletCliDeviceError, WalletCliDeviceError } from "./wallet-cli-device-error";
 
-describe("toWalletCliDeviceError", () => {
-  it("maps LOCKED_DEVICE / LockedDeviceError to a wallet-cli locked message", () => {
+describe("WalletCliDeviceError / toWalletCliDeviceError", () => {
+  it("LOCKED_DEVICE / LockedDeviceError → state.code=locked, exitCode=6", () => {
     const fromSw = toWalletCliDeviceError(new TransportStatusError(StatusCodes.LOCKED_DEVICE));
-    expect(fromSw.message).toContain("locked");
-    expect(fromSw.message).toContain("[wallet-cli]");
+    expect(fromSw).toBeInstanceOf(WalletCliDeviceError);
+    expect(fromSw.state.code).toBe("locked");
+    expect(fromSw.exitCode).toBe(DEVICE_EXIT_CODES.timeout);
+    expect(fromSw.message).toMatch(/locked/i);
     expect(fromSw.cause).toBeInstanceOf(TransportStatusError);
 
     const direct = toWalletCliDeviceError(new LockedDeviceError());
-    expect(direct.message).toContain("locked");
+    expect(direct.state.code).toBe("locked");
     expect(direct.cause).toBeInstanceOf(LockedDeviceError);
   });
 
-  it("maps ManagerDeviceLockedError", () => {
+  it("ManagerDeviceLockedError → locked", () => {
     const out = toWalletCliDeviceError(new ManagerDeviceLockedError());
-    expect(out.message).toContain("[wallet-cli]");
-    expect(out.message).toContain("locked");
+    expect(out.state.code).toBe("locked");
     expect(out.cause).toBeInstanceOf(ManagerDeviceLockedError);
   });
 
-  it("maps SECURITY_STATUS_NOT_SATISFIED (0x6982)", () => {
+  it("SECURITY_STATUS_NOT_SATISFIED (0x6982) → locked", () => {
     const out = toWalletCliDeviceError(new TransportStatusError(0x6982));
-    expect(out.message).toContain("[wallet-cli]");
-    expect(out.message).toMatch(/security|locked/i);
+    expect(out.state.code).toBe("locked");
     expect(out.cause).toBeInstanceOf(TransportStatusError);
   });
 
-  it("maps CONDITIONS_OF_USE_NOT_SATISFIED (0x6985)", () => {
+  it("CONDITIONS_OF_USE_NOT_SATISFIED (0x6985) → rejected, exit 2", () => {
     const out = toWalletCliDeviceError(new TransportStatusError(0x6985));
-    expect(out.message).toMatch(/rejected|cancelled/i);
-    expect(out.cause).toBeInstanceOf(TransportStatusError);
+    expect(out.state.code).toBe("rejected");
+    expect(out.exitCode).toBe(DEVICE_EXIT_CODES.rejected);
+    expect(out.message).toMatch(/rejected/i);
   });
 
-  it("maps CLA_NOT_SUPPORTED and INS_NOT_SUPPORTED", () => {
-    const cla = toWalletCliDeviceError(new TransportStatusError(StatusCodes.CLA_NOT_SUPPORTED));
-    expect(cla.message).toContain("correct app");
-    const ins = toWalletCliDeviceError(new TransportStatusError(StatusCodes.INS_NOT_SUPPORTED));
-    expect(ins.message).toContain("correct app");
+  it("CLA_NOT_SUPPORTED / INS_NOT_SUPPORTED → wrong_app with expectedApp, exit 4", () => {
+    const cla = toWalletCliDeviceError(new TransportStatusError(StatusCodes.CLA_NOT_SUPPORTED), {
+      expectedApp: "Ethereum",
+    });
+    expect(cla.state.code).toBe("wrong_app");
+    expect(cla.exitCode).toBe(DEVICE_EXIT_CODES.wrong_app);
+    expect(cla.message).toMatch(/Ethereum/);
+
+    const ins = toWalletCliDeviceError(new TransportStatusError(StatusCodes.INS_NOT_SUPPORTED), {
+      expectedApp: "Bitcoin",
+    });
+    expect(ins.state.code).toBe("wrong_app");
+    expect(ins.message).toMatch(/Bitcoin/);
   });
 
-  it("maps SendApduTimeoutError and tagged SendApduTimeout", () => {
+  it("SendApduTimeoutError and tagged SendApduTimeout → timeout, exit 6", () => {
     const inst = toWalletCliDeviceError(new SendApduTimeoutError("t"));
-    expect(inst.message).toContain("Timed out");
-    expect(inst.message).toMatch(/PIN|locked/i);
-    expect(inst.cause).toBeInstanceOf(SendApduTimeoutError);
+    expect(inst.state.code).toBe("timeout");
+    expect(inst.exitCode).toBe(DEVICE_EXIT_CODES.timeout);
+    expect(inst.message).toMatch(/Timed out/);
 
     const tagged = toWalletCliDeviceError({ _tag: "SendApduTimeoutError" as const });
-    expect(tagged.message).toContain("Timed out");
+    expect(tagged.state.code).toBe("timeout");
   });
 
-  it("maps transport framing errors (ReceiverApduError, UnknownDeviceExchangeError) to a user-friendly message", () => {
+  it("transport framing errors (ReceiverApduError, UnknownDeviceExchangeError) → timeout", () => {
     const receiver = toWalletCliDeviceError({ _tag: "ReceiverApduError" as const });
-    expect(receiver.message).toContain("[wallet-cli]");
-    expect(receiver.message).toMatch(/communicate|locked/i);
+    expect(receiver.state.code).toBe("timeout");
     expect(receiver.cause).toEqual({ _tag: "ReceiverApduError" });
 
     const exchange = toWalletCliDeviceError({ _tag: "UnknownDeviceExchangeError" as const });
-    expect(exchange.message).toContain("[wallet-cli]");
-    expect(exchange.message).toMatch(/communicate|locked/i);
-    expect(exchange.cause).toEqual({ _tag: "UnknownDeviceExchangeError" });
+    expect(exchange.state.code).toBe("timeout");
   });
 
-  it("passes through unrelated Error instances", () => {
+  it("wraps non-device Error instances as unknown with exit 1", () => {
     const err = new Error("custom");
-    expect(toWalletCliDeviceError(err)).toBe(err);
+    const out = toWalletCliDeviceError(err);
+    expect(out).toBeInstanceOf(WalletCliDeviceError);
+    expect(out.state.code).toBe("unknown");
+    expect(out.exitCode).toBe(DEVICE_EXIT_CODES.generic);
+    expect(out.message).toBe("custom");
+    expect(out.cause).toBe(err);
+  });
+
+  it("fromKnownDeviceError leaves non-device errors unwrapped", () => {
+    const err = new Error("validation failed");
+    expect(WalletCliDeviceError.fromKnownDeviceError(err)).toBeUndefined();
+  });
+
+  it("fromKnownDeviceError wraps classified device errors", () => {
+    const err = new TransportStatusError(StatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED);
+    const out = WalletCliDeviceError.fromKnownDeviceError(err, { rejectedContext: "sign" });
+    expect(out).toBeInstanceOf(WalletCliDeviceError);
+    expect(out?.state.code).toBe("rejected");
+    expect(out?.cause).toBe(err);
+  });
+
+  it("returns the same instance when given an existing WalletCliDeviceError", () => {
+    const original = new WalletCliDeviceError({ code: "disconnected" });
+    const out = toWalletCliDeviceError(original);
+    expect(out).toBe(original);
   });
 
   it("wraps non-Error values", () => {
     const out = toWalletCliDeviceError("oops");
+    expect(out.state.code).toBe("unknown");
     expect(out.message).toBe("oops");
   });
 });

--- a/apps/wallet-cli/src/device/wallet-cli-device-error.ts
+++ b/apps/wallet-cli/src/device/wallet-cli-device-error.ts
@@ -1,85 +1,50 @@
-import { SendApduTimeoutError } from "@ledgerhq/device-management-kit";
-import { LockedDeviceError, ManagerDeviceLockedError } from "@ledgerhq/errors";
-import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
+/**
+ * Strongly-typed wallet-cli error carrying a classified `DeviceState` + process exit code.
+ *
+ * All device-requiring commands throw (or re-throw) this class so the output layer
+ * (`output.ts`) can render the canonical glyph + message and exit with the taxonomy
+ * code declared in `device-state.ts`.
+ */
 
-function isSendApduTimeoutTagged(error: unknown): error is { _tag: "SendApduTimeoutError" } {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "_tag" in error &&
-    (error as { _tag: string })._tag === "SendApduTimeoutError"
-  );
-}
+import { classifyDeviceError, type ClassifyContext } from "./classify-device-error";
+import { type DeviceState, type DeviceExitCode, renderDeviceState } from "./device-state";
 
-const TRANSPORT_FRAMING_TAGS = new Set(["ReceiverApduError", "UnknownDeviceExchangeError"]);
+export class WalletCliDeviceError extends Error {
+  readonly state: DeviceState;
+  readonly exitCode: DeviceExitCode;
 
-function isTransportFramingError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "_tag" in error &&
-    TRANSPORT_FRAMING_TAGS.has((error as { _tag: string })._tag)
-  );
+  constructor(state: DeviceState, options?: { cause?: unknown }) {
+    const { message, exitCode } = renderDeviceState(state);
+    super(message, options);
+    this.name = "WalletCliDeviceError";
+    this.state = state;
+    this.exitCode = exitCode;
+  }
+
+  static fromUnknown(error: unknown, ctx?: ClassifyContext): WalletCliDeviceError {
+    if (error instanceof WalletCliDeviceError) return error;
+    const state = classifyDeviceError(error, ctx);
+    return new WalletCliDeviceError(state, { cause: error });
+  }
+
+  static fromKnownDeviceError(
+    error: unknown,
+    ctx?: ClassifyContext,
+  ): WalletCliDeviceError | undefined {
+    if (error instanceof WalletCliDeviceError) return error;
+    const state = classifyDeviceError(error, ctx);
+    if (state.code === "unknown") return undefined;
+    return new WalletCliDeviceError(state, { cause: error });
+  }
 }
 
 /**
- * Maps device / transport errors to concise wallet-cli messages. Passes through unrelated errors.
+ * Convenience wrapper used on error boundaries: ensures any thrown value becomes a
+ * `WalletCliDeviceError`, preserving the original as `cause`.
  */
-export function toWalletCliDeviceError(error: unknown): Error {
-  if (error instanceof ManagerDeviceLockedError || error instanceof LockedDeviceError) {
-    return new Error(
-      "[wallet-cli] Device is locked. Unlock your Ledger with your PIN and try again.",
-      { cause: error },
-    );
-  }
-
-  if (error instanceof TransportStatusError) {
-    const { statusCode } = error;
-    if (statusCode === StatusCodes.LOCKED_DEVICE) {
-      return new Error(
-        "[wallet-cli] Device is locked. Unlock your Ledger with your PIN and try again.",
-        { cause: error },
-      );
-    }
-    if (statusCode === StatusCodes.SECURITY_STATUS_NOT_SATISFIED) {
-      return new Error(
-        "[wallet-cli] The device reported a security error (often the Ledger is locked or the operation is not allowed). Unlock the device and try again.",
-        { cause: error },
-      );
-    }
-    if (statusCode === StatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED) {
-      return new Error("[x] Transaction Cancelled: Rejected on device. No funds moved.", {
-        cause: error,
-      });
-    }
-    if (
-      statusCode === StatusCodes.CLA_NOT_SUPPORTED ||
-      statusCode === StatusCodes.INS_NOT_SUPPORTED
-    ) {
-      return new Error(
-        "[wallet-cli] Could not execute the command on the app. Unlock the Ledger, open the correct app for this currency, and try again.",
-        { cause: error },
-      );
-    }
-  }
-
-  if (error instanceof SendApduTimeoutError || isSendApduTimeoutTagged(error)) {
-    return new Error(
-      "[wallet-cli] Timed out talking to the Ledger over USB. The device may be waiting for your PIN, locked, or busy. Retry the command, check the cable, and make sure no other app is using the device.",
-      { cause: error },
-    );
-  }
-
-  if (isTransportFramingError(error)) {
-    return new Error(
-      "[wallet-cli] Could not communicate with the device (garbled APDU). The device may be locked or busy. Unlock it and try again.",
-      { cause: error },
-    );
-  }
-
-  if (error instanceof Error) {
-    return error;
-  }
-
-  return new Error(String(error));
+export function toWalletCliDeviceError(
+  error: unknown,
+  ctx?: ClassifyContext,
+): WalletCliDeviceError {
+  return WalletCliDeviceError.fromUnknown(error, ctx);
 }

--- a/apps/wallet-cli/src/output-json.test.ts
+++ b/apps/wallet-cli/src/output-json.test.ts
@@ -1,0 +1,187 @@
+import "./live-common-setup";
+import { beforeEach, describe, expect, it } from "bun:test";
+import { installOutputCapture } from "./shared/ui";
+import { CliProcessExitError } from "./cli-process-exit-error";
+
+const { createCommandOutput } = await import("./output");
+
+describe("JsonCommandOutput", () => {
+  const providerError = {
+    code: "PAIR_NOT_SUPPORTED",
+    type: "float" as const,
+    provider: "paraswap",
+    message: "Pair not supported",
+    parameter: { from: "ethereum", to: "bitcoin" },
+  };
+
+  let writes: string[] = [];
+  let restoreCapture: (() => void) | null = null;
+
+  beforeEach(() => {
+    writes = [];
+    restoreCapture = installOutputCapture({
+      stdout: chunk => {
+        writes.push(chunk);
+      },
+    });
+  });
+
+  // afterEach is not strictly needed since installOutputCapture is stacked, but keeps state clean
+  // We restore after each test to avoid leaking capture across tests
+  const restore = () => {
+    restoreCapture?.();
+    restoreCapture = null;
+  };
+
+  it("emits device-state events as NDJSON before the final envelope", () => {
+    try {
+      const out = createCommandOutput("json", {
+        command: "receive",
+        network: "ethereum:main",
+        account: "js:2:ethereum:0x123",
+      });
+
+      out.deviceState({ code: "awaiting_approval", reason: "unlock" });
+      out.address("0xabc");
+    } finally {
+      restore();
+    }
+
+    const lines = writes
+      .join("")
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line));
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toEqual({
+      type: "device-state",
+      command: "receive",
+      network: "ethereum:main",
+      account: "js:2:ethereum:0x123",
+      state: { code: "awaiting_approval", reason: "unlock" },
+      message: "Ledger is locked. Enter your PIN on the device.",
+    });
+    expect(lines[1]).toMatchObject({
+      status: "success",
+      command: "receive",
+      network: "ethereum:main",
+      account: "js:2:ethereum:0x123",
+      address: "0xabc",
+    });
+  });
+
+  it("emits a signature-requested device-state event during send before the final envelope", () => {
+    try {
+      const out = createCommandOutput("json", {
+        command: "send",
+        network: "ethereum:main",
+        account: "js:2:ethereum:0x123",
+      });
+
+      out.sendEvent({ type: "prepared", recipient: "0xabc", amount: "0.1 ETH", fees: "0.001 ETH" });
+      out.sendEvent({ type: "device-signature-requested" });
+      out.sendEvent({ type: "broadcasted", txHash: "0xdeadbeef" });
+      out.sendComplete();
+    } finally {
+      restore();
+    }
+
+    const lines = writes
+      .join("")
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line));
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toEqual({
+      type: "device-state",
+      command: "send",
+      network: "ethereum:main",
+      account: "js:2:ethereum:0x123",
+      state: { code: "awaiting_approval", reason: "sign" },
+      message: "Review on device. Approve or reject.",
+    });
+    expect(lines[1]).toMatchObject({
+      status: "success",
+      command: "send",
+      network: "ethereum:main",
+      account: "js:2:ethereum:0x123",
+      recipient: "0xabc",
+      amount: "0.1 ETH",
+      fee: "0.001 ETH",
+      tx_hash: "0xdeadbeef",
+    });
+  });
+
+  it("emits swap quote output as NDJSON with provider errors", () => {
+    try {
+      const out = createCommandOutput("json", {
+        command: "swap quote",
+        network: "ethereum",
+      });
+
+      out.swapQuotes({
+        quotes: [
+          {
+            quoteId: "quote-1",
+            from: "ethereum",
+            to: "bitcoin",
+            rate: 3000,
+            providerFee: null,
+            networkFee: "gas 21000 (ETH)",
+            receiveAmount: 0.05,
+            provider: "paraswap",
+            amountFrom: "0.1",
+          },
+        ],
+        partialErrors: [providerError],
+      });
+    } finally {
+      restore();
+    }
+
+    const lines = writes
+      .join("")
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      status: "success",
+      command: "swap quote",
+      network: "ethereum",
+      provider_errors: [providerError],
+    });
+    expect(lines[0].quotes[0]).toMatchObject({ quoteId: "quote-1", provider: "paraswap" });
+  });
+
+  it("emits swap quote unavailability as an NDJSON error envelope", () => {
+    try {
+      const out = createCommandOutput("json", {
+        command: "swap quote",
+        network: "ethereum",
+      });
+
+      expect(() => out.swapQuotesUnavailable("No quotes available", [providerError])).toThrow(
+        CliProcessExitError,
+      );
+    } finally {
+      restore();
+    }
+
+    const lines = writes
+      .join("")
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line));
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toEqual({
+      ok: false,
+      error: {
+        command: "swap quote",
+        code: "swap_quotes_unavailable",
+        message: "No quotes available",
+        provider_errors: [providerError],
+      },
+    });
+  });
+});

--- a/apps/wallet-cli/src/output.test.ts
+++ b/apps/wallet-cli/src/output.test.ts
@@ -1,0 +1,101 @@
+import "./live-common-setup";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+type MockSpinner = {
+  text: string;
+  isSpinning: boolean;
+  start: () => MockSpinner;
+  stop: () => MockSpinner;
+  success: (text?: string) => MockSpinner;
+  error: (text?: string) => MockSpinner;
+  clear: () => MockSpinner;
+};
+
+const createdSpinners: MockSpinner[] = [];
+
+mock.module("yocto-spinner", () => ({
+  default: ({ text }: { text: string }) => {
+    const spin: MockSpinner = {
+      text,
+      isSpinning: false,
+      start() {
+        this.isSpinning = true;
+        return this;
+      },
+      stop() {
+        this.isSpinning = false;
+        return this;
+      },
+      success(text?: string) {
+        if (text) this.text = text;
+        this.isSpinning = false;
+        return this;
+      },
+      error(text?: string) {
+        if (text) this.text = text;
+        this.isSpinning = false;
+        return this;
+      },
+      clear() {
+        return this;
+      },
+    };
+    createdSpinners.push(spin);
+    return spin;
+  },
+}));
+
+const { createCommandOutput } = await import("./output");
+
+describe("HumanCommandOutput", () => {
+  const envVars = [
+    "CLAUDECODE",
+    "CLAUDE_CODE",
+    "CURSOR_AGENT",
+    "CODEX_ENABLED",
+    "GEMINI_CLI",
+    "OPENCODE",
+    "AMP_CURRENT_THREAD_ID",
+  ];
+
+  let savedEnv: Record<string, string | undefined> = {};
+  let stderrIsTTY: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    createdSpinners.length = 0;
+    savedEnv = {};
+    for (const k of [...envVars, "AGENT"]) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    stderrIsTTY = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
+    Object.defineProperty(process.stderr, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (stderrIsTTY) {
+      Object.defineProperty(process.stderr, "isTTY", stderrIsTTY);
+    }
+  });
+
+  it("uses the canonical device-state text for signature requests", () => {
+    const out = createCommandOutput("human", {
+      command: "send",
+      network: "ethereum:main",
+      account: "js:2:ethereum:0x123",
+    });
+    const spin = out.spin("Preparing transaction…") as unknown as MockSpinner;
+
+    out.sendEvent({ type: "device-signature-requested" });
+
+    expect(spin.text).toBe("[⧖] Review on device. Approve or reject.");
+    expect(createdSpinners).toHaveLength(1);
+  });
+});

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -11,10 +11,12 @@
 import type { Spinner } from "yocto-spinner";
 import { getCryptoAssetsStore } from "@ledgerhq/cryptoassets";
 import { CliProcessExitError } from "./cli-process-exit-error";
+import { type DeviceState, isTerminalDeviceState, renderDeviceState } from "./device/device-state";
+import { WalletCliDeviceError } from "./device/wallet-cli-device-error";
 import { HumanFormatter } from "./wallet/formatter/human";
 import { JsonFormatter } from "./wallet/formatter/json";
 import { makeEnvelope } from "./shared/response";
-import { spinner, colors, writeStdout, writeStderr } from "./shared/ui";
+import { spinner, colors, writeStdout, writeStderr, isInteractive } from "./shared/ui";
 import {
   formatSwapQuoteHuman,
   type SwapQuoteLine,
@@ -48,14 +50,15 @@ export interface CommandOutput {
 
   /**
    * Error-handling boundary for the command handler body.
-   * Human: re-throws errors (Bunli handles display).
-   * Json: catches errors, writes a JSON error envelope, and exits with code 1.
+   * Human: exits immediately for WalletCliDeviceError, otherwise re-throws for Bunli.
+   * Json: catches errors, writes a JSON error envelope, and exits with the mapped code.
    */
   run(fn: () => Promise<void>): Promise<void>;
 
   /**
    * Immediately handle an error.
-   * Human: throws it. Json: writes error envelope + exits.
+   * Human: exits immediately for WalletCliDeviceError, otherwise throws it.
+   * Json: writes error envelope + exits.
    */
   fail(e: unknown): never;
 
@@ -93,6 +96,15 @@ export interface CommandOutput {
    * Human: error lines + exit 1.
    */
   swapQuotesUnavailable(message: string, errors: SwapQuoteProviderError[]): never;
+
+  /**
+   * Emit an intermediate device-state transition (awaiting_approval, exchange_app_needed).
+   * Human: update the active spinner with the canonical glyph + message.
+   * Json: emit an NDJSON device-state event so non-interactive clients can react before the
+   * final success/error envelope. Terminal failures are still surfaced through
+   * WalletCliDeviceError handling in run()/fail().
+   */
+  deviceState(state: DeviceState): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -105,6 +117,10 @@ class HumanCommandOutput implements CommandOutput {
   constructor(private readonly _fmt: HumanFormatter) {}
 
   spin(text: string): Spinner | null {
+    if (!isInteractive()) {
+      process.stderr.write(text + "\n");
+      return null;
+    }
     const s = spinner(text);
     this._activeSpin = s;
     return s;
@@ -126,14 +142,40 @@ class HumanCommandOutput implements CommandOutput {
     try {
       await fn();
     } catch (err) {
-      this._activeSpin?.error(HumanFormatter.formatError(err));
+      if (err instanceof WalletCliDeviceError) {
+        this._exitWithDeviceError(err);
+      }
+      const displayText = HumanCommandOutput._formatErrorForSpinner(err);
+      this._activeSpin?.error(displayText);
       this._activeSpin = null;
       throw err;
     }
   }
 
   fail(e: unknown): never {
+    if (e instanceof WalletCliDeviceError) {
+      this._exitWithDeviceError(e);
+    }
     throw e;
+  }
+
+  private static _formatErrorForSpinner(err: unknown): string {
+    if (err instanceof WalletCliDeviceError) {
+      const { glyph, message } = renderDeviceState(err.state);
+      return `${glyph} ${message}`;
+    }
+    return HumanFormatter.formatError(err);
+  }
+
+  private _exitWithDeviceError(err: WalletCliDeviceError): never {
+    const displayText = HumanCommandOutput._formatErrorForSpinner(err);
+    if (isInteractive() && this._activeSpin) {
+      this._activeSpin.error(displayText);
+    } else {
+      process.stderr.write(displayText + "\n");
+    }
+    this._activeSpin = null;
+    process.exit(err.exitCode);
   }
 
   async balances(items: Balance[]): Promise<void> {
@@ -209,9 +251,16 @@ class HumanCommandOutput implements CommandOutput {
       case "device-streaming":
         if (s) s.text = `Streaming to device… ${Math.round(event.progress * 100)}%`;
         break;
-      case "device-signature-requested":
-        if (s) s.text = "Please confirm on device…";
+      case "device-signature-requested": {
+        if (s) {
+          const { glyph, message } = renderDeviceState({
+            code: "awaiting_approval",
+            reason: "sign",
+          });
+          s.text = `${glyph} ${message}`;
+        }
         break;
+      }
       case "device-signature-granted":
         if (s) s.text = "Signed, broadcasting…";
         break;
@@ -228,26 +277,65 @@ class HumanCommandOutput implements CommandOutput {
     /* noop */
   }
 
+  private _renderSwapProviderError(e: SwapQuoteProviderError): string {
+    return colors.dim(`  ${e.provider} (${e.type}): ${e.code} - ${e.message}`);
+  }
+
+  private _printSwapProviderErrors(
+    message: string,
+    errors: SwapQuoteProviderError[],
+    asFailure: boolean,
+  ): void {
+    if (isInteractive()) {
+      const s = spinner("");
+      if (asFailure) s.error(message);
+      else s.error(colors.dim(message));
+      for (const e of errors) {
+        s.error(this._renderSwapProviderError(e));
+      }
+      return;
+    }
+
+    process.stderr.write(message + "\n");
+    for (const e of errors) {
+      process.stderr.write(this._renderSwapProviderError(e) + "\n");
+    }
+  }
+
   swapQuotes(args: { quotes: SwapQuoteLine[]; partialErrors: SwapQuoteProviderError[] }): void {
     for (const q of args.quotes) {
       writeStdout(`${formatSwapQuoteHuman(q)}\n`);
     }
     if (args.partialErrors.length > 0) {
-      const s = spinner("");
-      s.error(colors.dim(`${args.partialErrors.length} provider(s) returned errors:`));
-      for (const e of args.partialErrors) {
-        s.error(colors.dim(`  ${e.provider} (${e.type}): ${e.code} — ${e.message}`));
-      }
+      this._printSwapProviderErrors(
+        `${args.partialErrors.length} provider(s) returned errors:`,
+        args.partialErrors,
+        false,
+      );
     }
   }
 
   swapQuotesUnavailable(message: string, errors: SwapQuoteProviderError[]): never {
-    const s = spinner("");
-    s.error(message);
-    for (const e of errors) {
-      s.error(colors.dim(`  ${e.provider} (${e.type}): ${e.code} — ${e.message}`));
-    }
+    this._printSwapProviderErrors(message, errors, true);
     throw new CliProcessExitError(1);
+  }
+
+  deviceState(state: DeviceState): void {
+    if (isTerminalDeviceState(state)) {
+      // Terminal states are surfaced via thrown WalletCliDeviceError; avoid double-render.
+      return;
+    }
+    const { glyph, message } = renderDeviceState(state);
+    const text = `${glyph} ${message}`;
+    if (isInteractive()) {
+      if (this._activeSpin) {
+        this._activeSpin.text = text;
+      } else {
+        this.spin(text);
+      }
+    } else {
+      process.stderr.write(text + "\n");
+    }
   }
 }
 
@@ -267,20 +355,61 @@ class JsonCommandOutput implements CommandOutput {
     this._jsonFmt = new JsonFormatter(fmt);
   }
 
-  private _envelope(data: Record<string, unknown>): string {
-    return JSON.stringify(
-      makeEnvelope(this._ctx.command, this._ctx.network, data, this._ctx.account),
-      null,
-      2,
-    );
+  private _envelope(data: Record<string, unknown>): Record<string, unknown> {
+    return makeEnvelope(this._ctx.command, this._ctx.network, data, this._ctx.account);
   }
 
-  private _errorEnvelope(e: unknown): string {
-    return JSON.stringify(
-      { ok: false, error: { command: this._ctx.command, message: HumanFormatter.formatError(e) } },
-      null,
-      2,
-    );
+  private _errorEnvelope(e: unknown): Record<string, unknown> {
+    if (e instanceof WalletCliDeviceError) {
+      const { message } = renderDeviceState(e.state);
+      return {
+        ok: false,
+        error: {
+          command: this._ctx.command,
+          code: e.state.code,
+          message,
+        },
+      };
+    }
+    return {
+      ok: false,
+      error: { command: this._ctx.command, message: HumanFormatter.formatError(e) },
+    };
+  }
+
+  private _swapQuoteErrorEnvelope(
+    message: string,
+    errors: SwapQuoteProviderError[],
+  ): Record<string, unknown> {
+    return {
+      ok: false,
+      error: {
+        command: this._ctx.command,
+        code: "swap_quotes_unavailable",
+        message,
+        provider_errors: errors,
+      },
+    };
+  }
+
+  private _exitCode(e: unknown): number {
+    return e instanceof WalletCliDeviceError ? e.exitCode : 1;
+  }
+
+  private _writeNdjson(value: unknown): void {
+    writeStdout(JSON.stringify(value));
+  }
+
+  private _emitDeviceStateEvent(state: DeviceState): void {
+    const { message } = renderDeviceState(state);
+    this._writeNdjson({
+      type: "device-state",
+      command: this._ctx.command,
+      network: this._ctx.network,
+      ...(this._ctx.account == null ? {} : { account: this._ctx.account }),
+      state,
+      message,
+    });
   }
 
   spin(_text: string): null {
@@ -295,31 +424,29 @@ class JsonCommandOutput implements CommandOutput {
     try {
       await fn();
     } catch (e) {
-      // Re-throw CliProcessExitError so the exit code propagates cleanly to runMain()
-      // without being double-printed. All other errors are written as a JSON envelope.
       if (e instanceof CliProcessExitError) throw e;
-      writeStdout(this._errorEnvelope(e));
-      throw new CliProcessExitError(1);
+      this._writeNdjson(this._errorEnvelope(e));
+      throw new CliProcessExitError(this._exitCode(e));
     }
   }
 
   fail(e: unknown): never {
-    writeStdout(this._errorEnvelope(e));
-    throw new CliProcessExitError(1);
+    this._writeNdjson(this._errorEnvelope(e));
+    throw new CliProcessExitError(this._exitCode(e));
   }
 
   async balances(items: Balance[]): Promise<void> {
     const balances = await this._jsonFmt.balances(items);
-    writeStdout(this._envelope({ balances }));
+    this._writeNdjson(this._envelope({ balances }));
   }
 
   async operations(items: Operation[], currencyId: string, nextCursor?: string): Promise<void> {
     const operations = await this._jsonFmt.operations(items, currencyId, this._ctx.account ?? "");
-    writeStdout(this._envelope({ operations, nextCursor }));
+    this._writeNdjson(this._envelope({ operations, nextCursor }));
   }
 
   address(addr: string): void {
-    writeStdout(this._envelope({ address: addr }));
+    this._writeNdjson(this._envelope({ address: addr }));
   }
 
   discoveredAccount(d: DiscoveredAccount): void {
@@ -328,21 +455,23 @@ class JsonCommandOutput implements CommandOutput {
 
   flushDiscovery(): void {
     const accounts = JsonFormatter.discoveredAccounts(this._discoveredAccounts);
-    writeStdout(this._envelope({ accounts }));
+    this._writeNdjson(this._envelope({ accounts }));
   }
 
-  sessionSaved(_added: number): void { /* noop */ }
+  sessionSaved(_added: number): void {
+    /* noop */
+  }
 
   sessionReset(count: number): void {
-    writeStdout(this._envelope({ removed: count }));
+    this._writeNdjson(this._envelope({ removed: count }));
   }
 
   sessionView(accounts: readonly SessionEntry[]): void {
-    writeStdout(this._envelope({ accounts }));
+    this._writeNdjson(this._envelope({ accounts }));
   }
 
   sendDryRun(p: { recipient: string; amount: string; fees: string }): void {
-    writeStdout(
+    this._writeNdjson(
       this._envelope({ dry_run: true, recipient: p.recipient, amount: p.amount, fee: p.fees }),
     );
   }
@@ -352,6 +481,8 @@ class JsonCommandOutput implements CommandOutput {
       this._sendResult.recipient = event.recipient;
       this._sendResult.amount = event.amount;
       this._sendResult.fee = event.fees;
+    } else if (event.type === "device-signature-requested") {
+      this._emitDeviceStateEvent({ code: "awaiting_approval", reason: "sign" });
     } else if (event.type === "broadcasted") {
       this._sendResult.tx_hash = event.txHash;
     } else if (event.type === "dry-run") {
@@ -360,15 +491,24 @@ class JsonCommandOutput implements CommandOutput {
   }
 
   sendComplete(): void {
-    writeStdout(this._envelope(this._sendResult));
+    this._writeNdjson(this._envelope(this._sendResult));
+  }
+
+  deviceState(state: DeviceState): void {
+    this._emitDeviceStateEvent(state);
   }
 
   swapQuotes(args: { quotes: SwapQuoteLine[]; partialErrors: SwapQuoteProviderError[] }): void {
-    writeStdout(this._envelope({ quotes: args.quotes }));
+    this._writeNdjson(
+      this._envelope({
+        quotes: args.quotes,
+        ...(args.partialErrors.length === 0 ? {} : { provider_errors: args.partialErrors }),
+      }),
+    );
   }
 
-  swapQuotesUnavailable(message: string, _errors: SwapQuoteProviderError[]): never {
-    writeStdout(this._errorEnvelope(message));
+  swapQuotesUnavailable(message: string, errors: SwapQuoteProviderError[]): never {
+    this._writeNdjson(this._swapQuoteErrorEnvelope(message, errors));
     throw new CliProcessExitError(1);
   }
 }

--- a/apps/wallet-cli/src/session/bridge-device-session.test.ts
+++ b/apps/wallet-cli/src/session/bridge-device-session.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { DeviceActionStatus } from "@ledgerhq/device-management-kit";
+import { Observable } from "rxjs";
+
+const calls = {
+  ensure: 0,
+  execute: [] as Array<{
+    sessionId: string;
+    deviceAction: unknown;
+  }>,
+  reset: 0,
+};
+
+function completedAction() {
+  return {
+    observable: new Observable(observer => {
+      observer.next({ status: DeviceActionStatus.Completed, output: {} } as const);
+      observer.complete();
+    }),
+    cancel: (): void => {},
+  };
+}
+
+function errorAction(error: unknown) {
+  return {
+    observable: new Observable(observer => {
+      observer.next({ status: DeviceActionStatus.Error, error } as const);
+      observer.complete();
+    }),
+    cancel: (): void => {},
+  };
+}
+
+const testTransport = {
+  dmk: {
+    _unsafeBypassIntentQueue: (): void => {},
+    executeDeviceAction: ({
+      sessionId,
+      deviceAction,
+    }: {
+      sessionId: string;
+      deviceAction: unknown;
+    }) => {
+      calls.execute.push({ sessionId, deviceAction });
+      return executeImpl();
+    },
+  },
+  sessionId: "test-session-id",
+};
+
+let ensureImpl: () => Promise<typeof testTransport>;
+let executeImpl: () => { observable: Observable<unknown>; cancel: () => void };
+let resetImpl: () => Promise<void>;
+
+mock.module("../device/register-dmk-transport", () => {
+  let _leakedTestTransport: unknown = null;
+  return {
+    WALLET_CLI_DMK_DEVICE_ID: "wallet-cli-dmk",
+    // Allow cli-runner (running in a worker that received the leaked mock) to
+    // install a test transport so DMK-dependent commands still work.
+    _setTestDmkTransport: (t: unknown) => {
+      _leakedTestTransport = t;
+    },
+    ensureWalletCliDmkTransport: async () => {
+      if (_leakedTestTransport) return _leakedTestTransport;
+      calls.ensure += 1;
+      return ensureImpl();
+    },
+    resetWalletCliDmkSession: async () => {
+      calls.reset += 1;
+      return resetImpl();
+    },
+    disposeWalletCliDmkTransportFully: async () => {},
+    registerWalletCliDmkTransport: () => {},
+  };
+});
+
+const { WalletCliDeviceError } = await import("../device/wallet-cli-device-error");
+const { getManagerAppNameForCurrencyId, withCurrencyDeviceSession } =
+  await import("./bridge-device-session");
+
+describe("withCurrencyDeviceSession", () => {
+  beforeEach(() => {
+    calls.ensure = 0;
+    calls.execute = [];
+    calls.reset = 0;
+    ensureImpl = async () => testTransport;
+    executeImpl = () => completedAction();
+    resetImpl = async () => {};
+  });
+
+  it("wraps setup failures as WalletCliDeviceError", async () => {
+    const usbError = new Error("USB down");
+    ensureImpl = async () => {
+      throw usbError;
+    };
+
+    await expect(withCurrencyDeviceSession("ethereum", async () => "ok")).rejects.toBeInstanceOf(
+      WalletCliDeviceError,
+    );
+    expect(calls.ensure).toBe(1);
+    expect(calls.execute).toHaveLength(0);
+    expect(calls.reset).toBe(0);
+  });
+
+  it("wraps connect failures as WalletCliDeviceError", async () => {
+    executeImpl = () => errorAction(new Error("connect failed"));
+
+    await expect(withCurrencyDeviceSession("ethereum", async () => "ok")).rejects.toBeInstanceOf(
+      WalletCliDeviceError,
+    );
+    expect(calls.ensure).toBe(1);
+    expect(calls.execute).toHaveLength(1);
+    expect(calls.reset).toBe(0);
+  });
+
+  it("rethrows callback failures unchanged after resetting the session", async () => {
+    const callbackError = new Error("HTTP parsing bug");
+
+    await expect(
+      withCurrencyDeviceSession("ethereum", async () => {
+        throw callbackError;
+      }),
+    ).rejects.toBe(callbackError);
+
+    expect(calls.execute).toHaveLength(1);
+    expect(calls.execute[0].sessionId).toBe(testTransport.sessionId);
+    expect(
+      (
+        calls.execute[0].deviceAction as {
+          input: { application: { name: string } };
+        }
+      ).input.application.name,
+    ).toBe("Ethereum");
+    expect(calls.reset).toBe(1);
+  });
+
+  it("resets the session after a successful callback", async () => {
+    const result = await withCurrencyDeviceSession("bitcoin", async () => "done");
+
+    expect(result).toBe("done");
+    expect(calls.reset).toBe(1);
+  });
+});
+
+describe("getManagerAppNameForCurrencyId", () => {
+  it("returns the Ledger manager app name for currencies with dedicated apps", () => {
+    expect(getManagerAppNameForCurrencyId("bitcoin")).toBe("Bitcoin");
+    expect(getManagerAppNameForCurrencyId("ethereum")).toBe("Ethereum");
+  });
+
+  it("returns the shared manager app name for currencies reusing another app", () => {
+    expect(getManagerAppNameForCurrencyId("base")).toBe("Ethereum");
+  });
+});

--- a/apps/wallet-cli/src/session/bridge-device-session.ts
+++ b/apps/wallet-cli/src/session/bridge-device-session.ts
@@ -1,31 +1,47 @@
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { connectLedgerApp } from "../device/connect-ledger-app";
-import { toWalletCliDeviceError } from "../device/wallet-cli-device-error";
+import type { DeviceState } from "../device/device-state";
+import { WalletCliDeviceError } from "../device/wallet-cli-device-error";
 import {
   ensureWalletCliDmkTransport,
   resetWalletCliDmkSession,
 } from "../device/register-dmk-transport";
 import { walletCliDebug } from "../shared/log";
 
+export type CurrencyDeviceSessionOptions = {
+  /** Observer for every intermediate device-state transition during connect/open-app. */
+  onStateChange?: (state: DeviceState) => void;
+  /** Max time to wait for the device to unlock. Defaults in connect-ledger-app. */
+  deviceTimeoutMs?: number;
+};
+
+export function getManagerAppNameForCurrencyId(currencyId: string): string {
+  return getCryptoCurrencyById(currencyId).managerAppName;
+}
+
 export async function withCurrencyDeviceSession<T>(
   currencyId: string,
   fn: () => Promise<T>,
+  options: CurrencyDeviceSessionOptions = {},
 ): Promise<T> {
-  const { managerAppName } = getCryptoCurrencyById(currencyId);
+  const managerAppName = getManagerAppNameForCurrencyId(currencyId);
   walletCliDebug("Ensuring DMK transport…");
   try {
     const transport = await ensureWalletCliDmkTransport();
     walletCliDebug(`Connecting Ledger app (${managerAppName})…`);
-    await connectLedgerApp(transport.dmk, transport.sessionId, managerAppName);
-    walletCliDebug("Device session ready.");
-    try {
-      return await fn();
-    } finally {
-      walletCliDebug("Resetting device session…");
-      await resetWalletCliDmkSession();
-    }
+    await connectLedgerApp(transport.dmk, transport.sessionId, managerAppName, {
+      onStateChange: options.onStateChange,
+      deviceTimeoutMs: options.deviceTimeoutMs,
+    });
   } catch (e) {
-    throw toWalletCliDeviceError(e);
+    throw WalletCliDeviceError.fromUnknown(e, { expectedApp: managerAppName });
+  }
+  walletCliDebug("Device session ready.");
+  try {
+    return await fn();
+  } finally {
+    walletCliDebug("Resetting device session…");
+    await resetWalletCliDmkSession();
   }
 }
 
@@ -39,10 +55,14 @@ const FAMILY_CURRENCY_ID: Record<string, string> = {
   solana: "solana",
 };
 
-export async function withBridgeDeviceSession<T>(family: string, fn: () => Promise<T>): Promise<T> {
+export async function withBridgeDeviceSession<T>(
+  family: string,
+  fn: () => Promise<T>,
+  options: CurrencyDeviceSessionOptions = {},
+): Promise<T> {
   const currencyId = FAMILY_CURRENCY_ID[family];
   if (!currencyId) {
     throw new Error(`No canonical currency for family "${family}".`);
   }
-  return withCurrencyDeviceSession(currencyId, fn);
+  return withCurrencyDeviceSession(currencyId, fn, options);
 }

--- a/apps/wallet-cli/src/session/session-store.test.ts
+++ b/apps/wallet-cli/src/session/session-store.test.ts
@@ -126,7 +126,12 @@ describe("Session.addDescriptors", () => {
   });
 
   it("skips already-known descriptors", () => {
-    const existing = [{ label: "bitcoin-native-1", descriptor: "account:1:utxo:bitcoin:main:xpub6BosfCnifzxcA:m/84h/0h/0h" }];
+    const existing = [
+      {
+        label: "bitcoin-native-1",
+        descriptor: "account:1:utxo:bitcoin:main:xpub6BosfCnifzxcA:m/84h/0h/0h",
+      },
+    ];
     const session = Session.from(existing);
     const added = session.addDescriptors([btcNative]);
     expect(added).toBe(0);
@@ -134,7 +139,12 @@ describe("Session.addDescriptors", () => {
   });
 
   it("never removes existing entries", () => {
-    const existing = [{ label: "bitcoin-native-1", descriptor: "account:1:utxo:bitcoin:main:xpub6BosfCnifzxcA:m/84h/0h/0h" }];
+    const existing = [
+      {
+        label: "bitcoin-native-1",
+        descriptor: "account:1:utxo:bitcoin:main:xpub6BosfCnifzxcA:m/84h/0h/0h",
+      },
+    ];
     const session = Session.from(existing);
     session.addDescriptors([]);
     expect(session.accounts).toHaveLength(1);
@@ -142,7 +152,12 @@ describe("Session.addDescriptors", () => {
   });
 
   it("increments label counter to avoid collision with existing", () => {
-    const existing = [{ label: "bitcoin-native-1", descriptor: "account:1:utxo:bitcoin:main:xpubOTHER:m/84h/0h/0h" }];
+    const existing = [
+      {
+        label: "bitcoin-native-1",
+        descriptor: "account:1:utxo:bitcoin:main:xpubOTHER:m/84h/0h/0h",
+      },
+    ];
     const session = Session.from(existing);
     session.addDescriptors([btcNative]);
     expect(session.accounts).toHaveLength(2);

--- a/apps/wallet-cli/src/shared/ui-spinner.test.ts
+++ b/apps/wallet-cli/src/shared/ui-spinner.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+type MockSpinner = {
+  text: string;
+  isSpinning: boolean;
+  start: () => MockSpinner;
+  stop: () => MockSpinner;
+  success: () => MockSpinner;
+  error: () => MockSpinner;
+  clear: () => MockSpinner;
+};
+
+const createdSpinners: MockSpinner[] = [];
+
+mock.module("yocto-spinner", () => ({
+  default: ({ text }: { text: string }) => {
+    const spin: MockSpinner = {
+      text,
+      isSpinning: false,
+      start() {
+        this.isSpinning = true;
+        return this;
+      },
+      stop() {
+        this.isSpinning = false;
+        return this;
+      },
+      success() {
+        this.isSpinning = false;
+        return this;
+      },
+      error() {
+        this.isSpinning = false;
+        return this;
+      },
+      clear() {
+        return this;
+      },
+    };
+    createdSpinners.push(spin);
+    return spin;
+  },
+}));
+
+const { spinner } = await import("./ui");
+
+describe("spinner", () => {
+  const envVars = [
+    "CLAUDECODE",
+    "CLAUDE_CODE",
+    "CURSOR_AGENT",
+    "CODEX_ENABLED",
+    "GEMINI_CLI",
+    "OPENCODE",
+    "AMP_CURRENT_THREAD_ID",
+  ];
+
+  let savedEnv: Record<string, string | undefined> = {};
+  let stderrIsTTY: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    createdSpinners.length = 0;
+    savedEnv = {};
+    for (const k of [...envVars, "AGENT"]) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    stderrIsTTY = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
+    Object.defineProperty(process.stderr, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (stderrIsTTY) {
+      Object.defineProperty(process.stderr, "isTTY", stderrIsTTY);
+    }
+  });
+
+  it("stops the previous spinner before starting a new one", () => {
+    const first = spinner("first") as unknown as MockSpinner;
+    expect(first.isSpinning).toBe(true);
+
+    const second = spinner("second") as unknown as MockSpinner;
+    expect(first.isSpinning).toBe(false);
+    expect(second.isSpinning).toBe(true);
+    expect(createdSpinners).toHaveLength(2);
+  });
+});

--- a/apps/wallet-cli/src/shared/ui.test.ts
+++ b/apps/wallet-cli/src/shared/ui.test.ts
@@ -13,7 +13,6 @@ describe("isInteractive", () => {
   ];
 
   let saved: Record<string, string | undefined> = {};
-
   beforeEach(() => {
     saved = {};
     for (const k of [...envVars, "AGENT"]) {

--- a/apps/wallet-cli/src/shared/ui.ts
+++ b/apps/wallet-cli/src/shared/ui.ts
@@ -11,10 +11,7 @@ type Writer = (chunk: string) => void;
 let stdoutWriter: Writer | null = null;
 let stderrWriter: Writer | null = null;
 
-export function installOutputCapture(writers: {
-  stdout?: Writer;
-  stderr?: Writer;
-}): () => void {
+export function installOutputCapture(writers: { stdout?: Writer; stderr?: Writer }): () => void {
   const previousStdout = stdoutWriter;
   const previousStderr = stderrWriter;
   stdoutWriter = writers.stdout ?? null;
@@ -41,6 +38,21 @@ export function writeStderr(message: string): void {
   process.stderr.write(message);
 }
 
+let activeSpinner: Spinner | null = null;
+
+export function isAgentEnvironment(): boolean {
+  return Boolean(
+    process.env.CLAUDECODE ||
+    process.env.CLAUDE_CODE ||
+    process.env.CURSOR_AGENT ||
+    process.env.CODEX_ENABLED ||
+    process.env.GEMINI_CLI ||
+    process.env.OPENCODE ||
+    process.env.AMP_CURRENT_THREAD_ID ||
+    process.env.AGENT === "amp",
+  );
+}
+
 /**
  * Returns true when running in an interactive terminal.
  * Returns false when the CLI is piped, redirected, or invoked by an AI agent.
@@ -51,17 +63,7 @@ export function writeStderr(message: string): void {
  *  - AI agent env vars: same signals used by @bunli/plugin-ai-detect
  */
 export function isInteractive(): boolean {
-  if (
-    process.env.CLAUDECODE ||
-    process.env.CLAUDE_CODE ||
-    process.env.CURSOR_AGENT ||
-    process.env.CODEX_ENABLED ||
-    process.env.GEMINI_CLI ||
-    process.env.OPENCODE ||
-    process.env.AMP_CURRENT_THREAD_ID ||
-    process.env.AGENT === "amp"
-  )
-    return false;
+  if (isAgentEnvironment()) return false;
   return process.stderr.isTTY === true;
 }
 
@@ -82,7 +84,11 @@ const noopSpinner: Spinner = new Proxy({} as Spinner, {
 
 export function spinner(text: string): Spinner {
   if (!isInteractive()) return noopSpinner;
-  return yoctoSpinner({ text, stream: process.stderr }).start();
+  if (activeSpinner?.isSpinning) {
+    activeSpinner.stop();
+  }
+  activeSpinner = yoctoSpinner({ text, stream: process.stderr }).start();
+  return activeSpinner;
 }
 
 export async function withSpinner<T>(

--- a/apps/wallet-cli/src/test/commands/balances.test.ts
+++ b/apps/wallet-cli/src/test/commands/balances.test.ts
@@ -29,7 +29,10 @@ describe("balances command", () => {
   let sessionCleanup: (() => void) | undefined;
   beforeAll(() => server.start());
   afterAll(() => server.stop());
-  afterEach(() => { sessionCleanup?.(); sessionCleanup = undefined; });
+  afterEach(() => {
+    sessionCleanup?.();
+    sessionCleanup = undefined;
+  });
 
   it("human output: prints ETH balance line", async () => {
     const { stdout, exitCode, stderr } = await runCli(["balances", "--account", ETH_DESCRIPTOR], {

--- a/apps/wallet-cli/src/test/commands/discover.test.ts
+++ b/apps/wallet-cli/src/test/commands/discover.test.ts
@@ -41,7 +41,10 @@ describe("account discover — session persistence", () => {
 
   beforeAll(() => server.start());
   afterAll(() => server.stop());
-  afterEach(() => { cleanup?.(); cleanup = undefined; });
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
 
   it("writes discovered accounts to session.yaml with generated labels", async () => {
     const fixture = makeSessionDir([]);
@@ -54,7 +57,9 @@ describe("account discover — session persistence", () => {
     expect(exitCode, `stderr: ${stderr}`).toBe(0);
 
     const sessionPath = join(fixture.env.XDG_STATE_HOME, "ledger-wallet-cli", "session.yaml");
-    const session = YAML.parse(await Bun.file(sessionPath).text()) as { accounts: Array<{ label: string; descriptor: string }> };
+    const session = YAML.parse(await Bun.file(sessionPath).text()) as {
+      accounts: Array<{ label: string; descriptor: string }>;
+    };
     expect(Array.isArray(session.accounts)).toBe(true);
     expect(session.accounts.length).toBeGreaterThan(0);
     expect(session.accounts[0].label).toMatch(/^ethereum-\d+$/);

--- a/apps/wallet-cli/src/test/commands/output.test.ts
+++ b/apps/wallet-cli/src/test/commands/output.test.ts
@@ -1,0 +1,31 @@
+import path from "node:path";
+import { describe, expect, it } from "bun:test";
+import { DEVICE_EXIT_CODES } from "../../device/device-state";
+import { WalletCliDeviceError } from "../../device/wallet-cli-device-error";
+
+const ROOT = path.resolve(import.meta.dir, "../../..");
+const HUMAN_DEVICE_ERROR_EXIT = path.resolve(
+  import.meta.dir,
+  "../helpers/human-device-error-exit.ts",
+);
+
+describe("output command handling", () => {
+  it("human output exits with the WalletCliDeviceError exit code", async () => {
+    const proc = Bun.spawn(["bun", "--cwd", ROOT, HUMAN_DEVICE_ERROR_EXIT], {
+      env: {
+        ...process.env,
+        CLAUDECODE: "1",
+        NO_COLOR: "1",
+      },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(DEVICE_EXIT_CODES.timeout);
+    expect(await new Response(proc.stderr).text()).toContain(
+      new WalletCliDeviceError({ code: "timeout" }).message,
+    );
+  });
+});

--- a/apps/wallet-cli/src/test/commands/receive.test.ts
+++ b/apps/wallet-cli/src/test/commands/receive.test.ts
@@ -23,9 +23,19 @@ describe("receive --verify command (mock DMK)", () => {
     );
     expect(exitCode, `stderr: ${stderr}`).toBe(0);
 
-    const data = JSON.parse(stdout);
+    const lines = stdout.split("\n").map(line => JSON.parse(line));
+    expect(lines[0]).toMatchObject({
+      type: "device-state",
+      command: "receive",
+      network: "ethereum:main",
+      state: { code: "awaiting_approval", reason: "verify_address" },
+      message: "Review address on device. Approve or reject.",
+    });
+
+    const data = lines.at(-1);
     expect(data.command).toBe("receive");
     expect(data.network).toBe("ethereum:main");
+    expect(lines[0].account).toBe(data.account);
     expect(typeof data.address).toBe("string");
     // The mock device returns our known address
     expect(data.address.toLowerCase()).toBe(MOCK_ETH_ADDRESS.toLowerCase());

--- a/apps/wallet-cli/src/test/commands/session.test.ts
+++ b/apps/wallet-cli/src/test/commands/session.test.ts
@@ -6,7 +6,10 @@ import { ETH_DESCRIPTOR, ETH_ADDRESS } from "../helpers/constants";
 const ETH_DESCRIPTOR_2 = `account:1:address:ethereum:main:${ETH_ADDRESS}:m/44h/60h/1h/0/0`;
 
 let cleanup: (() => void) | undefined;
-afterEach(() => { cleanup?.(); cleanup = undefined; });
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
 
 describe("session view", () => {
   it("empty session: prints empty message", async () => {

--- a/apps/wallet-cli/src/test/helpers/human-device-error-exit.ts
+++ b/apps/wallet-cli/src/test/helpers/human-device-error-exit.ts
@@ -1,0 +1,12 @@
+import "../../live-common-setup";
+import { createCommandOutput } from "../../output";
+import { WalletCliDeviceError } from "../../device/wallet-cli-device-error";
+
+const out = createCommandOutput("human", {
+  command: "test-human-device-error-exit",
+  network: "ethereum:main",
+});
+
+await out.run(async () => {
+  throw new WalletCliDeviceError({ code: "timeout" });
+});

--- a/apps/wallet-cli/src/wallet/compatibility/bridge.ts
+++ b/apps/wallet-cli/src/wallet/compatibility/bridge.ts
@@ -130,9 +130,7 @@ export class BridgeAdapter {
     options: SendOptions,
   ): Observable<SendEvent> {
     return new Observable(subscriber => {
-      this.executeSend(descriptor, intent, options, subscriber).catch(err =>
-        subscriber.error(err),
-      );
+      this.executeSend(descriptor, intent, options, subscriber).catch(err => subscriber.error(err));
     });
   }
 

--- a/apps/wallet-cli/src/wallet/models.ts
+++ b/apps/wallet-cli/src/wallet/models.ts
@@ -58,7 +58,6 @@ export function parseAccountDescriptor(input: string): AccountDescriptor {
   return parseShortAccountDescriptor(input);
 }
 
-
 export const CurrencyIdSchema = z.string().min(1);
 export type CurrencyId = z.infer<typeof CurrencyIdSchema>;
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli errors handling

### 📝 Description

Centralize wallet-cli device error classification into a shared device-state model so human and JSON output use the same messages, codes, and exit behavior.
Improve command UX with device timeout support, non-interactive spinner handling, and broader test coverage for device/session flows.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28257]
- **ADR link (if any)**: 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-28257]: https://ledgerhq.atlassian.net/browse/LIVE-28257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ