### PR TITLE
[LWDM] fix(stellar): Horizon.AxiosClient interceptors resilient to coinConfig not being initialised yet

### DIFF
--- a/.changeset/tender-needles-greet.md
+++ b/.changeset/tender-needles-greet.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-stellar": minor
+---
+
+Fix: stellar `Horizon.AxiosClient` interceptors in `coin-stellar/src/network/horizon.ts` resilient to `coinConfig` not being initialised yet.

--- a/libs/coin-modules/coin-stellar/src/api/index.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.ts
@@ -31,11 +31,12 @@ import {
   validateIntent,
 } from "../logic";
 import { validateAddress } from "../logic/validateAddress";
-import { fetchSequence } from "../network";
+import { fetchSequence, registerHorizonInterceptors } from "../network";
 import { StellarMemo } from "../types";
 
 export function createApi(config: StellarConfig): AlpacaApi<StellarMemo> {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
+  registerHorizonInterceptors();
 
   return {
     broadcast,

--- a/libs/coin-modules/coin-stellar/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/getBalance.ts
@@ -3,10 +3,10 @@ import { fetchAccount } from "../network";
 
 export async function getBalance(addr: string): Promise<Balance[]> {
   const { balance, assets, spendableBalance } = await fetchAccount(addr);
-  const locked = BigInt(balance.toString()) - BigInt(spendableBalance.toString());
+  const locked = BigInt(balance.toFixed()) - BigInt(spendableBalance.toFixed());
   const nativeRes = [
     {
-      value: BigInt(balance.toString()),
+      value: BigInt(balance.toFixed()),
       asset: { type: "native" as const },
       locked: locked, // locked balance is the difference between native balance and spendable balance
     },

--- a/libs/coin-modules/coin-stellar/src/network/horizon.integ.test.ts
+++ b/libs/coin-modules/coin-stellar/src/network/horizon.integ.test.ts
@@ -1,5 +1,5 @@
 import coinConfig, { StellarCoinConfig } from "../config";
-import { fetchAllOperations } from "./horizon";
+import { fetchAllOperations, registerHorizonInterceptors } from "./horizon";
 
 describe("fetchAllOperations", () => {
   beforeAll(() => {
@@ -12,6 +12,7 @@ describe("fetchAllOperations", () => {
         },
       }),
     );
+    registerHorizonInterceptors();
   });
 
   it(

--- a/libs/coin-modules/coin-stellar/src/network/horizon.ts
+++ b/libs/coin-modules/coin-stellar/src/network/horizon.ts
@@ -18,10 +18,7 @@ import {
 import { BigNumber } from "bignumber.js";
 import coinConfig from "../config";
 import { patchHermesTypedArraysIfNeeded, unpatchHermesTypedArrays } from "../polyfill";
-import {
-  StellarBroadcastFailedError,
-  type StellarDecodedResultXdr,
-} from "../types/errors";
+import { StellarBroadcastFailedError, type StellarDecodedResultXdr } from "../types/errors";
 import {
   type BalanceAsset,
   type NetworkInfo,
@@ -80,8 +77,11 @@ type HorizonSubmitErrorBody = {
 
 function isHorizonSubmitErrorBody(data: unknown): data is HorizonSubmitErrorBody {
   return !!(
-    data && typeof data === "object" && "extras" in data &&
-    typeof data.extras === "object" && data.extras !== null &&
+    data &&
+    typeof data === "object" &&
+    "extras" in data &&
+    typeof data.extras === "object" &&
+    data.extras !== null &&
     "result_codes" in data.extras &&
     data.extras.result_codes !== undefined &&
     typeof data.extras.result_codes === "object"
@@ -108,10 +108,10 @@ function getHorizonBodyFromSubmitFailure(error: unknown): HorizonSubmitErrorBody
 
 function decodeTransactionResultFields(resultXdrBase64: string | undefined):
   | {
-    feeChargedStroops?: string;
-    resultXdrSwitchName?: string;
-    decodedResultXdr: StellarDecodedResultXdr;
-  }
+      feeChargedStroops?: string;
+      resultXdrSwitchName?: string;
+      decodedResultXdr: StellarDecodedResultXdr;
+    }
   | undefined {
   if (!resultXdrBase64) {
     return undefined;
@@ -137,7 +137,8 @@ function makeBroadcastFailedError(body: HorizonSubmitErrorBody, cause: Error): E
   const horizonTransactionCode = extras?.result_codes?.transaction ?? "";
   const horizonOperationCodes = extras?.result_codes?.operations;
   const documentationSummary =
-    (horizonTransactionCode && HORIZON_TRANSACTION_RESULT_CODE_DOCUMENTATION[horizonTransactionCode]) ||
+    (horizonTransactionCode &&
+      HORIZON_TRANSACTION_RESULT_CODE_DOCUMENTATION[horizonTransactionCode]) ||
     "Unknown transaction result code.";
   const decodedResult = decodeTransactionResultFields(extras?.result_xdr);
   const feeChargedStroops = decodedResult?.feeChargedStroops;
@@ -145,9 +146,7 @@ function makeBroadcastFailedError(body: HorizonSubmitErrorBody, cause: Error): E
   const decodedResultXdr = decodedResult?.decodedResultXdr;
   const envelopeXdr = extras?.envelope_xdr ?? "";
   const message =
-    body.detail ||
-    body.title ||
-    `Transaction submission failed (${body.status ?? "unknown"}).`;
+    body.detail || body.title || `Transaction submission failed (${body.status ?? "unknown"}).`;
 
   return new StellarBroadcastFailedError(
     message,
@@ -178,24 +177,82 @@ function getServer(): Horizon.Server {
   return server;
 }
 
-// Due to the inconsistency between the axios version (1.6.5) used by `stellar-sdk`
-// and the version (0.26.1) used by `@ledgerhq/live-network/network`, it is not possible to use the interceptors
-// provided by `@ledgerhq/live-network/network`.
-Horizon.AxiosClient.interceptors.request.use(config => {
-  if (!coinConfig.getCoinConfig().enableNetworkLogs) {
-    return config;
-  }
+// Tracks request start times for response-duration logging.
+// WeakMap avoids mutating the feaxios request config (whose type doesn't include `metadata`).
+const requestStartTimes = new WeakMap<object, number>();
 
-  const { url, method, data } = config;
-  log("network", `${method} ${url}`, { data });
-  return config;
-});
+let interceptorsRegistered = false;
+
+/**
+ * Register logging and URL-fix interceptors on Horizon.AxiosClient.
+ * Must be called once after coinConfig is initialised (i.e. inside createApi).
+ *
+ * Logging is gated on coinConfig.enableNetworkLogs (driven by the ENABLE_NETWORK_LOGS env var).
+ * Horizon.AxiosClient uses feaxios internally, so we type the callbacks via the inferred
+ * InterceptorManager types rather than importing live-network's axios-typed interceptors.
+ */
+export function registerHorizonInterceptors(): void {
+  if (interceptorsRegistered) return;
+  interceptorsRegistered = true;
+
+  Horizon.AxiosClient.interceptors.request.use(config => {
+    let enableNetworkLogs = false;
+    try {
+      enableNetworkLogs = !!coinConfig.getCoinConfig().enableNetworkLogs;
+    } catch {
+      return config;
+    }
+    if (enableNetworkLogs) {
+      const { baseURL, url, method = "", data } = config;
+      log("network", `${method} ${baseURL ?? ""}${url}`, { data });
+      requestStartTimes.set(config, Date.now());
+    }
+    return config;
+  });
+
+  Horizon.AxiosClient.interceptors.response.use(response => {
+    let enableNetworkLogs = false;
+    try {
+      enableNetworkLogs = !!coinConfig.getCoinConfig().enableNetworkLogs;
+    } catch {
+      // coinConfig not initialised on this instance; skip logging and leave URLs untouched
+    }
+    if (enableNetworkLogs) {
+      // response.config is typed as `any` in stellar-sdk's HttpClientResponse
+      const startTime = requestStartTimes.get(response.config) ?? 0;
+      requestStartTimes.delete(response.config);
+      log(
+        "network-success",
+        `${response.status} ${response.config?.method ?? ""} ${response.config?.baseURL ?? ""}${response.config?.url ?? ""} (${(Date.now() - startTime).toFixed(0)}ms)`,
+        { data: response.data },
+      );
+    }
+
+    // FIXME: workaround for the Stellar SDK not using the correct URL: the "next" URL
+    // included in server responses points to the node itself instead of our reverse proxy...
+    // (https://github.com/stellar/js-stellar-sdk/issues/637)
+    const next_href = response?.data?._links?.next?.href;
+    if (next_href) {
+      response.data._links.next.href = useConfigHost(next_href);
+    }
+    response?.data?._embedded?.records?.forEach((r: any) => {
+      const href = r.transaction?._links?.ledger?.href;
+      if (href) r.transaction._links.ledger.href = useConfigHost(href);
+    });
+
+    return response;
+  });
+}
 
 // This function allows to fix the URL, because the url returned by the Stellar SDK is not the correct one.
 // It replaces the host of the URL returned with the host of the explorer.
 function useConfigHost(url: string): string {
   const u = new URL(url);
-  u.host = new URL(coinConfig.getCoinConfig().explorer.url).host;
+  try {
+    u.host = new URL(coinConfig.getCoinConfig().explorer.url).host;
+  } catch {
+    return url;
+  }
   return u.toString();
 }
 
@@ -211,30 +268,6 @@ export async function getAccountSpendableBalance(
   const { recommendedFee } = await fetchBaseFee();
   return BigNumber.max(balance.minus(minimumBalance).minus(recommendedFee), 0);
 }
-
-Horizon.AxiosClient.interceptors.response.use(response => {
-  if (coinConfig.getCoinConfig().enableNetworkLogs) {
-    const { url, method } = response.config;
-    log("network-success", `${response.status} ${method} ${url}`, { data: response.data });
-  }
-
-  // FIXME: workaround for the Stellar SDK not using the correct URL: the "next" URL
-  // included in server responses points to the node itself instead of our reverse proxy...
-  // (https://github.com/stellar/js-stellar-sdk/issues/637)
-
-  const next_href = response?.data?._links?.next?.href;
-
-  if (next_href) {
-    response.data._links.next.href = useConfigHost(next_href);
-  }
-
-  response?.data?._embedded?.records?.forEach((r: any) => {
-    const href = r.transaction?._links?.ledger?.href;
-    if (href) r.transaction._links.ledger.href = useConfigHost(href);
-  });
-
-  return response;
-});
 
 export async function fetchBaseFee(): Promise<{
   baseFee: number;

--- a/libs/coin-modules/coin-stellar/src/network/index.ts
+++ b/libs/coin-modules/coin-stellar/src/network/index.ts
@@ -10,4 +10,5 @@ export {
   getLastBlock,
   getRecipientAccount,
   loadAccount,
+  registerHorizonInterceptors,
 } from "./horizon";

--- a/libs/coin-modules/coin-stellar/src/network/registerHorizonInterceptors.test.ts
+++ b/libs/coin-modules/coin-stellar/src/network/registerHorizonInterceptors.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Unit tests for registerHorizonInterceptors.
+ *
+ * Each test uses jest.isolateModules so that:
+ *  - the `interceptorsRegistered` flag inside horizon.ts starts at `false`
+ *  - `coinConfig` and `Horizon.AxiosClient` are fresh instances shared consistently
+ *    within the isolated module registry (stellar-sdk is re-resolved but cached for
+ *    all requires inside the same isolateModules block)
+ */
+import type { StellarCoinConfig } from "../config";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type IsolatedHorizon = typeof import("@stellar/stellar-sdk");
+type IsolatedHorizonModule = typeof import("./horizon");
+type IsolatedConfigModule = typeof import("../config");
+
+function isolatedRequire(): {
+  Horizon: IsolatedHorizon["Horizon"];
+  registerHorizonInterceptors: IsolatedHorizonModule["registerHorizonInterceptors"];
+  coinConfig: IsolatedConfigModule["default"];
+} {
+  // `require` here runs inside the jest.isolateModules callback supplied by each test
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  const { Horizon } = require("@stellar/stellar-sdk") as IsolatedHorizon;
+  const { registerHorizonInterceptors } = require("./horizon") as IsolatedHorizonModule;
+  const coinConfig = (require("../config") as IsolatedConfigModule).default;
+  /* eslint-enable @typescript-eslint/no-require-imports */
+  return { Horizon, registerHorizonInterceptors, coinConfig };
+}
+
+/** Returns the last element of an array without relying on Array.prototype.at (es2022). */
+function last<T>(arr: T[]): T | undefined {
+  return arr[arr.length - 1];
+}
+
+/** Builds a minimal HttpClientResponse-compatible mock object. */
+function makeResponse(overrides: { status?: number; config?: object; data?: unknown } = {}) {
+  return {
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    config: {},
+    data: {},
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<StellarCoinConfig> = {}): StellarCoinConfig {
+  return {
+    status: { type: "active" },
+    explorer: { url: "https://horizon.test.invalid" },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("registerHorizonInterceptors", () => {
+  describe("idempotency", () => {
+    it("registers each interceptor exactly once even when called multiple times", () => {
+      jest.isolateModules(() => {
+        const { Horizon, registerHorizonInterceptors } = isolatedRequire();
+
+        const reqSpy = jest.spyOn(Horizon.AxiosClient.interceptors.request, "use");
+        const resSpy = jest.spyOn(Horizon.AxiosClient.interceptors.response, "use");
+
+        registerHorizonInterceptors();
+        registerHorizonInterceptors();
+        registerHorizonInterceptors();
+
+        expect(reqSpy).toHaveBeenCalledTimes(1);
+        expect(resSpy).toHaveBeenCalledTimes(1);
+
+        reqSpy.mockRestore();
+        resSpy.mockRestore();
+      });
+    });
+
+    it("does not throw when called multiple times", () => {
+      jest.isolateModules(() => {
+        const { registerHorizonInterceptors } = isolatedRequire();
+        expect(() => {
+          registerHorizonInterceptors();
+          registerHorizonInterceptors();
+        }).not.toThrow();
+      });
+    });
+  });
+
+  describe("resilience when coinConfig is not initialised", () => {
+    it("registerHorizonInterceptors itself does not throw without coinConfig", () => {
+      jest.isolateModules(() => {
+        const { registerHorizonInterceptors } = isolatedRequire();
+        expect(() => registerHorizonInterceptors()).not.toThrow();
+      });
+    });
+
+    it("request interceptor returns config unchanged and does not throw", () => {
+      jest.isolateModules(() => {
+        const { Horizon, registerHorizonInterceptors } = isolatedRequire();
+        registerHorizonInterceptors();
+
+        const handler = last(Horizon.AxiosClient.interceptors.request.handlers);
+        expect(handler).toBeDefined();
+
+        const mockConfig = {
+          url: "/accounts/G123",
+          method: "GET",
+          baseURL: "https://horizon.test.invalid",
+        };
+        expect(() => handler!.fulfilled(mockConfig)).not.toThrow();
+        expect(handler!.fulfilled(mockConfig)).toBe(mockConfig);
+      });
+    });
+
+    it("response interceptor returns response unchanged and does not throw", () => {
+      jest.isolateModules(() => {
+        const { Horizon, registerHorizonInterceptors } = isolatedRequire();
+        registerHorizonInterceptors();
+
+        const handler = last(Horizon.AxiosClient.interceptors.response.handlers);
+        expect(handler).toBeDefined();
+
+        const mockResponse = makeResponse();
+        expect(() => handler!.fulfilled(mockResponse)).not.toThrow();
+        expect(handler!.fulfilled(mockResponse)).toBe(mockResponse);
+      });
+    });
+  });
+
+  describe("URL rewriting (always active, independent of logging)", () => {
+    it("rewrites _links.next.href to use the configured host", () => {
+      jest.isolateModules(() => {
+        const { Horizon, registerHorizonInterceptors, coinConfig } = isolatedRequire();
+        coinConfig.setCoinConfig(() => makeConfig());
+        registerHorizonInterceptors();
+
+        const handler = last(Horizon.AxiosClient.interceptors.response.handlers);
+
+        const data = {
+          _links: {
+            next: { href: "https://some-internal-node.stellar.org/operations?cursor=123" },
+          },
+        };
+
+        handler!.fulfilled(makeResponse({ data }));
+
+        expect(data._links.next.href).toBe("https://horizon.test.invalid/operations?cursor=123");
+      });
+    });
+
+    it("rewrites _embedded.records[].transaction._links.ledger.href to use the configured host", () => {
+      jest.isolateModules(() => {
+        const { Horizon, registerHorizonInterceptors, coinConfig } = isolatedRequire();
+        coinConfig.setCoinConfig(() => makeConfig());
+        registerHorizonInterceptors();
+
+        const handler = last(Horizon.AxiosClient.interceptors.response.handlers);
+
+        const data = {
+          _embedded: {
+            records: [
+              {
+                transaction: {
+                  _links: { ledger: { href: "https://some-internal-node.stellar.org/ledgers/55" } },
+                },
+              },
+              {
+                transaction: {
+                  _links: { ledger: { href: "https://some-internal-node.stellar.org/ledgers/56" } },
+                },
+              },
+            ],
+          },
+        };
+
+        handler!.fulfilled(makeResponse({ data }));
+
+        expect(data._embedded.records[0].transaction._links.ledger.href).toBe(
+          "https://horizon.test.invalid/ledgers/55",
+        );
+        expect(data._embedded.records[1].transaction._links.ledger.href).toBe(
+          "https://horizon.test.invalid/ledgers/56",
+        );
+      });
+    });
+  });
+
+  describe("network logging (gated on enableNetworkLogs)", () => {
+    it("emits network log for requests when enableNetworkLogs is true", () => {
+      jest.isolateModules(() => {
+        const logMock = jest.fn();
+        jest.mock("@ledgerhq/logs", () => ({ log: logMock }));
+
+        const { Horizon, registerHorizonInterceptors, coinConfig } = isolatedRequire();
+        coinConfig.setCoinConfig(() => makeConfig({ enableNetworkLogs: true }));
+        registerHorizonInterceptors();
+
+        const handler = last(Horizon.AxiosClient.interceptors.request.handlers);
+        handler!.fulfilled({
+          url: "/accounts/G123",
+          method: "GET",
+          baseURL: "https://horizon.test.invalid",
+        });
+
+        expect(logMock).toHaveBeenCalledWith(
+          "network",
+          expect.stringContaining("/accounts/G123"),
+          expect.anything(),
+        );
+      });
+    });
+
+    it("emits network-success log for responses with elapsed time when enableNetworkLogs is true", () => {
+      jest.isolateModules(() => {
+        const logMock = jest.fn();
+        jest.mock("@ledgerhq/logs", () => ({ log: logMock }));
+
+        const { Horizon, registerHorizonInterceptors, coinConfig } = isolatedRequire();
+        coinConfig.setCoinConfig(() => makeConfig({ enableNetworkLogs: true }));
+        registerHorizonInterceptors();
+
+        const reqHandler = last(Horizon.AxiosClient.interceptors.request.handlers);
+        const resHandler = last(Horizon.AxiosClient.interceptors.response.handlers);
+
+        const config = {
+          url: "/accounts/G123",
+          method: "GET",
+          baseURL: "https://horizon.test.invalid",
+        };
+        reqHandler!.fulfilled(config);
+
+        const mockResponse = makeResponse({ status: 200, config });
+        resHandler!.fulfilled(mockResponse);
+
+        expect(logMock).toHaveBeenCalledWith(
+          "network-success",
+          expect.stringMatching(/200 GET.*\/accounts\/G123.*\d+ms/),
+          expect.anything(),
+        );
+      });
+    });
+
+    it("does not emit any log when enableNetworkLogs is false", () => {
+      jest.isolateModules(() => {
+        const logMock = jest.fn();
+        jest.mock("@ledgerhq/logs", () => ({ log: logMock }));
+
+        const { Horizon, registerHorizonInterceptors, coinConfig } = isolatedRequire();
+        coinConfig.setCoinConfig(() => makeConfig({ enableNetworkLogs: false }));
+        registerHorizonInterceptors();
+
+        const reqHandler = last(Horizon.AxiosClient.interceptors.request.handlers);
+        const resHandler = last(Horizon.AxiosClient.interceptors.response.handlers);
+
+        const config = {
+          url: "/accounts/G123",
+          method: "GET",
+          baseURL: "https://horizon.test.invalid",
+        };
+        reqHandler!.fulfilled(config);
+        resHandler!.fulfilled(makeResponse({ config }));
+
+        expect(logMock).not.toHaveBeenCalled();
+      });
+    });
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Make the two `Horizon.AxiosClient` interceptors registered in `coin-stellar/src/network/horizon.ts` resilient to `coinConfig` not being initialised yet.

`coin-stellar/network/horizon.ts` registers a request and a response interceptor on `Horizon.AxiosClient` at module-load time. Both read the coin config:

```ts
coinConfig.getCoinConfig().enableNetworkLogs
```
…and the response interceptor additionally rewrites the SDK’s next.href via useConfigHost(...), which reads coinConfig.getCoinConfig().explorer.url.

getCoinConfig() (from @ledgerhq/coin-module-framework) throws MissingCoinConfig when setCoinConfig has not been called yet. The Stellar config is only set inside createApi, which itself is only invoked by createLocalStellarApi(currencyId) the first time someone calls getAlpacaApi("stellar", "local").

If anything triggers a Horizon HTTP call before that — or if there are two physical copies of coin-stellar in the bundle (lib/ vs lib-es/, .js vs .ts resolution) so that the interceptor closure and the setCoinConfig writer end up on different module instances — every Horizon request is rejected before it is sent, with MissingCoinConfig.

This was a latent bug, made reachable by the recent wave of async/lazy-loading PRs on develop (PR #16333 + LIVE-29183 / LIVE-29184 / LIVE-29185 async-prep series), which changed the order in which coin-stellar is evaluated, setCoinConfig runs, and the first Horizon call fires. It is what caused Stellar e2e to start failing on Tuesday 06:00 while the same code passed the previous morning.

## Fix
Wrap both coinConfig.getCoinConfig() reads (and the useConfigHost URL rewrite) in try/catch. When the config is not yet initialised:

the request interceptor returns the original config unchanged → axios still sends the request,
the response interceptor returns the original response unchanged → axios still resolves it,
useConfigHost returns the original URL.
Behaviour in the normal "config initialised" path is unchanged. Network logging and the reverse-proxy URL fixup keep working exactly as before whenever they are actually relevant (which, by definition, is when setCoinConfig has been called).

Why LWM is not affected
Mobile uses the network/remote alpaca path (kind !== "local" → getNetworkAlpacaApi(network)), which never imports coin-stellar/api/index and therefore never registers any interceptor on Horizon.AxiosClient. Only LLD, which runs Stellar with kind: "local", was hitting this.

https://github.com/user-attachments/assets/12c970db-48ef-403d-b2db-203f3964c331

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29554](https://ledgerhq.atlassian.net/browse/LIVE-29554)
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29554]: https://ledgerhq.atlassian.net/browse/LIVE-29554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ