### PR TITLE
[LWDM] fix(coin-solana): [LIVE-29618] getBalance must includes stakes

### DIFF
--- a/.changeset/sixty-colts-watch.md
+++ b/.changeset/sixty-colts-watch.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-tester-solana": minor
+"@ledgerhq/coin-solana": minor
+---
+
+Add stakes entries to getBalance result in Alpaca API for Solana

--- a/libs/coin-modules/coin-solana/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-solana/src/logic/getBalance.ts
@@ -1,9 +1,9 @@
-import type { Balance } from "@ledgerhq/coin-module-framework/api/index";
+import type { Balance, Stake, StakeState } from "@ledgerhq/coin-module-framework/api/index";
 import type { ChainAPI } from "../network";
 import { PARSED_PROGRAMS } from "../network/chain/program/constants";
 import type { ParsedOnChainTokenAccount } from "../network/chain/web3";
 import type { SolanaTokenProgram } from "../types";
-import { computeUnstakeReserve, getStakeAccounts } from "./getStakes";
+import { computeUnstakeReserve, getStakeAccounts, type StakeAccount } from "./getStakes";
 
 export async function getBalance(
   api: ChainAPI,
@@ -43,6 +43,8 @@ export async function getBalance(
     locked: rawLocked > totalBalance ? totalBalance : rawLocked,
   };
 
+  const stakeBalances = mapStakeAccountsToBalances(stakeAccounts);
+
   const splBalances = mapTokenAccountsToBalances(
     splTokenAccounts,
     PARSED_PROGRAMS.SPL_TOKEN,
@@ -54,7 +56,38 @@ export async function getBalance(
     address,
   );
 
-  return [nativeBalance, ...splBalances, ...token2022Balances];
+  return [nativeBalance, ...stakeBalances, ...splBalances, ...token2022Balances];
+}
+
+function mapStakeAccountsToBalances(stakeAccounts: StakeAccount[]): Balance[] {
+  return stakeAccounts.map(({ account, activation }) => {
+    const delegation = account.info.stake?.delegation;
+    const delegateAddress = delegation?.voter.toBase58();
+    const amount = BigInt(account.onChainAcc.account.lamports);
+
+    const stake: Stake = {
+      uid: account.onChainAcc.pubkey.toBase58(),
+      address: account.onChainAcc.pubkey.toBase58(),
+      state: activation.state as StakeState,
+      asset: { type: "native" },
+      amount,
+    };
+
+    if (delegateAddress) {
+      stake.delegate = delegateAddress;
+    }
+    if (delegation) {
+      const deposited = BigInt(delegation.stake.toString());
+      stake.amountDeposited = deposited;
+      stake.amountRewarded = amount > deposited ? amount - deposited : 0n;
+    }
+
+    return {
+      value: amount,
+      asset: { type: "native" as const },
+      stake,
+    };
+  });
 }
 
 function mapTokenAccountsToBalances(

--- a/libs/coin-modules/coin-solana/src/logic/getStakes.ts
+++ b/libs/coin-modules/coin-solana/src/logic/getStakes.ts
@@ -37,7 +37,9 @@ export async function getStakes(
       stake.delegate = delegateAddress;
     }
     if (delegation) {
-      stake.amountDeposited = BigInt(delegation.stake.toString());
+      const deposited = BigInt(delegation.stake.toString());
+      stake.amountDeposited = deposited;
+      stake.amountRewarded = stake.amount > deposited ? stake.amount - deposited : 0n;
     }
 
     return stake;

--- a/libs/coin-modules/coin-solana/src/logic/tests/getBalance.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getBalance.unit.test.ts
@@ -13,8 +13,44 @@ jest.mock("../getStakes", () => ({
 const mockGetStakeAccounts = jest.mocked(getStakeAccounts);
 const mockComputeUnstakeReserve = jest.mocked(computeUnstakeReserve);
 
-function makeStakeAccountStub(lamports: number) {
-  return { account: { onChainAcc: { account: { lamports } } } };
+const DEFAULT_RENT_EXEMPT_RESERVE = 2_282_880;
+
+function makeStakeAccountStub(
+  lamports: number,
+  options?: {
+    pubkey?: string;
+    state?: string;
+    voter?: string;
+    stake?: string;
+    rentExemptReserve?: number;
+  },
+) {
+  const pubkey = options?.pubkey ?? "StakeAddr1111111111111111111111111111111111";
+  const state = options?.state ?? "active";
+  const voter = options?.voter ?? "Validator111111111111111111111111111111111111";
+  const rentExemptReserve = options?.rentExemptReserve ?? DEFAULT_RENT_EXEMPT_RESERVE;
+  // On Solana delegation.stake includes the rent-exempt reserve (full amount deposited).
+  const delegatedStake = options?.stake ?? String(lamports);
+  return {
+    account: {
+      onChainAcc: {
+        pubkey: { toBase58: () => pubkey },
+        account: { lamports },
+      },
+      info: {
+        meta: { rentExemptReserve: { toString: () => String(rentExemptReserve) } },
+        stake: {
+          delegation: {
+            voter: { toBase58: () => voter },
+            activationEpoch: { toString: () => "100" },
+            deactivationEpoch: { toString: () => "9999999999999999" },
+            stake: { toString: () => delegatedStake },
+          },
+        },
+      },
+    },
+    activation: { state, active: lamports, inactive: 0 },
+  };
 }
 
 const TEST_ADDRESS = "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM";
@@ -177,6 +213,55 @@ describe("getBalance", () => {
         asset: { type: "native" },
         locked: 890880n + 2_000_000_000n,
       });
+      expect(result[1]).toMatchObject({
+        value: 2_000_000_000n,
+        asset: { type: "native" },
+        stake: expect.objectContaining({ amount: 2_000_000_000n, state: "active" }),
+      });
+      const stake = result[1].stake!;
+      // Invariant: total stake amount equals deposited principal plus accrued rewards.
+      expect(stake.amount).toBe((stake.amountDeposited ?? 0n) + (stake.amountRewarded ?? 0n));
+    });
+
+    it("should report zero rewards for a freshly delegated stake with no accrued rewards", async () => {
+      mockGetBalance.mockResolvedValue(1_000_000_000);
+      mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
+      mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
+      const lamports = 2_000_000_000;
+      // No-rewards case: delegated stake equals the full account lamports
+      // (e.g. just after delegation, before any epoch reward has accrued).
+      mockGetStakeAccounts.mockResolvedValue([
+        makeStakeAccountStub(lamports, { stake: String(lamports) }),
+      ] as StakeAccount[]);
+      mockComputeUnstakeReserve.mockResolvedValue(0);
+
+      const result = await getBalance(api, TEST_ADDRESS);
+
+      const stake = result[1].stake!;
+      expect(stake.amount).toBe(BigInt(lamports));
+      expect(stake.amountDeposited).toBe(BigInt(lamports));
+      expect(stake.amountRewarded).toBe(0n);
+      expect(stake.amount).toBe((stake.amountDeposited ?? 0n) + (stake.amountRewarded ?? 0n));
+    });
+
+    it("should compute amountRewarded as the delta between lamports and delegated stake", async () => {
+      mockGetBalance.mockResolvedValue(1_000_000_000);
+      mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
+      mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
+      const lamports = 2_050_000_000;
+      const delegated = lamports - DEFAULT_RENT_EXEMPT_RESERVE - 10_000_000;
+      mockGetStakeAccounts.mockResolvedValue([
+        makeStakeAccountStub(lamports, { stake: String(delegated) }),
+      ] as StakeAccount[]);
+      mockComputeUnstakeReserve.mockResolvedValue(0);
+
+      const result = await getBalance(api, TEST_ADDRESS);
+
+      const stake = result[1].stake!;
+      expect(stake.amount).toBe(BigInt(lamports));
+      expect(stake.amountDeposited).toBe(BigInt(delegated));
+      expect(stake.amountRewarded).toBe(BigInt(lamports - delegated));
+      expect(stake.amount).toBe((stake.amountDeposited ?? 0n) + (stake.amountRewarded ?? 0n));
     });
 
     it("should include unstakeReserve in locked", async () => {
@@ -221,8 +306,8 @@ describe("getBalance", () => {
       mockGetMinimumBalanceForRentExemption.mockResolvedValue(890880);
       mockGetParsedTokenAccountsByOwner.mockResolvedValue({ value: [] });
       mockGetStakeAccounts.mockResolvedValue([
-        makeStakeAccountStub(1_000_000_000),
-        makeStakeAccountStub(3_000_000_000),
+        makeStakeAccountStub(1_000_000_000, { pubkey: "Stake1" }),
+        makeStakeAccountStub(3_000_000_000, { pubkey: "Stake2" }),
       ] as StakeAccount[]);
       mockComputeUnstakeReserve.mockResolvedValue(0);
 
@@ -233,6 +318,10 @@ describe("getBalance", () => {
         asset: { type: "native" },
         locked: 890880n + 4_000_000_000n,
       });
+      // two stake balance entries
+      expect(result).toHaveLength(3);
+      expect(result[1]).toMatchObject({ value: 1_000_000_000n, stake: { uid: "Stake1" } });
+      expect(result[2]).toMatchObject({ value: 3_000_000_000n, stake: { uid: "Stake2" } });
     });
   });
 });

--- a/libs/coin-tester-modules/coin-tester-solana/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-solana/src/helpers.ts
@@ -10,12 +10,16 @@ import {
 import { getAlpacaCurrencyBridge } from "@ledgerhq/live-common/bridge/generic-alpaca/currencyBridge";
 import { getAlpacaAccountBridge } from "@ledgerhq/live-common/bridge/generic-alpaca/accountBridge";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-alpaca/types";
+import { registerCoinModules } from "@ledgerhq/live-common/coin-modules/registry";
+import { coinModuleLoaders } from "@ledgerhq/live-common/coin-modules/loaders";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { createBridges } from "@ledgerhq/coin-solana/bridge/js";
 import type { Transaction } from "@ledgerhq/coin-solana/types";
 import type { BridgeStrategy } from "@ledgerhq/coin-tester/types";
 import type { Signers } from "./signer";
 import BigNumber from "bignumber.js";
+
+registerCoinModules(coinModuleLoaders);
 
 export const solana = getCryptoCurrencyById("solana");
 

--- a/libs/coin-tester-modules/coin-tester-solana/src/scenarii/solana.ts
+++ b/libs/coin-tester-modules/coin-tester-solana/src/scenarii/solana.ts
@@ -12,6 +12,7 @@ import {
   initMSW,
   makeAccount,
 } from "../fixtures";
+import type { SolanaAccount } from "@ledgerhq/coin-solana/types";
 import BigNumber from "bignumber.js";
 import { setEnv } from "@ledgerhq/live-env";
 import { airdrop, killAgave, spawnAgave } from "../agave";
@@ -58,6 +59,68 @@ function computeSubAccountId(
     return encodeAccountIdWithTokenAccountAddress(parentAccountId, ata.toBase58());
   }
   return encodeTokenAccountId(parentAccountId, token);
+}
+
+function getSolanaStakes(account: Account): SolanaAccount["solanaResources"]["stakes"] {
+  return (account as SolanaAccount).solanaResources?.stakes ?? [];
+}
+
+interface StakingResourcesShape {
+  delegations: Array<{ validatorAddress: string; amount: BigNumber }>;
+  unbondings: Array<{ validatorAddress: string; amount: BigNumber }>;
+  delegatedBalance: BigNumber;
+  unbondingBalance: BigNumber;
+  pendingRewardsBalance: BigNumber;
+}
+
+/** Extract stakingResources set by the generic-alpaca bridge (not typed on Account). */
+function getStakingResources(account: Account): StakingResourcesShape | undefined {
+  const raw = (account as Account & { stakingResources?: StakingResourcesShape }).stakingResources;
+  return raw;
+}
+
+/**
+ * Strategy-agnostic staking assertions.
+ * Legacy exposes `solanaResources.stakes`, generic-adapter exposes `stakingResources`.
+ * These helpers verify the same semantic invariants regardless of strategy.
+ */
+function expectDelegationTo(
+  account: Account,
+  strat: BridgeStrategy,
+  validatorAddress: string,
+): void {
+  if (strat === "legacy") {
+    const stakes = getSolanaStakes(account);
+    const found = stakes.find(s => s.delegation?.voteAccAddr === validatorAddress);
+    expect(found).toBeDefined();
+  } else {
+    const sr = getStakingResources(account);
+    expect(sr).toBeDefined();
+    const found = sr!.delegations.find(d => d.validatorAddress === validatorAddress);
+    expect(found).toBeDefined();
+    expect(found!.amount.isGreaterThan(0)).toBe(true);
+  }
+}
+
+function expectStakeExists(account: Account, strat: BridgeStrategy, stakeAddress: string): void {
+  if (strat === "legacy") {
+    const found = getSolanaStakes(account).find(s => s.stakeAccAddr === stakeAddress);
+    expect(found).toBeDefined();
+  } else {
+    // generic-adapter doesn't expose individual stake addresses, check total staking > 0
+    const sr = getStakingResources(account);
+    expect(sr).toBeDefined();
+    const totalStaking = sr!.delegatedBalance.plus(sr!.unbondingBalance);
+    expect(totalStaking.isGreaterThan(0)).toBe(true);
+  }
+}
+
+function expectStakingResourcesDefined(account: Account, strat: BridgeStrategy): void {
+  if (strat === "legacy") {
+    expect(getSolanaStakes(account)).toBeDefined();
+  } else {
+    expect(getStakingResources(account)).toBeDefined();
+  }
 }
 
 function makeScenarioTransactions(
@@ -311,6 +374,8 @@ function makeScenarioTransactions(
       expect(currentAccount.spendableBalance).toStrictEqual(
         previousAccount.spendableBalance.minus(1e9 + 2297880),
       );
+      // Verify staking resources are populated after sync with delegation to the validator
+      expectDelegationTo(currentAccount, strategy, VOTE_ACCOUNT!.votePubkey);
     },
   };
 
@@ -333,6 +398,8 @@ function makeScenarioTransactions(
       expect(currentAccount.balance).toStrictEqual(
         previousAccount.balance.minus(latestOperation.value),
       );
+      // Verify the stake account is now delegated
+      expectDelegationTo(currentAccount, strategy, VOTE_ACCOUNT!.votePubkey);
     },
   };
 
@@ -350,6 +417,9 @@ function makeScenarioTransactions(
       expect(currentAccount.balance).toStrictEqual(
         previousAccount.balance.minus(latestOperation.value),
       );
+      // Verify the stake account still exists (state may be "deactivating" or still
+      // "active" depending on epoch boundary timing on the local validator)
+      expectStakeExists(currentAccount, strategy, STAKE_ACCOUNT!.publicKey.toBase58());
     },
   };
 
@@ -379,6 +449,9 @@ function makeScenarioTransactions(
       expect(currentAccount.spendableBalance).toStrictEqual(
         previousAccount.spendableBalance.plus(WITHDRAWABLE_AMOUNT),
       );
+      // Verify staking resources still exist after partial withdrawal
+      // (spendableBalance increase above already validates the withdraw landed)
+      expectStakingResourcesDefined(currentAccount, strategy);
     },
   };
 
@@ -403,6 +476,8 @@ function makeScenarioTransactions(
         previousAccount.balance.minus(latestOperation.value),
       );
       expect(currentAccount.spendableBalance).toStrictEqual(new BigNumber(0));
+      // Verify staking resources reflect the new stake
+      expectDelegationTo(currentAccount, strategy, VOTE_ACCOUNT!.votePubkey);
     },
   };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->
### ✅ Checklist                                                                                     
                                                                                                   
  - [x] `npx changeset` was attached.                                                                  
  - [x] **Covered by automatic tests.**                                                                
  - [x] **Impact of the changes:**                                                                     
    - Solana `/balance` now returns stake entries, enabling `stakingResources` in the generic-alpaca
  bridge                                                                                               
    - Solana `/stakes` now includes `amountRewarded`        
    - Coin-tester generic-adapter strategy for Solana is unblocked                                     
                                                                                                       
  ### 📝 Description
                                                                                                       
  Solana `getBalance` returned staked lamports as aggregate totals but never populated `Balance.stake`,
   so the generic-alpaca bridge couldn't build `stakingResources` (delegations, unbondings). Now
  `getBalance` returns one `Balance` entry per stake account with the `stake` field set.               
                                                            
  Also added `amountRewarded` to both `getBalance` and `getStakes` (required by Alpaca API spec), and  
  fixed the coin-tester generic-adapter setup (missing `registerCoinModules`).
                                                                                                       
  Staking assertions added to all 5 coin-tester staking scenarios, both strategies pass 13/13.         
   
  ### ❓ Context                                                                                       
                                                            
  - **JIRA or GitHub link**: LIVE-29618
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
