### PR TITLE
[LWD] refactor(desktop): refactor useravatar to mvvm with notification indicator

### DIFF
--- a/.changeset/orange-days-attack.md
+++ b/.changeset/orange-days-attack.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Refactor UserAvatar to add notification indicator support

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
@@ -23,7 +23,7 @@ export function ContextMenu() {
             aria-label="My wallet"
             className="cursor-pointer items-center justify-center rounded-full hover:bg-muted-hover"
           >
-            <UserAvatar />
+            <UserAvatar showNotification />
           </button>
         }
       />

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/TopBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/TopBar/TopBarView.tsx
@@ -6,8 +6,8 @@ import { UserAvatar } from "../UserAvatar";
 const TopBarView = ({ title, settingsAction, notificationAction }: MyWalletTopBarViewProps) => (
   <div className="flex justify-between items-center">
     <div className="flex items-center gap-12">
-      <UserAvatar />
-      <p className="body-2 text-base">{title}</p>
+      <UserAvatar showNotification={false} />
+      <p className="body-1-semi-bold text-base">{title}</p>
     </div>
     <div className="flex gap-16">
       <TopBarActionButton {...notificationAction} />

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/UserAvatarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/UserAvatarView.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Avatar } from "@ledgerhq/lumen-ui-react";
+import { UserAvatarViewProps } from "./types";
+
+export function UserAvatarView({ showNotification, unseenCount }: UserAvatarViewProps) {
+  const { t } = useTranslation();
+
+  const ariaLabel =
+    showNotification && unseenCount > 0
+      ? t("myWallet.avatar.labelWithNotifications", { count: unseenCount })
+      : t("myWallet.avatar.label");
+
+  return (
+    <Avatar
+      size="sm"
+      aria-label={ariaLabel}
+      data-testid="my-wallet-avatar"
+      className="text-black dark:text-white"
+      showNotification={showNotification}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/__tests__/UserAvatar.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/__tests__/UserAvatar.test.tsx
@@ -1,12 +1,23 @@
 import React from "react";
 import { render, screen } from "tests/testSetup";
+import { useNotificationIndicator } from "LLD/components/TopBar/hooks/useNotificationIndicator";
 import { UserAvatar } from "../index";
 
-describe("UserAvatar", () => {
-  it("renders the avatar with the correct testid", () => {
+jest.mock("LLD/components/TopBar/hooks/useNotificationIndicator");
+
+jest.mocked(useNotificationIndicator).mockReturnValue({
+  totalNotifCount: 2,
+  tooltip: "",
+  onClick: jest.fn(),
+  icon: Object.assign(jest.fn(), { displayName: "MockIcon" }),
+  isInteractive: true,
+});
+
+describe("UserAvatar (container)", () => {
+  it("wires the view model to the view", () => {
     render(<UserAvatar />);
 
     expect(screen.getByTestId("my-wallet-avatar")).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "Avatar" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Avatar, 2 unseen notifications" })).toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/__tests__/UserAvatarView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/__tests__/UserAvatarView.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { UserAvatarView } from "../UserAvatarView";
+
+describe("UserAvatarView", () => {
+  it.each([
+    { showNotification: false, unseenCount: 0, expectedLabel: "Avatar" },
+    { showNotification: true, unseenCount: 1, expectedLabel: "Avatar, 1 unseen notification" },
+    { showNotification: true, unseenCount: 5, expectedLabel: "Avatar, 5 unseen notifications" },
+  ])(
+    "renders aria-label '$expectedLabel' for showNotification=$showNotification, unseenCount=$unseenCount",
+    ({ showNotification, unseenCount, expectedLabel }) => {
+      render(<UserAvatarView showNotification={showNotification} unseenCount={unseenCount} />);
+
+      expect(screen.getByTestId("my-wallet-avatar")).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: expectedLabel })).toBeInTheDocument();
+    },
+  );
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/__tests__/useUserAvatarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/__tests__/useUserAvatarViewModel.test.ts
@@ -1,0 +1,53 @@
+import { renderHook } from "tests/testSetup";
+import { useNotificationIndicator } from "LLD/components/TopBar/hooks/useNotificationIndicator";
+import { useUserAvatarViewModel } from "../useUserAvatarViewModel";
+import type { UserAvatarProps, UserAvatarViewProps } from "../types";
+
+jest.mock("LLD/components/TopBar/hooks/useNotificationIndicator");
+
+const mockedUseNotificationIndicator = jest.mocked(useNotificationIndicator);
+
+const mockNotificationIndicator = (totalNotifCount: number) =>
+  mockedUseNotificationIndicator.mockReturnValue({
+    totalNotifCount,
+    tooltip: "",
+    onClick: jest.fn(),
+    icon: Object.assign(jest.fn(), { displayName: "MockIcon" }),
+    isInteractive: true,
+  });
+
+type TestCase = {
+  name: string;
+  notifCount: number;
+  props?: UserAvatarProps;
+  expected: UserAvatarViewProps;
+};
+
+const cases: TestCase[] = [
+  {
+    name: "hides when there are no unseen notifications",
+    notifCount: 0,
+    expected: { showNotification: false, unseenCount: 0 },
+  },
+  {
+    name: "auto-shows when there are unseen notifications",
+    notifCount: 2,
+    expected: { showNotification: true, unseenCount: 2 },
+  },
+  {
+    name: "is force-hidden when showNotification=false",
+    notifCount: 4,
+    props: { showNotification: false },
+    expected: { showNotification: false, unseenCount: 0 },
+  },
+];
+
+describe("useUserAvatarViewModel", () => {
+  it.each(cases)("$name", ({ notifCount, props = {}, expected }) => {
+    mockNotificationIndicator(notifCount);
+
+    const { result } = renderHook(() => useUserAvatarViewModel(props));
+
+    expect(result.current).toEqual(expected);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/index.tsx
@@ -1,13 +1,10 @@
 import React from "react";
-import { Avatar } from "@ledgerhq/lumen-ui-react";
+import { UserAvatarView } from "./UserAvatarView";
+import { useUserAvatarViewModel } from "./useUserAvatarViewModel";
+import { UserAvatarProps } from "./types";
 
-export function UserAvatar() {
-  return (
-    <Avatar
-      size="sm"
-      aria-label="Avatar"
-      data-testid="my-wallet-avatar"
-      className="text-black dark:text-white"
-    />
-  );
+export function UserAvatar(props: UserAvatarProps = {}) {
+  const viewProps = useUserAvatarViewModel(props);
+
+  return <UserAvatarView {...viewProps} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/types.ts
@@ -1,0 +1,6 @@
+export type UserAvatarViewProps = {
+  showNotification: boolean;
+  unseenCount: number;
+};
+
+export type UserAvatarProps = Partial<UserAvatarViewProps>;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/useUserAvatarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/useUserAvatarViewModel.ts
@@ -1,0 +1,17 @@
+import { useNotificationIndicator } from "LLD/components/TopBar/hooks/useNotificationIndicator";
+import type { UserAvatarProps, UserAvatarViewProps } from "./types";
+
+export function useUserAvatarViewModel({
+  showNotification,
+  unseenCount,
+}: UserAvatarProps): UserAvatarViewProps {
+  const { totalNotifCount } = useNotificationIndicator();
+
+  const resolvedShow = showNotification === false ? false : totalNotifCount > 0;
+  const resolvedCount = unseenCount ?? totalNotifCount;
+
+  return {
+    showNotification: resolvedShow,
+    unseenCount: resolvedShow ? resolvedCount : 0,
+  };
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8674,6 +8674,11 @@
   },
   "myWallet": {
     "title": "My Wallet",
+    "avatar": {
+      "label": "Avatar",
+      "labelWithNotifications_one": "Avatar, {{count}} unseen notification",
+      "labelWithNotifications_other": "Avatar, {{count}} unseen notifications"
+    },
     "actionsList": {
       "help": "Help",
       "recover": "[L] Recover",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - UserAvatar component rendering in MyWallet top bar and context menu
  - Notification indicator visibility and unseen count logic
  - Accessibility labels for avatar with/without notifications

### 📝 Description

The `UserAvatar` component was a simple wrapper around `<Avatar>` with no separation of concerns, making it hard to test and extend.

This PR refactors `UserAvatar` to the MVVM pattern and adds notification indicator support:
- **View** (`UserAvatarView`): pure presentational component with i18n-driven accessibility labels
- **ViewModel** (`useUserAvatarViewModel`): resolves `showNotification` and `unseenCount` from `useNotificationIndicator`
- **Container** (`index.tsx`): wires the view model to the view
- **Types** (`types.ts`): shared `UserAvatarProps` / `UserAvatarViewProps`
- Adds `showNotification` prop to control badge visibility from parent (TopBar hides it, ContextMenu shows it)
- Adds i18n keys with pluralization for accessible avatar labels


https://github.com/user-attachments/assets/4df39668-0edb-4315-b4f9-568dc076412b




### ❓ Context

- **JIRA or GitHub link**: [LIVE-29617](https://ledgerhq.atlassian.net/browse/LIVE-29617)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29617]: https://ledgerhq.atlassian.net/browse/LIVE-29617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ