### PR TITLE
[LWD] feat(desktop): add tooltip to context menu trigger

### DIFF
--- a/.changeset/bright-pears-dance.md
+++ b/.changeset/bright-pears-dance.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add tooltip to context menu trigger button

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/MyWalletTopBar.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/MyWalletTopBar.integration.test.tsx
@@ -34,14 +34,14 @@ describe("MyWallet ContextMenu", () => {
   it("should render My Wallet trigger button", () => {
     render(<ContextMenu />);
 
-    expect(screen.getByRole("button", { name: "My wallet" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "My Wallet" })).toBeVisible();
     expect(screen.getByTestId("my-wallet-avatar")).toBeVisible();
   });
 
   it("should show settings and notifications buttons inside the popover when opened", async () => {
     const { user } = render(<ContextMenu />);
 
-    await user.click(screen.getByRole("button", { name: "My wallet" }));
+    await user.click(screen.getByRole("button", { name: "My Wallet" }));
 
     await waitFor(() => {
       expect(screen.getByTestId("topbar-action-button-settings")).toBeVisible();
@@ -52,7 +52,7 @@ describe("MyWallet ContextMenu", () => {
   it("should navigate to /settings with 'mywallet' tracking source when clicking settings", async () => {
     const { user } = render(<ContextMenu />);
 
-    await user.click(screen.getByRole("button", { name: "My wallet" }));
+    await user.click(screen.getByRole("button", { name: "My Wallet" }));
 
     await waitFor(() => {
       expect(screen.getByTestId("topbar-action-button-settings")).toBeVisible();

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenu.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Popover, PopoverTrigger, PopoverContent } from "@ledgerhq/lumen-ui-react";
+import { Popover, PopoverContent } from "@ledgerhq/lumen-ui-react";
 import { Explore } from "./Explore";
 import TopBar from "./TopBar";
 import { ActionsList } from "./ActionsList";
 import { MyLedger } from "./MyLedger";
 import ContextMenuContext from "./ContextMenuContext";
-import { UserAvatar } from "./UserAvatar";
+import { ContextMenuTrigger } from "./ContextMenuTrigger";
 
 const side = "bottom";
 const align = "end";
@@ -17,16 +17,7 @@ export function ContextMenu() {
 
   return (
     <Popover overlay open={open} onOpenChange={setOpen}>
-      <PopoverTrigger
-        render={
-          <button
-            aria-label="My wallet"
-            className="cursor-pointer items-center justify-center rounded-full hover:bg-muted-hover"
-          >
-            <UserAvatar showNotification />
-          </button>
-        }
-      />
+      <ContextMenuTrigger popoverOpen={open} />
 
       <PopoverContent width="fixed" side={side} align={align} className="flex flex-col gap-24">
         <ContextMenuContext.Provider value={contextValue}>

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenuTrigger.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenuTrigger.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { PopoverTrigger, Tooltip, TooltipTrigger, TooltipContent } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
+import { UserAvatar } from "./UserAvatar";
+
+type ContextMenuTriggerProps = Readonly<{
+  popoverOpen: boolean;
+}>;
+
+export function ContextMenuTrigger({ popoverOpen }: ContextMenuTriggerProps) {
+  const { t } = useTranslation();
+  const label = t("myWallet.title");
+
+  return (
+    <PopoverTrigger
+      render={
+        <button
+          aria-label={label}
+          className="cursor-pointer items-center justify-center rounded-full hover:bg-muted-hover"
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <UserAvatar showNotification />
+              </span>
+            </TooltipTrigger>
+            {!popoverOpen && <TooltipContent side="bottom">{label}</TooltipContent>}
+          </Tooltip>
+        </button>
+      }
+    />
+  );
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _UI interaction behavior — tooltip visibility is best validated manually._
- [x] **Impact of the changes:**
  - Tooltip "My Wallet" appears on hover of the context menu avatar button
  - Tooltip is hidden while the popover is open
  - Tooltip does not re-trigger when the popover closes

### 📝 Description

The context menu avatar button had no tooltip, making it inconsistent with the other TopBar action buttons that all have tooltips.

This PR extracts the popover trigger into a `ContextMenuTrigger` component and adds a "My Wallet" tooltip using the same Lumen UI `Tooltip` components used elsewhere. The tooltip is conditionally hidden while the popover is open to prevent visual overlap, and the `Tooltip` is nested inside the `PopoverTrigger` to avoid Radix focus/hover conflicts on popover close.


https://github.com/user-attachments/assets/fd826f73-a61f-4208-89a2-df0ae05f2fdb




### ❓ Context

- **JIRA or GitHub link**: [LIVE-29632](https://ledgerhq.atlassian.net/browse/LIVE-29632)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29632]: https://ledgerhq.atlassian.net/browse/LIVE-29632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ