### PR TITLE
[LWM] feat(mobile): navigate directly to MyLedgerDevice from MyWallet

### DIFF
--- a/.changeset/perfect-kangaroos-begin.md
+++ b/.changeset/perfect-kangaroos-begin.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+update the redirection method

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/DeviceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/DeviceSectionView.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { Box, Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-rnative";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import type { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { useTranslation } from "~/context/Locale";
-import { type DeviceSectionDevice } from "./useDeviceSectionViewModel";
+import DeviceActionModal from "~/components/DeviceActionModal";
+import { type DeviceSectionDevice, type DeviceSectionViewModel } from "./useDeviceSectionViewModel";
 import { AddDeviceLink } from "./components/AddDeviceLink";
 import { DeviceListContent } from "./components/DeviceListContent";
 import { DeviceRemoveDrawer } from "./components/DeviceRemoveDrawer";
@@ -13,10 +16,15 @@ interface DeviceSectionViewProps {
   readonly onExploreDevices: () => void;
   readonly onDevicePress: (device: DeviceSectionDevice) => void;
   readonly onOpenMenu: (device: DeviceSectionDevice) => void;
-  readonly selectedDevice: DeviceSectionDevice | null;
+  readonly deviceToRemove: DeviceSectionDevice | null;
   readonly isRemoveDrawerOpen: boolean;
   readonly onCloseRemoveMenu: () => void;
   readonly onRemoveDevice: () => void;
+  readonly selectedDevice: Device | null;
+  readonly managerAction: DeviceSectionViewModel["managerAction"];
+  readonly onDeviceActionResult: (result: Result) => void;
+  readonly onDeviceActionClose: () => void;
+  readonly onDeviceActionError: (error: Error) => void;
 }
 
 export function DeviceSectionView({
@@ -26,10 +34,15 @@ export function DeviceSectionView({
   onExploreDevices,
   onDevicePress,
   onOpenMenu,
-  selectedDevice,
+  deviceToRemove,
   isRemoveDrawerOpen,
   onCloseRemoveMenu,
   onRemoveDevice,
+  selectedDevice,
+  managerAction,
+  onDeviceActionResult,
+  onDeviceActionClose,
+  onDeviceActionError,
 }: DeviceSectionViewProps) {
   const { t } = useTranslation();
 
@@ -56,10 +69,19 @@ export function DeviceSectionView({
       </Box>
 
       <DeviceRemoveDrawer
-        device={selectedDevice}
+        device={deviceToRemove}
         isOpen={isRemoveDrawerOpen}
         onClose={onCloseRemoveMenu}
         onRemove={onRemoveDevice}
+      />
+
+      <DeviceActionModal
+        device={selectedDevice}
+        action={managerAction}
+        request={null}
+        onResult={onDeviceActionResult}
+        onClose={onDeviceActionClose}
+        onError={onDeviceActionError}
       />
     </Box>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__integrations__/DeviceSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__integrations__/DeviceSection.integration.test.tsx
@@ -4,6 +4,18 @@ import { DeviceModelId } from "@ledgerhq/devices";
 import { DeviceSectionView } from "../DeviceSectionView";
 import { type DeviceSectionDevice } from "../useDeviceSectionViewModel";
 
+jest.mock("~/components/DeviceActionModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("~/hooks/deviceActions", () => ({
+  useManagerDeviceAction: () => ({
+    useHook: jest.fn(),
+    mapResult: jest.fn(),
+  }),
+}));
+
 const mockDevices: DeviceSectionDevice[] = [
   { id: "device-1", name: "Flex Pro", modelId: DeviceModelId.europa, available: false },
   { id: "device-2", name: "Flex Perso", modelId: DeviceModelId.europa, available: false },
@@ -16,11 +28,16 @@ const mockOnDevicePress = jest.fn();
 const mockOnOpenMenu = jest.fn();
 const mockOnCloseRemoveMenu = jest.fn();
 const mockOnRemoveDevice = jest.fn();
+const mockOnDeviceActionResult = jest.fn();
+const mockOnDeviceActionClose = jest.fn();
+const mockOnDeviceActionError = jest.fn();
+
+const mockManagerAction = { useHook: jest.fn(), mapResult: jest.fn() } as const;
 
 const renderView = (
   devices: readonly DeviceSectionDevice[],
   overrides: Partial<{
-    selectedDevice: DeviceSectionDevice | null;
+    deviceToRemove: DeviceSectionDevice | null;
     isRemoveDrawerOpen: boolean;
   }> = {},
 ) =>
@@ -32,10 +49,15 @@ const renderView = (
       onExploreDevices={mockOnExploreDevices}
       onDevicePress={mockOnDevicePress}
       onOpenMenu={mockOnOpenMenu}
-      selectedDevice={overrides.selectedDevice ?? null}
+      deviceToRemove={overrides.deviceToRemove ?? null}
       isRemoveDrawerOpen={overrides.isRemoveDrawerOpen ?? false}
       onCloseRemoveMenu={mockOnCloseRemoveMenu}
       onRemoveDevice={mockOnRemoveDevice}
+      selectedDevice={null}
+      managerAction={mockManagerAction}
+      onDeviceActionResult={mockOnDeviceActionResult}
+      onDeviceActionClose={mockOnDeviceActionClose}
+      onDeviceActionError={mockOnDeviceActionError}
     />,
   );
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
@@ -1,6 +1,8 @@
 import { Linking } from "react-native";
 import { DeviceModelId } from "@ledgerhq/devices";
+import { BluetoothRequired } from "@ledgerhq/errors";
 import { disconnect } from "@ledgerhq/live-common/hw/index";
+import { findMatchingNewDevice } from "@ledgerhq/live-dmk-mobile";
 import { act, renderHook } from "@tests/test-renderer";
 import { ScreenName } from "~/const";
 import { track } from "~/analytics";
@@ -39,9 +41,51 @@ const withKnownDevice = (state: State): State => ({
   },
 });
 
+const withMultipleKnownDevices = (state: State): State => ({
+  ...state,
+  ble: {
+    ...state.ble,
+    knownDevices: [
+      { id: "device-1", name: "Flex Pro", modelId: DeviceModelId.europa },
+      { id: "device-2", name: "Nano X", modelId: DeviceModelId.nanoX },
+    ],
+  },
+});
+
 describe("useDeviceSectionViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe("devices", () => {
+    it("should return an empty list when there are no known devices", () => {
+      const { result } = renderHook(() => useDeviceSectionViewModel());
+
+      expect(result.current.devices).toEqual([]);
+      expect(result.current.hasDevices).toBe(false);
+    });
+
+    it("should map known devices in reverse order with available: false by default", () => {
+      const { result } = renderHook(() => useDeviceSectionViewModel(), {
+        overrideInitialState: withMultipleKnownDevices,
+      });
+
+      expect(result.current.devices).toEqual([
+        { id: "device-2", name: "Nano X", modelId: DeviceModelId.nanoX, available: false },
+        { id: "device-1", name: "Flex Pro", modelId: DeviceModelId.europa, available: false },
+      ]);
+      expect(result.current.hasDevices).toBe(true);
+    });
+
+    it("should set available to true when a scanned device matches", () => {
+      jest.mocked(findMatchingNewDevice).mockReturnValue({} as never);
+
+      const { result } = renderHook(() => useDeviceSectionViewModel(), {
+        overrideInitialState: withKnownDevice,
+      });
+
+      expect(result.current.devices[0].available).toBe(true);
+    });
   });
 
   describe("onAddDevice", () => {
@@ -72,16 +116,75 @@ describe("useDeviceSectionViewModel", () => {
     });
   });
 
-  describe("onOpenRemoveMenu", () => {
-    it("should set selectedDevice and open the drawer", () => {
+  describe("onDevicePress", () => {
+    it("should set selectedDevice as a Device and track event", () => {
       const { result } = renderHook(() => useDeviceSectionViewModel());
 
       expect(result.current.selectedDevice).toBeNull();
+
+      act(() => result.current.onDevicePress(mockDevice));
+
+      expect(result.current.selectedDevice).toEqual({
+        deviceId: "device-1",
+        deviceName: "Flex Pro",
+        modelId: DeviceModelId.europa,
+        wired: false,
+      });
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Device",
+        page: ScreenName.MyWallet,
+        deviceModelId: DeviceModelId.europa,
+      });
+    });
+  });
+
+  describe("onDeviceActionClose", () => {
+    it("should clear selectedDevice", () => {
+      const { result } = renderHook(() => useDeviceSectionViewModel());
+
+      act(() => result.current.onDevicePress(mockDevice));
+      expect(result.current.selectedDevice).not.toBeNull();
+
+      act(() => result.current.onDeviceActionClose());
+
+      expect(result.current.selectedDevice).toBeNull();
+    });
+  });
+
+  describe("onDeviceActionError", () => {
+    it("should clear selectedDevice on BluetoothRequired error", () => {
+      const { result } = renderHook(() => useDeviceSectionViewModel());
+
+      act(() => result.current.onDevicePress(mockDevice));
+      expect(result.current.selectedDevice).not.toBeNull();
+
+      act(() => result.current.onDeviceActionError(new BluetoothRequired()));
+
+      expect(result.current.selectedDevice).toBeNull();
+    });
+
+    it("should not clear selectedDevice on other errors", () => {
+      const { result } = renderHook(() => useDeviceSectionViewModel());
+
+      act(() => result.current.onDevicePress(mockDevice));
+      const deviceBefore = result.current.selectedDevice;
+
+      act(() => result.current.onDeviceActionError(new Error("some error")));
+
+      expect(result.current.selectedDevice).toEqual(deviceBefore);
+    });
+  });
+
+  describe("onOpenRemoveMenu", () => {
+    it("should set deviceToRemove and open the drawer", () => {
+      const { result } = renderHook(() => useDeviceSectionViewModel());
+
+      expect(result.current.deviceToRemove).toBeNull();
       expect(result.current.isRemoveDrawerOpen).toBe(false);
 
       act(() => result.current.onOpenRemoveMenu(mockDevice));
 
-      expect(result.current.selectedDevice).toEqual(mockDevice);
+      expect(result.current.deviceToRemove).toEqual(mockDevice);
       expect(result.current.isRemoveDrawerOpen).toBe(true);
     });
   });
@@ -112,7 +215,7 @@ describe("useDeviceSectionViewModel", () => {
 
       expect(disconnect).toHaveBeenCalledWith("device-1");
       expect(result.current.isRemoveDrawerOpen).toBe(false);
-      expect(result.current.selectedDevice).toBeNull();
+      expect(result.current.deviceToRemove).toBeNull();
       expect(store.getState().ble.knownDevices).toEqual([]);
     });
 
@@ -139,7 +242,7 @@ describe("useDeviceSectionViewModel", () => {
         await result.current.onRemoveDevice();
       });
 
-      expect(result.current.selectedDevice).toBeNull();
+      expect(result.current.deviceToRemove).toBeNull();
       expect(result.current.isRemoveDrawerOpen).toBe(false);
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceRemoveDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceRemoveDrawer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Box, Button } from "@ledgerhq/lumen-ui-rnative";
+import { BottomSheetView, Box, Button } from "@ledgerhq/lumen-ui-rnative";
 import { Trash } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "~/context/Locale";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import { DeviceIllustration } from "~/components/DeviceIllustration";
@@ -15,17 +16,22 @@ type DeviceRemoveDrawerProps = {
 
 export function DeviceRemoveDrawer({ device, isOpen, onClose, onRemove }: DeviceRemoveDrawerProps) {
   const { t } = useTranslation();
+  const { bottom: bottomInset } = useSafeAreaInsets();
 
   return (
     <QueuedDrawerBottomSheet isRequestingToBeOpened={isOpen} onClose={onClose} enableDynamicSizing>
-      {device ? (
-        <Box lx={{ alignItems: "center", marginBottom: "s32" }}>
-          <DeviceIllustration deviceModelId={device.modelId} />
+      <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
+        <Box lx={{ padding: "s16", gap: "s24" }}>
+          {device ? (
+            <Box lx={{ alignItems: "center" }}>
+              <DeviceIllustration deviceModelId={device.modelId} />
+            </Box>
+          ) : null}
+          <Button appearance="red" size="lg" icon={Trash} onPress={onRemove}>
+            {t("common.forgetDevice")}
+          </Button>
         </Box>
-      ) : null}
-      <Button appearance="red" size="lg" icon={Trash} onPress={onRemove}>
-        {t("common.forgetDevice")}
-      </Button>
+      </BottomSheetView>
     </QueuedDrawerBottomSheet>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/index.tsx
@@ -3,31 +3,25 @@ import { useDeviceSectionViewModel } from "./useDeviceSectionViewModel";
 import { DeviceSectionView } from "./DeviceSectionView";
 
 export function DeviceSection() {
-  const {
-    devices,
-    hasDevices,
-    onAddDevice,
-    onExploreDevices,
-    onDevicePress,
-    selectedDevice,
-    isRemoveDrawerOpen,
-    onOpenRemoveMenu,
-    onCloseRemoveMenu,
-    onRemoveDevice,
-  } = useDeviceSectionViewModel();
+  const vm = useDeviceSectionViewModel();
 
   return (
     <DeviceSectionView
-      devices={devices}
-      hasDevices={hasDevices}
-      onAddDevice={onAddDevice}
-      onExploreDevices={onExploreDevices}
-      onDevicePress={onDevicePress}
-      onOpenMenu={onOpenRemoveMenu}
-      selectedDevice={selectedDevice}
-      isRemoveDrawerOpen={isRemoveDrawerOpen}
-      onCloseRemoveMenu={onCloseRemoveMenu}
-      onRemoveDevice={onRemoveDevice}
+      devices={vm.devices}
+      hasDevices={vm.hasDevices}
+      onAddDevice={vm.onAddDevice}
+      onExploreDevices={vm.onExploreDevices}
+      onDevicePress={vm.onDevicePress}
+      onOpenMenu={vm.onOpenRemoveMenu}
+      deviceToRemove={vm.deviceToRemove}
+      isRemoveDrawerOpen={vm.isRemoveDrawerOpen}
+      onCloseRemoveMenu={vm.onCloseRemoveMenu}
+      onRemoveDevice={vm.onRemoveDevice}
+      selectedDevice={vm.selectedDevice}
+      managerAction={vm.managerAction}
+      onDeviceActionResult={vm.onDeviceActionResult}
+      onDeviceActionClose={vm.onDeviceActionClose}
+      onDeviceActionError={vm.onDeviceActionError}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
@@ -4,6 +4,9 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Linking } from "react-native";
 import type { DeviceModelId } from "@ledgerhq/devices";
 import { disconnect } from "@ledgerhq/live-common/hw/index";
+import { BluetoothRequired } from "@ledgerhq/errors";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import type { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { findMatchingNewDevice, useBleDevicesScanning } from "@ledgerhq/live-dmk-mobile";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { bleDevicesSelector } from "~/reducers/ble";
@@ -12,6 +15,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { urls } from "~/utils/urls";
 import { track } from "~/analytics";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
+import { useManagerDeviceAction } from "~/hooks/deviceActions";
 
 export interface DeviceSectionDevice {
   readonly id: string;
@@ -20,17 +24,22 @@ export interface DeviceSectionDevice {
   readonly available: boolean;
 }
 
-interface DeviceSectionViewModel {
+export interface DeviceSectionViewModel {
   readonly devices: readonly DeviceSectionDevice[];
   readonly hasDevices: boolean;
   readonly onAddDevice: () => void;
   readonly onExploreDevices: () => void;
   readonly onDevicePress: (device: DeviceSectionDevice) => void;
-  readonly selectedDevice: DeviceSectionDevice | null;
+  readonly deviceToRemove: DeviceSectionDevice | null;
   readonly isRemoveDrawerOpen: boolean;
   readonly onOpenRemoveMenu: (device: DeviceSectionDevice) => void;
   readonly onCloseRemoveMenu: () => void;
   readonly onRemoveDevice: () => void;
+  readonly selectedDevice: Device | null;
+  readonly managerAction: ReturnType<typeof useManagerDeviceAction>;
+  readonly onDeviceActionResult: (result: Result) => void;
+  readonly onDeviceActionClose: () => void;
+  readonly onDeviceActionError: (error: Error) => void;
 }
 
 export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
@@ -38,9 +47,11 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
     useNavigation<NativeStackNavigationProp<{ [key: string]: object | undefined }>>();
   const dispatch = useDispatch();
   const knownDevices = useSelector(bleDevicesSelector);
-  const [selectedDevice, setSelectedDevice] = useState<DeviceSectionDevice | null>(null);
+  const [deviceToRemove, setDeviceToRemove] = useState<DeviceSectionDevice | null>(null);
   const [isRemoveDrawerOpen, setIsRemoveDrawerOpen] = useState(false);
   const { scannedDevices } = useBleDevicesScanning(true);
+  const managerAction = useManagerDeviceAction();
+  const [selectedDevice, setSelectedDevice] = useState<Device | null>(null);
 
   const devices = useMemo(
     () =>
@@ -69,30 +80,35 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
     Linking.openURL(exploreDevicesUrl);
   }, [exploreDevicesUrl]);
 
-  const onDevicePress = useCallback(
-    (device: DeviceSectionDevice) => {
-      track("button_clicked", {
-        button: "Device",
-        page: ScreenName.MyWallet,
-        deviceModelId: device.modelId,
-      });
-      navigation.navigate(NavigatorName.MyLedger, {
-        screen: ScreenName.MyLedgerChooseDevice,
-        params: {
-          device: {
-            deviceId: device.id,
-            deviceName: device.name,
-            modelId: device.modelId,
-            wired: false,
-          },
-        },
-      });
+  const onDevicePress = useCallback((device: DeviceSectionDevice) => {
+    track("button_clicked", {
+      button: "Device",
+      page: ScreenName.MyWallet,
+      deviceModelId: device.modelId,
+    });
+    setSelectedDevice({
+      deviceId: device.id,
+      deviceName: device.name,
+      modelId: device.modelId,
+      wired: false,
+    });
+  }, []);
+
+  const onDeviceActionResult = useCallback(
+    (result: Result) => {
+      setSelectedDevice(null);
+      if (result && "result" in result) {
+        navigation.navigate(NavigatorName.MyLedger, {
+          screen: ScreenName.MyLedgerDevice,
+          params: { ...result, tab: "CATALOG" },
+        });
+      }
     },
     [navigation],
   );
 
   const onOpenRemoveMenu = (device: DeviceSectionDevice) => {
-    setSelectedDevice(device);
+    setDeviceToRemove(device);
     setIsRemoveDrawerOpen(true);
   };
 
@@ -101,17 +117,27 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
   };
 
   const onRemoveDevice = useCallback(async () => {
-    if (!selectedDevice) return;
-    dispatch(removeKnownDevice(selectedDevice.id));
+    if (!deviceToRemove) return;
+    dispatch(removeKnownDevice(deviceToRemove.id));
     setIsRemoveDrawerOpen(false);
     try {
-      await disconnect(selectedDevice.id);
+      await disconnect(deviceToRemove.id);
       // eslint-disable-next-line @typescript-eslint/no-empty-function
     } catch {
       /* empty */
     }
+    setDeviceToRemove(null);
+  }, [deviceToRemove, dispatch]);
+
+  const onDeviceActionClose = useCallback(() => {
     setSelectedDevice(null);
-  }, [selectedDevice, dispatch]);
+  }, []);
+
+  const onDeviceActionError = useCallback((error: Error) => {
+    if (error instanceof BluetoothRequired) {
+      setSelectedDevice(null);
+    }
+  }, []);
 
   return {
     devices,
@@ -119,10 +145,15 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
     onAddDevice,
     onExploreDevices,
     onDevicePress,
-    selectedDevice,
+    deviceToRemove,
     isRemoveDrawerOpen,
     onOpenRemoveMenu,
     onCloseRemoveMenu,
     onRemoveDevice,
+    selectedDevice,
+    managerAction,
+    onDeviceActionResult,
+    onDeviceActionClose,
+    onDeviceActionError,
   };
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - When tapping a device in the MyWallet DeviceSection, the user now sees the device connection modal directly over MyWallet, then navigates straight to MyLedgerDevice (apps list, firmware info, etc.)
      - The intermediate MyLedgerChooseDevice screen (with SelectDevice2) is no longer part of the Wallet 4.0 flow

### 📝 Description

In the Wallet 4.0 MyWallet screen, tapping a paired device navigated to the legacy MyLedgerChooseDevice screen before reaching MyLedgerDevice. This added an unnecessary intermediate step showing the old device selector UI.

This PR removes that intermediate step by running the manager device action (DeviceActionModal) directly from the DeviceSection view. On success, the user is navigated straight to MyLedgerDevice with the connection result. The MyLedgerChooseDevice screen is preserved for legacy paths but is no longer used from the Wallet 4.0 flow.

https://github.com/user-attachments/assets/0b8166e3-3af5-4bc2-a3d2-c780263f13be


### ❓ Context

[ticket](https://ledgerhq.atlassian.net/browse/LIVE-26537)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)