### PR TITLE
fix(ci): add .mise/tasks to mobile workflow sparse checkouts

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -197,6 +197,7 @@ jobs:
             e2e/mobile
             .pnpmfile.cjs
             tools
+            .mise/tasks
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup the caches

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -122,6 +122,7 @@ jobs:
             pnpm-lock.yaml
             .pnpmfile.cjs
             tools
+            .mise/tasks
 
       - name: Determine cache keys
         id: cache-keys


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Mobile workflows use sparse checkout and omit .mise/, causing `mise run apt:update` to fail with "no task apt:update found". Add .mise/tasks to the sparse-checkout list so the task file is present when setup-caches runs on these jobs.

Fixes the post-merge regression seen in run 24831619038.
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
