### PR TITLE
[LWDM] fix(mobile,desktop): use correct UTMs for explore devices link

### DIFF
--- a/.changeset/fluffy-cups-behave.md
+++ b/.changeset/fluffy-cups-behave.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix UTM parameters on "Explore all Ledger devices" link in My Wallet

--- a/apps/ledger-live-desktop/src/config/urls.ts
+++ b/apps/ledger-live-desktop/src/config/urls.ts
@@ -45,8 +45,10 @@ export const urls = {
     "https://shop.ledger.com/pages/ledger-live-terms-of-use?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=terms",
   buyNew:
     "https://shop.ledger.com/pages/hardware-wallets-comparison?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=onboarding",
+  exploreLedgerDevices:
+    "https://shop.ledger.com/pages/hardware-wallets-comparison?utm_source=ledger_wallet_desktop&utm_medium=page_my_wallet&utm_content=explore_ledger_devices",
   reborn:
-    "https://shop.ledger.com/pages/unlock-ledger-wallet-desktop?utm_source=ledger_wallet_destkop&utm_medium=self_referral&utm_content=onboarding-2",
+    "https://shop.ledger.com/pages/unlock-ledger-wallet-desktop?utm_source=ledger_wallet_desktop&utm_medium=self_referral&utm_content=onboarding-2",
   noDevice: {
     learnMore:
       "https://www.ledger.com?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=onboarding",

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/hooks/useExploreViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/hooks/useExploreViewModel.ts
@@ -11,7 +11,7 @@ export type ExploreViewModel = {
 
 export function useExploreViewModel(): ExploreViewModel {
   const { t } = useTranslation();
-  const url = useLocalizedUrl(urls.buyNew);
+  const url = useLocalizedUrl(urls.exploreLedgerDevices);
 
   const handleClick = useCallback(() => {
     openURL(url, "button_clicked", {

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/index.test.tsx
@@ -30,7 +30,7 @@ describe("Explore", () => {
     await user.click(screen.getByText(t("myWallet.explore")));
 
     expect(openURL).toHaveBeenCalledTimes(1);
-    expect(openURL).toHaveBeenCalledWith(urls.buyNew, "button_clicked", {
+    expect(openURL).toHaveBeenCalledWith(urls.exploreLedgerDevices, "button_clicked", {
       button: "explore all",
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
@@ -42,7 +42,7 @@ describe("useDeviceSectionViewModel", () => {
 
       act(() => result.current.onExploreDevices());
 
-      expect(Linking.openURL).toHaveBeenCalledWith(urls.hardwareWallet);
+      expect(Linking.openURL).toHaveBeenCalledWith(urls.exploreLedgerDevices);
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "ExploreDevices",
         page: ScreenName.MyWallet,

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
@@ -52,7 +52,7 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
     navigation.navigate(ScreenName.BleDevicePairingFlow);
   }, [navigation]);
 
-  const exploreDevicesUrl = useLocalizedUrl(urls.hardwareWallet);
+  const exploreDevicesUrl = useLocalizedUrl(urls.exploreLedgerDevices);
 
   const onExploreDevices = useCallback(() => {
     track("button_clicked", { button: "ExploreDevices", page: ScreenName.MyWallet });

--- a/apps/ledger-live-mobile/src/utils/urls.tsx
+++ b/apps/ledger-live-mobile/src/utils/urls.tsx
@@ -65,6 +65,8 @@ export const urls = {
     "https://shop.ledger.com/products/ledger-nano-x?utm_source=ledger_live_mobile&utm_medium=self_referral&utm_content=onboarding",
   buyFlex:
     "https://shop.ledger.com/products/ledger-flex?utm_source=ledger_live_mobile&utm_medium=self_referral&utm_content=onboarding",
+  exploreLedgerDevices:
+    "https://shop.ledger.com/pages/hardware-wallets-comparison?utm_source=ledger_wallet_mobile&utm_medium=page_my_wallet&utm_content=explore_ledger_devices",
   hardwareWallet:
     "https://shop.ledger.com/pages/hardware-wallet?utm_source=ledger_live_mobile&utm_medium=self_referral&utm_content=swap",
   playstore: "https://play.google.com/store/apps/details?id=com.ledger.live",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - "Explore all Ledger devices" link UTM parameters on Desktop (My Wallet page)
      - "Explore all Ledger devices" link UTM parameters on Mobile (My Wallet device section)

### 📝 Description

The "Explore all Ledger devices" link on the My Wallet page was using incorrect UTM parameters on both platforms. Desktop was reusing the onboarding `buyNew` URL and mobile was reusing the swap-scoped `hardwareWallet` URL — neither matched the expected tracking values for the My Wallet context.

**Fix:** Added a dedicated `exploreLedgerDevices` URL constant on both platforms with the correct UTMs:
- **Desktop:** `utm_source=ledger_wallet_desktop`, `utm_medium=page_my_wallet`, `utm_content=explore_ledger_devices`
- **Mobile:** `utm_source=ledger_wallet_mobile`, `utm_medium=page_my_wallet`, `utm_content=explore_ledger_devices`

The existing `buyNew` (desktop) and `hardwareWallet` (mobile) URLs remain unchanged so other flows (onboarding, swap) are not affected.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29633](https://ledgerhq.atlassian.net/browse/LIVE-29633)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29633]: https://ledgerhq.atlassian.net/browse/LIVE-29633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ