### PR TITLE
[LWM] test(mobile): add receive warning and delegate e2e coverage

### DIFF
--- a/.changeset/mobile-e2e-warning-validator-coverage.md
+++ b/.changeset/mobile-e2e-warning-validator-coverage.md
@@ -1,0 +1,5 @@
+"live-mobile": patch
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Add mobile E2E coverage for receive warning messages and the default Solana delegation validator flow.

--- a/.changeset/mobile-e2e-warning-validator-coverage.md
+++ b/.changeset/mobile-e2e-warning-validator-coverage.md
@@ -1,3 +1,4 @@
+---
 "live-mobile": patch
 "ledger-live-mobile-e2e-tests": patch
 ---

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
@@ -429,7 +429,14 @@ function ReceiveConfirmationInner({ navigation, route, account, parentAccount }:
                 {t("transfer.receive.receiveConfirmation.utxoWarning")}
               </Text>
             )}
-            <Text variant="small" fontWeight="medium" color="neutral.c70" mb={4} textAlign="center">
+            <Text
+              variant="small"
+              fontWeight="medium"
+              color="neutral.c70"
+              mb={4}
+              textAlign="center"
+              testID="receive-network-warning"
+            >
               {t("transfer.receive.receiveConfirmation.sendWarning", {
                 network: network || currency.name,
               })}

--- a/e2e/mobile/page/trade/receive.page.ts
+++ b/e2e/mobile/page/trade/receive.page.ts
@@ -1,5 +1,4 @@
 import { Step } from "jest-allure2-reporter/api";
-import { AccountType } from "@ledgerhq/live-common/e2e/enum/Account";
 import { currencyParam, openDeeplink } from "../../helpers/commonHelpers";
 import { TokenType } from "@ledgerhq/live-common/e2e/enum/TokenType";
 import { ReceiveFundsOptionsType } from "@ledgerhq/live-common/e2e/enum/ReceiveFundsOptions";
@@ -25,9 +24,6 @@ export default class ReceivePage {
   receiveQrCodeContainerId = (t: string) => `receive-qr-code-container-${t}`;
   titleReceiveConfirmationPageId = (t: string) => `receive-confirmation-title-${t}`;
   receiveNetworkWarningId = "receive-network-warning";
-
-  sendAssetWarningMessage = (account: AccountType) =>
-    `Send only tokens from ${account.currency.name} network. Sending from another network may result in permanent loss of your tokens.`;
 
   @Step("Open receive via deeplink")
   async openViaDeeplink(): Promise<void> {
@@ -115,6 +111,19 @@ export default class ReceivePage {
     await detoxExpect(getElementById(qrCodeContainerID)).toBeVisible();
   }
 
+  @Step("Expect receive warning page is displayed")
+  async expectReceiveWarningPageIsDisplayed(
+    tickerName: string,
+    accountName: string,
+  ): Promise<void> {
+    const titleID = this.titleReceiveConfirmationPageId(tickerName);
+    const accountNameID = this.accountNameReceiveId(accountName);
+    await waitForElementById(this.accountAddress);
+    await waitForElementById(titleID);
+    await detoxExpect(getElementById(titleID)).toBeVisible();
+    await detoxExpect(getElementById(accountNameID)).toBeVisible();
+  }
+
   @Step("Verify address")
   async verifyAddress(address: string): Promise<void> {
     await detoxExpect(getElementById(this.accountAddress)).toHaveText(address);
@@ -139,11 +148,11 @@ export default class ReceivePage {
   }
 
   @Step("Expect receive network warning message for $0")
-  async expectSendCurrencyTokensWarningMessage(account: AccountType): Promise<void> {
+  async expectSendCurrencyTokensWarningMessage(expectedWarningMessage: string): Promise<void> {
     await scrollToId(this.receiveNetworkWarningId, this.receivePageScrollViewId);
     await detoxExpect(getElementById(this.receiveNetworkWarningId)).toBeVisible();
     await detoxExpect(getElementById(this.receiveNetworkWarningId)).toHaveText(
-      this.sendAssetWarningMessage(account),
+      expectedWarningMessage,
     );
   }
 

--- a/e2e/mobile/page/trade/receive.page.ts
+++ b/e2e/mobile/page/trade/receive.page.ts
@@ -1,4 +1,5 @@
 import { Step } from "jest-allure2-reporter/api";
+import { AccountType } from "@ledgerhq/live-common/e2e/enum/Account";
 import { currencyParam, openDeeplink } from "../../helpers/commonHelpers";
 import { TokenType } from "@ledgerhq/live-common/e2e/enum/TokenType";
 import { ReceiveFundsOptionsType } from "@ledgerhq/live-common/e2e/enum/ReceiveFundsOptions";
@@ -23,6 +24,10 @@ export default class ReceivePage {
     `option-button-content-${receiveFundsOption}`;
   receiveQrCodeContainerId = (t: string) => `receive-qr-code-container-${t}`;
   titleReceiveConfirmationPageId = (t: string) => `receive-confirmation-title-${t}`;
+  receiveNetworkWarningId = "receive-network-warning";
+
+  sendAssetWarningMessage = (account: AccountType) =>
+    `Send only tokens from ${account.currency.name} network. Sending from another network may result in permanent loss of your tokens.`;
 
   @Step("Open receive via deeplink")
   async openViaDeeplink(): Promise<void> {
@@ -130,6 +135,15 @@ export default class ReceivePage {
     await detoxExpect(getElementById(warnId)).toBeVisible();
     await detoxExpect(getElementById(descId)).toHaveText(
       "You first need to send at least 0.1 TRX to this address to activate it.",
+    );
+  }
+
+  @Step("Expect receive network warning message for $0")
+  async expectSendCurrencyTokensWarningMessage(account: AccountType): Promise<void> {
+    await scrollToId(this.receiveNetworkWarningId, this.receivePageScrollViewId);
+    await detoxExpect(getElementById(this.receiveNetworkWarningId)).toBeVisible();
+    await detoxExpect(getElementById(this.receiveNetworkWarningId)).toHaveText(
+      this.sendAssetWarningMessage(account),
     );
   }
 

--- a/e2e/mobile/page/trade/receive.page.ts
+++ b/e2e/mobile/page/trade/receive.page.ts
@@ -23,7 +23,7 @@ export default class ReceivePage {
     `option-button-content-${receiveFundsOption}`;
   receiveQrCodeContainerId = (t: string) => `receive-qr-code-container-${t}`;
   titleReceiveConfirmationPageId = (t: string) => `receive-confirmation-title-${t}`;
-  receiveNetworkWarningId = "receive-network-warning";
+  private readonly receiveNetworkWarningId = "receive-network-warning";
 
   @Step("Open receive via deeplink")
   async openViaDeeplink(): Promise<void> {
@@ -98,15 +98,22 @@ export default class ReceivePage {
     await tapById(this.noVerifyValidateButton);
   }
 
-  @Step("Expect account receive page is displayed")
-  async expectReceivePageIsDisplayed(tickerName: string, accountName: string): Promise<void> {
+  @Step("Expect receive page header")
+  private async expectReceivePageHeader(tickerName: string, accountName: string): Promise<void> {
     const titleID = this.titleReceiveConfirmationPageId(tickerName);
     const accountNameID = this.accountNameReceiveId(accountName);
-    const qrCodeContainerID = this.receiveQrCodeContainerId(accountName);
+
     await waitForElementById(this.accountAddress);
     await waitForElementById(titleID);
     await detoxExpect(getElementById(titleID)).toBeVisible();
     await detoxExpect(getElementById(accountNameID)).toBeVisible();
+  }
+
+  @Step("Expect account receive page is displayed")
+  async expectReceivePageIsDisplayed(tickerName: string, accountName: string): Promise<void> {
+    const qrCodeContainerID = this.receiveQrCodeContainerId(accountName);
+
+    await this.expectReceivePageHeader(tickerName, accountName);
     await scrollToId(qrCodeContainerID, this.receivePageScrollViewId);
     await detoxExpect(getElementById(qrCodeContainerID)).toBeVisible();
   }
@@ -116,12 +123,7 @@ export default class ReceivePage {
     tickerName: string,
     accountName: string,
   ): Promise<void> {
-    const titleID = this.titleReceiveConfirmationPageId(tickerName);
-    const accountNameID = this.accountNameReceiveId(accountName);
-    await waitForElementById(this.accountAddress);
-    await waitForElementById(titleID);
-    await detoxExpect(getElementById(titleID)).toBeVisible();
-    await detoxExpect(getElementById(accountNameID)).toBeVisible();
+    await this.expectReceivePageHeader(tickerName, accountName);
   }
 
   @Step("Verify address")

--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -65,6 +65,32 @@ export function runDelegateTest(delegation: DelegateType, tmsLinks: string[], ta
   });
 }
 
+export function runDelegateDefaultValidatorTest(
+  delegation: DelegateType,
+  tmsLinks: string[],
+  tags: string[],
+) {
+  tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+  tags.forEach(tag => $Tag(tag));
+  describe("Delegate - default validator", () => {
+    beforeAll(async () => {
+      await beforeAllFunction(delegation);
+    });
+
+    it(`Defaults to ${delegation.provider} on ${delegation.account.currency.name}`, async () => {
+      const currencyId =
+        getCurrencyManagerApp(delegation.account.currency.id) ?? delegation.account.currency.id;
+
+      await app.portfolio.goToAccounts(delegation.account.currency.name);
+      await app.common.goToAccountByName(delegation.account.accountName);
+      await app.account.tapEarn();
+
+      await app.stake.dismissDelegationStart(currencyId);
+      await app.stake.expectProvider(currencyId, delegation.provider);
+    });
+  });
+}
+
 export async function runLockCelo(
   delegation: DelegateType,
   tmsLinks: string[],

--- a/e2e/mobile/specs/delegate/delegateSOLDefaultValidator.spec.ts
+++ b/e2e/mobile/specs/delegate/delegateSOLDefaultValidator.spec.ts
@@ -1,0 +1,9 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runDelegateDefaultValidatorTest } from "./delegate";
+
+const delegation = new Delegate(Account.SOL_2, "0.001", "Ledger by Figment");
+runDelegateDefaultValidatorTest(
+  delegation,
+  ["B2CQA-2730"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@solana", "@family-solana"],
+);

--- a/e2e/mobile/specs/verifyAddress/verifyAddressWarning.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressWarning.ts
@@ -1,0 +1,35 @@
+import { AccountType } from "@ledgerhq/live-common/e2e/enum/Account";
+
+type VerifyAddressWarningOptions = {
+  skip?: boolean;
+};
+
+export function runVerifyAddressWarningTest(
+  account: AccountType,
+  tmsLinks: string[],
+  tags: string[],
+  options: VerifyAddressWarningOptions = {},
+) {
+  const describeFn = options.skip ? describe.skip : describe;
+
+  describeFn("Verify Address warnings", () => {
+    beforeAll(async () => {
+      await app.init({
+        speculosApp: account.currency.speculosApp,
+        cliCommands: [liveDataCommand(account)],
+      });
+      await app.portfolio.waitForPortfolioPageToLoad();
+    });
+
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+    it(`Verify address warning for ${account.currency.name}`, async () => {
+      await app.account.openViaDeeplink();
+      await app.account.goToAccountByName(account.accountName);
+      await app.account.tapReceive();
+      await app.receive.doNotVerifyAddress();
+      await app.receive.expectReceivePageIsDisplayed(account.currency.ticker, account.accountName);
+      await app.receive.expectSendCurrencyTokensWarningMessage(account);
+    });
+  });
+}

--- a/e2e/mobile/specs/verifyAddress/verifyAddressWarning.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressWarning.ts
@@ -6,6 +6,7 @@ type VerifyAddressWarningOptions = {
 
 export function runVerifyAddressWarningTest(
   account: AccountType,
+  expectedWarningMessage: string,
   tmsLinks: string[],
   tags: string[],
   options: VerifyAddressWarningOptions = {},
@@ -28,8 +29,11 @@ export function runVerifyAddressWarningTest(
       await app.account.goToAccountByName(account.accountName);
       await app.account.tapReceive();
       await app.receive.doNotVerifyAddress();
-      await app.receive.expectReceivePageIsDisplayed(account.currency.ticker, account.accountName);
-      await app.receive.expectSendCurrencyTokensWarningMessage(account);
+      await app.receive.expectReceiveWarningPageIsDisplayed(
+        account.currency.ticker,
+        account.accountName,
+      );
+      await app.receive.expectSendCurrencyTokensWarningMessage(expectedWarningMessage);
     });
   });
 }

--- a/e2e/mobile/specs/verifyAddress/verifyAddressWarningBSC.skip.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressWarningBSC.skip.spec.ts
@@ -1,0 +1,10 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runVerifyAddressWarningTest } from "./verifyAddressWarning";
+
+// TODO: re-enable this spec when LIVE-25852 is fixed.
+runVerifyAddressWarningTest(
+  Account.BSC_1,
+  ["B2CQA-2698"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@bsc", "@family-evm"],
+  { skip: true },
+);

--- a/e2e/mobile/specs/verifyAddress/verifyAddressWarningBSC.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressWarningBSC.spec.ts
@@ -1,10 +1,9 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { runVerifyAddressWarningTest } from "./verifyAddressWarning";
 
-// TODO: re-enable this spec when LIVE-25852 is fixed.
 runVerifyAddressWarningTest(
   Account.BSC_1,
+  "Send only tokens from BNB Chain network. Sending from another network may result in permanent loss of your tokens.",
   ["B2CQA-2698"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@bsc", "@family-evm"],
-  { skip: true },
 );

--- a/e2e/mobile/specs/verifyAddress/verifyAddressWarningETH.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressWarningETH.spec.ts
@@ -1,0 +1,8 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runVerifyAddressWarningTest } from "./verifyAddressWarning";
+
+runVerifyAddressWarningTest(
+  Account.ETH_1,
+  ["B2CQA-2697"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
+);

--- a/e2e/mobile/specs/verifyAddress/verifyAddressWarningETH.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressWarningETH.spec.ts
@@ -3,6 +3,7 @@ import { runVerifyAddressWarningTest } from "./verifyAddressWarning";
 
 runVerifyAddressWarningTest(
   Account.ETH_1,
+  "Send only tokens from Ethereum network. Sending from another network may result in permanent loss of your tokens.",
   ["B2CQA-2697"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
 );

--- a/e2e/mobile/specs/verifyAddress/verifyAddressWarningTRX.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressWarningTRX.spec.ts
@@ -1,0 +1,8 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { runVerifyAddressWarningTest } from "./verifyAddressWarning";
+
+runVerifyAddressWarningTest(
+  Account.TRX_1,
+  ["B2CQA-2699"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@tron", "@family-tron"],
+);

--- a/e2e/mobile/specs/verifyAddress/verifyAddressWarningTRX.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/verifyAddressWarningTRX.spec.ts
@@ -3,6 +3,7 @@ import { runVerifyAddressWarningTest } from "./verifyAddressWarning";
 
 runVerifyAddressWarningTest(
   Account.TRX_1,
+  "Send only tokens from Tron network. Sending from another network may result in permanent loss of your tokens.",
   ["B2CQA-2699"],
   ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@tron", "@family-tron"],
 );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Targeted iOS prerelease runs were validated for the ETH receive warning flow; the remaining mobile E2E scenarios should be exercised from this branch during QA._
- [x] **Impact of the changes:**
      - Mobile receive warning flows for ETH, TRX, and BSC after choosing not to verify the address
      - Exact warning-copy assertions on the receive confirmation warning screen
      - Mobile Solana delegation flow defaulting to the Ledger by Figment validator
      - Stability of the warning-only receive helper used by the new mobile E2E specs

### 📝 Description

This PR closes two mobile E2E coverage gaps by porting desktop-only checks to mobile for receive address warnings and Solana delegation. It adds dedicated mobile specs for the receive warning scenarios covered by QAA-1129 and a focused Solana default-validator delegation spec for QAA-1131.

To support those checks, the shared mobile receive-warning helpers now validate the exact warning copy expected for ETH, TRX, and BSC, and the Solana delegation coverage is isolated in its own spec without changing the existing full delegation flow. A small `testID` was also added in `live-mobile` so the receive network warning can be asserted reliably in Detox.

https://github.com/LedgerHQ/ledger-live/actions/runs/24833664286

### ❓ Context

- **JIRA or GitHub link**: [QAA-1129](https://ledgerhq.atlassian.net/browse/QAA-1129) and [QAA-1131](https://ledgerhq.atlassian.net/browse/QAA-1131)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1129]: https://ledgerhq.atlassian.net/browse/QAA-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ