### PR TITLE
[LWD] fix(desktop): add missing bottom padding on allocation page

### DIFF
--- a/.changeset/itchy-jobs-hunt.md
+++ b/.changeset/itchy-jobs-hunt.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix padding on allocation page

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
@@ -25,7 +25,7 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
   const { t } = useTranslation();
 
   return (
-    <div className="flex flex-col gap-32">
+    <div className="flex flex-col gap-32 pb-32">
       <TrackPage category="Analytics" range={selectedTimeRange} countervalue={counterValue} />
       <PageHeader title={t("analytics.title")} onBack={navigateToDashboard} />
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No focused automated coverage was added for this layout-only change, and local typecheck/Jest validation was skipped._
- [x] **Impact of the changes:**
      - Desktop analytics allocation page spacing
      - Bottom padding around the allocation table
      - Visual regression risk limited to the analytics page layout

### 📝 Description

This PR fixes a visual layout issue on Ledger Live Desktop where the allocation page table had no bottom padding and ended flush against the page edge.

The analytics page wrapper now applies bottom padding so the allocation section keeps the expected spacing at the bottom of the screen, matching the behavior requested in LIVE-29636.


<img width="1327" height="240" alt="Screenshot 2026-04-23 at 13 46 54" src="https://github.com/user-attachments/assets/58ebd462-f27b-44de-8407-c072c971b516" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29636](https://ledgerhq.atlassian.net/browse/LIVE-29636)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29636]: https://ledgerhq.atlassian.net/browse/LIVE-29636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ