### PR TITLE
[LWDM] fix: [LIVE-29665] include only transactions with block and transfer hash

### DIFF
--- a/.changeset/hungry-papayas-work.md
+++ b/.changeset/hungry-papayas-work.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+include only transactions with block and transfer hash

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.integ.test.ts
@@ -81,6 +81,7 @@ describe("listOperations — mainnet FA2 / convertTokenOperation", () => {
     expect(["IN", "OUT", "FEES"]).toContain(tokenOp.type);
     expect(tokenOp.value).toBeGreaterThanOrEqual(0n);
     expect(tokenOp.tx.hash).toMatch(/^o[1-9A-HJ-NP-Za-km-z]+/);
+    expect(tokenOp.tx.block.hash).toMatch(/^B[1-9A-HJ-NP-Za-km-z]+/);
     expect(tokenOp.tx.block.height).toBeGreaterThan(0);
     expect(tokenOp.tx.date).toBeInstanceOf(Date);
     const idParts = tokenOp.id.match(/^(.+)-token-(\d+)$/);

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
@@ -401,6 +401,39 @@ describe("listOperations", () => {
     expect(results.length).toBe(2);
   });
 
+  it("FA2 uses transfer.block as tx.block.hash even when a parent native transaction is joined", async () => {
+    const fa2WithBlock: APITokenTransfer & { hash: string; block: string } = {
+      id: 9002,
+      level: 100,
+      timestamp: "2023-06-01T12:00:00Z",
+      token: {
+        id: 1,
+        contract: { address: "KT1TokenContract" },
+        tokenId: "0",
+        standard: "fa2",
+        metadata: { decimals: "6" },
+      },
+      from: { address: someSenderAddress },
+      to: { address: someDestinationAddress },
+      amount: "1",
+      transactionId: transfer.id,
+      hash: someHash,
+      block: "BLK_FROM_TRANSFER",
+    };
+    const appliedTransfer = {
+      ...transfer,
+      status: "applied" as const,
+      block: "BLK_FROM_PARENT",
+    };
+    mockGetAccountOperations.mockResolvedValue([appliedTransfer]);
+    mockGetAccountTokenTransfers.mockResolvedValue([fa2WithBlock]);
+    const [results] = await listOperations(someDestinationAddress, options);
+    const tokenOp = results.find(o => o.asset.type === "fa2");
+
+    expect(tokenOp).toBeDefined();
+    expect(tokenOp!.tx.block.hash).toBe("BLK_FROM_TRANSFER");
+  });
+
   it("drops failed incoming native transactions (target is the listed account)", async () => {
     const failedIn: APITransactionType = {
       ...transfer,
@@ -545,8 +578,8 @@ describe("listOperations", () => {
     expect(tokenSelf!.details.ledgerOpType).toBe("FEES");
   });
 
-  it("FA2 transfer without parent transaction omits fees and uses empty block hash", async () => {
-    const fa2Orphan: APITokenTransfer & { hash: string } = {
+  it("FA2 transfer without parent transaction omits fees and falls back to transfer.block hash", async () => {
+    const fa2Orphan: APITokenTransfer & { hash: string; block: string } = {
       id: 9103,
       level: 103,
       timestamp: "2023-06-01T15:00:00Z",
@@ -560,6 +593,7 @@ describe("listOperations", () => {
       to: { address: someDestinationAddress },
       amount: "10",
       hash: "ooOrphanHash",
+      block: "BLK_ORPHAN",
     };
     mockGetAccountOperations.mockResolvedValue([]);
     mockGetAccountTokenTransfers.mockResolvedValue([fa2Orphan]);
@@ -568,7 +602,31 @@ describe("listOperations", () => {
     expect(orphan).toBeDefined();
     expect(orphan!.tx.fees).toBe(0n);
     expect(orphan!.tx.feesPayer).toBeUndefined();
-    expect(orphan!.tx.block.hash).toBe("");
+    expect(orphan!.tx.block.hash).toBe("BLK_ORPHAN");
     expect(orphan!.tx.failed).toBe(false);
+  });
+
+  it("FA2 transfer without parent and without transfer.block falls back to empty block hash", async () => {
+    const fa2NoBlock: APITokenTransfer & { hash: string } = {
+      id: 9104,
+      level: 104,
+      timestamp: "2023-06-01T16:00:00Z",
+      token: {
+        id: 5,
+        contract: { address: "KT1NoBlock" },
+        tokenId: "0",
+        standard: "fa2",
+      },
+      from: { address: someSenderAddress },
+      to: { address: someDestinationAddress },
+      amount: "10",
+      hash: "ooNoBlockHash",
+    };
+    mockGetAccountOperations.mockResolvedValue([]);
+    mockGetAccountTokenTransfers.mockResolvedValue([fa2NoBlock]);
+    const [results] = await listOperations(someDestinationAddress, options);
+    const noBlock = results.find(o => o.asset.type === "fa2");
+    expect(noBlock).toBeDefined();
+    expect(noBlock!.tx.block.hash).toBe("");
   });
 });

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
@@ -235,7 +235,7 @@ function convertOperation(
 
 function convertTokenOperation(
   address: string,
-  transfer: APITokenTransfer & { hash: string },
+  transfer: APITokenTransfer & { hash: string; block?: string },
   parent?: APITransactionType,
 ): Operation {
   const isOut = transfer.from?.address === address;
@@ -277,7 +277,7 @@ function convertTokenOperation(
       fees: fee,
       ...(feesPayer ? { feesPayer } : {}),
       block: {
-        hash: parent?.block ?? "",
+        hash: transfer.block ?? parent?.block ?? "",
         height: transfer.level,
         time: new Date(transfer.timestamp),
       },

--- a/libs/coin-modules/coin-tezos/src/network/types.ts
+++ b/libs/coin-modules/coin-tezos/src/network/types.ts
@@ -206,6 +206,7 @@ export type APITokenTransfer = {
    * Undefined for implicit/protocol-level transfers.
    */
   transactionId?: number;
+  originationId?: number;
 };
 
 /**

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
@@ -87,6 +87,10 @@ function makeTokenWithTxId(id: number, transactionId?: number): APITokenTransfer
   return { ...makeTokenItem(id), transactionId } as APITokenTransfer;
 }
 
+function makeTokenWithOrigId(id: number, originationId?: number): APITokenTransfer {
+  return { ...makeTokenItem(id), originationId } as APITokenTransfer;
+}
+
 const localSpies: jest.SpyInstance[] = [];
 
 function spyOnApi<K extends keyof typeof api>(method: K) {
@@ -258,6 +262,49 @@ describe("tzkt network API", () => {
   });
 
   // -------------------------------------------------------------------------
+  // api.getOperationsOrigination
+  // -------------------------------------------------------------------------
+
+  describe("api.getOperationsOrigination", () => {
+    it("fetches without cursor and strips undefined extra args", async () => {
+      const originations: (APITransactionType & { block: string; hash: string })[] = [
+        { id: 1, hash: "h1", block: "b1" } as APITransactionType & { hash: string; block: string },
+      ];
+      mockedNetwork.mockReturnValue(networkResponse(originations) as ReturnType<typeof network>);
+
+      const result = await api.getOperationsOrigination(100, undefined, {
+        foo: undefined,
+        bar: "x",
+      });
+
+      expect(result).toEqual(originations);
+      const params = (mockedNetwork.mock.calls[0][0] as { params: Record<string, unknown> }).params;
+      expect(params).toMatchObject({
+        "level.gte": 100,
+        limit: 1000,
+        "sort.asc": "id",
+        bar: "x",
+      });
+      expect(params).not.toHaveProperty("foo");
+      expect(params).not.toHaveProperty("offset.cr");
+      expect(mockedNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining("/v1/operations/originations"),
+        }),
+      );
+    });
+
+    it("includes offset.cr when cursor is set", async () => {
+      mockedNetwork.mockReturnValue(networkResponse([]) as ReturnType<typeof network>);
+
+      await api.getOperationsOrigination(5, 999);
+
+      const params = (mockedNetwork.mock.calls[0][0] as { params: Record<string, unknown> }).params;
+      expect(params["offset.cr"]).toBe(999);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // api.getTokenTransfers
   // -------------------------------------------------------------------------
 
@@ -308,16 +355,15 @@ describe("tzkt network API", () => {
         makeTokenWithTxId(2, undefined),
       ]);
       const spyTx = spyOnApi("getOperationsTransactions");
+      const spyOrig = spyOnApi("getOperationsOrigination");
 
       const result = await api.getAccountTokenTransfers("tz1x", {
         "level.ge": 10,
       });
 
       expect(spyTx).not.toHaveBeenCalled();
-      expect(result).toEqual([
-        expect.objectContaining({ id: 1, hash: "" }),
-        expect.objectContaining({ id: 2, hash: "" }),
-      ]);
+      expect(spyOrig).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
       expect(spyToken).toHaveBeenCalledWith(
         10,
         undefined,
@@ -335,8 +381,12 @@ describe("tzkt network API", () => {
         makeTokenWithTxId(2, 200),
       ]);
       spyOnApi("getOperationsTransactions").mockResolvedValue([
-        { id: 100, hash: "h100" } as APITransactionType,
+        { id: 100, hash: "h100", block: "BLK100" } as APITransactionType & {
+          hash: string;
+          block: string;
+        },
       ]);
+      const spyOrig = spyOnApi("getOperationsOrigination");
 
       const result = await api.getAccountTokenTransfers("tz1y", {
         "level.ge": 0,
@@ -344,12 +394,148 @@ describe("tzkt network API", () => {
       });
 
       expect(result).toEqual([
-        expect.objectContaining({ id: 1, hash: "h100" }),
-        expect.objectContaining({ id: 2, hash: "" }),
+        expect.objectContaining({ id: 1, hash: "h100", block: "BLK100" }),
+        expect.objectContaining({ id: 2, hash: "", block: "" }),
       ]);
       expect(api.getOperationsTransactions).toHaveBeenCalledWith(0, undefined, {
         "id.in": "100,200",
       });
+      expect(spyOrig).not.toHaveBeenCalled();
+    });
+
+    it("attaches parent hash and block from originations when only originationIds are present", async () => {
+      jest
+        .spyOn(api, "getTokenTransfers")
+        .mockResolvedValue([makeTokenWithOrigId(1, 100), makeTokenWithOrigId(2, 200)]);
+      const spyTx = jest.spyOn(api, "getOperationsTransactions");
+      jest.spyOn(api, "getOperationsOrigination").mockResolvedValue([
+        { id: 100, hash: "h100", block: "BLK100" } as APITransactionType & {
+          hash: string;
+          block: string;
+        },
+        { id: 200, hash: "h200", block: "BLK200" } as APITransactionType & {
+          hash: string;
+          block: string;
+        },
+      ]);
+
+      const result = await api.getAccountTokenTransfers("tz1o", {
+        "level.ge": 0,
+      });
+
+      expect(spyTx).not.toHaveBeenCalled();
+      expect(api.getOperationsOrigination).toHaveBeenCalledWith(0, undefined, {
+        "id.in": "100,200",
+      });
+      expect(result).toEqual([
+        expect.objectContaining({ id: 1, hash: "h100", block: "BLK100" }),
+        expect.objectContaining({ id: 2, hash: "h200", block: "BLK200" }),
+      ]);
+    });
+
+    it("joins both transactions and originations when both ids are present", async () => {
+      jest
+        .spyOn(api, "getTokenTransfers")
+        .mockResolvedValue([makeTokenWithTxId(1, 100), makeTokenWithOrigId(2, 500)]);
+      jest.spyOn(api, "getOperationsTransactions").mockResolvedValue([
+        { id: 100, hash: "hTx", block: "BLK_TX" } as APITransactionType & {
+          hash: string;
+          block: string;
+        },
+      ]);
+      jest.spyOn(api, "getOperationsOrigination").mockResolvedValue([
+        { id: 500, hash: "hOrig", block: "BLK_ORIG" } as APITransactionType & {
+          hash: string;
+          block: string;
+        },
+      ]);
+
+      const result = await api.getAccountTokenTransfers("tz1mix", {
+        "level.ge": 0,
+      });
+
+      expect(api.getOperationsTransactions).toHaveBeenCalledWith(0, undefined, {
+        "id.in": "100",
+      });
+      expect(api.getOperationsOrigination).toHaveBeenCalledWith(0, undefined, {
+        "id.in": "500",
+      });
+      expect(result).toEqual([
+        expect.objectContaining({ id: 1, hash: "hTx", block: "BLK_TX" }),
+        expect.objectContaining({ id: 2, hash: "hOrig", block: "BLK_ORIG" }),
+      ]);
+    });
+
+    it("keeps partial hash/block from the parent transaction without dropping transfers", async () => {
+      jest
+        .spyOn(api, "getTokenTransfers")
+        .mockResolvedValue([
+          makeTokenWithTxId(1, 100),
+          makeTokenWithTxId(2, 200),
+          makeTokenWithTxId(3, 300),
+        ]);
+      jest.spyOn(api, "getOperationsTransactions").mockResolvedValue([
+        { id: 100, hash: "h100", block: "" } as APITransactionType & {
+          hash: string;
+          block: string;
+        },
+        { id: 200, hash: "", block: "BLK200" } as APITransactionType & {
+          hash: string;
+          block: string;
+        },
+        { id: 300, hash: "h300", block: "BLK300" } as APITransactionType & {
+          hash: string;
+          block: string;
+        },
+      ]);
+      const spyOrig = jest.spyOn(api, "getOperationsOrigination");
+
+      const result = await api.getAccountTokenTransfers("tz1z", {
+        "level.ge": 0,
+      });
+
+      expect(result).toEqual([
+        expect.objectContaining({ id: 1, hash: "h100", block: "" }),
+        expect.objectContaining({ id: 2, hash: "", block: "BLK200" }),
+        expect.objectContaining({ id: 3, hash: "h300", block: "BLK300" }),
+      ]);
+      expect(spyOrig).not.toHaveBeenCalled();
+    });
+
+    it("keeps partial hash/block from the parent origination without dropping transfers", async () => {
+      jest
+        .spyOn(api, "getTokenTransfers")
+        .mockResolvedValue([
+          makeTokenWithOrigId(1, 100),
+          makeTokenWithOrigId(2, 200),
+          makeTokenWithOrigId(3, 300),
+        ]);
+      const spyTx = jest.spyOn(api, "getOperationsTransactions");
+      jest.spyOn(api, "getOperationsOrigination").mockResolvedValue([
+        { id: 100, hash: "h100", block: "" } as APITransactionType & {
+          hash: string;
+          block: string;
+        },
+        { id: 200, hash: "", block: "BLK200" } as APITransactionType & {
+          hash: string;
+          block: string;
+        },
+        { id: 300, hash: "h300", block: "BLK300" } as APITransactionType & {
+          hash: string;
+          block: string;
+        },
+      ]);
+
+      const result = await api.getAccountTokenTransfers("tz1origZ", {
+        "level.ge": 0,
+      });
+
+      expect(result).toEqual([
+        expect.objectContaining({ id: 1, hash: "h100", block: "" }),
+        expect.objectContaining({ id: 2, hash: "", block: "BLK200" }),
+        expect.objectContaining({ id: 3, hash: "h300", block: "BLK300" }),
+      ]);
+      expect(spyTx).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.ts
@@ -27,6 +27,33 @@ const clearUndefined = (obj: Record<string, unknown>) => {
   return newObj;
 };
 
+/**
+ * Internal helper shared by `getOperationsTransactions` and `getOperationsOrigination`.
+ * Both endpoints accept the same query shape; only the URL path differs.
+ */
+async function getOperationsByType(
+  type: "transactions" | "originations",
+  level: number,
+  cursor?: number,
+  apiQueryParams: Record<string, unknown> = {},
+): Promise<(APITransactionType & { block: string; hash: string })[]> {
+  // "sort.asc": "id" guarantees forward progress for cursor-based paging (offset.cr).
+  // Without an explicit sort the API default may be descending, which would cause the
+  // cursor to go backwards and produce duplicates or an infinite loop.
+  const params: Record<string, unknown> = {
+    "level.gte": level,
+    limit: BLOCK_PAGE_SIZE,
+    "sort.asc": "id",
+    ...clearUndefined(apiQueryParams),
+  };
+  if (cursor !== undefined) params["offset.cr"] = cursor;
+  const { data } = await network<(APITransactionType & { block: string; hash: string })[]>({
+    url: `${getExplorerUrl()}/v1/operations/${type}`,
+    params,
+  });
+  return data;
+}
+
 const api = {
   async getBlockCount(): Promise<number> {
     const { data } = await network<number>({
@@ -106,22 +133,20 @@ const api = {
     level: number,
     cursor?: number,
     apiQueryParams: Record<string, unknown> = {},
-  ): Promise<APITransactionType[]> {
-    // "sort.asc": "id" guarantees forward progress for cursor-based paging (offset.cr).
-    // Without an explicit sort the API default may be descending, which would cause the
-    // cursor to go backwards and produce duplicates or an infinite loop.
-    const params: Record<string, unknown> = {
-      "level.gte": level,
-      limit: BLOCK_PAGE_SIZE,
-      "sort.asc": "id",
-      ...clearUndefined(apiQueryParams),
-    };
-    if (cursor !== undefined) params["offset.cr"] = cursor;
-    const { data } = await network<APITransactionType[]>({
-      url: `${getExplorerUrl()}/v1/operations/transactions`,
-      params,
-    });
-    return data;
+  ): Promise<(APITransactionType & { block: string; hash: string })[]> {
+    return getOperationsByType("transactions", level, cursor, apiQueryParams);
+  },
+
+  /**
+   * Fetches a list of `originations` operations after the given level.
+   * https://api.tzkt.io/#operation/Operations_GetOriginations
+   */
+  async getOperationsOrigination(
+    level: number,
+    cursor?: number,
+    apiQueryParams: Record<string, unknown> = {},
+  ): Promise<(APITransactionType & { block: string; hash: string })[]> {
+    return getOperationsByType("originations", level, cursor, apiQueryParams);
   },
 
   /**
@@ -204,7 +229,7 @@ const api = {
   async getAccountTokenTransfers(
     address: string,
     query: TokenTransfersGetOptions,
-  ): Promise<(APITokenTransfer & { hash: string })[]> {
+  ): Promise<(APITokenTransfer & { hash: string; block: string })[]> {
     const params: Record<string, unknown> = {
       "anyof.from.to": address,
       "token.tokenId": "0",
@@ -217,21 +242,46 @@ const api = {
       .map(t => t.transactionId)
       .filter((id): id is number => typeof id === "number");
 
-    if (transactionIds.length === 0) {
-      return data.map(token => ({
-        ...token,
-        hash: "",
-      }));
+    const originationIds = data
+      .map(t => t.originationId)
+      .filter((id): id is number => typeof id === "number");
+
+    if (transactionIds.length === 0 && originationIds.length === 0) {
+      return [];
     }
 
-    const transactions = await api.getOperationsTransactions(query["level.ge"] || 0, undefined, {
-      "id.in": transactionIds.join(","),
-    });
+    const transactions = transactionIds.length
+      ? await api.getOperationsTransactions(query["level.ge"] || 0, undefined, {
+          "id.in": transactionIds.join(","),
+        })
+      : [];
 
-    return data.map(token => ({
-      ...token,
-      hash: transactions.find(t => t.id === token.transactionId)?.hash ?? "",
-    }));
+    const originations = originationIds.length
+      ? await api.getOperationsOrigination(query["level.ge"] || 0, undefined, {
+          "id.in": originationIds.join(","),
+        })
+      : [];
+
+    // Build id -> operation maps once so per-transfer lookups are O(1) instead of O(n).
+    // Keys are widened to `number | undefined` so lookups with a missing id naturally
+    // return `undefined` (no entry is ever stored under the `undefined` key).
+    const transactionsById = new Map<number | undefined, (typeof transactions)[number]>(
+      transactions.map(t => [t.id, t]),
+    );
+    const originationsById = new Map<number | undefined, (typeof originations)[number]>(
+      originations.map(o => [o.id, o]),
+    );
+
+    return data.map(token => {
+      const transaction = transactionsById.get(token.transactionId);
+      const origination = originationsById.get(token.originationId);
+
+      return {
+        ...token,
+        hash: transaction?.hash ?? origination?.hash ?? "",
+        block: transaction?.block ?? origination?.block ?? "",
+      };
+    });
   },
 
   /**


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Filters out transactions that are internal events on tezos blockchain.

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-29665


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
