### PR TITLE
[LWDM] feat(LIVE-29174): improvement :: missing `credits.aleo` filter when querying the records

### DIFF
--- a/.changeset/fast-tips-dress.md
+++ b/.changeset/fast-tips-dress.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+added filters to owned records api calls for Aleo

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
@@ -37,30 +37,13 @@ describe("listPrivateOperations", () => {
     expect(result.consumedRecordTags).toEqual(new Set());
   });
 
-  it("should filter out records from non-credits programs", async () => {
+  it("should pass non-credits program records to enrichPrivateRecord (filtering is done by the caller)", async () => {
     const record = getMockedRecord({
       program_name: "custom_token.aleo",
       function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
     });
 
-    const result = await listPrivateOperations({
-      currency: mockCurrency,
-      viewKey: mockViewKey,
-      address: mockAddress,
-      ledgerAccountId: mockLedgerAccountId,
-      privateRecords: [record],
-    });
-
-    expect(mockEnrichPrivateRecord).not.toHaveBeenCalled();
-    expect(result.operations).toEqual([]);
-    expect(result.consumedRecordTags).toEqual(new Set());
-  });
-
-  it("should filter out transfer_public records as they are not private operations", async () => {
-    const record = getMockedRecord({
-      program_name: PROGRAM_ID.CREDITS,
-      function_name: EXPLORER_TRANSFER_TYPES.PUBLIC,
-    });
+    mockEnrichPrivateRecord.mockResolvedValue(null);
 
     const result = await listPrivateOperations({
       currency: mockCurrency,
@@ -70,7 +53,13 @@ describe("listPrivateOperations", () => {
       privateRecords: [record],
     });
 
-    expect(mockEnrichPrivateRecord).not.toHaveBeenCalled();
+    expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(1);
+    expect(mockEnrichPrivateRecord).toHaveBeenCalledWith({
+      currency: mockCurrency,
+      rawRecord: record,
+      viewKey: mockViewKey,
+      address: mockAddress,
+    });
     expect(result.operations).toEqual([]);
     expect(result.consumedRecordTags).toEqual(new Set());
   });
@@ -261,20 +250,20 @@ describe("listPrivateOperations", () => {
     expect(result.operations).toEqual(expect.arrayContaining(ops));
   });
 
-  it("should skip non-native records while still processing valid ones", async () => {
-    const invalidRecord = getMockedRecord({
-      transaction_id: "tx-invalid",
+  it("should call enrichPrivateRecord for all records and only produce operations for non-null results", async () => {
+    const record1 = getMockedRecord({
+      transaction_id: "tx-non-credits",
       program_name: "custom_token.aleo",
       function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
     });
-    const validRecord = getMockedRecord({
+    const record2 = getMockedRecord({
       transaction_id: "tx-valid",
       program_name: PROGRAM_ID.CREDITS,
       function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
     });
-    const mockEnriched = getMockedEnrichedPrivateRecord({ rawRecord: validRecord });
+    const mockEnriched = getMockedEnrichedPrivateRecord({ rawRecord: record2 });
 
-    mockEnrichPrivateRecord.mockResolvedValue(mockEnriched);
+    mockEnrichPrivateRecord.mockResolvedValueOnce(null).mockResolvedValueOnce(mockEnriched);
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
 
     const result = await listPrivateOperations({
@@ -282,12 +271,17 @@ describe("listPrivateOperations", () => {
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
-      privateRecords: [invalidRecord, validRecord],
+      privateRecords: [record1, record2],
     });
 
-    expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(1);
-    expect(mockEnrichPrivateRecord).toHaveBeenCalledWith(
-      expect.objectContaining({ rawRecord: validRecord }),
+    expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(2);
+    expect(mockEnrichPrivateRecord).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ rawRecord: record1 }),
+    );
+    expect(mockEnrichPrivateRecord).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ rawRecord: record2 }),
     );
     expect(result.operations).toEqual([mockOp]);
   });

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
@@ -6,21 +6,8 @@ import type {
   EnrichedPrivateRecord,
   AleoTransitionValue,
 } from "../types";
-import { EXPLORER_TRANSFER_TYPES, PROGRAM_ID } from "../constants";
 import { enrichPrivateRecord } from "../network/utils";
 import { toPrivateBridgeOperation } from "./utils";
-
-const NATIVE_PRIVATE_FUNCTIONS = new Set([
-  EXPLORER_TRANSFER_TYPES.PRIVATE,
-  EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE,
-  EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
-]);
-
-function onlyNativeCoinOperations(record: AleoPrivateRecord): boolean {
-  return (
-    record.program_name === PROGRAM_ID.CREDITS && NATIVE_PRIVATE_FUNCTIONS.has(record.function_name)
-  );
-}
 
 function onlyRecordValue(
   value: AleoTransitionValue,
@@ -45,8 +32,7 @@ export async function listPrivateOperations({
   consumedRecordTags: Set<string>;
 }> {
   const consumedRecordTags = new Set<string>();
-  const nativePrivateRecords = privateRecords.filter(onlyNativeCoinOperations);
-  const enrichedRecords = await promiseAllBatched(2, nativePrivateRecords, rawRecord =>
+  const enrichedRecords = await promiseAllBatched(2, privateRecords, rawRecord =>
     enrichPrivateRecord({ currency, rawRecord, address, viewKey }),
   );
 

--- a/libs/coin-modules/coin-aleo/src/network/api.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.test.ts
@@ -1,6 +1,7 @@
 import network from "@ledgerhq/live-network";
 import { getNetworkConfig } from "../logic/utils";
 import type { AleoLatestBlockResponse } from "../types/api";
+import { EXPLORER_TRANSFER_TYPES } from "../constants";
 import {
   testnetPrivateRecord,
   getMockedTransactionDetails,
@@ -810,6 +811,155 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
           data: { filter: { page: 0 }, uuid: mockUuid },
+        }),
+      );
+    });
+
+    it("should include `filter.programs` when programs is a non-empty array", async () => {
+      const programs = ["credits.aleo", "custom.aleo"];
+      jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
+
+      await apiClient.getAccountOwnedRecords({
+        currency: mockCurrency,
+        uuid: mockUuid,
+        programs,
+      });
+
+      expect(network).toHaveBeenCalledTimes(1);
+      expect(network).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { filter: { programs }, uuid: mockUuid },
+        }),
+      );
+    });
+
+    it("should omit `filter.programs` when programs is an empty array", async () => {
+      jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
+
+      await apiClient.getAccountOwnedRecords({
+        currency: mockCurrency,
+        uuid: mockUuid,
+        programs: [],
+      });
+
+      const callData = jest.mocked(network).mock.calls[0][0].data as Record<string, unknown>;
+      expect(callData).not.toHaveProperty("filter");
+    });
+
+    it("should omit `filter.programs` when programs is not provided", async () => {
+      jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
+
+      await apiClient.getAccountOwnedRecords({
+        currency: mockCurrency,
+        uuid: mockUuid,
+      });
+
+      const callData = jest.mocked(network).mock.calls[0][0].data as Record<string, unknown>;
+      expect(callData).not.toHaveProperty("filter");
+    });
+
+    it("should combine programs with other filter fields and unspent flag", async () => {
+      const programs = ["credits.aleo"];
+      const mockStart = 14192648;
+      jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
+
+      await apiClient.getAccountOwnedRecords({
+        currency: mockCurrency,
+        uuid: mockUuid,
+        unspent: true,
+        start: mockStart,
+        resultsPerPage: 100,
+        page: 1,
+        programs,
+      });
+
+      expect(network).toHaveBeenCalledTimes(1);
+      expect(network).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {
+            unspent: true,
+            filter: { start: mockStart, results_per_page: 100, page: 1, programs },
+            uuid: mockUuid,
+          },
+        }),
+      );
+    });
+
+    it("should include `filter.functions` when functions is a non-empty array", async () => {
+      const functions = [
+        EXPLORER_TRANSFER_TYPES.PRIVATE,
+        EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE,
+      ];
+      jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
+
+      await apiClient.getAccountOwnedRecords({
+        currency: mockCurrency,
+        uuid: mockUuid,
+        functions,
+      });
+
+      expect(network).toHaveBeenCalledTimes(1);
+      expect(network).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { filter: { functions }, uuid: mockUuid },
+        }),
+      );
+    });
+
+    it("should omit `filter.functions` when functions is an empty array", async () => {
+      jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
+
+      await apiClient.getAccountOwnedRecords({
+        currency: mockCurrency,
+        uuid: mockUuid,
+        functions: [],
+      });
+
+      const callData = jest.mocked(network).mock.calls[0][0].data as Record<string, unknown>;
+      expect(callData).not.toHaveProperty("filter");
+    });
+
+    it("should omit `filter.functions` when functions is not provided", async () => {
+      jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
+
+      await apiClient.getAccountOwnedRecords({
+        currency: mockCurrency,
+        uuid: mockUuid,
+      });
+
+      const callData = jest.mocked(network).mock.calls[0][0].data as Record<string, unknown>;
+      expect(callData).not.toHaveProperty("filter");
+    });
+
+    it("should combine functions with programs and other filter fields", async () => {
+      const programs = ["credits.aleo"];
+      const functions = [
+        EXPLORER_TRANSFER_TYPES.PRIVATE,
+        EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE,
+        EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
+      ];
+      const mockStart = 14192648;
+      jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
+
+      await apiClient.getAccountOwnedRecords({
+        currency: mockCurrency,
+        uuid: mockUuid,
+        unspent: true,
+        start: mockStart,
+        resultsPerPage: 100,
+        page: 1,
+        programs,
+        functions,
+      });
+
+      expect(network).toHaveBeenCalledTimes(1);
+      expect(network).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {
+            unspent: true,
+            filter: { start: mockStart, results_per_page: 100, page: 1, programs, functions },
+            uuid: mockUuid,
+          },
         }),
       );
     });

--- a/libs/coin-modules/coin-aleo/src/network/api.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.ts
@@ -147,6 +147,8 @@ async function getAccountOwnedRecords({
   start,
   resultsPerPage,
   page,
+  programs,
+  functions,
 }: {
   currency: CryptoCurrency;
   uuid: string;
@@ -154,6 +156,8 @@ async function getAccountOwnedRecords({
   start?: number;
   resultsPerPage?: number;
   page?: number;
+  programs?: string[];
+  functions?: string[];
 }): Promise<AleoPrivateRecord[]> {
   const { nodeUrl, networkType } = getNetworkConfig(currency);
 
@@ -161,6 +165,8 @@ async function getAccountOwnedRecords({
     ...(typeof start === "number" && { start }),
     ...(typeof resultsPerPage === "number" && { results_per_page: resultsPerPage }),
     ...(typeof page === "number" && { page }),
+    ...(programs && programs.length > 0 && { programs }),
+    ...(functions && functions.length > 0 && { functions }),
   };
 
   const res = await network<AleoPrivateRecord[]>({

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/errors";
 import { AleoApiConfigurationResetError } from "../errors";
-import { EXPLORER_TRANSFER_TYPES, DEFAULT_RECORDS_PAGE_SIZE } from "../constants";
+import { EXPLORER_TRANSFER_TYPES, DEFAULT_RECORDS_PAGE_SIZE, PROGRAM_ID } from "../constants";
 import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
 import { sdkClient } from "../network/sdk";
 import type { ProvableApi } from "../types";
@@ -1475,6 +1475,12 @@ describe("network/utils", () => {
         uuid: mockUUID,
         resultsPerPage: DEFAULT_RECORDS_PAGE_SIZE,
         page: 0,
+        programs: [PROGRAM_ID.CREDITS],
+        functions: [
+          EXPLORER_TRANSFER_TYPES.PRIVATE,
+          EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE,
+          EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
+        ],
       });
       expect(result).toEqual(records);
     });
@@ -1497,12 +1503,24 @@ describe("network/utils", () => {
         uuid: mockUUID,
         resultsPerPage: pageSize,
         page: 0,
+        programs: [PROGRAM_ID.CREDITS],
+        functions: [
+          EXPLORER_TRANSFER_TYPES.PRIVATE,
+          EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE,
+          EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
+        ],
       });
       expect(mockGetAccountOwnedRecords).toHaveBeenNthCalledWith(2, {
         currency: mockCurrency,
         uuid: mockUUID,
         resultsPerPage: pageSize,
         page: 1,
+        programs: [PROGRAM_ID.CREDITS],
+        functions: [
+          EXPLORER_TRANSFER_TYPES.PRIVATE,
+          EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE,
+          EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
+        ],
       });
       expect(result).toEqual([...page0, ...page1]);
     });
@@ -1598,6 +1616,57 @@ describe("network/utils", () => {
       expect(mockGetAccountOwnedRecords).toHaveBeenCalledTimes(3);
       expect(result).toHaveLength(5);
       expect(result).toEqual([...page0, ...page1, ...page2]);
+    });
+
+    it("should always pass programs: [PROGRAM_ID.CREDITS] to every page request", async () => {
+      const pageSize = 2;
+      const page0 = [getMockedRecord({ tag: "a" }), getMockedRecord({ tag: "b" })];
+      const page1 = [getMockedRecord({ tag: "c" })];
+      mockGetAccountOwnedRecords.mockResolvedValueOnce(page0).mockResolvedValueOnce(page1);
+
+      await fetchAllOwnedRecords({
+        currency: mockCurrency,
+        uuid: mockUUID,
+        resultsPerPage: pageSize,
+      });
+
+      expect(mockGetAccountOwnedRecords).toHaveBeenCalledTimes(2);
+      expect(mockGetAccountOwnedRecords).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ programs: [PROGRAM_ID.CREDITS] }),
+      );
+      expect(mockGetAccountOwnedRecords).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ programs: [PROGRAM_ID.CREDITS] }),
+      );
+    });
+
+    it("should always pass the correct functions filter to every page request", async () => {
+      const pageSize = 2;
+      const page0 = [getMockedRecord({ tag: "a" }), getMockedRecord({ tag: "b" })];
+      const page1 = [getMockedRecord({ tag: "c" })];
+      mockGetAccountOwnedRecords.mockResolvedValueOnce(page0).mockResolvedValueOnce(page1);
+
+      await fetchAllOwnedRecords({
+        currency: mockCurrency,
+        uuid: mockUUID,
+        resultsPerPage: pageSize,
+      });
+
+      const expectedFunctions = [
+        EXPLORER_TRANSFER_TYPES.PRIVATE,
+        EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE,
+        EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
+      ];
+      expect(mockGetAccountOwnedRecords).toHaveBeenCalledTimes(2);
+      expect(mockGetAccountOwnedRecords).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ functions: expectedFunctions }),
+      );
+      expect(mockGetAccountOwnedRecords).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ functions: expectedFunctions }),
+      );
     });
 
     it("should propagate errors thrown by the underlying API call", async () => {

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -152,6 +152,12 @@ export async function fetchAllOwnedRecords({
       ...(typeof start === "number" && { start }),
       resultsPerPage,
       page,
+      programs: [PROGRAM_ID.CREDITS],
+      functions: [
+        EXPLORER_TRANSFER_TYPES.PRIVATE,
+        EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE,
+        EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
+      ],
     });
 
     allRecords.push(...records);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - added proper filters for aleo owned records

### 📝 Description

Added program and functions filter to provable api owned record call. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [https://ledgerhq.atlassian.net/browse/LIVE-29174](https://ledgerhq.atlassian.net/browse/LIVE-29174)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
