### PR TITLE
[LWD] fix(desktop): close My Wallet popover after Referral action

### DIFF
--- a/.changeset/wise-bags-suffer.md
+++ b/.changeset/wise-bags-suffer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+clicking on Referral the avatar menu now closes

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/useActionsListViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ActionsList/useActionsListViewModel.ts
@@ -85,7 +85,8 @@ export function useActionsListViewModel(): ActionsListViewModel {
         entry: "my_wallet_actions_list",
       });
     }
-  }, [referralProgramConfig, navigate, location.pathname]);
+    close();
+  }, [referralProgramConfig, navigate, location.pathname, close]);
 
   const actions: Action[] = [
     ...(recoverFeature?.enabled


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing ActionsList tests cover navigation and analytics; menu `close()` not asserted._
- [x] **Impact of the changes:**
      - My Wallet (avatar) popover: Referral action
      - Referral page: click Referral again while already on the route

### 📝 Description

**Problem:** From the My Wallet menu, Help and Recover closed the popover after navigation, but Referral did not call the context `close()` handler. On the referral route, clicking Referral again did not navigate, so the popover stayed open.

**Solution:** Call `close()` after handling Referral, consistent with the other actions in `useActionsListViewModel`.




https://github.com/user-attachments/assets/98806e8d-c37d-4c3b-b7f0-ecfa5e041ddb


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29634](https://ledgerhq.atlassian.net/browse/LIVE-29634)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29634]: https://ledgerhq.atlassian.net/browse/LIVE-29634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ