### PR TITLE
[LWDM] fix: update providers name changelly_v2, cic_v2

### DIFF
--- a/libs/ledger-live-common/src/e2e/enum/Provider.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Provider.ts
@@ -11,10 +11,10 @@ export class Provider {
     public readonly app?: AppInfos,
   ) {}
   // Swap providers
-  static readonly CHANGELLY = new Provider("changelly", "Changelly", false, true, true);
+  static readonly CHANGELLY = new Provider("changelly_v2", "Changelly", false, true, true);
   static readonly EXODUS = new Provider("exodus", "Exodus", false, true, true);
   static readonly MOONPAY = new Provider("moonpay", "MoonPay", true, false, true);
-  static readonly CIC = new Provider("cic", "CIC", false, true, true);
+  static readonly CIC = new Provider("cic_v2", "CIC", false, true, true);
   static readonly NEAR_INTENTS = new Provider("nearintents", "NEAR Intents", false, true, true);
   static readonly SWAPSXYZ = new Provider("swapsxyz", "Swaps.xyz", false, true, true);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Updates swap provider identifiers used by @ledgerhq/live-common E2E utilities to reflect the newer provider names for Changelly and CIC.

Changes:

Update Changelly provider id from changelly → changelly_v2
Update CIC provider id from cic → cic_v2

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->
https://ledgerhq.atlassian.net/browse/LIVE-24416 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
