### PR TITLE
[LWDM] feat(evm-staking): persist evm native staking

### DIFF
--- a/.changeset/super-apples-soup.md
+++ b/.changeset/super-apples-soup.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/live-common": minor
+---
+
+Persist EVM native staking resources through the `fromAccountRaw`/`toAccountRaw` cycle

--- a/libs/coin-modules/coin-evm/src/staking/index.ts
+++ b/libs/coin-modules/coin-evm/src/staking/index.ts
@@ -26,3 +26,9 @@ export {
   getRedelegationCompletionDate,
   parseAmountStringToNumber,
 } from "./logic";
+export {
+  assignFromAccountRaw,
+  assignToAccountRaw,
+  fromStakingResourcesRaw,
+  toStakingResourcesRaw,
+} from "./serialization";

--- a/libs/coin-modules/coin-evm/src/staking/serialization.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/serialization.test.ts
@@ -1,0 +1,183 @@
+import { BigNumber } from "bignumber.js";
+import type { Account, AccountRaw } from "@ledgerhq/types-live";
+import type {
+  StakingAccount,
+  StakingAccountRaw,
+  StakingResources,
+  StakingValidatorItem,
+} from "../types/staking";
+import {
+  assignFromAccountRaw,
+  assignToAccountRaw,
+  fromStakingResourcesRaw,
+  toStakingResourcesRaw,
+} from "./serialization";
+
+const completionDate = new Date("2042-01-02T03:04:05.000Z");
+
+const sampleResources: StakingResources = {
+  delegations: [
+    {
+      validatorAddress: "seivaloper1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx01",
+      amount: new BigNumber("1000000000000000000"),
+      pendingRewards: new BigNumber("123456789"),
+      status: "bonded",
+    },
+    {
+      validatorAddress: "seivaloper1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx02",
+      amount: new BigNumber("2000000000000000000"),
+      pendingRewards: new BigNumber("0"),
+      status: "unbonding",
+    },
+  ],
+  redelegations: [
+    {
+      validatorSrcAddress: "seivaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      validatorDstAddress: "seivaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      amount: new BigNumber("500000000000000000"),
+      completionDate,
+    },
+  ],
+  unbondings: [
+    {
+      validatorAddress: "seivaloper1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx01",
+      amount: new BigNumber("250000000000000000"),
+      completionDate,
+    },
+  ],
+  delegatedBalance: new BigNumber("3000000000000000000"),
+  pendingRewardsBalance: new BigNumber("123456789"),
+  unbondingBalance: new BigNumber("250000000000000000"),
+};
+
+/** Flatten BigNumber/Date to primitives for deep equality checks via `toEqual`. */
+function toPlain(r: StakingResources) {
+  return {
+    delegations: r.delegations.map(d => ({
+      validatorAddress: d.validatorAddress,
+      amount: d.amount.toString(),
+      pendingRewards: d.pendingRewards.toString(),
+      status: d.status,
+    })),
+    redelegations: r.redelegations.map(re => ({
+      validatorSrcAddress: re.validatorSrcAddress,
+      validatorDstAddress: re.validatorDstAddress,
+      amount: re.amount.toString(),
+      completionDate: re.completionDate.toISOString(),
+    })),
+    unbondings: r.unbondings.map(u => ({
+      validatorAddress: u.validatorAddress,
+      amount: u.amount.toString(),
+      completionDate: u.completionDate.toISOString(),
+    })),
+    delegatedBalance: r.delegatedBalance.toString(),
+    pendingRewardsBalance: r.pendingRewardsBalance.toString(),
+    unbondingBalance: r.unbondingBalance.toString(),
+  };
+}
+
+describe("coin-evm/staking/serialization", () => {
+  describe("toStakingResourcesRaw / fromStakingResourcesRaw", () => {
+    it("roundtrips StakingResources through the Raw form without data loss", () => {
+      const back = fromStakingResourcesRaw(toStakingResourcesRaw(sampleResources));
+      expect(toPlain(back)).toEqual(toPlain(sampleResources));
+    });
+
+    it("produces BigNumber instances for balances and amounts on the way back", () => {
+      const back = fromStakingResourcesRaw(toStakingResourcesRaw(sampleResources));
+
+      expect([
+        back.delegatedBalance,
+        back.pendingRewardsBalance,
+        back.unbondingBalance,
+        back.delegations[0].amount,
+        back.delegations[0].pendingRewards,
+        back.redelegations[0].amount,
+        back.unbondings[0].amount,
+      ]).toEqual(Array(7).fill(expect.any(BigNumber)));
+    });
+
+    it("produces Date instances for completion dates on the way back", () => {
+      const back = fromStakingResourcesRaw(toStakingResourcesRaw(sampleResources));
+
+      expect([back.redelegations[0].completionDate, back.unbondings[0].completionDate]).toEqual(
+        Array(2).fill(expect.any(Date)),
+      );
+    });
+
+    it("only propagates `validators` when defined", () => {
+      expect(toStakingResourcesRaw(sampleResources)).not.toHaveProperty("validators");
+      expect(toStakingResourcesRaw({ ...sampleResources, validators: [] })).toHaveProperty(
+        "validators",
+        [],
+      );
+    });
+
+    it("roundtrips `validators` through the Raw form when defined", () => {
+      const validators: StakingValidatorItem[] = [
+        {
+          validatorAddress: "seivaloper1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx01",
+          name: "Validator One",
+          votingPower: 0.12,
+          commission: 0.05,
+          estimatedYearlyRewardsRate: 0.08,
+          tokens: 1234567,
+        },
+      ];
+      const back = fromStakingResourcesRaw(
+        toStakingResourcesRaw({ ...sampleResources, validators }),
+      );
+      expect(back.validators).toEqual(validators);
+    });
+  });
+
+  describe("assignToAccountRaw / assignFromAccountRaw", () => {
+    it("is a no-op when the account has no stakingResources", () => {
+      const account = {} as Account;
+      const accountRaw = {} as AccountRaw;
+
+      assignToAccountRaw(account, accountRaw);
+      expect((accountRaw as StakingAccountRaw).stakingResources).toBeUndefined();
+
+      assignFromAccountRaw(accountRaw, account);
+      expect((account as StakingAccount).stakingResources).toBeUndefined();
+    });
+
+    it("serializes stakingResources on the raw side and rehydrates them on the account side", () => {
+      const account = { stakingResources: sampleResources } as unknown as Account;
+      const accountRaw = {} as AccountRaw;
+      const expectedRaw = toStakingResourcesRaw(sampleResources);
+
+      assignToAccountRaw(account, accountRaw);
+      expect((accountRaw as StakingAccountRaw).stakingResources).toEqual(expectedRaw);
+
+      const rehydrated = {} as Account;
+      assignFromAccountRaw(accountRaw, rehydrated);
+      const expectedAccount = fromStakingResourcesRaw(expectedRaw);
+      expect((rehydrated as StakingAccount).stakingResources).toEqual(expectedAccount);
+    });
+
+    it("propagates `validators` through the assign hooks roundtrip", () => {
+      const validators: StakingValidatorItem[] = [
+        {
+          validatorAddress: "seivaloper1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx01",
+          name: "Validator One",
+          votingPower: 0.12,
+          commission: 0.05,
+          estimatedYearlyRewardsRate: 0.08,
+          tokens: 1234567,
+        },
+      ];
+      const account = {
+        stakingResources: { ...sampleResources, validators },
+      } as unknown as Account;
+      const accountRaw = {} as AccountRaw;
+
+      assignToAccountRaw(account, accountRaw);
+      const rehydrated = {} as Account;
+      assignFromAccountRaw(accountRaw, rehydrated);
+
+      expect((rehydrated as StakingAccount).stakingResources?.validators).toEqual(validators);
+    });
+  });
+});

--- a/libs/coin-modules/coin-evm/src/staking/serialization.ts
+++ b/libs/coin-modules/coin-evm/src/staking/serialization.ts
@@ -1,0 +1,124 @@
+import { BigNumber } from "bignumber.js";
+import type { Account, AccountRaw } from "@ledgerhq/types-live";
+import type {
+  StakingAccount,
+  StakingAccountRaw,
+  StakingDelegation,
+  StakingDelegationRaw,
+  StakingRedelegation,
+  StakingRedelegationRaw,
+  StakingResources,
+  StakingResourcesRaw,
+  StakingUnbonding,
+  StakingUnbondingRaw,
+} from "../types/staking";
+
+function toStakingDelegationRaw(d: StakingDelegation): StakingDelegationRaw {
+  return {
+    validatorAddress: d.validatorAddress,
+    amount: d.amount.toString(),
+    pendingRewards: d.pendingRewards.toString(),
+    status: d.status,
+  };
+}
+
+function fromStakingDelegationRaw(d: StakingDelegationRaw): StakingDelegation {
+  return {
+    validatorAddress: d.validatorAddress,
+    amount: new BigNumber(d.amount),
+    pendingRewards: new BigNumber(d.pendingRewards),
+    status: d.status,
+  };
+}
+
+function toStakingRedelegationRaw(r: StakingRedelegation): StakingRedelegationRaw {
+  return {
+    validatorSrcAddress: r.validatorSrcAddress,
+    validatorDstAddress: r.validatorDstAddress,
+    amount: r.amount.toString(),
+    completionDate: r.completionDate.toISOString(),
+  };
+}
+
+function fromStakingRedelegationRaw(r: StakingRedelegationRaw): StakingRedelegation {
+  return {
+    validatorSrcAddress: r.validatorSrcAddress,
+    validatorDstAddress: r.validatorDstAddress,
+    amount: new BigNumber(r.amount),
+    completionDate: new Date(r.completionDate),
+  };
+}
+
+function toStakingUnbondingRaw(u: StakingUnbonding): StakingUnbondingRaw {
+  return {
+    validatorAddress: u.validatorAddress,
+    amount: u.amount.toString(),
+    completionDate: u.completionDate.toISOString(),
+  };
+}
+
+function fromStakingUnbondingRaw(u: StakingUnbondingRaw): StakingUnbonding {
+  return {
+    validatorAddress: u.validatorAddress,
+    amount: new BigNumber(u.amount),
+    completionDate: new Date(u.completionDate),
+  };
+}
+
+/**
+ * Serialize only the `stakingResources` slice of an EVM account.
+ *
+ * Required `StakingResources` fields are serialized unconditionally. Optional
+ * fields are propagated conditionally (for example `validators`), while
+ * `fromStakingResourcesRaw` remains tolerant of missing keys from legacy raw
+ * payloads by applying defaults during deserialization.
+ */
+export function toStakingResourcesRaw(r: StakingResources): StakingResourcesRaw {
+  const raw: StakingResourcesRaw = {
+    delegations: r.delegations.map(toStakingDelegationRaw),
+    redelegations: r.redelegations.map(toStakingRedelegationRaw),
+    unbondings: r.unbondings.map(toStakingUnbondingRaw),
+    delegatedBalance: r.delegatedBalance.toString(),
+    pendingRewardsBalance: r.pendingRewardsBalance.toString(),
+    unbondingBalance: r.unbondingBalance.toString(),
+  };
+
+  if (r.validators !== undefined) {
+    raw.validators = r.validators;
+  }
+
+  return raw;
+}
+
+export function fromStakingResourcesRaw(r: StakingResourcesRaw): StakingResources {
+  const resources: StakingResources = {
+    delegations: (r.delegations ?? []).map(fromStakingDelegationRaw),
+    redelegations: (r.redelegations ?? []).map(fromStakingRedelegationRaw),
+    unbondings: (r.unbondings ?? []).map(fromStakingUnbondingRaw),
+    delegatedBalance: new BigNumber(r.delegatedBalance ?? "0"),
+    pendingRewardsBalance: new BigNumber(r.pendingRewardsBalance ?? "0"),
+    unbondingBalance: new BigNumber(r.unbondingBalance ?? "0"),
+  };
+
+  if (r.validators !== undefined) {
+    resources.validators = r.validators;
+  }
+
+  return resources;
+}
+
+export function assignToAccountRaw(account: Account, accountRaw: AccountRaw): void {
+  const stakingAccount = account as StakingAccount;
+  if (stakingAccount.stakingResources) {
+    (accountRaw as StakingAccountRaw).stakingResources = toStakingResourcesRaw(
+      stakingAccount.stakingResources,
+    );
+  }
+}
+
+export function assignFromAccountRaw(accountRaw: AccountRaw, account: Account): void {
+  const stakingResourcesRaw = (accountRaw as StakingAccountRaw).stakingResources;
+  if (stakingResourcesRaw) {
+    (account as StakingAccount).stakingResources = fromStakingResourcesRaw(stakingResourcesRaw);
+  }
+}

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/accountBridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/accountBridge.ts
@@ -17,6 +17,7 @@ import { genericSignOperation } from "./signOperation";
 import { genericSignRawOperation } from "./signRawOperation";
 import { postSync } from "./postSync";
 import { getValidateAddress } from "./validateAddress";
+import { getAccountRawAssignHooks } from "./accountRawAssign";
 import type { GenericTransaction, AlpacaSigner } from "./types";
 
 export function getAlpacaAccountBridge(
@@ -25,6 +26,7 @@ export function getAlpacaAccountBridge(
   customSigner?: AlpacaSigner,
 ): AccountBridge<GenericTransaction> {
   const signer = customSigner ?? getSigner(network);
+  const { assignFromAccountRaw, assignToAccountRaw } = getAccountRawAssignHooks(network);
   return {
     sync: makeSync({ getAccountShape: genericGetAccountShape(network, kind), postSync }),
     receive: makeAccountBridgeReceive(getAddressWrapper(signer.getAddress)),
@@ -36,7 +38,9 @@ export function getAlpacaAccountBridge(
     broadcast: genericBroadcast(network, kind),
     signOperation: genericSignOperation(network, kind)(signer.context),
     signRawOperation: genericSignRawOperation(network, kind)(signer.context),
-    getSerializedAddressParameters, // NOTE: check wether it should be exposed by coin-module's api instead?
+    assignFromAccountRaw,
+    assignToAccountRaw,
+    getSerializedAddressParameters, // NOTE: check whether it should be exposed by coin-module's api instead?
     validateAddress: getValidateAddress(network),
   } satisfies Partial<AccountBridge<GenericTransaction>>;
 }

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/accountRawAssign.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/accountRawAssign.ts
@@ -1,0 +1,24 @@
+import type { AccountBridge } from "@ledgerhq/types-live";
+import evmAccountRawAssign from "./families/evm/accountRawAssign";
+import type { GenericTransaction } from "./types";
+
+type AccountRawAssignHooks = {
+  assignFromAccountRaw?: AccountBridge<GenericTransaction>["assignFromAccountRaw"];
+  assignToAccountRaw?: AccountBridge<GenericTransaction>["assignToAccountRaw"];
+};
+
+/**
+ * Dispatch per-family hooks that persist family-specific account resources
+ * through the `fromAccountRaw` / `toAccountRaw` cycle.
+ *
+ * The default Alpaca pipeline only knows about generic account fields; each
+ * family can expose a local adapter here when it needs extra raw assignment.
+ */
+export function getAccountRawAssignHooks(network: string): AccountRawAssignHooks {
+  switch (network) {
+    case "evm":
+      return evmAccountRawAssign;
+    default:
+      return {};
+  }
+}

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/families/evm/accountRawAssign.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/families/evm/accountRawAssign.ts
@@ -1,0 +1,16 @@
+import { assignFromAccountRaw, assignToAccountRaw } from "@ledgerhq/coin-evm/staking/serialization";
+
+/**
+ * EVM-specific hooks that persist `stakingResources` through the
+ * `fromAccountRaw` / `toAccountRaw` cycle (the default alpaca pipeline
+ * does not serialize family-specific account resources).
+ *
+ * Kept in a dedicated adapter module — like `families/evm/signer.ts` and
+ * `families/evm/bridge.ts` — so that `generic-alpaca/accountBridge.ts`
+ * stays family-agnostic and does not need to reach into `@ledgerhq/coin-evm`
+ * directly.
+ */
+export default {
+  assignFromAccountRaw,
+  assignToAccountRaw,
+};


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

## 📝 Description

Persist EVM native staking resources through the `fromAccountRaw`/`toAccountRaw` cycle.

The generic Alpaca bridge only knows how to serialize common `Account` fields, so EVM-specific `stakingResources` were being lost on every roundtrip through storage. As a result, delegation info on SEI accounts only appeared after a full sync. This PR wires EVM-specific `assign{From || To}AccountRaw` hooks into the Alpaca bridge so staking data survives the cycle and shows up almost instantly when opening the account page.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **[JIRA or GitHub link](https://ledgerhq.atlassian.net/browse/LIVE-29708)** <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
