### PR TITLE
[LWD] feat: enable sorting by address in crypto addresses table

### DIFF
--- a/.changeset/plain-otters-order.md
+++ b/.changeset/plain-otters-order.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add sort-by-address to the crypto addresses table

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountAddressCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountAddressCell.tsx
@@ -8,11 +8,18 @@ type AccountAddressCellProps = {
   readonly lookupParentAccount: (id: string) => Account | undefined | null;
 };
 
+/** Fresh address used for display and table sorting (token rows use the parent account). */
+export function getCryptoTableRowFreshAddress(
+  account: AccountLike,
+  lookupParentAccount: (id: string) => Account | undefined | null,
+): string {
+  return account.type === "Account"
+    ? account.freshAddress
+    : lookupParentAccount(account.parentId)?.freshAddress ?? "";
+}
+
 export function AccountAddressCell({ account, lookupParentAccount }: AccountAddressCellProps) {
-  const address =
-    account.type === "Account"
-      ? account.freshAddress
-      : (lookupParentAccount(account.parentId)?.freshAddress ?? "");
+  const address = getCryptoTableRowFreshAddress(account, lookupParentAccount);
   const formatted = formatAddress(address, { prefixLength: 5, suffixLength: 5 });
   return <TableCellContent title={formatted} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/index.ts
@@ -1,5 +1,5 @@
 export { AccountNameCell } from "./AccountNameCell";
-export { AccountAddressCell } from "./AccountAddressCell";
+export { AccountAddressCell, getCryptoTableRowFreshAddress } from "./AccountAddressCell";
 export { AccountValueCell } from "./AccountValueCell";
 export { AccountRowActionCell } from "./AccountRowActionCell";
 export { AggregatedAccountNameCell } from "./AggregatedAccountNameCell";

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/__tests__/CryptoTable.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/__tests__/CryptoTable.test.tsx
@@ -1,9 +1,20 @@
 import React from "react";
+import BigNumber from "bignumber.js";
 import { within } from "@testing-library/react";
 import { render, screen } from "tests/testSetup";
 import { CryptoTable } from "../CryptoTable";
-import { ETH_ACCOUNT, ETH_ACCOUNT_WITH_USDC } from "LLD/features/__mocks__/accounts.mock";
+import { getCryptoTableRowFreshAddress } from "../Cell";
+import {
+  ETH_ACCOUNT,
+  ETH_ACCOUNT_2,
+  ETH_ACCOUNT_WITH_USDC,
+} from "LLD/features/__mocks__/accounts.mock";
 import { createWalletState } from "../../../testUtils/createWalletState";
+
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: jest.fn(),
+  setAnalyticsFeatureFlagMethod: jest.fn(),
+}));
 
 function expectColumnHeaders(): void {
   expect(screen.getByRole("columnheader", { name: "Name" })).toBeVisible();
@@ -11,12 +22,15 @@ function expectColumnHeaders(): void {
   expect(screen.getByRole("columnheader", { name: "Value" })).toBeVisible();
 }
 
-function tbodyRows(): HTMLElement[] {
-  const table = screen.getByRole("table");
-  const tbody = within(table)
-    .getAllByRole("rowgroup")
-    .find(el => el.tagName === "TBODY");
-  return tbody ? within(tbody).queryAllByRole("row", { hidden: true }) : [];
+/** Data rows only (exclude header row, which contains columnheaders). */
+function dataRowsInTable(): HTMLElement[] {
+  return screen
+    .getAllByRole("row")
+    .filter(row => within(row).queryAllByRole("columnheader").length === 0);
+}
+
+function elementPrecedesInDocumentOrder(a: Element, b: Element): boolean {
+  return Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
 }
 
 describe("CryptoTable", () => {
@@ -33,32 +47,52 @@ describe("CryptoTable", () => {
     );
 
     expectColumnHeaders();
-    expect(tbodyRows()).toHaveLength(0);
+    expect(dataRowsInTable()).toHaveLength(0);
   });
 
-  it("renders column headers, account name, ticker, and value cell per row", () => {
-    render(
+  it("sorts rows by address when the Address header sort control is activated", async () => {
+    const accountHighBalance = {
+      ...ETH_ACCOUNT,
+      freshAddress: "0xffffffffffffffffffffffffffffffffffffffff",
+      balance: new BigNumber("1000000"),
+    };
+    const accountLowBalance = {
+      ...ETH_ACCOUNT_2,
+      freshAddress: "0x0000000000000000000000000000000000000001",
+      balance: new BigNumber("1"),
+    };
+
+    const { user } = render(
       <CryptoTable
-        rows={[ETH_ACCOUNT]}
+        rows={[accountHighBalance, accountLowBalance]}
         lookupParentAccount={mockLookupParent}
         onRowClick={mockOnRowClick}
       />,
       {
-        initialState: createWalletState(new Map([[ETH_ACCOUNT.id, "Ethereum main"]])),
+        initialState: createWalletState(
+          new Map([
+            [accountHighBalance.id, "High balance row"],
+            [accountLowBalance.id, "Low balance row"],
+          ]),
+        ),
       },
     );
 
-    expectColumnHeaders();
-    expect(screen.getByText("Ethereum main")).toBeVisible();
-    expect(screen.getByText("ETH")).toBeVisible();
-    const table = screen.getByRole("table");
-    const tbody = within(table).getAllByRole("rowgroup").find(el => el.tagName === "TBODY");
-    expect(tbody).toBeDefined();
-    const dataCells = tbody ? within(tbody as HTMLElement).getAllByRole("cell") : [];
-    expect(dataCells).toHaveLength(4);
+    const highRow = screen.getByTestId("crypto-account-row-High-balance-row");
+    const lowRow = screen.getByTestId("crypto-account-row-Low-balance-row");
+
+    expect(elementPrecedesInDocumentOrder(highRow, lowRow)).toBe(true);
+
+    await user.click(
+      within(screen.getByRole("columnheader", { name: "Address" })).getByRole("button"),
+    );
+
+    expect(elementPrecedesInDocumentOrder(lowRow, highRow)).toBe(true);
   });
 
-  it("calls onRowClick with account when a data row is clicked", async () => {
+  it("renders one account row with expected cells and calls onRowClick when the name control is used", async () => {
+    const accountLabel = "Ethereum main";
+
     const { user } = render(
       <CryptoTable
         rows={[ETH_ACCOUNT]}
@@ -66,11 +100,22 @@ describe("CryptoTable", () => {
         onRowClick={mockOnRowClick}
       />,
       {
-        initialState: createWalletState(new Map([[ETH_ACCOUNT.id, "Row click account"]])),
+        initialState: createWalletState(new Map([[ETH_ACCOUNT.id, accountLabel]])),
       },
     );
 
-    await user.click(screen.getByRole("button", { name: /Row click account/ }));
+    expectColumnHeaders();
+    expect(screen.getByText(accountLabel)).toBeVisible();
+    expect(screen.getByText("ETH")).toBeVisible();
+    const table = screen.getByRole("table");
+    const tbodyElements = within(table)
+      .getAllByRole("rowgroup")
+      .filter((el): el is HTMLElement => el.tagName === "TBODY");
+    expect(tbodyElements).toHaveLength(1);
+    const dataCells = within(tbodyElements[0]).getAllByRole("cell");
+    expect(dataCells).toHaveLength(4);
+
+    await user.click(screen.getByRole("button", { name: new RegExp(accountLabel) }));
 
     expect(mockOnRowClick).toHaveBeenCalledTimes(1);
     expect(mockOnRowClick).toHaveBeenCalledWith(ETH_ACCOUNT, undefined);
@@ -106,5 +151,20 @@ describe("CryptoTable", () => {
     await user.click(screen.getByRole("button", { name: /USDT on Eth/ }));
     expect(mockOnRowClick).toHaveBeenCalledTimes(1);
     expect(mockOnRowClick).toHaveBeenCalledWith(tokenAccount, parentAccount);
+  });
+});
+
+describe("getCryptoTableRowFreshAddress", () => {
+  it("returns the account fresh address for Account rows", () => {
+    expect(getCryptoTableRowFreshAddress(ETH_ACCOUNT, jest.fn())).toBe(ETH_ACCOUNT.freshAddress);
+  });
+
+  it("returns the parent account fresh address for TokenAccount rows", () => {
+    const parent = ETH_ACCOUNT_WITH_USDC;
+    const token = parent.subAccounts![0];
+    const lookup = jest.fn((id: string) => (id === parent.id ? parent : undefined));
+
+    expect(getCryptoTableRowFreshAddress(token, lookup)).toBe(parent.freshAddress);
+    expect(lookup).toHaveBeenCalledWith(token.parentId);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/__tests__/CryptoTable.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/__tests__/CryptoTable.test.tsx
@@ -10,11 +10,10 @@ import {
   ETH_ACCOUNT_WITH_USDC,
 } from "LLD/features/__mocks__/accounts.mock";
 import { createWalletState } from "../../../testUtils/createWalletState";
-
-jest.mock("~/renderer/analytics/segment", () => ({
-  track: jest.fn(),
-  setAnalyticsFeatureFlagMethod: jest.fn(),
-}));
+import {
+  buildMainAccountByIdMap,
+  lookupParentAccountFromMap,
+} from "../../../utils/parentAccountLookup";
 
 function expectColumnHeaders(): void {
   expect(screen.getByRole("columnheader", { name: "Name" })).toBeVisible();
@@ -125,9 +124,8 @@ describe("CryptoTable", () => {
     const parentAccount = ETH_ACCOUNT_WITH_USDC;
     const tokenAccount = parentAccount.subAccounts![0];
 
-    mockLookupParent.mockImplementation((id: string) =>
-      id === parentAccount.id ? parentAccount : undefined,
-    );
+    const mainById = buildMainAccountByIdMap([parentAccount]);
+    mockLookupParent.mockImplementation(id => lookupParentAccountFromMap(mainById, id));
 
     const { user } = render(
       <CryptoTable
@@ -162,7 +160,8 @@ describe("getCryptoTableRowFreshAddress", () => {
   it("returns the parent account fresh address for TokenAccount rows", () => {
     const parent = ETH_ACCOUNT_WITH_USDC;
     const token = parent.subAccounts![0];
-    const lookup = jest.fn((id: string) => (id === parent.id ? parent : undefined));
+    const mainById = buildMainAccountByIdMap([parent]);
+    const lookup = jest.fn((id: string) => lookupParentAccountFromMap(mainById, id));
 
     expect(getCryptoTableRowFreshAddress(token, lookup)).toBe(parent.freshAddress);
     expect(lookup).toHaveBeenCalledWith(token.parentId);

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoAccountRows.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoAccountRows.ts
@@ -7,6 +7,10 @@ import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/wall
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { walletSelector } from "~/renderer/reducers/wallet";
 import { accountMatchesSearch } from "LLD/utils/accountMatchesSearch";
+import {
+  buildMainAccountByIdMap,
+  lookupParentAccountFromMap,
+} from "../../../utils/parentAccountLookup";
 
 export function useCryptoAccountRows(searchValue: string) {
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
@@ -23,15 +27,7 @@ export function useCryptoAccountRows(searchValue: string) {
   );
   const flattenedAccounts = useFlattenSortAccounts(flattenOptions);
 
-  const accountById = useMemo(() => {
-    const map = new Map<string, Account>();
-    for (const a of nestedAccounts) {
-      if (a.type === "Account") {
-        map.set(a.id, a);
-      }
-    }
-    return map;
-  }, [nestedAccounts]);
+  const accountById = useMemo(() => buildMainAccountByIdMap(nestedAccounts), [nestedAccounts]);
 
   const sortedMainAccounts = useMemo(() => {
     const mainAccounts = nestedAccounts.filter((a): a is Account => a.type === "Account");
@@ -61,9 +57,7 @@ export function useCryptoAccountRows(searchValue: string) {
   ]);
 
   const lookupParentAccount = useCallback(
-    (id: string): Account | undefined | null => {
-      return accountById.get(id) ?? null;
-    },
+    (id: string): Account | undefined | null => lookupParentAccountFromMap(accountById, id),
     [accountById],
   );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
@@ -22,6 +22,7 @@ import {
   AccountValueCell,
   AggregatedAccountNameCell,
   AggregatedAccountValueCell,
+  getCryptoTableRowFreshAddress,
 } from "../Cell";
 import { useSyncPhase } from "LLD/hooks/useSyncPhase";
 
@@ -89,7 +90,13 @@ export function useCryptoDataTable({
       },
       {
         id: "address",
-        enableSorting: false,
+        accessorFn: row => getCryptoTableRowFreshAddress(row, lookupParentAccount),
+        sortingFn: (rowA, rowB) =>
+          getCryptoTableRowFreshAddress(rowA.original, lookupParentAccount).localeCompare(
+            getCryptoTableRowFreshAddress(rowB.original, lookupParentAccount),
+            undefined,
+            { sensitivity: "base" },
+          ),
         header: t("cryptoAddresses.table.columns.address"),
         cell: ({ row }) => (
           <AccountAddressCell account={row.original} lookupParentAccount={lookupParentAccount} />

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/__tests__/parentAccountLookup.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/__tests__/parentAccountLookup.test.ts
@@ -1,0 +1,25 @@
+import { ETH_ACCOUNT_WITH_USDC } from "LLD/features/__mocks__/accounts.mock";
+import { buildMainAccountByIdMap, lookupParentAccountFromMap } from "../parentAccountLookup";
+
+describe("parentAccountLookup", () => {
+  describe("buildMainAccountByIdMap", () => {
+    it("indexes only main accounts by id", () => {
+      const parent = ETH_ACCOUNT_WITH_USDC;
+      const token = parent.subAccounts![0];
+      const map = buildMainAccountByIdMap([parent, token]);
+
+      expect(map.get(parent.id)).toBe(parent);
+      expect(map.has(token.id)).toBe(false);
+    });
+  });
+
+  describe("lookupParentAccountFromMap", () => {
+    it("returns the account for a known id and null otherwise", () => {
+      const parent = ETH_ACCOUNT_WITH_USDC;
+      const map = buildMainAccountByIdMap([parent]);
+
+      expect(lookupParentAccountFromMap(map, parent.id)).toBe(parent);
+      expect(lookupParentAccountFromMap(map, "unknown")).toBeNull();
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/parentAccountLookup.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/parentAccountLookup.ts
@@ -1,0 +1,21 @@
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+
+/** Main (chain) accounts indexed by id — used for token parent resolution and search. */
+export function buildMainAccountByIdMap(
+  accounts: readonly AccountLike[],
+): Map<string, Account> {
+  const map = new Map<string, Account>();
+  for (const a of accounts) {
+    if (a.type === "Account") {
+      map.set(a.id, a);
+    }
+  }
+  return map;
+}
+
+export function lookupParentAccountFromMap(
+  mainAccountById: ReadonlyMap<string, Account>,
+  id: string,
+): Account | null {
+  return mainAccountById.get(id) ?? null;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request adds the ability to sort the crypto addresses table by address in Ledger Live Desktop and refactors related code to support this feature. It introduces a utility function to consistently extract the correct address for both accounts and token accounts, updates the table column definition to enable sorting, and adds comprehensive tests to verify sorting and address extraction logic.


https://github.com/user-attachments/assets/621db0a4-a0bf-4c2f-a1fc-caec27fff848


### ❓ Context

[LIVE-29638](https://ledgerhq.atlassian.net/browse/LIVE-29638)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29638]: https://ledgerhq.atlassian.net/browse/LIVE-29638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ