### PR TITLE
[LWDM] refactor(live-common): useBridgeTransaction async ready

### DIFF
--- a/.changeset/async-useaccountbridge.md
+++ b/.changeset/async-useaccountbridge.md
@@ -2,4 +2,4 @@
 "@ledgerhq/live-common": minor
 ---
 
-Add `useAccountBridge` hook as a suspend-compatible replacement for `getAccountBridge` in components                                         
+Add `useAccountBridge` hook as a suspend-compatible replacement for `getAccountBridge` in components

--- a/.changeset/live-29193-suspense-ready-bridge-hooks.md
+++ b/.changeset/live-29193-suspense-ready-bridge-hooks.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Refactor `useBridgeTransaction` to accept `bridge` as an explicit first argument
+and initialise state synchronously via `useReducer`'s lazy initialiser, removing
+the previous `use(Promise)` suspension path entirely.
+
+All call sites in desktop and mobile updated to obtain the bridge via
+`useAccountBridge` / `useAccountBridgeOrNull` and pass it as the first argument
+to `useBridgeTransaction` (LIVE-29193).

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendFlowTransaction.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendFlowTransaction.test.ts
@@ -2,12 +2,17 @@ import { renderHook, act } from "tests/testSetup";
 import { useSendFlowTransaction } from "../useSendFlowTransaction";
 import * as bridgeModule from "@ledgerhq/live-common/bridge/index";
 import * as useBridgeTransactionModule from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import * as useAccountBridgeModule from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import BigNumber from "bignumber.js";
 
 jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction");
 jest.mock("@ledgerhq/live-common/bridge/index");
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: jest.fn(),
+  useAccountBridgeOrNull: jest.fn(),
+}));
 
 describe("useSendFlowTransaction", () => {
   const mockAccount = {
@@ -26,8 +31,14 @@ describe("useSendFlowTransaction", () => {
   const mockSetAccount = jest.fn();
   const mockUpdateTransaction = jest.fn((tx, updates) => ({ ...tx, ...updates }));
 
+  const mockBridge = { updateTransaction: jest.fn() };
+
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockBridge.updateTransaction = mockUpdateTransaction;
+
+    (useAccountBridgeModule.useAccountBridgeOrNull as jest.Mock).mockReturnValue(mockBridge);
 
     (useBridgeTransactionModule.default as jest.Mock).mockReturnValue({
       transaction: mockTransaction,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
@@ -33,7 +33,7 @@ export function useSendFlowTransaction({
     bridgeError,
     bridgePending,
     setAccount,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     if (!account) return {};
     return { account, parentAccount: parentAccount ?? undefined };
   });

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/Body.tsx
@@ -9,8 +9,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -24,7 +24,7 @@ import StepAsset, { StepAssetFooter } from "./steps/StepAsset";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { AlgorandAccount } from "@ledgerhq/live-common/families/algorand/types";
+import { AlgorandAccount, Transaction as AlgorandTransaction } from "@ledgerhq/live-common/families/algorand/types";
 
 export type Data = {
   account: AlgorandAccount;
@@ -76,6 +76,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<AlgorandTransaction>(params.account);
   const {
     transaction,
     setTransaction,
@@ -84,10 +85,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account } = params;
     invariant(account, "algorand: account required");
-    const bridge = getAccountBridge(account);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "optIn",

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.tsx
@@ -9,8 +9,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -24,7 +24,7 @@ import StepInfo, { StepInfoFooter } from "./steps/StepInfo";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { AlgorandAccount } from "@ledgerhq/live-common/families/algorand/types";
+import { AlgorandAccount, Transaction as AlgorandTransaction } from "@ledgerhq/live-common/families/algorand/types";
 
 export type Data = {
   account: AlgorandAccount | TokenAccount;
@@ -75,6 +75,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<AlgorandTransaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -84,10 +85,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account } = params;
     invariant(account, "algorand: account required");
-    const bridge = getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "claimReward",

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/Body.tsx
@@ -8,10 +8,10 @@ import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { St, StepId } from "./types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import logger from "~/renderer/logger";
@@ -21,7 +21,7 @@ import Track from "~/renderer/analytics/Track";
 import Stepper from "~/renderer/components/Stepper";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { useSteps } from "./steps";
-import { AptosAccount } from "@ledgerhq/live-common/families/aptos/types";
+import { AptosAccount, Transaction as AptosTransaction } from "@ledgerhq/live-common/families/aptos/types";
 import { Account, Operation } from "@ledgerhq/types-live";
 
 export type Data = {
@@ -69,6 +69,7 @@ function Body({
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
 
+  const bridge = useAccountBridge<AptosTransaction>(accountProp, undefined);
   const {
     account,
     transaction,
@@ -77,10 +78,9 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     invariant(accountProp.aptosResources, "aptos: account and aptos resources required");
 
-    const bridge = getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const mode = "restake";
     const recipient = validatorAddress;

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/Body.tsx
@@ -8,8 +8,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -23,7 +23,7 @@ import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepCo
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
 import { AptosAccount, Transaction } from "@ledgerhq/live-common/families/aptos/types";
-import { Account, AccountBridge, Operation } from "@ledgerhq/types-live";
+import { Account, Operation } from "@ledgerhq/types-live";
 
 export type Data = {
   account: AptosAccount;
@@ -90,9 +90,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { account, source = "Account Page" } = params;
+  const bridge = useAccountBridge<Transaction>(account);
   const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
-      const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+    useBridgeTransaction(bridge, () => {
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "stake",

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/Body.tsx
@@ -8,10 +8,10 @@ import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { St, StepId } from "./types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import logger from "~/renderer/logger";
@@ -21,7 +21,7 @@ import Track from "~/renderer/analytics/Track";
 import Stepper from "~/renderer/components/Stepper";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { useSteps } from "./steps";
-import { AptosAccount } from "@ledgerhq/live-common/families/aptos/types";
+import { AptosAccount, Transaction as AptosTransaction } from "@ledgerhq/live-common/families/aptos/types";
 import { Account, Operation } from "@ledgerhq/types-live";
 
 export type Data = {
@@ -69,6 +69,7 @@ function Body({
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
 
+  const bridge = useAccountBridge<AptosTransaction>(accountProp, undefined);
   const {
     account,
     transaction,
@@ -77,10 +78,9 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     invariant(accountProp.aptosResources, "aptos: account and aptos resources required");
 
-    const bridge = getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const mode = "unstake";
     const recipient = validatorAddress;

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/Body.tsx
@@ -8,10 +8,10 @@ import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { St, StepId } from "./types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import logger from "~/renderer/logger";
@@ -21,7 +21,7 @@ import Track from "~/renderer/analytics/Track";
 import Stepper from "~/renderer/components/Stepper";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { useSteps } from "./steps";
-import { AptosAccount } from "@ledgerhq/live-common/families/aptos/types";
+import { AptosAccount, Transaction as AptosTransaction } from "@ledgerhq/live-common/families/aptos/types";
 import { Account, Operation } from "@ledgerhq/types-live";
 
 export type Data = {
@@ -69,6 +69,7 @@ function Body({
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
 
+  const bridge = useAccountBridge<AptosTransaction>(accountProp, undefined);
   const {
     account,
     transaction,
@@ -77,10 +78,9 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     invariant(accountProp.aptosResources, "aptos: account and aptos resources required");
 
-    const bridge = getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const mode = "withdraw";
     const recipient = validatorAddress;

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/Body.tsx
@@ -18,6 +18,7 @@ import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { isOldestBitcoinPendingOperation } from "@ledgerhq/live-common/operation";
 import { getEnv } from "@ledgerhq/live-env";
@@ -151,6 +152,7 @@ const Body = ({
 
   const transactionToUpdate = fromTransactionRaw(params.transactionRaw);
 
+  const bridge = useAccountBridge(params?.account || accounts[0], params?.parentAccount);
   const {
     transaction,
     setTransaction,
@@ -160,7 +162,7 @@ const Body = ({
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction<Transaction>(() => {
+  } = useBridgeTransaction<Transaction>(bridge, () => {
     const parentAccount = params?.parentAccount;
     const account = params?.account || accounts[0];
     return {

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/Body.tsx
@@ -8,8 +8,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, St, StepId } from "./types";
 import { Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -23,7 +23,7 @@ import StepDelegation, { StepDelegationFooter } from "./steps/StepDelegation";
 import StepSummary, { StepSummaryFooter } from "./steps/StepSummary";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
-import { CardanoAccount } from "@ledgerhq/live-common/families/cardano/types";
+import { CardanoAccount, Transaction as CardanoTransaction } from "@ledgerhq/live-common/families/cardano/types";
 import { TFunction } from "i18next";
 import { StakePool } from "@ledgerhq/live-common/families/cardano/staking";
 
@@ -100,6 +100,7 @@ const Body = ({
   const [signed, setSigned] = useState(false);
   const [selectedPool, setSelectedPool] = useState<StakePool | null>(null);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<CardanoTransaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -108,13 +109,12 @@ const Body = ({
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account } = params;
     invariant(
       account && account.cardanoResources,
       "cardano: account and cardano resources required",
     );
-    const bridge = getAccountBridge(account, undefined);
     let transaction = bridge.createTransaction(account);
     transaction = bridge.updateTransaction(transaction, { mode: "delegate" });
 

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/Body.tsx
@@ -8,8 +8,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, St, StepId } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -21,7 +21,7 @@ import Stepper from "~/renderer/components/Stepper";
 import StepSummary, { StepSummaryFooter } from "./steps/StepSummary";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
-import { CardanoAccount } from "@ledgerhq/live-common/families/cardano/types";
+import { CardanoAccount, Transaction as CardanoTransaction } from "@ledgerhq/live-common/families/cardano/types";
 import { TFunction } from "i18next";
 import { Device } from "@ledgerhq/types-devices";
 
@@ -86,6 +86,7 @@ const Body = ({
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<CardanoTransaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -94,13 +95,12 @@ const Body = ({
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account } = params;
     invariant(
       account && account.cardanoResources,
       "cardano: account and cardano resources required",
     );
-    const bridge = getAccountBridge(account, undefined);
     const transaction = bridge.createTransaction(account);
     const updatedTransaction = bridge.updateTransaction(transaction, {
       mode: "undelegate",

--- a/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/Body.tsx
@@ -7,9 +7,9 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import Track from "~/renderer/analytics/Track";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
@@ -20,7 +20,7 @@ import StepVote, { StepVoteFooter } from "./steps/StepVote";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { CeloAccount, CeloVote } from "@ledgerhq/live-common/families/celo/types";
+import { CeloAccount, CeloVote, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { StepId, StepProps, St } from "./types";
@@ -77,9 +77,10 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { account, parentAccount, vote, source } = params;
+  const bridge = useAccountBridge<CeloTransaction>(account, parentAccount);
   const { transaction, setTransaction, status, bridgeError, bridgePending } = useBridgeTransaction(
+    bridge,
     () => {
-      const bridge = getAccountBridge(account, parentAccount);
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "activate",

--- a/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/Body.tsx
@@ -7,8 +7,8 @@ import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
@@ -22,7 +22,7 @@ import logger from "~/renderer/logger";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
+import { CeloAccount, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 
 export type Data = {
   account: CeloAccount | TokenAccount;
@@ -75,9 +75,10 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { account, parentAccount, source } = params;
+  const bridge = useAccountBridge<CeloTransaction>(account, parentAccount);
   const { transaction, setTransaction, status, bridgeError, bridgePending } = useBridgeTransaction(
+    bridge,
     () => {
-      const bridge = getAccountBridge(account, parentAccount);
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "lock",

--- a/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/Body.tsx
@@ -1,8 +1,8 @@
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { Trans, withTranslation } from "react-i18next";
@@ -23,7 +23,7 @@ import StepAmount, { StepAmountFooter } from "./steps/StepAmount";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import StepVote, { StepVoteFooter } from "./steps/StepVote";
 import { CeloAccount, CeloVote, Transaction } from "@ledgerhq/live-common/families/celo/types";
-import { AccountBridge, Operation, Account, TokenAccount } from "@ledgerhq/types-live";
+import { Operation, Account, TokenAccount } from "@ledgerhq/types-live";
 import { St, StepProps, StepId } from "./types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 
@@ -85,6 +85,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<Transaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -94,13 +95,12 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account, vote } = params;
     invariant(
       account?.type === "Account" && account.celoResources,
       "celo: account and celo resources required",
     );
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, undefined);
     const transaction = bridge.updateTransaction(bridge.createTransaction(account), {
       mode: "revoke",
       recipient: vote?.validatorGroup,

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SimpleOperationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SimpleOperationFlowModal/Body.tsx
@@ -9,8 +9,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
@@ -24,7 +24,7 @@ import logger from "~/renderer/logger";
 import { StepId, StepProps, St, Mode } from "./types";
 import { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { CeloAccount, TransactionStatus } from "@ledgerhq/live-common/families/celo/types";
+import { CeloAccount, Transaction as CeloTransaction, TransactionStatus } from "@ledgerhq/live-common/families/celo/types";
 
 export type Data = {
   account: CeloAccount | TokenAccount;
@@ -84,6 +84,7 @@ const Body = ({ t, stepId, device, openModal, onClose, onChangeStepId, params, m
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<CeloTransaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -93,10 +94,9 @@ const Body = ({ t, stepId, device, openModal, onClose, onChangeStepId, params, m
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account } = params;
     invariant(account, "celo: account required");
-    const bridge = getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode,

--- a/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/Body.tsx
@@ -7,8 +7,8 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
@@ -22,7 +22,7 @@ import logger from "~/renderer/logger";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
+import { CeloAccount, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 
 export type Data = {
   account: CeloAccount | TokenAccount;
@@ -73,6 +73,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<CeloTransaction>(params.account, params.parentAccount);
   const {
     transaction,
     setTransaction,
@@ -81,9 +82,8 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account, parentAccount } = params;
-    const bridge = getAccountBridge(account, parentAccount);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "unlock",

--- a/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/Body.tsx
@@ -1,8 +1,8 @@
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import React, { useCallback, useEffect, useState } from "react";
 import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
@@ -24,7 +24,7 @@ import StepValidatorGroup, { StepValidatorGroupFooter } from "./steps/StepValida
 import { defaultValidatorGroupAddress } from "@ledgerhq/live-common/families/celo/logic";
 import { useValidatorGroups } from "@ledgerhq/live-common/families/celo/react";
 import { CeloAccount, Transaction } from "@ledgerhq/live-common/families/celo/types";
-import { AccountBridge, Operation, Account, TokenAccount } from "@ledgerhq/types-live";
+import { Operation, Account, TokenAccount } from "@ledgerhq/types-live";
 import { St, StepProps, StepId } from "./types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 
@@ -87,6 +87,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { account, source } = params;
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const validatorGroups = useValidatorGroups();
   const {
     transaction,
@@ -96,8 +97,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, undefined);
+  } = useBridgeTransaction(bridge, () => {
     const transaction = bridge.updateTransaction(bridge.createTransaction(account), {
       mode: "vote",
       recipient: validatorGroups[0]?.address ?? defaultValidatorGroupAddress(),
@@ -114,12 +114,11 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   useEffect(() => {
     if (!transaction || !validatorGroups.length) return;
     if (!validatorGroups.find(vg => vg.address === transaction.recipient)) {
-      const bridge = getAccountBridge(account, undefined);
       setTransaction(
         bridge.updateTransaction(transaction, { recipient: validatorGroups[0].address }),
       );
     }
-  }, [validatorGroups, transaction, account, setTransaction]);
+  }, [validatorGroups, transaction, account, setTransaction, bridge]);
 
   const handleStepChange = useCallback((e: St) => onChangeStepId(e.id), [onChangeStepId]);
   const handleRetry = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/Body.tsx
@@ -7,9 +7,9 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import Track from "~/renderer/analytics/Track";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
@@ -23,7 +23,7 @@ import logger from "~/renderer/logger";
 import { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { StepId, StepProps, St } from "./types";
-import { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
+import { CeloAccount, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 
 export type Data = {
   account: CeloAccount | TokenAccount;
@@ -74,6 +74,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<CeloTransaction>(params.account, params.parentAccount);
   const {
     transaction,
     setTransaction,
@@ -82,9 +83,8 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account, parentAccount } = params;
-    const bridge = getAccountBridge(account, parentAccount);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "withdraw",

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.tsx
@@ -9,8 +9,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -24,7 +24,7 @@ import StepClaimRewards, { StepClaimRewardsFooter } from "./steps/StepClaimRewar
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import type { CosmosAccount } from "@ledgerhq/coin-cosmos/types/index";
+import type { CosmosAccount, Transaction as CosmosTransaction } from "@ledgerhq/coin-cosmos/types/index";
 
 export type Data = {
   account: CosmosAccount;
@@ -75,6 +75,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<CosmosTransaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -84,7 +85,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account, validatorAddress } = params;
     invariant(account && account.cosmosResources, "cosmos: account and cosmos resources required");
 
@@ -98,7 +99,6 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
         address: validatorAddress,
         amount: pendingRewards,
       }));
-    const bridge = getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "claimReward",

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Body.tsx
@@ -9,8 +9,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -27,7 +27,7 @@ import StepDelegation, { StepDelegationFooter } from "./steps/StepDelegation";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { CosmosAccount } from "@ledgerhq/live-common/families/cosmos/types";
+import { CosmosAccount, Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
 
 export type Data = {
   account: CosmosAccount;
@@ -88,6 +88,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { account, source = "Account Page" } = params;
+  const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
   const {
     transaction,
     setTransaction,
@@ -96,15 +97,14 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     invariant(account && account.cosmosResources, "cosmos: account and cosmos resources required");
-    const bridge = getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "delegate",
       validators: [
         {
-          address: cryptoFactory(account.currency.id).ledgerValidator,
+          address: cryptoFactory(account.currency.id).ledgerValidator ?? "",
           amount: BigNumber(0),
         },
       ],

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/Body.tsx
@@ -10,8 +10,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -26,7 +26,7 @@ import StepDestinationValidators from "./steps/StepDestinationValidators";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { CosmosAccount } from "@ledgerhq/live-common/families/cosmos/types";
+import { CosmosAccount, Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
 export type Data = {
   account: CosmosAccount;
   validatorAddress: string | undefined | null;
@@ -95,6 +95,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { account, validatorAddress, validatorDstAddress = "", source = "Account Page" } = params;
+  const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
   const {
     transaction,
     setTransaction,
@@ -103,18 +104,17 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     invariant(account && account.cosmosResources, "cosmos: account and cosmos resources required");
     const source = account.cosmosResources?.delegations.find(
       d => d.validatorAddress === validatorAddress,
     );
-    const bridge = getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "redelegate",
       validators: [
         {
-          address: validatorDstAddress,
+          address: validatorDstAddress ?? "",
           amount: source?.amount ?? BigNumber(0),
         },
       ],

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/Body.tsx
@@ -8,9 +8,9 @@ import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { StepId, St } from "./types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -22,7 +22,7 @@ import Track from "~/renderer/analytics/Track";
 import Stepper from "~/renderer/components/Stepper";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { useSteps } from "./steps";
-import { CosmosAccount } from "@ledgerhq/live-common/families/cosmos/types";
+import { CosmosAccount, Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
 
 export type Data = {
   account: CosmosAccount;
@@ -62,6 +62,7 @@ function Body({
   const [optimisticOperation, setOptimisticOperation] = useState<Operation | null>(null);
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
+  const bridge = useAccountBridge<CosmosTransaction>(accountProp, undefined);
   const {
     account,
     transaction,
@@ -70,13 +71,12 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     invariant(accountProp.cosmosResources, "cosmos: account and cosmos resources required");
     const delegations = accountProp.cosmosResources.delegations || [];
-    const bridge = getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const newTx = {
-      mode: "undelegate",
+      mode: "undelegate" as const,
       validators: delegations
         .filter(d => d.validatorAddress === validatorAddress)
         .slice(0, 1)

--- a/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/Body.tsx
@@ -9,8 +9,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -26,6 +26,7 @@ import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmati
 import logger from "~/renderer/logger";
 import type { StakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
 import { isStakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
+import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
 
 export type Data = {
   account: StakingAccount;
@@ -90,6 +91,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
   const dispatch = useDispatch();
   const { account, source = "Account Page" } = params;
 
+  const bridge = useAccountBridge<EvmTransaction>(account, undefined);
   const {
     transaction,
     setTransaction,
@@ -98,9 +100,8 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     invariant(isStakingAccount(account), "evm: account with staking resources required");
-    const bridge = getAccountBridge(account, undefined);
     const baseTransaction = bridge.createTransaction(account);
     // NB: `mode` is intentionally not set here. It is set later together with `valAddress`
     // (see StepDelegation → updateValidator) once the user has picked a validator.

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/Body.tsx
@@ -11,6 +11,7 @@ import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { isOldestPendingOperation } from "@ledgerhq/live-common/operation";
 import { getEnv } from "@ledgerhq/live-env";
@@ -130,6 +131,7 @@ const Body = ({
 
   const transactionToUpdate = fromTransactionRaw(params.transactionRaw);
 
+  const bridge = useAccountBridge(params?.account || accounts[0], params?.parentAccount);
   const {
     transaction,
     setTransaction,
@@ -139,7 +141,7 @@ const Body = ({
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction<Transaction>(() => {
+  } = useBridgeTransaction<Transaction>(bridge, () => {
     const parentAccount = params?.parentAccount;
     const account = params?.account || accounts[0];
     return {

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
@@ -9,8 +9,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -25,6 +25,7 @@ import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmati
 import logger from "~/renderer/logger";
 import type { StakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
 import { isStakingAccount } from "@ledgerhq/live-common/families/evm/staking/types";
+import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
 
 export type Data = {
   account: StakingAccount;
@@ -81,6 +82,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { account, validatorAddress, source = "Account Page" } = params;
+  const bridge = useAccountBridge<EvmTransaction>(account, undefined);
 
   const {
     transaction,
@@ -90,14 +92,13 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     invariant(isStakingAccount(account), "evm: account with staking resources required");
     // Pre-populate the transaction with the existing delegation amount so the user starts
     // on a valid "undelegate all" intent. The amount field lets them reduce it afterwards.
     const delegation = account.stakingResources.delegations.find(
       d => d.validatorAddress === validatorAddress,
     );
-    const bridge = getAccountBridge(account, undefined);
     const baseTransaction = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(baseTransaction, {
       mode: "undelegate",
@@ -105,7 +106,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
       recipient: account.freshAddress,
       amount: delegation?.amount,
       useAllAmount: false,
-    });
+    } as unknown as Partial<EvmTransaction>);
     return {
       account,
       parentAccount: undefined,

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/Body.tsx
@@ -7,12 +7,12 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account, Operation } from "@ledgerhq/types-live";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import type { HederaAccount } from "@ledgerhq/live-common/families/hedera/types";
+import type { HederaAccount, Transaction as HederaTransaction } from "@ledgerhq/live-common/families/hedera/types";
 import type { Device } from "@ledgerhq/types-devices";
 import Track from "~/renderer/analytics/Track";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
@@ -84,9 +84,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<HederaTransaction>(account);
   const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
-      const bridge = getAccountBridge(account);
+    useBridgeTransaction(bridge, () => {
       const t = bridge.createTransaction(account);
 
       const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
@@ -6,14 +6,14 @@ import { Trans, withTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import type { Account, AccountBridge, Operation } from "@ledgerhq/types-live";
+import type { Account, Operation } from "@ledgerhq/types-live";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { HederaAccount, Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { getDefaultValidator } from "@ledgerhq/live-common/families/hedera/utils";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import Track from "~/renderer/analytics/Track";
@@ -94,9 +94,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const validators = useHederaValidators(account.currency);
+  const bridge = useAccountBridge<Transaction>(account);
   const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
-      const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+    useBridgeTransaction(bridge, () => {
       const t = bridge.createTransaction(account);
       const defaultValidator = getDefaultValidator(validators);
 

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
@@ -7,7 +7,7 @@ import { createStructuredSelector } from "reselect";
 import invariant from "invariant";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { isTokenAssociationRequired } from "@ledgerhq/live-common/families/hedera/utils";
@@ -146,6 +146,7 @@ const Body = ({
   const currencyName = currency ? currency.name : undefined;
   const mainAccount = getMainAccount(account, parentAccount);
 
+  const bridgeInstance = useAccountBridge<Transaction>(account, parentAccount);
   const {
     transaction,
     status,
@@ -153,11 +154,10 @@ const Body = ({
     bridgePending,
     updateTransaction,
     setAccount: updateTransactionAccount,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridgeInstance, () => {
     invariant(account, "hedera: account is required");
 
-    const bridge = getAccountBridge(account, parentAccount);
-    const transaction = bridge.createTransaction(account);
+    const transaction = bridgeInstance.createTransaction(account);
 
     return {
       account,
@@ -190,7 +190,7 @@ const Body = ({
       setParentAccount(parentAccount);
 
       updateTransactionAccount(account, parentAccount);
-      updateTransaction(prev => ({ ...prev, ...getTransactionProperties(token) }));
+      updateTransaction(prev => ({ ...prev, ...getTransactionProperties(token) }) as Transaction);
     },
     [
       token,
@@ -206,7 +206,7 @@ const Body = ({
     (token?: TokenCurrency | null) => {
       setToken(token ?? null);
 
-      updateTransaction(prev => ({ ...prev, ...getTransactionProperties(token) }));
+      updateTransaction(prev => ({ ...prev, ...getTransactionProperties(token) }) as Transaction);
     },
     [getTransactionProperties, updateTransaction],
   );

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
@@ -7,12 +7,12 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account, Operation } from "@ledgerhq/types-live";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import type { HederaAccount } from "@ledgerhq/live-common/families/hedera/types";
+import type { HederaAccount, Transaction as HederaTransaction } from "@ledgerhq/live-common/families/hedera/types";
 import type { Device } from "@ledgerhq/types-devices";
 import Track from "~/renderer/analytics/Track";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
@@ -84,9 +84,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<HederaTransaction>(account);
   const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
-      const bridge = getAccountBridge(account);
+    useBridgeTransaction(bridge, () => {
       const t = bridge.createTransaction(account);
 
       const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/Body.tsx
@@ -7,12 +7,12 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
-import type { Account, AccountBridge, Operation } from "@ledgerhq/types-live";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Account, Operation } from "@ledgerhq/types-live";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import type { HederaAccount } from "@ledgerhq/live-common/families/hedera/types";
+import type { HederaAccount, Transaction as HederaTransaction } from "@ledgerhq/live-common/families/hedera/types";
 import type { Device } from "@ledgerhq/types-devices";
 import Track from "~/renderer/analytics/Track";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
@@ -84,9 +84,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<HederaTransaction>(account);
   const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
-      const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+    useBridgeTransaction(bridge, () => {
       const t = bridge.createTransaction(account);
 
       const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Claim/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Claim/Body.tsx
@@ -8,8 +8,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { OpenModal, openModal } from "~/renderer/actions/modals";
@@ -20,7 +20,7 @@ import StepClaimRewards, { StepClaimRewardsFooter } from "./steps/StepClaimRewar
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { AccountBridge, Operation, Account } from "@ledgerhq/types-live";
+import { Operation, Account } from "@ledgerhq/types-live";
 import { DelegationType } from "~/renderer/families/multiversx/types";
 import { StepProps, St, StepId } from "./types";
 import {
@@ -82,6 +82,7 @@ const Body = (props: Props) => {
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<Transaction>(params.account, undefined);
   const {
     account,
     transaction,
@@ -91,8 +92,7 @@ const Body = (props: Props) => {
     bridgePending,
     status,
     parentAccount,
-  } = useBridgeTransaction(() => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(params.account, undefined);
+  } = useBridgeTransaction(bridge, () => {
     const transaction: Transaction = bridge.createTransaction(params.account);
     return {
       account: params.account,

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Delegate/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Delegate/Body.tsx
@@ -7,8 +7,8 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
@@ -22,7 +22,7 @@ import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmati
 import Track from "~/renderer/analytics/Track";
 import logger from "~/renderer/logger";
 import { MULTIVERSX_LEDGER_VALIDATOR_ADDRESS } from "@ledgerhq/live-common/families/multiversx/constants";
-import { Account, AccountBridge, Operation } from "@ledgerhq/types-live";
+import { Account, Operation } from "@ledgerhq/types-live";
 import { DelegationType } from "~/renderer/families/multiversx/types";
 import { StepProps, St, StepId } from "./types";
 import {
@@ -97,6 +97,7 @@ const Body = (props: Props) => {
     validator => validator.contract === MULTIVERSX_LEDGER_VALIDATOR_ADDRESS,
   );
   const { account, source = "Account Page" } = params;
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const {
     transaction,
     setTransaction,
@@ -105,8 +106,7 @@ const Body = (props: Props) => {
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, undefined);
+  } = useBridgeTransaction(bridge, () => {
     const transaction: Transaction = bridge.createTransaction(account);
     return {
       account,

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Undelegate/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Undelegate/Body.tsx
@@ -7,9 +7,9 @@ import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import logger from "~/renderer/logger";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import { OpenModal, openModal } from "~/renderer/actions/modals";
@@ -17,7 +17,7 @@ import Track from "~/renderer/analytics/Track";
 import Stepper from "~/renderer/components/Stepper";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { useSteps } from "./steps";
-import { Account, AccountBridge, Operation } from "@ledgerhq/types-live";
+import { Account, Operation } from "@ledgerhq/types-live";
 import {
   Transaction,
   MultiversXAccount,
@@ -75,6 +75,7 @@ const Body = (props: Props) => {
   const [optimisticOperation, setOptimisticOperation] = useState<Operation | null>(null);
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
+  const bridge = useAccountBridge<Transaction>(accountProp, undefined);
   const {
     account,
     transaction,
@@ -83,8 +84,7 @@ const Body = (props: Props) => {
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(accountProp, undefined);
+  } = useBridgeTransaction(bridge, () => {
     const transaction: Transaction = bridge.createTransaction(accountProp);
     return {
       account: accountProp,

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Withdraw/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Withdraw/Body.tsx
@@ -7,8 +7,8 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
@@ -20,11 +20,12 @@ import StepWithdraw, { StepWithdrawFooter } from "./steps/StepWithdraw";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { Account, AccountBridge, Operation } from "@ledgerhq/types-live";
+import { Account, Operation } from "@ledgerhq/types-live";
 import { StepProps, St, StepId } from "./types";
 import {
   MultiversXAccount,
   MultiversXProvider,
+  Transaction as MultiversxTransaction,
 } from "@ledgerhq/live-common/families/multiversx/types";
 import { Device } from "@ledgerhq/types-devices";
 import { UnbondingType } from "../../../types";
@@ -82,6 +83,7 @@ const Body = (props: Props) => {
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<MultiversxTransaction>(params.account, undefined);
   const {
     account,
     transaction,
@@ -91,8 +93,7 @@ const Body = (props: Props) => {
     bridgePending,
     status,
     parentAccount,
-  } = useBridgeTransaction(() => {
-    const bridge: AccountBridge<Transaction> = getAccountBridge(params.account, undefined);
+  } = useBridgeTransaction(bridge, () => {
     const transaction: Transaction = bridge.createTransaction(params.account);
     return {
       account: params.account,

--- a/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/Body.tsx
@@ -8,8 +8,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -25,7 +25,7 @@ import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepCo
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
 import { NearAccount, Transaction } from "@ledgerhq/live-common/families/near/types";
-import { Account, AccountBridge, Operation } from "@ledgerhq/types-live";
+import { Account, Operation } from "@ledgerhq/types-live";
 export type Data = {
   account: NearAccount;
   source?: string;
@@ -84,9 +84,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { account, source = "Account Page" } = params;
+  const bridge = useAccountBridge<Transaction>(account);
   const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
-      const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+    useBridgeTransaction(bridge, () => {
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "stake",

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/Body.tsx
@@ -8,10 +8,10 @@ import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getMaxAmount } from "@ledgerhq/live-common/families/near/logic";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { St, StepId } from "./types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import logger from "~/renderer/logger";
@@ -22,7 +22,7 @@ import Track from "~/renderer/analytics/Track";
 import Stepper from "~/renderer/components/Stepper";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { useSteps } from "./steps";
-import { NearAccount } from "@ledgerhq/live-common/families/near/types";
+import { NearAccount, Transaction as NearTransaction } from "@ledgerhq/live-common/families/near/types";
 import { Account, Operation } from "@ledgerhq/types-live";
 
 export type Data = {
@@ -64,6 +64,7 @@ function Body({
   const [optimisticOperation, setOptimisticOperation] = useState<Operation | null>(null);
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
+  const bridge = useAccountBridge<NearTransaction>(accountProp, undefined);
   const {
     account,
     transaction,
@@ -72,9 +73,8 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     invariant(accountProp.nearResources, "near: account and near resources required");
-    const bridge = getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const mode = "unstake";
     const recipient = validatorAddress;

--- a/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/Body.tsx
@@ -8,10 +8,10 @@ import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getMaxAmount } from "@ledgerhq/live-common/families/near/logic";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { St, StepId } from "./types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import logger from "~/renderer/logger";
@@ -22,7 +22,7 @@ import Track from "~/renderer/analytics/Track";
 import Stepper from "~/renderer/components/Stepper";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { useSteps } from "./steps";
-import { NearAccount } from "@ledgerhq/live-common/families/near/types";
+import { NearAccount, Transaction as NearTransaction } from "@ledgerhq/live-common/families/near/types";
 import { Account, Operation } from "@ledgerhq/types-live";
 
 export type Data = {
@@ -64,6 +64,7 @@ function Body({
   const [optimisticOperation, setOptimisticOperation] = useState<Operation | null>(null);
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
+  const bridge = useAccountBridge<NearTransaction>(accountProp, undefined);
   const {
     account,
     transaction,
@@ -72,9 +73,8 @@ function Body({
     updateTransaction,
     bridgePending,
     status,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     invariant(accountProp.nearResources, "near: account and near resources required");
-    const bridge = getAccountBridge(accountProp, undefined);
     const initTx = bridge.createTransaction(accountProp);
     const mode = "withdraw";
     const recipient = validatorAddress;

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/Body.tsx
@@ -7,8 +7,8 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -21,7 +21,7 @@ import StepAmount, { StepAmountFooter } from "./steps/StepAmount";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { PolkadotAccount } from "@ledgerhq/live-common/families/polkadot/types";
+import { PolkadotAccount, Transaction as PolkadotTransaction } from "@ledgerhq/live-common/families/polkadot/types";
 
 export type Data = {
   account: PolkadotAccount;
@@ -72,10 +72,10 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<PolkadotTransaction>(params.account);
   const { transaction, setTransaction, account, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(bridge, () => {
       const { account } = params;
-      const bridge = getAccountBridge(account);
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "bond",

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/Body.tsx
@@ -9,8 +9,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -24,7 +24,7 @@ import StepNomination, { StepNominationFooter } from "./steps/StepNomination";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { PolkadotAccount } from "@ledgerhq/live-common/families/polkadot/types";
+import { PolkadotAccount, Transaction as PolkadotTransaction } from "@ledgerhq/live-common/families/polkadot/types";
 
 export type Data = {
   account: PolkadotAccount;
@@ -77,6 +77,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<PolkadotTransaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -86,13 +87,12 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account } = params;
     invariant(
       account && account.polkadotResources,
       "polkadot: account and polkadot resources required",
     );
-    const bridge = getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const initialValidators = (account?.polkadotResources?.nominations || [])
       .filter(nomination => !!nomination.status)

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/Body.tsx
@@ -7,8 +7,8 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -22,7 +22,7 @@ import StepAmount, { StepAmountFooter } from "./steps/StepAmount";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { PolkadotAccount } from "@ledgerhq/live-common/families/polkadot/types";
+import { PolkadotAccount, Transaction as PolkadotTransaction } from "@ledgerhq/live-common/families/polkadot/types";
 
 export type Data = {
   account: PolkadotAccount;
@@ -73,10 +73,10 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<PolkadotTransaction>(params.account);
   const { transaction, setTransaction, account, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(bridge, () => {
       const { account } = params;
-      const bridge = getAccountBridge(account);
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "rebond",

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/Body.tsx
@@ -9,8 +9,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St, Mode } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -24,7 +24,7 @@ import StepInfo, { StepInfoFooter } from "./steps/StepInfo";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { PolkadotAccount, TransactionStatus } from "@ledgerhq/live-common/families/polkadot/types";
+import { PolkadotAccount, Transaction as PolkadotTransaction, TransactionStatus } from "@ledgerhq/live-common/families/polkadot/types";
 
 export type Data = {
   account: PolkadotAccount;
@@ -85,6 +85,7 @@ const Body = ({ t, stepId, device, openModal, onChangeStepId, params, onClose, m
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<PolkadotTransaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -94,10 +95,9 @@ const Body = ({ t, stepId, device, openModal, onChangeStepId, params, onClose, m
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account } = params;
     invariant(account, "polkadot: account required");
-    const bridge = getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode,

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/types.ts
@@ -8,7 +8,7 @@ import {
   TransactionStatus,
 } from "@ledgerhq/live-common/families/polkadot/types";
 import { OpenModal } from "~/renderer/actions/modals";
-export type Mode = "withdrawUnbonded" | "chill" | "claimRewards" | "setController";
+export type Mode = "withdrawUnbonded" | "chill" | "claimReward" | "setController";
 export type StepId = "info" | "connectDevice" | "confirmation";
 
 export type StepProps = {

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/Body.tsx
@@ -7,8 +7,8 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -22,7 +22,7 @@ import StepAmount, { StepAmountFooter } from "./steps/StepAmount";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
-import { PolkadotAccount } from "@ledgerhq/live-common/families/polkadot/types";
+import { PolkadotAccount, Transaction as PolkadotTransaction } from "@ledgerhq/live-common/families/polkadot/types";
 
 export type Data = {
   account: PolkadotAccount;
@@ -74,10 +74,10 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<PolkadotTransaction>(params.account);
   const { transaction, setTransaction, account, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(bridge, () => {
       const { account } = params;
-      const bridge = getAccountBridge(account);
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "unbond",

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/Body.tsx
@@ -1,14 +1,14 @@
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   SolanaAccount,
   SolanaStakeWithMeta,
   Transaction,
 } from "@ledgerhq/live-common/families/solana/types";
-import { AccountBridge, Operation, Account } from "@ledgerhq/types-live";
+import { Operation, Account } from "@ledgerhq/types-live";
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { Trans, withTranslation } from "react-i18next";
@@ -78,6 +78,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<Transaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -87,10 +88,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account, stakeWithMeta } = params;
     invariant(account && account.solanaResources, "solana: account and solana resources required");
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, undefined);
     const transaction = bridge.updateTransaction(bridge.createTransaction(account), {
       model: {
         kind: "stake.delegate",

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/Body.tsx
@@ -1,14 +1,14 @@
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   SolanaAccount,
   SolanaStakeWithMeta,
   Transaction,
 } from "@ledgerhq/live-common/families/solana/types";
-import { AccountBridge, Operation, Account } from "@ledgerhq/types-live";
+import { Operation, Account } from "@ledgerhq/types-live";
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { Trans, withTranslation } from "react-i18next";
@@ -77,6 +77,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<Transaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -86,10 +87,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account, stakeWithMeta } = params;
     invariant(account && account.solanaResources, "solana: account and solana resources required");
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, undefined);
     const transaction = bridge.updateTransaction(bridge.createTransaction(account), {
       model: {
         kind: "stake.undelegate",

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/Body.tsx
@@ -1,10 +1,10 @@
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { SolanaAccount, Transaction } from "@ledgerhq/live-common/families/solana/types";
-import { AccountBridge, Operation, Account } from "@ledgerhq/types-live";
+import { Operation, Account } from "@ledgerhq/types-live";
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { Trans, withTranslation } from "react-i18next";
@@ -85,6 +85,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { account, source = "Account Page" } = params;
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const {
     transaction,
     setTransaction,
@@ -93,9 +94,8 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     invariant(account && account.solanaResources, "solana: account and solana resources required");
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, undefined);
     const transaction = bridge.updateTransaction(bridge.createTransaction(account), {
       model: {
         kind: "stake.createAccount",

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/Body.tsx
@@ -1,14 +1,14 @@
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   Transaction,
   SolanaStakeWithMeta,
   SolanaAccount,
 } from "@ledgerhq/live-common/families/solana/types";
-import { AccountBridge, Operation, Account } from "@ledgerhq/types-live";
+import { Operation, Account } from "@ledgerhq/types-live";
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { Trans, withTranslation } from "react-i18next";
@@ -78,6 +78,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<Transaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -87,7 +88,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account, stakeWithMeta } = params;
     const { stake } = stakeWithMeta;
     invariant(account && account.solanaResources, "solana: account and solana resources required");
@@ -95,7 +96,6 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
       stake.delegation && stake.activation.state === "deactivating",
       "solana: can reactivate only delegated stake in <deactivating> state",
     );
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, undefined);
     const transaction = bridge.updateTransaction(bridge.createTransaction(account), {
       model: {
         kind: "stake.delegate",

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/Body.tsx
@@ -1,14 +1,14 @@
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   Transaction,
   SolanaStakeWithMeta,
   SolanaAccount,
 } from "@ledgerhq/live-common/families/solana/types";
-import { AccountBridge, Operation, Account } from "@ledgerhq/types-live";
+import { Operation, Account } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
@@ -79,6 +79,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<Transaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -88,7 +89,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account, stakeWithMeta } = params;
     const { stake } = stakeWithMeta;
     invariant(account && account.solanaResources, "solana: account and solana resources required");
@@ -96,7 +97,6 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
       stake.withdrawable > 0,
       "solana: can withdraw only if there is something to withdraw",
     );
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, undefined);
     const transaction = bridge.updateTransaction(bridge.createTransaction(account), {
       amount: new BigNumber(stake.withdrawable),
       model: {

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/Body.tsx
@@ -9,8 +9,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, StepId, St } from "./types";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -24,6 +24,7 @@ import StepAsset, { StepAssetFooter } from "./steps/StepAsset";
 import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepConnectDevice";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
+import { Transaction as StellarTransaction } from "@ledgerhq/live-common/families/stellar/types";
 
 export type Data = {
   account: Account;
@@ -74,6 +75,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<StellarTransaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -83,10 +85,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account } = params;
     invariant(account, "stellar: account required");
-    const bridge = getAccountBridge(account, undefined);
     const t = bridge.createTransaction(account);
     const transaction = bridge.updateTransaction(t, {
       mode: "changeTrust",

--- a/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/Body.tsx
@@ -8,8 +8,8 @@ import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
 
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -25,7 +25,7 @@ import GenericStepConnectDevice from "~/renderer/modals/Send/steps/GenericStepCo
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import logger from "~/renderer/logger";
 import { SuiAccount, Transaction } from "@ledgerhq/live-common/families/sui/types";
-import { Account, AccountBridge, Operation } from "@ledgerhq/types-live";
+import { Account, Operation } from "@ledgerhq/types-live";
 
 export type Data = {
   account: SuiAccount;
@@ -86,9 +86,9 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
   const { account, source = "Account Page" } = params;
+  const bridge = useAccountBridge<Transaction>(account);
   const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
-    useBridgeTransaction(() => {
-      const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+    useBridgeTransaction(bridge, () => {
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
         mode: "delegate",

--- a/apps/ledger-live-desktop/src/renderer/families/sui/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/UnstakingFlowModal/Body.tsx
@@ -1,10 +1,10 @@
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { SuiAccount, Transaction } from "@ledgerhq/live-common/families/sui/types";
-import { AccountBridge, Operation, Account } from "@ledgerhq/types-live";
+import { Operation, Account } from "@ledgerhq/types-live";
 import React, { useCallback, useState } from "react";
 import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
@@ -77,6 +77,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
+  const bridge = useAccountBridge<Transaction>(params.account, undefined);
   const {
     transaction,
     setTransaction,
@@ -86,9 +87,8 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const { account, stakedSuiId, amount } = params;
-    const bridge: AccountBridge<Transaction> = getAccountBridge(account, undefined);
     const transaction = bridge.updateTransaction(bridge.createTransaction(account), {
       mode: "undelegate",
       stakedSuiId,

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
@@ -113,7 +113,7 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction<Transaction>(() => {
+  } = useBridgeTransaction<Transaction>(bridge, () => {
     const account = params.account;
     const parentAccount = params.parentAccount;
 

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
@@ -157,6 +157,7 @@ const Body = ({
     setMaybeRecipient(null);
   }, [setMaybeRecipient]);
 
+  const initBridge = useAccountBridge(params?.account || accounts[0], params?.parentAccount);
   const {
     transaction,
     setTransaction,
@@ -168,7 +169,7 @@ const Body = ({
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(initBridge, () => {
     const parentAccount = params?.parentAccount;
     const account = params?.account || accounts[0];
     return {

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "LLD/hooks/redux";
 
 import { useTranslation } from "react-i18next";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Account, AccountLike, SignedOperation } from "@ledgerhq/types-live";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import Stepper from "~/renderer/components/Stepper";
@@ -17,10 +18,9 @@ import StepConnectDevice from "./steps/StepConnectDevice";
 import StepSummary, { StepSummaryFooter } from "./steps/StepSummary";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import { St, StepId } from "./types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import logger from "~/renderer/logger";
 import Text from "~/renderer/components/Text";
-import { TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { ModalData } from "../types";
 import { DeviceTransactionField } from "@ledgerhq/live-common/transaction/index";
 import { useDeviceTransactionConfig } from "@ledgerhq/live-common/hooks/useDeviceTransactionConfig";
@@ -121,6 +121,7 @@ export default function Body({ onChangeStepId, onClose, setError, stepId, params
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const { canEditFees, transactionData } = params;
+  const bridge = useAccountBridge<Transaction>(params?.account, params?.parentAccount);
   const {
     transaction,
     setTransaction,
@@ -131,10 +132,9 @@ export default function Body({ onChangeStepId, onClose, setError, stepId, params
     status,
     bridgeError,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const parentAccount = params && params.parentAccount;
     const account = params && params.account;
-    const bridge = getAccountBridge(account, parentAccount);
     const tx = bridge.createTransaction(account);
     const { recipient, ...txData } = transactionData;
     const tx2 = bridge.updateTransaction(tx, {
@@ -192,7 +192,8 @@ export default function Body({ onChangeStepId, onClose, setError, stepId, params
   const { fields } = useDeviceTransactionConfig({
     account: params.account,
     parentAccount,
-    transaction,
+    // transaction is null until the bridge initializes; the hook guards on null internally
+    transaction: transaction as Transaction,
     status,
   });
 

--- a/apps/ledger-live-mobile/src/families/algorand/OptInFlow/01-SelectToken.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/OptInFlow/01-SelectToken.tsx
@@ -3,14 +3,17 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, SafeAreaView, FlatList, TouchableOpacity } from "react-native";
 import { Trans } from "~/context/Locale";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useTokensData } from "@ledgerhq/cryptoassets/cal-client/hooks/useTokensData";
 import { extractTokenId } from "@ledgerhq/live-common/families/algorand/tokens";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { TokenAccount } from "@ledgerhq/types-live";
 import { useTheme } from "@react-navigation/native";
-import { AlgorandAccount, Transaction as AlgorandTransaction } from "@ledgerhq/live-common/families/algorand/types";
+import {
+  AlgorandAccount,
+  AlgorandTransaction,
+} from "@ledgerhq/live-common/families/algorand/types";
 import { ScreenName } from "~/const";
 import LText from "~/components/LText";
 import { TrackScreen } from "~/analytics";
@@ -89,7 +92,7 @@ export default function DelegationStarted({ navigation, route }: Props) {
   const mainAccount = getMainAccount(account) as AlgorandAccount;
   const bridge = useAccountBridge<AlgorandTransaction>(mainAccount);
   invariant(mainAccount && mainAccount.algorandResources, "algorand Account required");
-  const { transaction } = useBridgeTransaction(() => {
+  const { transaction } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/01-Started.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/01-Started.tsx
@@ -37,11 +37,11 @@ export default function DelegationStarted({ navigation, route }: Props) {
   const { locale } = useSettings();
   invariant(account, "Account required");
   const mainAccount = getMainAccount(account, undefined) as AlgorandAccount;
-  const bridge = useAccountBridge<AlgorandTransaction>(mainAccount, undefined);
   invariant(mainAccount && mainAccount.algorandResources, "algorand Account required");
   const { rewards } = mainAccount.algorandResources;
   const unit = useAccountUnit(mainAccount);
-  const { transaction, status } = useBridgeTransaction(() => {
+  const bridge = useAccountBridge<AlgorandTransaction>(mainAccount, undefined);
+  const { transaction, status } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/EditTransactionSummary.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/EditTransactionSummary.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@ledgerhq/coin-bitcoin/types";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import React, { useEffect, useState } from "react";
@@ -46,13 +47,14 @@ function BitcoinEditTransactionSummaryContent({
   invariant(transactionRaw, "transactionRaw is missing");
 
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge(account, parentAccount);
 
   const {
     transaction,
     setTransaction,
     status: txStatus,
     bridgePending,
-  } = useBridgeTransaction(() => ({
+  } = useBridgeTransaction(bridge, () => ({
     transaction: route.params.transaction,
     account,
     parentAccount,

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
@@ -66,7 +66,7 @@ function MethodSelectionComponent({ navigation, route }: Props) {
     };
   }, [operation.hash, mainAccount.freshAddress]);
 
-  const { transaction, setTransaction } = useBridgeTransaction<BtcTransaction>(() => ({
+  const { transaction, setTransaction } = useBridgeTransaction<BtcTransaction>(bridge, () => ({
     account,
     parentAccount,
     transaction: transactionToEdit,

--- a/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
@@ -98,7 +98,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
   tx = bridge.updateTransaction(tx, { mode: "delegate" });
 
   const { transaction, updateTransaction, setTransaction, status, bridgePending, bridgeError } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(bridge, () => {
       if (chosenPool) {
         tx = bridge.updateTransaction(tx, { poolId: chosenPool.poolId });
       }

--- a/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
@@ -51,6 +51,7 @@ export default function UndelegationSummary({ navigation, route }: Props) {
   const bridge = useAccountBridge<CardanoTransaction>(account, undefined);
 
   const { transaction, status, bridgePending, bridgeError, setTransaction } = useBridgeTransaction(
+    bridge,
     () => {
       const tx = route.params.transaction;
 

--- a/apps/ledger-live-mobile/src/families/celo/ActivateFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/ActivateFlow/02-Summary.tsx
@@ -1,8 +1,12 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useValidatorGroups } from "@ledgerhq/live-common/families/celo/react";
-import { CeloValidatorGroup, CeloAccount, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
+import {
+  CeloValidatorGroup,
+  CeloAccount,
+  Transaction as CeloTransaction,
+} from "@ledgerhq/live-common/families/celo/types";
 import { activatableVotes } from "@ledgerhq/live-common/families/celo/logic";
 import { useTheme } from "@react-navigation/native";
 import invariant from "invariant";
@@ -51,7 +55,7 @@ export default function ActivateSummary({ navigation, route }: Props) {
   }, [votes, validator, validators]);
 
   const { transaction, updateTransaction, setTransaction, status, bridgePending, bridgeError } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(bridge, () => {
       const tx = route.params.transaction;
 
       if (!tx) {

--- a/apps/ledger-live-mobile/src/families/celo/LockFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/LockFlow/01-Amount.tsx
@@ -44,7 +44,7 @@ export default function LockAmount({ navigation, route }: Props) {
 
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
 
-  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction(() => {
+  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
 
     const transaction = bridge.updateTransaction(t, {
@@ -76,7 +76,7 @@ export default function LockAmount({ navigation, route }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [bridge, account, parentAccount, debouncedTransaction]);
+  }, [account, parentAccount, debouncedTransaction, bridge]);
 
   const onChange = useCallback(
     (amount: BigNumber) => {
@@ -96,7 +96,7 @@ export default function LockAmount({ navigation, route }: Props) {
         useAllAmount: !transaction.useAllAmount,
       }),
     );
-  }, [setTransaction, bridge, transaction]);
+  }, [setTransaction, transaction, bridge]);
 
   const onContinue = useCallback(() => {
     navigation.navigate(ScreenName.CeloLockSelectDevice, {

--- a/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/01-Started.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/01-Started.tsx
@@ -1,12 +1,12 @@
 import invariant from "invariant";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Text } from "@ledgerhq/native-ui";
 import { useTheme } from "@react-navigation/native";
 import React, { useCallback } from "react";
 import { Trans } from "~/context/Locale";
 import { StyleSheet, View } from "react-native";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { TrackScreen } from "~/analytics";
 import Button from "~/components/Button";
@@ -28,7 +28,7 @@ export default function RegisterAccountStarted({ navigation, route }: Props) {
   const mainAccount = getMainAccount(account, parentAccount);
   const bridge = useAccountBridge<CeloTransaction>(account, parentAccount);
 
-  const { transaction, status } = useBridgeTransaction(() => {
+  const { transaction, status } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
 
     const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/01-Summary.tsx
@@ -3,7 +3,11 @@ import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge"
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useValidatorGroups } from "@ledgerhq/live-common/families/celo/react";
-import type { CeloValidatorGroup, CeloAccount, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
+import type {
+  CeloValidatorGroup,
+  CeloAccount,
+  Transaction as CeloTransaction,
+} from "@ledgerhq/live-common/families/celo/types";
 import { revokableVotes } from "@ledgerhq/live-common/families/celo/logic";
 import { AccountLike } from "@ledgerhq/types-live";
 import { useTheme } from "@react-navigation/native";
@@ -69,7 +73,7 @@ export default function RevokeSummary({ navigation, route }: Props) {
   }, [vote, votes]);
 
   const { transaction, updateTransaction, setTransaction, status, bridgePending, bridgeError } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(bridge, () => {
       const tx = route.params.transaction;
 
       if (!tx) {
@@ -79,7 +83,7 @@ export default function RevokeSummary({ navigation, route }: Props) {
           account,
           transaction: bridge.updateTransaction(t, {
             mode: "revoke",
-            amount: route.params.amount ?? new BigNumber(0),
+            amount: new BigNumber(route.params.amount ?? 0),
           }),
         };
       }

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/VoteAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/VoteAmount.tsx
@@ -45,7 +45,7 @@ export default function VoteAmount({ navigation, route }: Props) {
 
   const bridge = useAccountBridge<CeloTransaction>(account);
 
-  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction(() => {
+  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction(bridge, () => {
     return {
       account,
       transaction: {

--- a/apps/ledger-live-mobile/src/families/celo/UnlockFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/UnlockFlow/01-Amount.tsx
@@ -46,7 +46,7 @@ export default function UnlockAmount({ navigation, route }: Props) {
 
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
 
-  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction(() => {
+  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
 
     const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/02-Summary.tsx
@@ -3,7 +3,10 @@ import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge"
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { useValidatorGroups } from "@ledgerhq/live-common/families/celo/react";
-import { CeloValidatorGroup, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
+import {
+  CeloValidatorGroup,
+  Transaction as CeloTransaction,
+} from "@ledgerhq/live-common/families/celo/types";
 import { defaultValidatorGroupAddress } from "@ledgerhq/live-common/families/celo/logic";
 import { AccountLike } from "@ledgerhq/types-live";
 import { Text, Icons } from "@ledgerhq/native-ui";
@@ -56,7 +59,7 @@ export default function VoteSummary({ navigation, route }: Props) {
   }, [validators, validator]);
 
   const { transaction, updateTransaction, setTransaction, status, bridgePending, bridgeError } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(bridge, () => {
       const tx = route.params.transaction;
 
       if (!tx) {

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/VoteAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/VoteAmount.tsx
@@ -13,6 +13,7 @@ import { Trans } from "~/context/Locale";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
 import LText from "~/components/LText";
@@ -25,7 +26,6 @@ import SendRowsFee from "../SendRowsFee";
 import { getFirstStatusError } from "../../helpers";
 import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import type { CeloVoteFlowParamList } from "./types";
-import type { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -41,14 +41,14 @@ export default function VoteAmount({ navigation, route }: Props) {
 
   const bridge = useAccountBridge<CeloTransaction>(account);
 
-  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction<CeloTransaction>(() => {
+  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction<CeloTransaction>(bridge, () => {
     return {
       account,
       transaction: {
         ...route.params.transaction,
         amount: new BigNumber(route.params.amount ?? 0),
         mode: "vote",
-      },
+      } as CeloTransaction,
     };
   });
 

--- a/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
@@ -10,7 +10,10 @@ import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge"
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { rgba, Text, Icons } from "@ledgerhq/native-ui";
-import { CeloAccount, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
+import {
+  CeloAccount,
+  Transaction as CeloTransaction,
+} from "@ledgerhq/live-common/families/celo/types";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
 import Button from "~/components/Button";
@@ -46,6 +49,7 @@ export default function WithdrawAmount({ navigation, route }: Props) {
   const mainAccount = getMainAccount(account, parentAccount);
 
   const { transaction, setTransaction, status, bridgeError, bridgePending } = useBridgeTransaction(
+    bridge,
     () => {
       const t = bridge.createTransaction(mainAccount);
       const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/01-SelectValidator.tsx
@@ -6,6 +6,7 @@ import type {
   CosmosMappedDelegation,
   CosmosValidatorItem,
   Transaction,
+  Transaction as CosmosTransaction,
 } from "@ledgerhq/live-common/families/cosmos/types";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
@@ -30,10 +31,10 @@ function ClaimRewardsSelectValidator({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
   const mainAccount = getMainAccount(account, undefined) as CosmosAccount;
-  const bridge = useAccountBridge<Transaction>(account, undefined);
+  const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
   const { cosmosResources } = mainAccount;
   invariant(cosmosResources, "cosmosResources required");
-  const transaction = useBridgeTransaction(() => {
+  const transaction = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.tsx
@@ -3,7 +3,12 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans } from "~/context/Locale";
-import type { CosmosAccount, CosmosOperationMode, Transaction } from "@ledgerhq/live-common/families/cosmos/types";
+import type {
+  CosmosAccount,
+  CosmosOperationMode,
+  Transaction,
+  Transaction as CosmosTransaction,
+} from "@ledgerhq/live-common/families/cosmos/types";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -56,11 +61,11 @@ function ClaimRewardsAmount({ navigation, route }: Props) {
   const { colors } = useTheme();
   const account = useAccountScreen(route).account as CosmosAccount;
   invariant(account && account.cosmosResources, "account and cosmos transaction required");
-  const bridge = useAccountBridge<Transaction>(account, undefined);
+  const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const unit = useAccountUnit(mainAccount);
   const currency = getAccountCurrency(mainAccount);
-  const bridgeTransaction = useBridgeTransaction(() => {
+  const bridgeTransaction = useBridgeTransaction(bridge, () => {
     const tx = route.params.transaction;
 
     if (!tx) {

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
@@ -4,7 +4,11 @@ import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransact
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { getMaxDelegationAvailable } from "@ledgerhq/live-common/families/cosmos/logic";
 import { useLedgerFirstShuffledValidatorsCosmosFamily } from "@ledgerhq/live-common/families/cosmos/react";
-import { CosmosAccount, CosmosValidatorItem, Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
+import {
+  CosmosAccount,
+  CosmosValidatorItem,
+  Transaction as CosmosTransaction,
+} from "@ledgerhq/live-common/families/cosmos/types";
 import cosmosBase from "@ledgerhq/coin-cosmos/chain/cosmosBase";
 import { AccountLike } from "@ledgerhq/types-live";
 import { Text, Icons } from "@ledgerhq/native-ui";
@@ -61,7 +65,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
   }, [validators, validator, mainAccount.currency.id]);
 
   const { transaction, updateTransaction, setTransaction, status, bridgePending, bridgeError } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(bridge, () => {
       const tx = route.params.transaction;
 
       if (!tx) {

--- a/apps/ledger-live-mobile/src/families/cosmos/Delegations/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/Delegations/index.tsx
@@ -87,7 +87,7 @@ function Delegations({ account }: Props) {
     cosmosResources.unbondings &&
     mapUnbondings(cosmosResources.unbondings, validators, unit);
   const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
-  const { transaction } = useBridgeTransaction(() => {
+  const { transaction } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     const { validatorSrcAddress } = { ...banner };
     return {

--- a/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/01-SelectValidator.tsx
@@ -14,10 +14,11 @@ import type {
   CosmosAccount,
   CosmosValidatorItem,
   Transaction,
+  Transaction as CosmosTransaction,
 } from "@ledgerhq/live-common/families/cosmos/types";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useLedgerFirstShuffledValidatorsCosmosFamily } from "@ledgerhq/live-common/families/cosmos/react";
 import { useTheme } from "@react-navigation/native";
 import SelectValidatorSearchBox from "../../tron/VoteFlow/01-SelectValidator/SearchBox";
@@ -39,11 +40,11 @@ function RedelegationSelectValidator({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
   const mainAccount = getMainAccount(account, undefined) as CosmosAccount;
-  const bridge = useAccountBridge<Transaction>(account, undefined);
   const { cosmosResources } = mainAccount;
   invariant(cosmosResources, "cosmosResources required");
   const delegations = cosmosResources.delegations;
-  const bridgeTransaction = useBridgeTransaction(() => {
+  const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
+  const bridgeTransaction = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/01-Amount.tsx
@@ -1,9 +1,9 @@
 import invariant from "invariant";
 import React from "react";
 import { BigNumber } from "bignumber.js";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
 import SelectAmount from "../shared/02-SelectAmount";
@@ -20,11 +20,11 @@ type Props = StackNavigatorProps<
 function UndelegationAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const validator = route.params.delegation.validator;
   const amount = route.params.delegation.amount;
-  const { transaction } = useBridgeTransaction(() => {
+  const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
+  const { transaction } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/cosmos/shared/03-BridgeTransaction.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/shared/03-BridgeTransaction.tsx
@@ -3,9 +3,12 @@ import invariant from "invariant";
 import { Flex } from "@ledgerhq/native-ui";
 import { BigNumber } from "bignumber.js";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
-import type { CosmosAccount, Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type {
+  CosmosAccount,
+  Transaction as CosmosTransaction,
+} from "@ledgerhq/live-common/families/cosmos/types";
 import { ScreenName } from "~/const";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { CosmosRedelegationFlowParamList } from "../RedelegationFlow/types";
@@ -28,10 +31,10 @@ export default function CosmosBridgeTransaction({ navigation, route }: Props) {
   invariant(account, "account required");
 
   const mainAccount = getMainAccount(account) as CosmosAccount;
-  const bridge = useAccountBridge<CosmosTransaction>(account);
   const { transaction: initialTx, mode } = route.params;
+  const bridge = useAccountBridge<CosmosTransaction>(account);
 
-  const { transaction, bridgePending, status } = useBridgeTransaction(() => {
+  const { transaction, bridgePending, status } = useBridgeTransaction(bridge, () => {
     if (!initialTx) {
       const t = bridge.createTransaction(mainAccount);
 

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/02-SelectAmount.tsx
@@ -55,6 +55,7 @@ export default function SelectAmount({ navigation, route }: Props) {
   const bridge = useAccountBridge<GenericTransaction>(account);
   const unit = useAccountUnit(account);
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    bridge,
     () => ({
       account,
       parentAccount: undefined,

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/EditTransactionSummary.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/EditTransactionSummary.tsx
@@ -10,6 +10,7 @@ import { isCurrencySupported } from "@ledgerhq/ledger-wallet-framework/currencie
 import { NotEnoughGas } from "@ledgerhq/errors";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import invariant from "invariant";
 import React, { useCallback } from "react";
@@ -42,12 +43,14 @@ function EditTransactionSummaryContent({ navigation, route, transactionToUpdate 
   invariant(account, "account is missing");
   invariant(transactionRaw, "transactionRaw is missing");
 
+  const bridge = useAccountBridge(account, parentAccount);
+
   const {
     transaction,
     setTransaction,
     status: txStatus,
     bridgePending,
-  } = useBridgeTransaction(() => ({
+  } = useBridgeTransaction(bridge, () => ({
     transaction: route.params.transaction,
     account,
     parentAccount,

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
@@ -47,7 +47,7 @@ function MethodSelectionComponent({ navigation, route }: Props) {
     operation.transactionRaw as TransactionRaw,
   );
 
-  const { transaction, setTransaction } = useBridgeTransaction<EvmTransaction>(() => ({
+  const { transaction, setTransaction } = useBridgeTransaction<EvmTransaction>(bridge, () => ({
     account,
     parentAccount,
     transaction: transactionToEdit,

--- a/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/Evm1559CustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/Evm1559CustomFees.tsx
@@ -1,5 +1,5 @@
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { getGasLimit } from "@ledgerhq/coin-evm/utils";
 import type { EvmTransactionEIP1559 } from "@ledgerhq/coin-evm/types/index";
@@ -54,6 +54,7 @@ const Evm1559CustomFees = ({
   const bridge = useAccountBridge<EvmTransactionEIP1559>(account);
 
   const { transaction, setTransaction, status } = useBridgeTransaction<EvmTransactionEIP1559>(
+    bridge,
     () => ({
       account,
       transaction: { ...originalTransaction, maxFeePerGas, maxPriorityFeePerGas },

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/02-Summary.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { Trans } from "~/context/Locale";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import { Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { View, SafeAreaView, StyleSheet } from "react-native";
@@ -34,9 +34,9 @@ export default function Summary({ navigation, route }: Props) {
 
   invariant(account, "hedera: account is required");
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
 
-  const { transaction, status, bridgeError, bridgePending } = useBridgeTransaction(() => {
-    const bridge = getAccountBridge(account, parentAccount);
+  const { transaction, status, bridgeError, bridgePending } = useBridgeTransaction(bridge, () => {
     const transaction = bridge.createTransaction(account);
     const updatedTransaction = bridge.updateTransaction(transaction, {
       mode: HEDERA_TRANSACTION_MODES.TokenAssociate,
@@ -57,7 +57,7 @@ export default function Summary({ navigation, route }: Props) {
   const navigateToNext = useCallback(() => {
     navigation.navigate(ScreenName.HederaAssociateTokenSelectDevice, {
       ...route.params,
-      transaction,
+      transaction: transaction ?? undefined,
       status,
     });
   }, [navigation, transaction, status, route]);

--- a/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/Claim.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/Claim.tsx
@@ -34,8 +34,8 @@ function ClaimRewardsClaim({ navigation, route }: Props) {
 
   const { selectedDelegation } = route.params;
   const unit = useAccountUnit(account);
-  const bridge = useAccountBridge<Transaction>(account);
-  const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(() => {
+  const bridge: AccountBridge<Transaction> = useAccountBridge(account);
+  const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(account);
 
     const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
@@ -45,12 +45,12 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
   invariant(account, "account must be defined");
   invariant(account.type === "Account", "account type must be Account");
 
-  const bridge = useAccountBridge<Transaction>(account);
+  const bridge: AccountBridge<Transaction> = useAccountBridge(account);
   const validators = useHederaValidators(account.currency);
   const defaultValidator = getDefaultValidator(validators);
 
   const { transaction, updateTransaction, status, bridgePending, bridgeError } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(bridge, () => {
       const t = bridge.createTransaction(account);
 
       const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/Amount.tsx
@@ -36,8 +36,8 @@ function RedelegationAmount({ navigation, route }: Props) {
   invariant(account.type === "Account", "account type must be Account");
 
   const unit = useAccountUnit(account);
-  const bridge = useAccountBridge<Transaction>(account);
-  const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(() => {
+  const bridge: AccountBridge<Transaction> = useAccountBridge(account);
+  const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(account);
 
     const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/Amount.tsx
@@ -36,8 +36,8 @@ function UndelegationAmount({ navigation, route }: Props) {
   invariant(account.type === "Account", "account type must be Account");
 
   const unit = useAccountUnit(account);
-  const bridge = useAccountBridge<Transaction>(account);
-  const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(() => {
+  const bridge: AccountBridge<Transaction> = useAccountBridge(account);
+  const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(account);
 
     const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickMethod/PickMethod.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickMethod/PickMethod.tsx
@@ -86,7 +86,7 @@ const PickMethod = (props: PickMethodPropsType) => {
    * If no transaction sent through the parameters of the navigation, instantiate a new one, otherwise, return the old one.
    */
 
-  const { transaction, status, updateTransaction } = useBridgeTransaction(() => {
+  const { transaction, status, updateTransaction } = useBridgeTransaction(bridge, () => {
     if (route.params.transaction) {
       return {
         account,

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickValidator/PickValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickValidator/PickValidator.tsx
@@ -2,11 +2,11 @@ import React, { useMemo, useCallback } from "react";
 import { View, FlatList } from "react-native";
 import { useTheme } from "@react-navigation/native";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account";
 
 import BigNumber from "bignumber.js";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
-import type { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 
 import { ScreenName } from "~/const";
 import Item from "./components/Item";
@@ -33,7 +33,7 @@ const PickValidator = (props: PickValidatorPropsType) => {
    * Initialize a new transaction on mount and set the mode to "claimRewards".
    */
 
-  const { transaction } = useBridgeTransaction(() => ({
+  const { transaction } = useBridgeTransaction(bridge, () => ({
     account,
     transaction: bridge.updateTransaction(bridge.createTransaction(mainAccount), {
       mode: "claimRewards",

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/SetDelegation/SetDelegation.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/SetDelegation/SetDelegation.tsx
@@ -2,8 +2,6 @@ import React, { useMemo, useEffect, useCallback } from "react";
 import { Image, View, Animated } from "react-native";
 import { useTheme } from "@react-navigation/native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import type { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 import {
   handleTransactionStatus,
   denominate,
@@ -13,6 +11,8 @@ import { getAccountCurrency, getMainAccount } from "@ledgerhq/ledger-wallet-fram
 import { Text, Icons } from "@ledgerhq/native-ui";
 import { Trans } from "~/context/Locale";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 import BigNumber from "bignumber.js";
 
 import { MULTIVERSX_LEDGER_VALIDATOR_ADDRESS } from "@ledgerhq/live-common/families/multiversx/constants";
@@ -46,9 +46,9 @@ const SetDelegation = (props: SetDelegationPropsType) => {
 
   const currency = getAccountCurrency(account);
   const color = getCurrencyColor(currency);
-  const bridge = useAccountBridge<MultiversXTransaction>(account);
   const mainAccount = getMainAccount(account, undefined);
   const unit = useAccountUnit(account);
+  const bridge = useAccountBridge<MultiversXTransaction>(account);
 
   /*
    * Find the validator that'll be picked by default, which is the one from Ledger.
@@ -63,14 +63,16 @@ const SetDelegation = (props: SetDelegationPropsType) => {
    * Instantiate the transaction when opening the flow. Only gets runned once.
    */
 
-  const { transaction, updateTransaction, status, bridgeError } = useBridgeTransaction(() => ({
-    account,
-    transaction: bridge.updateTransaction(bridge.createTransaction(mainAccount), {
-      amount: new BigNumber(0),
-      recipient: defaultValidator ? defaultValidator.contract : "",
-      mode: "delegate",
-    }),
-  }));
+  const { transaction, updateTransaction, status, bridgeError } = useBridgeTransaction(bridge, () => {
+    return {
+      account,
+      transaction: bridge.updateTransaction(bridge.createTransaction(mainAccount), {
+        amount: new BigNumber(0),
+        recipient: defaultValidator ? defaultValidator.contract : "",
+        mode: "delegate",
+      }),
+    };
+  });
 
   /*
    * Use the transaction recipient to find the chosen validator and access more data about it..

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/components/PickAmount/PickAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/components/PickAmount/PickAmount.tsx
@@ -3,7 +3,7 @@ import { View, Keyboard, TouchableOpacity, TouchableWithoutFeedback, Platform } 
 import { Trans } from "~/context/Locale";
 import { BigNumber } from "bignumber.js";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import type { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
+import { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 import { denominate } from "@ledgerhq/live-common/families/multiversx/helpers";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useTheme } from "styled-components/native";
@@ -43,7 +43,7 @@ const PickAmount = (props: PickAmountPropsType) => {
    * Instantiate the transaction when opening the flow. Only gets runned once.
    */
 
-  const { transaction, updateTransaction } = useBridgeTransaction(() => ({
+  const { transaction, updateTransaction } = useBridgeTransaction(bridge, () => ({
     account,
     transaction: bridge.updateTransaction(bridge.createTransaction(account), {
       recipient: validator.contract,

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/components/WithdrawFunds/WithdrawFunds.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/components/WithdrawFunds/WithdrawFunds.tsx
@@ -3,13 +3,13 @@ import { View } from "react-native";
 import { Trans } from "~/context/Locale";
 import { useTheme } from "@react-navigation/native";
 import { handleTransactionStatus } from "@ledgerhq/live-common/families/multiversx/helpers";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import type { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 import {
   getMainAccount,
   getAccountCurrency,
 } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 
 import Button from "~/components/Button";
 import LText from "~/components/LText";
@@ -35,22 +35,24 @@ const WithdrawFunds = (props: WithdrawFundsPropsType) => {
 
   const mainAccount = getMainAccount(account, undefined);
   const currency = getAccountCurrency(mainAccount);
-  const bridge = useAccountBridge<MultiversXTransaction>(account);
   const unit = useAccountUnit(mainAccount);
   const name = validator.identity.name || validator.contract;
+  const bridge = useAccountBridge<MultiversXTransaction>(account);
 
   /*
    * Instantiate a new transaction with the given arguments.
    */
 
-  const { transaction, status } = useBridgeTransaction(() => ({
-    account,
-    transaction: bridge.updateTransaction(bridge.createTransaction(mainAccount), {
-      mode: "withdraw",
-      recipient: validator.contract,
-      amount,
-    }),
-  }));
+  const { transaction, status } = useBridgeTransaction(bridge, () => {
+    return {
+      account,
+      transaction: bridge.updateTransaction(bridge.createTransaction(mainAccount), {
+        mode: "withdraw",
+        recipient: validator.contract,
+        amount,
+      }),
+    };
+  });
 
   /*
    * Callback called when navigating to the next screen of the current flow.

--- a/apps/ledger-live-mobile/src/families/near/StakingFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/near/StakingFlow/02-Summary.tsx
@@ -57,6 +57,7 @@ export default function StakingSummary({ navigation, route }: Props) {
   }, [validators, validator]);
 
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    bridge,
     () => {
       const tx = route.params.transaction;
 

--- a/apps/ledger-live-mobile/src/families/near/UnstakingFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/near/UnstakingFlow/01-Amount.tsx
@@ -19,15 +19,15 @@ type Props = BaseComposite<
 function UnstakingAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = useAccountBridge<Transaction>(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const { validatorId } = route.params.stakingPosition;
   const {
     transaction: bridgeTransaction,
     updateTransaction,
     status,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/01-Amount.tsx
@@ -19,15 +19,15 @@ type Props = BaseComposite<
 function WithdrawingAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = useAccountBridge<Transaction>(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const { validatorId } = route.params.stakingPosition;
   const {
     transaction: bridgeTransaction,
     updateTransaction,
     status,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/polkadot/BondFlow/02-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/BondFlow/02-Amount.tsx
@@ -84,7 +84,7 @@ export default function PolkadotBondAmount({ navigation, route }: Props) {
   const mainAccount = getMainAccount(account, parentAccount) as PolkadotAccount;
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
   const [infoModalOpen, setInfoModalOpen] = useState<boolean>();
-  const bridgeTransaction = useBridgeTransaction(() => {
+  const bridgeTransaction = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     const transaction = bridge.updateTransaction(t, {
       mode: "bond",
@@ -116,7 +116,7 @@ export default function PolkadotBondAmount({ navigation, route }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [account, parentAccount, debouncedTransaction, bridge]);
+  }, [bridge, account, parentAccount, debouncedTransaction]);
   const onChange = useCallback(
     (amount: BigNumber) => {
       if (!amount.isNaN()) {

--- a/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
@@ -72,7 +72,7 @@ function NominateSelectValidator({ navigation, route }: Props) {
   const [drawerValidator, setDrawerValidator] = useState<PolkadotValidator | null | undefined>();
   const { polkadotResources } = mainAccount;
   invariant(polkadotResources, "polkadotResources required");
-  const bridgeTransaction = useBridgeTransaction(() => {
+  const bridgeTransaction = useBridgeTransaction(bridge, () => {
     const tx = route.params.transaction;
 
     if (!tx) {

--- a/apps/ledger-live-mobile/src/families/polkadot/RebondFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/RebondFlow/01-Amount.tsx
@@ -1,5 +1,6 @@
 import invariant from "invariant";
 import { BigNumber } from "bignumber.js";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import React, { useCallback, useState, useEffect } from "react";
 import {
@@ -15,7 +16,6 @@ import { useTheme } from "@react-navigation/native";
 import type { Transaction as PolkadotTransaction } from "@ledgerhq/live-common/families/polkadot/types";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
@@ -44,7 +44,7 @@ export default function PolkadotRebondAmount({ navigation, route }: NavigationPr
   const bridge = useAccountBridge<PolkadotTransaction>(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
-  const bridgeTransaction = useBridgeTransaction(() => {
+  const bridgeTransaction = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     const transaction = bridge.updateTransaction(t, {
       mode: "rebond",

--- a/apps/ledger-live-mobile/src/families/polkadot/SimpleOperationFlow/01-Started.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/SimpleOperationFlow/01-Started.tsx
@@ -47,6 +47,7 @@ export default function PolkadotSimpleOperationStarted({ navigation, route }: Na
   const { polkadotResources } = mainAccount as PolkadotAccount;
   invariant(polkadotResources, "polkadotResources required");
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    bridge,
     () => {
       const t = bridge.createTransaction(mainAccount);
       const transaction = bridge.updateTransaction(t, {

--- a/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
@@ -44,6 +44,7 @@ export default function PolkadotUnbondAmount({ navigation, route }: Props) {
   const mainAccount = getMainAccount(account, parentAccount);
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    bridge,
     () => {
       const t = bridge.createTransaction(mainAccount);
       const transaction = bridge.updateTransaction(t, {
@@ -73,7 +74,7 @@ export default function PolkadotUnbondAmount({ navigation, route }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [account, parentAccount, debouncedTransaction, bridge]);
+  }, [bridge, account, parentAccount, debouncedTransaction]);
   const onChange = useCallback(
     (amount: BigNumber) => {
       if (!amount.isNaN() && transaction) {

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectAmount.tsx
@@ -52,6 +52,7 @@ export default function DelegationSelectAmount({ navigation, route }: Props) {
   const bridge = useAccountBridge<SolanaTransaction>(account);
 
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction<SolanaTransaction>(
+    bridge,
     () => ({
       account,
       transaction: {
@@ -64,7 +65,7 @@ export default function DelegationSelectAmount({ navigation, route }: Props) {
             delegate: { voteAccAddress: "" },
           },
         },
-      },
+      } as SolanaTransaction,
     }),
   );
 

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
@@ -1,4 +1,5 @@
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { useValidators } from "@ledgerhq/live-common/families/solana/react";
@@ -52,6 +53,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
   invariant(account, "account must be defined");
   invariant(account.type === "Account", "account type must be Account");
 
+  const bridge = useAccountBridge(account, parentAccount);
   const validators = useValidators(account.currency);
 
   const chosenValidator = useMemo(() => {
@@ -73,6 +75,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
   }, [validators, validator, delegationAction]);
 
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    bridge,
     () => ({
       account,
       parentAccount,

--- a/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/01-SelectAsset.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/01-SelectAsset.tsx
@@ -95,7 +95,7 @@ export default function DelegationStarted({ navigation, route }: Props) {
   const mainAccount = getMainAccount(account);
   const bridge = useAccountBridge<StellarTransaction>(mainAccount);
   invariant(mainAccount, "stellar Account required");
-  const { transaction, status } = useBridgeTransaction(() => {
+  const { transaction, status } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/sui/StakingFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/StakingFlow/02-Summary.tsx
@@ -45,10 +45,10 @@ export default function StakingSummary({ navigation, route }: Props) {
   const validators = useLedgerFirstShuffledValidatorsSui("");
   const chosenValidator = validator || validators[0];
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = useAccountBridge<SuiTransaction>(account, undefined);
+  const bridge = useAccountBridge<SuiTransaction>(account, parentAccount);
 
   const { transaction, updateTransaction, setTransaction, status, bridgePending, bridgeError } =
-    useBridgeTransaction(() => {
+    useBridgeTransaction(bridge, () => {
       const tx = route.params.transaction;
 
       if (!tx) {

--- a/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/01-Amount.tsx
@@ -18,15 +18,15 @@ type Props = BaseComposite<
 function UnstakingAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = useAccountBridge<Transaction>(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const { stakedSuiId, principal } = route.params.stakingPosition;
   const {
     transaction: bridgeTransaction,
     updateTransaction,
     status,
     bridgePending,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     const t = bridge.createTransaction(mainAccount);
     return {
       account,

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
@@ -160,6 +160,7 @@ export default function SelectValidator({ navigation, route }: Props) {
   invariant(account, "account is undefined");
   const bridge = useAccountBridge<TezosTransaction>(account, parentAccount);
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    bridge,
     () => ({
       account,
       parentAccount,

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
@@ -115,6 +115,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
   const bridge = useAccountBridge<TezosTransaction>(account, parentAccount);
 
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    bridge,
     () => ({
       account,
       parentAccount,
@@ -148,7 +149,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
         bridge.updateTransaction(transaction, patch),
       );
     }
-  }, [account, bridge, defaultBaker, navigation, parentAccount, setTransaction, transaction, route.params]);
+  }, [account, bridge, defaultBaker, navigation, setTransaction, transaction, route.params]);
 
   const [rotateAnim] = useState(() => new Animated.Value(0));
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendFlowTransaction.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendFlowTransaction.test.ts
@@ -2,12 +2,17 @@ import { renderHook, act } from "@tests/test-renderer";
 import { useSendFlowTransaction } from "../useSendFlowTransaction";
 import * as bridgeModule from "@ledgerhq/live-common/bridge/index";
 import * as useBridgeTransactionModule from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import * as useAccountBridgeModule from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import BigNumber from "bignumber.js";
 
 jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction");
 jest.mock("@ledgerhq/live-common/bridge/index");
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: jest.fn(),
+  useAccountBridgeOrNull: jest.fn(),
+}));
 
 describe("useSendFlowTransaction", () => {
   const mockAccount = {
@@ -26,8 +31,14 @@ describe("useSendFlowTransaction", () => {
   const mockSetAccount = jest.fn();
   const mockUpdateTransaction = jest.fn((tx, updates) => ({ ...tx, ...updates }));
 
+  const mockBridge = { updateTransaction: jest.fn() };
+
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockBridge.updateTransaction = mockUpdateTransaction;
+
+    (useAccountBridgeModule.useAccountBridgeOrNull as jest.Mock).mockReturnValue(mockBridge);
 
     (useBridgeTransactionModule.default as jest.Mock).mockReturnValue({
       transaction: mockTransaction,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendFlowTransaction.ts
@@ -34,7 +34,7 @@ export function useSendFlowTransaction({
     bridgeError,
     bridgePending,
     setAccount,
-  } = useBridgeTransaction(() => {
+  } = useBridgeTransaction(bridge, () => {
     if (!account) return {};
     return { account, parentAccount: parentAccount ?? undefined };
   });

--- a/apps/ledger-live-mobile/src/screens/FreezeFunds/02-Amount.tsx
+++ b/apps/ledger-live-mobile/src/screens/FreezeFunds/02-Amount.tsx
@@ -73,6 +73,7 @@ export default function FreezeAmount({ navigation, route }: NavigatorProps) {
   const [infoModalOpen, setInfoModalOpen] = useState<boolean>();
 
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    bridge,
     () => {
       const t = bridge.createTransaction(account);
 
@@ -85,7 +86,7 @@ export default function FreezeAmount({ navigation, route }: NavigatorProps) {
     },
   );
 
-  const options = useMemo(
+  const options = useMemo<Array<{ value: TronResource; label: string }>>(
     () => [
       {
         value: "BANDWIDTH",
@@ -169,7 +170,7 @@ export default function FreezeAmount({ navigation, route }: NavigatorProps) {
       if (!transaction) return;
       setTransaction(
         bridge.updateTransaction(transaction, {
-          resource: options[optionIndex].value as TronResource,
+          resource: options[optionIndex].value,
         }),
       );
     },

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -2,13 +2,13 @@ import { isConfirmedOperation } from "@ledgerhq/ledger-wallet-framework/operatio
 import { RecipientRequired } from "@ledgerhq/errors";
 import { Text } from "@ledgerhq/native-ui";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import {
   SyncOneAccountOnMount,
   SyncSkipUnderPriority,
 } from "@ledgerhq/live-common/bridge/react/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
@@ -75,6 +75,7 @@ export default function SendSelectRecipient({ route }: Props) {
     params?.supportedCurrencyIds?.includes(mainAccount.currency.id) || false;
 
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    bridge,
     () => ({
       account,
       parentAccount,
@@ -225,8 +226,6 @@ export default function SendSelectRecipient({ route }: Props) {
 
   if (!account || !transaction) return null;
 
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, mainAccount);
-
   const error = withoutHiddenError(status.errors.recipient);
   const warning = status.warnings.recipient;
   const isSomeIncomingTxPending = account.operations?.some(
@@ -255,6 +254,7 @@ export default function SendSelectRecipient({ route }: Props) {
     !!status.errors.transaction ||
     !!status.errors.sender;
 
+  const stuckAccountAndOperation = getStuckAccountAndOperation(account, mainAccount);
   const extensions = getTokenExtensions(account);
 
   return (

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -5,10 +5,10 @@ import Switch from "~/components/Switch";
 import SafeAreaView from "~/components/SafeAreaView";
 import { Trans, useTranslation } from "~/context/Locale";
 import { useTheme } from "@react-navigation/native";
-import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { AccountLike, Account } from "@ledgerhq/types-live";
+import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { ScreenName } from "~/const";
@@ -64,6 +64,7 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
   const [infoModalOpen, setInfoModalOpen] = useState(false);
 
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    bridge,
     () => ({
       transaction: route.params.transaction,
       account,

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
@@ -1,3 +1,4 @@
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import React, { useState, useCallback, useEffect } from "react";
 import { View, StyleSheet } from "react-native";
@@ -55,7 +56,9 @@ function SendSummary({ navigation, route }: Props) {
 
   invariant(account, "account is missing");
 
-  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction(() => ({
+  const bridge = useAccountBridge(account, parentAccount);
+
+  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction(bridge, () => ({
     transaction: route.params.transaction,
     account,
     parentAccount,

--- a/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
@@ -3,6 +3,7 @@ import React, { memo, useCallback, useMemo } from "react";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import type { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
 import { dependenciesToAppRequests } from "@ledgerhq/live-common/hw/actions/app";
@@ -38,7 +39,8 @@ function ConnectDevice({ navigation, route }: SignTransactionConnectDeviceProps)
   invariant(account, "account is required");
   const { appName, dependencies, onSuccess } = route.params;
   const mainAccount = getMainAccount(account, parentAccount);
-  const { transaction, status } = useBridgeTransaction(() => ({
+  const bridge = useAccountBridge(account, parentAccount);
+  const { transaction, status } = useBridgeTransaction(bridge, () => ({
     account: mainAccount,
     transaction: route.params.transaction,
   }));

--- a/apps/ledger-live-mobile/src/screens/UnfreezeFunds/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/screens/UnfreezeFunds/01-Amount.tsx
@@ -64,6 +64,7 @@ function UnfreezeAmountInner({ account }: InnerProps) {
     [account],
   );
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+    bridge,
     () => {
       const t = bridge.createTransaction(account);
       const transaction = bridge.updateTransaction(t, {
@@ -100,11 +101,11 @@ function UnfreezeAmountInner({ account }: InnerProps) {
     setTransaction(bridge.updateTransaction(transaction, {}));
   }, [bridge, setTransaction, transaction]);
   const onChangeResource = useCallback(
-    (resource: string) => {
+    (resource: TronResource) => {
       if (!transaction) return;
       setTransaction(
         bridge.updateTransaction(transaction, {
-          resource: resource as TronResource,
+          resource,
         }),
       );
     },

--- a/libs/ledger-live-common/src/bridge/useBridgeTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/useBridgeTransaction.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import "../__tests__/test-helpers/dom-polyfill";
+import React from "react";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { genAccount } from "../mock/account";
@@ -13,10 +14,12 @@ import useBridgeTransaction, {
 } from "./useBridgeTransaction";
 import { setSupportedCurrencies } from "../currencies";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import { setEnv } from "@ledgerhq/live-env";
 
 const BTC = getCryptoCurrencyById("bitcoin");
 
 setSupportedCurrencies(["bitcoin"]);
+setEnv("MOCK", "1");
 
 LiveConfig.setConfig({
   config_currency_bitcoin: {
@@ -34,35 +37,55 @@ jest.mock("@ledgerhq/live-config/LiveConfig", () => ({
   },
 }));
 
+// Prevent real network calls from bitcoin's prepareTransaction (getFeeItems).
+jest.mock("../families/bitcoin/bridge/api", () => ({
+  getFeeItems: jest.fn().mockResolvedValue({ items: [], defaultFeePerByte: null }),
+}));
+
+const suspenseWrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(React.Suspense, { fallback: null }, children);
+
 describe("useBridgeTransaction", () => {
   test("initialize with a BTC account settles the transaction", async () => {
     const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-    const { result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })));
+    const bridge = getAccountBridge(mainAccount);
+    let result: ReturnType<typeof renderHook<ReturnType<typeof useBridgeTransaction>, void>>["result"];
+    await act(async () => {
+      ({ result } = renderHook(
+        () => useBridgeTransaction(bridge, () => ({ account: mainAccount })),
+        { wrapper: suspenseWrapper },
+      ));
+    });
 
     await waitFor(
       () => {
-        expect(result.current.bridgePending).toBeFalsy();
-        expect(result.current.bridgeError).toBeFalsy();
-        expect(result.current.transaction).not.toBeFalsy();
-        expect(result.current.account).not.toBeFalsy();
+        expect(result!.current.bridgePending).toBeFalsy();
+        expect(result!.current.bridgeError).toBeFalsy();
+        expect(result!.current.transaction).not.toBeFalsy();
+        expect(result!.current.account).not.toBeFalsy();
       },
       { timeout: 10000 },
     );
-  });
+  }, 30000);
 
   test("bridgeError go through", async () => {
     const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-    const { result } = renderHook(() =>
-      useBridgeTransaction(() => {
-        const bridge = getAccountBridge(mainAccount);
-        const transaction = bridge.updateTransaction(bridge.createTransaction(mainAccount), {
-          recipient: "criticalcrash",
-        });
-        return { account: mainAccount, transaction };
-      }),
-    );
-    await waitFor(() => expect(result.current.bridgeError).not.toBeFalsy());
-  });
+    const bridge = getAccountBridge(mainAccount);
+    let result: ReturnType<typeof renderHook<ReturnType<typeof useBridgeTransaction>, void>>["result"];
+    await act(async () => {
+      ({ result } = renderHook(
+        () =>
+          useBridgeTransaction(bridge, () => {
+            const transaction = bridge.updateTransaction(bridge.createTransaction(mainAccount), {
+              recipient: "criticalcrash",
+            });
+            return { account: mainAccount, transaction };
+          }),
+        { wrapper: suspenseWrapper },
+      ));
+    });
+    await waitFor(() => expect(result!.current.bridgeError).not.toBeFalsy(), { timeout: 10000 });
+  }, 30000);
 
   test("bridgeError can be caught with globalOnBridgeError", async () => {
     const before = getGlobalOnBridgeError();
@@ -70,22 +93,26 @@ describe("useBridgeTransaction", () => {
       const errors: Array<any> = [];
       setGlobalOnBridgeError(error => errors.push(error));
       const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-      renderHook(() =>
-        useBridgeTransaction(() => {
-          const bridge = getAccountBridge(mainAccount);
-          const transaction = bridge.updateTransaction(bridge.createTransaction(mainAccount), {
-            recipient: "criticalcrash",
-          });
-          return { account: mainAccount, transaction };
-        }),
-      );
+      const bridge = getAccountBridge(mainAccount);
+      await act(async () => {
+        renderHook(
+          () =>
+            useBridgeTransaction(bridge, () => {
+              const transaction = bridge.updateTransaction(bridge.createTransaction(mainAccount), {
+                recipient: "criticalcrash",
+              });
+              return { account: mainAccount, transaction };
+            }),
+          { wrapper: suspenseWrapper },
+        );
+      });
 
-      await waitFor(() => expect(errors.length).toBe(1));
+      await waitFor(() => expect(errors.length).toBe(1), { timeout: 10000 });
       expect(errors[0]).toMatchObject(new Error("isInvalidRecipient_mock_criticalcrash"));
     } finally {
       setGlobalOnBridgeError(before);
     }
-  });
+  }, 30000);
 
   describe("shouldSyncBeforeTx", () => {
     const mockCurrency = { id: "btc" } as any;
@@ -146,49 +173,70 @@ describe("useBridgeTransaction", () => {
   describe("updateAccount", () => {
     test("updates account reference without resetting the transaction", async () => {
       const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-      const { result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })));
+      const bridge = getAccountBridge(mainAccount);
+      let result: ReturnType<typeof renderHook<ReturnType<typeof useBridgeTransaction>, void>>["result"];
+      await act(async () => {
+        ({ result } = renderHook(
+          () => useBridgeTransaction(bridge, () => ({ account: mainAccount })),
+          { wrapper: suspenseWrapper },
+        ));
+      });
 
-      await waitFor(() => expect(result.current.transaction).not.toBeFalsy(), { timeout: 10000 });
+      await waitFor(() => expect(result!.current.transaction).not.toBeFalsy(), { timeout: 10000 });
 
-      const transactionBefore = result.current.transaction;
+      const transactionBefore = result!.current.transaction;
 
       const updatedAccount = { ...mainAccount, blockHeight: (mainAccount.blockHeight ?? 0) + 1 };
       act(() => {
-        result.current.updateAccount(updatedAccount);
+        result!.current.updateAccount(updatedAccount);
       });
 
-      expect(result.current.account).toBe(updatedAccount);
-      expect(result.current.account).not.toBe(mainAccount);
+      expect(result!.current.account).toBe(updatedAccount);
+      expect(result!.current.account).not.toBe(mainAccount);
       // transaction must not be reset
-      expect(result.current.transaction).toBe(transactionBefore);
-    });
+      expect(result!.current.transaction).toBe(transactionBefore);
+    }, 30000);
 
     test("is a no-op when the account id does not match", async () => {
       const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-      const { result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })));
+      const bridge = getAccountBridge(mainAccount);
+      let result: ReturnType<typeof renderHook<ReturnType<typeof useBridgeTransaction>, void>>["result"];
+      await act(async () => {
+        ({ result } = renderHook(
+          () => useBridgeTransaction(bridge, () => ({ account: mainAccount })),
+          { wrapper: suspenseWrapper },
+        ));
+      });
 
-      await waitFor(() => expect(result.current.account).not.toBeFalsy(), { timeout: 10000 });
+      await waitFor(() => expect(result!.current.account).not.toBeFalsy(), { timeout: 10000 });
 
       const differentAccount = genAccount("mocked-account-2", { currency: BTC });
       act(() => {
-        result.current.updateAccount(differentAccount);
+        result!.current.updateAccount(differentAccount);
       });
 
-      expect(result.current.account).toBe(mainAccount);
-    });
+      expect(result!.current.account).toBe(mainAccount);
+    }, 30000);
 
     test("is a no-op when the account reference is identical", async () => {
       const mainAccount = genAccount("mocked-account-1", { currency: BTC });
-      const { result } = renderHook(() => useBridgeTransaction(() => ({ account: mainAccount })));
-
-      await waitFor(() => expect(result.current.account).not.toBeFalsy(), { timeout: 10000 });
-
-      const accountBefore = result.current.account;
-      act(() => {
-        result.current.updateAccount(mainAccount);
+      const bridge = getAccountBridge(mainAccount);
+      let result: ReturnType<typeof renderHook<ReturnType<typeof useBridgeTransaction>, void>>["result"];
+      await act(async () => {
+        ({ result } = renderHook(
+          () => useBridgeTransaction(bridge, () => ({ account: mainAccount })),
+          { wrapper: suspenseWrapper },
+        ));
       });
 
-      expect(result.current.account).toBe(accountBefore);
-    });
+      await waitFor(() => expect(result!.current.account).not.toBeFalsy(), { timeout: 10000 });
+
+      const accountBefore = result!.current.account;
+      act(() => {
+        result!.current.updateAccount(mainAccount);
+      });
+
+      expect(result!.current.account).toBe(accountBefore);
+    }, 30000);
   });
 });

--- a/libs/ledger-live-common/src/bridge/useBridgeTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/useBridgeTransaction.ts
@@ -27,7 +27,7 @@ export type Result<T extends Transaction = Transaction> = {
   updateTransaction: (updater: (arg0: T) => T) => void;
   account: AccountLike | null | undefined;
   parentAccount: Account | null | undefined;
-  setAccount: (arg0: AccountLike, arg1: Account | null | undefined) => void;
+  setAccount: (arg0: AccountLike, arg1: Account | null | undefined) => Promise<void>;
   updateAccount: (account: AccountLike) => void;
   status: TransactionStatus;
   bridgeError: Error | null | undefined;
@@ -39,6 +39,7 @@ type Actions<T extends Transaction = Transaction> =
       type: "setAccount";
       account: AccountLike;
       parentAccount: Account | null | undefined;
+      bridge: AccountBridge<any>;
     }
   | {
       type: "setTransaction";
@@ -107,6 +108,7 @@ export const shouldSyncBeforeTx = (currency: CryptoCurrency): boolean => {
 
 const makeInit =
   <T extends Transaction = Transaction>(
+    bridge: AccountBridge<any> | null | undefined,
     optionalInit: (() => Partial<State<T>>) | null | undefined,
   ) =>
   (): State<T> => {
@@ -116,11 +118,12 @@ const makeInit =
       const patch = optionalInit();
       const { account, parentAccount, transaction } = patch;
 
-      if (account) {
+      if (account && bridge) {
         s = (reducer as Reducer<T>)(s, {
           type: "setAccount",
           account,
           parentAccount,
+          bridge,
         });
       }
 
@@ -141,11 +144,10 @@ const reducer = <T extends Transaction = Transaction>(
 ): State<T> => {
   switch (action.type) {
     case "setAccount": {
-      const { account, parentAccount } = action;
+      const { account, parentAccount, bridge } = action;
 
       try {
         const mainAccount = getMainAccount(account, parentAccount);
-        const bridge = getAccountBridge(account, parentAccount) as AccountBridge<T>;
         const subAccountId = account.type !== "Account" && account.id;
         let t = bridge.createTransaction(mainAccount);
 
@@ -234,6 +236,7 @@ const ERROR_RETRY_DELAY_MULTIPLIER = 1.5;
 const DEBOUNCE_STATUS_DELAY = 300;
 
 const useBridgeTransaction = <T extends Transaction = Transaction>(
+  bridge: AccountBridge<any> | null | undefined,
   optionalInit?: (() => Partial<State<T>>) | null | undefined,
 ): Result<T> => {
   const [
@@ -249,14 +252,18 @@ const useBridgeTransaction = <T extends Transaction = Transaction>(
       errorStatus,
     },
     dispatch,
-  ] = useReducer(reducer as Reducer<T>, undefined, makeInit<T>(optionalInit));
+  ] = useReducer(reducer as Reducer<T>, undefined, makeInit(bridge, optionalInit));
+
   const setAccount = useCallback(
-    (account, parentAccount) =>
+    async (account, parentAccount) => {
+      const bridge = await getAccountBridge(account, parentAccount);
       dispatch({
         type: "setAccount",
         account,
         parentAccount,
-      }),
+        bridge,
+      });
+    },
     [dispatch],
   );
 

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useFromState.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useFromState.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import "../../../__tests__/test-helpers/dom-polyfill";
+import React from "react";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { Account } from "@ledgerhq/types-live";
 import { renderHook, act } from "@testing-library/react";
@@ -12,9 +13,11 @@ import { genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account
 import { genAccount } from "../../../mock/account";
 import { useFromState } from "./useFromState";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import { setSupportedCurrencies } from "../../../currencies";
 
 const BTC = getCryptoCurrencyById("bitcoin");
 const ETH = getCryptoCurrencyById("ethereum");
+setSupportedCurrencies(["bitcoin", "ethereum"]);
 LiveConfig.setConfig({
   config_currency_bitcoin: {
     type: "object",
@@ -55,28 +58,40 @@ const mockedAccounts: Account[] = [
 const mockedTokenAccount = genTokenAccount(1, mockedAccounts[1], USDT);
 const allAccounts = [...mockedAccounts, mockedTokenAccount] as Account[];
 
+const suspenseWrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(React.Suspense, { fallback: null }, children);
+
+// Settle useBridgeTransaction's async init inside a Suspense boundary.
+// Four microtask ticks: one for the async makeInit return, three for React Suspense wakeUp.
+async function initHook<T>(fn: () => T) {
+  let result!: { current: T };
+  await act(async () => {
+    ({ result } = renderHook(fn, { wrapper: suspenseWrapper }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return result;
+}
+
 describe("useFromState", () => {
-  test("call hook without arguments", () => {
-    const { result } = renderHook(() => {
-      const bridgeTransaction = useBridgeTransaction();
-      return useFromState({
-        bridgeTransaction,
-      });
+  test("call hook without arguments", async () => {
+    const result = await initHook(() => {
+      const bridgeTransaction = useBridgeTransaction(null);
+      return useFromState({ bridgeTransaction });
     });
     expect(result.current).toMatchObject({
       fromState: selectorStateDefaultValues,
     });
   });
 
-  test("call hook with default currency", () => {
+  test("call hook with default currency", async () => {
     const defaultCurrency = BTC;
 
-    const { result } = renderHook(() => {
-      const bridgeTransaction = useBridgeTransaction();
-      return useFromState({
-        defaultCurrency,
-        bridgeTransaction,
-      });
+    const result = await initHook(() => {
+      const bridgeTransaction = useBridgeTransaction(null);
+      return useFromState({ defaultCurrency, bridgeTransaction });
     });
     expect(result.current).toMatchObject({
       fromState: {
@@ -86,17 +101,13 @@ describe("useFromState", () => {
     });
   });
 
-  test("call hook with default accounts", () => {
+  test("call hook with default accounts", async () => {
     const defaultAccount = mockedTokenAccount;
     const defaultParentAccount = mockedAccounts[1];
 
-    const { result } = renderHook(() => {
-      const bridgeTransaction = useBridgeTransaction();
-      return useFromState({
-        defaultAccount,
-        defaultParentAccount,
-        bridgeTransaction,
-      });
+    const result = await initHook(() => {
+      const bridgeTransaction = useBridgeTransaction(null);
+      return useFromState({ defaultAccount, defaultParentAccount, bridgeTransaction });
     });
     expect(result.current).toMatchObject({
       fromState: {
@@ -107,14 +118,11 @@ describe("useFromState", () => {
     });
   });
 
-  test("call hook and set the account and all the related properties", () => {
-    const { result } = renderHook(() => {
-      const bridgeTransaction = useBridgeTransaction();
+  test("call hook and set the account and all the related properties", async () => {
+    const result = await initHook(() => {
+      const bridgeTransaction = useBridgeTransaction(null);
       return {
-        ...useFromState({
-          accounts: allAccounts,
-          bridgeTransaction,
-        }),
+        ...useFromState({ accounts: allAccounts, bridgeTransaction }),
         bridgeTransaction,
       };
     });
@@ -123,8 +131,11 @@ describe("useFromState", () => {
       fromState: selectorStateDefaultValues,
     });
 
-    act(() => {
+    // setAccount is async (awaits getAccountBridge); use await act to flush the microtask.
+    await act(async () => {
       result.current.setFromAccount(mockedTokenAccount);
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
     expect(result.current).toMatchObject({
@@ -142,13 +153,10 @@ describe("useFromState", () => {
     });
   });
 
-  test("call hook and set the amount after 400ms", () => {
-    const { result } = renderHook(() => {
-      const bridgeTransaction = useBridgeTransaction();
-      return useFromState({
-        accounts: allAccounts,
-        bridgeTransaction,
-      });
+  test("call hook and set the amount after 400ms", async () => {
+    const result = await initHook(() => {
+      const bridgeTransaction = useBridgeTransaction(null);
+      return useFromState({ accounts: allAccounts, bridgeTransaction });
     });
 
     expect(result.current).toMatchObject({
@@ -178,13 +186,10 @@ describe("useFromState", () => {
     });
   });
 
-  test("call hook and set the the most recent amount input after 400ms", () => {
-    const { result } = renderHook(() => {
-      const bridgeTransaction = useBridgeTransaction();
-      return useFromState({
-        accounts: allAccounts,
-        bridgeTransaction,
-      });
+  test("call hook and set the the most recent amount input after 400ms", async () => {
+    const result = await initHook(() => {
+      const bridgeTransaction = useBridgeTransaction(null);
+      return useFromState({ accounts: allAccounts, bridgeTransaction });
     });
 
     expect(result.current).toMatchObject({

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -10,6 +10,7 @@ import {
 import { Account } from "@ledgerhq/types-live";
 import { useEffect, useMemo, useState } from "react";
 import useBridgeTransaction, { Result } from "../../../bridge/useBridgeTransaction";
+import { useAccountBridgeOrNull } from "../../../bridge/useAccountBridge";
 import { Transaction } from "../../../coin-modules/transaction-types";
 import {
   ExchangeRate,
@@ -127,7 +128,8 @@ export const useSwapTransaction = ({
   isEnabled,
   sponsored,
 }: UseSwapTransactionProps): SwapTransactionType => {
-  const bridgeTransaction = useBridgeTransaction(() => ({
+  const bridge = useAccountBridgeOrNull(defaultAccount ?? null, defaultParentAccount);
+  const bridgeTransaction = useBridgeTransaction(bridge, () => ({
     account: defaultAccount,
     parentAccount: defaultParentAccount,
   }));


### PR DESCRIPTION
These must land first:
- [x] https://github.com/LedgerHQ/ledger-live/pull/17109
- [x] https://github.com/LedgerHQ/ledger-live/pull/17110

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Unit tests updated for `useBridgeTransaction` and `useFromState`.
- [x] **Impact of the changes:**
  - refactoring of `useBridgeTransaction` signature. ~107 call-sites in desktop and mobile updated — no behaviour change visible to users.

### 📝 Description

**`useBridgeTransaction`** now takes `bridge` as an explicit first argument and initialises state synchronously via `useReducer`'s lazy initialiser. This allows to be future proof and compliant to `getAccountBridge` becoming asynchronous soon.

Consumer migration:

```diff
- const { transaction } = useBridgeTransaction(() => ({ account, parentAccount }));
+ const bridge = useAccountBridge(account, parentAccount);
+ const { transaction } = useBridgeTransaction(bridge, () => ({ account, parentAccount }));
```

### ❓ Context

- **JIRA or GitHub link**: LIVE-29193
- **ADR link (if any)**: N/A