### PR TITLE
ci(wallet-cli): remove redundant setup-bun step

### DIFF
--- a/.github/workflows/build-wallet-cli-reusable.yml
+++ b/.github/workflows/build-wallet-cli-reusable.yml
@@ -52,11 +52,6 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
-        with:
-          bun-version: "1.3.11"
-
       - name: Install dependencies
         run: pnpm i --filter "@ledgerhq/wallet-cli..." --filter "ledger-live"
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** CI-only change, no code logic affected.
- [x] **Impact of the changes:** No functional impact — removes a redundant step.

### 📝 Description

`mise.toml` defines `bun = '1.3.11'`, and the `setup-caches` step already runs `jdx/mise-action` with `use-mise: true`, which calls `mise install` and makes Bun available. The explicit `oven-sh/setup-bun` step was therefore installing Bun a second time unnecessarily.

A test PR (#16744) has been opened targeting this branch to verify the wallet-cli build still passes without the explicit `setup-bun` step.

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A
- **Test PR**: #16744