### PR TITLE
test(wallet-cli): verify bun available via mise (DO NOT MERGE)

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -123,7 +123,7 @@ jobs:
     name: "Build Wallet CLI"
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'wallet-cli') && !github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/build-wallet-cli-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/build-wallet-cli-reusable.yml@test/wallet-cli-bun-via-mise
     secrets: inherit
 
   test-additional:

--- a/.github/workflows/build-wallet-cli-reusable.yml
+++ b/.github/workflows/build-wallet-cli-reusable.yml
@@ -52,11 +52,6 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
-        with:
-          bun-version: "1.3.11"
-
       - name: Install dependencies
         run: pnpm i --filter "@ledgerhq/wallet-cli..." --filter "ledger-live"
 

--- a/.github/workflows/build-wallet-cli-reusable.yml
+++ b/.github/workflows/build-wallet-cli-reusable.yml
@@ -39,7 +39,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@fix/remove-redundant-setup-bun-wallet-cli
         id: setup-caches
         with:
           use-mise: true

--- a/apps/wallet-cli/bunfig.toml
+++ b/apps/wallet-cli/bunfig.toml
@@ -3,3 +3,4 @@
 [test]
 coverageReporter = ["lcov"]
 coverageDir = "coverage"
+# test: bun available via mise (no explicit setup-bun step)


### PR DESCRIPTION
### 📝 Description

Testing branch only — do not merge.

Pins `setup-caches` to the current `develop` SHA to verify that removing the explicit `oven-sh/setup-bun` step still works, since bun is already installed by mise.

Targets #16739 rather than `develop` to bypass the workflow files sync check.

### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** This IS the test.
- [x] **Impact of the changes:** Testing only, no functional change.

### ❓ Context

- **Related PR**: #16739