### PR TITLE
[LWDM] feat(live-common): add useAccountBridge suspend-ready hook

### DIFF
--- a/.changeset/async-useaccountbridge.md
+++ b/.changeset/async-useaccountbridge.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add `useAccountBridge` hook as a suspend-compatible replacement for `getAccountBridge` in components                                         

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/steps/StepAsset.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/steps/StepAsset.tsx
@@ -3,7 +3,8 @@ import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/algorand/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -20,7 +21,7 @@ export default function StepAsset({
   t,
 }: StepProps) {
   invariant(account && transaction, "account and transaction required");
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const onUpdateAsset = useCallback(
     (t?: TokenCurrency | null) => {
       // NOTE: to match the signature of AsaSelector, i had to change a bit the function

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/steps/Amount.tsx
@@ -2,9 +2,9 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps } from "../types";
-import { AptosMappedStakingPosition } from "@ledgerhq/live-common/families/aptos/types";
+import { AptosMappedStakingPosition, Transaction } from "@ledgerhq/live-common/families/aptos/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -26,7 +26,7 @@ export default function StepAmount({
   const validators = useAptosValidators(account.currency);
 
   const [staked, setStaked] = useState(transaction.amount);
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const updateValidator = useCallback(
     ({ address, amount }: { address: string; amount: BigNumber }) => {

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/steps/Amount.tsx
@@ -2,9 +2,9 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps } from "../types";
-import { AptosMappedStakingPosition } from "@ledgerhq/live-common/families/aptos/types";
+import { AptosMappedStakingPosition, Transaction } from "@ledgerhq/live-common/families/aptos/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -26,7 +26,7 @@ export default function StepAmount({
   const validators = useAptosValidators(account.currency);
 
   const [staked, setStaked] = useState(transaction.amount);
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const updateValidator = useCallback(
     ({ address, amount }: { address: string; amount: BigNumber }) => {

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/steps/Amount.tsx
@@ -2,9 +2,9 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps } from "../types";
-import { AptosMappedStakingPosition } from "@ledgerhq/live-common/families/aptos/types";
+import { AptosMappedStakingPosition, Transaction } from "@ledgerhq/live-common/families/aptos/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -20,7 +20,7 @@ export default function StepAmount({
   error,
 }: Readonly<StepProps>) {
   const [available, setAvailable] = useState(transaction.amount);
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const updateValidator = useCallback(
     ({ address, amount }: { address: string; amount: BigNumber }) => {

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/CoinControlModal.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/CoinControlModal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getUTXOStatus } from "@ledgerhq/live-common/families/bitcoin/logic";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Button from "~/renderer/components/Button";
@@ -26,7 +26,7 @@ type Props = {
   onClose: () => void;
   account: Account;
   transaction: Transaction;
-  onChange: (a: (t: Transaction, p: Partial<Transaction>) => void) => void;
+  onChange: (a: Transaction) => void;
   updateTransaction: (updater: (t: Transaction) => Transaction) => void;
   status: TransactionStatus;
 };
@@ -48,13 +48,13 @@ const CoinControlModal = ({
   const onClickLink = useCallback(() => openURL(urls.coinControl), []);
 
   const unit = useAccountUnit(account);
+  const bridge = useAccountBridge<Transaction>(account);
   if (!account.bitcoinResources) return null;
   const { bitcoinResources } = account;
   const { utxoStrategy } = transaction;
   const totalExcludedUTXOS = account.bitcoinResources?.utxos
     .map(u => getUTXOStatus(u, utxoStrategy))
     .filter(({ excluded }) => excluded).length;
-  const bridge = getAccountBridge(account);
   const errorKeys = Object.keys(status.errors);
   const error = errorKeys.length ? status.errors[errorKeys[0]] : null;
   const returning = (status.txOutputs || []).find(output => !!output.isChange);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/FeesField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/FeesField.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { Trans } from "react-i18next";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/bitcoin/types";
 import { Account } from "@ledgerhq/types-live";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import InputCurrency from "~/renderer/components/InputCurrency";
 import Box from "~/renderer/components/Box";
 import Label from "~/renderer/components/Label";
@@ -24,7 +24,7 @@ const InputRight = styled(Box).attrs(() => ({
 }))``;
 export const FeesField = ({ transaction, account, onChange, status }: Props) => {
   invariant(transaction.family === "bitcoin", "FeeField: bitcoin family expected");
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const { feePerByte, networkInfo } = transaction;
   const inputRef = useRef<HTMLInputElement | null>(null);
   const { units } = account.currency;

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/PickingStrategy.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/PickingStrategy.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Trans } from "react-i18next";
 import { bitcoinPickingStrategy, Transaction } from "@ledgerhq/live-common/families/bitcoin/types";
 import { Account } from "@ledgerhq/types-live";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
 import Select from "~/renderer/components/Select";
@@ -10,10 +10,10 @@ import useBitcoinPickingStrategy from "./useBitcoinPickingStrategy";
 type Props = {
   account: Account;
   transaction: Transaction;
-  onChange: (a: (t: Transaction, p: Partial<Transaction>) => void) => void;
+  onChange: (a: Transaction) => void;
 };
 export const PickingStrategy = ({ transaction, account, onChange }: Props) => {
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const { item, options } = useBitcoinPickingStrategy(transaction.utxoStrategy.strategy);
   return (
     <Box flow={2} horizontal alignItems="center" justifyContent="space-between">

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendAmountFields.tsx
@@ -1,4 +1,4 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useFeesStrategy } from "@ledgerhq/live-common/families/bitcoin/react";
 import { Transaction } from "@ledgerhq/live-common/families/bitcoin/types";
 import React, { useCallback, useState } from "react";
@@ -33,7 +33,7 @@ const Fields: Props = ({
   mapStrategies,
   trackProperties = {},
 }) => {
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const { t } = useTranslation();
   const [coinControlOpened, setCoinControlOpened] = useState(false);
   const [isAdvanceMode, setAdvanceMode] = useState(
@@ -55,7 +55,7 @@ const Fields: Props = ({
       updateTransaction((transaction: Transaction) =>
         bridge.updateTransaction(transaction, {
           feePerByte: amount,
-          feesStrategy,
+          feesStrategy: feesStrategy as Transaction["feesStrategy"],
         }),
       );
     },
@@ -124,7 +124,6 @@ const Fields: Props = ({
             <CoinControlModal
               transaction={transaction}
               account={account}
-              // @ts-expect-error We use the same onChangeTrack function on 2 components yet their onChange signature is different, please halp
               onChange={onChangeAndTrack}
               status={status}
               isOpened={coinControlOpened}

--- a/apps/ledger-live-desktop/src/renderer/families/canton/CommentField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/CommentField.tsx
@@ -1,4 +1,4 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/canton/types";
 import { Account } from "@ledgerhq/types-live";
 import invariant from "invariant";
@@ -23,7 +23,7 @@ const CommentField = ({
 
   const { t } = useTranslation();
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const onCommentFieldChange = useCallback(
     (value: string) => {

--- a/apps/ledger-live-desktop/src/renderer/families/canton/ExpiryDurationField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/ExpiryDurationField.tsx
@@ -1,4 +1,4 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/canton/types";
 import { DurationEnum } from "@ledgerhq/coin-canton/types";
 import { Account } from "@ledgerhq/types-live";
@@ -33,7 +33,7 @@ const ExpiryDurationField = ({
   status: TransactionStatus;
 }) => {
   const { t } = useTranslation();
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const options: DurationOption[] = useMemo(
     () => [

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/SendRecipientFields/MemoValueField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/SendRecipientFields/MemoValueField.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import {
   CardanoAccount,
@@ -25,7 +25,7 @@ const MemoValueField = ({
   autoFocus?: boolean;
 }) => {
   invariant(transaction.family === "cardano", "Memo: cardano family expected");
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const onMemoValueChange = useCallback(
     (memo: string) => {
       track("button_clicked2", {

--- a/apps/ledger-live-desktop/src/renderer/families/casper/MemoField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/MemoField.tsx
@@ -1,16 +1,17 @@
 import React, { useCallback } from "react";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import { useTranslation } from "react-i18next";
 import MemoTagField from "LLD/features/MemoTag/components/MemoTagField";
 import { MemoTagFieldProps } from "./types";
+import type { Transaction } from "@ledgerhq/live-common/families/casper/types";
 
 const MemoField = ({ onChange, account, transaction, status, autoFocus }: MemoTagFieldProps) => {
   invariant(transaction.family === "casper", "TransferIdField: casper family expected");
 
   const { t } = useTranslation();
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const onTransferIdFieldChange = useCallback(
     (value: string) => {

--- a/apps/ledger-live-desktop/src/renderer/families/casper/TransferIdField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/TransferIdField.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import Input from "~/renderer/components/Input";
 import invariant from "invariant";
 import type { Account } from "@ledgerhq/types-live";
@@ -21,7 +21,7 @@ const TranferIdField = ({
 
   const { t } = useTranslation();
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const onTransferIdFieldChange = useCallback(
     (value: string) => {

--- a/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/steps/StepVote.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/steps/StepVote.tsx
@@ -1,7 +1,8 @@
 import invariant from "invariant";
 import React, { useCallback, useMemo } from "react";
 import { Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/celo/types";
 import {
   activatableVotes,
   fallbackValidatorGroup,
@@ -57,7 +58,7 @@ const StepVote = ({
     account && transaction && account.celoResources && account.celoResources.votes,
     "account with votes and transaction required",
   );
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const unit = useAccountUnit(account);
 
   const onChange = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/fields/AmountField.tsx
@@ -3,7 +3,7 @@ import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { TFunction } from "i18next";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   CeloAccount,
   Transaction,
@@ -34,7 +34,7 @@ const AmountField = ({
   status,
 }: Props) => {
   invariant(account && transaction && account.spendableBalance, "account and transaction required");
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {

--- a/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/fields/AmountField.tsx
@@ -3,7 +3,7 @@ import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { TFunction } from "i18next";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import SpendableAmount from "~/renderer/components/SpendableAmount";
 import Label from "~/renderer/components/Label";
 import Box from "~/renderer/components/Box";
@@ -35,7 +35,7 @@ const AmountField = ({
   status,
 }: Props) => {
   invariant(account && transaction && account.spendableBalance, "account and transaction required");
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {

--- a/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/steps/StepVote.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/steps/StepVote.tsx
@@ -1,4 +1,5 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/celo/types";
 import invariant from "invariant";
 import React, { useCallback, useMemo } from "react";
 import { Trans } from "react-i18next";
@@ -57,7 +58,7 @@ const StepVote = ({
     "celo account, resources and transaction required",
   );
   const unit = useAccountUnit(account);
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const onChange = useCallback(
     (recipient: string, index: number) => {
       onChangeTransaction(

--- a/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/fields/AmountField.tsx
@@ -1,4 +1,4 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   CeloAccount,
   Transaction,
@@ -35,7 +35,7 @@ const AmountField = ({
   status,
 }: Props) => {
   invariant(account && transaction && account.spendableBalance, "account and transaction required");
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {

--- a/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/steps/StepAmount.tsx
@@ -1,7 +1,8 @@
 import invariant from "invariant";
 import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/celo/types";
 import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -68,7 +69,7 @@ const StepAmount = ({
   );
 
   const unit = useAccountUnit(account);
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const onChange = useCallback(
     (index: number) => {
       onChangeTransaction(

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/SendRecipientFields/components/MemoField/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/SendRecipientFields/components/MemoField/index.tsx
@@ -1,5 +1,5 @@
 import { MAX_MEMO_LENGTH } from "@ledgerhq/coin-concordium/constants";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/concordium/types";
 import { Account } from "@ledgerhq/types-live";
 import MemoTagField from "LLD/features/MemoTag/components/MemoTagField";
@@ -23,7 +23,7 @@ const MemoField = ({
   trackProperties = {},
   autoFocus,
 }: Props) => {
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const onMemoChange = useCallback(
     (memo: string) => {

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.tsx
@@ -3,7 +3,8 @@ import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/cosmos/types";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -32,11 +33,13 @@ export default function StepClaimRewards({
 }: StepProps) {
   const locale = useSelector(localeSelector);
   invariant(account && account.cosmosResources && transaction, "account and transaction required");
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const unit = useAccountUnit(account);
   const updateClaimRewards = useCallback(
     (newTransaction: Partial<CosmosLikeTransaction>) => {
-      onUpdateTransaction(transaction => bridge.updateTransaction(transaction, newTransaction));
+      onUpdateTransaction(transaction =>
+        bridge.updateTransaction(transaction, newTransaction as Partial<Transaction>),
+      );
     },
     [bridge, onUpdateTransaction],
   );

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/MemoValueField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/MemoValueField.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import {
   CosmosAccount,
@@ -21,7 +21,7 @@ const MemoValueField = ({
   autoFocus?: boolean;
 }) => {
   invariant(transaction.family === "cosmos", "MemoTypeField: cosmos family expected");
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const onMemoValueChange = useCallback(
     (memo: string) => {
       onChange(

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/steps/StepDestinationValidators.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/steps/StepDestinationValidators.tsx
@@ -2,7 +2,7 @@ import invariant from "invariant";
 import React, { useCallback } from "react";
 import { BigNumber } from "bignumber.js";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import ValidatorField from "../fields/ValidatorField";
 import { Transaction } from "@ledgerhq/live-common/families/cosmos/types";
 export default function StepValidators({
@@ -13,7 +13,7 @@ export default function StepValidators({
   transitionTo,
 }: StepProps) {
   invariant(account && account.cosmosResources && transaction, "account and transaction required");
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const updateRedelegation = useCallback(
     (newTransaction: Partial<Transaction>) => {
       onUpdateTransaction(transaction => bridge.updateTransaction(transaction, newTransaction));

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/steps/StepValidators.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/steps/StepValidators.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { Trans } from "react-i18next";
 import { BigNumber } from "bignumber.js";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useCosmosFamilyPreloadData } from "@ledgerhq/live-common/families/cosmos/react";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
@@ -20,7 +20,7 @@ import CosmosFamilyLedgerValidatorIcon from "~/renderer/families/cosmos/shared/c
 import Text from "~/renderer/components/Text";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import cryptoFactory from "@ledgerhq/coin-cosmos/chain/chain";
-import { CosmosMappedDelegation } from "@ledgerhq/live-common/families/cosmos/types";
+import { CosmosMappedDelegation, Transaction } from "@ledgerhq/live-common/families/cosmos/types";
 
 const SelectButton = styled(Base)`
   border-radius: 4px;
@@ -61,7 +61,7 @@ export default function StepValidators({
   transitionTo,
 }: StepProps) {
   invariant(account && account.cosmosResources && transaction, "account and transaction required");
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const sourceValidator = useMemo(() => {
     const found = account.cosmosResources?.delegations.find(
       d => d.validatorAddress === transaction.sourceValidator,

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Amount.tsx
@@ -2,11 +2,12 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback, useMemo } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps } from "../types";
 import {
   CosmosDelegationInfo,
   CosmosMappedDelegation,
+  Transaction,
 } from "@ledgerhq/live-common/families/cosmos/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
@@ -29,7 +30,7 @@ export default function StepAmount({
   onClose,
 }: StepProps) {
   invariant(account && transaction && transaction.validators, "account and transaction required");
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const updateValidator = useCallback(
     (validatorFields: Partial<CosmosDelegationInfo>) => {
       onUpdateTransaction(tx =>
@@ -43,7 +44,7 @@ export default function StepAmount({
                     ...validatorFields,
                   },
                 ]
-              : [validatorFields],
+              : [validatorFields as CosmosDelegationInfo],
         }),
       );
     },

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/GasPriceField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/GasPriceField.tsx
@@ -1,4 +1,5 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/coin-evm/types/index";
 import { Range, inferDynamicRange } from "@ledgerhq/live-common/range";
 import invariant from "invariant";
 import React, { memo, useCallback } from "react";
@@ -15,7 +16,7 @@ const FeesField: NonNullable<EvmFamily["sendAmountFields"]>["component"] = ({
   updateTransaction,
 }) => {
   invariant(transaction.family === "evm", "GasPriceField: evm family expected");
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const onGasPriceChange = useCallback(
     (gasPrice: BigNumber) => {
       updateTransaction(transaction =>

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/MaxFeeField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/MaxFeeField.tsx
@@ -1,7 +1,6 @@
 import { Transaction } from "@ledgerhq/coin-evm/types/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
-import { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import React, { memo, useCallback, useMemo } from "react";
@@ -53,7 +52,7 @@ const FeesField: NonNullable<EvmFamily["sendAmountFields"]>["component"] = ({
   invariant(transaction.family === "evm", "MaxFeeField: evm family expected");
   invariant(transaction.type === 2, "MaxFeeField: transaction should be of type 2 (EIP1559)");
 
-  const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const { t } = useTranslation();
 
   const onMaxFeeChange = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/PriorityFeeField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/PriorityFeeField.tsx
@@ -1,7 +1,6 @@
 import { Strategy, Transaction } from "@ledgerhq/coin-evm/types/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
-import { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import React, { memo, useCallback, useMemo } from "react";
@@ -55,7 +54,7 @@ const FeesField: NonNullable<EvmFamily["sendAmountFields"]>["component"] = ({
   invariant(transaction.family === "evm", "PriorityFeeField: evm family expected");
   invariant(transaction.type === 2, "PriorityFeeField: transaction should be of type 2 (EIP1559)");
 
-  const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const { t } = useTranslation();
 
   const onPriorityFeeChange = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/index.tsx
@@ -1,8 +1,7 @@
 import { Transaction as EvmTransaction, Strategy } from "@ledgerhq/coin-evm/types/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useGasOptions } from "@ledgerhq/live-common/families/evm/react";
 import { log } from "@ledgerhq/logs";
-import { AccountBridge } from "@ledgerhq/types-live";
 import React, { useCallback, useEffect, useState } from "react";
 import SendFeeMode from "~/renderer/components/SendFeeMode";
 import Spinner from "~/renderer/components/Spinner";
@@ -15,7 +14,7 @@ import SelectFeeStrategy from "./SelectFeeStrategy";
 
 const Root: NonNullable<EvmFamily["sendAmountFields"]>["component"] = props => {
   const { account, updateTransaction, transaction } = props;
-  const bridge: AccountBridge<EvmTransaction> = getAccountBridge(account);
+  const bridge = useAccountBridge<EvmTransaction>(account);
 
   const [gasOptions, error, loading] = useGasOptions({
     currency: account.currency,

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/MemoField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/MemoField.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { HEDERA_MAX_MEMO_SIZE } from "@ledgerhq/live-common/families/hedera/constants";
+import { Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { track } from "~/renderer/analytics/segment";
 import { SendAmountProps } from "./types";
 import Text from "~/renderer/components/Text";
@@ -16,7 +17,7 @@ const MemoField = ({
   autoFocus,
 }: SendAmountProps) => {
   const [memoLength, setMemoLength] = React.useState(0);
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const onMemoChange = useCallback(
     (memo: string) => {
       track("button_clicked2", {

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/MemoField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/MemoField.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import { Account } from "@ledgerhq/types-live";
 import {
@@ -23,7 +23,7 @@ const MemoField = ({
 }) => {
   invariant(transaction.family === "internet_computer", "Memo: Internet Computer family expected");
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const onMemoFieldChange = useCallback(
     (value: string) => {

--- a/apps/ledger-live-desktop/src/renderer/families/kaspa/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/kaspa/SendAmountFields.tsx
@@ -1,4 +1,4 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useFeesStrategy } from "@ledgerhq/live-common/families/kaspa/react";
 import { Transaction } from "@ledgerhq/live-common/families/kaspa/types";
 import React, { useCallback, useEffect, useState } from "react";
@@ -38,32 +38,30 @@ const Fields: Props = ({
   trackProperties = {},
 }) => {
   const [isAdvanceMode, setAdvanceMode] = useState(!transaction.feesStrategy);
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const strategies = useFeesStrategy(account, transaction);
 
   useEffect(() => {
     updateTransaction((t: Transaction) =>
       bridge.updateTransaction(t, {
-        rbf: true,
         // initially "fast" is selected - set this feerate
-        feerate: strategies.filter(x => x.label === "fast")[0].amount,
+        customFeeRate: strategies.filter(x => x.label === "fast")[0].amount,
       }),
     );
   }, []); // oxlint-disable-line react-hooks/exhaustive-deps
 
   const onFeeStrategyClick = useCallback(
     ({ feesStrategy }: OnClickType) => {
-      updateTransaction(
-        (transaction: Transaction) =>
-          !isAdvanceMode &&
-          bridge.updateTransaction(transaction, {
-            feesStrategy,
-          }),
+      if (isAdvanceMode) return;
+      updateTransaction((transaction: Transaction) =>
+        bridge.updateTransaction(transaction, {
+          feesStrategy: feesStrategy as Transaction["feesStrategy"],
+        }),
       );
     },
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-    [updateTransaction, bridge],
+    [updateTransaction, bridge, isAdvanceMode],
   );
 
   const setAdvanceModeAndTrack = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/families/mina/MemoField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/mina/MemoField.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/mina/types";
@@ -21,7 +21,7 @@ const MemoField = ({
 
   const { t } = useTranslation();
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const onMemoFieldChange = useCallback(
     (value: string) => {

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Claim/steps/StepClaimRewards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Claim/steps/StepClaimRewards.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useCallback } from "react";
 import { Trans } from "react-i18next";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { denominate } from "@ledgerhq/live-common/families/multiversx/helpers";
 import invariant from "invariant";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -32,7 +32,7 @@ const StepClaimRewards = (props: StepProps) => {
     contract,
   } = props;
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const updateClaimRewards = useCallback(
     (newTransaction: Partial<Transaction>) => {
       onUpdateTransaction(transaction => bridge.updateTransaction(transaction, newTransaction));

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Delegate/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Delegate/steps/StepDelegation.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from "react";
 import { Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
@@ -16,7 +16,7 @@ const StepDelegation = (props: StepProps) => {
   invariant(account && transaction, "account and transaction required");
   const { multiversxResources } = account;
   invariant(multiversxResources, "multiversxResources required");
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const onSelectValidator = (recipient: string) =>
     onUpdateTransaction(
       (transaction: Transaction): Transaction =>

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Undelegate/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Undelegate/steps/Amount.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState, Fragment } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { BigNumber } from "bignumber.js";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
@@ -15,14 +15,14 @@ import { Transaction } from "@ledgerhq/live-common/families/multiversx/types";
 import { DelegationType } from "~/renderer/families/multiversx/types";
 import { StepProps } from "../types";
 
-const StepAmount = (props: StepProps) => {
+const StepAmountContent = (props: StepProps) => {
   const { account, onUpdateTransaction, status, error, contract, amount, delegations } = props;
   const [initialAmount, setInitialAmount] = useState(BigNumber(amount));
   const [value, setValue] = useState(BigNumber(amount));
-  const bridge = account && getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const updateValidator = useCallback(
     (payload: Partial<Transaction>) => {
-      onUpdateTransaction(transaction => bridge?.updateTransaction(transaction, payload));
+      onUpdateTransaction(transaction => bridge.updateTransaction(transaction, payload));
     },
     [onUpdateTransaction, bridge],
   );
@@ -52,12 +52,11 @@ const StepAmount = (props: StepProps) => {
       if (transaction.amount.isEqualTo(value)) {
         return transaction;
       }
-      return bridge?.updateTransaction(transaction, {
+      return bridge.updateTransaction(transaction, {
         amount: value,
       });
     });
   }, [bridge, onUpdateTransaction, value]);
-  if (!account) return null;
   return (
     <Box flow={1}>
       <TrackPage
@@ -97,6 +96,10 @@ const StepAmount = (props: StepProps) => {
       </Alert>
     </Box>
   );
+};
+const StepAmount = (props: StepProps) => {
+  if (!props.account) return null;
+  return <StepAmountContent {...props} />;
 };
 const StepAmountFooter = (props: StepProps) => {
   const { transitionTo, account, onClose, status, bridgePending } = props;

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Withdraw/steps/StepWithdraw.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Withdraw/steps/StepWithdraw.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useCallback } from "react";
 import { denominate } from "@ledgerhq/live-common/families/multiversx/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Trans } from "react-i18next";
 import { BigNumber } from "bignumber.js";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -29,7 +29,7 @@ const StepWithdraw = (props: StepProps) => {
     name,
   } = props;
   const unit = useAccountUnit(account);
-  const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const onDelegationChange = useCallback(
     // @ts-expect-error another TS puzzle for another day
     validator => {

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Amount.tsx
@@ -2,9 +2,9 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps } from "../types";
-import { NearMappedStakingPosition } from "@ledgerhq/live-common/families/near/types";
+import { NearMappedStakingPosition, Transaction } from "@ledgerhq/live-common/families/near/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -24,7 +24,7 @@ export default function StepAmount({
   onClose,
 }: StepProps) {
   const [staked, setStaked] = useState(transaction.amount);
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const updateValidator = useCallback(
     ({ address, amount }: { address: string; amount: BigNumber }) => {
       onUpdateTransaction(tx =>

--- a/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/steps/Amount.tsx
@@ -2,9 +2,9 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps } from "../types";
-import { NearMappedStakingPosition } from "@ledgerhq/live-common/families/near/types";
+import { NearMappedStakingPosition, Transaction } from "@ledgerhq/live-common/families/near/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -19,7 +19,7 @@ export default function StepAmount({
   error,
 }: StepProps) {
   const [available, setAvailable] = useState(transaction.amount);
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const updateValidator = useCallback(
     ({ address, amount }: { address: string; amount: BigNumber }) => {
       onUpdateTransaction(tx =>

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/fields/AmountField.tsx
@@ -3,7 +3,7 @@ import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/polkadot/types";
 import SpendableAmount from "~/renderer/components/SpendableAmount";
@@ -42,7 +42,7 @@ const AmountField = ({
   status,
 }: Props) => {
   invariant(account && transaction && account.spendableBalance, "account and transaction required");
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/steps/StepAmount.tsx
@@ -2,7 +2,8 @@ import invariant from "invariant";
 import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { isStash } from "@ledgerhq/live-common/families/polkadot/logic";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/polkadot/types";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { urls } from "~/config/urls";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
@@ -23,7 +24,7 @@ export default function StepAmount({
   error,
 }: StepProps) {
   invariant(account && transaction, "account and transaction required");
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const { rewardDestination } = transaction;
   const setRewardDestination = useCallback(
     (rewardDestination: string) => {

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/steps/StepNomination.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/steps/StepNomination.tsx
@@ -1,14 +1,15 @@
 import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/polkadot/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import ValidatorsField from "../fields/ValidatorsField";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
-export default function StepNomination({
+function StepNominationContent({
   account,
   onUpdateTransaction,
   transaction,
@@ -18,8 +19,8 @@ export default function StepNomination({
   openModal,
   onClose,
   t,
-}: StepProps) {
-  const bridge = account && getAccountBridge(account);
+}: StepProps & { transaction: Transaction }) {
+  const bridge = useAccountBridge<Transaction>(account);
   const onGoToChill = useCallback(() => {
     onClose();
     openModal("MODAL_POLKADOT_SIMPLE_OPERATION", {
@@ -30,14 +31,13 @@ export default function StepNomination({
   const updateNomination = useCallback(
     (updater: (a: string[]) => string[]) => {
       onUpdateTransaction(transaction =>
-        bridge?.updateTransaction(transaction, {
+        bridge.updateTransaction(transaction, {
           validators: updater(transaction.validators || []),
         }),
       );
     },
     [bridge, onUpdateTransaction],
   );
-  if (!account || !transaction) return null;
   const { polkadotResources } = account;
   const nominations = polkadotResources.nominations || [];
   return (
@@ -62,6 +62,11 @@ export default function StepNomination({
       />
     </Box>
   );
+}
+
+export default function StepNomination(props: StepProps) {
+  if (!props.account || !props.transaction) return null;
+  return <StepNominationContent {...props} transaction={props.transaction} />;
 }
 export function StepNominationFooter({
   transitionTo,

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/fields/AmountField.tsx
@@ -4,7 +4,7 @@ import { Trans } from "react-i18next";
 import { TFunction } from "i18next";
 import styled from "styled-components";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   PolkadotAccount,
   Transaction,
@@ -42,7 +42,7 @@ type Props = {
 };
 const AmountField = ({ account, onChangeTransaction, transaction, status }: Props) => {
   invariant(account && transaction && account.spendableBalance, "account and transaction required");
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/fields/AmountField.tsx
@@ -3,7 +3,7 @@ import { Trans } from "react-i18next";
 import { TFunction } from "i18next";
 import styled from "styled-components";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   PolkadotAccount,
   Transaction,
@@ -39,7 +39,7 @@ type Props = {
   bridgePending: boolean;
 };
 const AmountField = ({ account, onChangeTransaction, transaction, status }: Props) => {
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {

--- a/apps/ledger-live-desktop/src/renderer/families/solana/MemoValueField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/MemoValueField.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import Input from "~/renderer/components/Input";
 import invariant from "invariant";
 import {
@@ -25,7 +25,7 @@ const MemoValueField = ({ onChange, account, transaction, status, autoFocus }: P
   const lldMemoTag = useFeature("lldMemoTag");
 
   invariant(transaction.family === "solana", "Memo: solana family expected");
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const onMemoValueChange = useCallback(
     (memo: string) => {
       onChange(
@@ -36,7 +36,7 @@ const MemoValueField = ({ onChange, account, transaction, status, autoFocus }: P
               ...transaction.model.uiState,
               memo,
             },
-          },
+          } as Transaction["model"],
         }),
       );
     },

--- a/apps/ledger-live-desktop/src/renderer/families/stacks/MemoValueField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stacks/MemoValueField.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import invariant from "invariant";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/stacks/types";
@@ -16,7 +16,7 @@ type Props = {
 const MemoValueField = ({ onChange, account, transaction, status, autoFocus }: Props) => {
   invariant(transaction.family === "stacks", "MemoField: stacks family expected");
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const onMemoValueChange = useCallback(
     (memoValue: string) => {

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/steps/StepAsset.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/steps/StepAsset.tsx
@@ -2,7 +2,8 @@ import invariant from "invariant";
 import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { StepProps } from "../types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { Transaction } from "@ledgerhq/live-common/families/stellar/types";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -23,7 +24,7 @@ export default function StepAsset({
   t,
 }: StepProps) {
   invariant(account && transaction, "account and transaction required");
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const onUpdateAsset = useCallback(
     (token?: TokenCurrency | null) => {
       if (!token) return;

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/FeeField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/FeeField.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import Box from "~/renderer/components/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";
 import Text from "~/renderer/components/Text";
@@ -27,12 +27,12 @@ const FeeField = ({
   invariant(transaction.family === "stellar", "FeeField: stellar family expected");
 
   const unit = useAccountUnit(account);
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const onFeeValueChange = useCallback(
     (fees: BigNumber) => {
       onChange(
         bridge.updateTransaction(transaction, {
-          customFees: { parameters: { fees: fees } },
+          customFees: { value: 0n, parameters: { fees } },
         }),
       );
     },

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/MemoTypeField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/MemoTypeField.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StellarMemoType, Transaction } from "@ledgerhq/live-common/families/stellar/types";
 import Select from "~/renderer/components/Select";
 import { Account } from "@ledgerhq/types-live";
@@ -19,7 +19,7 @@ const MemoTypeField = ({
   account: Account;
   transaction: Transaction;
 }) => {
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const selectedMemoType =
     options.find(option => option.value === transaction.memoType) || options[0];
   const onMemoTypeChange = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/MemoValueField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/MemoValueField.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import Input from "~/renderer/components/Input";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/stellar/types";
@@ -15,7 +15,7 @@ const MemoValueField = ({
   transaction: Transaction;
   status: TransactionStatus;
 }) => {
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const onMemoValueChange = useCallback(
     (memoValue: string) => {
       onChange(bridge.updateTransaction(transaction, { memoValue }));

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/SendAmountFields.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/stellar/types";
 import SendFeeMode from "./SendFeeMode";
 import FeeField from "./FeeField";
@@ -19,16 +19,16 @@ type Props = {
 const Root = (props: Props) => {
   const { transaction, trackProperties } = props;
   const { fees } = transaction;
-  const bridge = getAccountBridge(props.account);
+  const bridge = useAccountBridge<Transaction>(props.account);
   const [estimatedFees, setEstimatedFees] = useState(fees || null);
 
   React.useEffect(() => {
     const fetchEstimatedFees = async () => {
       const preparedTransaction = await bridge.prepareTransaction(props.account, {
         ...transaction,
-        customFees: { parameters: { fees: null } },
+        customFees: { value: 0n, parameters: { fees: null } },
       });
-      setEstimatedFees(preparedTransaction.fees);
+      setEstimatedFees(preparedTransaction.fees ?? null);
     };
 
     fetchEstimatedFees();
@@ -49,7 +49,7 @@ const Root = (props: Props) => {
       props.updateTransaction(t =>
         bridge.updateTransaction(t, {
           fees: estimatedFees,
-          customFees: { parameters: { fees: estimatedFees } },
+          customFees: { value: 0n, parameters: { fees: estimatedFees } },
         }),
       );
     }

--- a/apps/ledger-live-desktop/src/renderer/families/sui/UnstakingFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/UnstakingFlowModal/steps/StepAmount.tsx
@@ -6,14 +6,14 @@ import Button from "~/renderer/components/Button";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import Label from "~/renderer/components/Label";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import ErrorDisplay from "../../shared/components/ErrorDisplay";
 import AmountField from "../fields/AmountField";
 import ValidatorField from "../fields/ValidatorField";
 import { StepProps } from "../types";
 import BigNumber from "bignumber.js";
 import Alert from "~/renderer/components/Alert";
-import { MappedStake } from "@ledgerhq/live-common/families/sui/types";
+import { MappedStake, Transaction } from "@ledgerhq/live-common/families/sui/types";
 
 export default function StepAmount({
   account,
@@ -25,7 +25,7 @@ export default function StepAmount({
   const { t } = useTranslation();
 
   const [staked, setStaked] = useState(transaction.amount);
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
 
   const updateAmount = useCallback(
     (amount: BigNumber) => {

--- a/apps/ledger-live-desktop/src/renderer/families/ton/CommentField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/ton/CommentField.tsx
@@ -1,4 +1,4 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/ton/types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Account } from "@ledgerhq/types-live";
@@ -25,7 +25,7 @@ const CommentField = ({
 
   const { t } = useTranslation();
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const lldMemoTag = useFeature("lldMemoTag");
 
   const onCommentFieldChange = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/AmountField.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, useEffect } from "react";
 import { BigNumber } from "bignumber.js";
 import { Trans } from "react-i18next";
 import { TFunction } from "i18next";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Account, AccountLike, TransactionCommon } from "@ledgerhq/types-live";
-import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import { TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import Box from "~/renderer/components/Box";
 import Label from "~/renderer/components/Label";
 import RequestAmount from "~/renderer/components/RequestAmount";
@@ -14,7 +14,7 @@ import Text from "~/renderer/components/Text";
 type Props<T extends TransactionCommon> = {
   parentAccount?: Account | null;
   account: AccountLike;
-  transaction: Transaction;
+  transaction: T;
   onChangeTransaction: (_: T) => void;
   status: TransactionStatus;
   bridgePending: boolean;
@@ -38,18 +38,18 @@ const AmountField = <T extends TransactionCommon>({
   walletConnectProxy,
   withUseMaxLabel,
 }: Props<T>) => {
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<T>(account, parentAccount);
 
   useEffect(() => {
     if (initValue && !initValue.eq(transaction.amount || new BigNumber(0))) {
-      onChangeTransaction(bridge.updateTransaction(transaction, { amount: initValue }));
+      onChangeTransaction(bridge.updateTransaction(transaction, { amount: initValue } as Partial<T>));
       resetInitValue?.();
     }
   }, []); // oxlint-disable-line react-hooks/exhaustive-deps
 
   const onChange = useCallback(
     (amount: BigNumber) => {
-      onChangeTransaction(bridge.updateTransaction(transaction, { amount }));
+      onChangeTransaction(bridge.updateTransaction(transaction, { amount } as Partial<T>));
     },
     [bridge, transaction, onChangeTransaction],
   );
@@ -60,7 +60,7 @@ const AmountField = <T extends TransactionCommon>({
         bridge.updateTransaction(transaction, {
           useAllAmount,
           amount: new BigNumber(0),
-        }),
+        } as Partial<T>),
       );
     },
     [bridge, transaction, onChangeTransaction],

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useState } from "react";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { Account } from "@ledgerhq/types-live";
 import type { TFunction } from "i18next";
@@ -32,7 +32,7 @@ const RecipientField = <T extends Transaction, TS extends TransactionStatus>({
   initValue,
   resetInitValue,
 }: Props<T, TS>) => {
-  const bridge = getAccountBridge(account, null);
+  const bridge = useAccountBridge<T>(account, null);
   const [value, setValue] = useState(
     initValue || transaction?.recipientDomain?.domain || transaction.recipient || "",
   );
@@ -43,7 +43,7 @@ const RecipientField = <T extends Transaction, TS extends TransactionStatus>({
 
   useEffect(() => {
     if (value !== "" && value !== transaction.recipient) {
-      onChangeTransaction(bridge.updateTransaction(transaction, { recipient: value }));
+      onChangeTransaction(bridge.updateTransaction(transaction, { recipient: value } as Partial<T>));
       resetInitValue?.();
     }
   }, [account]); // oxlint-disable-line react-hooks/exhaustive-deps
@@ -56,7 +56,7 @@ const RecipientField = <T extends Transaction, TS extends TransactionStatus>({
       onChangeTransaction(
         bridge.updateTransaction(transaction, {
           recipient: invalidRecipient ? "" : recipient,
-        }),
+        } as Partial<T>),
       );
     },
     [account.currency.scheme, bridge, onChangeTransaction, transaction],

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
@@ -1,5 +1,5 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { SwapTransactionType } from "@ledgerhq/live-common/exchange/swap/types";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { Button, Divider, Flex } from "@ledgerhq/react-ui";
@@ -47,7 +47,7 @@ export default function FeesDrawerLiveApp({
   const mainAccount = getMainAccount(account, parentAccount);
   const isPreparingRef = useRef(false);
 
-  const bridge = getAccountBridge(mainAccount, parentAccount);
+  const bridge = useAccountBridge<Transaction>(mainAccount, parentAccount);
   const { amount: amountError, gasPrice: gasPriceError } = transactionStatus.errors;
 
   const handleSetTransaction = useCallback(

--- a/apps/ledger-live-mobile/src/families/algorand/OptInFlow/01-SelectToken.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/OptInFlow/01-SelectToken.tsx
@@ -3,14 +3,14 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, SafeAreaView, FlatList, TouchableOpacity } from "react-native";
 import { Trans } from "~/context/Locale";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useTokensData } from "@ledgerhq/cryptoassets/cal-client/hooks/useTokensData";
 import { extractTokenId } from "@ledgerhq/live-common/families/algorand/tokens";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { TokenAccount } from "@ledgerhq/types-live";
 import { useTheme } from "@react-navigation/native";
-import { AlgorandAccount } from "@ledgerhq/live-common/families/algorand/types";
+import { AlgorandAccount, Transaction as AlgorandTransaction } from "@ledgerhq/live-common/families/algorand/types";
 import { ScreenName } from "~/const";
 import LText from "~/components/LText";
 import { TrackScreen } from "~/analytics";
@@ -87,7 +87,7 @@ export default function DelegationStarted({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "Account required");
   const mainAccount = getMainAccount(account) as AlgorandAccount;
-  const bridge = getAccountBridge(mainAccount);
+  const bridge = useAccountBridge<AlgorandTransaction>(mainAccount);
   invariant(mainAccount && mainAccount.algorandResources, "algorand Account required");
   const { transaction } = useBridgeTransaction(() => {
     const t = bridge.createTransaction(mainAccount);
@@ -101,6 +101,7 @@ export default function DelegationStarted({ navigation, route }: Props) {
   });
   const onNext = useCallback(
     (assetId: string) => {
+      if (!transaction) return;
       navigation.navigate(ScreenName.AlgorandOptInSelectDevice, {
         ...route.params,
         transaction: bridge.updateTransaction(transaction, {

--- a/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/01-Started.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/01-Started.tsx
@@ -5,7 +5,7 @@ import { Trans } from "~/context/Locale";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type {
   AlgorandAccount,
   AlgorandTransaction,
@@ -37,7 +37,7 @@ export default function DelegationStarted({ navigation, route }: Props) {
   const { locale } = useSettings();
   invariant(account, "Account required");
   const mainAccount = getMainAccount(account, undefined) as AlgorandAccount;
-  const bridge = getAccountBridge(mainAccount, undefined);
+  const bridge = useAccountBridge<AlgorandTransaction>(mainAccount, undefined);
   invariant(mainAccount && mainAccount.algorandResources, "algorand Account required");
   const { rewards } = mainAccount.algorandResources;
   const unit = useAccountUnit(mainAccount);

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
@@ -13,7 +13,7 @@ import type {
 import { isOldestBitcoinPendingOperation } from "@ledgerhq/ledger-wallet-framework/operation";
 import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { fromTransactionRaw } from "@ledgerhq/live-common/transaction/index";
 import { getEnv } from "@ledgerhq/live-env";
@@ -100,7 +100,7 @@ function MethodSelectionComponent({ navigation, route }: Props) {
 
   const isOldestEditableOperation = isOldestBitcoinPendingOperation(mainAccount, operation.date);
 
-  const bridge: AccountBridge<BtcTransaction> = getAccountBridge(account, parentAccount as Account);
+  const bridge = useAccountBridge<BtcTransaction>(account, parentAccount as Account);
 
   const onSelect = useCallback(
     async (option: EditType) => {

--- a/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/02-Summary.tsx
@@ -5,7 +5,7 @@ import React, { ReactNode, useCallback, useEffect, useMemo, useState } from "rea
 import { Trans, useTranslation } from "~/context/Locale";
 import { Animated, SafeAreaView, StyleSheet, View } from "react-native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import {
@@ -59,7 +59,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
 
   const { cardanoResources } = account as CardanoAccount;
   const currentDelegation = cardanoResources.delegation;
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<Transaction>(account, undefined);
 
   const [isFetchingPoolDetails, setIsFetchingPoolDetails] = useState(false);
   const [ledgerPools, setLedgerPools] = useState<Array<StakePool>>([]);
@@ -116,9 +116,8 @@ export default function DelegationSummary({ navigation, route }: Props) {
   const onBridgeErrorRetry = useCallback(() => {
     setBridgeErr(null);
     if (!transaction) return;
-    const bridge = getAccountBridge(account, parentAccount);
     setTransaction(bridge.updateTransaction(transaction, {}));
-  }, [setTransaction, account, parentAccount, transaction]);
+  }, [setTransaction, bridge, transaction]);
 
   invariant(transaction, "transaction must be defined");
   invariant(transaction.family === "cardano", "transaction cardano");

--- a/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
@@ -5,12 +5,13 @@ import React, { ReactNode, useCallback, useEffect, useMemo, useState } from "rea
 import { Trans, useTranslation } from "~/context/Locale";
 import { SafeAreaView, StyleSheet, View } from "react-native";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import type {
   CardanoAccount,
   CardanoDelegation,
+  Transaction as CardanoTransaction,
   TransactionStatus,
 } from "@ledgerhq/live-common/families/cardano/types";
 import { Text, Box } from "@ledgerhq/native-ui";
@@ -47,7 +48,7 @@ export default function UndelegationSummary({ navigation, route }: Props) {
   const { cardanoResources } = account as CardanoAccount;
   const currentDelegation = cardanoResources.delegation as CardanoDelegation;
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<CardanoTransaction>(account, undefined);
 
   const { transaction, status, bridgePending, bridgeError, setTransaction } = useBridgeTransaction(
     () => {
@@ -82,7 +83,7 @@ export default function UndelegationSummary({ navigation, route }: Props) {
     navigation.navigate(ScreenName.CardanoUndelegationSelectDevice, {
       accountId: account.id,
       parentId: parentAccount?.id || undefined,
-      transaction,
+      transaction: transaction ?? undefined,
       status,
     });
   }, [status, account, parentAccount, navigation, transaction]);
@@ -98,9 +99,8 @@ export default function UndelegationSummary({ navigation, route }: Props) {
   const onBridgeErrorRetry = useCallback(() => {
     setBridgeErr(null);
     if (!transaction) return;
-    const bridge = getAccountBridge(account, parentAccount);
     setTransaction(bridge.updateTransaction(transaction, {}));
-  }, [setTransaction, account, parentAccount, transaction]);
+  }, [setTransaction, bridge, transaction]);
 
   const hasNotEnoughtBalanceError = bridgeError instanceof CardanoNotEnoughFunds;
 

--- a/apps/ledger-live-mobile/src/families/celo/ActivateFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/ActivateFlow/02-Summary.tsx
@@ -1,8 +1,8 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useValidatorGroups } from "@ledgerhq/live-common/families/celo/react";
-import { CeloValidatorGroup, CeloAccount } from "@ledgerhq/live-common/families/celo/types";
+import { CeloValidatorGroup, CeloAccount, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { activatableVotes } from "@ledgerhq/live-common/families/celo/logic";
 import { useTheme } from "@react-navigation/native";
 import invariant from "invariant";
@@ -36,7 +36,7 @@ export default function ActivateSummary({ navigation, route }: Props) {
   const validators = useValidatorGroups();
   const votes = activatableVotes(account as CeloAccount);
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<CeloTransaction>(account, undefined);
 
   const chosenValidator = useMemo(() => {
     if (validator !== undefined) {

--- a/apps/ledger-live-mobile/src/families/celo/LockFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/LockFlow/01-Amount.tsx
@@ -14,7 +14,7 @@ import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
@@ -39,7 +39,7 @@ export default function LockAmount({ navigation, route }: Props) {
   const { account, parentAccount } = useAccountScreen(route);
   invariant(account, "account is required");
 
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<CeloTransaction>(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
 
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
@@ -60,7 +60,7 @@ export default function LockAmount({ navigation, route }: Props) {
     if (!account) return;
 
     let cancelled = false;
-    getAccountBridge(account, parentAccount)
+    bridge
       .estimateMaxSpendable({
         account,
         parentAccount,
@@ -76,11 +76,11 @@ export default function LockAmount({ navigation, route }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [account, parentAccount, debouncedTransaction]);
+  }, [bridge, account, parentAccount, debouncedTransaction]);
 
   const onChange = useCallback(
     (amount: BigNumber) => {
-      if (!amount.isNaN()) {
+      if (!amount.isNaN() && transaction) {
         setTransaction(bridge.updateTransaction(transaction, { amount }));
       }
     },
@@ -88,7 +88,6 @@ export default function LockAmount({ navigation, route }: Props) {
   );
 
   const toggleUseAllAmount = useCallback(() => {
-    const bridge = getAccountBridge(account, parentAccount);
     if (!transaction) return;
 
     setTransaction(
@@ -97,7 +96,7 @@ export default function LockAmount({ navigation, route }: Props) {
         useAllAmount: !transaction.useAllAmount,
       }),
     );
-  }, [setTransaction, account, parentAccount, transaction]);
+  }, [setTransaction, bridge, transaction]);
 
   const onContinue = useCallback(() => {
     navigation.navigate(ScreenName.CeloLockSelectDevice, {

--- a/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/01-Started.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/01-Started.tsx
@@ -6,7 +6,7 @@ import React, { useCallback } from "react";
 import { Trans } from "~/context/Locale";
 import { StyleSheet, View } from "react-native";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { TrackScreen } from "~/analytics";
 import Button from "~/components/Button";
@@ -26,7 +26,7 @@ export default function RegisterAccountStarted({ navigation, route }: Props) {
   invariant(account, "account needed");
 
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<CeloTransaction>(account, parentAccount);
 
   const { transaction, status } = useBridgeTransaction(() => {
     const t = bridge.createTransaction(mainAccount);

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/01-Summary.tsx
@@ -1,9 +1,9 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useValidatorGroups } from "@ledgerhq/live-common/families/celo/react";
-import type { CeloValidatorGroup, CeloAccount } from "@ledgerhq/live-common/families/celo/types";
+import type { CeloValidatorGroup, CeloAccount, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { revokableVotes } from "@ledgerhq/live-common/families/celo/logic";
 import { AccountLike } from "@ledgerhq/types-live";
 import { useTheme } from "@react-navigation/native";
@@ -42,7 +42,7 @@ export default function RevokeSummary({ navigation, route }: Props) {
   const validators = useValidatorGroups();
   const votes = revokableVotes(account as CeloAccount);
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<CeloTransaction>(account, undefined);
 
   const chosenValidator = useMemo(() => {
     if (validator !== undefined) {
@@ -79,7 +79,7 @@ export default function RevokeSummary({ navigation, route }: Props) {
           account,
           transaction: bridge.updateTransaction(t, {
             mode: "revoke",
-            amount: route.params.amount ?? 0,
+            amount: route.params.amount ?? new BigNumber(0),
           }),
         };
       }

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/VoteAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/VoteAmount.tsx
@@ -12,7 +12,7 @@ import {
 import { Trans } from "~/context/Locale";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
@@ -43,7 +43,7 @@ export default function VoteAmount({ navigation, route }: Props) {
 
   const [maxSpendable, setMaxSpendable] = useState(0);
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<CeloTransaction>(account);
 
   const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction(() => {
     return {

--- a/apps/ledger-live-mobile/src/families/celo/SendSelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/SendSelectRecipient.tsx
@@ -7,7 +7,7 @@ import { Icons, Text } from "@ledgerhq/native-ui";
 import Circle from "~/components/Circle";
 import QueuedDrawer from "~/components/QueuedDrawer";
 import LText from "~/components/LText";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { findSubAccountById, getMainAccount } from "@ledgerhq/live-common/account/index";
 import {
   FEE_CURRENCY_BY_CONTRACT,
@@ -37,6 +37,7 @@ export function SendRecipientFields({
   const { colors } = useTheme();
   const [drawerOpen, setDrawerOpen] = useState(false);
 
+  const bridge = useAccountBridge<CeloTransaction>(account, parentAccount);
   const celoTransaction = transaction as CeloTransaction;
   const mainAccount = getMainAccount(account, parentAccount) as CeloAccount;
 
@@ -64,26 +65,24 @@ export function SendRecipientFields({
     }));
 
   const onSelectNative = useCallback(() => {
-    const bridge = getAccountBridge(account, parentAccount);
     setTransaction(
-      bridge.updateTransaction(transaction, {
+      bridge.updateTransaction(celoTransaction, {
         feeCurrency: null,
         feeCurrencyUnwrapped: null,
         feeCurrencyAccountId: null,
       }),
     );
     setDrawerOpen(false);
-  }, [account, parentAccount, transaction, setTransaction]);
+  }, [bridge, celoTransaction, setTransaction]);
 
   const onSelectToken = useCallback(
     (tokenAccount: AccountLike) => {
       if (tokenAccount.type !== "TokenAccount") return;
-      const bridge = getAccountBridge(account, parentAccount);
       const contractAddress = tokenAccount.token.contractAddress;
       const matchedOption = FEE_CURRENCY_BY_CONTRACT.get(contractAddress.toLowerCase());
       if (!matchedOption) {
         setTransaction(
-          bridge.updateTransaction(transaction, {
+          bridge.updateTransaction(celoTransaction, {
             feeCurrency: null,
             feeCurrencyUnwrapped: null,
             feeCurrencyAccountId: null,
@@ -97,7 +96,7 @@ export function SendRecipientFields({
       const feeCurrencyUnwrapped = matchedOption?.contractAddress ?? null;
 
       setTransaction(
-        bridge.updateTransaction(transaction, {
+        bridge.updateTransaction(celoTransaction, {
           feeCurrency,
           feeCurrencyUnwrapped,
           feeCurrencyAccountId: tokenAccount.id,
@@ -105,7 +104,7 @@ export function SendRecipientFields({
       );
       setDrawerOpen(false);
     },
-    [account, parentAccount, transaction, setTransaction],
+    [bridge, celoTransaction, setTransaction],
   );
 
   return (

--- a/apps/ledger-live-mobile/src/families/celo/UnlockFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/UnlockFlow/01-Amount.tsx
@@ -15,7 +15,7 @@ import { useTheme } from "@react-navigation/native";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
 import LText from "~/components/LText";
@@ -41,7 +41,7 @@ export default function UnlockAmount({ navigation, route }: Props) {
   const { account, parentAccount } = useAccountScreen(route);
   invariant(account, "account is required");
 
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<CeloTransaction>(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
 
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
@@ -82,7 +82,7 @@ export default function UnlockAmount({ navigation, route }: Props) {
 
   const onChange = useCallback(
     (amount: BigNumber) => {
-      if (!amount.isNaN()) {
+      if (!amount.isNaN() && transaction) {
         setTransaction(bridge.updateTransaction(transaction, { amount }));
       }
     },

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/02-Summary.tsx
@@ -1,9 +1,9 @@
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { useValidatorGroups } from "@ledgerhq/live-common/families/celo/react";
-import { CeloValidatorGroup } from "@ledgerhq/live-common/families/celo/types";
+import { CeloValidatorGroup, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { defaultValidatorGroupAddress } from "@ledgerhq/live-common/families/celo/logic";
 import { AccountLike } from "@ledgerhq/types-live";
 import { Text, Icons } from "@ledgerhq/native-ui";
@@ -45,7 +45,7 @@ export default function VoteSummary({ navigation, route }: Props) {
 
   const validators = useValidatorGroups();
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<CeloTransaction>(account, undefined);
 
   const chosenValidator = useMemo(() => {
     if (validator !== undefined) {
@@ -67,7 +67,7 @@ export default function VoteSummary({ navigation, route }: Props) {
           transaction: bridge.updateTransaction(t, {
             mode: "vote",
             recipient: validators[0]?.address ?? defaultValidatorGroupAddress(),
-            amount: route.params.amount ?? 0,
+            amount: route.params.amount ?? new BigNumber(0),
           }),
         };
       }

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/VoteAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/VoteAmount.tsx
@@ -12,7 +12,7 @@ import {
 import { Trans } from "~/context/Locale";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
 import LText from "~/components/LText";
@@ -25,6 +25,7 @@ import SendRowsFee from "../SendRowsFee";
 import { getFirstStatusError } from "../../helpers";
 import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import type { CeloVoteFlowParamList } from "./types";
+import type { Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -38,9 +39,9 @@ export default function VoteAmount({ navigation, route }: Props) {
 
   const [maxSpendable, setMaxSpendable] = useState(0);
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<CeloTransaction>(account);
 
-  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction(() => {
+  const { transaction, setTransaction, status, bridgePending } = useBridgeTransaction<CeloTransaction>(() => {
     return {
       account,
       transaction: {

--- a/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
@@ -6,11 +6,11 @@ import { Trans } from "~/context/Locale";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { rgba, Text, Icons } from "@ledgerhq/native-ui";
-import { CeloAccount } from "@ledgerhq/live-common/families/celo/types";
+import { CeloAccount, Transaction as CeloTransaction } from "@ledgerhq/live-common/families/celo/types";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
 import Button from "~/components/Button";
@@ -42,7 +42,7 @@ export default function WithdrawAmount({ navigation, route }: Props) {
   const { account, parentAccount } = useAccountScreen(route);
   invariant(account, "account is required");
 
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<CeloTransaction>(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
 
   const { transaction, setTransaction, status, bridgeError, bridgePending } = useBridgeTransaction(

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/01-SelectValidator.tsx
@@ -7,7 +7,7 @@ import type {
   CosmosValidatorItem,
   Transaction,
 } from "@ledgerhq/live-common/families/cosmos/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useCosmosFamilyMappedDelegations } from "@ledgerhq/live-common/families/cosmos/react";
@@ -30,7 +30,7 @@ function ClaimRewardsSelectValidator({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
   const mainAccount = getMainAccount(account, undefined) as CosmosAccount;
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const { cosmosResources } = mainAccount;
   invariant(cosmosResources, "cosmosResources required");
   const transaction = useBridgeTransaction(() => {
@@ -52,7 +52,7 @@ function ClaimRewardsSelectValidator({ navigation, route }: Props) {
         validators: [
           {
             address: validator.validatorAddress,
-            amount: value,
+            amount: value ?? new BigNumber(0),
           },
         ],
       });

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.tsx
@@ -3,8 +3,8 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans } from "~/context/Locale";
-import type { CosmosAccount, Transaction } from "@ledgerhq/live-common/families/cosmos/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import type { CosmosAccount, CosmosOperationMode, Transaction } from "@ledgerhq/live-common/families/cosmos/types";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useTheme } from "@react-navigation/native";
@@ -56,7 +56,7 @@ function ClaimRewardsAmount({ navigation, route }: Props) {
   const { colors } = useTheme();
   const account = useAccountScreen(route).account as CosmosAccount;
   invariant(account && account.cosmosResources, "account and cosmos transaction required");
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const unit = useAccountUnit(mainAccount);
   const currency = getAccountCurrency(mainAccount);
@@ -116,7 +116,7 @@ function ClaimRewardsAmount({ navigation, route }: Props) {
     (mode: string) => {
       updateTransaction(() =>
         bridge.updateTransaction(transaction, {
-          mode,
+          mode: mode as CosmosOperationMode,
         }),
       );
     },

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
@@ -1,10 +1,10 @@
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { getMaxDelegationAvailable } from "@ledgerhq/live-common/families/cosmos/logic";
 import { useLedgerFirstShuffledValidatorsCosmosFamily } from "@ledgerhq/live-common/families/cosmos/react";
-import { CosmosAccount, CosmosValidatorItem } from "@ledgerhq/live-common/families/cosmos/types";
+import { CosmosAccount, CosmosValidatorItem, Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
 import cosmosBase from "@ledgerhq/coin-cosmos/chain/cosmosBase";
 import { AccountLike } from "@ledgerhq/types-live";
 import { Text, Icons } from "@ledgerhq/native-ui";
@@ -48,7 +48,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
 
   const mainAccount = getMainAccount(account, parentAccount);
   const validators = useLedgerFirstShuffledValidatorsCosmosFamily(mainAccount.currency.id);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
 
   const chosenValidator = useMemo(() => {
     if (validator !== undefined) {

--- a/apps/ledger-live-mobile/src/families/cosmos/Delegations/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/Delegations/index.tsx
@@ -13,6 +13,7 @@ import type {
   CosmosAccount,
   CosmosMappedDelegation,
   CosmosMappedUnbonding,
+  Transaction as CosmosTransaction,
 } from "@ledgerhq/live-common/families/cosmos/types";
 import {
   mapUnbondings,
@@ -28,7 +29,7 @@ import {
 } from "@ledgerhq/live-common/families/cosmos/banner";
 import cryptoFactory from "@ledgerhq/coin-cosmos/chain/chain";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { AccountLike } from "@ledgerhq/types-live";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import AccountDelegationInfo from "~/components/AccountDelegationInfo";
@@ -85,7 +86,7 @@ function Delegations({ account }: Props) {
     cosmosResources &&
     cosmosResources.unbondings &&
     mapUnbondings(cosmosResources.unbondings, validators, unit);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
   const { transaction } = useBridgeTransaction(() => {
     const t = bridge.createTransaction(mainAccount);
     const { validatorSrcAddress } = { ...banner };

--- a/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/01-SelectValidator.tsx
@@ -15,7 +15,7 @@ import type {
   CosmosValidatorItem,
   Transaction,
 } from "@ledgerhq/live-common/families/cosmos/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useLedgerFirstShuffledValidatorsCosmosFamily } from "@ledgerhq/live-common/families/cosmos/react";
@@ -39,7 +39,7 @@ function RedelegationSelectValidator({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
   const mainAccount = getMainAccount(account, undefined) as CosmosAccount;
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const { cosmosResources } = mainAccount;
   invariant(cosmosResources, "cosmosResources required");
   const delegations = cosmosResources.delegations;

--- a/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/01-Amount.tsx
@@ -1,10 +1,11 @@
 import invariant from "invariant";
 import React from "react";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
 import SelectAmount from "../shared/02-SelectAmount";
 import { ScreenName } from "~/const";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
@@ -19,7 +20,7 @@ type Props = StackNavigatorProps<
 function UndelegationAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const validator = route.params.delegation.validator;
   const amount = route.params.delegation.amount;

--- a/apps/ledger-live-mobile/src/families/cosmos/shared/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/shared/02-SelectAmount.tsx
@@ -11,9 +11,9 @@ import {
 } from "react-native";
 import { Trans } from "~/context/Locale";
 import { BigNumber } from "bignumber.js";
-import type { CosmosAccount } from "@ledgerhq/live-common/families/cosmos/types";
+import type { CosmosAccount, Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
 import { getMaxEstimatedBalance } from "@ledgerhq/live-common/families/cosmos/logic";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useTheme } from "styled-components/native";
 import Button from "~/components/Button";
@@ -54,7 +54,7 @@ function DelegationAmount({ navigation, route }: Props) {
     "unsupported cosmos transaction mode",
   );
 
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<CosmosTransaction>(account, undefined);
   const unit = useAccountUnit(account);
   const initialValue = useMemo(() => route?.params?.value ?? BigNumber(0), [route]);
   const redelegatedBalance = route?.params?.redelegatedBalance ?? BigNumber(0);

--- a/apps/ledger-live-mobile/src/families/cosmos/shared/03-BridgeTransaction.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/shared/03-BridgeTransaction.tsx
@@ -3,9 +3,9 @@ import invariant from "invariant";
 import { Flex } from "@ledgerhq/native-ui";
 import { BigNumber } from "bignumber.js";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
-import type { CosmosAccount } from "@ledgerhq/live-common/families/cosmos/types";
+import type { CosmosAccount, Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
 import { ScreenName } from "~/const";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { CosmosRedelegationFlowParamList } from "../RedelegationFlow/types";
@@ -28,7 +28,7 @@ export default function CosmosBridgeTransaction({ navigation, route }: Props) {
   invariant(account, "account required");
 
   const mainAccount = getMainAccount(account) as CosmosAccount;
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<CosmosTransaction>(account);
   const { transaction: initialTx, mode } = route.params;
 
   const { transaction, bridgePending, status } = useBridgeTransaction(() => {
@@ -40,7 +40,7 @@ export default function CosmosBridgeTransaction({ navigation, route }: Props) {
         return {
           account,
           transaction: bridge.updateTransaction(t, {
-            mode: "undelegation",
+            mode: "undelegate",
             validators: [
               {
                 address: validator?.validatorAddress ?? "",

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
@@ -9,7 +9,7 @@ import { Transaction as EvmTransaction, TransactionRaw } from "@ledgerhq/coin-ev
 import { isOldestPendingOperation } from "@ledgerhq/ledger-wallet-framework/operation";
 import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { getEnv } from "@ledgerhq/live-env";
 import { log } from "@ledgerhq/logs";
@@ -84,7 +84,7 @@ function MethodSelectionComponent({ navigation, route }: Props) {
         : false,
     [mainAccount, transactionToEdit],
   );
-  const bridge: AccountBridge<EvmTransaction> = getAccountBridge(account, parentAccount as Account);
+  const bridge: AccountBridge<EvmTransaction> = useAccountBridge<EvmTransaction>(account, parentAccount as Account);
 
   const onSelect = useCallback(
     async (option: EditType) => {

--- a/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/Evm1559CustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/Evm1559CustomFees.tsx
@@ -1,4 +1,4 @@
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { getGasLimit } from "@ledgerhq/coin-evm/utils";
@@ -51,7 +51,7 @@ const Evm1559CustomFees = ({
 
   // Creating a new transaction to simulate the bridge status response before updating
   // the original transaction
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<EvmTransactionEIP1559>(account);
 
   const { transaction, setTransaction, status } = useBridgeTransaction<EvmTransactionEIP1559>(
     () => ({

--- a/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.tsx
@@ -1,11 +1,10 @@
 import { getEstimatedFees } from "@ledgerhq/coin-evm/utils";
 import type { Transaction, TransactionStatus } from "@ledgerhq/coin-evm/types/index";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useGasOptions } from "@ledgerhq/live-common/families/evm/react";
 import { log } from "@ledgerhq/logs";
 import { InfiniteLoader } from "@ledgerhq/native-ui";
-import { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import React, { useCallback, useEffect, useState } from "react";
 import { ScreenName } from "~/const";
@@ -49,7 +48,7 @@ export default function EvmFeesStrategy({
   ...props
 }: Props<Transaction>) {
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge: AccountBridge<Transaction> = getAccountBridge(mainAccount);
+  const bridge = useAccountBridge<Transaction>(mainAccount);
   const { colors } = useTheme();
   const { t } = useTranslation();
   const unit = useAccountUnit(mainAccount);
@@ -165,7 +164,6 @@ export default function EvmFeesStrategy({
 
   const onFeesSelected = useCallback(
     ({ feesStrategy }: { feesStrategy: StrategyWithCustom }) => {
-      const bridge = getAccountBridge(account, parentAccount);
 
       const patch: Partial<Transaction> =
         feesStrategy === "custom" && customStrategyTransactionPatch
@@ -178,8 +176,7 @@ export default function EvmFeesStrategy({
     },
     [
       setTransaction,
-      account,
-      parentAccount,
+      bridge,
       transaction,
       customStrategyTransactionPatch,
       gasOptions,

--- a/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/Claim.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/Claim.tsx
@@ -8,7 +8,7 @@ import type { AccountBridge } from "@ledgerhq/types-live";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { TrackScreen } from "~/analytics";
 import Button from "~/components/Button";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
@@ -34,7 +34,7 @@ function ClaimRewardsClaim({ navigation, route }: Props) {
 
   const { selectedDelegation } = route.params;
   const unit = useAccountUnit(account);
-  const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(() => {
     const t = bridge.createTransaction(account);
 

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
@@ -3,7 +3,7 @@ import Config from "react-native-config";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import {
   getDefaultValidator,
   isStakingTransaction,
@@ -45,7 +45,7 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
   invariant(account, "account must be defined");
   invariant(account.type === "Account", "account type must be Account");
 
-  const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const validators = useHederaValidators(account.currency);
   const defaultValidator = getDefaultValidator(validators);
 

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/Amount.tsx
@@ -6,7 +6,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useTheme } from "@react-navigation/native";
 import { Text } from "@ledgerhq/native-ui";
 import type { AccountBridge } from "@ledgerhq/types-live";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
@@ -36,7 +36,7 @@ function RedelegationAmount({ navigation, route }: Props) {
   invariant(account.type === "Account", "account type must be Account");
 
   const unit = useAccountUnit(account);
-  const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(() => {
     const t = bridge.createTransaction(account);
 

--- a/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/Amount.tsx
@@ -6,7 +6,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useTheme } from "@react-navigation/native";
 import { Text } from "@ledgerhq/native-ui";
 import type { AccountBridge } from "@ledgerhq/types-live";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
@@ -36,7 +36,7 @@ function UndelegationAmount({ navigation, route }: Props) {
   invariant(account.type === "Account", "account type must be Account");
 
   const unit = useAccountUnit(account);
-  const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const { transaction, status, bridgePending, bridgeError } = useBridgeTransaction(() => {
     const t = bridge.createTransaction(account);
 

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickMethod/PickMethod.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickMethod/PickMethod.tsx
@@ -3,7 +3,7 @@ import { View, TouchableOpacity } from "react-native";
 import { useTheme } from "@react-navigation/native";
 import { Trans } from "~/context/Locale";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { handleTransactionStatus } from "@ledgerhq/live-common/families/multiversx/helpers";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/ledger-wallet-framework/account";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -43,7 +43,7 @@ const PickMethod = (props: PickMethodPropsType) => {
 
   const mainAccount = getMainAccount(account, undefined);
   const currency = getAccountCurrency(mainAccount);
-  const bridge: AccountBridge<Transaction> = getAccountBridge(account);
+  const bridge: AccountBridge<Transaction> = useAccountBridge(account);
   const unit = useAccountUnit(mainAccount);
   const methods = [TransactionMethodEnum.claimRewards, TransactionMethodEnum.reDelegateRewards];
 

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickValidator/PickValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/components/PickValidator/PickValidator.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useCallback } from "react";
 import { View, FlatList } from "react-native";
 import { useTheme } from "@react-navigation/native";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account";
 
 import BigNumber from "bignumber.js";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
+import type { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 
 import { ScreenName } from "~/const";
 import Item from "./components/Item";
@@ -25,7 +26,7 @@ const PickValidator = (props: PickValidatorPropsType) => {
   const { colors } = useTheme();
 
   const mainAccount = getMainAccount(account, undefined);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<MultiversXTransaction>(account, undefined);
   const unit = useAccountUnit(account);
 
   /*
@@ -55,7 +56,7 @@ const PickValidator = (props: PickValidatorPropsType) => {
 
   const onSelect = useCallback(
     (validator: onSelectType["validator"], value: onSelectType["value"]) => {
-      if (validator) {
+      if (validator && transaction) {
         navigation.navigate(ScreenName.MultiversXClaimRewardsMethod, {
           value,
           account,

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/PickAmount/PickAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/PickAmount/PickAmount.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { View, Keyboard, TouchableOpacity, TouchableWithoutFeedback, Platform } from "react-native";
 import { Trans } from "~/context/Locale";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { denominate } from "@ledgerhq/live-common/families/multiversx/helpers";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useTheme } from "styled-components/native";
@@ -34,7 +34,7 @@ const PickAmount = (props: PickAmountPropsType) => {
 
   const unit = useAccountUnit(account);
   const { locale } = useSettings();
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<Transaction>(account);
   const transaction = route.params.transaction as Transaction;
 
   const [maxSpendable, setMaxSpendable] = useState(new BigNumber(0));
@@ -45,7 +45,6 @@ const PickAmount = (props: PickAmountPropsType) => {
    */
 
   const getMaxSpendable = useCallback(() => {
-    const bridge = getAccountBridge(account);
     const fetchMaxSpendable = async () => {
       const amount = await bridge.estimateMaxSpendable({
         account,
@@ -59,7 +58,7 @@ const PickAmount = (props: PickAmountPropsType) => {
     };
 
     fetchMaxSpendable();
-  }, [account, transaction]);
+  }, [account, transaction, bridge]);
 
   /*
    * Handle the ration selection callback.

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/PickValidator/PickValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/PickValidator/PickValidator.tsx
@@ -3,7 +3,8 @@ import { useTranslation, Trans } from "~/context/Locale";
 import { useTheme } from "@react-navigation/native";
 import { Box, SearchInput, Text } from "@ledgerhq/native-ui";
 import { FlatList, View } from "react-native";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 
 import { useSearchValidators } from "@ledgerhq/live-common/families/multiversx/react";
 
@@ -27,7 +28,7 @@ const PickValidator = (props: PickValidatorPropsType) => {
   const { account, validators, transaction } = route.params;
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<MultiversXTransaction>(account);
 
   /*
    * Filter out the providers, by the search query, and disabled them if not enough delegation cap available.
@@ -40,11 +41,11 @@ const PickValidator = (props: PickValidatorPropsType) => {
 
   const onSelect = useCallback(
     (validator: onSelectType["validator"]) => {
-      if (validator) {
+      if (validator && transaction) {
         navigation.navigate(ScreenName.MultiversXDelegationValidator, {
           account,
           validators,
-          transaction: bridge.updateTransaction(transaction, {
+          transaction: bridge.updateTransaction(transaction as MultiversXTransaction, {
             recipient: validator.contract,
           }),
         });

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/SetDelegation/SetDelegation.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/SetDelegation/SetDelegation.tsx
@@ -2,7 +2,8 @@ import React, { useMemo, useEffect, useCallback } from "react";
 import { Image, View, Animated } from "react-native";
 import { useTheme } from "@react-navigation/native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 import {
   handleTransactionStatus,
   denominate,
@@ -45,7 +46,7 @@ const SetDelegation = (props: SetDelegationPropsType) => {
 
   const currency = getAccountCurrency(account);
   const color = getCurrencyColor(currency);
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<MultiversXTransaction>(account);
   const mainAccount = getMainAccount(account, undefined);
   const unit = useAccountUnit(account);
 
@@ -184,7 +185,7 @@ const SetDelegation = (props: SetDelegationPropsType) => {
     const returnedTransaction = route.params.transaction;
 
     if (returnedTransaction) {
-      updateTransaction(() => returnedTransaction);
+      updateTransaction(() => returnedTransaction as MultiversXTransaction);
     }
   }, [route.params.transaction, updateTransaction]);
 

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/components/PickAmount/PickAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/components/PickAmount/PickAmount.tsx
@@ -2,7 +2,8 @@ import React, { useCallback, useMemo, useState } from "react";
 import { View, Keyboard, TouchableOpacity, TouchableWithoutFeedback, Platform } from "react-native";
 import { Trans } from "~/context/Locale";
 import { BigNumber } from "bignumber.js";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 import { denominate } from "@ledgerhq/live-common/families/multiversx/helpers";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useTheme } from "styled-components/native";
@@ -33,7 +34,7 @@ const PickAmount = (props: PickAmountPropsType) => {
   const { amount, account, validator } = route.params;
 
   const unit = useAccountUnit(account);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<MultiversXTransaction>(account, undefined);
   const { locale } = useSettings();
 
   const [value, setValue] = useState(new BigNumber(amount));

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/components/WithdrawFunds/WithdrawFunds.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/components/WithdrawFunds/WithdrawFunds.tsx
@@ -3,7 +3,8 @@ import { View } from "react-native";
 import { Trans } from "~/context/Locale";
 import { useTheme } from "@react-navigation/native";
 import { handleTransactionStatus } from "@ledgerhq/live-common/families/multiversx/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as MultiversXTransaction } from "@ledgerhq/live-common/families/multiversx/types";
 import {
   getMainAccount,
   getAccountCurrency,
@@ -34,7 +35,7 @@ const WithdrawFunds = (props: WithdrawFundsPropsType) => {
 
   const mainAccount = getMainAccount(account, undefined);
   const currency = getAccountCurrency(mainAccount);
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<MultiversXTransaction>(account);
   const unit = useAccountUnit(mainAccount);
   const name = validator.identity.name || validator.contract;
 

--- a/apps/ledger-live-mobile/src/families/near/StakingFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/near/StakingFlow/02-Summary.tsx
@@ -1,9 +1,9 @@
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { useLedgerFirstShuffledValidatorsNear } from "@ledgerhq/live-common/families/near/react";
-import { NearValidatorItem, NearAccount } from "@ledgerhq/live-common/families/near/types";
+import { NearValidatorItem, NearAccount, Transaction as NearTransaction } from "@ledgerhq/live-common/families/near/types";
 import { FIGMENT_NEAR_VALIDATOR_ADDRESS } from "@ledgerhq/live-common/families/near/constants";
 import { getMaxAmount } from "@ledgerhq/live-common/families/near/logic";
 import { AccountLike } from "@ledgerhq/types-live";
@@ -46,7 +46,7 @@ export default function StakingSummary({ navigation, route }: Props) {
 
   const validators = useLedgerFirstShuffledValidatorsNear("");
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<NearTransaction>(account, undefined);
 
   const chosenValidator = useMemo(() => {
     if (validator !== undefined) {

--- a/apps/ledger-live-mobile/src/families/near/UnstakingFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/near/UnstakingFlow/01-Amount.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { BigNumber } from "bignumber.js";
 import type { Transaction, NearAccount } from "@ledgerhq/live-common/families/near/types";
 import { getMaxAmount } from "@ledgerhq/live-common/families/near/logic";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import SelectAmount from "../shared/02-SelectAmount";
@@ -19,7 +19,7 @@ type Props = BaseComposite<
 function UnstakingAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const { validatorId } = route.params.stakingPosition;
   const {

--- a/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/01-Amount.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { BigNumber } from "bignumber.js";
 import type { Transaction, NearAccount } from "@ledgerhq/live-common/families/near/types";
 import { getMaxAmount } from "@ledgerhq/live-common/families/near/logic";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import SelectAmount from "../shared/02-SelectAmount";
@@ -19,7 +19,7 @@ type Props = BaseComposite<
 function WithdrawingAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const { validatorId } = route.params.stakingPosition;
   const {

--- a/apps/ledger-live-mobile/src/families/near/shared/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/near/shared/02-SelectAmount.tsx
@@ -11,8 +11,8 @@ import {
 } from "react-native";
 import { Trans } from "~/context/Locale";
 import { BigNumber } from "bignumber.js";
-import type { NearAccount } from "@ledgerhq/live-common/families/near/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import type { NearAccount, Transaction as NearTransaction } from "@ledgerhq/live-common/families/near/types";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useTheme } from "styled-components/native";
 import Button from "~/components/Button";
@@ -47,7 +47,7 @@ function StakingAmount({ navigation, route }: Props) {
     account && account.nearResources && route.params.transaction,
     "account and near transaction required",
   );
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<NearTransaction>(account, undefined);
   const unit = useAccountUnit(account);
   const initialValue = useMemo(() => route?.params?.value ?? new BigNumber(0), [route]);
   const [value, setValue] = useState(() => initialValue);

--- a/apps/ledger-live-mobile/src/families/polkadot/BondFlow/02-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/BondFlow/02-Amount.tsx
@@ -17,7 +17,7 @@ import { useTheme } from "@react-navigation/native";
 import type { Transaction as PolkadotTransaction } from "@ledgerhq/live-common/families/polkadot/types";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { isFirstBond } from "@ledgerhq/live-common/families/polkadot/logic";
 import { PolkadotAccount } from "@ledgerhq/live-common/families/polkadot/types";
 import { urls } from "~/utils/urls";
@@ -80,7 +80,7 @@ export default function PolkadotBondAmount({ navigation, route }: Props) {
   const { colors } = useTheme();
   const { account, parentAccount } = useAccountScreen(route);
   invariant(account, "account is required");
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<PolkadotTransaction>(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount) as PolkadotAccount;
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
   const [infoModalOpen, setInfoModalOpen] = useState<boolean>();
@@ -102,7 +102,7 @@ export default function PolkadotBondAmount({ navigation, route }: Props) {
   useEffect(() => {
     if (!account) return;
     let cancelled = false;
-    getAccountBridge(account, parentAccount)
+    bridge
       .estimateMaxSpendable({
         account,
         parentAccount,
@@ -116,7 +116,7 @@ export default function PolkadotBondAmount({ navigation, route }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [account, parentAccount, debouncedTransaction]);
+  }, [account, parentAccount, debouncedTransaction, bridge]);
   const onChange = useCallback(
     (amount: BigNumber) => {
       if (!amount.isNaN()) {
@@ -130,7 +130,6 @@ export default function PolkadotBondAmount({ navigation, route }: Props) {
     [setTransaction, transaction, bridge],
   );
   const toggleUseAllAmount = useCallback(() => {
-    const bridge = getAccountBridge(account, parentAccount);
     if (!transaction) return;
     setTransaction(
       bridge.updateTransaction(transaction, {
@@ -138,7 +137,7 @@ export default function PolkadotBondAmount({ navigation, route }: Props) {
         useAllAmount: !transaction.useAllAmount,
       }),
     );
-  }, [setTransaction, account, parentAccount, transaction]);
+  }, [setTransaction, bridge, transaction]);
   const onContinue = useCallback(() => {
     navigation.navigate(ScreenName.PolkadotBondSelectDevice, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
@@ -17,7 +17,7 @@ import type {
   PolkadotValidator,
   PolkadotAccount,
 } from "@ledgerhq/live-common/families/polkadot/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { getDefaultExplorerView, getAddressExplorer } from "@ledgerhq/live-common/explorers";
@@ -68,7 +68,7 @@ function NominateSelectValidator({ navigation, route }: Props) {
   const { locale } = useSettings();
   invariant(account, "account required");
   const mainAccount = getMainAccount(account, parentAccount) as PolkadotAccount;
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const [drawerValidator, setDrawerValidator] = useState<PolkadotValidator | null | undefined>();
   const { polkadotResources } = mainAccount;
   invariant(polkadotResources, "polkadotResources required");

--- a/apps/ledger-live-mobile/src/families/polkadot/RebondFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/RebondFlow/01-Amount.tsx
@@ -15,7 +15,7 @@ import { useTheme } from "@react-navigation/native";
 import type { Transaction as PolkadotTransaction } from "@ledgerhq/live-common/families/polkadot/types";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
@@ -41,7 +41,7 @@ export default function PolkadotRebondAmount({ navigation, route }: NavigationPr
   const { colors } = useTheme();
   const { account, parentAccount } = useAccountScreen(route);
   invariant(account, "account is required");
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<PolkadotTransaction>(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
   const bridgeTransaction = useBridgeTransaction(() => {
@@ -60,7 +60,7 @@ export default function PolkadotRebondAmount({ navigation, route }: NavigationPr
   useEffect(() => {
     if (!account) return;
     let cancelled = false;
-    getAccountBridge(account, parentAccount)
+    bridge
       .estimateMaxSpendable({
         account,
         parentAccount,
@@ -74,7 +74,7 @@ export default function PolkadotRebondAmount({ navigation, route }: NavigationPr
     return () => {
       cancelled = true;
     };
-  }, [account, parentAccount, debouncedTransaction]);
+  }, [account, parentAccount, debouncedTransaction, bridge]);
   const onChange = useCallback(
     (amount: BigNumber) => {
       if (!amount.isNaN()) {
@@ -88,7 +88,6 @@ export default function PolkadotRebondAmount({ navigation, route }: NavigationPr
     [setTransaction, transaction, bridge],
   );
   const toggleUseAllAmount = useCallback(() => {
-    const bridge = getAccountBridge(account, parentAccount);
     if (!transaction) return;
     setTransaction(
       bridge.updateTransaction(transaction, {
@@ -96,7 +95,7 @@ export default function PolkadotRebondAmount({ navigation, route }: NavigationPr
         useAllAmount: !transaction.useAllAmount,
       }),
     );
-  }, [setTransaction, account, parentAccount, transaction]);
+  }, [setTransaction, bridge, transaction]);
   const onContinue = useCallback(() => {
     navigation.navigate(ScreenName.PolkadotRebondSelectDevice, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/polkadot/SimpleOperationFlow/01-Started.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/SimpleOperationFlow/01-Started.tsx
@@ -7,7 +7,7 @@ import type {
   Transaction as PolkadotTransaction,
   TransactionStatus,
 } from "@ledgerhq/live-common/families/polkadot/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { Button, Alert, Text, Log } from "@ledgerhq/native-ui";
@@ -43,7 +43,7 @@ export default function PolkadotSimpleOperationStarted({ navigation, route }: Na
   const { account, parentAccount } = useAccountScreen(route);
   invariant(account, "account required");
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<PolkadotTransaction>(account, parentAccount);
   const { polkadotResources } = mainAccount as PolkadotAccount;
   invariant(polkadotResources, "polkadotResources required");
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(

--- a/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
@@ -15,7 +15,7 @@ import { useTheme } from "@react-navigation/native";
 import type { Transaction as PolkadotTransaction } from "@ledgerhq/live-common/families/polkadot/types";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
 import LText from "~/components/LText";
@@ -40,7 +40,7 @@ export default function PolkadotUnbondAmount({ navigation, route }: Props) {
   const { colors } = useTheme();
   const { account, parentAccount } = useAccountScreen(route);
   invariant(account, "account is required");
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<PolkadotTransaction>(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
@@ -59,7 +59,7 @@ export default function PolkadotUnbondAmount({ navigation, route }: Props) {
   useEffect(() => {
     if (!account) return;
     let cancelled = false;
-    getAccountBridge(account, parentAccount)
+    bridge
       .estimateMaxSpendable({
         account,
         parentAccount,
@@ -73,10 +73,10 @@ export default function PolkadotUnbondAmount({ navigation, route }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [account, parentAccount, debouncedTransaction]);
+  }, [account, parentAccount, debouncedTransaction, bridge]);
   const onChange = useCallback(
     (amount: BigNumber) => {
-      if (!amount.isNaN()) {
+      if (!amount.isNaN() && transaction) {
         setTransaction(
           bridge.updateTransaction(transaction, {
             amount,
@@ -87,7 +87,6 @@ export default function PolkadotUnbondAmount({ navigation, route }: Props) {
     [setTransaction, transaction, bridge],
   );
   const toggleUseAllAmount = useCallback(() => {
-    const bridge = getAccountBridge(account, parentAccount);
     if (!transaction) return;
     setTransaction(
       bridge.updateTransaction(transaction, {
@@ -95,7 +94,7 @@ export default function PolkadotUnbondAmount({ navigation, route }: Props) {
         useAllAmount: !transaction.useAllAmount,
       }),
     );
-  }, [setTransaction, account, parentAccount, transaction]);
+  }, [setTransaction, bridge, transaction]);
   const onContinue = useCallback(() => {
     navigation.navigate(ScreenName.PolkadotUnbondSelectDevice, {
       accountId: account.id,

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectAmount.tsx
@@ -1,7 +1,8 @@
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { SOLANA_DELEGATION_RESERVE } from "@ledgerhq/live-common/families/solana/staking";
+import type { Transaction as SolanaTransaction } from "@ledgerhq/live-common/families/solana/types";
 import { useTheme } from "@react-navigation/native";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
@@ -48,9 +49,9 @@ export default function DelegationSelectAmount({ navigation, route }: Props) {
 
   const [maxSpendable, setMaxSpendable] = useState(0);
 
-  const bridge = getAccountBridge(account);
+  const bridge = useAccountBridge<SolanaTransaction>(account);
 
-  const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
+  const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction<SolanaTransaction>(
     () => ({
       account,
       transaction: {

--- a/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/01-SelectAsset.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/01-SelectAsset.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { View, StyleSheet, SafeAreaView, FlatList, TouchableOpacity } from "react-native";
 import { Trans } from "~/context/Locale";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import type { Transaction as StellarTransaction } from "@ledgerhq/live-common/families/stellar/types";
 import type { TokenAccount } from "@ledgerhq/types-live";
@@ -93,7 +93,7 @@ export default function DelegationStarted({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "Account required");
   const mainAccount = getMainAccount(account);
-  const bridge = getAccountBridge(mainAccount);
+  const bridge = useAccountBridge<StellarTransaction>(mainAccount);
   invariant(mainAccount, "stellar Account required");
   const { transaction, status } = useBridgeTransaction(() => {
     const t = bridge.createTransaction(mainAccount);
@@ -106,6 +106,7 @@ export default function DelegationStarted({ navigation, route }: Props) {
   });
   const onNext = useCallback(
     (assetId: string) => {
+      if (!transaction) return;
       const tokenId = assetId.split("/")[2];
       const [assetCode, assetIssuer] = tokenId.split(":");
       const t = bridge.updateTransaction(transaction, {

--- a/apps/ledger-live-mobile/src/families/stellar/StellarFeeRow.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/StellarFeeRow.tsx
@@ -4,8 +4,9 @@ import type { AccountLike, Account } from "@ledgerhq/types-live";
 import { View, StyleSheet, Linking, TouchableOpacity, SafeAreaView } from "react-native";
 import { Trans } from "~/context/Locale";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { Transaction as StellarTransaction } from "@ledgerhq/live-common/families/stellar/types";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import SummaryRow from "~/screens/SendFunds/SummaryRow";
 import LText from "~/components/LText";
@@ -49,7 +50,7 @@ export default function StellarFeeRow({
     Linking.openURL(urls.feesMoreInfo);
   }, []);
 
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<StellarTransaction>(account, parentAccount);
   const mainAccount = getMainAccount(account, parentAccount);
   const unit = useMaybeAccountUnit(mainAccount);
   const fees = transaction.family === "stellar" ? transaction.fees : null;
@@ -59,10 +60,10 @@ export default function StellarFeeRow({
     if (transaction.family === "stellar" && unit) {
       const fetchEstimatedFees = async () => {
         const preparedTransaction = await bridge.prepareTransaction(account as Account, {
-          ...transaction,
-          customFees: { parameters: { fees: null } },
+          ...(transaction as StellarTransaction),
+          customFees: undefined,
         });
-        setEstimatedFees(preparedTransaction.fees);
+        setEstimatedFees(preparedTransaction.fees ?? null);
       };
 
       fetchEstimatedFees();
@@ -87,7 +88,7 @@ export default function StellarFeeRow({
       setTransaction(
         bridge.updateTransaction(transaction, {
           fees: estimatedFees,
-          customFees: { parameters: { fees: estimatedFees } },
+          customFees: { value: BigInt(estimatedFees?.toFixed(0) ?? 0), parameters: { fees: estimatedFees } },
         }),
       );
     }

--- a/apps/ledger-live-mobile/src/families/sui/StakingFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/StakingFlow/02-Summary.tsx
@@ -1,9 +1,9 @@
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { useLedgerFirstShuffledValidatorsSui } from "@ledgerhq/live-common/families/sui/react";
-import { SuiValidator } from "@ledgerhq/live-common/families/sui/types";
+import { SuiValidator, Transaction as SuiTransaction } from "@ledgerhq/live-common/families/sui/types";
 import { AccountLike } from "@ledgerhq/types-live";
 import { Text, Icons } from "@ledgerhq/native-ui";
 import { useTheme } from "@react-navigation/native";
@@ -45,7 +45,7 @@ export default function StakingSummary({ navigation, route }: Props) {
   const validators = useLedgerFirstShuffledValidatorsSui("");
   const chosenValidator = validator || validators[0];
   const mainAccount = getMainAccount(account, parentAccount);
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<SuiTransaction>(account, undefined);
 
   const { transaction, updateTransaction, setTransaction, status, bridgePending, bridgeError } =
     useBridgeTransaction(() => {

--- a/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/01-Amount.tsx
@@ -2,7 +2,7 @@ import invariant from "invariant";
 import React from "react";
 import { BigNumber } from "bignumber.js";
 import type { Transaction } from "@ledgerhq/live-common/families/sui/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import SelectAmount from "../shared/02-SelectAmount";
@@ -18,7 +18,7 @@ type Props = BaseComposite<
 function UnstakingAmount({ navigation, route }: Props) {
   const { account } = useAccountScreen(route);
   invariant(account, "account required");
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<Transaction>(account, undefined);
   const mainAccount = getMainAccount(account, undefined);
   const { stakedSuiId, principal } = route.params.stakingPosition;
   const {

--- a/apps/ledger-live-mobile/src/families/sui/shared/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/shared/02-SelectAmount.tsx
@@ -11,8 +11,8 @@ import {
 } from "react-native";
 import { Trans } from "~/context/Locale";
 import { BigNumber } from "bignumber.js";
-import type { SuiAccount } from "@ledgerhq/live-common/families/sui/types";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import type { SuiAccount, Transaction as SuiTransaction } from "@ledgerhq/live-common/families/sui/types";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useTheme } from "styled-components/native";
 import Button from "~/components/Button";
@@ -46,7 +46,7 @@ function StakingAmount({ navigation, route }: Props) {
     account?.suiResources && route.params.transaction,
     "account and sui transaction required",
   );
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<SuiTransaction>(account, undefined);
   const unit = useAccountUnit(account);
   const initialValue = useMemo(() => route?.params?.value ?? new BigNumber(0), [route]);
   const [value, setValue] = useState(() => initialValue);

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
@@ -15,7 +15,7 @@ import { useTranslation, Trans } from "~/context/Locale";
 import { Icons } from "@ledgerhq/native-ui";
 import { RecipientRequired } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type {
   Transaction as TezosTransaction,
   Baker,
@@ -158,17 +158,15 @@ export default function SelectValidator({ navigation, route }: Props) {
   }
 
   invariant(account, "account is undefined");
+  const bridge = useAccountBridge<TezosTransaction>(account, parentAccount);
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
-    () => {
-      const bridge = getAccountBridge(account, parentAccount);
-      return {
-        account,
-        parentAccount,
-        transaction: bridge.updateTransaction(route.params?.transaction, {
-          recipient: "",
-        }),
-      };
-    },
+    () => ({
+      account,
+      parentAccount,
+      transaction: bridge.updateTransaction(route.params?.transaction, {
+        recipient: "",
+      }),
+    }),
   );
   invariant(transaction, "transaction is undefined");
   let error: Error | null = bridgeError || status.errors.recipient;
@@ -179,14 +177,13 @@ export default function SelectValidator({ navigation, route }: Props) {
 
   const onChangeText = useCallback(
     (recipient: string) => {
-      const bridge = getAccountBridge(account, parentAccount);
       setTransaction(
         bridge.updateTransaction(transaction, {
           recipient,
         }),
       );
     },
-    [account, parentAccount, setTransaction, transaction],
+    [bridge, setTransaction, transaction],
   );
   const continueCustom = useCallback(() => {
     setEditingCustom(false);
@@ -210,7 +207,6 @@ export default function SelectValidator({ navigation, route }: Props) {
   }, []);
   const onItemPress = useCallback(
     (baker: Baker) => {
-      const bridge = getAccountBridge(account, parentAccount);
       const transaction = bridge.updateTransaction(route.params?.transaction, {
         recipient: baker.address,
       });
@@ -220,7 +216,7 @@ export default function SelectValidator({ navigation, route }: Props) {
         status,
       });
     },
-    [account, parentAccount, route.params, navigation, status],
+    [bridge, route.params, navigation, status],
   );
   const renderItem: ListRenderItem<Baker> = useCallback(
     ({ item }) => <BakerRow baker={item} onPress={onItemPress} />,

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
@@ -3,7 +3,8 @@ import { View, StyleSheet, Animated, TextStyle, StyleProp } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans, useTranslation } from "~/context/Locale";
 import invariant from "invariant";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { AccountLike } from "@ledgerhq/types-live";
 import { getAccountCurrency, shortAddressPreview } from "@ledgerhq/live-common/account/index";
 import { getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import type { Transaction as TezosTransaction } from "@ledgerhq/live-common/families/tezos/types";
@@ -15,7 +16,6 @@ import {
   useStakingPositions,
 } from "@ledgerhq/live-common/families/tezos/react";
 import { whitelist } from "@ledgerhq/live-common/families/tezos/staking";
-import type { AccountLike } from "@ledgerhq/types-live";
 import { useTheme } from "@react-navigation/native";
 import { Alert, Icons } from "@ledgerhq/native-ui";
 import { rgba } from "../../../colors";
@@ -109,6 +109,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
   const { account, parentAccount } = useAccountScreen(route);
   const { t } = useTranslation();
   const [defaultBaker] = useBakers(whitelist);
+  const bridge = useAccountBridge<TezosTransaction>(account as AccountLike, parentAccount);
 
   const { transaction, setTransaction, status, bridgePending, bridgeError } = useBridgeTransaction(
     () => ({
@@ -127,10 +128,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
     invariant(transaction.family === "tezos", "tezos tx");
 
     // make sure the mode is in sync (an account changes can reset it)
-    const patch: {
-      mode: string;
-      recipient?: string;
-    } = {
+    const patch: Partial<TezosTransaction> & { mode: string; recipient?: string } = {
       mode: route.params?.mode ?? "delegate",
     };
 
@@ -142,10 +140,10 @@ export default function DelegationSummary({ navigation, route }: Props) {
     // when changes, we set again
     if (patch.mode !== transaction.mode || patch.recipient) {
       setTransaction(
-        getAccountBridge(account, parentAccount).updateTransaction(transaction, patch),
+        bridge.updateTransaction(transaction, patch),
       );
     }
-  }, [account, defaultBaker, navigation, parentAccount, setTransaction, transaction, route.params]);
+  }, [account, bridge, defaultBaker, navigation, parentAccount, setTransaction, transaction, route.params]);
 
   const [rotateAnim] = useState(() => new Animated.Value(0));
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -11,7 +11,7 @@ import {
   getAccountCurrency,
   getMainAccount,
 } from "@ledgerhq/ledger-wallet-framework/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useSelector } from "~/context/hooks";
 import { counterValueCurrencySelector } from "~/reducers/settings";
@@ -55,6 +55,7 @@ export function useNetworkFees({
     () => getMainAccount(account, parentAccount ?? undefined),
     [account, parentAccount],
   );
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const accountCurrency = useMemo(() => getAccountCurrency(mainAccount), [mainAccount]);
   const accountUnit = useMaybeAccountUnit(mainAccount) ?? accountCurrency.units[0];
   const fiatUnit = counterValueCurrency.units[0];
@@ -87,11 +88,10 @@ export function useNetworkFees({
   const updateTransactionWithPatch = useCallback(
     (patch: Partial<Transaction>) => {
       transactionActions.updateTransaction(currentTx => {
-        const bridge = getAccountBridge(account, parentAccount ?? undefined);
         return bridge.updateTransaction(currentTx, patch);
       });
     },
-    [account, parentAccount, transactionActions],
+    [bridge, transactionActions],
   );
 
   const selectedFeeStrategy = transaction.feesStrategy ?? null;

--- a/apps/ledger-live-mobile/src/screens/FreezeFunds/02-Amount.tsx
+++ b/apps/ledger-live-mobile/src/screens/FreezeFunds/02-Amount.tsx
@@ -11,10 +11,10 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans, useTranslation } from "~/context/Locale";
 import invariant from "invariant";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import { GraphTabs, Text, IconsLegacy } from "@ledgerhq/native-ui";
-import { Transaction } from "@ledgerhq/live-common/families/tron/types";
+import { Transaction, TronResource } from "@ledgerhq/live-common/families/tron/types";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
 import LText from "~/components/LText";
@@ -63,7 +63,7 @@ export default function FreezeAmount({ navigation, route }: NavigatorProps) {
 
   invariant(account && account.type === "Account", "account is required");
 
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<Transaction>(account, undefined);
 
   const defaultUnit = useAccountUnit(account);
   const { spendableBalance } = account;
@@ -107,7 +107,7 @@ export default function FreezeAmount({ navigation, route }: NavigatorProps) {
 
   const onChange = useCallback(
     (amount: BigNumber, keepRatio?: boolean) => {
-      if (!amount.isNaN()) {
+      if (!amount.isNaN() && transaction) {
         if (!keepRatio) selectRatio(undefined);
         setTransaction(
           bridge.updateTransaction(transaction, {
@@ -166,9 +166,10 @@ export default function FreezeAmount({ navigation, route }: NavigatorProps) {
 
   const onChangeResource = useCallback(
     (optionIndex: number) => {
+      if (!transaction) return;
       setTransaction(
         bridge.updateTransaction(transaction, {
-          resource: options[optionIndex].value,
+          resource: options[optionIndex].value as TronResource,
         }),
       );
     },

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
@@ -16,6 +16,9 @@ jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useScrollToTop: jest.fn(),
 }));
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: jest.fn().mockReturnValue({ updateTransaction: jest.fn() }),
+}));
 
 describe("SendSelectRecipient", () => {
   it.each([

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -2,7 +2,8 @@ import { isConfirmedOperation } from "@ledgerhq/ledger-wallet-framework/operatio
 import { RecipientRequired } from "@ledgerhq/errors";
 import { Text } from "@ledgerhq/native-ui";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import {
   SyncOneAccountOnMount,
   SyncSkipUnderPriority,
@@ -67,6 +68,7 @@ export default function SendSelectRecipient({ route }: Props) {
   invariant(account, "account is missing");
 
   const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const currencySettings = useCurrencySettingsForAccount(mainAccount);
   const { enabled: isDomainResolutionEnabled, params } = useFeature("domainInputResolution") ?? {};
   const isCurrencySupported =
@@ -126,7 +128,6 @@ export default function SendSelectRecipient({ route }: Props) {
   const onChangeText = useCallback(
     (recipient: string) => {
       if (!account) return;
-      const bridge = getAccountBridge(account, parentAccount);
       setTransaction(
         bridge.updateTransaction(transaction, {
           recipient,
@@ -134,17 +135,16 @@ export default function SendSelectRecipient({ route }: Props) {
       );
       setValue(recipient);
     },
-    [account, parentAccount, setTransaction, transaction],
+    [account, bridge, setTransaction, transaction],
   );
 
   const memoTag = useMemoTagInput(
     mainAccount.currency.family,
     useCallback(
       patch => {
-        const bridge = getAccountBridge(account, parentAccount);
         setTransaction(bridge.updateTransaction(transaction, patch(transaction)));
       },
-      [account, parentAccount, setTransaction, transaction],
+      [bridge, setTransaction, transaction],
     ),
   );
 
@@ -152,10 +152,9 @@ export default function SendSelectRecipient({ route }: Props) {
     mainAccount.currency.family,
     useCallback(
       patch => {
-        const bridge = getAccountBridge(account, parentAccount);
         setTransaction(bridge.updateTransaction(transaction, patch(transaction)));
       },
-      [account, parentAccount, setTransaction, transaction],
+      [bridge, setTransaction, transaction],
     ),
   );
 
@@ -172,9 +171,8 @@ export default function SendSelectRecipient({ route }: Props) {
 
   const onBridgeErrorRetry = useCallback(() => {
     setBridgeErr(null);
-    const bridge = getAccountBridge(account, parentAccount);
     setTransaction(bridge.updateTransaction(transaction, {}));
-  }, [setTransaction, account, parentAccount, transaction]);
+  }, [setTransaction, bridge, transaction]);
 
   const [memoTagDrawerState, setMemoTagDrawerState] = useState<MemoTagDrawerState>(
     MemoTagDrawerState.INITIAL,
@@ -227,6 +225,8 @@ export default function SendSelectRecipient({ route }: Props) {
 
   if (!account || !transaction) return null;
 
+  const stuckAccountAndOperation = getStuckAccountAndOperation(account, mainAccount);
+
   const error = withoutHiddenError(status.errors.recipient);
   const warning = status.warnings.recipient;
   const isSomeIncomingTxPending = account.operations?.some(
@@ -255,7 +255,6 @@ export default function SendSelectRecipient({ route }: Props) {
     !!status.errors.transaction ||
     !!status.errors.sender;
 
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, mainAccount);
   const extensions = getTokenExtensions(account);
 
   return (

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -1,4 +1,3 @@
-import invariant from "invariant";
 import { BigNumber } from "bignumber.js";
 import React, { useCallback, useState, useEffect } from "react";
 import { View, StyleSheet, TouchableWithoutFeedback, Keyboard, Linking } from "react-native";
@@ -7,7 +6,9 @@ import SafeAreaView from "~/components/SafeAreaView";
 import { Trans, useTranslation } from "~/context/Locale";
 import { useTheme } from "@react-navigation/native";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { AccountLike, Account } from "@ledgerhq/types-live";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { ScreenName } from "~/const";
@@ -35,8 +36,28 @@ import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
 type Props = StackNavigatorProps<SendFundsNavigatorStackParamList, ScreenName.SendAmountCoin>;
 
 export default function SendAmountCoin({ navigation, route }: Props) {
-  const { colors } = useTheme();
   const { account, parentAccount } = useAccountScreen(route);
+  if (!account) return null;
+  return (
+    <SendAmountCoinContent
+      account={account}
+      parentAccount={parentAccount}
+      navigation={navigation}
+      route={route}
+    />
+  );
+}
+
+type ContentProps = {
+  account: AccountLike;
+  parentAccount: Account | null | undefined;
+  navigation: Props["navigation"];
+  route: Props["route"];
+};
+
+function SendAmountCoinContent({ navigation, route, account, parentAccount }: ContentProps) {
+  const { colors } = useTheme();
+  const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
   const { t } = useTranslation();
 
@@ -51,9 +72,8 @@ export default function SendAmountCoin({ navigation, route }: Props) {
   );
   const debouncedTransaction = useDebounce(transaction, 500);
   useEffect(() => {
-    if (!account) return;
     let cancelled = false;
-    getAccountBridge(account, parentAccount)
+    bridge
       .estimateMaxSpendable({
         account,
         parentAccount,
@@ -67,13 +87,10 @@ export default function SendAmountCoin({ navigation, route }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [account, parentAccount, debouncedTransaction]);
-  invariant(account, "account is needed");
+  }, [account, parentAccount, debouncedTransaction, bridge]);
   const onChange = useCallback(
     (amount: BigNumber) => {
-      if (!amount.isNaN()) {
-        if (!account) return;
-        const bridge = getAccountBridge(account, parentAccount);
+      if (!amount.isNaN() && transaction) {
         setTransaction(
           bridge.updateTransaction(transaction, {
             amount,
@@ -81,19 +98,17 @@ export default function SendAmountCoin({ navigation, route }: Props) {
         );
       }
     },
-    [setTransaction, account, parentAccount, transaction],
+    [setTransaction, bridge, transaction],
   );
   const toggleUseAllAmount = useCallback(() => {
-    if (!account || !transaction) return;
-    const bridge = getAccountBridge(account, parentAccount);
-
+    if (!transaction) return;
     setTransaction(
       bridge.updateTransaction(transaction, {
         amount: new BigNumber(0),
         useAllAmount: !transaction.useAllAmount,
       }),
     );
-  }, [setTransaction, account, parentAccount, transaction]);
+  }, [setTransaction, bridge, transaction]);
   const onContinue = useCallback(() => {
     if (!transaction) return;
     navigation.navigate(ScreenName.SendSummary, {
@@ -114,14 +129,13 @@ export default function SendAmountCoin({ navigation, route }: Props) {
   const onBridgeErrorRetry = useCallback(() => {
     setBridgeErr(null);
     if (!transaction) return;
-    const bridge = getAccountBridge(account, parentAccount);
     setTransaction(bridge.updateTransaction(transaction, {}));
-  }, [setTransaction, account, parentAccount, transaction]);
+  }, [setTransaction, bridge, transaction]);
   const blur = useCallback(() => Keyboard.dismiss(), []);
   const onMaxSpendableLearnMore = useCallback(() => Linking.openURL(urls.maxSpendable), []);
 
   const unit = useMaybeAccountUnit(account);
-  if (!account || !transaction || !unit) return null;
+  if (!transaction || !unit) return null;
   const { useAllAmount } = transaction;
   const { amount } = status;
   const currency = getAccountCurrency(account);

--- a/apps/ledger-live-mobile/src/screens/SendFunds/DomainServiceRecipientRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/DomainServiceRecipientRow.tsx
@@ -1,7 +1,8 @@
 import React, { memo, useEffect, useMemo, useState } from "react";
 import { getRegistriesForDomain } from "@ledgerhq/domain-service/registries/index";
 import { isError, isLoaded } from "@ledgerhq/domain-service/hooks/logic";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import type { Transaction as GeneratedTransaction } from "@ledgerhq/live-common/generated/types";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { Platform, StyleSheet, View } from "react-native";
@@ -41,7 +42,7 @@ const DomainServiceRecipientInput = ({
   warning,
   error,
 }: Props) => {
-  const bridge = getAccountBridge(account, parentAccount);
+  const bridge = useAccountBridge<GeneratedTransaction>(account, parentAccount);
 
   const domainServiceResponse = useDomain(value, "ens");
   const lowerCaseValue = useMemo(() => value.toLowerCase(), [value]);

--- a/apps/ledger-live-mobile/src/screens/UnfreezeFunds/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/screens/UnfreezeFunds/01-Amount.tsx
@@ -6,10 +6,11 @@ import { Trans } from "~/context/Locale";
 import { useNavigation, useTheme } from "@react-navigation/native";
 import type { Account } from "@ledgerhq/types-live";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import type {
   TronAccount,
+  TronResource,
   Transaction as TronTransaction,
 } from "@ledgerhq/live-common/families/tron/types";
 import { ScreenName } from "~/const";
@@ -54,7 +55,7 @@ type InnerProps = {
 function UnfreezeAmountInner({ account }: InnerProps) {
   const { colors } = useTheme();
   const navigation = useNavigation<StackNavigatorNavigation<UnfreezeNavigatorParamList>>();
-  const bridge = getAccountBridge(account, undefined);
+  const bridge = useAccountBridge<TronTransaction>(account, undefined);
   const unit = useAccountUnit(account);
   const { tronResources } = account as TronAccount;
   invariant(tronResources, "tron resources expected");
@@ -100,9 +101,10 @@ function UnfreezeAmountInner({ account }: InnerProps) {
   }, [bridge, setTransaction, transaction]);
   const onChangeResource = useCallback(
     (resource: string) => {
+      if (!transaction) return;
       setTransaction(
         bridge.updateTransaction(transaction, {
-          resource,
+          resource: resource as TronResource,
         }),
       );
     },

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -28,6 +28,7 @@
     "src/bridge/impl.ts",
     "src/bridge/index.ts",
     "src/bridge/react/index.ts",
+    "src/bridge/useAccountBridge.ts",
     "src/bridge/useBridgeTransaction.ts",
     "src/counterValues/state-manager/api.ts",
     "src/counterValues/state-manager/onSchemaFailure.ts",

--- a/libs/ledger-live-common/src/bridge/useAccountBridge.test.ts
+++ b/libs/ledger-live-common/src/bridge/useAccountBridge.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+import "../__tests__/test-helpers/dom-polyfill";
+import React from "react";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { renderHook, act } from "@testing-library/react";
+import { genAccount } from "../mock/account";
+import { setSupportedCurrencies } from "../currencies";
+import { useAccountBridge } from "./useAccountBridge";
+
+const BTC = getCryptoCurrencyById("bitcoin");
+setSupportedCurrencies(["bitcoin"]);
+
+const suspenseWrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(React.Suspense, { fallback: null }, children);
+
+describe("useAccountBridge", () => {
+  test("returns bridge synchronously without a Suspense boundary", () => {
+    const account = genAccount("mocked-account-sync", { currency: BTC });
+
+    // No suspenseWrapper — if useAccountBridge suspended it would throw here
+    const { result } = renderHook(() => useAccountBridge(account));
+
+    expect(typeof result.current.createTransaction).toBe("function");
+    expect(typeof result.current.updateTransaction).toBe("function");
+    expect(typeof result.current.prepareTransaction).toBe("function");
+  });
+
+  test("returns a bridge with createTransaction for a BTC account", async () => {
+    const account = genAccount("mocked-account-1", { currency: BTC });
+
+    let result: ReturnType<typeof renderHook<ReturnType<typeof useAccountBridge>, void>>["result"];
+    await act(async () => {
+      ({ result } = renderHook(() => useAccountBridge(account), { wrapper: suspenseWrapper }));
+      // Two microtask ticks: one for "await getAccountBridge", one for React's wakeUp to fire.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(typeof result!.current.createTransaction).toBe("function");
+    expect(typeof result!.current.updateTransaction).toBe("function");
+    expect(typeof result!.current.prepareTransaction).toBe("function");
+  });
+});

--- a/libs/ledger-live-common/src/bridge/useAccountBridge.ts
+++ b/libs/ledger-live-common/src/bridge/useAccountBridge.ts
@@ -1,0 +1,28 @@
+import { use, useMemo } from "react";
+import { getAccountBridge } from ".";
+import type { Account, AccountBridge, AccountLike, TransactionCommon } from "@ledgerhq/types-live";
+
+// Temporary: getAccountBridge is currently synchronous but will become async soon.
+// Pre-annotate the Promise as fulfilled so React's use() returns it on the first
+// render without suspending. Once getAccountBridge is truly async, remove
+// fulfilledPromise and return a plain Promise — use() will suspend once, handled
+// by the screenLayout <Suspense> boundary.
+function fulfilledPromise<T>(value: T): Promise<T> {
+  const p = Promise.resolve(value) as Promise<T> & { status: "fulfilled"; value: T };
+  p.status = "fulfilled";
+  p.value = value;
+  return p;
+}
+
+// Requires a <Suspense> boundary in the parent tree.
+export function useAccountBridge<T extends TransactionCommon>(
+  account: AccountLike,
+  parentAccount?: Account | null,
+): AccountBridge<T> {
+  const promise = useMemo(
+    () => fulfilledPromise(getAccountBridge(account, parentAccount) as AccountBridge<T>),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [account.id, parentAccount?.id],
+  );
+  return use(promise);
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Two unit tests added in `useAccountBridge.test.ts`:
  - sync render without a `<Suspense>` boundary (proves `fulfilledPromise` avoids suspending today)
  - render inside a `<Suspense>` boundary (forward-compat path for when `getAccountBridge` becomes async)
- [x] **Impact of the changes:**
  - New exported hook `useAccountBridge` in `@ledgerhq/live-common`
  - Will need a `<Suspense>` boundary in the parent tree (consistent with React 19 `use()` contract), but it will only be needed when we activate the async load.
    - a test is proving that currently, the use(fulfilledPromise) is resolved in sync.

### 📝 Description

Ships a new `useAccountBridge` hook using React 19 `use()` for Suspense-compatible account bridge access.

**Non-breaking:** uses a `fulfilledPromise` helper that pre-marks the Promise as already fulfilled, so `use()` returns synchronously on the first render — no Suspense boundary is triggered today.

**Forward-compatible:** once `getAccountBridge` becomes truly async, simply remove the `fulfilledPromise` wrapper and return a plain Promise — `use()` will suspend once, resolved by the existing `<Suspense>` boundary.

Consumer TLDR:

```ts
// Before (in a component)
const bridge = getAccountBridge(account, parentAccount)

// After
const bridge = useAccountBridge(account, parentAccount)
```

**Type improvement and bugs finding**: thanks to a stronger Bridge typing, code type-checking revealed a few cases of coin ui issues, I need coin team to carefully review the part mentionned.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) — partial delivery of umbrella PR #16733
- **ADR link (if any)**: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ