### PR TITLE
[LWDM] refactor(live-common): properly await loader in getDeviceTransactionConfig

### DIFF
--- a/.changeset/async-device-tx-config.md
+++ b/.changeset/async-device-tx-config.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Properly await family loader in getDeviceTransactionConfig

--- a/libs/ledger-live-common/src/transaction/deviceTransactionConfig.ts
+++ b/libs/ledger-live-common/src/transaction/deviceTransactionConfig.ts
@@ -26,7 +26,7 @@ export async function getDeviceTransactionConfig(arg: {
 }): Promise<Array<DeviceTransactionField>> {
   const mainAccount = getMainAccount(arg.account, arg.parentAccount);
   const family = mainAccount.currency.family;
-  const f = loadDeviceTxConfigForFamily(family);
+  const f = await loadDeviceTxConfigForFamily(family);
   if (!f) return [];
   return await f(arg);
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing unit tests cover the `getDeviceTransactionConfig` code path; `await` on a sync value is a no-op so no test changes are required.
- [x] **Impact of the changes:**
  - Live-common only: single call site change in `transaction/deviceTransactionConfig.ts`.
  - No behaviour change today — `await` on a synchronous return value is a no-op.
  - Forward-compatible: once `loadDeviceTxConfigForFamily` becomes fully async (umbrella PR #16733), no further edit will be needed here.

### 📝 Description

`getDeviceTransactionConfig` was already declared `async` and awaits the result of calling `f(arg)`, but it was not awaiting the loader call that resolves `f`:

```diff
- const f = loadDeviceTxConfigForFamily(family);
+ const f = await loadDeviceTxConfigForFamily(family);
```

Adding `await` here ensures that when `loadDeviceTxConfigForFamily` is promoted to a fully async loader (returning `Promise<DeviceTransactionConfigFn>`), this call site requires no further change.

The only production call site of this function is `useDeviceTransactionConfig.ts`, which already uses `await getDeviceTransactionConfig()`. Coin-module test files that reference `getDeviceTransactionConfig` import their own per-coin local function, not this registry-based one.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) — partial delivery of umbrella PR #16733
- **ADR link (if any)**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ