### PR TITLE
[LWDM] refactor(live-common): make isEditableOperation/isStuckOperation/getStuckAccountAndOperation async

### DIFF
--- a/.changeset/async-operation-ts.md
+++ b/.changeset/async-operation-ts.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Make isEditableOperation, isStuckOperation, getStuckAccountAndOperation async

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/DateCell.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/DateCell.tsx
@@ -2,7 +2,7 @@ import { isStuckOperation } from "@ledgerhq/live-common/operation";
 import { InfiniteLoader, IconsLegacy } from "@ledgerhq/react-ui";
 import { Operation } from "@ledgerhq/types-live";
 import { TFunction } from "i18next";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";
 import OperationDate from "./OperationDate";
@@ -39,6 +39,10 @@ const PendingLoadingIcon = ({ displayWarning }: { displayWarning: boolean }): Re
 };
 
 const DateCell = ({ t, family, operation, compact, text, editable }: Props): React.JSX.Element => {
+  const [isStuck, setIsStuck] = useState(false);
+  useEffect(() => {
+    isStuckOperation({ family, operation }).then(setIsStuck);
+  }, [family, operation]);
   const ellipsis = {
     display: "block",
     textOverflow: "ellipsis",
@@ -61,7 +65,7 @@ const DateCell = ({ t, family, operation, compact, text, editable }: Props): Rea
       {editable ? (
         <Box fontSize={3} color="neutral.c80">
           <Box ff="Inter|SemiBold" fontSize={3} color="neutral.c80" style={ellipsis}>
-            <PendingLoadingIcon displayWarning={isStuckOperation({ family, operation })} />
+            <PendingLoadingIcon displayWarning={isStuck} />
             <Box
               style={{
                 marginLeft: "4px",

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/OperationsListV1/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/OperationsListV1/index.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import React, { PureComponent, useEffect, useState } from "react";
 import styled from "styled-components";
 import { connect } from "react-redux";
 import { compose } from "redux";
@@ -26,6 +26,43 @@ import TableContainer, { TableHeader } from "../../TableContainer";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { isEditableOperation } from "@ledgerhq/live-common/operation";
+
+type OperationWithEditableProps = {
+  operation: Operation;
+  account: AccountLike;
+  parentAccount: Account | undefined;
+  mainAccount: Account;
+  onOperationClick: (operation: Operation, account: AccountLike, parentAccount?: Account) => void;
+  t: TFunction;
+  withAccount: boolean;
+};
+
+const OperationWithEditable = ({
+  operation,
+  account,
+  parentAccount,
+  mainAccount,
+  onOperationClick,
+  t,
+  withAccount,
+}: OperationWithEditableProps) => {
+  const [editable, setEditable] = useState(false);
+  useEffect(() => {
+    isEditableOperation({ account: mainAccount, operation }).then(setEditable);
+  }, [mainAccount, operation]);
+  return (
+    <OperationC
+      operation={operation}
+      account={account}
+      parentAccount={parentAccount}
+      key={`${account.id}_${operation.id}`}
+      onOperationClick={onOperationClick}
+      t={t}
+      withAccount={withAccount}
+      editable={editable}
+    />
+  );
+};
 
 const ShowMore = styled(Box).attrs(() => ({
   horizontal: true,
@@ -155,15 +192,15 @@ export class OperationsList extends PureComponent<Props, State> {
                 }
                 const mainAccount = getMainAccount(account, parentAccount);
                 return (
-                  <OperationC
+                  <OperationWithEditable
+                    key={`${account.id}_${operation.id}`}
                     operation={operation}
                     account={account}
                     parentAccount={parentAccount}
-                    key={`${account.id}_${operation.id}`}
+                    mainAccount={mainAccount}
                     onOperationClick={this.handleClickOperation}
                     t={t}
-                    withAccount={withAccount}
-                    editable={account && isEditableOperation({ account: mainAccount, operation })}
+                    withAccount={withAccount ?? false}
                   />
                 );
               })}

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -23,7 +23,7 @@ import { CryptoCurrency, CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike, Operation, OperationType } from "@ledgerhq/types-live";
 import { TFunction } from "i18next";
 import uniq from "lodash/uniq";
-import React, { Component, useCallback, useMemo } from "react";
+import React, { Component, useCallback, useEffect, useMemo, useState } from "react";
 import invariant from "invariant";
 import { Trans, useTranslation } from "react-i18next";
 import { connect } from "react-redux";
@@ -256,52 +256,66 @@ const OperationD = (props: Props) => {
   const currencyFamily = mainAccount.currency.family;
 
   // Determine if transaction editing is supported and which modal to use
-  const editConfig = useMemo(() => {
-    // Check for Bitcoin RBF support
-    if (currencyFamily === "bitcoin") {
-      // RBF only works for unconfirmed (pending) transactions
-      const isEditable = isEditableOperation({ account: mainAccount, operation });
-      if (
-        !isEditable ||
-        !bitcoinParams?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId)
-      ) {
-        return null;
+  const [editConfig, setEditConfig] = useState<{
+    modalName: "MODAL_BITCOIN_EDIT_TRANSACTION" | "MODAL_EVM_EDIT_TRANSACTION";
+    isSupported: boolean;
+  } | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    async function computeEditConfig() {
+      // Check for Bitcoin RBF support
+      if (currencyFamily === "bitcoin") {
+        const isEditable = await isEditableOperation({ account: mainAccount, operation });
+        if (cancelled) return;
+        if (
+          !isEditable ||
+          !bitcoinParams?.supportedCurrencyIds?.includes(
+            mainAccount.currency.id as CryptoCurrencyId,
+          )
+        ) {
+          setEditConfig(null);
+          return;
+        }
+        if (
+          isEditBitcoinTxEnabled &&
+          bitcoinParams?.supportedCurrencyIds?.includes(
+            mainAccount.currency.id as CryptoCurrencyId,
+          )
+        ) {
+          setEditConfig({ modalName: "MODAL_BITCOIN_EDIT_TRANSACTION", isSupported: true });
+          return;
+        }
+        setEditConfig(null);
+        return;
       }
 
-      if (
-        isEditBitcoinTxEnabled &&
-        bitcoinParams?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId)
-      ) {
-        return {
-          modalName: "MODAL_BITCOIN_EDIT_TRANSACTION" as const,
-          isSupported: true,
-        };
+      // For EVM, transactionRaw is required
+      if (!operation.transactionRaw) {
+        setEditConfig(null);
+        return;
       }
-      return null;
-    }
 
-    // For EVM, transactionRaw is required
-    if (!operation.transactionRaw) {
-      return null;
-    }
-
-    // Check for EVM support
-    if (currencyFamily === "evm") {
-      const isCurrencySupported =
-        params?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId) ||
-        false;
-      const isEditable = isEditableOperation({ account: mainAccount, operation });
-
-      if (isEditEvmTxEnabled && isCurrencySupported && isEditable) {
-        return {
-          modalName: "MODAL_EVM_EDIT_TRANSACTION" as const,
-          isSupported: true,
-        };
+      // Check for EVM support
+      if (currencyFamily === "evm") {
+        const isCurrencySupported =
+          params?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId) ||
+          false;
+        const isEditable = await isEditableOperation({ account: mainAccount, operation });
+        if (cancelled) return;
+        if (isEditEvmTxEnabled && isCurrencySupported && isEditable) {
+          setEditConfig({ modalName: "MODAL_EVM_EDIT_TRANSACTION", isSupported: true });
+          return;
+        }
+        setEditConfig(null);
+        return;
       }
-      return null;
-    }
 
-    return null;
+      setEditConfig(null);
+    }
+    computeEditConfig();
+    return () => {
+      cancelled = true;
+    };
   }, [
     currencyFamily,
     isEditEvmTxEnabled,
@@ -374,7 +388,10 @@ const OperationD = (props: Props) => {
     operation.hash,
   ]);
 
-  const isStuck = isStuckOperation({ family: mainAccount.currency.family, operation });
+  const [isStuck, setIsStuck] = useState(false);
+  useEffect(() => {
+    isStuckOperation({ family: mainAccount.currency.family, operation }).then(setIsStuck);
+  }, [mainAccount.currency.family, operation]);
   const feesCurrency = useMemo(() => getFeesCurrency(mainAccount), [mainAccount]);
   const feesUnit = useMemo(() => getFeesUnit(feesCurrency), [feesCurrency]);
 

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
@@ -4,7 +4,7 @@ import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
 import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import invariant from "invariant";
-import React, { memo } from "react";
+import React, { memo, useState, useEffect } from "react";
 import { SharedEditStuckTransactionPanelBodyHeader } from "~/renderer/components/SpeedUpCancel";
 
 type Props = {
@@ -20,11 +20,18 @@ const EditStuckTransactionPanelBodyHeader = ({ account, parentAccount }: Props) 
   const isCurrencySupported =
     params?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId) || false;
 
+  const [stuckAccountAndOperation, setStuckAccountAndOperation] = useState<
+    Awaited<ReturnType<typeof getStuckAccountAndOperation>>
+  >(undefined);
+
+  useEffect(() => {
+    if (!isEditEvmTxEnabled || !isCurrencySupported) return;
+    getStuckAccountAndOperation(account, parentAccount).then(setStuckAccountAndOperation);
+  }, [account, parentAccount, isEditEvmTxEnabled, isCurrencySupported]);
+
   if (!isEditEvmTxEnabled || !isCurrencySupported) {
     return null;
   }
-  // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, parentAccount);
 
   return (
     <SharedEditStuckTransactionPanelBodyHeader

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/EditTransactionComponents.test.tsx
@@ -187,8 +187,8 @@ describe("EVM EditTransaction components", () => {
     expect(transitionTo).toHaveBeenCalledWith("device");
   });
 
-  it("EditStuckTransactionPanelBodyHeader forwards feature/status to shared header", () => {
-    (getStuckAccountAndOperation as jest.Mock).mockReturnValue({
+  it("EditStuckTransactionPanelBodyHeader forwards feature/status to shared header", async () => {
+    (getStuckAccountAndOperation as jest.Mock).mockResolvedValue({
       operation: {},
       account,
       parentAccount: undefined,
@@ -198,6 +198,6 @@ describe("EVM EditTransaction components", () => {
       initialState: withFlagOverrides({ editEvmTx: { enabled: true, params: { supportedCurrencyIds: ["ethereum"] } } }),
     });
 
-    expect(screen.getByTestId("shared-stuck-header")).toHaveTextContent("true-true-true");
+    expect(await screen.findByTestId("shared-stuck-header")).toHaveTextContent("true-true-true");
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/evm/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/index.ts
@@ -1,5 +1,8 @@
 import { getMessageProperties } from "@ledgerhq/coin-evm/logic";
-import { isEditableOperation } from "@ledgerhq/live-common/operation";
+import { isEditableOperation } from "@ledgerhq/coin-evm/operation";
+import { getCurrencyConfiguration } from "@ledgerhq/live-common/config/index";
+import type { EvmConfigInfo } from "@ledgerhq/coin-evm/config";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
 import AccountBodyHeader from "./AccountBodyHeader";
 import AccountFooter from "./AccountFooter";
@@ -30,7 +33,11 @@ const family: EvmFamily = {
 
     const isCurrencySupported =
       featureFlags.evm.supportedCurrencyIds?.includes(mainAccount.currency.id) || false;
-    const isEditable = isEditableOperation({ account: mainAccount, operation });
+    const hasGasTracker = (currency: CryptoCurrency): boolean => {
+      const config = getCurrencyConfiguration<EvmConfigInfo>(currency.id);
+      return !!config.gasTracker;
+    };
+    const isEditable = isEditableOperation(mainAccount, operation, hasGasTracker);
 
     if (!featureFlags.evm.enabled || !isCurrencySupported || !isEditable) {
       return null;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
 import { Trans } from "react-i18next";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
@@ -68,13 +68,20 @@ export const DefaultStepRecipient = ({
     [isEnabledForFamily],
   );
 
+  const [stuckAccountAndOperation, setStuckAccountAndOperation] = useState<
+    Awaited<ReturnType<typeof getStuckAccountAndOperation>>
+  >(undefined);
+
+  useEffect(() => {
+    if (!account) return;
+    // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
+    getStuckAccountAndOperation(account, parentAccount).then(setStuckAccountAndOperation);
+  }, [account, parentAccount]);
+
   if (!status || !account) return null;
 
   const mainAccount = getMainAccount(account, parentAccount);
   const extensions = getTokenExtensions(account);
-
-  // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, parentAccount);
 
   return (
     <Box flow={4}>

--- a/apps/ledger-live-mobile/src/components/OperationRow/index.tsx
+++ b/apps/ledger-live-mobile/src/components/OperationRow/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { TouchableOpacity } from "react-native";
 import { Trans } from "~/context/Locale";
 import styled, { useTheme } from "styled-components/native";
@@ -158,9 +158,19 @@ function OperationRow({
 
   const text = <Trans i18nKey={`operations.types.${operation.type}`} />;
   const isOptimistic = operation.blockHeight === null;
-  const isOperationStuck =
-    isEditableOperation({ account: mainAccount, operation }) &&
-    isStuckOperation({ family: mainAccount.currency.family, operation });
+  const [isOperationStuck, setIsOperationStuck] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    isEditableOperation({ account: mainAccount, operation }).then(editable => {
+      if (cancelled || !editable) return;
+      isStuckOperation({ family: mainAccount.currency.family, operation }).then(stuck => {
+        if (!cancelled) setIsOperationStuck(stuck);
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [mainAccount, operation]);
 
   const spinner = isOperationStuck ? (
     <WarningMedium />

--- a/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
@@ -1,9 +1,10 @@
-import React, { ReactNode, useMemo } from "react";
+import React, { ReactNode, useEffect, useMemo, useState } from "react";
 import { LayoutChangeEvent } from "react-native";
 import { isAccountEmpty, getMainAccount } from "@ledgerhq/live-common/account/index";
 import {
   AccountLike,
   Account,
+  Operation,
   ValueChange,
   PortfolioRange,
   BalanceHistoryWithCountervalue,
@@ -98,34 +99,64 @@ export function useListHeaderComponents({
     () => (account ? getMainAccount(account, parentAccount) : undefined),
     [account, parentAccount],
   );
-  const oldestEditableOperation = useMemo(() => {
-    if (!account || !mainAccount) return undefined;
+  const pendingOperations = account?.pendingOperations;
+  const family = mainAccount?.currency.family ?? "";
 
-    const editablePendingOperations = account.pendingOperations.filter(pendingOperation =>
-      isEditableOperation({ account: mainAccount, operation: pendingOperation }),
-    );
+  const [oldestEditableOperation, setOldestEditableOperation] = useState<Operation | undefined>(
+    undefined,
+  );
+  const [isOperationStuck, setIsOperationStuck] = useState(false);
 
-    return mainAccount.currency.family === "bitcoin"
-      ? editablePendingOperations.sort(
-          (a, b) =>
-            (a.date instanceof Date ? a.date : new Date(a.date)).getTime() -
-            (b.date instanceof Date ? b.date : new Date(b.date)).getTime(),
-        )[0]
-      : editablePendingOperations.sort((a, b) => {
-          const aSeq = a.transactionSequenceNumber;
-          const bSeq = b.transactionSequenceNumber;
-          if (aSeq != null && bSeq != null) {
-            if (aSeq.isLessThan(bSeq)) return -1;
-            if (aSeq.isGreaterThan(bSeq)) return 1;
-            return 0;
-          }
-          return 0;
-        })[0];
-  }, [account, mainAccount]);
+  useEffect(() => {
+    if (!account || !mainAccount || !pendingOperations || !family) {
+      setOldestEditableOperation(undefined);
+      setIsOperationStuck(false);
+      return;
+    }
+    let cancelled = false;
+    Promise.all(
+      pendingOperations.map(op =>
+        isEditableOperation({ account: mainAccount, operation: op }).then(editable =>
+          editable ? op : null,
+        ),
+      ),
+    ).then(results => {
+      if (cancelled) return;
+      const editablePendingOperations = results.filter(
+        (op): op is NonNullable<typeof op> => op !== null,
+      );
+      const oldest =
+        family === "bitcoin"
+          ? editablePendingOperations.sort(
+              (a, b) =>
+                (a.date instanceof Date ? a.date : new Date(a.date)).getTime() -
+                (b.date instanceof Date ? b.date : new Date(b.date)).getTime(),
+            )[0]
+          : editablePendingOperations.sort((a, b) => {
+              const aSeq = a.transactionSequenceNumber;
+              const bSeq = b.transactionSequenceNumber;
+              if (aSeq != null && bSeq != null) {
+                if (aSeq.isLessThan(bSeq)) return -1;
+                if (aSeq.isGreaterThan(bSeq)) return 1;
+                return 0;
+              }
+              return 0;
+            })[0];
+      setOldestEditableOperation(oldest);
+      if (!oldest) {
+        setIsOperationStuck(false);
+        return;
+      }
+      isStuckOperation({ family, operation: oldest }).then(stuck => {
+        if (!cancelled) setIsOperationStuck(stuck);
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [account, mainAccount, pendingOperations, family]);
 
   if (!account || !mainAccount) return { listHeaderComponents: [], stickyHeaderIndices: undefined };
-
-  const family: string = mainAccount.currency.family;
 
   const empty = isAccountEmpty(account);
   const shouldUseCounterValue = countervalueAvailable && useCounterValue;
@@ -161,11 +192,6 @@ export function useListHeaderComponents({
     });
 
   const stickyHeaderIndices = empty ? [] : [0];
-
-  const isOperationStuck = Boolean(
-    oldestEditableOperation &&
-    isStuckOperation({ family: mainAccount.currency.family, operation: oldestEditableOperation }),
-  );
 
   const disableDelegation =
     currencyConfig &&

--- a/apps/ledger-live-mobile/src/screens/OperationDetails/Content.tsx
+++ b/apps/ledger-live-mobile/src/screens/OperationDetails/Content.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { View, StyleSheet, Linking } from "react-native";
 import uniq from "lodash/uniq";
 import { Trans, useTranslation } from "~/context/Locale";
@@ -122,8 +122,28 @@ export default function Content({
     currencySettings.confirmationsNb,
   );
 
-  const isEditable = isEditableOperation({ account: mainAccount, operation });
-  const isOperationStuck = isStuckOperation({ family: mainAccount.currency.family, operation });
+  const [isEditable, setIsEditable] = useState(false);
+  const [isOperationStuck, setIsOperationStuck] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    isEditableOperation({ account: mainAccount, operation }).then(editable => {
+      if (!cancelled) setIsEditable(editable);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [mainAccount, operation]);
+
+  useEffect(() => {
+    let cancelled = false;
+    isStuckOperation({ family: mainAccount.currency.family, operation }).then(stuck => {
+      if (!cancelled) setIsOperationStuck(stuck);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [mainAccount, operation]);
 
   const specificOperationDetails =
     byFamiliesOperationDetails[

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -225,6 +225,19 @@ export default function SendSelectRecipient({ route }: Props) {
     currency,
   ]);
 
+  const [stuckAccountAndOperation, setStuckAccountAndOperation] = useState<Awaited<
+    ReturnType<typeof getStuckAccountAndOperation>
+  >>(undefined);
+  useEffect(() => {
+    let cancelled = false;
+    getStuckAccountAndOperation(account, mainAccount).then(result => {
+      if (!cancelled) setStuckAccountAndOperation(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [account, mainAccount]);
+
   if (!account || !transaction) return null;
 
   const error = withoutHiddenError(status.errors.recipient);
@@ -255,7 +268,6 @@ export default function SendSelectRecipient({ route }: Props) {
     !!status.errors.transaction ||
     !!status.errors.sender;
 
-  const stuckAccountAndOperation = getStuckAccountAndOperation(account, mainAccount);
   const extensions = getTokenExtensions(account);
 
   return (

--- a/libs/ledger-live-common/src/operation.test.ts
+++ b/libs/ledger-live-common/src/operation.test.ts
@@ -20,45 +20,45 @@ const mockOperation = {} as any;
 beforeEach(() => jest.clearAllMocks());
 
 describe("isEditableOperation", () => {
-  it("delegates to loader and returns result", () => {
+  it("delegates to loader and returns result", async () => {
     const fn = jest.fn(() => true);
-    (loadIsEditableOperationForFamily as jest.Mock).mockReturnValue(fn);
-    expect(isEditableOperation({ account: mockAccount, operation: mockOperation })).toBe(true);
+    (loadIsEditableOperationForFamily as jest.Mock).mockResolvedValue(fn);
+    expect(await isEditableOperation({ account: mockAccount, operation: mockOperation })).toBe(true);
     expect(loadIsEditableOperationForFamily).toHaveBeenCalledWith("evm");
     expect(fn).toHaveBeenCalled();
   });
 
-  it("returns false when no loader", () => {
-    (loadIsEditableOperationForFamily as jest.Mock).mockReturnValue(undefined);
-    expect(isEditableOperation({ account: mockAccount, operation: mockOperation })).toBe(false);
+  it("returns false when no loader", async () => {
+    (loadIsEditableOperationForFamily as jest.Mock).mockResolvedValue(undefined);
+    expect(await isEditableOperation({ account: mockAccount, operation: mockOperation })).toBe(false);
   });
 });
 
 describe("isStuckOperation", () => {
-  it("delegates to loader", () => {
+  it("delegates to loader", async () => {
     const fn = jest.fn(() => true);
-    (loadIsStuckOperationForFamily as jest.Mock).mockReturnValue(fn);
-    expect(isStuckOperation({ family: "evm", operation: mockOperation })).toBe(true);
+    (loadIsStuckOperationForFamily as jest.Mock).mockResolvedValue(fn);
+    expect(await isStuckOperation({ family: "evm", operation: mockOperation })).toBe(true);
     expect(loadIsStuckOperationForFamily).toHaveBeenCalledWith("evm");
   });
 
-  it("returns false when no loader", () => {
-    (loadIsStuckOperationForFamily as jest.Mock).mockReturnValue(undefined);
-    expect(isStuckOperation({ family: "evm", operation: mockOperation })).toBe(false);
+  it("returns false when no loader", async () => {
+    (loadIsStuckOperationForFamily as jest.Mock).mockResolvedValue(undefined);
+    expect(await isStuckOperation({ family: "evm", operation: mockOperation })).toBe(false);
   });
 });
 
 describe("getStuckAccountAndOperation", () => {
-  it("delegates to loader", () => {
+  it("delegates to loader", async () => {
     const result = { account: mockAccount, parentAccount: undefined, operation: mockOperation };
     const fn = jest.fn(() => result);
-    (loadGetStuckAccountAndOperationForFamily as jest.Mock).mockReturnValue(fn);
-    expect(getStuckAccountAndOperation(mockAccount, null)).toBe(result);
+    (loadGetStuckAccountAndOperationForFamily as jest.Mock).mockResolvedValue(fn);
+    expect(await getStuckAccountAndOperation(mockAccount, null)).toBe(result);
     expect(loadGetStuckAccountAndOperationForFamily).toHaveBeenCalledWith("evm");
   });
 
-  it("returns undefined when no loader", () => {
-    (loadGetStuckAccountAndOperationForFamily as jest.Mock).mockReturnValue(undefined);
-    expect(getStuckAccountAndOperation(mockAccount, null)).toBeUndefined();
+  it("returns undefined when no loader", async () => {
+    (loadGetStuckAccountAndOperationForFamily as jest.Mock).mockResolvedValue(undefined);
+    expect(await getStuckAccountAndOperation(mockAccount, null)).toBeUndefined();
   });
 });

--- a/libs/ledger-live-common/src/operation.ts
+++ b/libs/ledger-live-common/src/operation.ts
@@ -15,38 +15,40 @@ function hasGasTracker(currency: CryptoCurrency): boolean {
   return !!config.gasTracker;
 }
 
-export const isEditableOperation = ({
+export const isEditableOperation = async ({
   account,
   operation,
 }: {
   account: Account;
   operation: Operation;
-}): boolean =>
-  loadIsEditableOperationForFamily(account.currency.family)?.(account, operation, hasGasTracker) ??
-  false;
+}): Promise<boolean> => {
+  const fn = await loadIsEditableOperationForFamily(account.currency.family);
+  return fn?.(account, operation, hasGasTracker) ?? false;
+};
 
-export const isStuckOperation = ({
+export const isStuckOperation = async ({
   family,
   operation,
 }: {
   family: string;
   operation: Operation;
-}): boolean => loadIsStuckOperationForFamily(family)?.(operation) ?? false;
+}): Promise<boolean> => {
+  const fn = await loadIsStuckOperationForFamily(family);
+  return fn?.(operation) ?? false;
+};
 
-export const getStuckAccountAndOperation = (
+export const getStuckAccountAndOperation = async (
   account: AccountLike,
   parentAccount: Account | undefined | null,
-):
+): Promise<
   | {
       account: AccountLike;
       parentAccount: Account | undefined;
       operation: Operation;
     }
-  | undefined => {
+  | undefined
+> => {
   const mainAccount = getMainAccount(account, parentAccount);
-  return loadGetStuckAccountAndOperationForFamily(mainAccount.currency.family)?.(
-    account,
-    parentAccount,
-    hasGasTracker,
-  );
+  const fn = await loadGetStuckAccountAndOperationForFamily(mainAccount.currency.family);
+  return fn?.(account, parentAccount, hasGasTracker);
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** (`operation.test.ts` updated with `await` + `mockResolvedValue`; evm test updated to `mockResolvedValue` + `findByTestId`)
- [ ] **Impact of the changes:**
  - All call sites in LLD/LLM now read async results via `useState`/`useEffect` (no behavioral change, values initialize to `false`/`undefined` then settle after the async loader resolves)
  - `evm/index.ts`'s `handlesEditTransaction` helper switches to the synchronous `isEditableOperation` from `@ledgerhq/coin-evm/operation` directly (the live-common wrapper is now async, but this sync call-site doesn't support async)

### 📝 Description

Makes `isEditableOperation`, `isStuckOperation`, and `getStuckAccountAndOperation` in `libs/ledger-live-common/src/operation.ts` return `Promise<>` by internally awaiting the coin-family module loaders (the loaders themselves stay synchronous `require()`).

**Technically, it means the editable state, warning, will be a bit deferred and appear after a frame. (this is to allow the coin to load)**

Call sites are updated to handle the async nature:
- **LLD** `DateCell.tsx`: `useState(false)` + `useEffect` calling `.then(setIsStuck)`
- **LLD** `OperationsListV1/index.tsx`: new `OperationWithEditable` component wrapping `useEffect` + `.then(setEditable)`
- **LLD** `OperationDetails/index.tsx`: `useMemo` → `useState` + `useEffect` with async IIFE + cancellation
- **LLD** `EditStuckTransactionPanelBodyHeader.tsx` (evm): `useState(undefined)` + `useEffect` calling `.then(setStuckAccountAndOperation)`
- **LLD** `StepRecipient.tsx` (Send modal): `useState(undefined)` + `useEffect` for `getStuckAccountAndOperation`
- **LLD** `evm/index.ts`: switches `isEditableOperation` import to `@ledgerhq/coin-evm/operation` (remains sync, adds inline `hasGasTracker` helper)
- **LLM** `OperationRow/index.tsx`: `useState(false)` + `useEffect` with cancellation flag
- **LLM** `OperationDetails/Content.tsx`: two `useState` + `useEffect` pairs with cancellation flags
- **LLM** `02-SelectRecipient.tsx`: `useState(undefined)` + `useEffect` with cancellation flag for `getStuckAccountAndOperation`

This is patch-level — same logical behavior, async wrapper only.

**Skipped files** (contain unrelated changes or call sync variants from other packages):
- `ListHeaderComponent.tsx` — also adds a Suspense boundary (unrelated change)
- `bitcoin/EditStuckTransactionPanelBodyHeader.tsx` — imports from `@ledgerhq/coin-bitcoin/operation` (stays sync)
- `bitcoin/__tests__/EditTransactionComponents.test.tsx` — mocks `@ledgerhq/coin-bitcoin/operation` (stays sync)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176) — partial delivery of umbrella PR [#16733](https://github.com/LedgerHQ/ledger-live/pull/16733)
- **ADR link (if any)**: N/A


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ