### PR TITLE
[LWDM] refactor(live-common): make hw/actions inferCommandParams async

### DIFF
--- a/.changeset/async-hw-actions-app.md
+++ b/.changeset/async-hw-actions-app.md
@@ -1,0 +1,12 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Make `inferCommandParams` async in `hw/actions/app.ts` to support lazy coin-module loading.
+
+`inferCommandParams` now awaits `loadAccountModuleForFamily`, and `createAction` moves from `useMemo`
+to `useState + useEffect + .then()` for request computation. As a result, `request` is `null` on
+the first render — the internal effect guards against this with `if (state.opened || !request) return`.
+
+Also makes `dispatch` in `hw/getAddress/index.ts` and `signMessage` in `hw/signMessage/index.ts`
+async to await `loadSetupForFamily`.

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import { interval, Observable, of } from "rxjs";
 import { scan, debounce, tap, takeWhile } from "rxjs/operators";
-import { useEffect, useCallback, useState, useMemo, useRef } from "react";
+import { useEffect, useCallback, useState, useRef } from "react";
 import { log } from "@ledgerhq/logs";
 import {
   getDerivationScheme,
@@ -384,7 +384,7 @@ const reducer = (state: State, e: Event): State => {
  * specify an account or a currency without resolving manually the actual
  * applications we depend on in order to access the flow.
  */
-function inferCommandParams(appRequest: AppRequest): ConnectAppRequest {
+async function inferCommandParams(appRequest: AppRequest): Promise<ConnectAppRequest> {
   let derivationMode;
   let derivationPath;
 
@@ -408,7 +408,9 @@ function inferCommandParams(appRequest: AppRequest): ConnectAppRequest {
 
   let dependencies: string[] | undefined = undefined;
   if (appDependencies) {
-    dependencies = appDependencies.map(d => inferCommandParams(d).appName);
+    dependencies = (await Promise.all(appDependencies.map(d => inferCommandParams(d)))).map(
+      p => p.appName,
+    );
   }
 
   if (!currency) {
@@ -425,7 +427,7 @@ function inferCommandParams(appRequest: AppRequest): ConnectAppRequest {
   if (account) {
     derivationMode = account.derivationMode;
     derivationPath = account.freshAddressPath;
-    const m = loadAccountModuleForFamily(account.currency.family);
+    const m = await loadAccountModuleForFamily(account.currency.family);
 
     if (m && m.injectGetAddressParams) {
       extra = m.injectGetAddressParams(account);
@@ -470,16 +472,16 @@ export const createAction = (
     const firmwareResolvedRef = useRef(false);
     const outdatedAppRef = useRef<AppAndVersion | undefined>(undefined);
 
-    const request = useMemo(
-      () => inferCommandParams(appRequest), // for now i don't have better
-      // oxlint-disable-next-line react-hooks/exhaustive-deps
-      [
-        appRequest.appName,
-        appRequest.account?.id,
-        appRequest.currency?.id,
-        appRequest.dependencies,
-      ],
-    );
+    const [request, setRequest] = useState<ConnectAppRequest | null>(null);
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => {
+      inferCommandParams(appRequest).then(setRequest);
+    }, [
+      appRequest.appName,
+      appRequest.account?.id,
+      appRequest.currency?.id,
+      appRequest.dependencies,
+    ]);
 
     const task: (arg0: ConnectAppInput) => Observable<ConnectAppEvent> = useCallback(
       ({ deviceId, deviceName, request }: ConnectAppInput) => {
@@ -517,7 +519,7 @@ export const createAction = (
     const deviceSubject = useReplaySubject(device);
 
     useEffect(() => {
-      if (state.opened) return;
+      if (state.opened || !request) return;
 
       const impl = getImplementation(currentMode)<ConnectAppEvent, ConnectAppRequest>({
         deviceSubject,

--- a/libs/ledger-live-common/src/hw/getAddress/index.ts
+++ b/libs/ledger-live-common/src/hw/getAddress/index.ts
@@ -4,9 +4,9 @@ import { log } from "@ledgerhq/logs";
 import { Resolver } from "./types";
 import { loadSetupForFamily } from "../../coin-modules/registry";
 
-const dispatch: Resolver = (transport, opts) => {
+const dispatch: Resolver = async (transport, opts) => {
   const { currency, verify } = opts;
-  const setup = loadSetupForFamily(currency.family);
+  const setup = await loadSetupForFamily(currency.family);
   const getAddress = setup.resolver;
   invariant(getAddress, `getAddress is not implemented for ${currency.id}`);
   return getAddress(transport, opts)

--- a/libs/ledger-live-common/src/hw/signMessage/index.ts
+++ b/libs/ledger-live-common/src/hw/signMessage/index.ts
@@ -31,9 +31,9 @@ export const prepareMessageToSign = async (account: Account, message: string): P
   return { message: utf8Message };
 };
 
-const signMessage: SignMessage = (transport, account, opts) => {
+const signMessage: SignMessage = async (transport, account, opts) => {
   const { currency } = account;
-  const setup = loadSetupForFamily(currency.family);
+  const setup = await loadSetupForFamily(currency.family);
   let signMessage = setup.messageSigner?.signMessage;
   if ("type" in opts) {
     switch (opts.type) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Existing tests pass; the async guard (`if (state.opened || !request) return`) is exercised by the existing `createConnectAppMock` + `InstallSetOfApps` test suite (uses `act()` + `waitFor()` which flush microtasks).
- [ ] **Impact of the changes:**
  - Device connection flows: `request` is briefly `null` before first render. The internal effect in `createAction` guards with `if (state.opened || !request) return` — no behavioural change visible to callers.
  - `hw/getAddress/index.ts` and `hw/signMessage/index.ts`: `dispatch` / `signMessage` are now async, matching their existing `Promise<Result>` return types.
  - No call-site changes needed: `useHook(device, AppRequest) → AppState` API is unchanged; callers never see `ConnectAppRequest` or the internal `null` state.

### 📝 Description

`inferCommandParams` in `hw/actions/app.ts` is now `async` so it can `await loadAccountModuleForFamily`, enabling lazy dynamic `import()` for coin modules.

Because `inferCommandParams` is async, `createAction` can no longer compute `request` synchronously in `useMemo`. It moves to `useState + useEffect + .then()`:

```diff
-const request = useMemo(() => inferCommandParams(appRequest), [...]);
+const [request, setRequest] = useState<ConnectAppRequest | null>(null);
+useEffect(() => {
+  inferCommandParams(appRequest).then(setRequest);
+}, [...]);
```

`request` is `null` on the first render. The device-subscription effect already guards this:

```diff
-if (state.opened) return;
+if (state.opened || !request) return;
```

Call sites use the unchanged `useHook(device, AppRequest) → AppState` API and are unaffected. During the one-microtask `null` window, state stays at initial (`opened: false`), which call sites already handle as a pending/loading state.

Same async pattern applied to:
- `hw/getAddress/index.ts` — `dispatch` awaits `loadSetupForFamily`
- `hw/signMessage/index.ts` — `signMessage` awaits `loadSetupForFamily`

The `await` on currently-sync registry functions is a TypeScript-valid no-op today (awaiting a non-Promise resolves immediately) and will seamlessly work once the registry is updated to return Promises in a follow-up.

### ❓ Context

- **JIRA**: [LIVE-29176](https://ledgerhq.atlassian.net/browse/LIVE-29176)
- **Umbrella PR**: #16733 (partial delivery)
- **ADR link**: N/A


[LIVE-29176]: https://ledgerhq.atlassian.net/browse/LIVE-29176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ