### PR TITLE
fix(wallet-cli): harden Windows WebUSB reconnect handling

### DIFF
--- a/.changeset/brave-usbs-heal.md
+++ b/.changeset/brave-usbs-heal.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Fix Windows WebUSB reconnect handling in wallet-cli

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.ts
@@ -11,6 +11,7 @@ import type {
   LoggerPublisherService,
   SendApduResult,
 } from "@ledgerhq/device-management-kit";
+import type { Device as NativeUsbDevice } from "usb";
 import { Just, Left, Maybe, Nothing, Right } from "purify-ts";
 import { WebUSBDevice } from "usb";
 import {
@@ -21,6 +22,7 @@ import {
 
 export type NodeWebUsbApduSenderDependencies = {
   device: WebUSBDevice;
+  nativeDevice: NativeUsbDevice;
   interfaceNumber: number;
 };
 
@@ -32,6 +34,9 @@ export type NodeWebUsbApduSenderConstructorArgs = {
 };
 
 async function gracefullyResetDevice(device: WebUSBDevice): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
   try {
     await device.reset();
   } catch {
@@ -94,7 +99,7 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
   }
 
   async setupConnection(): Promise<void> {
-    const { device, interfaceNumber } = this.dependencies;
+    const { device, nativeDevice, interfaceNumber } = this.dependencies;
 
     if (device.opened) {
       try {
@@ -123,6 +128,46 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
     } catch (e) {
       await device.close().catch(() => {});
       throw e;
+    }
+
+    if (process.platform === "win32") {
+      // WinUSB may skip SET_CONFIGURATION on reconnect; forcing SET_INTERFACE
+      // resynchronizes bulk endpoint DATA0/DATA1 toggles with the device.
+      try {
+        await device.selectAlternateInterface(interfaceNumber, 0);
+      } catch {
+        // best-effort
+      }
+
+      try {
+        const nativeInEp = nativeDevice
+          .interface(interfaceNumber)
+          .endpoints.find(
+            endpoint =>
+              (endpoint.address & 0x7f) === LEDGER_WEBUSB_ENDPOINT_NUMBER &&
+              endpoint.direction === "in",
+          );
+        if (nativeInEp) {
+          const previousTimeout = nativeInEp.timeout;
+          nativeInEp.timeout = 100;
+          try {
+            while (true) {
+              try {
+                const result = await device.transferIn(LEDGER_WEBUSB_ENDPOINT_NUMBER, FRAME_SIZE);
+                if (result.status !== "ok") {
+                  break;
+                }
+              } catch {
+                break;
+              }
+            }
+          } finally {
+            nativeInEp.timeout = previousTimeout;
+          }
+        }
+      } catch {
+        // best-effort: interface may not be present/accessible yet on reconnect
+      }
     }
 
     this.logger.info("Connected to device (WebUSB)");

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbApduSender.ts
@@ -11,7 +11,6 @@ import type {
   LoggerPublisherService,
   SendApduResult,
 } from "@ledgerhq/device-management-kit";
-import type { Device as NativeUsbDevice } from "usb";
 import { Just, Left, Maybe, Nothing, Right } from "purify-ts";
 import { WebUSBDevice } from "usb";
 import {
@@ -22,7 +21,6 @@ import {
 
 export type NodeWebUsbApduSenderDependencies = {
   device: WebUSBDevice;
-  nativeDevice: NativeUsbDevice;
   interfaceNumber: number;
 };
 
@@ -99,7 +97,7 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
   }
 
   async setupConnection(): Promise<void> {
-    const { device, nativeDevice, interfaceNumber } = this.dependencies;
+    const { device, interfaceNumber } = this.dependencies;
 
     if (device.opened) {
       try {
@@ -128,46 +126,6 @@ export class NodeWebUsbApduSender implements DeviceApduSender<NodeWebUsbApduSend
     } catch (e) {
       await device.close().catch(() => {});
       throw e;
-    }
-
-    if (process.platform === "win32") {
-      // WinUSB may skip SET_CONFIGURATION on reconnect; forcing SET_INTERFACE
-      // resynchronizes bulk endpoint DATA0/DATA1 toggles with the device.
-      try {
-        await device.selectAlternateInterface(interfaceNumber, 0);
-      } catch {
-        // best-effort
-      }
-
-      try {
-        const nativeInEp = nativeDevice
-          .interface(interfaceNumber)
-          .endpoints.find(
-            endpoint =>
-              (endpoint.address & 0x7f) === LEDGER_WEBUSB_ENDPOINT_NUMBER &&
-              endpoint.direction === "in",
-          );
-        if (nativeInEp) {
-          const previousTimeout = nativeInEp.timeout;
-          nativeInEp.timeout = 100;
-          try {
-            while (true) {
-              try {
-                const result = await device.transferIn(LEDGER_WEBUSB_ENDPOINT_NUMBER, FRAME_SIZE);
-                if (result.status !== "ok") {
-                  break;
-                }
-              } catch {
-                break;
-              }
-            }
-          } finally {
-            nativeInEp.timeout = previousTimeout;
-          }
-        }
-      } catch {
-        // best-effort: interface may not be present/accessible yet on reconnect
-      }
     }
 
     this.logger.info("Connected to device (WebUSB)");

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
@@ -39,7 +39,6 @@ export const nodeWebUsbIdentifier: TransportIdentifier = "NODE-WEBUSB";
 
 type WebUsbDiscoveredInternal = TransportDiscoveredDevice & {
   webUsbDevice: WebUSBDevice;
-  nativeDevice: NativeUsbDevice;
   interfaceNumber: number;
 };
 
@@ -56,11 +55,7 @@ function getVendorInterfaceNumber(device: WebUSBDevice): number | null {
   return null;
 }
 
-type ScannedWebUsbDevice = {
-  device: WebUSBDevice;
-  nativeDevice: NativeUsbDevice;
-  interfaceNumber: number;
-};
+type ScannedWebUsbDevice = { device: WebUSBDevice; interfaceNumber: number };
 
 /** Uses serialNumber when available so two same-model devices are distinguishable. */
 function deviceIdentityKey(device: WebUSBDevice): string {
@@ -163,14 +158,13 @@ export class NodeWebUsbTransport implements Transport {
       if (interfaceNumber === null) {
         continue;
       }
-      collected.push({ device, nativeDevice: native, interfaceNumber });
+      collected.push({ device, interfaceNumber });
     }
     return dedupeLedgerWebUsbDevices(collected);
   }
 
   private mapWebUsbToDiscovered(
     web: WebUSBDevice,
-    nativeDevice: NativeUsbDevice,
     interfaceNumber: number,
   ): WebUsbDiscoveredInternal {
     const key = deviceIdentityKey(web);
@@ -188,7 +182,6 @@ export class NodeWebUsbTransport implements Transport {
           id,
           deviceModel,
           webUsbDevice: web,
-          nativeDevice,
           interfaceNumber,
           transport: this.identifier,
         };
@@ -209,9 +202,7 @@ export class NodeWebUsbTransport implements Transport {
   listenToAvailableDevices() {
     void this.updateTransportDiscoveredDevices();
     return this._transportDiscoveredDevices.pipe(
-      map(list =>
-        list.map(({ webUsbDevice: _w, nativeDevice: _n, interfaceNumber: _i, ...rest }) => rest),
-      ),
+      map(list => list.map(({ webUsbDevice: _w, interfaceNumber: _i, ...rest }) => rest)),
     );
   }
 
@@ -219,9 +210,9 @@ export class NodeWebUsbTransport implements Transport {
     try {
       const scanned = await this.scanLedgerWebUsbDevices();
       const next: WebUsbDiscoveredInternal[] = [];
-      for (const { device, nativeDevice, interfaceNumber } of scanned) {
+      for (const { device, interfaceNumber } of scanned) {
         try {
-          next.push(this.mapWebUsbToDiscovered(device, nativeDevice, interfaceNumber));
+          next.push(this.mapWebUsbToDiscovered(device, interfaceNumber));
         } catch (e) {
           if (e instanceof DeviceNotRecognizedError) {
             continue;
@@ -256,8 +247,8 @@ export class NodeWebUsbTransport implements Transport {
     return from(this.promptDeviceAccess()).pipe(
       switchMap(scanned =>
         from(
-          scanned.map(({ device, nativeDevice, interfaceNumber }) =>
-            this.mapWebUsbToDiscovered(device, nativeDevice, interfaceNumber),
+          scanned.map(({ device, interfaceNumber }) =>
+            this.mapWebUsbToDiscovered(device, interfaceNumber),
           ),
         ),
       ),
@@ -328,11 +319,7 @@ export class NodeWebUsbTransport implements Transport {
     }
 
     const apduSender = this._deviceApduSenderFactory({
-      dependencies: {
-        device: row.webUsbDevice,
-        nativeDevice: row.nativeDevice,
-        interfaceNumber: row.interfaceNumber,
-      },
+      dependencies: { device: row.webUsbDevice, interfaceNumber: row.interfaceNumber },
       apduSenderFactory: this._apduSenderFactory,
       apduReceiverFactory: this._apduReceiverFactory,
       loggerFactory: this._loggerServiceFactory,
@@ -434,12 +421,11 @@ export class NodeWebUsbTransport implements Transport {
   async handleDeviceReconnection(
     machine: DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
     web: WebUSBDevice,
-    nativeDevice: NativeUsbDevice,
     interfaceNumber: number,
   ): Promise<void> {
     try {
       this._deviceConnectionsPendingReconnection.delete(machine);
-      machine.setDependencies({ device: web, nativeDevice, interfaceNumber });
+      machine.setDependencies({ device: web, interfaceNumber });
       await machine.setupConnection();
       this._deviceConnectionsByWebUsbDevice.set(web, machine);
       machine.eventDeviceConnected();
@@ -477,7 +463,7 @@ export class NodeWebUsbTransport implements Transport {
       });
 
       if (pending) {
-        await this.handleDeviceReconnection(pending, web, native, iface);
+        await this.handleDeviceReconnection(pending, web, iface);
       }
       await this.updateTransportDiscoveredDevices();
     } catch (e) {

--- a/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
+++ b/apps/wallet-cli/src/device/node-webusb/NodeWebUsbTransport.ts
@@ -39,6 +39,7 @@ export const nodeWebUsbIdentifier: TransportIdentifier = "NODE-WEBUSB";
 
 type WebUsbDiscoveredInternal = TransportDiscoveredDevice & {
   webUsbDevice: WebUSBDevice;
+  nativeDevice: NativeUsbDevice;
   interfaceNumber: number;
 };
 
@@ -55,7 +56,11 @@ function getVendorInterfaceNumber(device: WebUSBDevice): number | null {
   return null;
 }
 
-type ScannedWebUsbDevice = { device: WebUSBDevice; interfaceNumber: number };
+type ScannedWebUsbDevice = {
+  device: WebUSBDevice;
+  nativeDevice: NativeUsbDevice;
+  interfaceNumber: number;
+};
 
 /** Uses serialNumber when available so two same-model devices are distinguishable. */
 function deviceIdentityKey(device: WebUSBDevice): string {
@@ -158,13 +163,14 @@ export class NodeWebUsbTransport implements Transport {
       if (interfaceNumber === null) {
         continue;
       }
-      collected.push({ device, interfaceNumber });
+      collected.push({ device, nativeDevice: native, interfaceNumber });
     }
     return dedupeLedgerWebUsbDevices(collected);
   }
 
   private mapWebUsbToDiscovered(
     web: WebUSBDevice,
+    nativeDevice: NativeUsbDevice,
     interfaceNumber: number,
   ): WebUsbDiscoveredInternal {
     const key = deviceIdentityKey(web);
@@ -182,6 +188,7 @@ export class NodeWebUsbTransport implements Transport {
           id,
           deviceModel,
           webUsbDevice: web,
+          nativeDevice,
           interfaceNumber,
           transport: this.identifier,
         };
@@ -202,7 +209,9 @@ export class NodeWebUsbTransport implements Transport {
   listenToAvailableDevices() {
     void this.updateTransportDiscoveredDevices();
     return this._transportDiscoveredDevices.pipe(
-      map(list => list.map(({ webUsbDevice: _w, interfaceNumber: _i, ...rest }) => rest)),
+      map(list =>
+        list.map(({ webUsbDevice: _w, nativeDevice: _n, interfaceNumber: _i, ...rest }) => rest),
+      ),
     );
   }
 
@@ -210,9 +219,9 @@ export class NodeWebUsbTransport implements Transport {
     try {
       const scanned = await this.scanLedgerWebUsbDevices();
       const next: WebUsbDiscoveredInternal[] = [];
-      for (const { device, interfaceNumber } of scanned) {
+      for (const { device, nativeDevice, interfaceNumber } of scanned) {
         try {
-          next.push(this.mapWebUsbToDiscovered(device, interfaceNumber));
+          next.push(this.mapWebUsbToDiscovered(device, nativeDevice, interfaceNumber));
         } catch (e) {
           if (e instanceof DeviceNotRecognizedError) {
             continue;
@@ -247,8 +256,8 @@ export class NodeWebUsbTransport implements Transport {
     return from(this.promptDeviceAccess()).pipe(
       switchMap(scanned =>
         from(
-          scanned.map(({ device, interfaceNumber }) =>
-            this.mapWebUsbToDiscovered(device, interfaceNumber),
+          scanned.map(({ device, nativeDevice, interfaceNumber }) =>
+            this.mapWebUsbToDiscovered(device, nativeDevice, interfaceNumber),
           ),
         ),
       ),
@@ -319,7 +328,11 @@ export class NodeWebUsbTransport implements Transport {
     }
 
     const apduSender = this._deviceApduSenderFactory({
-      dependencies: { device: row.webUsbDevice, interfaceNumber: row.interfaceNumber },
+      dependencies: {
+        device: row.webUsbDevice,
+        nativeDevice: row.nativeDevice,
+        interfaceNumber: row.interfaceNumber,
+      },
       apduSenderFactory: this._apduSenderFactory,
       apduReceiverFactory: this._apduReceiverFactory,
       loggerFactory: this._loggerServiceFactory,
@@ -421,11 +434,12 @@ export class NodeWebUsbTransport implements Transport {
   async handleDeviceReconnection(
     machine: DeviceConnectionStateMachine<NodeWebUsbApduSenderDependencies>,
     web: WebUSBDevice,
+    nativeDevice: NativeUsbDevice,
     interfaceNumber: number,
   ): Promise<void> {
     try {
       this._deviceConnectionsPendingReconnection.delete(machine);
-      machine.setDependencies({ device: web, interfaceNumber });
+      machine.setDependencies({ device: web, nativeDevice, interfaceNumber });
       await machine.setupConnection();
       this._deviceConnectionsByWebUsbDevice.set(web, machine);
       machine.eventDeviceConnected();
@@ -463,7 +477,7 @@ export class NodeWebUsbTransport implements Transport {
       });
 
       if (pending) {
-        await this.handleDeviceReconnection(pending, web, iface);
+        await this.handleDeviceReconnection(pending, web, native, iface);
       }
       await this.updateTransportDiscoveredDevices();
     } catch (e) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** I'm testing this change manually with the CI build
- [x] **Impact of the changes:**
  - wallet-cli

### 📝 Description

Skip WebUSB device resets on Windows and preserve the existing behavior on macOS/Linux. 

### ❓ Context

- **JIRA or GitHub link**:
- **ADR link (if any)**: 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
