### PR TITLE
feat(mobile): asset aggregation on CryptoAddresses screen

### DIFF
--- a/.changeset/purple-wolves-dance.md
+++ b/.changeset/purple-wolves-dance.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/asset-aggregation": minor
+---
+
+Add computeAggregatedAccountsData to @ledgerhq/asset-aggregation and use it in LWM CryptoAddresses screen to show main accounts with aggregated fiat balance (main + sub-accounts), sorted by countervalue

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
@@ -11,10 +11,8 @@ import { walletSelector } from "~/renderer/reducers/wallet";
 import type { ColumnDef, Row, SortingState, Updater } from "@tanstack/react-table";
 import { track } from "~/renderer/analytics/segment";
 import { CRYPTO_TRACKING_PAGE_NAME } from "../../../constants";
-import {
-  computeAggregatedAccountsData,
-  computeBalanceSortCountervalueByAccountId,
-} from "../../../utils/aggregateAccounts";
+import { computeAggregatedAccountsData } from "@ledgerhq/asset-aggregation/index";
+import { computeBalanceSortCountervalueByAccountId } from "../../../utils/aggregateAccounts";
 import {
   AccountAddressCell,
   AccountNameCell,
@@ -104,10 +102,12 @@ export function useCryptoDataTable({
         header: t("cryptoAddresses.table.columns.value"),
         cell: ({ row }) => {
           const entry = aggregatedDataByAccountId?.get(row.original.id);
+          const assetsCount =
+            (entry?.subAccountsCount ?? 0) + (row.original.balance.isZero() ? 0 : 1);
           return shouldDisplayAggregatedAssets && aggregatedDataByAccountId ? (
             <AggregatedAccountValueCell
               aggregatedCountervalue={entry?.countervalue ?? new BigNumber(0)}
-              assetsCount={entry?.count ?? 0}
+              assetsCount={assetsCount}
             />
           ) : (
             <AccountValueCell account={row.original} />

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/__tests__/aggregateAccounts.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/__tests__/aggregateAccounts.test.ts
@@ -1,13 +1,8 @@
 import { BigNumber } from "bignumber.js";
-import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
-import {
-  BTC_ACCOUNT,
-  ETH_ACCOUNT,
-  ETH_ACCOUNT_WITH_USDC,
-} from "LLD/features/__mocks__/accounts.mock";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { BTC_ACCOUNT, ETH_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
 import {
   type CalculateCountervalue,
-  computeAggregatedAccountsData,
   computeBalanceSortCountervalueByAccountId,
 } from "../aggregateAccounts";
 
@@ -23,76 +18,6 @@ beforeEach(() => {
 function withBalance<T extends AccountLike>(account: T, balance: BigNumber): T {
   return { ...account, balance };
 }
-
-function firstSubAccount(account: Account): TokenAccount {
-  const sub = account.subAccounts?.[0];
-  if (!sub) throw new Error("Fixture must expose a sub-account");
-  return sub;
-}
-
-describe("computeAggregatedAccountsData", () => {
-  it("returns an empty map when rows are empty", () => {
-    const map = computeAggregatedAccountsData([], calculateCountervalue);
-    expect(map.size).toBe(0);
-  });
-
-  it("ignores rows that are not main accounts", () => {
-    const tokenAccount = firstSubAccount(ETH_ACCOUNT_WITH_USDC);
-    const map = computeAggregatedAccountsData([tokenAccount], calculateCountervalue);
-    expect(map.size).toBe(0);
-  });
-
-  it("counts a main account with non-zero balance as 1 asset", () => {
-    const account = withBalance(BTC_ACCOUNT, new BigNumber(100));
-    const map = computeAggregatedAccountsData([account], calculateCountervalue);
-    expect(map.get(account.id)?.count).toBe(1);
-    expect(map.get(account.id)?.countervalue.toString()).toBe("200");
-  });
-
-  it("excludes the main account from count and countervalue when its balance is zero", () => {
-    const account = withBalance(BTC_ACCOUNT, new BigNumber(0));
-    const map = computeAggregatedAccountsData([account], calculateCountervalue);
-    expect(map.get(account.id)?.count).toBe(0);
-    expect(map.get(account.id)?.countervalue.toString()).toBe("0");
-  });
-
-  it("always includes sub-accounts in count and countervalue, regardless of their balance", () => {
-    const usdc = firstSubAccount(ETH_ACCOUNT_WITH_USDC);
-    const parent: Account = {
-      ...ETH_ACCOUNT_WITH_USDC,
-      balance: new BigNumber(0),
-      subAccounts: [
-        { ...usdc, balance: new BigNumber(0) },
-        { ...usdc, id: `${usdc.id}-2`, balance: new BigNumber(50) },
-      ],
-    };
-
-    const map = computeAggregatedAccountsData([parent], calculateCountervalue);
-    expect(map.get(parent.id)?.count).toBe(2);
-    expect(map.get(parent.id)?.countervalue.toString()).toBe("100");
-  });
-
-  it("aggregates main account + sub-accounts when all have non-zero balances", () => {
-    const usdc = firstSubAccount(ETH_ACCOUNT_WITH_USDC);
-    const parent: Account = {
-      ...ETH_ACCOUNT_WITH_USDC,
-      balance: new BigNumber(100),
-      subAccounts: [{ ...usdc, balance: new BigNumber(50) }],
-    };
-
-    const map = computeAggregatedAccountsData([parent], calculateCountervalue);
-    expect(map.get(parent.id)?.count).toBe(2);
-    expect(map.get(parent.id)?.countervalue.toString()).toBe("300");
-  });
-
-  it("treats null/undefined countervalues as zero", () => {
-    calculateCountervalue.mockReturnValueOnce(null).mockReturnValueOnce(undefined);
-    const account = withBalance(BTC_ACCOUNT, new BigNumber(100));
-    const map = computeAggregatedAccountsData([account], calculateCountervalue);
-    expect(map.get(account.id)?.count).toBe(1);
-    expect(map.get(account.id)?.countervalue.toString()).toBe("0");
-  });
-});
 
 describe("computeBalanceSortCountervalueByAccountId", () => {
   it("returns per-account countervalues", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/aggregateAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/aggregateAccounts.ts
@@ -1,54 +1,12 @@
 import { BigNumber } from "bignumber.js";
 import type { AccountLike } from "@ledgerhq/types-live";
 import type { Currency } from "@ledgerhq/types-cryptoassets";
-import { getAccountCurrency, listSubAccounts } from "@ledgerhq/live-common/account/helpers";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 
 export type CalculateCountervalue = (
   from: Currency,
   value: BigNumber,
 ) => BigNumber | null | undefined;
-
-export type AggregatedEntry = {
-  readonly countervalue: BigNumber;
-  readonly count: number;
-};
-
-export type AggregatedAccountData = ReadonlyMap<string, AggregatedEntry>;
-
-export function computeAggregatedAccountsData(
-  rows: readonly AccountLike[],
-  calculateCountervalue: CalculateCountervalue,
-): AggregatedAccountData {
-  const map = new Map<string, AggregatedEntry>();
-
-  for (const account of rows) {
-    if (account.type !== "Account") continue;
-
-    let countervalue = new BigNumber(0);
-    let count = 0;
-
-    if (!account.balance.isZero()) {
-      const mainCurrency = getAccountCurrency(account);
-      countervalue = countervalue.plus(
-        calculateCountervalue(mainCurrency, account.balance) ?? new BigNumber(0),
-      );
-      count += 1;
-    }
-
-    const subs = listSubAccounts(account);
-    for (const sub of subs) {
-      const subCurrency = getAccountCurrency(sub);
-      countervalue = countervalue.plus(
-        calculateCountervalue(subCurrency, sub.balance) ?? new BigNumber(0),
-      );
-    }
-    count += subs.length;
-
-    map.set(account.id, { countervalue, count });
-  }
-
-  return map;
-}
 
 export function computeBalanceSortCountervalueByAccountId(
   rows: readonly AccountLike[],

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3218,7 +3218,9 @@
     "title": "Accounts",
     "addAccount": "Add account",
     "emptyState": "No accounts yet",
-    "errorState": "An error occurred while loading your accounts"
+    "errorState": "An error occurred while loading your accounts",
+    "assetsCount": "{{count}} assets",
+    "assetsCount_one": "{{count}} asset"
   },
   "crypto": {
     "title": "Crypto",

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/components/AccountItem/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/components/AccountItem/index.tsx
@@ -19,6 +19,7 @@ const View: React.FC<ViewProps> = ({
   hideBalanceInfo,
   withPlaceholder,
   accountId,
+  squaredIcon,
 }) => (
   <>
     <Flex flex={1} rowGap={2} flexShrink={1} testID={`account-item-${accountId}`}>
@@ -45,7 +46,7 @@ const View: React.FC<ViewProps> = ({
         <Text numberOfLines={1} variant="body" color="neutral.c70" flexShrink={1}>
           {formattedAddress}
         </Text>
-        <CurrencyIcon currency={currency} size={20} hideNetwork />
+        <CurrencyIcon squared={squaredIcon} currency={currency} size={20} hideNetwork />
       </Flex>
     </Flex>
     {!hideBalanceInfo && (

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/components/AccountItem/useAccountItemModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/components/AccountItem/useAccountItemModel.ts
@@ -19,6 +19,7 @@ export interface AccountItemProps {
   showUnit?: boolean;
   hideBalanceInfo?: boolean;
   withPlaceholder?: boolean;
+  squaredIcon?: boolean;
 }
 
 const useAccountItemModel = ({
@@ -27,6 +28,7 @@ const useAccountItemModel = ({
   showUnit,
   hideBalanceInfo,
   withPlaceholder,
+  squaredIcon,
 }: AccountItemProps) => {
   const allAccount = useSelector(accountsSelector);
   const isTokenAccount = isTokenAccountChecker(account);
@@ -60,6 +62,7 @@ const useAccountItemModel = ({
     hideBalanceInfo,
     withPlaceholder,
     accountId,
+    squaredIcon,
   };
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/components/DistributionCard.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/components/DistributionCard.tsx
@@ -14,6 +14,7 @@ import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import { track } from "~/analytics";
 import { DETAILED_ALLOCATION_PAGE } from "../../../const";
 import type { DistributionItem } from "../../../types/distribution";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 
 type Props = Readonly<{
   item: DistributionItem;
@@ -59,6 +60,7 @@ const DistributionRow = styled(Flex).attrs({
 function DistributionCard({ item: { currency, amount, distribution } }: Props) {
   const { colors } = useTheme();
   const navigation = useNavigation();
+  const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("mobile");
 
   const color = useMemo(
     () => ensureContrast(getCurrencyColor(currency), colors.background.main),
@@ -84,7 +86,7 @@ function DistributionCard({ item: { currency, amount, distribution } }: Props) {
     <Container onPress={navigateToAccounts}>
       <Flex flexDirection="row">
         <IconContainer>
-          <CurrencyIcon currency={currency} size={35} />
+          <CurrencyIcon currency={currency} size={35} hideNetwork={shouldDisplayAggregatedAssets} />
         </IconContainer>
         <CoinInfoContainer>
           <CurrencyRow>

--- a/apps/ledger-live-mobile/src/mvvm/features/Crypto/components/CryptoAssetList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Crypto/components/CryptoAssetList/index.tsx
@@ -25,6 +25,7 @@ export const CryptoAssetList: React.FC<CryptoAssetListProps> = ({ assets, onItem
         asset={item}
         onPress={onItemPress}
         precomputed={precomputedData.get(item.currency.id)!}
+        hideNetwork
       />
     ),
     [onItemPress, precomputedData],

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__integrations__/CryptoAddressesScreen.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__integrations__/CryptoAddressesScreen.integration.test.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
+import BigNumber from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 import { ScreenName } from "~/const";
 import useCryptoAddressesViewModel from "../useCryptoAddressesViewModel";
+import type { AggregatedAccountEntry } from "@ledgerhq/asset-aggregation/index";
 
 jest.mock("../useCryptoAddressesViewModel", () => jest.fn());
 
@@ -37,6 +39,7 @@ const mockAccount = { type: "Account", id: "account-1" } as Account;
 
 const baseViewModel: ReturnType<typeof useCryptoAddressesViewModel> = {
   accounts: [],
+  aggregatedAccountsData: new Map<string, AggregatedAccountEntry>(),
   hasNoAccount: true,
   isLoading: false,
   error: null,
@@ -84,6 +87,9 @@ describe("CryptoAddressesScreen", () => {
     it("should render account items when accounts exist", () => {
       renderScreen({
         accounts: [mockAccount],
+        aggregatedAccountsData: new Map([
+          ["account-1", { countervalue: new BigNumber(1000), subAccountsCount: 0 }],
+        ]),
         hasNoAccount: false,
       });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__tests__/useCryptoAddressesViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/__tests__/useCryptoAddressesViewModel.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from "@tests/test-renderer";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
-import { NavigatorName, ScreenName } from "~/const";
+import { ScreenName } from "~/const";
 import { track } from "~/analytics";
 import type { State } from "~/reducers/types";
 import useCryptoAddressesViewModel from "../useCryptoAddressesViewModel";
@@ -67,21 +67,27 @@ describe("useCryptoAddressesViewModel", () => {
     expect(result.current.sourceScreenName).toBeUndefined();
   });
 
-  it("should filter out blacklisted token accounts", () => {
+  it("should show only main accounts, not token accounts separately", () => {
     const parentWithToken = { ...ethAccount, subAccounts: [tokenAccount] };
 
     const { result } = renderHook(() => useCryptoAddressesViewModel(), {
-      overrideInitialState: (state: State) => ({
-        ...withAccounts([parentWithToken])(state),
-        settings: { ...state.settings, blacklistedTokenIds: [tokenAccount.token.id] },
-      }),
+      overrideInitialState: withAccounts([parentWithToken]),
     });
 
-    const tokenIds = result.current.accounts
-      .filter(a => a.type === "TokenAccount")
-      .map(a => (a as typeof tokenAccount).token.id);
+    expect(result.current.accounts).toHaveLength(1);
+    expect(result.current.accounts[0]?.id).toBe(parentWithToken.id);
+  });
 
-    expect(tokenIds).not.toContain(tokenAccount.token.id);
+  it("should expose aggregated data with sub-account count", () => {
+    const parentWithToken = { ...ethAccount, subAccounts: [tokenAccount] };
+
+    const { result } = renderHook(() => useCryptoAddressesViewModel(), {
+      overrideInitialState: withAccounts([parentWithToken]),
+    });
+
+    const entry = result.current.aggregatedAccountsData.get(parentWithToken.id);
+    expect(entry).toBeDefined();
+    expect(entry?.subAccountsCount).toBe(1);
   });
 
   describe("loading and error states", () => {
@@ -133,7 +139,7 @@ describe("useCryptoAddressesViewModel", () => {
   });
 
   describe("account navigation", () => {
-    it("should navigate and track for a regular Account", () => {
+    it("should navigate and track for a main Account", () => {
       const { result } = renderHook(() => useCryptoAddressesViewModel(), {
         overrideInitialState: withAccounts([btcAccount]),
       });
@@ -145,29 +151,6 @@ describe("useCryptoAddressesViewModel", () => {
       });
       expect(jest.mocked(track)).toHaveBeenCalledWith("account_clicked", {
         currency: "Bitcoin",
-        page: ScreenName.Accounts,
-      });
-    });
-
-    it("should navigate and track for a TokenAccount", () => {
-      const parentWithToken = { ...ethAccount, subAccounts: [tokenAccount] };
-
-      const { result } = renderHook(() => useCryptoAddressesViewModel(), {
-        overrideInitialState: withAccounts([parentWithToken]),
-      });
-
-      act(() => result.current.onAccountPress(tokenAccount));
-
-      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Accounts, {
-        screen: ScreenName.Account,
-        params: {
-          currencyId: tokenAccount.token.parentCurrency.id,
-          parentId: tokenAccount.parentId,
-          accountId: tokenAccount.id,
-        },
-      });
-      expect(jest.mocked(track)).toHaveBeenCalledWith("account_clicked", {
-        currency: tokenAccount.token.parentCurrency.name,
         page: ScreenName.Accounts,
       });
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/CryptoAddressesListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/CryptoAddressesListItem.tsx
@@ -1,19 +1,68 @@
 import React, { useCallback } from "react";
-import { AccountLike } from "@ledgerhq/types-live";
-import { ListItem } from "@ledgerhq/lumen-ui-rnative";
+import { Account } from "@ledgerhq/types-live";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemTrailing,
+  ListItemTitle,
+  ListItemDescription,
+} from "@ledgerhq/lumen-ui-rnative";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import BigNumber from "bignumber.js";
+import { useSelector } from "~/context/hooks";
+import {
+  counterValueCurrencySelector,
+  discreetModeSelector,
+  localeSelector,
+} from "~/reducers/settings";
 import AccountItem from "LLM/features/Accounts/components/AccountItem";
+import { useTranslation } from "~/context/Locale";
 
 type Props = Readonly<{
-  account: AccountLike;
-  onPress: (account: AccountLike) => void;
+  account: Account;
+  aggregatedCountervalue: BigNumber;
+  subAccountsCount: number;
+  onPress: (account: Account) => void;
 }>;
 
-export default function CryptoAddressesListItem({ account, onPress }: Props) {
+export default function CryptoAddressesListItem({
+  account,
+  aggregatedCountervalue,
+  subAccountsCount,
+  onPress,
+}: Props) {
+  const { t } = useTranslation();
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const locale = useSelector(localeSelector);
+  const discreet = useSelector(discreetModeSelector);
+
   const handlePress = useCallback(() => onPress(account), [account, onPress]);
+
+  const formattedBalance = formatCurrencyUnit(
+    counterValueCurrency.units[0],
+    aggregatedCountervalue,
+    { showCode: true, locale, discreet },
+  );
+
+  const displayedAssetsCount = subAccountsCount + 1;
 
   return (
     <ListItem onPress={handlePress}>
-      <AccountItem account={account} balance={account.balance} withPlaceholder />
+      <AccountItem
+        account={account}
+        balance={account.balance}
+        hideBalanceInfo
+        withPlaceholder
+        squaredIcon
+      />
+      <ListItemTrailing>
+        <ListItemContent>
+          <ListItemTitle>{formattedBalance}</ListItemTitle>
+          <ListItemDescription testID="assets-count">
+            {t("cryptoAddresses.assetsCount", { count: displayedAssetsCount })}
+          </ListItemDescription>
+        </ListItemContent>
+      </ListItemTrailing>
     </ListItem>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/__tests__/CryptoAddressesListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/__tests__/CryptoAddressesListItem.test.tsx
@@ -34,11 +34,60 @@ const mockAccount = {
 describe("CryptoAddressesListItem", () => {
   it("should render the account and call onPress with it when pressed", () => {
     const onPress = jest.fn();
-    render(<CryptoAddressesListItem account={mockAccount} onPress={onPress} />);
+    render(
+      <CryptoAddressesListItem
+        account={mockAccount}
+        aggregatedCountervalue={new BigNumber(1000)}
+        subAccountsCount={0}
+        onPress={onPress}
+      />,
+    );
 
     expect(screen.getByText("Bitcoin")).toBeVisible();
 
     fireEvent.press(screen.getByText("Bitcoin"));
     expect(onPress).toHaveBeenCalledWith(mockAccount);
+  });
+
+  it("should always show the assets count", () => {
+    const onPress = jest.fn();
+    render(
+      <CryptoAddressesListItem
+        account={mockAccount}
+        aggregatedCountervalue={new BigNumber(1000)}
+        subAccountsCount={0}
+        onPress={onPress}
+      />,
+    );
+
+    expect(screen.getByTestId("assets-count")).toBeVisible();
+  });
+
+  it("should count the main account itself as 1 asset when there are no sub-accounts", () => {
+    const onPress = jest.fn();
+    render(
+      <CryptoAddressesListItem
+        account={mockAccount}
+        aggregatedCountervalue={new BigNumber(1000)}
+        subAccountsCount={0}
+        onPress={onPress}
+      />,
+    );
+
+    expect(screen.getByTestId("assets-count")).toHaveTextContent("1 asset");
+  });
+
+  it("should count main account + sub-accounts", () => {
+    const onPress = jest.fn();
+    render(
+      <CryptoAddressesListItem
+        account={mockAccount}
+        aggregatedCountervalue={new BigNumber(1000)}
+        subAccountsCount={3}
+        onPress={onPress}
+      />,
+    );
+
+    expect(screen.getByTestId("assets-count")).toHaveTextContent("4 assets");
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/index.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useMemo } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FlashList, FlashListProps, ListRenderItemInfo } from "@shopify/flash-list";
-import { AccountLike } from "@ledgerhq/types-live";
+import { Account } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { TrackScreen } from "~/analytics";
@@ -22,10 +23,11 @@ type Props = BaseComposite<
   StackNavigatorProps<CryptoAddressesNavigator, ScreenName.CryptoAddresses>
 >;
 
-const SyncList = globalSyncRefreshControl<FlashListProps<AccountLike>>(FlashList);
+const SyncList = globalSyncRefreshControl<FlashListProps<Account>>(FlashList);
 
 function CryptoAddressesView({
   accounts,
+  aggregatedAccountsData,
   hasNoAccount,
   isLoading,
   error,
@@ -40,10 +42,18 @@ function CryptoAddressesView({
 }: Readonly<ReturnType<typeof useCryptoAddressesViewModel>>) {
   const { bottom } = useSafeAreaInsets();
   const renderItem = useCallback(
-    ({ item }: ListRenderItemInfo<AccountLike>) => (
-      <CryptoAddressesListItem account={item} onPress={onAccountPress} />
-    ),
-    [onAccountPress],
+    ({ item }: ListRenderItemInfo<Account>) => {
+      const data = aggregatedAccountsData.get(item.id);
+      return (
+        <CryptoAddressesListItem
+          account={item}
+          aggregatedCountervalue={data?.countervalue ?? new BigNumber(0)}
+          subAccountsCount={data?.subAccountsCount ?? 0}
+          onPress={onAccountPress}
+        />
+      );
+    },
+    [onAccountPress, aggregatedAccountsData],
   );
 
   const ListEmpty = useMemo(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/useCryptoAddressesViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/useCryptoAddressesViewModel.ts
@@ -3,20 +3,25 @@ import { useSelector } from "~/context/hooks";
 import { useFocusEffect, useNavigation } from "@react-navigation/core";
 import { useRefreshAccountsOrdering } from "~/actions/general";
 import { useGlobalSyncState } from "@ledgerhq/live-common/bridge/react/useGlobalSyncState";
-import { flattenAccountsSelector, isUpToDateSelector } from "~/reducers/accounts";
+import { accountsSelector, isUpToDateSelector } from "~/reducers/accounts";
 import { track } from "~/analytics";
-import { NavigatorName, ScreenName } from "~/const";
+import { ScreenName } from "~/const";
 import {
   BaseNavigationComposite,
   StackNavigatorNavigation,
 } from "~/components/RootNavigator/types/helpers";
 import { AccountsNavigatorParamList } from "~/components/RootNavigator/types/AccountsNavigator";
-import { Account, TokenAccount } from "@ledgerhq/types-live";
+import { Account } from "@ledgerhq/types-live";
 import isEqual from "lodash/isEqual";
-import { orderAccountsByFiatValue } from "@ledgerhq/live-countervalues/portfolio";
 import { useCountervaluesState } from "@ledgerhq/live-countervalues-react/index";
-import { blacklistedTokenIdsSelector, counterValueCurrencySelector } from "~/reducers/settings";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
+import { counterValueCurrencySelector } from "~/reducers/settings";
 import { useTranslation } from "~/context/Locale";
+import BigNumber from "bignumber.js";
+import {
+  computeAggregatedAccountsData,
+  type CalculateCountervalue,
+} from "@ledgerhq/asset-aggregation/index";
 
 type NavigationProp = BaseNavigationComposite<
   StackNavigatorNavigation<AccountsNavigatorParamList, ScreenName.CryptoAddresses>
@@ -27,20 +32,28 @@ export default function useCryptoAddressesViewModel(sourceScreenName?: ScreenNam
   const navigation = useNavigation<NavigationProp>();
   const countervalueState = useCountervaluesState();
   const toCurrency = useSelector(counterValueCurrencySelector);
-  const allAccounts = useSelector(flattenAccountsSelector, isEqual);
-  const orderedAccounts = orderAccountsByFiatValue(allAccounts, countervalueState, toCurrency);
+  const allAccounts = useSelector(accountsSelector, isEqual);
 
-  const excludedTokenIds = useSelector(blacklistedTokenIdsSelector);
-  const accounts = useMemo(
-    () =>
-      orderedAccounts.filter(account => {
-        if (account.type === "TokenAccount") {
-          return !excludedTokenIds.includes(account.token.id);
-        }
-        return true;
-      }),
-    [orderedAccounts, excludedTokenIds],
-  );
+  const aggregatedAccountsData = useMemo(() => {
+    const calculateCv: CalculateCountervalue = (from, value) => {
+      const raw = calculate(countervalueState, {
+        value: value.toNumber(),
+        from,
+        to: toCurrency,
+        disableRounding: true,
+      });
+      return raw == null ? undefined : new BigNumber(raw);
+    };
+    return computeAggregatedAccountsData(allAccounts, calculateCv);
+  }, [allAccounts, countervalueState, toCurrency]);
+
+  const accounts = useMemo((): Account[] => {
+    return [...allAccounts].sort((a, b) => {
+      const aCV = aggregatedAccountsData.get(a.id)?.countervalue ?? new BigNumber(0);
+      const bCV = aggregatedAccountsData.get(b.id)?.countervalue ?? new BigNumber(0);
+      return bCV.comparedTo(aCV);
+    });
+  }, [allAccounts, aggregatedAccountsData]);
 
   const hasNoAccount = accounts.length === 0;
 
@@ -62,35 +75,21 @@ export default function useCryptoAddressesViewModel(sourceScreenName?: ScreenNam
   const onCloseAddAccount = useCallback(() => setIsAddAccountOpen(false), []);
 
   const onAccountPress = useCallback(
-    (account: Account | TokenAccount) => {
-      if (account.type === "Account") {
-        track("account_clicked", {
-          currency: account.currency.name,
-          page: ScreenName.Accounts,
-        });
-        navigation.navigate(ScreenName.Account, {
-          accountId: account.id,
-        });
-      } else if (account.type === "TokenAccount") {
-        track("account_clicked", {
-          currency: account.token.parentCurrency.name,
-          page: ScreenName.Accounts,
-        });
-        navigation.navigate(NavigatorName.Accounts, {
-          screen: ScreenName.Account,
-          params: {
-            currencyId: account.token.parentCurrency.id,
-            parentId: account.parentId,
-            accountId: account.id,
-          },
-        });
-      }
+    (account: Account) => {
+      track("account_clicked", {
+        currency: account.currency.name,
+        page: ScreenName.Accounts,
+      });
+      navigation.navigate(ScreenName.Account, {
+        accountId: account.id,
+      });
     },
     [navigation],
   );
 
   return {
     accounts,
+    aggregatedAccountsData,
     hasNoAccount,
     isLoading,
     error,

--- a/libs/asset-aggregation/src/assetAggregation/__tests__/computeAggregatedAccountsData.test.ts
+++ b/libs/asset-aggregation/src/assetAggregation/__tests__/computeAggregatedAccountsData.test.ts
@@ -1,0 +1,88 @@
+import BigNumber from "bignumber.js";
+import { cryptocurrenciesById } from "@ledgerhq/cryptoassets";
+import type { Account } from "@ledgerhq/types-live";
+import {
+  type CalculateCountervalue,
+  computeAggregatedAccountsData,
+} from "../computeAggregatedAccountsData";
+import { createFixtureAccount, createFixtureTokenAccount } from "./fixtures";
+import { makeToken } from "../../assetCategorization/__tests__/fixtures";
+
+const bitcoin = cryptocurrenciesById["bitcoin"];
+const ethereum = cryptocurrenciesById["ethereum"];
+
+const BTC_ACCOUNT = createFixtureAccount("btc1", bitcoin);
+const ETH_ACCOUNT = createFixtureAccount("eth1", ethereum);
+const usdcToken = makeToken("ethereum/erc20/usdc", "USDC", "USD Coin");
+
+const calculateCountervalue: jest.Mock<ReturnType<CalculateCountervalue>> = jest.fn(
+  (_from, value: BigNumber) => value.times(2),
+);
+
+function withBalance<T extends Account>(account: T, balance: BigNumber): T {
+  return { ...account, balance };
+}
+
+beforeEach(() => {
+  calculateCountervalue.mockReset();
+  calculateCountervalue.mockImplementation((_from, value: BigNumber) => value.times(2));
+});
+
+describe("computeAggregatedAccountsData", () => {
+  it("returns an empty map when accounts are empty", () => {
+    const map = computeAggregatedAccountsData([], calculateCountervalue);
+    expect(map.size).toBe(0);
+  });
+
+  it("ignores non-main accounts (TokenAccount rows)", () => {
+    const usdc = createFixtureTokenAccount("usdc1", usdcToken);
+    const map = computeAggregatedAccountsData([usdc], calculateCountervalue);
+    expect(map.size).toBe(0);
+  });
+
+  it("computes countervalue for a main account with no sub-accounts", () => {
+    const account = withBalance(BTC_ACCOUNT, new BigNumber(100));
+    const map = computeAggregatedAccountsData([account], calculateCountervalue);
+    expect(map.get(account.id)?.countervalue.toString()).toBe("200");
+    expect(map.get(account.id)?.subAccountsCount).toBe(0);
+  });
+
+  it("sums main account and sub-account countervalues", () => {
+    const usdc = createFixtureTokenAccount("usdc1", usdcToken);
+    const parent: Account = {
+      ...ETH_ACCOUNT,
+      balance: new BigNumber(100),
+      subAccounts: [{ ...usdc, balance: new BigNumber(50) }],
+    };
+
+    const map = computeAggregatedAccountsData([parent], calculateCountervalue);
+    expect(map.get(parent.id)?.countervalue.toString()).toBe("300");
+    expect(map.get(parent.id)?.subAccountsCount).toBe(1);
+  });
+
+  it("includes sub-accounts even when main balance is zero", () => {
+    const usdc = createFixtureTokenAccount("usdc1", usdcToken);
+    const parent: Account = {
+      ...ETH_ACCOUNT,
+      balance: new BigNumber(0),
+      subAccounts: [{ ...usdc, balance: new BigNumber(50) }],
+    };
+
+    const map = computeAggregatedAccountsData([parent], calculateCountervalue);
+    expect(map.get(parent.id)?.countervalue.toString()).toBe("100");
+    expect(map.get(parent.id)?.subAccountsCount).toBe(1);
+  });
+
+  it("treats null/undefined countervalues as zero", () => {
+    calculateCountervalue.mockReturnValueOnce(null).mockReturnValueOnce(undefined);
+    const usdc = createFixtureTokenAccount("usdc1", usdcToken);
+    const parent: Account = {
+      ...ETH_ACCOUNT,
+      balance: new BigNumber(100),
+      subAccounts: [{ ...usdc, balance: new BigNumber(50) }],
+    };
+
+    const map = computeAggregatedAccountsData([parent], calculateCountervalue);
+    expect(map.get(parent.id)?.countervalue.toString()).toBe("0");
+  });
+});

--- a/libs/asset-aggregation/src/assetAggregation/computeAggregatedAccountsData.ts
+++ b/libs/asset-aggregation/src/assetAggregation/computeAggregatedAccountsData.ts
@@ -1,0 +1,37 @@
+import BigNumber from "bignumber.js";
+import type { AccountLike } from "@ledgerhq/types-live";
+import type { Currency } from "@ledgerhq/types-cryptoassets";
+
+export type CalculateCountervalue = (
+  from: Currency,
+  value: BigNumber,
+) => BigNumber | null | undefined;
+
+export type AggregatedAccountEntry = {
+  countervalue: BigNumber;
+  subAccountsCount: number;
+};
+
+export function computeAggregatedAccountsData(
+  accounts: AccountLike[],
+  calculateCountervalue: CalculateCountervalue,
+): Map<string, AggregatedAccountEntry> {
+  const map = new Map<string, AggregatedAccountEntry>();
+
+  for (const account of accounts) {
+    if (account.type !== "Account") continue;
+
+    const mainCv = calculateCountervalue(account.currency, account.balance);
+    let countervalue = new BigNumber(mainCv ?? 0);
+
+    const subs = account.subAccounts ?? [];
+    for (const sub of subs) {
+      const subCv = calculateCountervalue(sub.token, sub.balance);
+      countervalue = countervalue.plus(subCv ?? 0);
+    }
+
+    map.set(account.id, { countervalue, subAccountsCount: subs.length });
+  }
+
+  return map;
+}

--- a/libs/asset-aggregation/src/assetAggregation/index.ts
+++ b/libs/asset-aggregation/src/assetAggregation/index.ts
@@ -1,2 +1,7 @@
 export { groupAccountsByAsset, type GroupedAccount } from "./groupAccountsByAsset";
 export { calculateProviderTotals } from "./calculateProviderTotals";
+export {
+  computeAggregatedAccountsData,
+  type CalculateCountervalue,
+  type AggregatedAccountEntry,
+} from "./computeAggregatedAccountsData";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _`computeAggregatedAccountsData` is tested as a pure function in `@ledgerhq/asset-aggregation`. View model tests cover main-accounts-only rendering, sub-account count, and navigation._
- [x] **Impact of the changes:**
  - Accounts tab (LWM): only main accounts shown, no separate token account rows
  - Aggregated fiat balance per row (main balance + all sub-account balances, sorted by countervalue descending)
  - Assets count badge: `subAccountsCount + 1` (main account always counts as 1 asset)
  - `AccountItem` gains a `squaredIcon` prop (non-breaking)
  - `CurrencyIcon` network badge hidden in `DistributionCard` and `CryptoAssetList` when asset aggregation is enabled
  - LWD `useCryptoDataTable` migrated to use the shared lib function

### 📝 Description

**Problem**: The mobile Accounts tab showed a flat list of all accounts including each token account as a separate row, inconsistent with the desktop experience. The aggregation logic computing countervalue per account (main + sub-accounts) was also duplicated between LWD and LWM with no shared abstraction.

**Solution**:

1. **Extract `computeAggregatedAccountsData` into `@ledgerhq/asset-aggregation`** — the function takes a `CalculateCountervalue` callback (no hook dependencies), making it a pure function testable without mocks. Both LWD and LWM now import it from the lib. LWD retains only `computeBalanceSortCountervalueByAccountId` locally.

2. **Rewrite `CryptoAddressesScreen` on mobile** — `useCryptoAddressesViewModel` now uses `accountsSelector` (main accounts only) instead of `flattenAccountsSelector`, wraps `calculate()` into a `CalculateCountervalue` adapter, and delegates to the shared function. Accounts are sorted by aggregated countervalue via `BigNumber.comparedTo` (no precision loss). The list item displays the pre-formatted fiat total and an assets count.

Asset aggre with 300 Accounts

https://github.com/user-attachments/assets/9def56b1-92e2-4607-965c-11ffcbdca563

No Asset aggre with 300 Accounts

https://github.com/user-attachments/assets/faf62083-ee5f-46d9-bb03-e3c580d1a362




### ❓ Context

- **JIRA or GitHub link**: [LIVE-29283](https://ledgerhq.atlassian.net/browse/LIVE-29283)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29283]: https://ledgerhq.atlassian.net/browse/LIVE-29283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ