### PR TITLE
[LWDM] test(LIVE-27411): aleo transfer public e2e

### DIFF
--- a/.changeset/angry-suns-chew.md
+++ b/.changeset/angry-suns-chew.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop-e2e-tests": minor
+"@ledgerhq/live-cli": minor
+---
+
+test: e2e for aleo public transfer

--- a/apps/cli/src/commands-index.ts
+++ b/apps/cli/src/commands-index.ts
@@ -9,6 +9,7 @@ import generateTestScanAccounts from "./commands/blockchain/generateTestScanAcco
 import generateTestTransaction from "./commands/blockchain/generateTestTransaction";
 import getAddress from "./commands/blockchain/getAddress";
 import getTransactionStatus from "./commands/blockchain/getTransactionStatus";
+import getAleoViewKey from "./commands/blockchain/getAleoViewKey";
 import receive from "./commands/blockchain/receive";
 import send from "./commands/blockchain/send";
 import signMessage from "./commands/blockchain/signMessage";
@@ -70,6 +71,7 @@ export default {
   generateTestScanAccounts,
   generateTestTransaction,
   getAddress,
+  getAleoViewKey,
   getTransactionStatus,
   receive,
   send,

--- a/apps/cli/src/commands/blockchain/getAleoViewKey.ts
+++ b/apps/cli/src/commands/blockchain/getAleoViewKey.ts
@@ -1,0 +1,52 @@
+import { from } from "rxjs";
+import { mergeMap, map } from "rxjs/operators";
+import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
+import { viewKeyResolver } from "@ledgerhq/live-common/families/aleo/setup";
+import {
+  CurrencyCommonOpts,
+  currencyOpt,
+  DeviceCommonOpts,
+  deviceOpt,
+  inferCurrency,
+} from "../../scan";
+
+export type GetViewKeyJobOpts = CurrencyCommonOpts &
+  DeviceCommonOpts &
+  Partial<{
+    path?: string;
+  }>;
+
+// FIXME: Aleo specific code in place that feels generic
+export default {
+  description: "Get the Aleo view key for a derivation path (requires device confirmation)",
+  args: [
+    currencyOpt,
+    deviceOpt,
+    {
+      name: "path",
+      type: String,
+      desc: "HD derivation path",
+    },
+  ],
+  job: (arg: GetViewKeyJobOpts) =>
+    inferCurrency(arg).pipe(
+      mergeMap(currency => {
+        if (!currency) {
+          throw new Error("no currency provided");
+        }
+
+        if (!arg.path) {
+          throw new Error("--path is required");
+        }
+
+        return withDevice(arg.device || "")(t =>
+          from(
+            viewKeyResolver(t, {
+              path: arg.path as string,
+              currency,
+            }),
+          ).pipe(map(result => JSON.stringify(result))),
+        );
+      }),
+    ),
+};

--- a/e2e/desktop/tests/page/speculos.page.ts
+++ b/e2e/desktop/tests/page/speculos.page.ts
@@ -13,9 +13,9 @@ import {
   removeMemberLedgerSync,
   providePublicKey,
   exportUfvk,
-  shareViewKey,
 } from "@ledgerhq/live-common/e2e/speculos";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { shareViewKey } from "@ledgerhq/live-common/e2e/families/aleo";
 import { Transaction } from "@ledgerhq/live-common/e2e/models/Transaction";
 import { Delegate } from "@ledgerhq/live-common/e2e/models/Delegate";
 

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -11,6 +11,7 @@ import {
   liveDataWithRecipientAddressCommand,
   liveDataCommand,
 } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
+import { liveDataWithRecipientAddressCommand as aleoLiveDataCommand } from "@ledgerhq/live-common/e2e/families/aleo";
 import { Addresses } from "@ledgerhq/live-common/e2e/enum/Addresses";
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 
@@ -252,9 +253,18 @@ const transactionE2E = [
     transaction: new Transaction(Account.ICP_1, Account.ICP_2, "0.001"),
     xrayTicket: "B2CQA-4742",
   },
+  {
+    transaction: new Transaction(Account.ALEO_1, Account.ALEO_2, "0.000001"),
+    xrayTicket: "B2CQA-4731",
+  },
 ];
 
-const LNS_UNSUPPORTED_CURRENCIES = new Set([Currency.SUI.id, Currency.VET.id, Currency.HBAR.id]);
+const LNS_UNSUPPORTED_CURRENCIES = new Set([
+  Currency.SUI.id,
+  Currency.VET.id,
+  Currency.HBAR.id,
+  Currency.ALEO.id,
+]);
 
 function shouldSkipLNSTag(currencyId: string): boolean {
   return LNS_UNSUPPORTED_CURRENCIES.has(currencyId);
@@ -267,7 +277,11 @@ test.describe("Send flows", () => {
         teamOwner: Team.COIN_INTEGRATION,
         userdata: "skip-onboarding-with-last-seen-device",
         speculosApp: transaction.transaction.accountToDebit.currency.speculosApp,
-        cliCommands: [liveDataWithRecipientAddressCommand(transaction.transaction)],
+        cliCommands: [
+          transaction.transaction.accountToDebit.currency.id === Currency.ALEO.id
+            ? aleoLiveDataCommand(transaction.transaction)
+            : liveDataWithRecipientAddressCommand(transaction.transaction),
+        ],
       });
 
       const family = getFamilyByCurrencyId(transaction.transaction.accountToDebit.currency.id);
@@ -463,7 +477,7 @@ test.describe("Send flows", () => {
           transaction.transaction.accountToCredit.address =
             transaction.transaction.accountToCredit === Account.ETH_2_LOWER_CASE
               ? (transaction.transaction.accountToCredit.address ?? "").toLowerCase()
-              : transaction.transaction.accountToCredit.address ?? "";
+              : (transaction.transaction.accountToCredit.address ?? "");
 
           await app.send.fillRecipientInfo(transaction.transaction);
           await app.send.checkInputWarningMessage(transaction.expectedWarningMessage);

--- a/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
+++ b/libs/ledger-live-common/src/e2e/data/deviceLabelsData.ts
@@ -183,6 +183,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.KASPA.name]: DeviceLabels.APPROVE,
       [AppInfos.DOGECOIN.name]: DeviceLabels.ACCEPT,
       [AppInfos.BITCOIN_CASH.name]: DeviceLabels.ACCEPT,
+      [AppInfos.ALEO.name]: DeviceLabels.SIGN_TRANSACTION,
       default: DeviceLabels.CAPS_APPROVE,
     },
   },

--- a/libs/ledger-live-common/src/e2e/enum/Account.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Account.ts
@@ -18,6 +18,25 @@ export class Account {
   static readonly ADA_1 = new Account(Currency.ADA, "Cardano 1", 0, "1852'/1815'/0'/0/3");
   static readonly ADA_2 = new Account(Currency.ADA, "Cardano 2", 1, "1852'/1815'/1'/0/2");
 
+  static readonly ALEO_1 = new Account(
+    Currency.ALEO,
+    "Aleo 1",
+    0,
+    "44'/683'/0'/0'",
+    undefined,
+    undefined,
+    "aleo",
+  );
+  static readonly ALEO_2 = new Account(
+    Currency.ALEO,
+    "Aleo 2",
+    1,
+    "44'/683'/1'/0'",
+    undefined,
+    undefined,
+    "aleo",
+  );
+
   static readonly ALGO_1 = new Account(Currency.ALGO, "Algorand 1", 0, "44'/283'/0'/0/0");
   static readonly ALGO_2 = new Account(Currency.ALGO, "Algorand 2", 1, "44'/283'/1'/0/0");
 

--- a/libs/ledger-live-common/src/e2e/families/aleo.test.ts
+++ b/libs/ledger-live-common/src/e2e/families/aleo.test.ts
@@ -1,0 +1,112 @@
+import { encodeAccountId, decodeAccountId } from "../../account";
+import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
+import { patchAccountRawWithViewKey } from "./aleo";
+import type { AccountRaw, OperationRaw } from "@ledgerhq/types-live";
+
+const baseId = encodeAccountId({
+  type: "js",
+  version: "2",
+  currencyId: "aleo",
+  xpubOrAddress: "aleo1abc123",
+  derivationMode: "aleo",
+});
+
+const makeOp = (accountId: string, hash: string): OperationRaw => ({
+  id: encodeOperationId(accountId, hash, "OUT"),
+  accountId,
+  hash,
+  type: "OUT",
+  value: "1000",
+  fee: "100",
+  senders: [],
+  recipients: [],
+  blockHeight: 1,
+  blockHash: "blockhash",
+  date: new Date(0).toISOString(),
+  extra: {},
+});
+
+const makeAccountRaw = (overrides?: Partial<AccountRaw>): AccountRaw =>
+  ({
+    id: baseId,
+    currencyId: "aleo",
+    freshAddress: "aleo1abc123",
+    freshAddressPath: "44'/683'/0'/0'",
+    name: "Aleo 1",
+    balance: "100000",
+    spendableBalance: "100000",
+    blockHeight: 0,
+    operations: [],
+    pendingOperations: [],
+    operationsCount: 0,
+    lastSyncDate: new Date(0).toISOString(),
+    creationDate: new Date(0).toISOString(),
+    freshAddresses: [],
+    syncHash: "",
+    starred: false,
+    used: false,
+    unitMagnitude: 6,
+    index: 0,
+    derivationMode: "aleo",
+    ...overrides,
+  }) as AccountRaw;
+
+describe("patchAccountRawWithViewKey", () => {
+  const viewKey = "AViewKey1abcdefghijklmnop";
+
+  it("embeds viewKey as customData in the account ID", () => {
+    const patched = patchAccountRawWithViewKey(makeAccountRaw(), viewKey);
+    expect(decodeAccountId(patched.id).customData).toBe(viewKey);
+  });
+
+  it("preserves all other accountId segments", () => {
+    const raw = makeAccountRaw();
+    const patched = patchAccountRawWithViewKey(raw, viewKey);
+    const original = decodeAccountId(raw.id);
+    const updated = decodeAccountId(patched.id);
+
+    expect(updated.type).toBe(original.type);
+    expect(updated.version).toBe(original.version);
+    expect(updated.currencyId).toBe(original.currencyId);
+    expect(updated.xpubOrAddress).toBe(original.xpubOrAddress);
+    expect(updated.derivationMode).toBe(original.derivationMode);
+  });
+
+  it("updates operation IDs and accountId to use the new account ID", () => {
+    const raw = makeAccountRaw({ operations: [makeOp(baseId, "txhash1")] });
+    const patched = patchAccountRawWithViewKey(raw, viewKey);
+
+    expect(patched.operations[0].accountId).toBe(patched.id);
+    expect(patched.operations[0].id).toBe(encodeOperationId(patched.id, "txhash1", "OUT"));
+  });
+
+  it("updates pendingOperation IDs and accountId to use the new account ID", () => {
+    const raw = makeAccountRaw({ pendingOperations: [makeOp(baseId, "pendinghash1")] });
+    const patched = patchAccountRawWithViewKey(raw, viewKey);
+
+    expect(patched.pendingOperations[0].accountId).toBe(patched.id);
+    expect(patched.pendingOperations[0].id).toBe(
+      encodeOperationId(patched.id, "pendinghash1", "OUT"),
+    );
+  });
+
+  it("does not mutate the original AccountRaw", () => {
+    const raw = makeAccountRaw({ operations: [makeOp(baseId, "txhash1")] });
+    const originalId = raw.id;
+    const originalOpId = raw.operations[0].id;
+
+    patchAccountRawWithViewKey(raw, viewKey);
+
+    expect(raw.id).toBe(originalId);
+    expect(raw.operations[0].id).toBe(originalOpId);
+  });
+
+  it("handles an account with no operations", () => {
+    const raw = makeAccountRaw({ operations: [], pendingOperations: [] });
+    const patched = patchAccountRawWithViewKey(raw, viewKey);
+
+    expect(patched.operations).toHaveLength(0);
+    expect(patched.pendingOperations).toHaveLength(0);
+    expect(decodeAccountId(patched.id).customData).toBe(viewKey);
+  });
+});

--- a/libs/ledger-live-common/src/e2e/families/aleo.ts
+++ b/libs/ledger-live-common/src/e2e/families/aleo.ts
@@ -1,0 +1,110 @@
+import fs from "fs";
+import {
+  encodeAccountId,
+  decodeAccountId,
+} from "@ledgerhq/ledger-wallet-framework/account/accountId";
+import { encodeOperationId, decodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
+import type { AccountRaw, OperationRaw } from "@ledgerhq/types-live";
+import { getSendEvents, pressUntilTextFound } from "../speculos";
+import { isTouchDevice } from "../speculosAppVersion";
+import { DeviceLabels } from "../enum/DeviceLabels";
+import { longPressAndRelease, pressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
+import { Transaction } from "../models/Transaction";
+import { withDeviceController } from "../deviceInteraction/DeviceController";
+import { runCliLiveData, runCliGetViewKey } from "../runCli";
+import { getAccountAddress } from "../cliCommandsUtils";
+
+export const sendAleo = withDeviceController(
+  ({ getButtonsController }) =>
+    async (tx: Transaction) => {
+      const buttons = getButtonsController();
+
+      await getSendEvents(tx);
+      if (isTouchDevice()) {
+        await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
+      } else {
+        await buttons.both();
+      }
+    },
+);
+
+export const shareViewKey = withDeviceController(({ getButtonsController }) => async () => {
+  const buttons = getButtonsController();
+
+  await pressUntilTextFound(DeviceLabels.CONFIRM);
+
+  if (isTouchDevice()) {
+    await pressAndRelease(DeviceLabels.CONFIRM);
+  } else {
+    await buttons.both();
+  }
+});
+
+export function patchAccountRawWithViewKey(raw: AccountRaw, viewKey: string): AccountRaw {
+  const oldId = raw.id;
+  const newId = encodeAccountId({ ...decodeAccountId(oldId), customData: viewKey });
+
+  const patchOps = (ops: OperationRaw[]): OperationRaw[] =>
+    ops.map(op => {
+      const { hash, type } = decodeOperationId(op.id);
+
+      return {
+        ...op,
+        accountId: newId,
+        id: encodeOperationId(newId, hash, type),
+      };
+    });
+
+  return {
+    ...raw,
+    id: newId,
+    operations: patchOps(raw.operations),
+    pendingOperations: patchOps(raw.pendingOperations),
+  };
+}
+
+export const liveDataWithRecipientAddressCommand =
+  (tx: Transaction) =>
+  async (userdataPath?: string): Promise<string> => {
+    if (!userdataPath) {
+      throw new Error("userdataPath is required for Aleo liveDataWithRecipientAddressCommand");
+    }
+
+    await runCliLiveData({
+      currency: tx.accountToDebit.currency.speculosApp.name,
+      index: tx.accountToDebit.index,
+      add: true,
+      appjson: userdataPath,
+    });
+
+    const address = await getAccountAddress(tx.accountToCredit);
+    tx.accountToCredit.address = address;
+    tx.recipientAddress = address;
+
+    // get view key from speculos (CLI sends the APDU and blocks, shareViewKey() polls)
+    const [{ viewKey }] = await Promise.all([
+      runCliGetViewKey({
+        currency: tx.accountToDebit.currency.speculosApp.name,
+        path: tx.accountToDebit.accountPath,
+      }),
+      shareViewKey(),
+    ]);
+
+    // patch app.json with view key at AccountRaw level to avoid bridge setup
+    const appJson = JSON.parse(fs.readFileSync(userdataPath, "utf-8"));
+    appJson.data.accounts = appJson.data.accounts.map(
+      (entry: { data: AccountRaw; version: number }) => {
+        if (entry.data.currencyId !== tx.accountToDebit.currency.id) {
+          return entry;
+        }
+
+        return {
+          ...entry,
+          data: patchAccountRawWithViewKey(entry.data, viewKey),
+        };
+      },
+    );
+    fs.writeFileSync(userdataPath, JSON.stringify(appJson));
+
+    return address;
+  };

--- a/libs/ledger-live-common/src/e2e/runCli.ts
+++ b/libs/ledger-live-common/src/e2e/runCli.ts
@@ -52,6 +52,12 @@ export type GetAddressOpts = {
   verify?: boolean;
 };
 
+export type GetViewKeyOpts = {
+  currency?: string;
+  device?: string;
+  path?: string;
+};
+
 export type TokenApprovalOpts = {
   currency: string;
   index: number;
@@ -71,27 +77,27 @@ export type GetTokenAllowanceOpts = {
   ownerAddress: string;
 };
 
-function parseGetAddressCliOutput(output: string): unknown {
+function parseJsonCliOutput(commandName: string, output: string): unknown {
   const lines = output
     .split("\n")
     .map(line => line.trim())
     .filter(line => line.length > 0);
 
   if (lines.length === 0) {
-    throw new Error("CLI getAddress returned empty output");
+    throw new Error(`CLI ${commandName} returned empty output`);
   }
 
   const jsonLine =
     [...lines].reverse().find(line => line.startsWith("{") || line.startsWith("[")) ?? "";
 
   if (!jsonLine) {
-    throw new Error("CLI getAddress output does not contain JSON");
+    throw new Error(`CLI ${commandName} output does not contain JSON`);
   }
 
   try {
     return JSON.parse(jsonLine);
   } catch {
-    throw new Error("Failed to parse CLI getAddress output");
+    throw new Error(`Failed to parse CLI ${commandName} output`);
   }
 }
 
@@ -216,7 +222,16 @@ export async function runCliGetAddress(opts: GetAddressOpts): Promise<{ address:
   if (opts.derivationMode) cliOpts.push(`--derivationMode+${opts.derivationMode}`);
   if (opts.verify) cliOpts.push("--verify");
   const output = await runCliCommandWithRetry(cliOpts.join("+"));
-  return parseGetAddressCliOutput(output) as { address: string };
+  return parseJsonCliOutput("getAddress", output) as { address: string };
+}
+
+export async function runCliGetViewKey(opts: GetViewKeyOpts): Promise<{ viewKey: string }> {
+  const cliOpts = ["getAleoViewKey"];
+  if (opts.currency) cliOpts.push(`--currency+${opts.currency}`);
+  if (opts.device) cliOpts.push(`--device+${opts.device}`);
+  if (opts.path) cliOpts.push(`--path+${opts.path}`);
+  const output = await runCliCommandWithRetry(cliOpts.join("+"));
+  return parseJsonCliOutput("getAleoViewKey", output) as { viewKey: string };
 }
 
 export function runCliTokenApproval(opts: TokenApprovalOpts): Promise<string> {

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -55,6 +55,7 @@ import { getDeviceCoordinates } from "./deviceCoordinates";
 import { sendInternetComputer } from "./families/internet_computer";
 import { sleep } from "./index";
 import { delegateMina } from "./families/mina";
+import { sendAleo } from "./families/aleo";
 
 const isSpeculosRemote = process.env.REMOTE_SPECULOS === "true";
 
@@ -949,6 +950,9 @@ export async function signSendTransaction(tx: Transaction) {
     case Currency.ICP.id:
       await sendInternetComputer(tx);
       break;
+    case Currency.ALEO.id:
+      await sendAleo(tx);
+      break;
     default:
       throw new Error(`Unsupported currency: ${tx.accountToDebit.currency.ticker}`);
   }
@@ -1121,14 +1125,3 @@ export const exportUfvk = withDeviceController(
       }
     },
 );
-
-export const shareViewKey = withDeviceController(({ getButtonsController }) => async () => {
-  const buttons = getButtonsController();
-  await pressUntilTextFound(DeviceLabels.CONFIRM);
-
-  if (isTouchDevice()) {
-    await pressAndRelease(DeviceLabels.CONFIRM);
-  } else {
-    await buttons.both();
-  }
-});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - CLI command to get Aleo view key
  - E2E test for Aleo public transfer

### 📝 Description

This PR adds E2E test for Aleo public transfer. Unfortunately, it requires more changes than expected because each Aleo account must have a `viewKey` that is missing in `app.json`. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-27411


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
