### PR TITLE
[LWM] feat(mobile): my wallet followup - spacing and recover dot

### DIFF
--- a/.changeset/smooth-shields-repair.md
+++ b/.changeset/smooth-shields-repair.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add vertical padding on My Wallet device list items and dismiss Recover notification dot after first click

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -66,6 +66,7 @@ import {
   SettingsSetHasSeenWalletV4TourPayload,
   SettingsSetProductTourCompletedPayload,
   SettingsSetAnalyticsConsentInfoPayload,
+  SettingsSetHasClickedRecoverPayload,
 } from "./types";
 import { ImageType } from "~/components/CustomImage/types";
 
@@ -290,6 +291,10 @@ export const setHasSeenWalletV4Tour = createAction<SettingsSetHasSeenWalletV4Tou
 
 export const setProductTourCompleted = createAction<SettingsSetProductTourCompletedPayload>(
   SettingsActionTypes.SET_PRODUCT_TOUR_COMPLETED,
+);
+
+export const setHasClickedRecover = createAction<SettingsSetHasClickedRecoverPayload>(
+  SettingsActionTypes.SET_HAS_CLICKED_RECOVER,
 );
 
 type PortfolioRangeOption = {

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -314,6 +314,7 @@ export enum SettingsActionTypes {
   SET_PRODUCT_TOUR_COMPLETED = "SET_PRODUCT_TOUR_COMPLETED",
   DEPRECATION_DO_NOT_REMIND = "DEPRECATION_DO_NOT_REMIND",
   SET_ANALYTICS_CONSENT_INFO = "SET_ANALYTICS_CONSENT_INFO",
+  SET_HAS_CLICKED_RECOVER = "SET_HAS_CLICKED_RECOVER",
 }
 
 export type SettingsImportPayload = Partial<SettingsState>;
@@ -406,6 +407,7 @@ export type SettingsAddStarredMarketcoinsPayload = Unpacked<SettingsState["starr
 export type SettingsRemoveStarredMarketcoinsPayload = Unpacked<SettingsState["starredMarketCoins"]>;
 export type SettingsSetSelectedTabPortfolioAssetsPayload =
   SettingsState["selectedTabPortfolioAssets"];
+export type SettingsSetHasClickedRecoverPayload = SettingsState["hasClickedRecover"];
 
 export type SettingsPayload =
   | SettingsImportPayload
@@ -463,7 +465,8 @@ export type SettingsPayload =
   | SettingsAddStarredMarketcoinsPayload
   | SettingsRemoveStarredMarketcoinsPayload
   | SettingsSetHasSeenWalletV4TourPayload
-  | SettingsSetProductTourCompletedPayload;
+  | SettingsSetProductTourCompletedPayload
+  | SettingsSetHasClickedRecoverPayload;
 
 // === WALLET CONNECT ACTIONS ===
 export enum WalletConnectActionTypes {

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/AddDeviceItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/AddDeviceItem.tsx
@@ -18,7 +18,7 @@ export function AddDeviceItem({ onPress }: AddDeviceItemProps) {
 
   return (
     <ListItem
-      lx={{ backgroundColor: "surface", borderRadius: "md" }}
+      lx={{ backgroundColor: "surface", borderRadius: "md", paddingVertical: "s4" }}
       testID="my-wallet-device-section-add-device"
       onPress={onPress}
     >

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListContent.tsx
@@ -26,9 +26,14 @@ export function DeviceListContent({
 
   return (
     <>
-      <Box lx={{ backgroundColor: "surface", borderRadius: "md" }}>
+      <Box lx={{ backgroundColor: "surface", borderRadius: "md", paddingVertical: "s4" }}>
         {devices.map(device => (
-          <DeviceListItem key={device.id} device={device} onPress={onDevicePress} onOpenMenu={onOpenMenu} />
+          <DeviceListItem
+            key={device.id}
+            device={device}
+            onPress={onDevicePress}
+            onOpenMenu={onOpenMenu}
+          />
         ))}
       </Box>
       <ExploreDevicesItem onPress={onExploreDevices} />

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/ExploreDevicesItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/ExploreDevicesItem.tsx
@@ -20,12 +20,12 @@ export function ExploreDevicesItem({ onPress }: ExploreDevicesItemProps) {
 
   return (
     <ListItem
-      lx={{ backgroundColor: "surface", borderRadius: "md" }}
+      lx={{ backgroundColor: "surface", borderRadius: "md", paddingVertical: "s4" }}
       testID="my-wallet-device-section-explore"
       onPress={onPress}
     >
       <ListItemLeading>
-        <Image source={allDevicesImage} style={{ width: 40, height: 40 }} resizeMode="contain" />
+        <Image source={allDevicesImage} style={{ width: 48, height: 48 }} resizeMode="contain" />
         <ListItemContent>
           <ListItemTitle>{t("myWallet.deviceSection.exploreAllDevices")}</ListItemTitle>
         </ListItemContent>

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/__tests__/useQuickActionsRowViewModel.test.ts
@@ -1,6 +1,7 @@
 import { Linking } from "react-native";
 import { act, renderHook } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/types-devices";
+import { ShieldCheck, ShieldCheckNotification } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import type { State } from "~/reducers/types";
 import { NavigatorName, ScreenName } from "~/const";
@@ -25,6 +26,11 @@ const mockDevice: Device = {
 const withDevice = (state: State): State => ({
   ...state,
   settings: { ...state.settings, lastConnectedDevice: mockDevice },
+});
+
+const withHasClickedRecover = (state: State): State => ({
+  ...state,
+  settings: { ...state.settings, hasClickedRecover: true },
 });
 
 describe("useQuickActionsRowViewModel", () => {
@@ -101,6 +107,53 @@ describe("useQuickActionsRowViewModel", () => {
       const recoverAction = result.current.actions.find(a => a.id === "recover")!;
 
       expect(recoverAction.label).toBe("[L] Recover");
+    });
+
+    it("should show notification icon when recover has not been clicked yet", () => {
+      const { result } = renderHook(() => useQuickActionsRowViewModel());
+      const recoverAction = result.current.actions.find(a => a.id === "recover")!;
+
+      expect(recoverAction.icon).toBe(ShieldCheckNotification);
+    });
+
+    it("should show plain icon when recover has already been clicked", () => {
+      const { result } = renderHook(() => useQuickActionsRowViewModel(), {
+        overrideInitialState: withHasClickedRecover,
+      });
+      const recoverAction = result.current.actions.find(a => a.id === "recover")!;
+
+      expect(recoverAction.icon).toBe(ShieldCheck);
+    });
+
+    it("should persist hasClickedRecover in the store after the first press", () => {
+      const { result, store } = renderHook(() => useQuickActionsRowViewModel());
+
+      expect(store.getState().settings.hasClickedRecover).toBe(false);
+
+      act(() => {
+        const recoverAction = result.current.actions.find(a => a.id === "recover")!;
+        recoverAction.onPress();
+      });
+
+      expect(store.getState().settings.hasClickedRecover).toBe(true);
+    });
+
+    it("should not dispatch again when recover has already been clicked", () => {
+      const { result, store } = renderHook(() => useQuickActionsRowViewModel(), {
+        overrideInitialState: withHasClickedRecover,
+      });
+
+      const dispatchSpy = jest.spyOn(store, "dispatch");
+
+      act(() => {
+        const recoverAction = result.current.actions.find(a => a.id === "recover")!;
+        recoverAction.onPress();
+      });
+
+      const hasClickedRecoverDispatches = dispatchSpy.mock.calls.filter(
+        ([action]) => action.type === "SET_HAS_CLICKED_RECOVER",
+      );
+      expect(hasClickedRecoverDispatches).toHaveLength(0);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/QuickActionsRow/useQuickActionsRowViewModel.ts
@@ -1,15 +1,21 @@
 import { useCallback, useMemo } from "react";
 import { Linking } from "react-native";
 import { TileButtonProps } from "@ledgerhq/lumen-ui-rnative";
-import { ShieldCheckNotification, LifeRing, Gift } from "@ledgerhq/lumen-ui-rnative/symbols";
+import {
+  ShieldCheck,
+  ShieldCheckNotification,
+  LifeRing,
+  Gift,
+} from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
-import { useSelector } from "~/context/hooks";
+import { useSelector, useDispatch } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
 import { NavigatorName, ScreenName } from "~/const";
 import { urls } from "~/utils/urls";
-import { lastConnectedDeviceSelector } from "~/reducers/settings";
+import { lastConnectedDeviceSelector, hasClickedRecoverSelector } from "~/reducers/settings";
+import { setHasClickedRecover } from "~/actions/settings";
 import { track } from "~/analytics";
 
 export interface QuickActionRowItem {
@@ -26,25 +32,31 @@ interface QuickActionsRowViewModel {
 
 export const useQuickActionsRowViewModel = (): QuickActionsRowViewModel => {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
   const navigation =
     useNavigation<NativeStackNavigationProp<{ [key: string]: object | undefined }>>();
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+  const hasClickedRecover = useSelector(hasClickedRecoverSelector);
   const recoverFeature = useFeature("protectServicesMobile");
   const protectId = recoverFeature?.params?.protectId ?? "protect-prod";
 
   const hasDevice = lastConnectedDevice !== null;
+  const recoverIcon = hasClickedRecover ? ShieldCheck : ShieldCheckNotification;
 
   const recoverLabel = hasDevice
     ? t("myWallet.quickActions.recover")
     : t("myWallet.quickActions.backup");
 
   const handleRecoverPress = useCallback(() => {
+    if (!hasClickedRecover) {
+      dispatch(setHasClickedRecover(true));
+    }
     track("button_clicked", { button: "Recover", page: ScreenName.MyWallet });
     navigation.navigate(ScreenName.Recover, {
       platform: protectId,
       device: lastConnectedDevice ?? undefined,
     });
-  }, [navigation, protectId, lastConnectedDevice]);
+  }, [navigation, protectId, lastConnectedDevice, hasClickedRecover, dispatch]);
 
   const handleHelpPress = useCallback(() => {
     track("button_clicked", { button: "Help", page: ScreenName.MyWallet });
@@ -61,7 +73,7 @@ export const useQuickActionsRowViewModel = (): QuickActionsRowViewModel => {
       {
         id: "recover",
         label: recoverLabel,
-        icon: ShieldCheckNotification,
+        icon: recoverIcon,
         onPress: handleRecoverPress,
         testID: "my-wallet-quick-action-recover",
       },
@@ -80,7 +92,7 @@ export const useQuickActionsRowViewModel = (): QuickActionsRowViewModel => {
         testID: "my-wallet-quick-action-referral",
       },
     ],
-    [t, recoverLabel, handleRecoverPress, handleHelpPress, handleReferralPress],
+    [t, recoverLabel, recoverIcon, handleRecoverPress, handleHelpPress, handleReferralPress],
   );
 
   return { actions };

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -76,6 +76,7 @@ import type {
   SettingsSetHasSeenWalletV4TourPayload,
   SettingsSetProductTourCompletedPayload,
   SettingsSetAnalyticsConsentInfoPayload,
+  SettingsSetHasClickedRecoverPayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -176,6 +177,7 @@ export const INITIAL_STATE: SettingsState = {
   generalTermsVersionAccepted: undefined,
   hasSeenWalletV4Tour: false,
   productTourCompleted: false,
+  hasClickedRecover: false,
   deprecationDoNotRemind: [],
   analyticsConsentInfo: {
     consentDate: null,
@@ -677,6 +679,11 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     ...state,
     productTourCompleted: (action as Action<SettingsSetProductTourCompletedPayload>).payload,
   }),
+
+  [SettingsActionTypes.SET_HAS_CLICKED_RECOVER]: (state, action) => ({
+    ...state,
+    hasClickedRecover: (action as Action<SettingsSetHasClickedRecoverPayload>).payload,
+  }),
 };
 
 export default handleActions<SettingsState, SettingsPayload>(handlers, INITIAL_STATE);
@@ -918,3 +925,4 @@ export const selectedTabPortfolioAssetsSelector = (state: State) =>
 export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasSeenWalletV4Tour;
 export const productTourCompletedSelector = (state: State) => state.settings.productTourCompleted;
 export const analyticsConsentInfoSelector = (state: State) => state.settings.analyticsConsentInfo;
+export const hasClickedRecoverSelector = (state: State) => state.settings.hasClickedRecover;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -291,6 +291,7 @@ export type SettingsState = {
   productTourCompleted: boolean;
   deprecationDoNotRemind: string[];
   analyticsConsentInfo: AnalyticsConsentInfo;
+  hasClickedRecover: boolean;
 };
 
 export type AnalyticsConsentInfo = {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing tests pass. No new dedicated tests added for these UI-only changes._
- [x] **Impact of the changes:**
      - Verify 4px vertical padding on device list items (device cards, "Explore all Ledger devices" CTA, "Add device" item)
      - Verify the Recover button notification dot disappears after first click and stays dismissed across app restarts
      - Verify the "Explore all Ledger devices" image is slightly larger (48x48 vs 40x40)

### 📝 Description

Follow-up polish for the My Wallet screen on mobile (LIVE-29767).

- **Spacing**: Added 4px vertical padding (`paddingVertical: "s4"`) to device list items container, "Explore all Ledger devices" CTA, and "Add device" item for better visual breathing room.
- **Recover notification dot**: After clicking the Recover quick action once, the icon switches from `ShieldCheckNotification` (with purple dot) to `ShieldCheck` (without dot). The state is persisted in Redux settings (same pattern as desktop).
- **Explore image size**: Increased the "All Devices" image from 40x40 to 48x48 for better visibility.


### ❓ Context

- **JIRA or GitHub link**: [LIVE-29767](https://ledgerhq.atlassian.net/browse/LIVE-29767)
- 
<img width="350" height="750" alt="Simulator Screenshot - Test Ios - 2026-04-24 at 10 53 39" src="https://github.com/user-attachments/assets/4e577311-70ce-4864-9ea4-aab6469bd8bb" />
<img width="350" height="750" alt="Simulator Screenshot - Test Ios - 2026-04-24 at 10 52 54" src="https://github.com/user-attachments/assets/e436eee0-b3c3-4526-bc68-74558cf6a212" />

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29767]: https://ledgerhq.atlassian.net/browse/LIVE-29767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ