### PR TITLE
[LWM] feat(mobile): align swap top bar with my wallet feature flag

### DIFF
--- a/.changeset/live-29765-swap-topbar-mywallet.md
+++ b/.changeset/live-29765-swap-topbar-mywallet.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Align swap Live App top bar with My Wallet wallet-features flag (leading My Wallet vs My Ledger)

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/SwapTopBarHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/SwapTopBarHeader.tsx
@@ -12,19 +12,33 @@ import {
   TopBarActionIcon,
   useMyLedgerTopBarAction,
 } from "LLM/components/CustomTopBar";
+import { MyWalletTopBarAction } from "LLM/components/TopBar/components/MyWalletTopBarAction";
 
 import { Clock } from "@ledgerhq/lumen-ui-rnative/symbols";
 
 export function SwapTopBarHeader() {
   const insets = useSafeAreaInsets();
-  const { onMyLedgerPress, onSwapHistoryPress } = useSwapTopBarHeaderViewModel();
+  const {
+    onMyLedgerPress,
+    onMyWalletPress,
+    shouldDisplayMyWallet,
+    hasUnreadNotifications,
+    onSwapHistoryPress,
+  } = useSwapTopBarHeaderViewModel();
   const myLedgerAction = useMyLedgerTopBarAction(onMyLedgerPress);
   const containerStyle = useMemo(
     () => [styles.container, { marginTop: insets.top + TOP_BAR_WRAPPER_PADDING_TOP }],
     [insets.top],
   );
 
-  const leadingIcons = useMemo(() => [myLedgerAction], [myLedgerAction]);
+  const leadingElement = shouldDisplayMyWallet ? (
+    <MyWalletTopBarAction onPress={onMyWalletPress} showNotification={hasUnreadNotifications} />
+  ) : undefined;
+
+  const leadingIcons = useMemo(
+    () => (shouldDisplayMyWallet ? [] : [myLedgerAction]),
+    [shouldDisplayMyWallet, myLedgerAction],
+  );
 
   const trailingIcons: readonly TopBarActionIcon[] = useMemo(
     () => [
@@ -41,7 +55,11 @@ export function SwapTopBarHeader() {
 
   return (
     <Box style={containerStyle}>
-      <CustomTopBar leadingIcons={leadingIcons} trailingIcons={trailingIcons} />
+      <CustomTopBar
+        leadingElement={leadingElement}
+        leadingIcons={leadingIcons}
+        trailingIcons={trailingIcons}
+      />
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/SwapTopBarHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/SwapTopBarHeader.test.tsx
@@ -20,6 +20,9 @@ describe("SwapTopBarHeader", () => {
 
     mockedUseSwapTopBarHeaderViewModel.mockReturnValue({
       onMyLedgerPress,
+      onMyWalletPress: jest.fn(),
+      shouldDisplayMyWallet: false,
+      hasUnreadNotifications: false,
       onSwapHistoryPress,
     });
 
@@ -29,6 +32,64 @@ describe("SwapTopBarHeader", () => {
     await user.press(getByTestId("topbar-swap-history"));
 
     expect(onMyLedgerPress).toHaveBeenCalledTimes(1);
+    expect(onSwapHistoryPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should trigger my wallet and swap history when My Wallet feature is enabled", async () => {
+    const onMyWalletPress = jest.fn();
+    const onSwapHistoryPress = jest.fn();
+
+    mockedUseSwapTopBarHeaderViewModel.mockReturnValue({
+      onMyLedgerPress: jest.fn(),
+      onMyWalletPress,
+      shouldDisplayMyWallet: true,
+      hasUnreadNotifications: false,
+      onSwapHistoryPress,
+    });
+
+    const { user, getByTestId, queryByTestId } = render(<SwapTopBarHeader />);
+
+    expect(queryByTestId("topbar-myledger")).toBeNull();
+
+    await user.press(getByTestId("topbar-mywallet"));
+    await user.press(getByTestId("topbar-swap-history"));
+
+    expect(onMyWalletPress).toHaveBeenCalledTimes(1);
+    expect(onSwapHistoryPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not show My Wallet when the feature flag is off", () => {
+    mockedUseSwapTopBarHeaderViewModel.mockReturnValue({
+      onMyLedgerPress: jest.fn(),
+      onMyWalletPress: jest.fn(),
+      shouldDisplayMyWallet: false,
+      hasUnreadNotifications: true,
+      onSwapHistoryPress: jest.fn(),
+    });
+
+    const { queryByTestId } = render(<SwapTopBarHeader />);
+
+    expect(queryByTestId("topbar-mywallet")).toBeNull();
+  });
+
+  it("should render My Wallet with notifications when enabled and unread", async () => {
+    const onMyWalletPress = jest.fn();
+    const onSwapHistoryPress = jest.fn();
+
+    mockedUseSwapTopBarHeaderViewModel.mockReturnValue({
+      onMyLedgerPress: jest.fn(),
+      onMyWalletPress,
+      shouldDisplayMyWallet: true,
+      hasUnreadNotifications: true,
+      onSwapHistoryPress,
+    });
+
+    const { user, getByTestId } = render(<SwapTopBarHeader />);
+
+    await user.press(getByTestId("topbar-mywallet"));
+    await user.press(getByTestId("topbar-swap-history"));
+
+    expect(onMyWalletPress).toHaveBeenCalledTimes(1);
     expect(onSwapHistoryPress).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/useSwapTopBarHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/__tests__/useSwapTopBarHeaderViewModel.test.ts
@@ -16,6 +16,7 @@ jest.mock("LLM/components/TopBar/useTopBarViewModel", () => ({
 
 const mockNavigate = jest.fn();
 const mockOnMyLedgerPress = jest.fn();
+const mockOnMyWalletPress = jest.fn();
 const noop = jest.fn();
 
 const mockedUseNavigation = jest.mocked(useNavigation);
@@ -28,7 +29,7 @@ describe("useSwapTopBarHeaderViewModel", () => {
     mockedUseNavigation.mockImplementation(() => ({ navigate: mockNavigate }));
     mockedUseTopBarViewModel.mockImplementation(() => ({
       onMyLedgerPress: mockOnMyLedgerPress,
-      onMyWalletPress: noop,
+      onMyWalletPress: mockOnMyWalletPress,
       shouldDisplayMyWallet: false,
       shouldDisplayOperationsList: false,
       onDiscoverPress: noop,
@@ -52,6 +53,35 @@ describe("useSwapTopBarHeaderViewModel", () => {
     const { result } = renderHook(() => useSwapTopBarHeaderViewModel());
 
     expect(result.current.onMyLedgerPress).toBe(mockOnMyLedgerPress);
+  });
+
+  it("should forward My Wallet fields from top bar view model", () => {
+    mockedUseTopBarViewModel.mockImplementation(() => ({
+      onMyLedgerPress: mockOnMyLedgerPress,
+      onMyWalletPress: mockOnMyWalletPress,
+      shouldDisplayMyWallet: true,
+      shouldDisplayOperationsList: false,
+      onDiscoverPress: noop,
+      onNotificationsPress: noop,
+      onSettingsPress: noop,
+      onTransactionHistoryPress: noop,
+      hasUnreadNotifications: true,
+      hasAccounts: false,
+      isSyncError: false,
+      isSyncPending: false,
+      listOfErrorAccountNames: "",
+      syncAccessibilityLabel: "Synchronize",
+      isSyncDrawerOpen: false,
+      openSyncDrawer: noop,
+      closeSyncDrawer: noop,
+      onTryRefresh: noop,
+    }));
+
+    const { result } = renderHook(() => useSwapTopBarHeaderViewModel());
+
+    expect(result.current.onMyWalletPress).toBe(mockOnMyWalletPress);
+    expect(result.current.shouldDisplayMyWallet).toBe(true);
+    expect(result.current.hasUnreadNotifications).toBe(true);
   });
 
   it("should track and navigate to swap history when onSwapHistoryPress is called", () => {

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/useSwapTopBarHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/useSwapTopBarHeaderViewModel.ts
@@ -8,7 +8,8 @@ import { useTopBarViewModel } from "LLM/components/TopBar/useTopBarViewModel";
 export function useSwapTopBarHeaderViewModel() {
   const navigation =
     useNavigation<NativeStackNavigationProp<{ [key: string]: object | undefined }>>();
-  const { onMyLedgerPress } = useTopBarViewModel(navigation, ScreenName.SwapTab);
+  const { onMyLedgerPress, onMyWalletPress, shouldDisplayMyWallet, hasUnreadNotifications } =
+    useTopBarViewModel(navigation, ScreenName.SwapTab);
 
   const onSwapHistoryPress = useCallback(() => {
     track("button_clicked", { button: "SwapHistory", page: "Swap" });
@@ -19,6 +20,9 @@ export function useSwapTopBarHeaderViewModel() {
 
   return {
     onMyLedgerPress,
+    onMyWalletPress,
+    shouldDisplayMyWallet,
+    hasUnreadNotifications,
     onSwapHistoryPress,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Swap tab (Live App) header: leading control is My Ledger vs My Wallet depending on wallet features config
      - My Wallet entry, unread notification dot on avatar when applicable
      - Swap history (clock) trailing action unchanged

### 📝 Description

**Problem:** The swap Live App top bar always showed **My Ledger** on the leading side, even when **My Wallet** is enabled via the same wallet-features configuration used on the portfolio `TopBarView`.

**Solution:** `useSwapTopBarHeaderViewModel` now forwards `shouldDisplayMyWallet`, `onMyWalletPress`, and `hasUnreadNotifications` from `useTopBarViewModel`. `SwapTopBarHeader` mirrors `TopBarView`: when the flag is on, the leading slot uses `MyWalletTopBarAction`; otherwise it keeps the My Ledger icon. Unit tests cover both paths, forwarding from the hook, and unread notifications when My Wallet is shown.

https://github.com/user-attachments/assets/efacd7a5-0f6d-4d3a-bdea-b8b9c431897d



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29765](https://ledgerhq.atlassian.net/browse/LIVE-29765)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-29765]: https://ledgerhq.atlassian.net/browse/LIVE-29765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ