### PR TITLE
[LWM] fix(mobile): tighten crypto addresses card title spacing

### DIFF
--- a/.changeset/thick-plums-enjoy.md
+++ b/.changeset/thick-plums-enjoy.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Tighten vertical spacing for the crypto addresses card title on wallet assets

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/components/CryptoAddressesButton/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { StyleSheet } from "react-native";
 import {
   Box,
   Button,
@@ -39,7 +40,9 @@ export const CryptoAddressesButton: React.FC = () => {
           <CardLeading>
             <Spot appearance="icon" icon={Wallet} />
             <CardContent>
-              <CardContentTitle>{t("portfolio.cryptoAddresses.title")}</CardContentTitle>
+              <CardContentTitle style={styles.cardContentTitle}>
+                {t("portfolio.cryptoAddresses.title")}
+              </CardContentTitle>
               <CardContentRow>
                 {hasAccounts ? (
                   <>
@@ -105,3 +108,16 @@ export const CryptoAddressesButton: React.FC = () => {
     </>
   );
 };
+
+/*
+ * CardContentDescription uses body typography (~16px line height) while IconStack
+ * is 20px tall, so the row is visually taller than the text alone. A small
+ * negative margin on the title nudges it toward the row so vertical rhythm
+ * matches design. This is sensitive to font scaling (Dynamic Type): if the
+ * description grows, re-check alignment.
+ */
+const styles = StyleSheet.create({
+  cardContentTitle: {
+    marginBottom: -4,
+  },
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual spacing only; no automated coverage._
- [x] **Impact of the changes:**
      - Wallet assets screen: crypto addresses card
      - Title-to-content vertical spacing for `CardContentTitle`

### 📝 Description

**Problem:** The crypto addresses card title spacing did not match the intended layout for [LIVE-29775](https://ledgerhq.atlassian.net/browse/LIVE-29775).

**Solution:** Applied a small negative bottom margin on `CardContentTitle` (`marginBottom: -4`) so the title sits closer to the row of account count and currency icons below.

| Before | After |
| ------ | ----- |
|<img width="479" height="106" alt="image" src="https://github.com/user-attachments/assets/971febd5-21a3-4033-abbe-8138f7916f2d" /> |<img width="479" height="119" alt="image" src="https://github.com/user-attachments/assets/75a5c7eb-d18f-42b8-86a1-a1da9020054f" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29775](https://ledgerhq.atlassian.net/browse/LIVE-29775)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29775]: https://ledgerhq.atlassian.net/browse/LIVE-29775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-29775]: https://ledgerhq.atlassian.net/browse/LIVE-29775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ