### PR TITLE
fix: (agentskills) share skills with Claude

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+/Users/laurence.lord/Repos/ledger/ledger-live/.agents/skills


### PR DESCRIPTION
### 📝 Description

Ensure agent-skills (located in `.agents/skills` are available to Claude.

Provide a symlink `.claude/skills -> .agents/skills`

#### Claude sees the skills

<img width="908" height="278" alt="Screenshot 2026-04-24 at 11 36 47" src="https://github.com/user-attachments/assets/dfebe700-c439-4ffa-9858-3599e3adcb7c" />

#### Cursor sees the skills

<img width="639" height="326" alt="Screenshot 2026-04-24 at 11 37 01" src="https://github.com/user-attachments/assets/73235859-b4ca-44ab-9c7f-4b466f5b278a" />


### ❓ Context

With https://github.com/LedgerHQ/ledger-live/pull/16512 we accidentally removed the slash command skills from Claude

> Claude Code loads skills from .claude/skills/ (user-level at ~/.claude/skills/ or project-level at
  <project>/.claude/skills/), not .agents/skills/. The .agents/ directory isn't a path Claude Code
  scans.

