### PR TITLE
fix: claude skills symlink

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,1 @@
-/Users/laurence.lord/Repos/ledger/ledger-live/.agents/skills
+../.agents/skills


### PR DESCRIPTION
using a relative symlink path