### PR TITLE
fix(wallet-cli): route session reset/view output through CommandOutput interface

### DIFF
--- a/apps/wallet-cli/src/commands/session/reset.ts
+++ b/apps/wallet-cli/src/commands/session/reset.ts
@@ -1,8 +1,6 @@
 import { defineCommand } from "@bunli/core";
 import { Session } from "../../session/session-store";
 import { outputOption } from "../inputs";
-import { colors, writeStdout } from "../../shared/ui";
-import { makeEnvelope } from "../../shared/response";
 import { createCommandOutput } from "../../output";
 
 export default defineCommand({
@@ -24,18 +22,7 @@ export default defineCommand({
       }
       const count = session.clear();
       await session.write(); // always write: fixes corrupt files too
-
-      if (flags.output === "json") {
-        writeStdout(JSON.stringify(makeEnvelope("session reset", "all", { removed: count }), null, 2));
-        return;
-      }
-
-      const suffix = count === 1 ? "" : "s";
-      writeStdout(
-        count === 0
-          ? colors.dim("Session was already empty.")
-          : `Removed ${colors.bold(String(count))} account${suffix} from session.`,
-      );
+      out.sessionReset(count);
     });
   },
 });

--- a/apps/wallet-cli/src/commands/session/view.ts
+++ b/apps/wallet-cli/src/commands/session/view.ts
@@ -1,8 +1,6 @@
 import { defineCommand } from "@bunli/core";
 import { Session } from "../../session/session-store";
 import { outputOption } from "../inputs";
-import { colors, writeStdout } from "../../shared/ui";
-import { makeEnvelope } from "../../shared/response";
 import { createCommandOutput } from "../../output";
 
 export default defineCommand({
@@ -16,21 +14,7 @@ export default defineCommand({
 
     await out.run(async () => {
       const { accounts } = await Session.read();
-
-      if (flags.output === "json") {
-        writeStdout(JSON.stringify(makeEnvelope("session view", "all", { accounts }), null, 2));
-        return;
-      }
-
-      if (accounts.length === 0) {
-        writeStdout(colors.dim("No accounts in session. Run `account discover` first."));
-        return;
-      }
-
-      const maxLabel = Math.max(...accounts.map(e => e.label.length));
-      for (const entry of accounts) {
-        writeStdout(`${colors.bold(entry.label.padEnd(maxLabel))}  ${colors.dim(entry.descriptor)}`);
-      }
+      out.sessionView(accounts);
     });
   },
 });

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -16,6 +16,7 @@ import { JsonFormatter } from "./wallet/formatter/json";
 import { makeEnvelope } from "./shared/response";
 import { spinner, colors, writeStdout } from "./shared/ui";
 import type { Balance, Operation, DiscoveredAccount, SendEvent } from "./wallet/models";
+import type { SessionEntry } from "./session/session-store";
 
 // ---------------------------------------------------------------------------
 // Context & interface
@@ -66,6 +67,11 @@ export interface CommandOutput {
   flushDiscovery(): void;
   /** Note that N new accounts were persisted to session (human: dim footer; json: noop). */
   sessionSaved(added: number): void;
+
+  /** Output the result of a session reset (human: colored message; json: envelope with removed count). */
+  sessionReset(count: number): void;
+  /** Output session accounts (human: table or empty message; json: envelope with accounts array). */
+  sessionView(accounts: readonly SessionEntry[]): void;
 
   /** Output a dry-run prepared transaction (human: formatted lines; json: envelope). */
   sendDryRun(p: { recipient: string; amount: string; fees: string }): void;
@@ -147,6 +153,25 @@ class HumanCommandOutput implements CommandOutput {
 
   sessionSaved(added: number): void {
     writeStdout(colors.dim(`  session: ${added} new account${added === 1 ? "" : "s"} saved`));
+  }
+
+  sessionReset(count: number): void {
+    writeStdout(
+      count === 0
+        ? colors.dim("Session was already empty.")
+        : `Removed ${colors.bold(String(count))} account${count === 1 ? "" : "s"} from session.`,
+    );
+  }
+
+  sessionView(accounts: readonly SessionEntry[]): void {
+    if (accounts.length === 0) {
+      writeStdout(colors.dim("No accounts in session. Run `account discover` first."));
+      return;
+    }
+    const maxLabel = Math.max(...accounts.map(e => e.label.length));
+    for (const entry of accounts) {
+      writeStdout(`${colors.bold(entry.label.padEnd(maxLabel))}  ${colors.dim(entry.descriptor)}`);
+    }
   }
 
   private _printTransactionLines(p: { recipient: string; amount: string; fees: string }): void {
@@ -270,6 +295,14 @@ class JsonCommandOutput implements CommandOutput {
   }
 
   sessionSaved(_added: number): void { /* noop */ }
+
+  sessionReset(count: number): void {
+    writeStdout(this._envelope({ removed: count }));
+  }
+
+  sessionView(accounts: readonly SessionEntry[]): void {
+    writeStdout(this._envelope({ accounts }));
+  }
 
   sendDryRun(p: { recipient: string; amount: string; fees: string }): void {
     writeStdout(


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- **Impact of the changes:**
  - `session reset` and `session view` commands now use `out.sessionReset()` / `out.sessionView()` instead of inline `if (flags.output === "json")` branches with manual `writeStdout` calls
  - No behaviour change — both human and JSON output are identical

### 📝 Description

Addresses feedback from #16598: session commands were bypassing the `CommandOutput` abstraction and writing output directly via `writeStdout`. This adds `sessionReset(count)` and `sessionView(accounts)` to the `CommandOutput` interface:

- `HumanCommandOutput`: renders the coloured message / account table
- `JsonCommandOutput`: emits the JSON envelope (`{ removed }` / `{ accounts }`)

### ❓ Context

- **GitHub link**: #16598 (feedback: https://github.com/LedgerHQ/ledger-live/pull/16598#discussion_r3137312868)
- **ADR link (if any)**: N/A