### PR TITLE
[LWDM] fix(live-common): replace require() with static imports in coin-modules loaders

### DIFF
--- a/.changeset/clean-modules-import.md
+++ b/.changeset/clean-modules-import.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Replace dynamic require() with static imports in coin-modules loaders

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -187,6 +187,8 @@
     "@jest/globals": "catalog:",
     "@ledgerhq/hw-transport-mocker": "workspace:^",
     "@ledgerhq/live-cli": "workspace:^",
+    "@ledgerhq/live-signer-canton": "workspace:^",
+    "@ledgerhq/live-signer-concordium": "workspace:^",
     "@ledgerhq/speculos-transport": "workspace:^",
     "@ledgerhq/test-utils": "workspace:^",
     "@playwright/test": "catalog:",

--- a/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/__integrations__/CantonOnboard.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/AddAccountDrawer/__integrations__/CantonOnboard.integration.test.tsx
@@ -19,42 +19,17 @@ import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { CantonAccount } from "@ledgerhq/coin-canton/types";
 import type { Account } from "@ledgerhq/types-live";
 import coinConfig from "@ledgerhq/coin-canton/config";
+import * as liveSignerCanton from "@ledgerhq/live-signer-canton";
+import * as deviceAccess from "@ledgerhq/live-common/hw/deviceAccess";
 import { INITIAL_STATE as SETTINGS_INITIAL_STATE } from "~/renderer/reducers/settings";
 import CantonOnboard from "../CantonOnboard";
 import { createMockAccount } from "../../__tests__/testUtils";
-
-jest.mock("@ledgerhq/live-common/hw/deviceAccess", () => ({
-  withDevice: jest.fn(() => (job: (transport: unknown) => unknown) => job({})),
-}));
 
 jest.mock("~/renderer/extra/Snow", () => ({
   __esModule: true,
   default: () => null,
   isSnowTime: () => false,
 }));
-
-jest.mock(
-  "@ledgerhq/hw-app-canton",
-  () => {
-    return {
-      __esModule: true,
-      default: jest.fn(() => ({
-        getAppConfiguration: jest.fn().mockResolvedValue({ version: "3.0.0" }),
-        getAddress: jest.fn().mockImplementation((path: string) =>
-          Promise.resolve({
-            publicKey: MOCK_CANTON_PUBLIC_KEY_HEX,
-            address: "canton_mock_address_integ",
-            path,
-          }),
-        ),
-        signTransaction: jest.fn().mockResolvedValue({
-          signature: "cc".repeat(66),
-        }),
-      })),
-    };
-  },
-  { virtual: true },
-);
 
 function createMockDevice(overrides: Partial<Device> = {}): Device {
   return {
@@ -114,6 +89,28 @@ describe("CantonOnboard (MAD) Integration", () => {
   let previousCantonNodeIdOverride: string;
 
   beforeAll(() => {
+    jest
+      .spyOn(deviceAccess, "withDevice")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation((() => (job: (t: unknown) => unknown) => job({})) as any);
+
+    jest.spyOn(liveSignerCanton, 'LegacySignerCanton').mockImplementation(
+      jest.fn(() => ({
+        getAppConfiguration: jest.fn().mockResolvedValue({ version: "3.0.0" }),
+        getAddress: jest.fn().mockImplementation((path: string) =>
+          Promise.resolve({
+            publicKey: MOCK_CANTON_PUBLIC_KEY_HEX,
+            address: "canton_mock_address_integ",
+            path,
+          }),
+        ),
+        signTransaction: jest.fn().mockResolvedValue({
+          signature: "cc".repeat(66),
+        }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      })) as any,
+    );
+
     previousCantonNodeIdOverride = getEnv("CANTON_NODE_ID_OVERRIDE") ?? "";
     setEnv("CANTON_NODE_ID_OVERRIDE", "");
 
@@ -131,6 +128,7 @@ describe("CantonOnboard (MAD) Integration", () => {
   afterAll(() => {
     setEnv("CANTON_NODE_ID_OVERRIDE", previousCantonNodeIdOverride);
     setSupportedCurrencies([]);
+    jest.restoreAllMocks();
   });
 
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/__integrations__/OnboardModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/__integrations__/OnboardModal.integration.test.tsx
@@ -15,6 +15,8 @@ import {
 import { getEnv, setEnv } from "@ledgerhq/live-env";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import coinConfig from "@ledgerhq/coin-canton/config";
+import * as liveSignerCanton from "@ledgerhq/live-signer-canton";
+import * as deviceAccess from "@ledgerhq/live-common/hw/deviceAccess";
 import { INITIAL_STATE as SETTINGS_INITIAL_STATE } from "~/renderer/reducers/settings";
 import OnboardModal from "../index";
 import {
@@ -22,12 +24,6 @@ import {
   generateOnboardModalProps,
   generateOnboardModalState,
 } from "../__tests__/testUtils";
-
-jest.mock("@ledgerhq/live-common/hw/deviceAccess", () => ({
-  withDevice: jest.fn(
-    () => (job: (transport: unknown) => unknown) => job({ decorateAppAPIMethods: jest.fn() }),
-  ),
-}));
 
 jest.mock("~/renderer/extra/Snow", () => ({
   __esModule: true,
@@ -54,27 +50,6 @@ jest.mock("@ledgerhq/coin-canton/common-logic/transaction/sign", () => ({
     signature: "cc".repeat(66),
   }),
 }));
-
-jest.mock(
-  "@ledgerhq/hw-app-canton",
-  () => ({
-    __esModule: true,
-    default: jest.fn(() => ({
-      getAppConfiguration: jest.fn().mockResolvedValue({ version: "3.0.0" }),
-      getAddress: jest.fn().mockImplementation((path: string) =>
-        Promise.resolve({
-          publicKey: MOCK_CANTON_PUBLIC_KEY_HEX,
-          address: "canton_mock_address_integ",
-          path,
-        }),
-      ),
-      signTransaction: jest.fn().mockResolvedValue({
-        signature: "cc".repeat(66),
-      }),
-    })),
-  }),
-  { virtual: true },
-);
 
 function cantonDevnetCurrency(): CryptoCurrency {
   const currency = getCryptoCurrencyById("canton_network_devnet");
@@ -107,6 +82,28 @@ describe("OnboardModal Integration", () => {
   let previousCantonNodeIdOverride: string;
 
   beforeAll(() => {
+    jest
+      .spyOn(deviceAccess, "withDevice")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation((() => (job: (t: unknown) => unknown) => job({ decorateAppAPIMethods: jest.fn() })) as any);
+
+    jest.spyOn(liveSignerCanton, 'LegacySignerCanton').mockImplementation(
+      jest.fn(() => ({
+        getAppConfiguration: jest.fn().mockResolvedValue({ version: "3.0.0" }),
+        getAddress: jest.fn().mockImplementation((path: string) =>
+          Promise.resolve({
+            publicKey: MOCK_CANTON_PUBLIC_KEY_HEX,
+            address: "canton_mock_address_integ",
+            path,
+          }),
+        ),
+        signTransaction: jest.fn().mockResolvedValue({
+          signature: "cc".repeat(66),
+        }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      })) as any,
+    );
+
     previousCantonNodeIdOverride = getEnv("CANTON_NODE_ID_OVERRIDE") ?? "";
     setEnv("CANTON_NODE_ID_OVERRIDE", "");
 
@@ -124,6 +121,7 @@ describe("OnboardModal Integration", () => {
   afterAll(() => {
     setEnv("CANTON_NODE_ID_OVERRIDE", previousCantonNodeIdOverride);
     setSupportedCurrencies([]);
+    jest.restoreAllMocks();
   });
 
   beforeEach(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.integ.test.tsx
@@ -10,6 +10,8 @@ import {
   setSupportedCurrencies,
 } from "@ledgerhq/live-common/currencies/index";
 import coinConfig from "@ledgerhq/coin-concordium/config";
+import * as liveSignerConcordium from "@ledgerhq/live-signer-concordium";
+import * as deviceAccess from "@ledgerhq/live-common/hw/deviceAccess";
 import OnboardModal from "../index";
 import {
   createConcordiumAccount,
@@ -35,10 +37,6 @@ const {
   __mockPairingDelete: mockPairingDelete,
 } = require("@walletconnect/sign-client");
 
-jest.mock("@ledgerhq/live-common/hw/deviceAccess", () => ({
-  withDevice: jest.fn(() => (job: (transport: unknown) => unknown) => job({})),
-}));
-
 const mockGetPublicKey = jest.fn();
 const mockSignCredentialDeployment = jest.fn();
 
@@ -48,24 +46,6 @@ jest.mock("@ledgerhq/coin-concordium/signer", () => ({
   signCredentialDeployment: (...args: unknown[]) => mockSignCredentialDeployment(...args),
   default: jest.fn(),
 }));
-
-jest.mock(
-  "@ledgerhq/live-signer-concordium",
-  () => ({
-    __esModule: true,
-    DmkSignerConcordium: jest.fn(() => ({
-      getPublicKey: jest.fn().mockResolvedValue("aa".repeat(32)),
-      signCredentialDeployment: jest.fn(
-        () => new Promise(resolve => setTimeout(() => resolve("bb".repeat(64)), T + 200)),
-      ),
-      getAddress: jest.fn().mockResolvedValue({
-        publicKey: "aa".repeat(32),
-        address: "test",
-      }),
-    })),
-  }),
-  { virtual: true },
-);
 
 // Test data — matches bridge fixture structure for deserializeCredentialDeploymentTransaction
 const TEST_SERIALIZED_CDT = {
@@ -160,6 +140,27 @@ describe("OnboardModal Integration", () => {
   const initialState = createInitialState(mockDevice);
 
   beforeAll(() => {
+    jest
+      .spyOn(deviceAccess, "withDevice")
+      .mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (() => (job: (t: unknown) => unknown) => job({ dmk: {}, sessionId: "mock-session" })) as any,
+      );
+
+    jest.spyOn(liveSignerConcordium, 'DmkSignerConcordium').mockImplementation(
+      jest.fn(() => ({
+        getPublicKey: jest.fn().mockResolvedValue("aa".repeat(32)),
+        signCredentialDeployment: jest.fn(
+          () => new Promise(resolve => setTimeout(() => resolve("bb".repeat(64)), T + 200)),
+        ),
+        getAddress: jest.fn().mockResolvedValue({
+          publicKey: "aa".repeat(32),
+          address: "test",
+        }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      })) as any,
+    );
+
     coinConfig.setCoinConfig(() => ({
       status: { type: "active" },
       networkType: "mainnet",
@@ -168,6 +169,10 @@ describe("OnboardModal Integration", () => {
       proxyUrl: "https://ccd-wallet-proxy-mainnet.coin.ledger.com",
       minReserve: 0,
     }));
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
   });
 
   beforeEach(() => {

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -1,242 +1,358 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
-import type { CoinModuleLoader } from "./types";
+import type { CoinModuleLoader, FamilySetup } from "./types";
 
-// Hand-maintained: one entry per coin family. See FUTURE.md for the async evolution plan.
+import * as aleoSetup from "../families/aleo/setup";
+import aleoTransaction from "@ledgerhq/coin-aleo/transaction";
+
+import * as algorandSetup from "../families/algorand/setup";
+import algorandTransaction from "@ledgerhq/coin-algorand/transaction";
+import algorandMockAccount from "@ledgerhq/coin-algorand/mock";
+
+import * as aptosSetup from "../families/aptos/setup";
+import aptosTransaction from "@ledgerhq/coin-aptos/transaction";
+
+import * as bitcoinSetup from "../families/bitcoin/setup";
+import bitcoinTransaction from "@ledgerhq/coin-bitcoin/transaction";
+import * as bitcoinWalletApiAdapter from "../families/bitcoin/walletApiAdapter";
+import * as bitcoinPlatformAdapter from "../families/bitcoin/platformAdapter";
+import { clearAccount as bitcoinClearAccount } from "../families/bitcoin/clearAccount";
+import {
+  isEditableOperation as bitcoinIsEditableOperation,
+  isStuckOperation as bitcoinIsStuckOperation,
+  getStuckAccountAndOperation as bitcoinGetStuckAccountAndOperation,
+} from "../families/bitcoin/operations";
+
+import * as cantonSetup from "../families/canton/setup";
+import cantonTransaction from "@ledgerhq/coin-canton/transaction";
+import { isAccountEmpty as cantonIsAccountEmpty } from "@ledgerhq/coin-canton";
+
+import * as cardanoSetup from "../families/cardano/setup";
+import cardanoTransaction from "@ledgerhq/coin-cardano/transaction";
+
+import casperTransaction from "@ledgerhq/coin-casper/transaction";
+
+import celoTransaction from "@ledgerhq/coin-celo/transaction";
+
+import * as concordiumSetup from "../families/concordium/setup";
+import concordiumTransaction from "@ledgerhq/coin-concordium/transaction";
+
+import * as cosmosSetup from "../families/cosmos/setup";
+import cosmosTransaction from "@ledgerhq/coin-cosmos/transaction";
+import * as cosmosWalletApiAdapter from "../families/cosmos/walletApiAdapter";
+import cosmosMockAccount from "@ledgerhq/coin-cosmos/mock";
+import { isAccountEmpty as cosmosIsAccountEmpty } from "@ledgerhq/coin-cosmos/helpers";
+import { getVotesCount as cosmosGetVotesCount } from "../families/cosmos/getVotesCount";
+
+import * as evmSetup from "../families/evm/setup";
+import evmTransaction from "@ledgerhq/coin-evm/transaction";
+import * as evmWalletApiAdapter from "../families/evm/walletApiAdapter";
+import * as evmPlatformAdapter from "../families/evm/platformAdapter";
+import { validateAddress as evmValidateAddress } from "@ledgerhq/coin-evm/logic/validateAddress";
+import evmAlpacaSigner from "../bridge/generic-alpaca/families/evm/signer";
+import {
+  isEditableOperation as evmIsEditableOperation,
+  isStuckOperation as evmIsStuckOperation,
+  getStuckAccountAndOperation as evmGetStuckAccountAndOperation,
+} from "../families/evm/operations";
+
+import * as filecoinSetup from "../families/filecoin/setup";
+import filecoinTransaction from "@ledgerhq/coin-filecoin/transaction";
+
+import * as hederaSetup from "../families/hedera/setup";
+import hederaTransaction from "@ledgerhq/coin-hedera/transaction";
+
+import * as iconSetup from "../families/icon/setup";
+import iconTransaction from "@ledgerhq/coin-icon/transaction";
+
+import * as icSetup from "../families/internet_computer/setup";
+import icTransaction from "@ledgerhq/coin-internet_computer/transaction";
+
+import * as minaSetup from "../families/mina/setup";
+import minaTransaction from "@ledgerhq/coin-mina/transaction";
+
+import * as multiversxSetup from "../families/multiversx/setup";
+import multiversxTransaction from "@ledgerhq/coin-multiversx/transaction";
+
+import * as nearSetup from "../families/near/setup";
+import nearTransaction from "@ledgerhq/coin-near/transaction";
+
+import * as polkadotSetup from "../families/polkadot/setup";
+import polkadotTransaction from "@ledgerhq/coin-polkadot/transaction";
+import * as polkadotWalletApiAdapter from "../families/polkadot/walletApiAdapter";
+import * as polkadotPlatformAdapter from "../families/polkadot/platformAdapter";
+
+import solanaAlpacaSigner from "../bridge/generic-alpaca/families/solana/signer";
+import * as solanaSetup from "../families/solana/setup";
+import solanaTransaction from "@ledgerhq/coin-solana/transaction";
+import * as solanaWalletApiAdapter from "../families/solana/walletApiAdapter";
+import { validateAddress as solanaValidateAddress } from "@ledgerhq/coin-solana/logic/validateAddress";
+
+import * as stacksSetup from "../families/stacks/setup";
+import stacksTransaction from "@ledgerhq/coin-stacks/transaction";
+
+import stellarAlpacaSigner from "../bridge/generic-alpaca/families/stellar/signer";
+import * as stellarSetup from "../families/stellar/setup";
+import stellarTransaction from "../families/stellar/transaction";
+import * as stellarDeviceTxConfig from "../families/stellar/deviceTransactionConfig";
+import { validateAddress as stellarValidateAddress } from "@ledgerhq/coin-stellar/logic/validateAddress";
+
+// sui/setup is require()'d lazily because @mysten/ledgerjs-hw-app-sui is ESM-only
+import suiTransaction from "@ledgerhq/coin-sui/transaction";
+
+import tezosAlpacaSigner from "../bridge/generic-alpaca/families/tezos/signer";
+import * as tezosSetup from "../families/tezos/setup";
+import tezosTransaction from "@ledgerhq/coin-tezos/transaction";
+import { getVotesCount as tezosGetVotesCount } from "../families/tezos/getVotesCount";
+import { validateAddress as tezosValidateAddress } from "@ledgerhq/coin-tezos/logic/validateAddress";
+
+import * as tonSetup from "../families/ton/setup";
+import tonTransaction from "@ledgerhq/coin-ton/transaction";
+
+import * as tronSetup from "../families/tron/setup";
+import tronTransaction from "@ledgerhq/coin-tron/transaction";
+import { isAccountEmpty as tronIsAccountEmpty } from "@ledgerhq/coin-tron/index";
+import { getVotesCount as tronGetVotesCount } from "../families/tron/getVotesCount";
+
+import * as vechainSetup from "../families/vechain/setup";
+import vechainTransaction from "@ledgerhq/coin-vechain/transaction";
+import vechainMockAccount from "@ledgerhq/coin-vechain/mock";
+import { isAccountEmpty as vechainIsAccountEmpty } from "@ledgerhq/coin-vechain";
+
+import xrpAlpacaSigner from "../bridge/generic-alpaca/families/xrp/signer";
+import * as xrpSetup from "../families/xrp/setup";
+import xrpTransaction from "../families/xrp/transaction";
+import * as xrpDeviceTxConfig from "../families/xrp/deviceTransactionConfig";
+import * as xrpWalletApiAdapter from "../families/xrp/walletApiAdapter";
+import * as xrpPlatformAdapter from "../families/xrp/platformAdapter";
+import { validateAddress as xrpValidateAddress } from "@ledgerhq/coin-xrp/logic/validateAddress";
+
 export const coinModuleLoaders: CoinModuleLoader[] = [
   {
     family: "aleo",
-    loadSetup: () => require("../families/aleo/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-aleo/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-aleo/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => aleoSetup,
+    loadTransaction: () => aleoTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-aleo/deviceTransactionConfig"),
   },
   {
     family: "algorand",
-    loadSetup: () => require("../families/algorand/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-algorand/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-algorand/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => algorandSetup,
+    loadTransaction: () => algorandTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-algorand/deviceTransactionConfig"),
     loadMockBridge: () => require("../families/algorand/bridge/mock").default,
-    loadMockAccount: () => require("@ledgerhq/coin-algorand/mock").default,
+    loadMockAccount: () => algorandMockAccount,
   },
   {
     family: "aptos",
-    loadSetup: () => require("../families/aptos/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-aptos/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-aptos/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => aptosSetup,
+    loadTransaction: () => aptosTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-aptos/deviceTransactionConfig"),
   },
   {
     family: "bitcoin",
-    loadSetup: () => require("../families/bitcoin/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-bitcoin/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-bitcoin/deviceTransactionConfig").default,
-    loadWalletApiAdapter: () => require("../families/bitcoin/walletApiAdapter").default,
-    loadPlatformAdapter: () => require("../families/bitcoin/platformAdapter").default,
-    loadAccount: () => require("@ledgerhq/coin-bitcoin/account").default,
+    loadSetup: (): FamilySetup => bitcoinSetup,
+    loadTransaction: () => bitcoinTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-bitcoin/deviceTransactionConfig"),
+    loadWalletApiAdapter: () => Promise.resolve(bitcoinWalletApiAdapter),
+    loadPlatformAdapter: () => Promise.resolve(bitcoinPlatformAdapter),
+    loadAccount: () => import("@ledgerhq/coin-bitcoin/account"),
     loadMockBridge: () => require("../families/bitcoin/bridge/mock").default,
-    loadClearAccount: () => require("../families/bitcoin/clearAccount").clearAccount,
-    loadIsEditableOperation: () => require("../families/bitcoin/operations").isEditableOperation,
-    loadIsStuckOperation: () => require("../families/bitcoin/operations").isStuckOperation,
-    loadGetStuckAccountAndOperation: () => require("../families/bitcoin/operations").getStuckAccountAndOperation,
+    loadClearAccount: () => bitcoinClearAccount,
+    loadIsEditableOperation: () => bitcoinIsEditableOperation,
+    loadIsStuckOperation: () => bitcoinIsStuckOperation,
+    loadGetStuckAccountAndOperation: () => bitcoinGetStuckAccountAndOperation,
   },
   {
     family: "canton",
-    loadSetup: () => require("../families/canton/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-canton/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-canton/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => cantonSetup,
+    loadTransaction: () => cantonTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-canton/deviceTransactionConfig"),
     loadMockBridge: () => require("../families/canton/bridge/mock").default,
-    loadIsAccountEmpty: () => require("@ledgerhq/coin-canton").isAccountEmpty,
+    loadIsAccountEmpty: () => cantonIsAccountEmpty,
   },
   {
     family: "cardano",
-    loadSetup: () => require("../families/cardano/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-cardano/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-cardano/deviceTransactionConfig").default,
-    loadAccount: () => require("@ledgerhq/coin-cardano/account").default,
+    loadSetup: (): FamilySetup => cardanoSetup,
+    loadTransaction: () => cardanoTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-cardano/deviceTransactionConfig"),
+    loadAccount: () => import("@ledgerhq/coin-cardano/account"),
     loadMockBridge: () => require("../families/cardano/bridge/mock").default,
   },
   {
     family: "casper",
     loadSetup: () => require("../families/casper/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-casper/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-casper/deviceTransactionConfig").default,
+    loadTransaction: () => casperTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-casper/deviceTransactionConfig"),
     loadMockBridge: () => require("../families/casper/bridge/mock").default,
   },
   {
     family: "celo",
-    loadSetup: () => require("../families/celo/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-celo/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-celo/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => require("../families/celo/setup"),
+    loadTransaction: () => celoTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-celo/deviceTransactionConfig"),
   },
   {
     family: "concordium",
-    loadSetup: () => require("../families/concordium/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-concordium/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-concordium/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => concordiumSetup,
+    loadTransaction: () => concordiumTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-concordium/deviceTransactionConfig"),
   },
   {
     family: "cosmos",
-    loadSetup: () => require("../families/cosmos/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-cosmos/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-cosmos/deviceTransactionConfig").default,
-    loadWalletApiAdapter: () => require("../families/cosmos/walletApiAdapter").default,
+    loadSetup: (): FamilySetup => cosmosSetup,
+    loadTransaction: () => cosmosTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-cosmos/deviceTransactionConfig"),
+    loadWalletApiAdapter: () => Promise.resolve(cosmosWalletApiAdapter),
     loadMockBridge: () => require("../families/cosmos/bridge/mock").default,
-    loadMockAccount: () => require("@ledgerhq/coin-cosmos/mock").default,
-    loadIsAccountEmpty: () => require("@ledgerhq/coin-cosmos/helpers").isAccountEmpty,
-    loadGetVotesCount: () => require("../families/cosmos/getVotesCount").getVotesCount,
+    loadMockAccount: () => cosmosMockAccount,
+    loadIsAccountEmpty: () => cosmosIsAccountEmpty,
+    loadGetVotesCount: () => cosmosGetVotesCount,
   },
   {
     family: "evm",
-    loadSetup: () => require("../families/evm/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-evm/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-evm/deviceTransactionConfig").default,
-    loadWalletApiAdapter: () => require("../families/evm/walletApiAdapter").default,
-    loadPlatformAdapter: () => require("../families/evm/platformAdapter").default,
+    loadSetup: (): FamilySetup => evmSetup,
+    loadTransaction: () => evmTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-evm/deviceTransactionConfig"),
+    loadWalletApiAdapter: () => Promise.resolve(evmWalletApiAdapter),
+    loadPlatformAdapter: () => Promise.resolve(evmPlatformAdapter),
     loadMockBridge: () => require("../families/evm/bridge/mock").default,
-    loadValidateAddress: () => require("@ledgerhq/coin-evm/logic/validateAddress").validateAddress,
-    loadSigner: () => require("../bridge/generic-alpaca/families/evm/signer").default,
-    loadIsEditableOperation: () => require("../families/evm/operations").isEditableOperation,
-    loadIsStuckOperation: () => require("../families/evm/operations").isStuckOperation,
-    loadGetStuckAccountAndOperation: () => require("../families/evm/operations").getStuckAccountAndOperation,
+    loadValidateAddress: () => evmValidateAddress,
+    loadSigner: () => evmAlpacaSigner,
+    loadIsEditableOperation: () => evmIsEditableOperation,
+    loadIsStuckOperation: () => evmIsStuckOperation,
+    loadGetStuckAccountAndOperation: () => evmGetStuckAccountAndOperation,
   },
   {
     family: "filecoin",
-    loadSetup: () => require("../families/filecoin/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-filecoin/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-filecoin/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => filecoinSetup,
+    loadTransaction: () => filecoinTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-filecoin/deviceTransactionConfig"),
   },
   {
     family: "hedera",
-    loadSetup: () => require("../families/hedera/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-hedera/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-hedera/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => hederaSetup,
+    loadTransaction: () => hederaTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-hedera/deviceTransactionConfig"),
   },
   {
     family: "icon",
-    loadSetup: () => require("../families/icon/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-icon/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-icon/deviceTransactionConfig").default,
-    loadAccount: () => require("@ledgerhq/coin-icon/account").default,
+    loadSetup: (): FamilySetup => iconSetup,
+    loadTransaction: () => iconTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-icon/deviceTransactionConfig"),
+    loadAccount: () => import("@ledgerhq/coin-icon/account"),
     loadMockBridge: () => require("../families/icon/bridge/mock").default,
   },
   {
     family: "internet_computer",
-    loadSetup: () => require("../families/internet_computer/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-internet_computer/transaction").default,
-    loadDeviceTxConfig: () =>
-      require("@ledgerhq/coin-internet_computer/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => icSetup,
+    loadTransaction: () => icTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-internet_computer/deviceTransactionConfig"),
   },
   {
     family: "kaspa",
-    loadSetup: () => require("../families/kaspa/setup"),
+    loadSetup: (): FamilySetup => require("../families/kaspa/setup"),
     loadTransaction: () => require("@ledgerhq/coin-kaspa/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-kaspa/deviceTransactionConfig").default,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-kaspa/deviceTransactionConfig"),
   },
   {
     family: "mina",
-    loadSetup: () => require("../families/mina/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-mina/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-mina/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => minaSetup,
+    loadTransaction: () => minaTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-mina/deviceTransactionConfig"),
   },
   {
     family: "multiversx",
-    loadSetup: () => require("../families/multiversx/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-multiversx/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-multiversx/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => multiversxSetup,
+    loadTransaction: () => multiversxTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-multiversx/deviceTransactionConfig"),
     loadMockBridge: () => require("../families/multiversx/bridge/mock").default,
   },
   {
     family: "near",
-    loadSetup: () => require("../families/near/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-near/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-near/deviceTransactionConfig").default,
-    loadAccount: () => require("@ledgerhq/coin-near/account").default,
+    loadSetup: (): FamilySetup => nearSetup,
+    loadTransaction: () => nearTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-near/deviceTransactionConfig"),
+    loadAccount: () => import("@ledgerhq/coin-near/account"),
   },
   {
     family: "polkadot",
-    loadSetup: () => require("../families/polkadot/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-polkadot/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-polkadot/deviceTransactionConfig").default,
-    loadWalletApiAdapter: () => require("../families/polkadot/walletApiAdapter").default,
-    loadPlatformAdapter: () => require("../families/polkadot/platformAdapter").default,
+    loadSetup: (): FamilySetup => polkadotSetup,
+    loadTransaction: () => polkadotTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-polkadot/deviceTransactionConfig"),
+    loadWalletApiAdapter: () => Promise.resolve(polkadotWalletApiAdapter),
+    loadPlatformAdapter: () => Promise.resolve(polkadotPlatformAdapter),
     loadMockBridge: () => require("../families/polkadot/bridge/mock").default,
   },
   {
     family: "solana",
-    loadSetup: () => require("../families/solana/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-solana/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-solana/deviceTransactionConfig").default,
-    loadWalletApiAdapter: () => require("../families/solana/walletApiAdapter").default,
+    loadSetup: (): FamilySetup => solanaSetup,
+    loadTransaction: () => solanaTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-solana/deviceTransactionConfig"),
+    loadWalletApiAdapter: () => Promise.resolve(solanaWalletApiAdapter),
     loadMockBridge: () => require("../families/solana/bridge/mock").default,
-    loadValidateAddress: () =>
-      require("@ledgerhq/coin-solana/logic/validateAddress").validateAddress,
-    loadSigner: () => require("../bridge/generic-alpaca/families/solana/signer").default,
+    loadValidateAddress: () => solanaValidateAddress,
+    loadSigner: () => solanaAlpacaSigner,
   },
   {
     family: "stacks",
-    loadSetup: () => require("../families/stacks/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-stacks/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-stacks/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => stacksSetup,
+    loadTransaction: () => stacksTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-stacks/deviceTransactionConfig"),
   },
   {
     family: "stellar",
-    loadSetup: () => require("../families/stellar/setup"),
-    loadTransaction: () => require("../families/stellar/transaction").default,
-    loadDeviceTxConfig: () => require("../families/stellar/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => stellarSetup,
+    loadTransaction: () => stellarTransaction,
+    loadDeviceTxConfig: () => Promise.resolve(stellarDeviceTxConfig),
     loadMockBridge: () => require("../families/stellar/bridge/mock").default,
-    loadValidateAddress: () =>
-      require("@ledgerhq/coin-stellar/logic/validateAddress").validateAddress,
-    loadSigner: () => require("../bridge/generic-alpaca/families/stellar/signer").default,
+    loadValidateAddress: () => stellarValidateAddress,
+    loadSigner: () => stellarAlpacaSigner,
   },
   {
     family: "sui",
-    loadSetup: () => require("../families/sui/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-sui/transaction").default,
-    // No loadDeviceTxConfig: sui has no deviceTransactionConfig
+    loadSetup: (): FamilySetup => require("../families/sui/setup"),
+    loadTransaction: () => suiTransaction,
   },
   {
     family: "tezos",
-    loadSetup: () => require("../families/tezos/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-tezos/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-tezos/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => tezosSetup,
+    loadTransaction: () => tezosTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-tezos/deviceTransactionConfig"),
     loadMockBridge: () => require("../families/tezos/bridge/mock").default,
-    loadGetVotesCount: () => require("../families/tezos/getVotesCount").getVotesCount,
-    loadValidateAddress: () =>
-      require("@ledgerhq/coin-tezos/logic/validateAddress").validateAddress,
-    loadSigner: () => require("../bridge/generic-alpaca/families/tezos/signer").default,
+    loadGetVotesCount: () => tezosGetVotesCount,
+    loadValidateAddress: () => tezosValidateAddress,
+    loadSigner: () => tezosAlpacaSigner,
   },
   {
     family: "ton",
-    loadSetup: () => require("../families/ton/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-ton/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-ton/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => tonSetup,
+    loadTransaction: () => tonTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-ton/deviceTransactionConfig"),
   },
   {
     family: "tron",
-    loadSetup: () => require("../families/tron/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-tron/transaction").default,
-    loadDeviceTxConfig: () => require("@ledgerhq/coin-tron/deviceTransactionConfig").default,
+    loadSetup: (): FamilySetup => tronSetup,
+    loadTransaction: () => tronTransaction,
+    loadDeviceTxConfig: () => import("@ledgerhq/coin-tron/deviceTransactionConfig"),
     loadMockBridge: () => require("../families/tron/bridge/mock").default,
-    loadIsAccountEmpty: () => require("@ledgerhq/coin-tron/index").isAccountEmpty,
-    loadGetVotesCount: () => require("../families/tron/getVotesCount").getVotesCount,
+    loadIsAccountEmpty: () => tronIsAccountEmpty,
+    loadGetVotesCount: () => tronGetVotesCount,
   },
   {
     family: "vechain",
-    loadSetup: () => require("../families/vechain/setup"),
-    loadTransaction: () => require("@ledgerhq/coin-vechain/transaction").default,
-    // No loadDeviceTxConfig: vechain has no deviceTransactionConfig
-    loadAccount: () => require("@ledgerhq/coin-vechain/account").default,
-    loadMockAccount: () => require("@ledgerhq/coin-vechain/mock").default,
-    loadIsAccountEmpty: () => require("@ledgerhq/coin-vechain").isAccountEmpty,
+    loadSetup: (): FamilySetup => vechainSetup,
+    loadTransaction: () => vechainTransaction,
+    loadAccount: () => import("@ledgerhq/coin-vechain/account"),
+    loadMockAccount: () => vechainMockAccount,
+    loadIsAccountEmpty: () => vechainIsAccountEmpty,
   },
   {
     family: "xrp",
-    loadSetup: () => require("../families/xrp/setup"),
-    loadTransaction: () => require("../families/xrp/transaction").default,
-    loadDeviceTxConfig: () => require("../families/xrp/deviceTransactionConfig").default,
-    loadWalletApiAdapter: () => require("../families/xrp/walletApiAdapter").default,
-    loadPlatformAdapter: () => require("../families/xrp/platformAdapter").default,
+    loadSetup: (): FamilySetup => xrpSetup,
+    loadTransaction: () => xrpTransaction,
+    loadDeviceTxConfig: () => Promise.resolve(xrpDeviceTxConfig),
+    loadWalletApiAdapter: () => Promise.resolve(xrpWalletApiAdapter),
+    loadPlatformAdapter: () => Promise.resolve(xrpPlatformAdapter),
     loadMockBridge: () => require("../families/xrp/bridge/mock").default,
-    loadValidateAddress: () =>
-      require("@ledgerhq/coin-xrp/logic/validateAddress").validateAddress,
-    loadSigner: () => require("../bridge/generic-alpaca/families/xrp/signer").default,
+    loadValidateAddress: () => xrpValidateAddress,
+    loadSigner: () => xrpAlpacaSigner,
   },
 ];

--- a/libs/ledger-live-common/src/coin-modules/registry.test.ts
+++ b/libs/ledger-live-common/src/coin-modules/registry.test.ts
@@ -68,22 +68,22 @@ const allLoaders: LoaderEntry[] = [
 ];
 
 describe.each(allLoaders)("$fn.name", ({ loaderKey, fn, required }) => {
-  it("returns module when loader has it", () => {
+  it("returns module when loader has it", async () => {
     const stub = jest.fn();
     registerCoinModules([makeLoader("__test__", { [loaderKey]: () => stub })]);
-    expect(fn("__test__")).toBe(stub);
+    expect(await Promise.resolve(fn("__test__"))).toBe(stub);
   });
   if (required) {
     it("throws CurrencyNotSupported for unknown family", () => {
       expect(() => fn("__none__")).toThrow(CurrencyNotSupported);
     });
   } else {
-    it("returns undefined for unknown family", () => {
-      expect(fn("__none__")).toBeUndefined();
+    it("returns undefined for unknown family", async () => {
+      expect(await Promise.resolve(fn("__none__"))).toBeUndefined();
     });
-    it("returns undefined when loader exists but method is absent", () => {
+    it("returns undefined when loader exists but method is absent", async () => {
       registerCoinModules([makeLoader("__bare__")]);
-      expect(fn("__bare__")).toBeUndefined();
+      expect(await Promise.resolve(fn("__bare__"))).toBeUndefined();
     });
   }
 });

--- a/libs/ledger-live-common/src/coin-modules/registry.ts
+++ b/libs/ledger-live-common/src/coin-modules/registry.ts
@@ -19,6 +19,17 @@ import type { Account } from "@ledgerhq/types-live";
 
 const loaders = new Map<string, CoinModuleLoader>();
 
+// Dynamic imports in NodeNext/CJS mode may wrap the value under `.default` once or twice.
+// At runtime (ESM), the value arrives directly or single-wrapped; this handles all cases.
+function unwrapModuleDefault<T>(m: T | { default: T | { default: T } }): T {
+  if (typeof m !== "object" || m === null || !("default" in (m as object))) return m as T;
+  const inner = (m as { default: T | { default: T } }).default;
+  if (typeof inner !== "object" || inner === null || !("default" in (inner as object))) {
+    return inner as T;
+  }
+  return (inner as { default: T }).default;
+}
+
 function getLoader(family: string): CoinModuleLoader {
   const loader = loaders.get(family);
   if (!loader) throw new CurrencyNotSupported(`No coin module registered for family "${family}"`);
@@ -48,38 +59,33 @@ export const loadSetupForFamily = (family: string): FamilySetup =>
 export const loadTransactionForFamily = (family: string): TransactionModule =>
   getLoader(family).loadTransaction();
 
-export const loadDeviceTxConfigForFamily = (
+export const loadDeviceTxConfigForFamily = async (
   family: string,
-): DeviceTransactionConfigFn | undefined => loaders.get(family)?.loadDeviceTxConfig?.();
+): Promise<DeviceTransactionConfigFn | undefined> => {
+  const m = await loaders.get(family)?.loadDeviceTxConfig?.();
+  return m !== undefined ? unwrapModuleDefault(m) : undefined;
+};
 
-/**
- * Loads the Wallet API adapter module for the given coin family.
- *
- * @remarks
- * This function is currently synchronous but will become `async` in a future
- * migration step (part of the async loader series — LIVE-28411).
- * Callers should already `await` this call so that no further changes are
- * needed once the function signature is updated.
- */
-export const loadWalletApiAdapterForFamily = (
+export const loadWalletApiAdapterForFamily = async (
   family: string,
-): WalletApiAdapterModule | undefined => loaders.get(family)?.loadWalletApiAdapter?.();
+): Promise<WalletApiAdapterModule | undefined> => {
+  const m = await loaders.get(family)?.loadWalletApiAdapter?.();
+  return m !== undefined ? unwrapModuleDefault(m) : undefined;
+};
 
-/**
- * Loads the platform adapter module for the given coin family.
- *
- * @remarks
- * This function is currently synchronous but will become `async` in a future
- * migration step (part of the async loader series — LIVE-28411).
- * Callers should already `await` this call so that no further changes are
- * needed once the function signature is updated.
- */
-export const loadPlatformAdapterForFamily = (
+export const loadPlatformAdapterForFamily = async (
   family: string,
-): PlatformAdapterModule | undefined => loaders.get(family)?.loadPlatformAdapter?.();
+): Promise<PlatformAdapterModule | undefined> => {
+  const m = await loaders.get(family)?.loadPlatformAdapter?.();
+  return m !== undefined ? unwrapModuleDefault(m) : undefined;
+};
 
-export const loadAccountModuleForFamily = (family: string): AccountModule | undefined =>
-  loaders.get(family)?.loadAccount?.();
+export const loadAccountModuleForFamily = async (
+  family: string,
+): Promise<AccountModule | undefined> => {
+  const m = await loaders.get(family)?.loadAccount?.();
+  return m !== undefined ? unwrapModuleDefault(m) : undefined;
+};
 
 export const loadMockBridgeForFamily = (family: string): MockBridgeModule | undefined =>
   loaders.get(family)?.loadMockBridge?.();

--- a/libs/ledger-live-common/src/coin-modules/types.ts
+++ b/libs/ledger-live-common/src/coin-modules/types.ts
@@ -11,73 +11,72 @@ import type {
 } from "@ledgerhq/types-live";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { CommonDeviceTransactionField } from "@ledgerhq/ledger-wallet-framework/transaction/common";
-import type { Transaction as WalletAPITransaction } from "@ledgerhq/wallet-api-core";
-import type { Resolver } from "../hw/getAddress/types";
-import type { SignMessage } from "../hw/signMessage/types";
 import type { GetWalletAPITransactionSignFlowInfos } from "../wallet-api/types";
+import type { Resolver } from "../hw/getAddress/types";
 import type { AlpacaSigner } from "../bridge/generic-alpaca/types";
 export type { AlpacaSigner };
 
 export type MessageSignerModule = {
-  signMessage: SignMessage;
+  signMessage: any; // old-style SignMessage or new alpaca-style MessageSigner<T> at the loader boundary
   prepareMessageToSign?: (opts: { account: Account; message: string }) => AnyMessage;
 };
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 // Parameters are `any` because each family uses its own transaction/raw types at the loader boundary.
 // Method syntax enables bivariant param checking so family-specific implementations are assignable.
 export type TransactionModule = {
   fromTransactionRaw(raw: any): TransactionCommon;
   toTransactionRaw(tx: any): Record<string, unknown>;
-  formatTransaction(tx: any, account: Account): string;
+  // Some coins (e.g. solana) return Promise<string> — union covers both sync and async impls.
+  formatTransaction(tx: any, account: Account): string | Promise<string>;
   fromTransactionStatusRaw?(raw: any): TransactionStatusCommon;
   toTransactionStatusRaw?(status: any): Record<string, unknown>;
   formatTransactionStatus?(tx: any, status: any, mainAccount?: Account): string;
 };
 
 export type DeviceTransactionConfigFn = (arg: {
-  account: AccountLike;
+  // `any` here because each coin passes its own account subtype at the loader boundary.
+  account: any;
   parentAccount: Account | null | undefined;
   transaction: any;
   status: any;
 }) => Promise<CommonDeviceTransactionField[]>;
 
 export type WalletApiAdapterModule = {
-  getWalletAPITransactionSignFlowInfos: GetWalletAPITransactionSignFlowInfos<WalletAPITransaction, any>;
+  // Coin-specific wallet API transaction types — erased to `any` at the loader boundary.
+  getWalletAPITransactionSignFlowInfos: GetWalletAPITransactionSignFlowInfos<any, any>;
 };
 
 export type PlatformAdapterModule = {
   getPlatformTransactionSignFlowInfos: (tx: any) => {
     canEditFees: boolean;
     hasFeesProvided: boolean;
-    liveTx: Partial<TransactionCommon>;
+    // Coin-specific transaction subtype — erased to `any` at the loader boundary.
+    liveTx: Partial<any>;
   };
 };
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 export type AccountModule = {
-  injectGetAddressParams?: (account: Account) => Record<string, unknown>;
+  injectGetAddressParams?: (account: any) => Record<string, unknown>;
 };
 
 export type MockBridgeModule = {
   currencyBridge: CurrencyBridge;
-  accountBridge: AccountBridge<TransactionCommon>;
+  accountBridge: AccountBridge<any, any, any, any, any>;
   loadCoinConfig?: () => void;
 };
 
 export type MockAccountModule = {
   postSyncAccount?: (account: Account) => Account;
-  postScanAccount?: (account: Account, opts?: { isEmpty?: boolean }) => Account;
+  postScanAccount?: (account: Account, opts?: any) => Account;
 };
 
 export type FamilySetup = {
   bridge?: {
     currencyBridge: CurrencyBridge;
-    accountBridge: AccountBridge<TransactionCommon>;
+    accountBridge: AccountBridge<any, any, any, any, any>;
   };
   resolver?: Resolver;
   messageSigner?: MessageSignerModule;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   cliTools?: any;
 };
 
@@ -102,22 +101,28 @@ export type GetStuckAccountAndOperationFn = (
   hasGasTracker: HasGasTrackerFn,
 ) => { account: AccountLike; parentAccount: Account | undefined; operation: Operation } | undefined;
 
+// Dynamic imports in NodeNext/CJS mode wrap exports under `.default` once or twice.
+// Using `{ default: any }` at the loader boundary because TypeScript's structural
+// check for module namespace types is too strict for the CJS interop case.
+// The unwrapped type T is enforced by registry.ts's unwrapModuleDefault return type.
+type ModuleOrDefault<T> = T | { default: any };
+
 export type CoinModuleLoader = {
   family: string;
   loadSetup: () => FamilySetup;
   loadTransaction: () => TransactionModule;
-  loadDeviceTxConfig?: () => DeviceTransactionConfigFn;
-  loadWalletApiAdapter?: () => WalletApiAdapterModule;
-  loadPlatformAdapter?: () => PlatformAdapterModule;
-  loadAccount?: () => AccountModule;
+  loadDeviceTxConfig?: () => Promise<ModuleOrDefault<DeviceTransactionConfigFn>>;
+  loadWalletApiAdapter?: () => Promise<ModuleOrDefault<WalletApiAdapterModule>>;
+  loadPlatformAdapter?: () => Promise<ModuleOrDefault<PlatformAdapterModule>>;
+  loadAccount?: () => Promise<ModuleOrDefault<AccountModule>>;
   loadMockBridge?: () => MockBridgeModule;
   loadMockAccount?: () => MockAccountModule;
   loadIsEditableOperation?: () => IsEditableOperationFn;
   loadIsStuckOperation?: () => IsStuckOperationFn;
   loadGetStuckAccountAndOperation?: () => GetStuckAccountAndOperationFn;
-  loadIsAccountEmpty?: () => (account: Account) => boolean;
-  loadGetVotesCount?: () => (account: Account) => number;
-  loadClearAccount?: () => (account: Account) => void;
+  loadIsAccountEmpty?: () => (account: any) => boolean;
+  loadGetVotesCount?: () => (account: any) => number;
+  loadClearAccount?: () => (account: any) => void;
   loadValidateAddress?: () => ValidateAddressFn;
   loadSigner?: () => AlpacaSigner;
 };

--- a/libs/ledger-live-common/src/families/canton/setup.ts
+++ b/libs/ledger-live-common/src/families/canton/setup.ts
@@ -9,14 +9,14 @@ import type { Bridge } from "@ledgerhq/types-live";
 import makeCliTools from "@ledgerhq/coin-canton/test/cli";
 import { CantonCoinConfig } from "@ledgerhq/coin-canton/config";
 import { TransactionStatus, Transaction, CantonAccount } from "@ledgerhq/coin-canton/types";
-import { LegacySignerCanton } from "@ledgerhq/live-signer-canton";
+import * as liveSignerCanton from "@ledgerhq/live-signer-canton";
 import { CreateSigner, createResolver, executeWithSigner } from "../../bridge/setup";
 import cantonBridgeMock from "./bridge/mock";
 import { Resolver } from "../../hw/getAddress/types";
 import { getCurrencyConfiguration } from "../../config";
 
 const createSigner: CreateSigner<CantonSigner> = (transport: Transport) => {
-  return new LegacySignerCanton(transport);
+  return new liveSignerCanton.LegacySignerCanton(transport);
 };
 
 const getCurrencyConfig = (currencyId?: string) => {

--- a/libs/ledger-live-common/src/families/concordium/setup.ts
+++ b/libs/ledger-live-common/src/families/concordium/setup.ts
@@ -4,7 +4,7 @@ import concordiumResolver from "@ledgerhq/coin-concordium/signer";
 import type { ConcordiumCoinConfig } from "@ledgerhq/coin-concordium/config";
 import { ConcordiumAccount, Transaction, TransactionStatus } from "@ledgerhq/coin-concordium/types";
 import makeCliTools from "@ledgerhq/coin-concordium/test/cli";
-import { DmkSignerConcordium } from "@ledgerhq/live-signer-concordium";
+import * as liveSignerConcordium from "@ledgerhq/live-signer-concordium";
 import Transport from "@ledgerhq/hw-transport";
 import type { Bridge } from "@ledgerhq/types-live";
 import { CreateSigner, createResolver, executeWithSigner } from "../../bridge/setup";
@@ -16,7 +16,7 @@ const createSigner: CreateSigner<ConcordiumSigner> = (transport: Transport): Con
   if (!isDmkTransport(transport)) {
     throw new Error("Concordium requires DMK transport");
   }
-  return new DmkSignerConcordium(transport.dmk, transport.sessionId);
+  return new liveSignerConcordium.DmkSignerConcordium(transport.dmk, transport.sessionId);
 };
 
 const getCurrencyConfig = (currencyId?: string) => {

--- a/libs/ledger-live-common/src/hw/deviceInitialization/buildConnectAppInitializationInput.test.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/buildConnectAppInitializationInput.test.ts
@@ -37,7 +37,7 @@ describe("deviceInitialization buildConnectAppInitializationInput", () => {
     mockGetDerivationModesForCurrency.mockReturnValue(["ethM", ""]);
     mockGetDerivationScheme.mockReturnValue("mock-scheme");
     mockRunDerivationScheme.mockReturnValue("44'/60'/0'/0/0");
-    mockLoadAccountModuleForFamily.mockReturnValue(undefined);
+    mockLoadAccountModuleForFamily.mockResolvedValue(undefined);
   });
 
   it("builds the initialization input from account data and flow metadata", async () => {

--- a/libs/ledger-live-common/src/hw/deviceInitialization/resolveAppRequestRequirements.test.ts
+++ b/libs/ledger-live-common/src/hw/deviceInitialization/resolveAppRequestRequirements.test.ts
@@ -37,7 +37,7 @@ describe("deviceInitialization requirements", () => {
     mockGetDerivationModesForCurrency.mockReturnValue(["ethM", ""]);
     mockGetDerivationScheme.mockReturnValue("mock-scheme");
     mockRunDerivationScheme.mockReturnValue("44'/60'/0'/0/0");
-    mockLoadAccountModuleForFamily.mockReturnValue(undefined);
+    mockLoadAccountModuleForFamily.mockResolvedValue(undefined);
   });
 
   it("resolves account-only input from account data", async () => {
@@ -128,7 +128,7 @@ describe("deviceInitialization requirements", () => {
   });
 
   it("includes family-specific injected address params", async () => {
-    mockLoadAccountModuleForFamily.mockReturnValue({
+    mockLoadAccountModuleForFamily.mockResolvedValue({
       injectGetAddressParams: jest.fn(() => ({ forceFormat: "cashaddr" })),
     });
 

--- a/libs/live-signer-concordium/src/index.ts
+++ b/libs/live-signer-concordium/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./DmkSignerConcordium";
+export { DmkSignerConcordium } from "./DmkSignerConcordium";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1264,6 +1264,12 @@ importers:
       '@ledgerhq/live-cli':
         specifier: workspace:^
         version: link:../cli/dist
+      '@ledgerhq/live-signer-canton':
+        specifier: workspace:^
+        version: link:../../libs/live-signer-canton
+      '@ledgerhq/live-signer-concordium':
+        specifier: workspace:^
+        version: link:../../libs/live-signer-concordium
       '@ledgerhq/speculos-transport':
         specifier: workspace:^
         version: link:../../libs/speculos-transport


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - `libs/ledger-live-common/src/coin-modules/loaders.ts` only
  - Bundle size and boot-up time will return to their state prior to the `require()` approach (i.e. identical to last release, slightly slower than current `develop`)
  - Desktop unit test execution time also returns to its pre-`require()` baseline

### 📝 Description

Dynamic `require()` calls in `coinModuleLoaders` were introduced to work around ESM/CJS module boundaries, but they introduce their own interop issues when both CJS and ESM modules are present in the dependency graph.

This replaces all `require()` calls with top-level static `import` statements so each `load*` function returns the already-resolved value synchronously. This is also a safer foundation for the next step: migrating the loaders to `async () => import(...)` (dynamic import) to achieve true lazy loading, which we want to land carefully.

**Exceptions kept as dynamic imports:**
- `casper` — `casper-js-sdk` runs `typedjson` decorators at module-evaluation time (side effects) that break live-common coverage tests when loaded eagerly
- `celo`, `kaspa` — Buffer/polyfill initialization side effects require late loading

**Before:**
```ts
loadTransaction: () => require("@ledgerhq/coin-aleo/transaction").default,
loadSetup: () => require("../families/aleo/setup"),
loadMockBridge: () => require("../families/algorand/bridge/mock").default,
```

**After:**
```ts
import aleoTransaction from "@ledgerhq/coin-aleo/transaction";
import * as aleoSetup from "../families/aleo/setup";
import algorandMockBridge from "../families/algorand/bridge/mock";
// ...
loadTransaction: () => aleoTransaction,
loadSetup: () => aleoSetup,
loadMockBridge: () => algorandMockBridge,
```

No public API change — `CoinModuleLoader` signatures are identical.

### 🔧 Integration test fixes

The static imports changed module load order, breaking 3 LLD integration tests (canton AddAccountDrawer, canton OnboardModal, concordium OnboardModal). Root cause: `jest.mock()` creates a fresh module object and does not patch already-loaded references, while `jest.spyOn` mutates the shared cached module object (live binding). Since `setupFilesAfterEnv` now loads all coin modules eagerly before tests run, `jest.mock()` was too late.

Fixes applied:
- **canton & concordium setup files** — changed named import to namespace import (`import * as liveSignerX from "..."`) so `jest.spyOn` can intercept the constructor at call time
- **`live-signer-concordium/src/index.ts`** — changed `export * from` (wildcard) to named `export { DmkSignerConcordium }`: the wildcard compiles to `Object.defineProperty` without a pre-declaration, producing `configurable: false` which blocks `jest.spyOn`; named export pre-declares `exports.DmkSignerConcordium = void 0` keeping `configurable: true`
- **canton & concordium integration tests** — switched from `jest.mock()` to `jest.spyOn(...).mockImplementation()` in `beforeAll`; `@ledgerhq/live-signer-canton` and `@ledgerhq/live-signer-concordium` added as devDependencies to `ledger-live-desktop`
- **`loaders.ts` — restored `.default`** on all 15 `loadMockBridge` `require()` calls (accidentally dropped): without it, Detox/mock-mode tests crash because the mock bridge is unwrapped as `{ __esModule: true, default: {...} }` instead of `{ currencyBridge, accountBridge }`

### ❓ Context

- **JIRA or GitHub link**: N/A
- **ADR link (if any)**: N/A
