### PR TITLE
Use newer protocol for the bitcoin app in `hw-app-btc`

### DIFF
--- a/.changeset/empty-moons-sneeze.md
+++ b/.changeset/empty-moons-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-btc": major
+---
+
+Use protocol version 1 of the Bitcoin application, supported since version 2.1.0.

--- a/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts
@@ -538,10 +538,10 @@ export default class BtcNew {
  * the bitcoin descriptor template.
  */
 function descrTemplFrom(addressFormat: AddressFormat): DefaultDescriptorTemplate {
-  if (addressFormat == "legacy") return "pkh(@0)";
-  if (addressFormat == "p2sh") return "sh(wpkh(@0))";
-  if (addressFormat == "bech32") return "wpkh(@0)";
-  if (addressFormat == "bech32m") return "tr(@0)";
+  if (addressFormat == "legacy") return "pkh(@0/**)";
+  if (addressFormat == "p2sh") return "sh(wpkh(@0/**))";
+  if (addressFormat == "bech32") return "wpkh(@0/**)";
+  if (addressFormat == "bech32m") return "tr(@0/**)";
   throw new Error("Unsupported address format " + addressFormat);
 }
 

--- a/libs/ledgerjs/packages/hw-app-btc/src/newops/accounttype.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/newops/accounttype.ts
@@ -195,7 +195,7 @@ export class p2pkh extends SingleKeyAccount {
   }
 
   getDescriptorTemplate(): DefaultDescriptorTemplate {
-    return "pkh(@0)";
+    return "pkh(@0/**)";
   }
 }
 
@@ -227,7 +227,7 @@ export class p2tr extends SingleKeyAccount {
   }
 
   getDescriptorTemplate(): DefaultDescriptorTemplate {
-    return "tr(@0)";
+    return "tr(@0/**)";
   }
 
   /**
@@ -284,7 +284,7 @@ export class p2wpkhWrapped extends SingleKeyAccount {
   }
 
   getDescriptorTemplate(): DefaultDescriptorTemplate {
-    return "sh(wpkh(@0))";
+    return "sh(wpkh(@0/**))";
   }
 
   private createRedeemScript(pubkey: Buffer): Buffer {
@@ -322,6 +322,6 @@ export class p2wpkh extends SingleKeyAccount {
   }
 
   getDescriptorTemplate(): DefaultDescriptorTemplate {
-    return "wpkh(@0)";
+    return "wpkh(@0/**)";
   }
 }

--- a/libs/ledgerjs/packages/hw-app-btc/src/newops/appClient.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/newops/appClient.ts
@@ -4,11 +4,13 @@ import { PsbtV2 } from "@ledgerhq/psbtv2";
 import { MerkelizedPsbt } from "./merkelizedPsbt";
 import { ClientCommandInterpreter } from "./clientCommands";
 import { WalletPolicy } from "./policy";
-import { createVarint } from "../varint";
+import { createVarint, getVarint } from "../varint";
 import { hashLeaf, Merkle } from "./merkle";
 
 const CLA_BTC = 0xe1;
 const CLA_FRAMEWORK = 0xf8;
+
+const CURRENT_PROTOCOL_VERSION = 1; // supported from version 2.1.0 of the app
 
 enum BitcoinIns {
   GET_PUBKEY = 0x00,
@@ -40,7 +42,7 @@ export class AppClient {
     data: Buffer,
     cci?: ClientCommandInterpreter,
   ): Promise<Buffer> {
-    let response: Buffer = await this.transport.send(CLA_BTC, ins, 0, 0, data, [0x9000, 0xe000]);
+    let response: Buffer = await this.transport.send(CLA_BTC, ins, 0, CURRENT_PROTOCOL_VERSION, data, [0x9000, 0xe000]);
     while (response.readUInt16BE(response.length - 2) === 0xe000) {
       if (!cci) {
         throw new Error("Unexpected SW_INTERRUPTED_EXECUTION");
@@ -53,7 +55,7 @@ export class AppClient {
         CLA_FRAMEWORK,
         FrameworkIns.CONTINUE_INTERRUPTED,
         0,
-        0,
+        CURRENT_PROTOCOL_VERSION,
         commandResponse,
         [0x9000, 0xe000],
       );
@@ -87,9 +89,10 @@ export class AppClient {
       throw new Error("Invalid HMAC length");
     }
 
-    const clientInterpreter = new ClientCommandInterpreter(() => {});
+    const clientInterpreter = new ClientCommandInterpreter(() => { });
     clientInterpreter.addKnownList(walletPolicy.keys.map(k => Buffer.from(k, "ascii")));
     clientInterpreter.addKnownPreimage(walletPolicy.serialize());
+    clientInterpreter.addKnownPreimage(Buffer.from(walletPolicy.descriptorTemplate, "ascii"));
 
     const addressIndexBuffer = Buffer.alloc(4);
     addressIndexBuffer.writeUInt32BE(addressIndex, 0);
@@ -126,6 +129,7 @@ export class AppClient {
     // prepare ClientCommandInterpreter
     clientInterpreter.addKnownList(walletPolicy.keys.map(k => Buffer.from(k, "ascii")));
     clientInterpreter.addKnownPreimage(walletPolicy.serialize());
+    clientInterpreter.addKnownPreimage(Buffer.from(walletPolicy.descriptorTemplate, "ascii"));
 
     clientInterpreter.addKnownMapping(merkelizedPsbt.globalMerkleMap);
     for (const map of merkelizedPsbt.inputMerkleMaps) {
@@ -162,7 +166,12 @@ export class AppClient {
 
     const ret: Map<number, Buffer> = new Map();
     for (const inputAndSig of yielded) {
-      ret.set(inputAndSig[0], inputAndSig.slice(1));
+      // V2 yield format:
+      // <inputIndex : varint> <pubkeyLen : 1 byte> <pubkey : pubkeyLen bytes> <signature : variable length>
+      const [inputIndex, inputIndexLen] = getVarint(inputAndSig, 0);
+      const pubkeyAugmLen = inputAndSig[inputIndexLen];
+      const signature = inputAndSig.subarray(inputIndexLen + 1 + pubkeyAugmLen);
+      ret.set(inputIndex, signature);
     }
     return ret;
   }
@@ -176,7 +185,7 @@ export class AppClient {
       throw new Error("Path too long. At most 6 levels allowed.");
     }
 
-    const clientInterpreter = new ClientCommandInterpreter(() => {});
+    const clientInterpreter = new ClientCommandInterpreter(() => { });
 
     // prepare ClientCommandInterpreter
     const nChunks = Math.ceil(message.length / 64);

--- a/libs/ledgerjs/packages/hw-app-btc/src/newops/policy.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/newops/policy.ts
@@ -3,7 +3,7 @@ import { pathArrayToString } from "../bip32";
 import { BufferWriter } from "@ledgerhq/psbtv2";
 import { hashLeaf, Merkle } from "./merkle";
 
-export type DefaultDescriptorTemplate = "pkh(@0)" | "sh(wpkh(@0))" | "wpkh(@0)" | "tr(@0)";
+export type DefaultDescriptorTemplate = "pkh(@0/**)" | "sh(wpkh(@0/**))" | "wpkh(@0/**)" | "tr(@0/**)";
 
 /**
  * The Bitcon hardware app uses a descriptors-like thing to describe
@@ -36,9 +36,10 @@ export class WalletPolicy {
     const m = new Merkle(keyBuffers.map(k => hashLeaf(k)));
 
     const buf = new BufferWriter();
-    buf.writeUInt8(0x01); // wallet type (policy map)
+    buf.writeUInt8(0x02); // wallet policy version (2 is supported from version 2.1.0 of the app)
     buf.writeUInt8(0); // length of wallet name (empty string for default wallets)
-    buf.writeVarSlice(Buffer.from(this.descriptorTemplate, "ascii"));
+    buf.writeVarInt(this.descriptorTemplate.length); // length of descriptor template
+    buf.writeSlice(crypto.sha256(Buffer.from(this.descriptorTemplate, "ascii"))); // hash of descriptor template
     buf.writeVarInt(this.keys.length), buf.writeSlice(m.getRoot());
     return buf.buffer();
   }
@@ -46,5 +47,5 @@ export class WalletPolicy {
 
 export function createKey(masterFingerprint: Buffer, path: number[], xpub: string): string {
   const accountPath = pathArrayToString(path);
-  return `[${masterFingerprint.toString("hex")}${accountPath.substring(1)}]${xpub}/**`;
+  return `[${masterFingerprint.toString("hex")}${accountPath.substring(1)}]${xpub}`;
 }

--- a/libs/ledgerjs/packages/hw-app-btc/src/signPsbt/accountTypeResolver.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/signPsbt/accountTypeResolver.ts
@@ -7,13 +7,13 @@ import type { ScriptType } from "./types";
 function descrTemplFrom(addressFormat: AddressFormat): DefaultDescriptorTemplate {
   switch (addressFormat) {
     case "legacy":
-      return "pkh(@0)";
+      return "pkh(@0/**)";
     case "p2sh":
-      return "sh(wpkh(@0))";
+      return "sh(wpkh(@0/**))";
     case "bech32":
-      return "wpkh(@0)";
+      return "wpkh(@0/**)";
     case "bech32m":
-      return "tr(@0)";
+      return "tr(@0/**)";
     default:
       throw new Error("Unsupported address format " + addressFormat);
   }
@@ -63,13 +63,13 @@ export function createAccountTypeFromAddressFormat(
   const descrTemplate = descrTemplFrom(addressFormat);
 
   switch (descrTemplate) {
-    case "pkh(@0)":
+    case "pkh(@0/**)":
       return new p2pkh(psbt, masterFp);
-    case "wpkh(@0)":
+    case "wpkh(@0/**)":
       return new p2wpkh(psbt, masterFp);
-    case "sh(wpkh(@0))":
+    case "sh(wpkh(@0/**))":
       return new p2wpkhWrapped(psbt, masterFp);
-    case "tr(@0)":
+    case "tr(@0/**)":
       return new p2tr(psbt, masterFp);
     default:
       throw new Error(`Unsupported descriptor template: ${descrTemplate}`);

--- a/libs/ledgerjs/packages/hw-app-btc/tests/newops/BtcNew.test.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/tests/newops/BtcNew.test.ts
@@ -59,20 +59,20 @@ import {
 } from "./testtx";
 
 test("getWalletPublicKey p2pkh", async () => {
-  await testGetWalletPublicKey("m/44'/1'/0'", "pkh(@0)");
-  await testGetWalletPublicKey("m/44'/0'/17'", "pkh(@0)");
+  await testGetWalletPublicKey("m/44'/1'/0'", "pkh(@0/**)");
+  await testGetWalletPublicKey("m/44'/0'/17'", "pkh(@0/**)");
 });
 test("getWalletPublicKey p2wpkh", async () => {
-  await testGetWalletPublicKey("m/84'/1'/0'", "wpkh(@0)");
-  await testGetWalletPublicKey("m/84'/0'/17'", "wpkh(@0)");
+  await testGetWalletPublicKey("m/84'/1'/0'", "wpkh(@0/**)");
+  await testGetWalletPublicKey("m/84'/0'/17'", "wpkh(@0/**)");
 });
 test("getWalletPublicKey wrapped p2wpkh", async () => {
-  await testGetWalletPublicKey("m/49'/1'/0'", "sh(wpkh(@0))");
-  await testGetWalletPublicKey("m/49'/0'/17'", "sh(wpkh(@0))");
+  await testGetWalletPublicKey("m/49'/1'/0'", "sh(wpkh(@0/**))");
+  await testGetWalletPublicKey("m/49'/0'/17'", "sh(wpkh(@0/**))");
 });
 test("getWalletPublicKey p2tr", async () => {
-  await testGetWalletPublicKey("m/86'/1'/0'", "tr(@0)");
-  await testGetWalletPublicKey("m/86'/0'/17'", "tr(@0)");
+  await testGetWalletPublicKey("m/86'/1'/0'", "tr(@0/**)");
+  await testGetWalletPublicKey("m/86'/0'/17'", "tr(@0/**)");
 });
 
 test("getWalletXpub normal path", async () => {
@@ -197,7 +197,7 @@ async function testGetWalletPublicKey(
     "tpubDHcN44A4UHqdHJZwBxgTbu8Cy87ZrZkN8tQnmJGhcijHqe4rztuvGcD4wo36XSviLmiqL5fUbDnekYaQ7LzAnaqauBb9RsyahsTTFHdeJGd";
   client.mockGetPubkeyResponse(accountPath, accountXpub);
   client.mockGetPubkeyResponse(path, keyXpub);
-  const key = `[${masterFingerprint.toString("hex")}${accountPath.substring(1)}]${accountXpub}/**`;
+  const key = `[${masterFingerprint.toString("hex")}${accountPath.substring(1)}]${accountXpub}`;
   client.mockGetWalletAddressResponse(
     new WalletPolicy(expectedDescriptorTemplate, key),
     0,

--- a/libs/ledgerjs/packages/hw-app-btc/tests/newops/integrationtools.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/tests/newops/integrationtools.ts
@@ -81,10 +81,10 @@ export async function runSignTransaction(
 export function addressFormatFromDescriptorTemplate(
   descTemp: DefaultDescriptorTemplate,
 ): AddressFormat {
-  if (descTemp == "tr(@0)") return "bech32m";
-  if (descTemp == "pkh(@0)") return "legacy";
-  if (descTemp == "wpkh(@0)") return "bech32";
-  if (descTemp == "sh(wpkh(@0))") return "p2sh";
+  if (descTemp == "tr(@0/**)") return "bech32m";
+  if (descTemp == "pkh(@0/**)") return "legacy";
+  if (descTemp == "wpkh(@0/**)") return "bech32";
+  if (descTemp == "sh(wpkh(@0/**))") return "p2sh";
   throw new Error();
 }
 

--- a/libs/ledgerjs/packages/hw-app-btc/tests/signPsbt/accountTypeResolver.test.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/tests/signPsbt/accountTypeResolver.test.ts
@@ -73,26 +73,26 @@ describe("accountTypeResolver", () => {
   describe("createAccountTypeFromScriptType", () => {
     it("returns account type with wpkh template for p2wpkh", () => {
       const accountType = createAccountTypeFromScriptType("p2wpkh", psbt, masterFp);
-      expect(accountType.getDescriptorTemplate()).toBe("wpkh(@0)");
+      expect(accountType.getDescriptorTemplate()).toBe("wpkh(@0/**)");
     });
 
     it("returns account type with tr template for p2tr", () => {
       const accountType = createAccountTypeFromScriptType("p2tr", psbt, masterFp);
-      expect(accountType.getDescriptorTemplate()).toBe("tr(@0)");
+      expect(accountType.getDescriptorTemplate()).toBe("tr(@0/**)");
     });
 
     it("returns account type with sh(wpkh) template for p2sh and p2sh-p2wpkh", () => {
       expect(createAccountTypeFromScriptType("p2sh", psbt, masterFp).getDescriptorTemplate()).toBe(
-        "sh(wpkh(@0))",
+        "sh(wpkh(@0/**))",
       );
       expect(
         createAccountTypeFromScriptType("p2sh-p2wpkh", psbt, masterFp).getDescriptorTemplate(),
-      ).toBe("sh(wpkh(@0))");
+      ).toBe("sh(wpkh(@0/**))");
     });
 
     it("returns account type with pkh template for p2pkh", () => {
       const accountType = createAccountTypeFromScriptType("p2pkh", psbt, masterFp);
-      expect(accountType.getDescriptorTemplate()).toBe("pkh(@0)");
+      expect(accountType.getDescriptorTemplate()).toBe("pkh(@0/**)");
     });
   });
 
@@ -110,7 +110,7 @@ describe("accountTypeResolver", () => {
       } as unknown as PsbtV2;
       const result = determineAccountTypeFromWitnessUtxo(psbtWithWitness, 0, masterFp);
       expect(result).not.toBeNull();
-      expect(result!.getDescriptorTemplate()).toBe("wpkh(@0)");
+      expect(result!.getDescriptorTemplate()).toBe("wpkh(@0/**)");
     });
 
     it("throws when witness UTXO has unsupported script type", () => {
@@ -126,22 +126,22 @@ describe("accountTypeResolver", () => {
   describe("createAccountTypeFromAddressFormat", () => {
     it("returns p2pkh for legacy format", () => {
       const accountType = createAccountTypeFromAddressFormat("legacy", psbt, masterFp);
-      expect(accountType.getDescriptorTemplate()).toBe("pkh(@0)");
+      expect(accountType.getDescriptorTemplate()).toBe("pkh(@0/**)");
     });
 
     it("returns p2wpkhWrapped for p2sh format", () => {
       const accountType = createAccountTypeFromAddressFormat("p2sh", psbt, masterFp);
-      expect(accountType.getDescriptorTemplate()).toBe("sh(wpkh(@0))");
+      expect(accountType.getDescriptorTemplate()).toBe("sh(wpkh(@0/**))");
     });
 
     it("returns p2wpkh for bech32 format", () => {
       const accountType = createAccountTypeFromAddressFormat("bech32", psbt, masterFp);
-      expect(accountType.getDescriptorTemplate()).toBe("wpkh(@0)");
+      expect(accountType.getDescriptorTemplate()).toBe("wpkh(@0/**)");
     });
 
     it("returns p2tr for bech32m format", () => {
       const accountType = createAccountTypeFromAddressFormat("bech32m", psbt, masterFp);
-      expect(accountType.getDescriptorTemplate()).toBe("tr(@0)");
+      expect(accountType.getDescriptorTemplate()).toBe("tr(@0/**)");
     });
 
     it("throws for unsupported address format", () => {
@@ -163,7 +163,7 @@ describe("accountTypeResolver", () => {
         masterFp,
       );
       expect(result).not.toBeNull();
-      expect(result!.getDescriptorTemplate()).toBe("pkh(@0)");
+      expect(result!.getDescriptorTemplate()).toBe("pkh(@0/**)");
     });
 
     it("returns p2wpkhWrapped for purpose 49'", () => {
@@ -173,7 +173,7 @@ describe("accountTypeResolver", () => {
         masterFp,
       );
       expect(result).not.toBeNull();
-      expect(result!.getDescriptorTemplate()).toBe("sh(wpkh(@0))");
+      expect(result!.getDescriptorTemplate()).toBe("sh(wpkh(@0/**))");
     });
 
     it("returns p2wpkh for purpose 84'", () => {
@@ -183,7 +183,7 @@ describe("accountTypeResolver", () => {
         masterFp,
       );
       expect(result).not.toBeNull();
-      expect(result!.getDescriptorTemplate()).toBe("wpkh(@0)");
+      expect(result!.getDescriptorTemplate()).toBe("wpkh(@0/**)");
     });
 
     it("returns p2tr for purpose 86'", () => {
@@ -193,7 +193,7 @@ describe("accountTypeResolver", () => {
         masterFp,
       );
       expect(result).not.toBeNull();
-      expect(result!.getDescriptorTemplate()).toBe("tr(@0)");
+      expect(result!.getDescriptorTemplate()).toBe("tr(@0/**)");
     });
 
     it("returns null for unknown purpose", () => {
@@ -204,7 +204,7 @@ describe("accountTypeResolver", () => {
   describe("determineAccountType", () => {
     it("uses detectedScriptType when provided", () => {
       const result = determineAccountType(psbt, 0, masterFp, "p2tr", [], undefined);
-      expect(result.getDescriptorTemplate()).toBe("tr(@0)");
+      expect(result.getDescriptorTemplate()).toBe("tr(@0/**)");
     });
 
     it("falls back to witness UTXO when no detectedScriptType", () => {
@@ -213,7 +213,7 @@ describe("accountTypeResolver", () => {
         getInputRedeemScript: () => undefined,
       } as unknown as PsbtV2;
       const result = determineAccountType(psbtWithWitness, 0, masterFp, undefined, [], undefined);
-      expect(result.getDescriptorTemplate()).toBe("wpkh(@0)");
+      expect(result.getDescriptorTemplate()).toBe("wpkh(@0/**)");
     });
 
     it("falls back to redeem script (p2sh-p2wpkh) when no witness UTXO", () => {
@@ -222,7 +222,7 @@ describe("accountTypeResolver", () => {
         getInputRedeemScript: () => Buffer.alloc(1),
       } as unknown as PsbtV2;
       const result = determineAccountType(psbtWithRedeem, 0, masterFp, undefined, [], undefined);
-      expect(result.getDescriptorTemplate()).toBe("sh(wpkh(@0))");
+      expect(result.getDescriptorTemplate()).toBe("sh(wpkh(@0/**))");
     });
 
     it("falls back to addressFormat when no witness or redeem script", () => {
@@ -231,7 +231,7 @@ describe("accountTypeResolver", () => {
         getInputRedeemScript: () => undefined,
       } as unknown as PsbtV2;
       const result = determineAccountType(psbtEmpty, 0, masterFp, undefined, [], "bech32m");
-      expect(result.getDescriptorTemplate()).toBe("tr(@0)");
+      expect(result.getDescriptorTemplate()).toBe("tr(@0/**)");
     });
 
     it("falls back to purpose from account path when no addressFormat", () => {
@@ -247,7 +247,7 @@ describe("accountTypeResolver", () => {
         [0x80000054, 0x80000000, 0x80000000],
         undefined,
       );
-      expect(result.getDescriptorTemplate()).toBe("wpkh(@0)");
+      expect(result.getDescriptorTemplate()).toBe("wpkh(@0/**)");
     });
 
     it("defaults to p2wpkh when no other source available", () => {
@@ -263,7 +263,7 @@ describe("accountTypeResolver", () => {
         [0x80000000],
         undefined,
       );
-      expect(result.getDescriptorTemplate()).toBe("wpkh(@0)");
+      expect(result.getDescriptorTemplate()).toBe("wpkh(@0/**)");
     });
   });
 });

--- a/libs/ledgerjs/packages/hw-app-btc/tests/signPsbt/signAndFinalize.test.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/tests/signPsbt/signAndFinalize.test.ts
@@ -27,9 +27,9 @@ describe("signAndFinalize", () => {
   describe("createWalletPolicy", () => {
     it("returns a WalletPolicy with descriptor from account type and key from masterFp, path and xpub", () => {
       const policy = createWalletPolicy(masterFp, accountPath, accountXpub, {
-        getDescriptorTemplate: () => "wpkh(@0)",
+        getDescriptorTemplate: () => "wpkh(@0/**)",
       } as any);
-      expect(policy.descriptorTemplate).toBe("wpkh(@0)");
+      expect(policy.descriptorTemplate).toBe("wpkh(@0/**)");
       expect(policy.keys).toHaveLength(1);
       expect(policy.keys[0]).toContain(accountXpub);
       expect(policy.keys[0]).toContain(masterFp.toString("hex"));


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** discussed below

### 📝 Description

Version 2.1.0 of the Bitcoin app made some opt-in changes to the wire protocol. The old version is currently still supported but deprecated, and will eventually be removed in a future version of the bitcoin app.

This updates `hw-app-btc` to always use the newer protocol when talking to the new bitcoin app.

Impact:
- Anything using `hw-app-btc` will no longer work for app versions `>= 2.0.0, <2.1.0` of the bitcoin app.
 
Version 2.1.0 of the Bitcoin app was released at the beginning of 2023.

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
