### PR TITLE
ci(sonar): aggregate shared and domain coverage [LIVE-29779]

### DIFF
--- a/.changeset/sonar-shared-domain-coverage.md
+++ b/.changeset/sonar-shared-domain-coverage.md
@@ -1,0 +1,11 @@
+---
+"@shared/feature-flags": minor
+"@shared/schema-primitives": minor
+"@domain/entity-currency": minor
+"@domain/entity-currency-crypto": minor
+"@domain/entity-currency-fiat": minor
+"@domain/entity-currency-token": minor
+"@domain/entity-currency-unit": minor
+---
+
+Wire SonarQube coverage aggregation for `shared/*` and `domain/entity/*` packages (LIVE-29779): add `coverage` scripts and jest-sonar reporter config, tag the packages via the Nx project-tags plugin, and introduce dedicated `test-shared` / `test-domain` reusable workflows that feed coverage into both the PR and scheduled Sonar scans.

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -94,6 +94,20 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/test-features-reusable.yml@develop
     secrets: inherit
 
+  test-shared:
+    name: "Test Shared"
+    needs: determine-affected
+    if: ${{contains(needs.determine-affected.outputs.paths, 'shared') && !github.event.pull_request.head.repo.fork}}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-shared-reusable.yml@develop
+    secrets: inherit
+
+  test-domain:
+    name: "Test Domain"
+    needs: determine-affected
+    if: ${{contains(needs.determine-affected.outputs.paths, 'domain') && !github.event.pull_request.head.repo.fork}}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-domain-reusable.yml@develop
+    secrets: inherit
+
   test-design-system:
     name: "Test UI Libs"
     needs: determine-affected
@@ -162,16 +176,20 @@ jobs:
       - test-mobile
       - test-libraries
       - test-features
+      - test-shared
+      - test-domain
       - build-wallet-cli
       - determine-affected
     uses: LedgerHQ/ledger-live/.github/workflows/scan-sonar-reusable.yml@develop
-    if: ${{ always() && !cancelled() && !github.event.pull_request.head.repo.fork && (needs.test-desktop.result == 'success' || needs.test-mobile.result == 'success' || needs.test-libraries.result == 'success' || needs.test-features.result == 'success' || needs.build-wallet-cli.result == 'success' || contains(needs.determine-affected.outputs.paths, 'e2e')) }}
+    if: ${{ always() && !cancelled() && !github.event.pull_request.head.repo.fork && (needs.test-desktop.result == 'success' || needs.test-mobile.result == 'success' || needs.test-libraries.result == 'success' || needs.test-features.result == 'success' || needs.test-shared.result == 'success' || needs.test-domain.result == 'success' || needs.build-wallet-cli.result == 'success' || contains(needs.determine-affected.outputs.paths, 'e2e')) }}
     secrets: inherit
     with:
       should_download_desktop_coverage: ${{ needs.test-desktop.outputs.coverage_generated }}
       should_download_mobile_coverage: ${{ needs.test-mobile.outputs.coverage_generated }}
       should_download_libs_coverage: ${{ needs.test-libraries.outputs.coverage_generated }}
       should_download_features_coverage: ${{ needs.test-features.outputs.coverage_generated }}
+      should_download_shared_coverage: ${{ needs.test-shared.outputs.coverage_generated }}
+      should_download_domain_coverage: ${{ needs.test-domain.outputs.coverage_generated }}
       should_download_wallet_cli_coverage: ${{ needs.build-wallet-cli.outputs.coverage_generated }}
 
   # Final Check required
@@ -184,6 +202,8 @@ jobs:
       - build-test-mobile
       - test-libraries
       - test-features
+      - test-shared
+      - test-domain
       - test-design-system
       - build-web-tools
       - test-cli

--- a/.github/workflows/scan-sonar-reusable.yml
+++ b/.github/workflows/scan-sonar-reusable.yml
@@ -19,6 +19,14 @@ on:
         required: false
         default: "false"
         type: string
+      should_download_shared_coverage:
+        required: false
+        default: "false"
+        type: string
+      should_download_domain_coverage:
+        required: false
+        default: "false"
+        type: string
       should_download_wallet_cli_coverage:
         required: false
         default: "false"
@@ -86,6 +94,20 @@ jobs:
           name: coverage-features
           path: coverage-features
 
+      - name: Download shared unit test coverage
+        if: ${{ inputs.should_download_shared_coverage == 'true' }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: coverage-shared
+          path: coverage-shared
+
+      - name: Download domain unit test coverage
+        if: ${{ inputs.should_download_domain_coverage == 'true' }}
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: coverage-domain
+          path: coverage-domain
+
       - name: Download wallet-cli unit test coverage
         if: ${{ inputs.should_download_wallet_cli_coverage == 'true' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -114,6 +136,16 @@ jobs:
             echo "Merging features coverage files"
             cat ./coverage-features/lcov.info >> ./lcov.info
             cat ./coverage-features/sonar-executionTests-report.xml >> ./sonar-executionTests-report.xml
+          fi
+          if [ -d ./coverage-shared ]; then
+            echo "Merging shared coverage files"
+            cat ./coverage-shared/lcov.info >> ./lcov.info
+            cat ./coverage-shared/sonar-executionTests-report.xml >> ./sonar-executionTests-report.xml
+          fi
+          if [ -d ./coverage-domain ]; then
+            echo "Merging domain coverage files"
+            cat ./coverage-domain/lcov.info >> ./lcov.info
+            cat ./coverage-domain/sonar-executionTests-report.xml >> ./sonar-executionTests-report.xml
           fi
           if [ -d ./coverage-wallet-cli ]; then
             echo "Merging wallet-cli coverage files"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           LANG: en_US.UTF-8
         run: |
-          pnpm i --filter="./libs/**" --filter="./features/**" --filter="live-mobile..." --filter="ledger-live-desktop..." --no-frozen-lockfile --unsafe-perm
+          pnpm i --filter="./libs/**" --filter="./features/**" --filter="./shared/**" --filter="./domain/**" --filter="live-mobile..." --filter="ledger-live-desktop..." --no-frozen-lockfile --unsafe-perm
 
       - name: Build dependencies
         run: |
@@ -106,6 +106,52 @@ jobs:
             fi
           done
 
+      - name: Generate Unit test coverage for shared
+        run: |
+          mkdir -p shared/coverage
+          touch shared/coverage/lcov.info
+          touch shared/coverage/sonar-executionTests-report.xml
+
+          pnpm exec nx run-many -t coverage --projects=tag:scope:shared --parallel=4 -- --runInBand=1
+
+          for package_json in $(find ./shared -name "package.json" -not -path "*/node_modules/*" -not -path "*/coverage/*"); do
+            pkg=$(dirname "$package_json")
+            echo "Processing package at path: $pkg"
+
+            if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json" > /dev/null 2>&1; then
+              if [ -f "$pkg/coverage/lcov.info" ] && [ -f "$pkg/coverage/sonar-executionTests-report.xml" ]; then
+                echo "Appending coverage files for $pkg"
+                cat "$pkg/coverage/lcov.info" >> shared/coverage/lcov.info
+                cat "$pkg/coverage/sonar-executionTests-report.xml" >> shared/coverage/sonar-executionTests-report.xml
+              fi
+            else
+              echo "No coverage script found for $pkg, skipping."
+            fi
+          done
+
+      - name: Generate Unit test coverage for domain
+        run: |
+          mkdir -p domain/coverage
+          touch domain/coverage/lcov.info
+          touch domain/coverage/sonar-executionTests-report.xml
+
+          pnpm exec nx run-many -t coverage --projects=tag:scope:domain --parallel=4 -- --runInBand=1
+
+          for package_json in $(find ./domain -name "package.json" -not -path "*/node_modules/*" -not -path "*/coverage/*"); do
+            pkg=$(dirname "$package_json")
+            echo "Processing package at path: $pkg"
+
+            if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json" > /dev/null 2>&1; then
+              if [ -f "$pkg/coverage/lcov.info" ] && [ -f "$pkg/coverage/sonar-executionTests-report.xml" ]; then
+                echo "Appending coverage files for $pkg"
+                cat "$pkg/coverage/lcov.info" >> domain/coverage/lcov.info
+                cat "$pkg/coverage/sonar-executionTests-report.xml" >> domain/coverage/sonar-executionTests-report.xml
+              fi
+            else
+              echo "No coverage script found for $pkg, skipping."
+            fi
+          done
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
@@ -125,8 +171,8 @@ jobs:
 
       - name: Merge coverage files
         run: |
-          cat libs/coverage/lcov.info features/coverage/lcov.info apps/ledger-live-desktop/coverage/lcov.info apps/ledger-live-mobile/coverage/lcov.info apps/wallet-cli/coverage/lcov.info > ./lcov.info
-          cat libs/coverage/sonar-executionTests-report.xml features/coverage/sonar-executionTests-report.xml apps/ledger-live-desktop/coverage/sonar-executionTests-report.xml apps/ledger-live-mobile/coverage/sonar-executionTests-report.xml > ./sonar-executionTests-report.xml
+          cat libs/coverage/lcov.info features/coverage/lcov.info shared/coverage/lcov.info domain/coverage/lcov.info apps/ledger-live-desktop/coverage/lcov.info apps/ledger-live-mobile/coverage/lcov.info apps/wallet-cli/coverage/lcov.info > ./lcov.info
+          cat libs/coverage/sonar-executionTests-report.xml features/coverage/sonar-executionTests-report.xml shared/coverage/sonar-executionTests-report.xml domain/coverage/sonar-executionTests-report.xml apps/ledger-live-desktop/coverage/sonar-executionTests-report.xml apps/ledger-live-mobile/coverage/sonar-executionTests-report.xml > ./sonar-executionTests-report.xml
 
       - name: Sonarqube Scan
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6

--- a/.github/workflows/test-domain-reusable.yml
+++ b/.github/workflows/test-domain-reusable.yml
@@ -1,0 +1,92 @@
+name: "[Domain] - Test - Called"
+
+on:
+  workflow_call:
+    outputs:
+      coverage_generated:
+        value: ${{ jobs.test-domain.outputs.coverage_generated }}
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: |
+          If you run this manually, and want to run on a PR, the correct ref should be refs/pull/{PR_NUMBER}/merge to
+          have the "normal" scenario involving checking out a merge commit between your branch and the base branch.
+          If you want to run only on a branch or specific commit, you can use either the sha or the branch name instead (prefer the first version for PRs).
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test-domain:
+    name: "Domain Test"
+    timeout-minutes: 10
+    env:
+      NODE_OPTIONS: "--max-old-space-size=7168"
+      FORCE_COLOR: 3
+      CI_OS: ubuntu-22.04
+    outputs:
+      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
+
+    runs-on: [ledger-live-linux-8CPU-32RAM]
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup the caches
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        id: setup-caches
+        with:
+          skip-turbo-cache: "false"
+          use-mise: true
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+          nx-key: ${{ secrets.NX_KEY }}
+          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+          region: ${{ secrets.AWS_CACHE_REGION }}
+          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm i --filter="./domain/**" --filter="./shared/**"
+
+      - name: Run coverage on domain packages
+        env:
+          TURBO_API: "http://127.0.0.1:${{ steps.setup-caches.outputs.port }}"
+          TURBO_TOKEN: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+          TURBO_TEAM: "foo"
+        run: |
+          mkdir -p ${{ github.workspace }}/coverage
+          touch ${{ github.workspace }}/coverage/lcov.info
+          touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
+
+          pnpm exec nx run-many -t coverage --projects=tag:scope:domain --parallel=4 -- --runInBand=1
+
+      - name: Process coverage files
+        id: process-coverage
+        run: |
+          for package_json in $(find ./domain -name "package.json" -not -path "*/node_modules/*"); do
+            pkg=$(dirname "$package_json")
+            echo "Processing package at path: $pkg"
+            if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json" > /dev/null 2>&1; then
+              if [ -f "$pkg/coverage/lcov.info" ] && [ -f "$pkg/coverage/sonar-executionTests-report.xml" ]; then
+                echo "Appending coverage files for $pkg"
+                cat "$pkg/coverage/lcov.info" >> ${{ github.workspace }}/coverage/lcov.info
+                cat "$pkg/coverage/sonar-executionTests-report.xml" >> ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
+              fi
+            else
+              echo "No coverage script found for $pkg, skipping."
+            fi
+          done
+        shell: bash
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ !cancelled() }}
+        id: generate_coverage
+        with:
+          name: coverage-domain
+          path: ${{ github.workspace }}/coverage

--- a/.github/workflows/test-shared-reusable.yml
+++ b/.github/workflows/test-shared-reusable.yml
@@ -1,0 +1,92 @@
+name: "[Shared] - Test - Called"
+
+on:
+  workflow_call:
+    outputs:
+      coverage_generated:
+        value: ${{ jobs.test-shared.outputs.coverage_generated }}
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: |
+          If you run this manually, and want to run on a PR, the correct ref should be refs/pull/{PR_NUMBER}/merge to
+          have the "normal" scenario involving checking out a merge commit between your branch and the base branch.
+          If you want to run only on a branch or specific commit, you can use either the sha or the branch name instead (prefer the first version for PRs).
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test-shared:
+    name: "Shared Test"
+    timeout-minutes: 10
+    env:
+      NODE_OPTIONS: "--max-old-space-size=7168"
+      FORCE_COLOR: 3
+      CI_OS: ubuntu-22.04
+    outputs:
+      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
+
+    runs-on: [ledger-live-linux-8CPU-32RAM]
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup the caches
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        id: setup-caches
+        with:
+          skip-turbo-cache: "false"
+          use-mise: true
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+          nx-key: ${{ secrets.NX_KEY }}
+          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+          region: ${{ secrets.AWS_CACHE_REGION }}
+          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm i --filter="./shared/**"
+
+      - name: Run coverage on shared packages
+        env:
+          TURBO_API: "http://127.0.0.1:${{ steps.setup-caches.outputs.port }}"
+          TURBO_TOKEN: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+          TURBO_TEAM: "foo"
+        run: |
+          mkdir -p ${{ github.workspace }}/coverage
+          touch ${{ github.workspace }}/coverage/lcov.info
+          touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
+
+          pnpm exec nx run-many -t coverage --projects=tag:scope:shared --parallel=4 -- --runInBand=1
+
+      - name: Process coverage files
+        id: process-coverage
+        run: |
+          for package_json in $(find ./shared -name "package.json" -not -path "*/node_modules/*"); do
+            pkg=$(dirname "$package_json")
+            echo "Processing package at path: $pkg"
+            if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json" > /dev/null 2>&1; then
+              if [ -f "$pkg/coverage/lcov.info" ] && [ -f "$pkg/coverage/sonar-executionTests-report.xml" ]; then
+                echo "Appending coverage files for $pkg"
+                cat "$pkg/coverage/lcov.info" >> ${{ github.workspace }}/coverage/lcov.info
+                cat "$pkg/coverage/sonar-executionTests-report.xml" >> ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
+              fi
+            else
+              echo "No coverage script found for $pkg, skipping."
+            fi
+          done
+        shell: bash
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ !cancelled() }}
+        id: generate_coverage
+        with:
+          name: coverage-shared
+          path: ${{ github.workspace }}/coverage

--- a/domain/entity/currency-crypto/jest.config.js
+++ b/domain/entity/currency-crypto/jest.config.js
@@ -12,4 +12,9 @@ module.exports = {
       },
     ],
   },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
 };

--- a/domain/entity/currency-crypto/package.json
+++ b/domain/entity/currency-crypto/package.json
@@ -7,10 +7,10 @@
   "types": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage"
   },
   "dependencies": {
     "@domain/entity-currency-unit": "workspace:*",

--- a/domain/entity/currency-crypto/project.json
+++ b/domain/entity/currency-crypto/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/currency-fiat/jest.config.js
+++ b/domain/entity/currency-fiat/jest.config.js
@@ -12,4 +12,9 @@ module.exports = {
       },
     ],
   },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
 };

--- a/domain/entity/currency-fiat/package.json
+++ b/domain/entity/currency-fiat/package.json
@@ -7,10 +7,10 @@
   "types": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage"
   },
   "dependencies": {
     "@domain/entity-currency-unit": "workspace:*",

--- a/domain/entity/currency-fiat/project.json
+++ b/domain/entity/currency-fiat/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/currency-token/jest.config.js
+++ b/domain/entity/currency-token/jest.config.js
@@ -12,4 +12,9 @@ module.exports = {
       },
     ],
   },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
 };

--- a/domain/entity/currency-token/package.json
+++ b/domain/entity/currency-token/package.json
@@ -7,10 +7,10 @@
   "types": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage"
   },
   "dependencies": {
     "@domain/entity-currency-unit": "workspace:*",

--- a/domain/entity/currency-token/project.json
+++ b/domain/entity/currency-token/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/currency-unit/jest.config.js
+++ b/domain/entity/currency-unit/jest.config.js
@@ -14,4 +14,9 @@ module.exports = {
     ],
   },
   testPathIgnorePatterns: ["lib/"],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
 };

--- a/domain/entity/currency-unit/package.json
+++ b/domain/entity/currency-unit/package.json
@@ -7,10 +7,10 @@
   "types": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage"
   },
   "dependencies": {
     "zod": "catalog:"

--- a/domain/entity/currency-unit/project.json
+++ b/domain/entity/currency-unit/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/currency/jest.config.js
+++ b/domain/entity/currency/jest.config.js
@@ -12,4 +12,9 @@ module.exports = {
       },
     ],
   },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
 };

--- a/domain/entity/currency/package.json
+++ b/domain/entity/currency/package.json
@@ -7,10 +7,10 @@
   "types": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage"
   },
   "dependencies": {
     "@domain/entity-currency-crypto": "workspace:*",

--- a/domain/entity/currency/project.json
+++ b/domain/entity/currency/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/shared/feature-flags/jest.config.js
+++ b/shared/feature-flags/jest.config.js
@@ -12,4 +12,9 @@ module.exports = {
       },
     ],
   },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
 };

--- a/shared/feature-flags/package.json
+++ b/shared/feature-flags/package.json
@@ -7,10 +7,10 @@
   "types": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage"
   },
   "dependencies": {
     "@reduxjs/toolkit": "catalog:",

--- a/shared/feature-flags/project.json
+++ b/shared/feature-flags/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/shared/schema-primitives/jest.config.js
+++ b/shared/schema-primitives/jest.config.js
@@ -12,4 +12,9 @@ module.exports = {
       },
     ],
   },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
 };

--- a/shared/schema-primitives/package.json
+++ b/shared/schema-primitives/package.json
@@ -7,10 +7,10 @@
   "types": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage"
   },
   "dependencies": {
     "zod": "catalog:"

--- a/shared/schema-primitives/project.json
+++ b/shared/schema-primitives/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -36,6 +36,10 @@ libs/**/e2e/**,\
 libs/coin-tester*/**,\
 features/**.test.ts,\
 features/**.test.tsx,\
+shared/**.test.ts,\
+shared/**.test.tsx,\
+domain/**.test.ts,\
+domain/**.test.tsx,\
 e2e/**/userdata/*.json,\
 **/__mocks__/**,\
 **/__tests__/**,\
@@ -71,7 +75,7 @@ e2e/**/userdata/*.json,\
 sonar.coverage.exclusions=e2e/**/*
 sonar.javascript.lcov.reportPaths=lcov.info
 sonar.testExecutionReportPaths=sonar-executionTests-report.xml
-sonar.typescript.tsconfigPaths=tsconfig.base.json,apps/**/tsconfig.json,e2e/**/tsconfig.json,features/**/tsconfig.json
+sonar.typescript.tsconfigPaths=tsconfig.base.json,apps/**/tsconfig.json,e2e/**/tsconfig.json,features/**/tsconfig.json,shared/**/tsconfig.json,domain/**/tsconfig.json
 sonar.organization=ledger
 sonar.javascript.node.maxspace=24576
 sonar.c.file.suffixes=-

--- a/tools/nx-plugins/project-tags/plugin.js
+++ b/tools/nx-plugins/project-tags/plugin.js
@@ -41,6 +41,14 @@ function inferTags(projectRoot, packageName) {
     tags.add("scope:tools");
   }
 
+  if (projectRoot.startsWith("shared/")) {
+    tags.add("scope:shared");
+  }
+
+  if (projectRoot.startsWith("domain/")) {
+    tags.add("scope:domain");
+  }
+
   if (!(projectRoot === "apps" || projectRoot.startsWith("apps/"))) {
     tags.add("scope:no-apps");
   }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached (`.changeset/sonar-shared-domain-coverage.md`).
- [x] **Covered by automatic tests.** Verified locally by running `pnpm exec nx run-many -t coverage --projects=tag:scope:shared,tag:scope:domain` — all 7 packages produce `coverage/lcov.info` with correct `SF:` paths. Full CI validation comes from the new PR-level `test-shared` and `test-domain` jobs feeding coverage into `scan-sonar`.
- [x] **Impact of the changes:**
  - CI-only: SonarQube aggregated coverage now includes `shared/*` and `domain/entity/*` packages. No runtime changes to any app or library.
  - New PR jobs `test-shared` and `test-domain` fire on `shared/`/`domain/` affected paths; they run in parallel with the existing `test-libraries` and `test-features` jobs.
  - New artifacts `coverage-shared` and `coverage-domain` consumed by `scan-sonar-reusable.yml`.
  - Scheduled `sonar.yml` gains two new aggregation steps and references the new coverage directories in the final merge.
  - `sonar-project.properties` excludes `shared/**.test.ts(x)` and `domain/**.test.ts(x)` from analysis and adds both dirs to `sonar.typescript.tsconfigPaths`.

### 📝 Description

Before this PR, modifying code in `shared/*` or `domain/entity/*` resulted in SonarQube reporting 0% coverage for the changed files: neither the Nx project-tags plugin, nor the CI coverage pipelines, nor the affected Jest configs produced or aggregated any coverage output for these packages. Source files were already listed in `sonar.sources`, so Sonar flagged them as uncovered rather than unmeasured.

The fix wires the same pattern already used by `libs/` and `features/`:

1. **Nx plugin** (`tools/nx-plugins/project-tags/plugin.js`) now emits `scope:shared` and `scope:domain` based on path prefix so `nx run-many --projects=tag:scope:shared` (and domain) dispatch as expected.
2. **Jest configs** in the 7 affected packages (`shared/feature-flags`, `shared/schema-primitives`, and the 5 `domain/entity/*` packages) gain `coverageReporters` (lcov + json + text) and the `jest-sonar` reporter so `pnpm <pkg> coverage` emits `lcov.info` + `sonar-executionTests-report.xml`. `projectRoot` is set per nesting depth (`../../` for shared, `../../../` for domain) so `SF:` paths are relative from the repo root.
3. **Package scripts** gain a `coverage: jest --coverage` entry so the CI loops that filter on `jq -e '.scripts.coverage'` pick them up.
4. **Two new reusable workflows** — `test-shared-reusable.yml` and `test-domain-reusable.yml` — mirror `test-features-reusable.yml` exactly, each producing its own `coverage-shared` / `coverage-domain` artifact.
5. **PR orchestrator** (`build-and-test-pr.yml`) gets two new jobs triggered on `contains(paths, 'shared')` / `contains(paths, 'domain')`; both are wired into `scan-sonar`'s `needs`, `if`, `with`, and the final `ok` gate.
6. **`scan-sonar-reusable.yml`** gets two new inputs, two new download steps (artifacts `coverage-shared` / `coverage-domain`), and two new merge blocks.
7. **Scheduled `sonar.yml`** gains two dedicated coverage-generation steps (one per scope) writing to `shared/coverage/` and `domain/coverage/`; the final merge concatenates both.
8. **`sonar-project.properties`** excludes `shared/**.test.ts(x)` + `domain/**.test.ts(x)` from analysis and extends `sonar.typescript.tsconfigPaths`.

Commits are split by phase for review convenience (nx plugin → package configs → reusable workflows → orchestrator wiring).

### ❓ Context

- **JIRA link**: [LIVE-29779](https://ledgerhq.atlassian.net/browse/LIVE-29779)
- **ADR link (if any)**: n/a

[LIVE-29779]: https://ledgerhq.atlassian.net/browse/LIVE-29779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ