### PR TITLE
support(e2e): refactor build-ai-artifact script to use allure report

### DIFF
--- a/e2e/mobile/scripts/build-ai-artifact.sh
+++ b/e2e/mobile/scripts/build-ai-artifact.sh
@@ -1,43 +1,49 @@
 #!/usr/bin/env bash
 # Builds a filtered artifact directory for AI analysis.
-# - Only failed/broken *-result.json files are included (passed tests are counted
-#   and stored in a summary file so the parser can still report totals).
+# - All test-cases from the Allure report are included.
 # - Attachments are included only for failed/broken tests, excluding images and videos.
 set -euo pipefail
 shopt -s nullglob
 
 ARTIFACTS="${ARTIFACTS:-e2e/mobile/artifacts}"
-OUT="${OUT:-e2e/mobile/artifacts-ai}"
+OUT="${OUT:-e2e/mobile/artifacts/artifacts-ai}"
 
+# Safety guard: refuse to delete if OUT is empty, is the repo root, or is the artifacts source.
+if [[ -z "$OUT" || "$OUT" == "/" || "$OUT" == "." || "$(realpath "$OUT" 2>/dev/null || echo "$OUT")" == "$(realpath "$ARTIFACTS")" ]]; then
+  echo "Error: OUT='$OUT' is unsafe to delete. Aborting." >&2
+  exit 1
+fi
+
+rm -rf "$OUT"
 mkdir -p "$OUT/attachments"
 
-for f in categories.json executor.json environment.properties speculos-instances.json appVersion; do
+for f in categories.json executor.json environment.properties speculos-instances.json; do
   [[ -f "$ARTIFACTS/$f" ]] && cp "$ARTIFACTS/$f" "$OUT/"
 done
+[[ -d "$ARTIFACTS/appVersion" ]] && cp -r "$ARTIFACTS/appVersion" "$OUT/"
 
-results=("$ARTIFACTS"/*-result.json)
-if [[ ${#results[@]} -eq 0 ]]; then
-  echo "No result files found in $ARTIFACTS, skipping AI artifact build." >&2
+test_cases=("$ARTIFACTS/allure-report/data/test-cases"/*.json)
+if [[ ${#test_cases[@]} -eq 0 ]]; then
+  echo "No test-case files found in $ARTIFACTS/allure-report/data/test-cases, skipping AI artifact build." >&2
   exit 0
 fi
 
-total=0
-passed=0
+# No deduplication needed — Allure already handles retries.
+for tc in "${test_cases[@]}"; do
+  status=$(jq -r '.status' "$tc")
 
-for result in "${results[@]}"; do
-  status=$(jq -r '.status' "$result")
-  total=$((total + 1))
+  cp "$tc" "$OUT/"
 
   if [[ "$status" == "failed" || "$status" == "broken" ]]; then
-    cp "$result" "$OUT/"
-
     while IFS= read -r src; do
-      [[ -f "$ARTIFACTS/$src" ]] && \
-        cp "$ARTIFACTS/$src" "$OUT/attachments/"
-    done < <(jq -r '.. | .attachments? // empty | .[] | select(.type | startswith("video/") or startswith("image/") | not) | .source' "$result" | sort -u)
-  elif [[ "$status" == "passed" ]]; then
-    passed=$((passed + 1))
+      [[ -f "$ARTIFACTS/allure-report/data/attachments/$src" ]] && \
+        cp "$ARTIFACTS/allure-report/data/attachments/$src" "$OUT/attachments/"
+    done < <(jq -r '.. | .attachments? // empty | .[] | select(.type | startswith("video/") or startswith("image/") | not) | .source' "$tc" | sort -u)
   fi
 done
 
-printf '{"total_results":%d,"passed_results":%d}\n' "$total" "$passed" > "$OUT/summary.json"
+if [[ -f "$ARTIFACTS/allure-report/widgets/summary.json" ]]; then
+  cp "$ARTIFACTS/allure-report/widgets/summary.json" "$OUT/summary.json"
+else
+  echo "Warning: allure-report/widgets/summary.json not found, skipping summary." >&2
+fi


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Source changed from *-result.json → allure-report/data/test-cases/*.json
- All test-cases now included (passed + failed), attachments only for failed/broken — gives the AI the full picture without bloating the output with logs
- Attachment path corrected to allure-report/data/attachments/

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
