### PR TITLE
ci(desktop): restore smoke workflow env propagation

### DIFF
--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -136,8 +136,6 @@ jobs:
       FORCE_COLOR: 3
       CI_OS: "ubuntu-latest"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      SPECULOS_IMAGE_TAG: ${{ env.SMOKE_SPECULOS_IMAGE_TAG }}
-      SPECULOS_FIRMWARE_VERSION: ${{ env.SMOKE_SPECULOS_FIRMWARE_VERSION }}
       SPECULOS_DEVICE: nanoSP
     runs-on: [ledger-live-4xlarge]
     steps:
@@ -167,7 +165,7 @@ jobs:
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-speculos_image@develop
         with:
           coinapps_path: coin-apps
-          speculos_tag: ${{ env.SPECULOS_IMAGE_TAG }}
+          speculos_tag: ${{ env.SMOKE_SPECULOS_IMAGE_TAG }}
           bot_id: ${{ secrets.GH_BOT_APP_ID }}
           bot_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - name: Set test environment variables
@@ -194,6 +192,8 @@ jobs:
           TEST_EXECUTION: ""
           PROJECT_KEY: B2CQA
           SWAP_API_BASE: ${{ env.SWAP_API_BASE }}
+          SPECULOS_IMAGE_TAG: ${{ env.SMOKE_SPECULOS_IMAGE_TAG }}
+          SPECULOS_FIRMWARE_VERSION: ${{ env.SMOKE_SPECULOS_FIRMWARE_VERSION }}
       - name: Upload Allure Results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _No changeset is needed because this PR only fixes GitHub Actions workflow wiring._
- [ ] **Covered by automatic tests.** _No automated app tests were added; the fix was validated by parsing the workflow YAML locally because this PR only changes CI configuration._
- [x] **Impact of the changes:**
      - PR and push workflows that call `test-desktop-reusable.yml`
      - Desktop smoke NanoSP setup and environment propagation
      - Pinned Speculos image `ghcr.io/ledgerhq/speculos:v0.26.5` and firmware `1.6.0`

### 📝 Description

This follow-up fixes the regression introduced by #16713, where callers of the desktop reusable workflow failed at parse time before any jobs could run.

The problem was that the smoke Speculos image and firmware pins were referenced through `${{ env.* }}` inside `jobs.speculos-e2e-tests-linux.env`, which is not a supported expression context in reusable workflow parsing. The fix keeps the two smoke values pinned at the workflow level and passes them only in supported step contexts, so the workflow can parse again while preserving the intended pinned versions.

### ❓ Context

- **JIRA or GitHub link**: [#16713](https://github.com/LedgerHQ/ledger-live/pull/16713)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)