### PR TITLE
[LWM] fix(llm): redirect Firmware-update-required CTA to OS update flow

### DIFF
--- a/.changeset/fix-live-29661-firmware-update-cta.md
+++ b/.changeset/fix-live-29661-firmware-update-cta.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix "Go to my ledger" CTA in the "Firmware update required" modal so it opens the OS update release notes screen instead of Home, and rename the CTA to "Go to OS Update" (LIVE-29661).

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -648,7 +648,13 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
     }
 
     if (error instanceof LatestFirmwareVersionRequired) {
-      return <RequiredFirmwareUpdate navigation={navigation} device={selectedDevice} />;
+      return (
+        <RequiredFirmwareUpdate
+          navigation={navigation}
+          device={selectedDevice}
+          onClose={onClose}
+        />
+      );
     }
 
     if (error instanceof UnsupportedFeatureError) {

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -775,44 +775,16 @@ export function RequiredFirmwareUpdate({
 
   const usbFwUpdateActivated = !!lastSeenDevice;
   const deviceName = getDeviceModel(device.modelId).productName;
-  const isDeviceConnectedViaUSB = device.wired;
 
-  // Goes to the manager if a firmware update is available, but only automatically
-  // displays the firmware update drawer if the device is already connected via USB
   const onPress = () => {
     track("button_clicked", {
-      button: "OpenMyLedger",
+      button: "GoToOSUpdate",
       page: "Update_OS_To_Continue",
     });
-    navigation.reset({
-      index: 0,
-      routes: [
-        {
-          name: NavigatorName.Base,
-          state: {
-            routes: [
-              {
-                name: NavigatorName.Main,
-                state: {
-                  routes: [
-                    {
-                      name: NavigatorName.MyLedger,
-                      state: {
-                        routes: [
-                          {
-                            name: ScreenName.MyLedgerChooseDevice,
-                            params: { device, firmwareUpdate: isDeviceConnectedViaUSB },
-                          },
-                        ],
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      ],
+    navigation.navigate(ScreenName.FirmwareUpdate, {
+      device,
+      deviceInfo: lastSeenDevice?.deviceInfo,
+      onBackFromUpdate: () => {},
     });
   };
 

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useRef } from "react";
 import type { TFunction } from "i18next";
 import { Image, Linking, ScrollView } from "react-native";
 import { useSelector } from "~/context/hooks";
@@ -20,6 +20,10 @@ import {
 } from "@ledgerhq/errors";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
 import { isSyncOnboardingSupported } from "@ledgerhq/live-common/device/use-cases/screenSpecs";
+import {
+  getLatestFirmwareForDeviceUseCase,
+  type FirmwareUpdateContextEntity,
+} from "@ledgerhq/live-common/device/use-cases/getLatestFirmwareForDeviceUseCase";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
@@ -765,9 +769,11 @@ export function NanoSNotSupportedComponent() {
 export function RequiredFirmwareUpdate({
   device,
   navigation,
+  onClose,
 }: Omit<RawProps, "t"> & {
   navigation: NativeStackNavigationProp<ParamListBase>;
   device: Device;
+  onClose?: () => void;
 }) {
   const { t } = useTranslation();
   const track = useTrack();
@@ -776,16 +782,40 @@ export function RequiredFirmwareUpdate({
   const usbFwUpdateActivated = !!lastSeenDevice;
   const deviceName = getDeviceModel(device.modelId).productName;
 
-  const onPress = () => {
+  const latestFirmwarePromiseRef = useRef<Promise<FirmwareUpdateContextEntity | null> | null>(null);
+  const fetchLatestFirmware = useCallback(() => {
+    const deviceInfo = lastSeenDevice?.deviceInfo;
+    if (!deviceInfo) return null;
+    if (!latestFirmwarePromiseRef.current) {
+      latestFirmwarePromiseRef.current = getLatestFirmwareForDeviceUseCase(deviceInfo).catch(
+        () => null,
+      );
+    }
+    return latestFirmwarePromiseRef.current;
+  }, [lastSeenDevice?.deviceInfo]);
+  useEffect(() => {
+    fetchLatestFirmware();
+  }, [fetchLatestFirmware]);
+
+  const onPress = async () => {
     track("button_clicked", {
       button: "GoToOSUpdate",
       page: "Update_OS_To_Continue",
     });
-    navigation.navigate(ScreenName.FirmwareUpdate, {
+    const firmwareUpdateContext = (await fetchLatestFirmware()) ?? undefined;
+    let targetNav: NativeStackNavigationProp<ParamListBase> = navigation;
+    while (!targetNav.getState()?.routeNames?.includes(ScreenName.FirmwareUpdate)) {
+      const parent = targetNav.getParent();
+      if (!parent) break;
+      targetNav = parent as NativeStackNavigationProp<ParamListBase>;
+    }
+    targetNav.navigate(ScreenName.FirmwareUpdate, {
       device,
       deviceInfo: lastSeenDevice?.deviceInfo,
-      onBackFromUpdate: () => {},
+      firmwareUpdateContext,
+      onBackFromUpdate: () => targetNav.goBack(),
     });
+    onClose?.();
   };
 
   return (

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -5299,7 +5299,7 @@
     "updateAvailableFromLLM": {
       "title": "Firmware update required",
       "description": "To perform this action, you first need to update the firmware of your {{ deviceName }}.",
-      "cta": "Go to My Ledger"
+      "cta": "Go to OS Update"
     },
     "updateNotAvailableFromLLM": {
       "title": "Firmware update required on computer",

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
@@ -74,8 +74,10 @@ const PlatformCompleteExchange: React.FC<Props> = ({
   }, [onResult, error]);
 
   const onCloseHandler = useCallback(() => {
-    // Prevent onClose being called twice
-    if (!hasPopped.current) {
+    // Only pop if the user actually dismissed the drawer on this screen.
+    // When the drawer closes due to a redirect (navigation away), isFocused is false
+    // and popping here would unwind the just-pushed destination.
+    if (!hasPopped.current && navigation.isFocused()) {
       navigation.pop();
     }
     hasPopped.current = true;

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
@@ -25,8 +25,10 @@ export default function PlatformStartExchange({ navigation, route }: Props) {
   const hasPopped = useRef(false);
 
   const onClose = useCallback(() => {
-    // Prevent onClose being called twice
-    if (!hasPopped.current) {
+    // Only pop if the user actually dismissed the drawer on this screen.
+    // When the drawer closes due to a redirect (navigation away), isFocused is false
+    // and popping here would unwind the just-pushed destination.
+    if (!hasPopped.current && navigation.isFocused()) {
       navigation.pop();
     }
     hasPopped.current = true;


### PR DESCRIPTION
## Summary

- Redirects the "Firmware update required" modal CTA from the old `MyLedgerChooseDevice` reset to `ScreenName.FirmwareUpdate` (release-notes screen), matching the Home-banner entry point.
- Renames the CTA copy from "Go to My Ledger" to "Go to OS Update".
- Ensures the redirect works on the **first tap** whether the modal is rendered full-screen (e.g. 1inch swap) or inside a bottom drawer (e.g. Changelly swap).

## Why the drawer case needed extra work

The drawer version initially required two taps. Root causes:

1. `navigate(FirmwareUpdate)` was dispatched on the nested PlatformExchange navigator, which doesn't register `FirmwareUpdate` — so the action silently failed on first tap. Fix: walk up the navigator tree to the ancestor that has `FirmwareUpdate` registered before dispatching.
2. `FirmwareUpdate` requires `firmwareUpdateContext` to render. Fix: prefetch it imperatively on mount via `getLatestFirmwareForDeviceUseCase` and `await` the cached promise in `onPress`, so the first tap always has the data.
3. `PlatformStartExchange`/`PlatformCompleteExchange.onClose` unconditionally called `navigation.pop()` on drawer close — including the drawer auto-close triggered by focus loss when we navigated away — which unwound the just-pushed `FirmwareUpdate`. Fix: guard the pop with `navigation.isFocused()` so it only fires on genuine user dismissal.

Ticket: LIVE-29661

## Test plan

- [ ] 1inch swap → trigger firmware-update-required modal → tap "Go to OS Update" → lands on release-notes screen on first tap
- [ ] Changelly swap → trigger firmware-update-required modal (renders inside bottom drawer) → tap "Go to OS Update" → lands on release-notes screen on first tap
- [ ] In both flows, close the release-notes screen (X button) → back to expected previous screen, no navigation artifacts
- [ ] Normal drawer dismissal (user taps backdrop/close without tapping the CTA) still pops the exchange screen as before