### PR TITLE
[LWD] Fix completion detection rules

### DIFF
--- a/.changeset/poor-carpets-fold.md
+++ b/.changeset/poor-carpets-fold.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": patch
 ---
 
-Update completion detectio rules
+Update completion detection rules

--- a/.changeset/poor-carpets-fold.md
+++ b/.changeset/poor-carpets-fold.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Update completion detectio rules

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -310,6 +310,7 @@ apps/ledger-live-desktop/src/mvvm/features/DynamicContent/                      
 apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/                                          @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/                               @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/AnalyticsConsentDialog/                             @ledgerhq/engagement
+apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/                                   @ledgerhq/engagement
 apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/AnalyticsConsentOptInDevTool/  @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/WalletV4Tour/                                       @ledgerhq/engagement
 apps/ledger-live-desktop/src/mvvm/features/BuyDevice/                                          @ledgerhq/engagement

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/FinishOnboardingDialogView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/FinishOnboardingDialogView.tsx
@@ -14,12 +14,10 @@ import { cn } from "LLD/utils/cn";
 import type { FinishOnboardingDialogViewProps } from "./hooks/useFinishOnboardingDialogViewModel";
 
 const FinishOnboardingDialogView = ({
-  accounts,
   actions,
   allActionsCompleted,
   completedActionsAmount,
   deviceModelId,
-  isLedgerSyncActive,
   isOpen,
   onClose,
   onGotIt,
@@ -61,13 +59,10 @@ const FinishOnboardingDialogView = ({
           */}
           <PostOnboardingAction
             key={PostOnboardingActionId.deviceOnboarded}
-            accounts={accounts}
             buttonLabelForAnalyticsEvent=""
             completed
             description=""
             deviceModelId={deviceModelId}
-            getIsAlreadyCompletedByState={() => true}
-            isLedgerSyncActive={isLedgerSyncActive}
             lumenSymbol={LedgerDevices}
             postOnboardingActionId={PostOnboardingActionId.deviceOnboarded}
             shouldCompleteOnStart={false}
@@ -77,13 +72,10 @@ const FinishOnboardingDialogView = ({
           {actions.map(action => (
             <PostOnboardingAction
               key={action.id}
-              accounts={accounts}
               buttonLabelForAnalyticsEvent={action.buttonLabelForAnalyticsEvent ?? ""}
               completed={action.completed}
               description={action.description ?? ""}
               deviceModelId={deviceModelId}
-              getIsAlreadyCompletedByState={action.getIsAlreadyCompletedByState ?? (() => false)}
-              isLedgerSyncActive={isLedgerSyncActive}
               lumenSymbol={action.lumenSymbol}
               postOnboardingActionId={action.id}
               shouldCompleteOnStart={action.shouldCompleteOnStart ?? false}

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/FinishOnboardingDialogView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/FinishOnboardingDialogView.tsx
@@ -66,6 +66,7 @@ const FinishOnboardingDialogView = ({
             completed
             description=""
             deviceModelId={deviceModelId}
+            getIsAlreadyCompletedByState={() => true}
             isLedgerSyncActive={isLedgerSyncActive}
             lumenSymbol={LedgerDevices}
             postOnboardingActionId={PostOnboardingActionId.deviceOnboarded}
@@ -81,6 +82,7 @@ const FinishOnboardingDialogView = ({
               completed={action.completed}
               description={action.description ?? ""}
               deviceModelId={deviceModelId}
+              getIsAlreadyCompletedByState={action.getIsAlreadyCompletedByState ?? (() => false)}
               isLedgerSyncActive={isLedgerSyncActive}
               lumenSymbol={action.lumenSymbol}
               postOnboardingActionId={action.id}

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/FinishOnboardingDialogView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/FinishOnboardingDialogView.tsx
@@ -59,7 +59,6 @@ const FinishOnboardingDialogView = ({
           */}
           <PostOnboardingAction
             key={PostOnboardingActionId.deviceOnboarded}
-            buttonLabelForAnalyticsEvent=""
             completed
             description=""
             deviceModelId={deviceModelId}
@@ -72,7 +71,7 @@ const FinishOnboardingDialogView = ({
           {actions.map(action => (
             <PostOnboardingAction
               key={action.id}
-              buttonLabelForAnalyticsEvent={action.buttonLabelForAnalyticsEvent ?? ""}
+              buttonLabelForAnalyticsEvent={action.buttonLabelForAnalyticsEvent}
               completed={action.completed}
               description={action.description ?? ""}
               deviceModelId={deviceModelId}

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/__integrations__/FinishOnboardingDialog.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/__integrations__/FinishOnboardingDialog.integration.test.tsx
@@ -39,7 +39,9 @@ function postOnboardingActiveState(
   };
 }
 
-function renderWithStore(reduxState: { postOnboarding: PostOnboardingState } & Pick<State, "dialogs">) {
+function renderWithStore(
+  reduxState: { postOnboarding: PostOnboardingState } & Pick<State, "dialogs">,
+) {
   const store = createStore({
     state: {
       postOnboarding: reduxState.postOnboarding,

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/PostOnboardingActionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/PostOnboardingActionView.tsx
@@ -46,7 +46,9 @@ const PostOnboardingActionView = memo(function PostOnboardingActionView({
         )}
         <ListItemContent>
           <ListItemTitle>{t(title)}</ListItemTitle>
-          <ListItemDescription>{completed ? t("postOnboarding.dialog.actionCompletedLabel") : t(description)}</ListItemDescription>
+          <ListItemDescription>
+            {completed ? t("postOnboarding.dialog.actionCompletedLabel") : t(description)}
+          </ListItemDescription>
         </ListItemContent>
       </ListItemLeading>
       <ListItemTrailing>

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__integrations__/PostOnboardingAction.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__integrations__/PostOnboardingAction.integration.test.tsx
@@ -16,7 +16,6 @@ describe("PostOnboardingAction integration", () => {
         lumenSymbol={getLumenSymbolForActionId(PostOnboardingActionId.assetsTransfer)}
         deviceModelId={null}
         startAction={() => {}}
-        buttonLabelForAnalyticsEvent=""
         shouldCompleteOnStart={false}
       />,
     );

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__integrations__/PostOnboardingAction.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__integrations__/PostOnboardingAction.integration.test.tsx
@@ -15,12 +15,9 @@ describe("PostOnboardingAction integration", () => {
         postOnboardingActionId={PostOnboardingActionId.assetsTransfer}
         lumenSymbol={getLumenSymbolForActionId(PostOnboardingActionId.assetsTransfer)}
         deviceModelId={null}
-        isLedgerSyncActive={false}
-        accounts={[]}
         startAction={() => {}}
         buttonLabelForAnalyticsEvent=""
         shouldCompleteOnStart={false}
-        getIsAlreadyCompletedByState={() => false}
       />,
     );
     expect(screen.getByText("Transfer assets")).toBeVisible();

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__integrations__/PostOnboardingAction.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__integrations__/PostOnboardingAction.integration.test.tsx
@@ -11,7 +11,6 @@ describe("PostOnboardingAction integration", () => {
         title="Transfer assets"
         description="Move funds from an exchange"
         completed={false}
-        onAction={jest.fn()}
         testId="my-action"
         postOnboardingActionId={PostOnboardingActionId.assetsTransfer}
         lumenSymbol={getLumenSymbolForActionId(PostOnboardingActionId.assetsTransfer)}
@@ -21,12 +20,16 @@ describe("PostOnboardingAction integration", () => {
         startAction={() => {}}
         buttonLabelForAnalyticsEvent=""
         shouldCompleteOnStart={false}
+        getIsAlreadyCompletedByState={() => false}
       />,
     );
     expect(screen.getByText("Transfer assets")).toBeVisible();
     expect(screen.getByText("Move funds from an exchange")).toBeVisible();
     const row = screen.getByTestId("my-action");
     expect(row).toBeVisible();
-    expect(row).toHaveAttribute("data-post-onboarding-action-id", PostOnboardingActionId.assetsTransfer);
+    expect(row).toHaveAttribute(
+      "data-post-onboarding-action-id",
+      PostOnboardingActionId.assetsTransfer,
+    );
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__tests__/usePostOnboardingActionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__tests__/usePostOnboardingActionViewModel.test.ts
@@ -8,14 +8,6 @@ import { track } from "~/renderer/analytics/segment";
 const completeActionMock = jest.fn();
 const openActivationDrawerMock = jest.fn();
 
-jest.mock("~/renderer/analytics/segment", () => {
-  const actual = jest.requireActual("~/renderer/analytics/segment");
-  return {
-    ...actual,
-    track: jest.fn(),
-  };
-});
-
 jest.mock("~/renderer/components/PostOnboardingHub/logic/useCompleteAction", () => ({
   useCompleteActionCallback: () => completeActionMock,
 }));
@@ -98,6 +90,23 @@ describe("usePostOnboardingActionViewModel", () => {
         completed: true,
         deviceModelId: DeviceModelId.nanoX,
         startAction,
+      }),
+    );
+    act(() => {
+      result.current.onRowActivate();
+    });
+    expect(startAction).not.toHaveBeenCalled();
+  });
+
+  it("should not call startAction when completion comes from getIsAlreadyCompletedByState", () => {
+    const startAction = jest.fn();
+    const { result } = renderHook(() =>
+      usePostOnboardingActionViewModel({
+        ...defaultActionProps,
+        completed: false,
+        deviceModelId: DeviceModelId.nanoX,
+        startAction,
+        getIsAlreadyCompletedByState: () => true,
       }),
     );
     act(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__tests__/usePostOnboardingActionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__tests__/usePostOnboardingActionViewModel.test.ts
@@ -1,4 +1,4 @@
-import { PostOnboardingActionId, type Account } from "@ledgerhq/types-live";
+import { PostOnboardingActionId } from "@ledgerhq/types-live";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { act, renderHook } from "tests/testSetup";
 import { getLumenSymbolForActionId } from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/utils";
@@ -21,12 +21,9 @@ jest.mock("LLD/features/LedgerSyncEntryPoints/useLedgerSyncEntryPointViewModel",
 
 const requiredPostOnboardingActionProps = {
   deviceModelId: null as DeviceModelId | null,
-  isLedgerSyncActive: false,
-  accounts: [] as Account[],
   startAction: () => {},
   buttonLabelForAnalyticsEvent: "",
   shouldCompleteOnStart: false,
-  getIsAlreadyCompletedByState: () => false,
 };
 
 const defaultActionProps = {
@@ -90,23 +87,6 @@ describe("usePostOnboardingActionViewModel", () => {
         completed: true,
         deviceModelId: DeviceModelId.nanoX,
         startAction,
-      }),
-    );
-    act(() => {
-      result.current.onRowActivate();
-    });
-    expect(startAction).not.toHaveBeenCalled();
-  });
-
-  it("should not call startAction when completion comes from getIsAlreadyCompletedByState", () => {
-    const startAction = jest.fn();
-    const { result } = renderHook(() =>
-      usePostOnboardingActionViewModel({
-        ...defaultActionProps,
-        completed: false,
-        deviceModelId: DeviceModelId.nanoX,
-        startAction,
-        getIsAlreadyCompletedByState: () => true,
       }),
     );
     act(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__tests__/usePostOnboardingActionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__tests__/usePostOnboardingActionViewModel.test.ts
@@ -22,7 +22,6 @@ jest.mock("LLD/features/LedgerSyncEntryPoints/useLedgerSyncEntryPointViewModel",
 const requiredPostOnboardingActionProps = {
   deviceModelId: null as DeviceModelId | null,
   startAction: () => {},
-  buttonLabelForAnalyticsEvent: "",
   shouldCompleteOnStart: false,
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__tests__/usePostOnboardingActionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/__tests__/usePostOnboardingActionViewModel.test.ts
@@ -3,6 +3,29 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import { act, renderHook } from "tests/testSetup";
 import { getLumenSymbolForActionId } from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/utils";
 import { usePostOnboardingActionViewModel } from "LLD/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/usePostOnboardingActionViewModel";
+import { track } from "~/renderer/analytics/segment";
+
+const completeActionMock = jest.fn();
+const openActivationDrawerMock = jest.fn();
+
+jest.mock("~/renderer/analytics/segment", () => {
+  const actual = jest.requireActual("~/renderer/analytics/segment");
+  return {
+    ...actual,
+    track: jest.fn(),
+  };
+});
+
+jest.mock("~/renderer/components/PostOnboardingHub/logic/useCompleteAction", () => ({
+  useCompleteActionCallback: () => completeActionMock,
+}));
+
+jest.mock("LLD/features/LedgerSyncEntryPoints/useLedgerSyncEntryPointViewModel", () => ({
+  __esModule: true,
+  default: () => ({
+    openDrawer: openActivationDrawerMock,
+  }),
+}));
 
 const requiredPostOnboardingActionProps = {
   deviceModelId: null as DeviceModelId | null,
@@ -11,6 +34,7 @@ const requiredPostOnboardingActionProps = {
   startAction: () => {},
   buttonLabelForAnalyticsEvent: "",
   shouldCompleteOnStart: false,
+  getIsAlreadyCompletedByState: () => false,
 };
 
 const defaultActionProps = {
@@ -22,19 +46,33 @@ const defaultActionProps = {
 };
 
 describe("usePostOnboardingActionViewModel", () => {
-  it("should call onAction when onRowActivate runs and onAction is provided", () => {
-    const onAction = jest.fn();
+  beforeEach(() => {
+    completeActionMock.mockClear();
+    openActivationDrawerMock.mockClear();
+    jest.mocked(track).mockClear();
+  });
+
+  it("should call startAction with expected hub callbacks when row is activated", () => {
+    const startAction = jest.fn();
     const { result } = renderHook(() =>
       usePostOnboardingActionViewModel({
         ...defaultActionProps,
         completed: false,
-        onAction,
+        deviceModelId: DeviceModelId.nanoX,
+        startAction,
       }),
     );
     act(() => {
       result.current.onRowActivate();
     });
-    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(startAction).toHaveBeenCalledTimes(1);
+    expect(startAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceModelId: DeviceModelId.nanoX,
+        openActivationDrawer: openActivationDrawerMock,
+        protectId: expect.any(String),
+      }),
+    );
   });
 
   it("should close the finish post-onboarding dialog when onRowActivate runs", () => {
@@ -52,19 +90,57 @@ describe("usePostOnboardingActionViewModel", () => {
     expect(store.getState().dialogs.FINISH_POST_ONBOARDING).toBe(false);
   });
 
-  it("should not call onAction when completed", () => {
-    const onAction = jest.fn();
+  it("should not call startAction when completed", () => {
+    const startAction = jest.fn();
     const { result } = renderHook(() =>
       usePostOnboardingActionViewModel({
         ...defaultActionProps,
         completed: true,
-        onAction,
+        deviceModelId: DeviceModelId.nanoX,
+        startAction,
       }),
     );
     act(() => {
       result.current.onRowActivate();
     });
-    expect(onAction).not.toHaveBeenCalled();
+    expect(startAction).not.toHaveBeenCalled();
+  });
+
+  it("should complete the action when shouldCompleteOnStart is true", () => {
+    const { result } = renderHook(() =>
+      usePostOnboardingActionViewModel({
+        ...defaultActionProps,
+        completed: false,
+        deviceModelId: DeviceModelId.nanoX,
+        postOnboardingActionId: PostOnboardingActionId.syncAccounts,
+        shouldCompleteOnStart: true,
+      }),
+    );
+    act(() => {
+      result.current.onRowActivate();
+    });
+    expect(completeActionMock).toHaveBeenCalledWith(PostOnboardingActionId.syncAccounts);
+  });
+
+  it("should send analytics when button label and deviceModelId are provided", () => {
+    const { result } = renderHook(() =>
+      usePostOnboardingActionViewModel({
+        ...defaultActionProps,
+        completed: false,
+        buttonLabelForAnalyticsEvent: "cta_label",
+        deviceModelId: DeviceModelId.nanoX,
+      }),
+    );
+
+    act(() => {
+      result.current.onRowActivate();
+    });
+
+    expect(track).toHaveBeenCalledWith("button_clicked2", {
+      button: "cta_label",
+      deviceModelId: DeviceModelId.nanoX,
+      flow: "post-onboarding",
+    });
   });
 
   it("should pass through postOnboardingActionId and lumenSymbol", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/types.ts
@@ -1,5 +1,5 @@
 import { LedgerDevices } from "@ledgerhq/lumen-ui-react/symbols";
-import type { PostOnboardingActionId, Account, StartActionArgs } from "@ledgerhq/types-live";
+import type { PostOnboardingActionId, StartActionArgs } from "@ledgerhq/types-live";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { ComponentProps, ComponentType } from "react";
 
@@ -21,20 +21,14 @@ export type PostOnboardingActionI18nKeys = {
  * matches the live-common `PostOnboardingAction` model where applicable.
  */
 export type PostOnboardingActionProps = PostOnboardingActionI18nKeys & {
-  readonly accounts: Account[];
   readonly buttonLabelForAnalyticsEvent: string;
   readonly completed: boolean;
   readonly deviceModelId: DeviceModelId | null;
-  readonly isLedgerSyncActive: boolean;
   /** Lumen symbol for the list row leading visual when the action is not completed. */
   readonly lumenSymbol: FinishFlowLumenSymbol;
   readonly postOnboardingActionId: PostOnboardingActionId;
   readonly shouldCompleteOnStart: boolean;
   readonly startAction: (args: StartActionArgs) => void;
-  readonly getIsAlreadyCompletedByState: (args: {
-    isLedgerSyncActive: boolean;
-    accounts: Account[];
-  }) => boolean;
   readonly testId?: string;
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/types.ts
@@ -21,7 +21,7 @@ export type PostOnboardingActionI18nKeys = {
  * matches the live-common `PostOnboardingAction` model where applicable.
  */
 export type PostOnboardingActionProps = PostOnboardingActionI18nKeys & {
-  readonly buttonLabelForAnalyticsEvent: string;
+  readonly buttonLabelForAnalyticsEvent?: string;
   readonly completed: boolean;
   readonly deviceModelId: DeviceModelId | null;
   /** Lumen symbol for the list row leading visual when the action is not completed. */

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/types.ts
@@ -28,10 +28,13 @@ export type PostOnboardingActionProps = PostOnboardingActionI18nKeys & {
   readonly isLedgerSyncActive: boolean;
   /** Lumen symbol for the list row leading visual when the action is not completed. */
   readonly lumenSymbol: FinishFlowLumenSymbol;
-  readonly onAction?: () => void;
   readonly postOnboardingActionId: PostOnboardingActionId;
   readonly shouldCompleteOnStart: boolean;
   readonly startAction: (args: StartActionArgs) => void;
+  readonly getIsAlreadyCompletedByState: (args: {
+    isLedgerSyncActive: boolean;
+    accounts: Account[];
+  }) => boolean;
   readonly testId?: string;
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/usePostOnboardingActionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/usePostOnboardingActionViewModel.ts
@@ -24,9 +24,6 @@ export function usePostOnboardingActionViewModel(
     lumenSymbol,
     postOnboardingActionId,
     shouldCompleteOnStart,
-    getIsAlreadyCompletedByState,
-    isLedgerSyncActive,
-    accounts,
     startAction,
     testId = DEFAULT_TEST_ID,
     title,
@@ -41,10 +38,7 @@ export function usePostOnboardingActionViewModel(
     needEligibleDevice: true,
   });
 
-  const isActionCompleted = useMemo(() => {
-    const isAlreadyCompleted = getIsAlreadyCompletedByState?.({ isLedgerSyncActive, accounts });
-    return completed || !!isAlreadyCompleted;
-  }, [completed, getIsAlreadyCompletedByState, isLedgerSyncActive, accounts]);
+  const isActionCompleted = completed;
   const completeAction = useCompleteActionCallback();
 
   const handleStartAction = useCallback(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/usePostOnboardingActionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/usePostOnboardingActionViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { useDispatch } from "LLD/hooks/redux";
@@ -10,7 +10,6 @@ import { track } from "~/renderer/analytics/segment";
 import { useCompleteActionCallback } from "~/renderer/components/PostOnboardingHub/logic/useCompleteAction";
 import { AllModalNames } from "~/renderer/modals/types";
 import type { PostOnboardingActionProps, PostOnboardingActionViewProps } from "./types";
-import { DeviceModelId } from "@ledgerhq/devices";
 
 const DEFAULT_TEST_ID = "post-onboarding-action";
 
@@ -42,15 +41,10 @@ export function usePostOnboardingActionViewModel(
     needEligibleDevice: true,
   });
 
-  const [isActionCompleted, setIsActionCompleted] = useState(false);
-  const initIsActionCompleted = useCallback(async () => {
+  const isActionCompleted = useMemo(() => {
     const isAlreadyCompleted = getIsAlreadyCompletedByState?.({ isLedgerSyncActive, accounts });
-    setIsActionCompleted(completed || !!isAlreadyCompleted);
-  }, [setIsActionCompleted, completed, getIsAlreadyCompletedByState, isLedgerSyncActive, accounts]);
-
-  useEffect(() => {
-    initIsActionCompleted();
-  }, [initIsActionCompleted]);
+    return completed || !!isAlreadyCompleted;
+  }, [completed, getIsAlreadyCompletedByState, isLedgerSyncActive, accounts]);
   const completeAction = useCompleteActionCallback();
 
   const handleStartAction = useCallback(() => {
@@ -91,10 +85,10 @@ export function usePostOnboardingActionViewModel(
   ]);
 
   const onRowActivate = useCallback(() => {
-    if (completed) return;
+    if (isActionCompleted) return;
     handleStartAction();
     dispatch(closeFinishPostOnboarding());
-  }, [completed, dispatch, handleStartAction]);
+  }, [dispatch, handleStartAction, isActionCompleted]);
 
   return useMemo(
     () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/usePostOnboardingActionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/components/PostOnboardingAction/usePostOnboardingActionViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { useDispatch } from "LLD/hooks/redux";
@@ -10,6 +10,7 @@ import { track } from "~/renderer/analytics/segment";
 import { useCompleteActionCallback } from "~/renderer/components/PostOnboardingHub/logic/useCompleteAction";
 import { AllModalNames } from "~/renderer/modals/types";
 import type { PostOnboardingActionProps, PostOnboardingActionViewProps } from "./types";
+import { DeviceModelId } from "@ledgerhq/devices";
 
 const DEFAULT_TEST_ID = "post-onboarding-action";
 
@@ -22,9 +23,11 @@ export function usePostOnboardingActionViewModel(
     description,
     deviceModelId,
     lumenSymbol,
-    onAction,
     postOnboardingActionId,
     shouldCompleteOnStart,
+    getIsAlreadyCompletedByState,
+    isLedgerSyncActive,
+    accounts,
     startAction,
     testId = DEFAULT_TEST_ID,
     title,
@@ -34,12 +37,20 @@ export function usePostOnboardingActionViewModel(
   const navigate = useNavigate();
   const recoverServices = useFeature("protectServicesDesktop");
   const protectId = recoverServices?.params?.protectId ?? "protect-prod";
-
   const { openDrawer: openActivationDrawer } = useLedgerSyncEntryPointViewModel({
     entryPoint: EntryPoint.postOnboarding,
     needEligibleDevice: true,
   });
 
+  const [isActionCompleted, setIsActionCompleted] = useState(false);
+  const initIsActionCompleted = useCallback(async () => {
+    const isAlreadyCompleted = getIsAlreadyCompletedByState?.({ isLedgerSyncActive, accounts });
+    setIsActionCompleted(completed || !!isAlreadyCompleted);
+  }, [setIsActionCompleted, completed, getIsAlreadyCompletedByState, isLedgerSyncActive, accounts]);
+
+  useEffect(() => {
+    initIsActionCompleted();
+  }, [initIsActionCompleted]);
   const completeAction = useCompleteActionCallback();
 
   const handleStartAction = useCallback(() => {
@@ -49,7 +60,6 @@ export function usePostOnboardingActionViewModel(
     const navigationCallback = (location: Record<string, unknown> | string) => {
       navigate(location);
     };
-
     if (deviceModelId !== null) {
       startAction({
         openModalCallback,
@@ -66,7 +76,7 @@ export function usePostOnboardingActionViewModel(
         });
       }
     }
-    if (shouldCompleteOnStart) completeAction(postOnboardingActionId);
+    if (shouldCompleteOnStart) { completeAction(postOnboardingActionId); }
   }, [
     buttonLabelForAnalyticsEvent,
     completeAction,
@@ -82,17 +92,13 @@ export function usePostOnboardingActionViewModel(
 
   const onRowActivate = useCallback(() => {
     if (completed) return;
+    handleStartAction();
     dispatch(closeFinishPostOnboarding());
-    if (onAction) {
-      onAction();
-    } else {
-      handleStartAction();
-    }
-  }, [completed, dispatch, onAction, handleStartAction]);
+  }, [completed, dispatch, handleStartAction]);
 
   return useMemo(
     () => ({
-      completed,
+      completed: isActionCompleted,
       description,
       lumenSymbol,
       onRowActivate,
@@ -101,7 +107,7 @@ export function usePostOnboardingActionViewModel(
       title,
     }),
     [
-      completed,
+      isActionCompleted,
       description,
       lumenSymbol,
       onRowActivate,

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/__tests__/useFinishOnboardingDialogViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/__tests__/useFinishOnboardingDialogViewModel.test.ts
@@ -5,6 +5,7 @@ import { PostOnboardingActionId, type PostOnboardingHubState } from "@ledgerhq/t
 import i18n from "~/renderer/i18n/init";
 import { getLumenSymbolForActionId } from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/utils";
 import useFinishOnboardingDialogViewModel from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialogViewModel";
+import { track } from "~/renderer/analytics/segment";
 
 jest.mock("@ledgerhq/live-common/postOnboarding/hooks/index");
 
@@ -129,6 +130,11 @@ describe("useFinishOnboardingDialogViewModel", () => {
     });
 
     expect(store.getState().dialogs.FINISH_POST_ONBOARDING).toBe(false);
+    expect(jest.mocked(track)).toHaveBeenCalledWith("button_clicked2", {
+      button: "Close",
+      deviceModelId: DeviceModelId.nanoX,
+      flow: "post-onboarding",
+    });
   });
 
   it("should close the dialog and dismiss the post-onboarding wallet entry point when onGotIt runs", () => {
@@ -142,5 +148,10 @@ describe("useFinishOnboardingDialogViewModel", () => {
 
     expect(store.getState().dialogs.FINISH_POST_ONBOARDING).toBe(false);
     expect(store.getState().postOnboarding.walletEntryPointDismissed).toBe(true);
+    expect(jest.mocked(track)).toHaveBeenCalledWith("button_clicked2", {
+      button: "Got it",
+      deviceModelId: DeviceModelId.nanoX,
+      flow: "post-onboarding",
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/__tests__/usePostOnboardingFinishProgress.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/__tests__/usePostOnboardingFinishProgress.test.ts
@@ -1,5 +1,9 @@
 import { renderHook } from "tests/testSetup";
-import { PostOnboardingActionId, type PostOnboardingHubState, type StartActionArgs } from "@ledgerhq/types-live";
+import {
+  PostOnboardingActionId,
+  type PostOnboardingHubState,
+  type StartActionArgs,
+} from "@ledgerhq/types-live";
 import { usePostOnboardingFinishProgress } from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/usePostOnboardingFinishProgress";
 import {
   type FinishPostOnboardingListItem,

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialogViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialogViewModel.ts
@@ -7,6 +7,7 @@ import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { Account, type StartActionArgs } from "@ledgerhq/types-live";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { accountsSelector } from "~/renderer/reducers/accounts";
+import { track } from "~/renderer/analytics/segment";
 import {
   closeFinishPostOnboarding,
   selectIsFinishPostOnboardingOpen,
@@ -61,13 +62,23 @@ export default function useFinishOnboardingDialogViewModel(): FinishOnboardingDi
     usePostOnboardingFinishProgress(actionsState);
 
   const onGotIt = useCallback(() => {
+    track("button_clicked2", {
+      button: "Got it",
+      deviceModelId,
+      flow: "post-onboarding",
+    });
     dispatch(closeFinishPostOnboarding());
     dispatch(hidePostOnboardingWalletEntryPoint());
-  }, [dispatch]);
+  }, [deviceModelId, dispatch]);
 
   const onClose = useCallback(() => {
+    track("button_clicked2", {
+      button: "Close",
+      deviceModelId,
+      flow: "post-onboarding",
+    });
     dispatch(closeFinishPostOnboarding());
-  }, [dispatch]);
+  }, [deviceModelId, dispatch]);
 
   return useMemo(
     () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialogViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialogViewModel.ts
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { hidePostOnboardingWalletEntryPoint } from "@ledgerhq/live-common/postOnboarding/actions";
 import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
-import { Account, type StartActionArgs } from "@ledgerhq/types-live";
+import { type StartActionArgs } from "@ledgerhq/types-live";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { track } from "~/renderer/analytics/segment";
@@ -26,7 +26,6 @@ export type FinishOnboardingDialogAction = Omit<FinishPostOnboardingListItem, "s
 export interface FinishOnboardingDialogViewProps {
   /** True when every listed post-onboarding action (excl. device row) is completed. */
   readonly allActionsCompleted: boolean;
-  readonly accounts: Account[];
   /**
    * Rows from {@link usePostOnboardingFinishProgress} with `startAction` resolved for the dialog
    * (see {@link resolveFinishPostOnboardingStartAction} in `./utils`).
@@ -37,7 +36,6 @@ export interface FinishOnboardingDialogViewProps {
   /** From the hook: `actionList`.length + 1 (same implicit device step in the stepper). */
   readonly totalActionsAmount: number;
   readonly deviceModelId: DeviceModelId | null;
-  readonly isLedgerSyncActive: boolean;
   readonly isOpen: boolean;
   readonly onClose: () => void;
   readonly onGotIt: () => void;
@@ -83,16 +81,20 @@ export default function useFinishOnboardingDialogViewModel(): FinishOnboardingDi
   return useMemo(
     () => ({
       allActionsCompleted,
-      accounts,
       actions: actionList.map(
         (item): FinishOnboardingDialogAction => ({
           ...item,
+          completed:
+            item.completed ||
+            !!item.getIsAlreadyCompletedByState?.({
+              isLedgerSyncActive,
+              accounts,
+            }),
           startAction: resolveFinishPostOnboardingStartAction(item),
         }),
       ),
       completedActionsAmount,
       deviceModelId,
-      isLedgerSyncActive,
       isOpen: isDialogOpen,
       onClose,
       onGotIt,
@@ -107,10 +109,10 @@ export default function useFinishOnboardingDialogViewModel(): FinishOnboardingDi
       deviceModelId,
       actionList,
       isDialogOpen,
-      isLedgerSyncActive,
       onClose,
       onGotIt,
       t,
+      isLedgerSyncActive,
       totalActionsAmount,
     ],
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/usePostOnboardingFinishProgress.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/usePostOnboardingFinishProgress.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { type PostOnboardingAction, type PostOnboardingActionState } from "@ledgerhq/types-live";
 import {
   EXCLUDED_FROM_FINISH_FLOW_ID,
@@ -19,13 +19,14 @@ import {
 export function usePostOnboardingFinishProgress(
   actionsState: (PostOnboardingAction & PostOnboardingActionState)[],
 ) {
-  const { allActionsCompleted, completedActionsAmount, actionList, totalActionsAmount } = useMemo(
-    () => {
+  const { allActionsCompleted, completedActionsAmount, actionList, totalActionsAmount } =
+    useMemo(() => {
       // 1. Drop buyCrypto. 2. Map to view-ready list items (see ./utils).
       // Stepper values add IMPLICIT_DEVICE_STEP_OFFSET for the view’s first hardcoded device row.
       const actionList: FinishPostOnboardingListItem[] = actionsState
         .filter(action => action.id !== EXCLUDED_FROM_FINISH_FLOW_ID)
         .map(toFinishPostOnboardingListItem);
+
       const completedInList = actionList.filter(a => a.completed).length;
       const totalInList = actionList.length;
 
@@ -37,9 +38,7 @@ export function usePostOnboardingFinishProgress(
         actionList,
         totalActionsAmount: totalInList + IMPLICIT_DEVICE_STEP_OFFSET,
       };
-    },
-    [actionsState],
-  );
+    }, [actionsState]);
 
   return {
     allActionsCompleted,

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/usePostOnboardingFinishProgress.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/usePostOnboardingFinishProgress.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { type PostOnboardingAction, type PostOnboardingActionState } from "@ledgerhq/types-live";
 import {
   EXCLUDED_FROM_FINISH_FLOW_ID,

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingWidget/FinishOnboardingWidgetView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingWidget/FinishOnboardingWidgetView.tsx
@@ -26,7 +26,7 @@ const FinishOnboardingWidgetView = memo(function FinishOnboardingWidgetView({
       type="button"
       data-testid="finish-onboarding-widget"
       onClick={handleOpenFinishOnboardingDialog}
-      className="cursor-pointer border-none bg-transparent p-0 text-left w-1/2"
+      className="min-w-0 cursor-pointer border-none bg-transparent p-0 text-left w-1/2"
     >
       <ContentBanner>
         <Stepper


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Finish onboarding dialog completion flow
  - Post-onboarding action completion detection
  - Analytics tracking triggered when onboarding actions complete

### 📝 Description

This PR fixes completion detection for finish onboarding actions. The previous flow could rely on stale or static completion state, which made the UI and tracking less reliable when an action became completed after the dialog was already mounted.

The solution moves completion checks into the dialog and post-onboarding view models so they can evaluate the latest app state when an action finishes. It also updates the related hooks, view props, and tests to cover the completion path and avoid double-running the finish flow.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26395](https://ledgerhq.atlassian.net/browse/LIVE-26395)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29481]: https://ledgerhq.atlassian.net/browse/LIVE-29481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-26395]: https://ledgerhq.atlassian.net/browse/LIVE-26395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ