### PR TITLE
[LWD] Recover widget in post onboarding

### DIFF
--- a/.changeset/nasty-trees-care.md
+++ b/.changeset/nasty-trees-care.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add Recover Widget

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/RecoverWidgetView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/RecoverWidgetView.tsx
@@ -1,0 +1,49 @@
+import React, { memo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  ContentBanner,
+  ContentBannerContent,
+  ContentBannerDescription,
+  ContentBannerTitle,
+  Spot,
+} from "@ledgerhq/lumen-ui-react";
+import type { RecoverWidgetViewProps } from "./useRecoverWidgetViewModel";
+import { ShieldCheck } from "@ledgerhq/lumen-ui-react/symbols";
+
+// TODO: I did not find a way to change the Spot appearance color
+const WARNING_SPOT_STYLE = {
+  backgroundColor: "#FFBD4226",
+  color: "#FFD373",
+} as const;
+
+const RecoverWidgetView = memo(function RecoverWidgetView({
+  isVisible,
+  titleKey,
+  descriptionKey,
+  onOpenRecover,
+}: RecoverWidgetViewProps) {
+  const { t } = useTranslation();
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid="recover-finish-onboarding-widget"
+      onClick={onOpenRecover}
+      className="min-w-0 w-1/2 cursor-pointer border-none bg-transparent p-0 text-left"
+    >
+      <ContentBanner>
+        <Spot appearance="icon" icon={ShieldCheck} size={48} style={WARNING_SPOT_STYLE} />
+        <ContentBannerContent>
+          <ContentBannerTitle>{t(titleKey)}</ContentBannerTitle>
+          <ContentBannerDescription>{t(descriptionKey)}</ContentBannerDescription>
+        </ContentBannerContent>
+      </ContentBanner>
+    </button>
+  );
+});
+
+export default RecoverWidgetView;

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/RecoverWidgetView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/RecoverWidgetView.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ContentBanner,
@@ -9,12 +9,7 @@ import {
 } from "@ledgerhq/lumen-ui-react";
 import type { RecoverWidgetViewProps } from "./useRecoverWidgetViewModel";
 import { ShieldCheck } from "@ledgerhq/lumen-ui-react/symbols";
-
-// TODO: I did not find a way to change the Spot appearance color
-const WARNING_SPOT_STYLE = {
-  backgroundColor: "#FFBD4226",
-  color: "#FFD373",
-} as const;
+import useTheme from "~/renderer/hooks/useTheme";
 
 const RecoverWidgetView = memo(function RecoverWidgetView({
   isVisible,
@@ -23,6 +18,14 @@ const RecoverWidgetView = memo(function RecoverWidgetView({
   onOpenRecover,
 }: RecoverWidgetViewProps) {
   const { t } = useTranslation();
+  const { colors } = useTheme();
+  const warningSpotStyle = useMemo(
+    () => ({
+      backgroundColor: colors.warning.c10,
+      color: colors.warning.c70,
+    }),
+    [colors],
+  );
 
   if (!isVisible) {
     return null;
@@ -36,7 +39,7 @@ const RecoverWidgetView = memo(function RecoverWidgetView({
       className="min-w-0 w-1/2 cursor-pointer border-none bg-transparent p-0 text-left"
     >
       <ContentBanner>
-        <Spot appearance="icon" icon={ShieldCheck} size={48} style={WARNING_SPOT_STYLE} />
+        <Spot appearance="icon" icon={ShieldCheck} size={48} style={warningSpotStyle} />
         <ContentBannerContent>
           <ContentBannerTitle>{t(titleKey)}</ContentBannerTitle>
           <ContentBannerDescription>{t(descriptionKey)}</ContentBannerDescription>

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
@@ -1,0 +1,110 @@
+/** Real `electron-store` is not usable in Jest. */
+jest.mock("~/renderer/store", () => ({
+  getStoreValue: jest.fn(),
+  setStoreValue: jest.fn(),
+  resetStore: jest.fn(),
+}));
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(),
+}));
+jest.mock("@ledgerhq/live-common/hooks/recoverFeatureFlag", () => ({
+  useUpsellPath: jest.fn(),
+}));
+jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/featureFlags/index"),
+  useFeature: jest.fn(),
+}));
+
+import React from "react";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { PostOnboardingActionId, type PostOnboardingState } from "@ledgerhq/types-live";
+import { initialState as postOnboardingInitialState } from "@ledgerhq/live-common/postOnboarding/reducer";
+import { render, screen, waitFor } from "tests/testSetup";
+import { useNavigate } from "react-router";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { getStoreValue } from "~/renderer/store";
+import PostOnboardingProviderWrapped from "~/renderer/components/PostOnboardingHub/logic/PostOnboardingProviderWrapped";
+import dbMiddleware from "~/renderer/middlewares/db";
+import type { State } from "~/renderer/reducers";
+import createStore from "~/state-manager/configureStore";
+import RecoverWidget from "LLD/features/FinishOnboarding/RecoverWidget";
+
+const mockNavigate = jest.fn();
+const mockUseNavigate = jest.mocked(useNavigate);
+const mockUseFeature = jest.mocked(useFeature);
+const mockUseUpsellPath = jest.mocked(useUpsellPath);
+const mockGetStoreValue = jest.mocked(getStoreValue);
+
+function postOnboardingActive(
+  deviceModelId: DeviceModelId = DeviceModelId.stax,
+): PostOnboardingState {
+  return {
+    ...postOnboardingInitialState,
+    deviceModelId,
+    walletEntryPointDismissed: false,
+    entryPointFirstDisplayedDate: new Date("2024-06-01"),
+    walletEntryPointEligibleForPortfolio: true,
+    actionsToComplete: [PostOnboardingActionId.syncAccounts],
+    actionsCompleted: { [PostOnboardingActionId.syncAccounts]: false },
+    lastActionCompleted: null,
+    postOnboardingInProgress: true,
+  };
+}
+
+function renderWithProvider(postOnboarding: PostOnboardingState) {
+  const store = createStore({
+    state: { postOnboarding } as State,
+    dbMiddleware,
+  });
+  return render(
+    <PostOnboardingProviderWrapped>
+      <RecoverWidget />
+    </PostOnboardingProviderWrapped>,
+    { store },
+  );
+}
+
+describe("RecoverWidget integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+    mockUseUpsellPath.mockReturnValue("/protect/upsell");
+    mockGetStoreValue.mockImplementation(async () => "NO_SUBSCRIPTION");
+    mockUseFeature.mockImplementation((id: string) =>
+      id === "protectServicesDesktop"
+        ? {
+            enabled: true,
+            params: {
+              protectId: "protect-prod",
+              compatibleDevices: [{ name: DeviceModelId.stax, available: true }],
+            },
+          }
+        : null,
+    ) as unknown as typeof useFeature;
+  });
+
+  it("renders the recover CTA and navigates to the upsell when clicked", async () => {
+    const { user } = renderWithProvider(postOnboardingActive());
+
+    const button = await screen.findByRole("button", {
+      name: /Finish securing your backup/i,
+    });
+    expect(button).toBeInTheDocument();
+
+    await user.click(button);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/protect/upsell");
+  });
+
+  it("renders nothing for the recover widget when the upsell is unavailable", async () => {
+    mockUseUpsellPath.mockReturnValue(undefined);
+    const { container } = renderWithProvider(postOnboardingActive());
+    await waitFor(() => {
+      expect(mockGetStoreValue).toHaveBeenCalled();
+    });
+    expect(container.querySelector('[data-testid="recover-finish-onboarding-widget"]')).toBeNull();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
@@ -1,3 +1,19 @@
+import React from "react";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { PostOnboardingActionId, type PostOnboardingState } from "@ledgerhq/types-live";
+import { initialState as postOnboardingInitialState } from "@ledgerhq/live-common/postOnboarding/reducer";
+import { render, screen, waitFor } from "tests/testSetup";
+import { useNavigate } from "react-router";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { getStoreValue } from "~/renderer/store";
+import PostOnboardingProviderWrapped from "~/renderer/components/PostOnboardingHub/logic/PostOnboardingProviderWrapped";
+import dbMiddleware from "~/renderer/middlewares/db";
+import type { State } from "~/renderer/reducers";
+import createStore from "~/state-manager/configureStore";
+import RecoverWidget from "LLD/features/FinishOnboarding/RecoverWidget";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+
 /** Real `electron-store` is not usable in Jest. */
 jest.mock("~/renderer/store", () => ({
   getStoreValue: jest.fn(),
@@ -16,22 +32,6 @@ jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
   ...jest.requireActual("@ledgerhq/live-common/featureFlags/index"),
   useFeature: jest.fn(),
 }));
-
-import React from "react";
-import { DeviceModelId } from "@ledgerhq/types-devices";
-import { PostOnboardingActionId, type PostOnboardingState } from "@ledgerhq/types-live";
-import { initialState as postOnboardingInitialState } from "@ledgerhq/live-common/postOnboarding/reducer";
-import { render, screen, waitFor } from "tests/testSetup";
-import { useNavigate } from "react-router";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
-import { getStoreValue } from "~/renderer/store";
-import PostOnboardingProviderWrapped from "~/renderer/components/PostOnboardingHub/logic/PostOnboardingProviderWrapped";
-import dbMiddleware from "~/renderer/middlewares/db";
-import type { State } from "~/renderer/reducers";
-import createStore from "~/state-manager/configureStore";
-import RecoverWidget from "LLD/features/FinishOnboarding/RecoverWidget";
-import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 
 const mockNavigate = jest.fn();
 const mockUseNavigate = jest.mocked(useNavigate);

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
@@ -31,6 +31,7 @@ import dbMiddleware from "~/renderer/middlewares/db";
 import type { State } from "~/renderer/reducers";
 import createStore from "~/state-manager/configureStore";
 import RecoverWidget from "LLD/features/FinishOnboarding/RecoverWidget";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 
 const mockNavigate = jest.fn();
 const mockUseNavigate = jest.mocked(useNavigate);
@@ -72,7 +73,7 @@ describe("RecoverWidget integration", () => {
     jest.clearAllMocks();
     mockUseNavigate.mockReturnValue(mockNavigate);
     mockUseUpsellPath.mockReturnValue("/protect/upsell");
-    mockGetStoreValue.mockReturnValue("NO_SUBSCRIPTION");
+    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE);
     mockUseFeature.mockImplementation((id: string) =>
       id === "protectServicesDesktop"
         ? {
@@ -101,6 +102,15 @@ describe("RecoverWidget integration", () => {
 
   it("renders nothing for the recover widget when the upsell is unavailable", async () => {
     mockUseUpsellPath.mockReturnValue(undefined);
+    const { container } = renderWithProvider(postOnboardingActive());
+    await waitFor(() => {
+      expect(mockGetStoreValue).toHaveBeenCalled();
+    });
+    expect(container.querySelector('[data-testid="recover-finish-onboarding-widget"]')).toBeNull();
+  });
+
+  it("renders nothing when recover was never started (NO_SUBSCRIPTION)", async () => {
+    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION);
     const { container } = renderWithProvider(postOnboardingActive());
     await waitFor(() => {
       expect(mockGetStoreValue).toHaveBeenCalled();

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
@@ -72,7 +72,7 @@ describe("RecoverWidget integration", () => {
     jest.clearAllMocks();
     mockUseNavigate.mockReturnValue(mockNavigate);
     mockUseUpsellPath.mockReturnValue("/protect/upsell");
-    mockGetStoreValue.mockImplementation(async () => "NO_SUBSCRIPTION");
+    mockGetStoreValue.mockReturnValue("NO_SUBSCRIPTION");
     mockUseFeature.mockImplementation((id: string) =>
       id === "protectServicesDesktop"
         ? {

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx
@@ -1,11 +1,10 @@
 import React from "react";
+import { Route, Routes } from "react-router";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { PostOnboardingActionId, type PostOnboardingState } from "@ledgerhq/types-live";
+import { DEFAULT_FEATURES } from "@ledgerhq/live-common/featureFlags/defaultFeatures";
 import { initialState as postOnboardingInitialState } from "@ledgerhq/live-common/postOnboarding/reducer";
-import { render, screen, waitFor } from "tests/testSetup";
-import { useNavigate } from "react-router";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { render, screen, waitFor, withFlagOverrides } from "tests/testSetup";
 import { getStoreValue } from "~/renderer/store";
 import PostOnboardingProviderWrapped from "~/renderer/components/PostOnboardingHub/logic/PostOnboardingProviderWrapped";
 import dbMiddleware from "~/renderer/middlewares/db";
@@ -21,23 +20,29 @@ jest.mock("~/renderer/store", () => ({
   resetStore: jest.fn(),
 }));
 
-jest.mock("react-router", () => ({
-  ...jest.requireActual("react-router"),
-  useNavigate: jest.fn(),
-}));
-jest.mock("@ledgerhq/live-common/hooks/recoverFeatureFlag", () => ({
-  useUpsellPath: jest.fn(),
-}));
-jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
-  ...jest.requireActual("@ledgerhq/live-common/featureFlags/index"),
-  useFeature: jest.fn(),
-}));
-
-const mockNavigate = jest.fn();
-const mockUseNavigate = jest.mocked(useNavigate);
-const mockUseFeature = jest.mocked(useFeature);
-const mockUseUpsellPath = jest.mocked(useUpsellPath);
 const mockGetStoreValue = jest.mocked(getStoreValue);
+
+/** Must match `useUpsellPath`: `ledgerlive://…` → same path with `/` prefix. */
+const RECOVER_UPSELL_PATH = "/protect/upsell";
+const RECOVER_UPSELL_LEDGER_LIVE_URI = "ledgerlive://protect/upsell";
+
+const protectDesktopDefaultParams = DEFAULT_FEATURES.protectServicesDesktop.params!;
+
+const protectServicesForStax = (onboardingUpsellUri: string) =>
+  withFlagOverrides({
+    protectServicesDesktop: {
+      enabled: true,
+      params: {
+        ...protectDesktopDefaultParams,
+        protectId: "protect-prod",
+        compatibleDevices: [{ name: DeviceModelId.stax, available: true, comingSoon: false }],
+        onboardingCompleted: {
+          ...protectDesktopDefaultParams.onboardingCompleted,
+          upsellURI: onboardingUpsellUri,
+        },
+      },
+    },
+  });
 
 function postOnboardingActive(
   deviceModelId: DeviceModelId = DeviceModelId.stax,
@@ -55,40 +60,44 @@ function postOnboardingActive(
   };
 }
 
-function renderWithProvider(postOnboarding: PostOnboardingState) {
+function renderWithProvider(postOnboarding: PostOnboardingState, featureFlagSlice: ReturnType<typeof withFlagOverrides>) {
   const store = createStore({
-    state: { postOnboarding } as State,
+    state: {
+      postOnboarding,
+      ...featureFlagSlice,
+    } as State,
     dbMiddleware,
   });
   return render(
-    <PostOnboardingProviderWrapped>
-      <RecoverWidget />
-    </PostOnboardingProviderWrapped>,
-    { store },
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <PostOnboardingProviderWrapped>
+            <RecoverWidget />
+          </PostOnboardingProviderWrapped>
+        }
+      />
+      <Route
+        path={RECOVER_UPSELL_PATH}
+        element={<div data-testid="recover-upsell-screen">Recover upsell</div>}
+      />
+    </Routes>,
+    { store, initialRoute: "/" },
   );
 }
 
 describe("RecoverWidget integration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-    mockUseUpsellPath.mockReturnValue("/protect/upsell");
     mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE);
-    mockUseFeature.mockImplementation((id: string) =>
-      id === "protectServicesDesktop"
-        ? {
-            enabled: true,
-            params: {
-              protectId: "protect-prod",
-              compatibleDevices: [{ name: DeviceModelId.stax, available: true }],
-            },
-          }
-        : null,
-    ) as unknown as typeof useFeature;
   });
 
   it("renders the recover CTA and navigates to the upsell when clicked", async () => {
-    const { user } = renderWithProvider(postOnboardingActive());
+    const { user } = renderWithProvider(
+      postOnboardingActive(),
+      protectServicesForStax(RECOVER_UPSELL_LEDGER_LIVE_URI),
+    );
 
     const button = await screen.findByRole("button", {
       name: /Finish securing your backup/i,
@@ -97,24 +106,27 @@ describe("RecoverWidget integration", () => {
 
     await user.click(button);
 
-    expect(mockNavigate).toHaveBeenCalledWith("/protect/upsell");
+    expect(await screen.findByTestId("recover-upsell-screen")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Finish securing your backup/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders nothing for the recover widget when the upsell is unavailable", async () => {
-    mockUseUpsellPath.mockReturnValue(undefined);
-    const { container } = renderWithProvider(postOnboardingActive());
+    renderWithProvider(postOnboardingActive(), protectServicesForStax(""));
     await waitFor(() => {
-      expect(mockGetStoreValue).toHaveBeenCalled();
+      expect(screen.queryByTestId("recover-finish-onboarding-widget")).not.toBeInTheDocument();
     });
-    expect(container.querySelector('[data-testid="recover-finish-onboarding-widget"]')).toBeNull();
   });
 
   it("renders nothing when recover was never started (NO_SUBSCRIPTION)", async () => {
     mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION);
-    const { container } = renderWithProvider(postOnboardingActive());
+    renderWithProvider(
+      postOnboardingActive(),
+      protectServicesForStax(RECOVER_UPSELL_LEDGER_LIVE_URI),
+    );
     await waitFor(() => {
-      expect(mockGetStoreValue).toHaveBeenCalled();
+      expect(screen.queryByTestId("recover-finish-onboarding-widget")).not.toBeInTheDocument();
     });
-    expect(container.querySelector('[data-testid="recover-finish-onboarding-widget"]')).toBeNull();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/recoverPortfolioWidgetVisibility.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/recoverPortfolioWidgetVisibility.test.ts
@@ -1,0 +1,43 @@
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+import {
+  hasStartedLedgerRecoverFlowForPostOnboarding,
+  shouldShowRecoverPortfolioWidget,
+} from "../recoverPortfolioWidgetVisibility";
+
+describe("recoverPortfolioWidgetVisibility", () => {
+  describe("hasStartedLedgerRecoverFlowForPostOnboarding (parity with LLM checkCanShow)", () => {
+    it.each<
+      Readonly<{
+        state: LedgerRecoverSubscriptionStateEnum | undefined;
+        expected: boolean;
+      }>
+    >([
+      { state: undefined, expected: false },
+      { state: LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION, expected: false },
+      { state: LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE, expected: true },
+      { state: LedgerRecoverSubscriptionStateEnum.BACKUP_VERIFY_IDENTITY, expected: true },
+      { state: LedgerRecoverSubscriptionStateEnum.BACKUP_DEVICE_CONNECTION, expected: true },
+      { state: LedgerRecoverSubscriptionStateEnum.BACKUP_DONE, expected: true },
+    ])("returns $expected when state is $state", ({ state, expected }) => {
+      expect(hasStartedLedgerRecoverFlowForPostOnboarding(state)).toBe(expected);
+    });
+  });
+
+  describe("shouldShowRecoverPortfolioWidget", () => {
+    it.each<
+      Readonly<{
+        state: LedgerRecoverSubscriptionStateEnum | undefined;
+        expected: boolean;
+      }>
+    >([
+      { state: undefined, expected: false },
+      { state: LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION, expected: false },
+      { state: LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE, expected: true },
+      { state: LedgerRecoverSubscriptionStateEnum.BACKUP_VERIFY_IDENTITY, expected: true },
+      { state: LedgerRecoverSubscriptionStateEnum.BACKUP_DEVICE_CONNECTION, expected: true },
+      { state: LedgerRecoverSubscriptionStateEnum.BACKUP_DONE, expected: false },
+    ])("returns $expected when state is $state", ({ state, expected }) => {
+      expect(shouldShowRecoverPortfolioWidget(state)).toBe(expected);
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
@@ -1,0 +1,139 @@
+/** Real `electron-store` is not usable in Jest; keep persistence at the boundary. */
+jest.mock("~/renderer/store", () => ({
+  getStoreValue: jest.fn(),
+  setStoreValue: jest.fn(),
+  resetStore: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/postOnboarding/hooks/index");
+jest.mock("@ledgerhq/live-common/featureFlags/index");
+jest.mock("@ledgerhq/live-common/hooks/recoverFeatureFlag", () => ({
+  useUpsellPath: jest.fn(),
+}));
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(),
+}));
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: jest.fn(),
+  setAnalyticsFeatureFlagMethod: jest.fn(),
+}));
+
+import { act, renderHook, waitFor } from "tests/testSetup";
+import { useNavigate } from "react-router";
+import { track } from "~/renderer/analytics/segment";
+import { getStoreValue } from "~/renderer/store";
+import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { isRecoverDisplayed, useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { useRecoverWidgetViewModel } from "LLD/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+
+const mockNavigate = jest.fn();
+const mockUseNavigate = jest.mocked(useNavigate);
+const mockUsePostOnboardingHubState = jest.mocked(usePostOnboardingHubState);
+const mockUseFeature = jest.mocked(useFeature);
+const mockGetStoreValue = jest.mocked(getStoreValue);
+const mockIsRecoverDisplayed = jest.mocked(isRecoverDisplayed);
+const mockUseUpsellPath = jest.mocked(useUpsellPath);
+const recoverFeature = {
+  enabled: true,
+  params: {
+    protectId: "protect-prod",
+    compatibleDevices: [{ name: DeviceModelId.stax, available: true }],
+  },
+};
+
+function setHub(overrides: {
+  postOnboardingInProgress?: boolean;
+  deviceModelId?: DeviceModelId | null;
+}) {
+  mockUsePostOnboardingHubState.mockReturnValue({
+    lastActionCompleted: null,
+    actionsState: [],
+    postOnboardingInProgress: overrides.postOnboardingInProgress ?? true,
+    deviceModelId: overrides.deviceModelId ?? DeviceModelId.stax,
+  });
+}
+
+describe("useRecoverWidgetViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+    mockUseFeature.mockReturnValue(recoverFeature);
+    mockUseUpsellPath.mockReturnValue("/protect/upsell");
+    mockIsRecoverDisplayed.mockReturnValue(true);
+    setHub({});
+
+    mockGetStoreValue.mockImplementation(
+      async () => LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
+    );
+  });
+
+  it("returns isVisible true after subscription loads when the recover offer is available", async () => {
+    const { result } = renderHook(() => useRecoverWidgetViewModel());
+
+    await waitFor(() => {
+      expect(result.current.isVisible).toBe(true);
+    });
+  });
+
+  it("returns isVisible false when post-onboarding is not in progress", async () => {
+    setHub({ postOnboardingInProgress: false });
+    const { result } = renderHook(() => useRecoverWidgetViewModel());
+
+    await waitFor(() => {
+      expect(mockGetStoreValue).toHaveBeenCalled();
+    });
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("returns isVisible false when recover is not offered for this device", async () => {
+    mockIsRecoverDisplayed.mockReturnValue(false);
+    const { result } = renderHook(() => useRecoverWidgetViewModel());
+
+    await waitFor(() => {
+      expect(mockGetStoreValue).toHaveBeenCalled();
+    });
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("returns isVisible false when backup is already done", async () => {
+    mockGetStoreValue.mockImplementation(
+      async () => LedgerRecoverSubscriptionStateEnum.BACKUP_DONE,
+    );
+    const { result } = renderHook(() => useRecoverWidgetViewModel());
+
+    await waitFor(() => {
+      expect(result.current.isVisible).toBe(false);
+    });
+  });
+
+  it("returns isVisible false when there is no upsell path", async () => {
+    mockUseUpsellPath.mockReturnValue(undefined);
+    const { result } = renderHook(() => useRecoverWidgetViewModel());
+
+    await waitFor(() => {
+      expect(mockGetStoreValue).toHaveBeenCalled();
+    });
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("navigates to the upsell path and tracks when the CTA is used", async () => {
+    const { result } = renderHook(() => useRecoverWidgetViewModel());
+    await waitFor(() => {
+      expect(result.current.isVisible).toBe(true);
+    });
+
+    act(() => {
+      result.current.onOpenRecover();
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/protect/upsell");
+    expect(jest.mocked(track)).toHaveBeenCalledWith("button_clicked", {
+      deviceModelId: DeviceModelId.stax,
+      button: "Post onboarding recover widget",
+      flow: "post-onboarding",
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
@@ -14,10 +14,6 @@ jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
   useNavigate: jest.fn(),
 }));
-jest.mock("~/renderer/analytics/segment", () => ({
-  track: jest.fn(),
-  setAnalyticsFeatureFlagMethod: jest.fn(),
-}));
 
 import { act, renderHook, waitFor } from "tests/testSetup";
 import { useNavigate } from "react-router";
@@ -66,9 +62,7 @@ describe("useRecoverWidgetViewModel", () => {
     mockIsRecoverDisplayed.mockReturnValue(true);
     setHub({});
 
-    mockGetStoreValue.mockImplementation(
-      async () => LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
-    );
+    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION);
   });
 
   it("returns isVisible true after subscription loads when the recover offer is available", async () => {
@@ -100,9 +94,7 @@ describe("useRecoverWidgetViewModel", () => {
   });
 
   it("returns isVisible false when backup is already done", async () => {
-    mockGetStoreValue.mockImplementation(
-      async () => LedgerRecoverSubscriptionStateEnum.BACKUP_DONE,
-    );
+    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.BACKUP_DONE);
     const { result } = renderHook(() => useRecoverWidgetViewModel());
 
     await waitFor(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
@@ -1,3 +1,14 @@
+import { act, renderHook, waitFor } from "tests/testSetup";
+import { useNavigate } from "react-router";
+import { track } from "~/renderer/analytics/segment";
+import { getStoreValue } from "~/renderer/store";
+import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { isRecoverDisplayed, useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { useRecoverWidgetViewModel } from "LLD/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+
 /** Real `electron-store` is not usable in Jest; keep persistence at the boundary. */
 jest.mock("~/renderer/store", () => ({
   getStoreValue: jest.fn(),
@@ -14,17 +25,6 @@ jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
   useNavigate: jest.fn(),
 }));
-
-import { act, renderHook, waitFor } from "tests/testSetup";
-import { useNavigate } from "react-router";
-import { track } from "~/renderer/analytics/segment";
-import { getStoreValue } from "~/renderer/store";
-import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
-import { isRecoverDisplayed, useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
-import { DeviceModelId } from "@ledgerhq/types-devices";
-import { useRecoverWidgetViewModel } from "LLD/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel";
-import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 
 const mockNavigate = jest.fn();
 const mockUseNavigate = jest.mocked(useNavigate);
@@ -93,14 +93,14 @@ describe("useRecoverWidgetViewModel", () => {
     expect(result.current.isVisible).toBe(false);
   });
 
-  it("returns isVisible false when post-onboarding is not in progress", async () => {
+  it("returns isVisible true when post-onboarding hub is not in progress but recover criteria are met", async () => {
     setHub({ postOnboardingInProgress: false });
     const { result } = renderHook(() => useRecoverWidgetViewModel());
 
     await waitFor(() => {
       expect(mockGetStoreValue).toHaveBeenCalled();
     });
-    expect(result.current.isVisible).toBe(false);
+    expect(result.current.isVisible).toBe(true);
   });
 
   it("returns isVisible false when recover is not offered for this device", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts
@@ -62,15 +62,35 @@ describe("useRecoverWidgetViewModel", () => {
     mockIsRecoverDisplayed.mockReturnValue(true);
     setHub({});
 
-    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION);
+    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.STARGATE_SUBSCRIBE);
   });
 
-  it("returns isVisible true after subscription loads when the recover offer is available", async () => {
+  it("returns isVisible true when recover flow is in progress and the offer is available", async () => {
     const { result } = renderHook(() => useRecoverWidgetViewModel());
 
     await waitFor(() => {
       expect(result.current.isVisible).toBe(true);
     });
+  });
+
+  it("returns isVisible false when subscription is NO_SUBSCRIPTION (never started recover)", async () => {
+    mockGetStoreValue.mockReturnValue(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION);
+    const { result } = renderHook(() => useRecoverWidgetViewModel());
+
+    await waitFor(() => {
+      expect(mockGetStoreValue).toHaveBeenCalled();
+    });
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("returns isVisible false when subscription state is undefined", async () => {
+    mockGetStoreValue.mockReturnValue(undefined);
+    const { result } = renderHook(() => useRecoverWidgetViewModel());
+
+    await waitFor(() => {
+      expect(mockGetStoreValue).toHaveBeenCalled();
+    });
+    expect(result.current.isVisible).toBe(false);
   });
 
   it("returns isVisible false when post-onboarding is not in progress", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/index.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import RecoverWidgetView from "./RecoverWidgetView";
+import { useRecoverWidgetViewModel } from "./useRecoverWidgetViewModel";
+
+const RecoverWidget = () => <RecoverWidgetView {...useRecoverWidgetViewModel()} />;
+
+export default RecoverWidget;

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/recoverPortfolioWidgetVisibility.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/recoverPortfolioWidgetVisibility.ts
@@ -1,0 +1,35 @@
+import {
+  LedgerRecoverSubscriptionStateEnum,
+  LedgerRecoverSubscriptionStateInProgressEnum,
+} from "~/types/recoverSubscriptionState";
+
+/**
+ * Same predicate as mobile `checkCanShow` in
+ * `apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenPostOnboardingCallback.ts`:
+ * Recover is only relevant after the user has started Ledger Recover (persisted subscription state).
+ */
+export function hasStartedLedgerRecoverFlowForPostOnboarding(
+  state: LedgerRecoverSubscriptionStateEnum | undefined,
+): boolean {
+  if (state === undefined) {
+    return false;
+  }
+  return (
+    state in LedgerRecoverSubscriptionStateInProgressEnum ||
+    state === LedgerRecoverSubscriptionStateEnum.BACKUP_DONE
+  );
+}
+
+/**
+ * Portfolio Recover CTA: show only while backup is still in progress.
+ * Aligns with mobile hub inclusion (`hasStarted...`) except `BACKUP_DONE`, where the hub may list
+ * Recover as completed but the upsell CTA must not appear.
+ */
+export function shouldShowRecoverPortfolioWidget(
+  state: LedgerRecoverSubscriptionStateEnum | undefined,
+): boolean {
+  return (
+    hasStartedLedgerRecoverFlowForPostOnboarding(state) &&
+    state !== LedgerRecoverSubscriptionStateEnum.BACKUP_DONE
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { isRecoverDisplayed, useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { getStoreValue } from "~/renderer/store";
+import { track } from "~/renderer/analytics/segment";
+import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+
+const TRACK = {
+  button: "Post onboarding recover widget",
+  flow: "post-onboarding",
+} as const;
+
+export type RecoverWidgetViewProps = {
+  readonly isVisible: boolean;
+  readonly titleKey: string;
+  readonly descriptionKey: string;
+  readonly onOpenRecover: () => void;
+};
+
+export const RECOVER_WIDGET_TITLE_I18N_KEY = "postOnboarding.dialog.actions.recover.title";
+export const RECOVER_WIDGET_DESCRIPTION_I18N_KEY =
+  "postOnboarding.dialog.actions.recover.description";
+
+export function useRecoverWidgetViewModel(): RecoverWidgetViewProps {
+  const navigate = useNavigate();
+  const recoverServices = useFeature("protectServicesDesktop");
+  const upsellPath = useUpsellPath(recoverServices);
+  const { postOnboardingInProgress, deviceModelId } = usePostOnboardingHubState();
+
+  const protectId = recoverServices?.params?.protectId ?? "protect-prod";
+  const [subscriptionState, setSubscriptionState] = useState<
+    LedgerRecoverSubscriptionStateEnum | undefined | null
+  >(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const value = await getStoreValue("SUBSCRIPTION_STATE", protectId);
+        if (!cancelled) {
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          setSubscriptionState(value as LedgerRecoverSubscriptionStateEnum);
+        }
+      } catch {
+        if (!cancelled) {
+          setSubscriptionState(undefined);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [protectId]);
+
+  const isRecoverOfferAvailable = isRecoverDisplayed(recoverServices, deviceModelId ?? undefined);
+
+  const isVisible = useMemo(() => {
+    if (subscriptionState === null) {
+      return false;
+    }
+    if (!postOnboardingInProgress) {
+      return false;
+    }
+    if (!isRecoverOfferAvailable) {
+      return false;
+    }
+    if (subscriptionState === LedgerRecoverSubscriptionStateEnum.BACKUP_DONE) {
+      return false;
+    }
+    if (!upsellPath) {
+      return false;
+    }
+    return true;
+  }, [isRecoverOfferAvailable, postOnboardingInProgress, subscriptionState, upsellPath]);
+
+  const onOpenRecover = useCallback(() => {
+    if (!upsellPath) {
+      return;
+    }
+    track("button_clicked", {
+      deviceModelId,
+      ...TRACK,
+    });
+    navigate(upsellPath);
+  }, [deviceModelId, navigate, upsellPath]);
+
+  return useMemo(
+    () => ({
+      isVisible,
+      titleKey: RECOVER_WIDGET_TITLE_I18N_KEY,
+      descriptionKey: RECOVER_WIDGET_DESCRIPTION_I18N_KEY,
+      onOpenRecover,
+    }),
+    [isVisible, onOpenRecover],
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
@@ -28,7 +28,7 @@ export function useRecoverWidgetViewModel(): RecoverWidgetViewProps {
   const navigate = useNavigate();
   const recoverServices = useFeature("protectServicesDesktop");
   const upsellPath = useUpsellPath(recoverServices);
-  const { postOnboardingInProgress, deviceModelId } = usePostOnboardingHubState();
+  const { deviceModelId } = usePostOnboardingHubState();
 
   const protectId = recoverServices?.params?.protectId ?? "protect-prod";
   const [subscriptionState, setSubscriptionState] = useState<LedgerRecoverSubscriptionStateEnum | undefined>(
@@ -54,9 +54,6 @@ export function useRecoverWidgetViewModel(): RecoverWidgetViewProps {
   const isRecoverOfferAvailable = isRecoverDisplayed(recoverServices, deviceModelId ?? undefined);
 
   const isVisible = useMemo(() => {
-    if (!postOnboardingInProgress) {
-      return false;
-    }
     if (!isRecoverOfferAvailable) {
       return false;
     }
@@ -67,7 +64,7 @@ export function useRecoverWidgetViewModel(): RecoverWidgetViewProps {
       return false;
     }
     return true;
-  }, [isRecoverOfferAvailable, postOnboardingInProgress, subscriptionState, upsellPath]);
+  }, [isRecoverOfferAvailable, subscriptionState, upsellPath]);
 
   const onOpenRecover = useCallback(() => {
     if (!upsellPath) {

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
@@ -6,6 +6,7 @@ import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/
 import { getStoreValue } from "~/renderer/store";
 import { track } from "~/renderer/analytics/segment";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
+import { shouldShowRecoverPortfolioWidget } from "./recoverPortfolioWidgetVisibility";
 
 const TRACK = {
   button: "Post onboarding recover widget",
@@ -59,7 +60,7 @@ export function useRecoverWidgetViewModel(): RecoverWidgetViewProps {
     if (!isRecoverOfferAvailable) {
       return false;
     }
-    if (subscriptionState === LedgerRecoverSubscriptionStateEnum.BACKUP_DONE) {
+    if (!shouldShowRecoverPortfolioWidget(subscriptionState)) {
       return false;
     }
     if (!upsellPath) {

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts
@@ -30,36 +30,29 @@ export function useRecoverWidgetViewModel(): RecoverWidgetViewProps {
   const { postOnboardingInProgress, deviceModelId } = usePostOnboardingHubState();
 
   const protectId = recoverServices?.params?.protectId ?? "protect-prod";
-  const [subscriptionState, setSubscriptionState] = useState<
-    LedgerRecoverSubscriptionStateEnum | undefined | null
-  >(null);
+  const [subscriptionState, setSubscriptionState] = useState<LedgerRecoverSubscriptionStateEnum | undefined>(
+    () => {
+      try {
+        return getStoreValue<LedgerRecoverSubscriptionStateEnum>("SUBSCRIPTION_STATE", protectId);
+      } catch {
+        return undefined;
+      }
+    },
+  );
 
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const value = await getStoreValue("SUBSCRIPTION_STATE", protectId);
-        if (!cancelled) {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          setSubscriptionState(value as LedgerRecoverSubscriptionStateEnum);
-        }
-      } catch {
-        if (!cancelled) {
-          setSubscriptionState(undefined);
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+    try {
+      setSubscriptionState(
+        getStoreValue<LedgerRecoverSubscriptionStateEnum>("SUBSCRIPTION_STATE", protectId),
+      );
+    } catch {
+      setSubscriptionState(undefined);
+    }
   }, [protectId]);
 
   const isRecoverOfferAvailable = isRecoverDisplayed(recoverServices, deviceModelId ?? undefined);
 
   const isVisible = useMemo(() => {
-    if (subscriptionState === null) {
-      return false;
-    }
     if (!postOnboardingInProgress) {
       return false;
     }

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/index.tsx
@@ -7,6 +7,7 @@ import PostOnboardingHubBanner from "~/renderer/components/PostOnboardingHub/Pos
 import RecoverBanner from "~/renderer/components/RecoverBanner/RecoverBanner";
 import ActionContentCards from "~/renderer/screens/dashboard/ActionContentCards";
 import { useBannersVisibility } from "../hooks/useBannersVisibility";
+import RecoverWidget from "LLD/features/FinishOnboarding/RecoverWidget";
 
 /**
  * Renders the portfolio banner block. Order of evaluation (first match wins):
@@ -35,7 +36,12 @@ export const PortfolioBannerContent = memo(function PortfolioBannerContent() {
   }
 
   if (isFinishOnboardingWidgetVisible) {
-    return <FinishOnboardingWidget />;
+    return (
+      <div className="flex w-full gap-12">
+        <FinishOnboardingWidget />
+        <RecoverWidget />
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add recover widget

### 📝 Description
This pull request introduces the new "Recover Widget" to the Ledger Live Desktop app, enhancing the post-onboarding experience by offering users a clear call-to-action to secure their backup. The widget is conditionally displayed based on feature flags, device compatibility, subscription status, and onboarding state. Comprehensive tests are included to ensure correct behavior. The widget is integrated into the dashboard alongside the existing Finish Onboarding widget.

**New Feature: Recover Widget**

* Added the `RecoverWidget` component, which displays a call-to-action for users to finish securing their backup, and only appears when specific conditions are met (feature flag enabled, device compatible, user eligible, and backup not already done). (`apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/index.tsx`, `apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/RecoverWidgetView.tsx`, `apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel.ts`) [[1]](diffhunk://#diff-c9069dbcd57ec8cd8cd5830cbeb6338d2f4d0c97ad02feb8ea94f52bdf5702caR1-R7) [[2]](diffhunk://#diff-cedbeb657609060e8264234161a818e9fbe632f59a9a66e31a6434728e2f3cfaR1-R49) [[3]](diffhunk://#diff-9c949aa440d966aaab2664607c097fff71aeeca76e86c6b0be7c585231221348R1-R98)

**Integration and UI Updates**

* Integrated `RecoverWidget` into the dashboard's portfolio banner area, displaying it alongside the existing Finish Onboarding widget when appropriate. (`apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/index.tsx`) [[1]](diffhunk://#diff-1f28ac940d0a9e25d20daf2accdfbd34508bfa9771c5dc44eeb3905415f8f561R10) [[2]](diffhunk://#diff-1f28ac940d0a9e25d20daf2accdfbd34508bfa9771c5dc44eeb3905415f8f561L38-R44)

**Testing and Quality Assurance**

* Added integration and unit tests to verify widget visibility logic, user interaction (navigation and analytics tracking), and correct behavior under various onboarding and subscription states. (`apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__integrations__/RecoverWidget.integration.test.tsx`, `apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/RecoverWidget/__tests__/useRecoverWidgetViewModel.test.ts`) [[1]](diffhunk://#diff-71173e6d1ff2845e3c5a2e9c803d592ba33303efac4e79736107136fde953e36R1-R110) [[2]](diffhunk://#diff-d0e6e1e5556ec32d15e72183fa6c455d106924a9e2097db6a3b16c993433de55R1-R139)

**Documentation and Release**

* Added a changeset documenting the addition of the Recover Widget as a minor feature. (`.changeset/nasty-trees-care.md`)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26398]
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->

<img width="1026" height="851" alt="image" src="https://github.com/user-attachments/assets/dccdc0c2-b5d4-431e-b80e-b9f7a36e22a0" />

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-26398]: https://ledgerhq.atlassian.net/browse/LIVE-26398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ