### PR TITLE
[LWM] chore(lwm): import `useBroadcast` from common

### DIFF
--- a/.changeset/pink-eagles-smell.md
+++ b/.changeset/pink-eagles-smell.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+chore(lwm): import `useBroadcast` from common

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -27,6 +27,7 @@ import {
 import { formatTransaction } from "@ledgerhq/live-common/transaction/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { execAndWaitAtLeast } from "@ledgerhq/live-common/promise";
+import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
 import { getEnv } from "@ledgerhq/live-env";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
@@ -251,15 +252,6 @@ export const broadcastSignedTx = async (
       }),
   );
 };
-
-// TODO move to live-common
-function useBroadcast({ account, parentAccount, broadcastConfig }: SignTransactionArgs) {
-  return useCallback(
-    async (signedOperation: SignedOperation): Promise<Operation> =>
-      broadcastSignedTx(account, parentAccount, signedOperation, broadcastConfig),
-    [account, parentAccount, broadcastConfig],
-  );
-}
 
 export function useSignedTxHandler({
   account,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LWM broadcast

### 📝 Description

Ledger Live Mobile defines its own `useBroadcast` in `screenTransactionHooks.ts`, even though the same hook already exists in `ledger-live-common` and is used on desktop. This change removes the duplicate implementation and imports `useBroadcast` from `@ledgerhq/live-common/hooks/useBroadcast`, closing the `TODO` to move it to live-common.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-29854
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
