### PR TITLE
[LWDM] feat(tezos): enhance staking validation with stricter checks and erro…

### DIFF
--- a/.changeset/many-geckos-applaud.md
+++ b/.changeset/many-geckos-applaud.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+validateIntent staking

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6968,6 +6968,9 @@
     "RecommendUndelegation": {
       "title": "Please undelegate the account before emptying it"
     },
+    "MustDelegateBeforeStaking": {
+      "title": "Please delegate your account before staking"
+    },
     "RecommendSubAccountsToEmpty": {
       "title": "Please empty all subaccounts first"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -889,6 +889,9 @@
     "RecommendUndelegation": {
       "title": "Please undelegate the account before emptying it"
     },
+    "MustDelegateBeforeStaking": {
+      "title": "Please delegate your account before staking"
+    },
     "RecommendSubAccountsToEmpty": {
       "title": "Please empty all subaccounts first"
     },

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -1,3 +1,4 @@
+import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
 import {
   RecipientRequired,
   InvalidAddress,
@@ -8,10 +9,9 @@ import {
   NotEnoughBalanceToDelegate,
 } from "@ledgerhq/errors";
 import coinConfig from "../config";
-import { InvalidAddressBecauseAlreadyDelegated } from "../types/errors";
+import { InvalidAddressBecauseAlreadyDelegated, MustDelegateBeforeStaking } from "../types/errors";
 import { validateIntent } from "./validateIntent";
 
-// Module-level mocks
 const mockEstimateFees = jest.fn();
 jest.mock("./estimateFees", () => ({
   estimateFees: (...args: unknown[]) => mockEstimateFees(...args),
@@ -31,6 +31,20 @@ describe("validateIntent", () => {
   const senderAddress = "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8";
   const validRecipient = "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx";
 
+  const makeUserAccount = (overrides: Record<string, unknown> = {}) => ({
+    type: "user" as const,
+    address: senderAddress,
+    publicKey: "edpk...",
+    balance: 5000000,
+    revealed: true,
+    counter: 0,
+    delegationLevel: 0,
+    delegationTime: "2021-01-01T00:00:00Z",
+    numTransactions: 0,
+    firstActivityTime: "2021-01-01T00:00:00Z",
+    ...overrides,
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -49,25 +63,13 @@ describe("validateIntent", () => {
     }));
 
     mockEstimateFees.mockResolvedValue({
-      fees: BigInt(1000),
-      gasLimit: BigInt(10000),
-      storageLimit: BigInt(0),
-      estimatedFees: BigInt(1000),
+      fees: 1000n,
+      gasLimit: 10000n,
+      storageLimit: 0n,
+      estimatedFees: 1000n,
     });
 
-    mockGetAccountByAddress.mockResolvedValue({
-      type: "user",
-      address: senderAddress,
-      publicKey: "edpk...",
-      balance: 5000000,
-      revealed: true,
-      counter: 0,
-      delegationLevel: 0,
-      delegationTime: "2021-01-01T00:00:00Z",
-      numTransactions: 0,
-      firstActivityTime: "2021-01-01T00:00:00Z",
-    });
-
+    mockGetAccountByAddress.mockResolvedValue(makeUserAccount());
     mockGetTokensBalances.mockResolvedValue([]);
   });
 
@@ -79,7 +81,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: "",
-        amount: BigInt(1000),
+        amount: 1000n,
       });
 
       expect(result.errors.recipient).toBeInstanceOf(RecipientRequired);
@@ -92,7 +94,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: "invalid_address",
-        amount: BigInt(1000),
+        amount: 1000n,
       });
 
       expect(result.errors.recipient).toBeInstanceOf(InvalidAddress);
@@ -105,7 +107,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: senderAddress,
-        amount: BigInt(1000),
+        amount: 1000n,
       });
 
       expect(result.errors.recipient).toBeInstanceOf(InvalidAddressBecauseDestinationIsAlsoSource);
@@ -120,7 +122,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: validRecipient,
-        amount: BigInt(0),
+        amount: 0n,
         useAllAmount: false,
       });
 
@@ -134,7 +136,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: validRecipient,
-        amount: BigInt(0),
+        amount: 0n,
         useAllAmount: true,
       });
 
@@ -154,45 +156,83 @@ describe("validateIntent", () => {
       expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
     });
 
-    it.each([["stake"], ["unstake"]])(
-      "returns 0 as amount when the transaction intent is '%s'",
-      async intentType => {
-        const result = await validateIntent({
-          intentType: "transaction",
-          asset: { type: "native" },
-          type: intentType,
-          sender: "tz1TzrmTBSuiVHV2VfMnGRMYvTEPCP42oSM8",
-          recipient: "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx",
-          amount: BigInt(0),
-          useAllAmount: true,
-        });
+    it("uses the staked amount as amount and amount + fees as totalSpent for stake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
 
-        expect(result).toEqual({
-          errors: {},
-          warnings: {},
-          estimatedFees: 1000n,
-          amount: 0n,
-          totalSpent: 1000n,
-        });
-      },
-    );
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 2500n,
+      });
+
+      expect(result).toEqual({
+        errors: {},
+        warnings: {},
+        estimatedFees: 1000n,
+        amount: 2500n,
+        totalSpent: 3500n,
+      });
+    });
+
+    it("uses only fees as totalSpent for unstake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 4000 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 2500n,
+      });
+
+      expect(result).toEqual({
+        errors: {},
+        warnings: {},
+        estimatedFees: 1000n,
+        amount: 2500n,
+        totalSpent: 1000n,
+      });
+    });
+
+    it("uses amount 0 and only fees as totalSpent for finalize_unstake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ unstakedFinalizable: 1234 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "finalize_unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 0n,
+      } satisfies TransactionIntent);
+
+      expect(result).toEqual({
+        errors: {},
+        warnings: {},
+        estimatedFees: 1000n,
+        amount: 0n,
+        totalSpent: 1000n,
+      });
+    });
   });
 
   describe("transaction constraints", () => {
     it("should return RecommendUndelegation when send-max native XTZ on a delegated account", async () => {
-      mockGetAccountByAddress.mockResolvedValue({
-        type: "user",
-        address: senderAddress,
-        publicKey: "edpk...",
-        balance: 5000000,
-        revealed: true,
-        counter: 0,
-        delegate: { alias: "baker", address: validRecipient, active: true },
-        delegationLevel: 1,
-        delegationTime: "2021-01-01T00:00:00Z",
-        numTransactions: 0,
-        firstActivityTime: "2021-01-01T00:00:00Z",
-      });
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
 
       const result = await validateIntent({
         intentType: "transaction",
@@ -208,51 +248,112 @@ describe("validateIntent", () => {
       expect(mockEstimateFees).not.toHaveBeenCalled();
     });
 
-    it("should return NotEnoughBalanceToDelegate when stake intent and balance is zero", async () => {
-      mockGetAccountByAddress.mockResolvedValue({
-        type: "user",
-        address: senderAddress,
-        publicKey: "edpk...",
-        balance: 0,
-        revealed: true,
-        counter: 0,
-        delegationLevel: 0,
-        delegationTime: "2021-01-01T00:00:00Z",
-        numTransactions: 0,
-        firstActivityTime: "2021-01-01T00:00:00Z",
+    it("should return MustDelegateBeforeStaking when stake intent has no delegate", async () => {
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 1n,
       });
+
+      expect(result.errors.amount).toBeInstanceOf(MustDelegateBeforeStaking);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should return AmountRequired when stake amount is zero", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
 
       const result = await validateIntent({
         intentType: "staking",
         asset: { type: "native" },
         type: "stake",
         sender: senderAddress,
-        recipient: validRecipient,
-        amount: BigInt(0),
+        recipient: "",
+        amount: 0n,
       });
 
-      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalanceToDelegate);
+      expect(result.errors.amount).toBeInstanceOf(AmountRequired);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should return NotEnoughBalance when unstake has no staked balance", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 0 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 1n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should return AmountRequired when unstake amount is zero", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 4000 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 0n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(AmountRequired);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should return NotEnoughBalance when unstake amount exceeds staked balance", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 4000 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 5000n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should return NotEnoughBalance when finalize_unstake has nothing finalizable", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ unstakedFinalizable: 0 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "finalize_unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 0n,
+      } satisfies TransactionIntent);
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
       expect(mockEstimateFees).not.toHaveBeenCalled();
     });
   });
 
   describe("balance validation", () => {
     it("should return NotEnoughBalance error when amount exceeds balance", async () => {
-      const balance = 1000000; // 1 XTZ
-      const amount = 2000000; // 2 XTZ
+      const balance = 1000000;
+      const amount = 2000000;
 
-      mockGetAccountByAddress.mockResolvedValue({
-        type: "user",
-        address: senderAddress,
-        publicKey: "edpk...",
-        balance,
-        revealed: true,
-        counter: 0,
-        delegationLevel: 0,
-        delegationTime: "2021-01-01T00:00:00Z",
-        numTransactions: 0,
-        firstActivityTime: "2021-01-01T00:00:00Z",
-      });
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ balance }));
 
       const result = await validateIntent({
         intentType: "transaction",
@@ -267,33 +368,18 @@ describe("validateIntent", () => {
     });
 
     it("should pass validation when amount is within balance", async () => {
-      const balance = 5000000; // 5 XTZ
-      const amount = 1000000; // 1 XTZ
-
-      mockGetAccountByAddress.mockResolvedValue({
-        type: "user",
-        address: senderAddress,
-        publicKey: "edpk...",
-        balance,
-        revealed: true,
-        counter: 0,
-        delegationLevel: 0,
-        delegationTime: "2021-01-01T00:00:00Z",
-        numTransactions: 0,
-        firstActivityTime: "2021-01-01T00:00:00Z",
-      });
-
+      const amount = 1000000n;
       const result = await validateIntent({
         intentType: "transaction",
         asset: { type: "native" },
         type: "send",
         sender: senderAddress,
         recipient: validRecipient,
-        amount: BigInt(amount),
+        amount,
       });
 
       expect(result.errors.amount).toBeUndefined();
-      expect(result.amount).toBe(BigInt(amount));
+      expect(result.amount).toBe(amount);
     });
   });
 
@@ -305,7 +391,7 @@ describe("validateIntent", () => {
         type: "delegate",
         sender: senderAddress,
         recipient: validRecipient,
-        amount: BigInt(0),
+        amount: 0n,
       });
 
       expect(result.errors).toEqual({});
@@ -318,34 +404,58 @@ describe("validateIntent", () => {
         type: "undelegate",
         sender: senderAddress,
         recipient: "",
-        amount: BigInt(0),
+        amount: 0n,
       });
 
       expect(result.errors).toEqual({});
     });
 
-    it("should handle stake intent (mapped to delegate)", async () => {
+    it("should pass validation for stake transaction when already delegated", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
+
       const result = await validateIntent({
         intentType: "staking",
         asset: { type: "native" },
         type: "stake",
         sender: senderAddress,
-        recipient: validRecipient,
-        amount: BigInt(0),
+        recipient: "",
+        amount: 1000n,
       });
 
       expect(result.errors).toEqual({});
     });
 
-    it("should handle unstake intent (mapped to undelegate)", async () => {
+    it("should pass validation for unstake transaction", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 4000 }));
+
       const result = await validateIntent({
         intentType: "staking",
         asset: { type: "native" },
         type: "unstake",
         sender: senderAddress,
         recipient: "",
-        amount: BigInt(0),
+        amount: 1000n,
       });
+
+      expect(result.errors).toEqual({});
+    });
+
+    it("should pass validation for finalize_unstake transaction", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ unstakedFinalizable: 4000 }));
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "finalize_unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 0n,
+      } satisfies TransactionIntent);
 
       expect(result.errors).toEqual({});
     });
@@ -374,6 +484,13 @@ describe("validateIntent", () => {
     });
 
     it("maps balance_too_low to NotEnoughBalanceToDelegate for stake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
+
       mockEstimateFees.mockResolvedValue({
         fees: 0n,
         gasLimit: 0n,
@@ -387,8 +504,8 @@ describe("validateIntent", () => {
         asset: { type: "native" },
         type: "stake",
         sender: senderAddress,
-        recipient: validRecipient,
-        amount: 0n,
+        recipient: "",
+        amount: 1n,
       });
 
       expect(result.errors.amount).toBeInstanceOf(NotEnoughBalanceToDelegate);
@@ -416,6 +533,13 @@ describe("validateIntent", () => {
     });
 
     it("maps delegate.unchanged to InvalidAddressBecauseAlreadyDelegated for stake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
+
       mockEstimateFees.mockResolvedValue({
         fees: 0n,
         gasLimit: 0n,
@@ -429,8 +553,8 @@ describe("validateIntent", () => {
         asset: { type: "native" },
         type: "stake",
         sender: senderAddress,
-        recipient: validRecipient,
-        amount: 0n,
+        recipient: "",
+        amount: 1n,
       });
 
       expect(result.errors.recipient).toBeInstanceOf(InvalidAddressBecauseAlreadyDelegated);
@@ -455,6 +579,55 @@ describe("validateIntent", () => {
       });
 
       expect(result.errors.amount).toBeInstanceOf(NotEnoughBalanceToDelegate);
+    });
+
+    it("maps staking.too_much_unstaked to NotEnoughBalance for unstake", async () => {
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ stakedBalance: 4000 }));
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 500n,
+        taquitoError: "proto.alpha.staking.too_much_unstaked",
+      });
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "unstake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 1000n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("maps contract.must_be_delegated_to_stake to MustDelegateBeforeStaking", async () => {
+      mockGetAccountByAddress.mockResolvedValue(
+        makeUserAccount({
+          delegate: { alias: "baker", address: validRecipient, active: true },
+          delegationLevel: 1,
+        }),
+      );
+      mockEstimateFees.mockResolvedValue({
+        fees: 0n,
+        gasLimit: 0n,
+        storageLimit: 0n,
+        estimatedFees: 500n,
+        taquitoError: "proto.alpha.contract.must_be_delegated_to_stake",
+      });
+
+      const result = await validateIntent({
+        intentType: "staking",
+        asset: { type: "native" },
+        type: "stake",
+        sender: senderAddress,
+        recipient: "",
+        amount: 1000n,
+      });
+
+      expect(result.errors.amount).toBeInstanceOf(MustDelegateBeforeStaking);
     });
 
     it("maps unknown taquito errors to a generic Error on amount", async () => {
@@ -482,18 +655,7 @@ describe("validateIntent", () => {
 
   describe("account fetch and reveal", () => {
     it("uses fixed estimated fees when account is not revealed and skips estimateFees", async () => {
-      mockGetAccountByAddress.mockResolvedValue({
-        type: "user",
-        address: senderAddress,
-        publicKey: "edpk...",
-        balance: 5000000,
-        revealed: false,
-        counter: 0,
-        delegationLevel: 0,
-        delegationTime: "2021-01-01T00:00:00Z",
-        numTransactions: 0,
-        firstActivityTime: "2021-01-01T00:00:00Z",
-      });
+      mockGetAccountByAddress.mockResolvedValue(makeUserAccount({ revealed: false }));
 
       const amount = 1000000n;
       const result = await validateIntent({
@@ -610,7 +772,7 @@ describe("validateIntent", () => {
         type: "send",
         sender: senderAddress,
         recipient: validRecipient,
-        amount: BigInt(1_000_000),
+        amount: 1000000n,
       });
 
       expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
@@ -638,10 +800,10 @@ describe("validateIntent", () => {
   describe("native XTZ send max", () => {
     it("should fall back to balance minus fees when estimateFees returns amount 0n", async () => {
       mockEstimateFees.mockResolvedValue({
-        fees: BigInt(1000),
-        gasLimit: BigInt(10000),
-        storageLimit: BigInt(0),
-        estimatedFees: BigInt(1000),
+        fees: 1000n,
+        gasLimit: 10000n,
+        storageLimit: 0n,
+        estimatedFees: 1000n,
         amount: 0n,
       });
 
@@ -661,12 +823,12 @@ describe("validateIntent", () => {
     });
 
     it("should prefer positive estimatedAmount from estimateFees over balance minus fees", async () => {
-      const estimatedFromTaquito = 3_000_000n;
+      const estimatedFromTaquito = 3000000n;
       mockEstimateFees.mockResolvedValue({
-        fees: BigInt(1000),
-        gasLimit: BigInt(10000),
-        storageLimit: BigInt(0),
-        estimatedFees: BigInt(1000),
+        fees: 1000n,
+        gasLimit: 10000n,
+        storageLimit: 0n,
+        estimatedFees: 1000n,
         amount: estimatedFromTaquito,
       });
 
@@ -687,13 +849,13 @@ describe("validateIntent", () => {
 
   describe("successful validation", () => {
     it("should return valid result with correct values", async () => {
-      const amount = BigInt(1000000);
-      const estimatedFees = BigInt(1500);
+      const amount = 1000000n;
+      const estimatedFees = 1500n;
 
       mockEstimateFees.mockResolvedValue({
-        fees: BigInt(1000),
-        gasLimit: BigInt(10000),
-        storageLimit: BigInt(0),
+        fees: 1000n,
+        gasLimit: 10000n,
+        storageLimit: 0n,
         estimatedFees,
       });
 

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -14,11 +14,35 @@ import {
 import { validateAddress, ValidationResult } from "@taquito/utils";
 import api from "../network/tzkt";
 import type { APIAccount } from "../network/types";
-import { InvalidAddressBecauseAlreadyDelegated } from "../types/errors";
+import { InvalidAddressBecauseAlreadyDelegated, MustDelegateBeforeStaking } from "../types/errors";
 import { parseTezosTokenAsset, resolveTezosOperationMode } from "../utils";
 import { estimateFees } from "./estimateFees";
+import type { TezosOperationMode } from "../types/model";
 
 type APIUserAccount = Extract<APIAccount, { type: "user" }>;
+
+function resolveValidationOperationMode(intent: TransactionIntent): TezosOperationMode {
+  switch (intent.type) {
+    case "stake":
+    case "unstake":
+    case "finalize_unstake":
+      return intent.type;
+    default:
+      return resolveTezosOperationMode(intent.type, intent.asset);
+  }
+}
+
+function validateStrictlyPositiveAmount(amount: bigint): Error | undefined {
+  if (amount === 0n) {
+    return new AmountRequired();
+  }
+
+  if (amount < 0n) {
+    return new NotEnoughBalance();
+  }
+
+  return undefined;
+}
 
 /**
  * Validates basic recipient and amount for send transactions
@@ -60,17 +84,46 @@ function validateTransactionConstraints(
   if (
     intent.type === "send" &&
     intent.useAllAmount &&
-    resolveTezosOperationMode(intent.type, intent.asset) === "send" &&
+    resolveValidationOperationMode(intent) === "send" &&
     senderInfo.delegate?.address
   ) {
     errors.amount = new RecommendUndelegation();
   }
 
-  // stake requires non-zero balance
   if (intent.type === "stake") {
-    const balance = BigInt(senderInfo.balance || "0");
-    if (balance === 0n) {
-      errors.amount = new NotEnoughBalanceToDelegate();
+    if (!senderInfo.delegate?.address) {
+      errors.amount = new MustDelegateBeforeStaking();
+      return errors;
+    }
+
+    const amountError = validateStrictlyPositiveAmount(intent.amount);
+    if (amountError) {
+      errors.amount = amountError;
+    }
+  }
+
+  if (intent.type === "unstake") {
+    const stakedBalance = BigInt(senderInfo.stakedBalance ?? 0);
+    if (stakedBalance <= 0n) {
+      errors.amount = new NotEnoughBalance();
+      return errors;
+    }
+
+    const amountError = validateStrictlyPositiveAmount(intent.amount);
+    if (amountError) {
+      errors.amount = amountError;
+      return errors;
+    }
+
+    if (intent.amount > stakedBalance) {
+      errors.amount = new NotEnoughBalance();
+    }
+  }
+
+  if (intent.type === "finalize_unstake") {
+    const unstakedFinalizable = BigInt(senderInfo.unstakedFinalizable ?? 0);
+    if (unstakedFinalizable <= 0n) {
+      errors.amount = new NotEnoughBalance();
     }
   }
 
@@ -89,6 +142,10 @@ function mapTaquitoErrors(taquitoError: string, intentType: string): Record<stri
     } else {
       errors.amount = new NotEnoughBalance();
     }
+  } else if (taquitoError.endsWith("staking.too_much_unstaked")) {
+    errors.amount = new NotEnoughBalance();
+  } else if (taquitoError.endsWith("contract.must_be_delegated_to_stake")) {
+    errors.amount = new MustDelegateBeforeStaking();
   } else if (taquitoError.endsWith("delegate.unchanged") && intentType === "stake") {
     errors.recipient = new InvalidAddressBecauseAlreadyDelegated();
   } else if (taquitoError.includes("empty_implicit_contract")) {
@@ -124,7 +181,15 @@ function calculateAmounts(
   estimatedAmount: bigint | undefined,
   tokenBalanceForSendMax?: bigint,
 ): { amount: bigint; totalSpent: bigint } {
-  if (intent.type === "stake" || intent.type === "unstake") {
+  if (intent.type === "stake") {
+    return { amount: intent.amount, totalSpent: intent.amount + estimatedFees };
+  }
+
+  if (intent.type === "unstake") {
+    return { amount: intent.amount, totalSpent: estimatedFees };
+  }
+
+  if (intent.type === "finalize_unstake") {
     return { amount: 0n, totalSpent: estimatedFees };
   }
 
@@ -170,7 +235,7 @@ async function estimateFeesForIntent(
     return { estimatedFees: 2000n, estimatedAmount: undefined, errors: {} };
   }
 
-  const tezosMode = resolveTezosOperationMode(intent.type, intent.asset);
+  const tezosMode = resolveValidationOperationMode(intent);
   const tokenInfo = tezosMode === "send_token" ? parseTezosTokenAsset(intent.asset)! : undefined;
   const estimation = await estimateFees({
     account: {
@@ -182,7 +247,9 @@ async function estimateFeesForIntent(
     transaction: {
       mode: tezosMode,
       recipient: intent.recipient,
-      amount: intent.amount,
+      // finalize_unstake is a parameter-less operation; normalize amount to 0n so
+      // fee estimation and the returned validation amount stay consistent.
+      amount: intent.type === "finalize_unstake" ? 0n : intent.amount,
       useAllAmount: !!intent.useAllAmount,
       ...(tokenInfo && {
         contractAddress: tokenInfo.contractAddress,

--- a/libs/coin-modules/coin-tezos/src/types/errors.ts
+++ b/libs/coin-modules/coin-tezos/src/types/errors.ts
@@ -8,3 +8,6 @@ export const UnsupportedTransactionMode = createCustomErrorClass<
   { mode: string },
   LedgerErrorConstructor<{ mode: string }>
 >("UnsupportedTransactionMode");
+export const MustDelegateBeforeStaking = createCustomErrorClass(
+  "MustDelegateBeforeStaking",
+);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Tezos staking validation now enforces delegation prerequisites and correct amount semantics end-to-end, replacing silent fee errors with actionable typed errors.

### 📝 Description

This PR updates Tezos `validateIntent` to apply stricter validation rules for staking intents (stake/unstake/finalize_unstake) and extends Taquito error-to-Ledger-error mapping accordingly.

**Changes:**
- Add staking-specific constraint checks (must be delegated to stake, positive amount for stake/unstake, staked/finalizable balance checks).
- Update fee/amount/totalSpent calculations to reflect staking semantics (stake spends amount+fees; unstake spends fees only; finalize_unstake spends fees only).
- Extend Taquito error mapping for staking-related protocol errors and update unit tests + add a changeset.

### Reviewed changes

Copilot reviewed 3 out of 3 changed files in this pull request and generated 5 comments.

| File | Description |
| ---- | ----------- |
| libs/coin-modules/coin-tezos/src/logic/validateIntent.ts | Adds stricter staking validation, updates operation-mode resolution for fee estimation, and adjusts amount/fee accounting for stake/unstake/finalize_unstake. |
| libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts | Expands/updates unit tests to cover new staking validation rules, amount/totalSpent semantics, and new Taquito error mappings. |
| .changeset/many-geckos-applaud.md | Declares a minor bump for `@ledgerhq/coin-tezos` due to behavior changes in `validateIntent` staking flows. |




### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-28764
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
