### PR TITLE
[LWDM] feat(coin-tezos): enhance operation mode mapping

### DIFF
--- a/.changeset/popular-snails-hide.md
+++ b/.changeset/popular-snails-hide.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+`mapIntentTypeToTezosMode` to correctly map staking intents (`stake`, `unstake`, `finalize_unstake`) to their own operation modes instead of aliasing them to `delegate`/`undelegate`

--- a/libs/coin-modules/coin-tezos/src/utils.test.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.test.ts
@@ -65,13 +65,31 @@ describe("resolveTezosOperationMode", () => {
     expect(resolveTezosOperationMode("send", { type: "native" })).toBe("send");
   });
 
-  it("maps stake to delegate regardless of asset", () => {
+  it("returns stake for stake intent regardless of asset", () => {
     expect(
       resolveTezosOperationMode("stake", {
         type: "token",
         assetReference: "KT1CpeSQKdkhWi4pinYcseCFKmDhs5M74BkU:0",
       }),
-    ).toBe("delegate");
+    ).toBe("stake");
+  });
+
+  it("returns unstake for unstake intent", () => {
+    expect(resolveTezosOperationMode("unstake", { type: "native" })).toBe("unstake");
+  });
+
+  it("returns finalize_unstake for finalize_unstake intent", () => {
+    expect(resolveTezosOperationMode("finalize_unstake", { type: "native" })).toBe(
+      "finalize_unstake",
+    );
+  });
+
+  it("returns delegate for delegate intent", () => {
+    expect(resolveTezosOperationMode("delegate", { type: "native" })).toBe("delegate");
+  });
+
+  it("returns undelegate for undelegate intent", () => {
+    expect(resolveTezosOperationMode("undelegate", { type: "native" })).toBe("undelegate");
   });
 });
 

--- a/libs/coin-modules/coin-tezos/src/utils.ts
+++ b/libs/coin-modules/coin-tezos/src/utils.ts
@@ -29,14 +29,18 @@ export const OP_SIZE_XTZ_TRANSFER = 154;
 /**
  * Helper function to map generic staking intents to Tezos operation modes
  */
-export function mapIntentTypeToTezosMode(intentType: string): "send" | "delegate" | "undelegate" {
+export function mapIntentTypeToTezosMode(intentType: string): Exclude<TezosOperationMode, "send_token"> {
   switch (intentType) {
-    case "stake":
     case "delegate":
       return "delegate";
-    case "unstake":
     case "undelegate":
       return "undelegate";
+    case "stake":
+      return "stake";
+    case "unstake":
+      return "unstake";
+    case "finalize_unstake":
+      return "finalize_unstake";
     default:
       return "send";
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - minor: mapIntentTypeToTezosMode("stake") now returns "stake" instead of "delegate"

### 📝 Description
Updates Tezos coin-module utilities to map staking-related transaction intents to more specific Tezos operation modes, and adjusts unit tests accordingly.

**Changes:**
- Extend `mapIntentTypeToTezosMode` to return `"stake"`, `"unstake"`, and `"finalize_unstake"` instead of mapping staking intents to delegation modes.
- Update `resolveTezosOperationMode` expectations via new/updated unit tests.

### Reviewed changes

Copilot reviewed 2 out of 2 changed files in this pull request and generated 3 comments.

| File | Description |
| ---- | ----------- |
| `libs/coin-modules/coin-tezos/src/utils.ts` | Expands intent→operation-mode mapping to include stake/unstake/finalize_unstake. |
| `libs/coin-modules/coin-tezos/src/utils.test.ts` | Updates/adds tests to validate the new operation-mode mapping behavior. |




### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-28757

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
