### PR TITLE
[LWM] feat(live-dmk-mobile): add DMK HTTP proxy transport for dev mode

### DIFF
--- a/.changeset/gorgeous-sheep-know.md
+++ b/.changeset/gorgeous-sheep-know.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-dmk-mobile": minor
+"@ledgerhq/live-cli": minor
+---
+
+Add DMK HTTP proxy transport so DMK-only coin families work via the `ledger-live proxy` CLI in dev mode

--- a/apps/cli/src/commands/device/proxy.ts
+++ b/apps/cli/src/commands/device/proxy.ts
@@ -209,16 +209,14 @@ const job = ({
 
       pending = false;
       const result = {
-        data,
-        error,
+        data: data?.toString("hex") ?? null,
+        error: error?.message ?? null,
       };
 
       if (data) {
-        //  @ts-expect-error 3 args only, we give 5
-        log("proxy", "HTTP:", req.body.apduHex, "=>", data.toString("hex"));
+        log("proxy", `HTTP: ${req.body.apduHex} => ${data.toString("hex")}`);
       } else {
-        //  @ts-expect-error 3 args only, we give 5
-        log("proxy", "HTTP:", req.body.apduHex, "=>", error);
+        log("proxy", `HTTP: ${req.body.apduHex} =>`, error);
       }
 
       res.json(result);

--- a/apps/ledger-live-mobile/src/services/registerTransports.ts
+++ b/apps/ledger-live-mobile/src/services/registerTransports.ts
@@ -7,7 +7,10 @@ import { getDeviceModel } from "@ledgerhq/devices";
 import { DescriptorEvent } from "@ledgerhq/hw-transport";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import getBLETransport from "~/transport/bleTransport";
-import { DeviceManagementKitHIDTransport } from "@ledgerhq/live-dmk-mobile";
+import {
+  DeviceManagementKitHIDTransport,
+  DeviceManagementKitHTTPProxyTransport,
+} from "@ledgerhq/live-dmk-mobile";
 import { DeviceManagementKitTransportSpeculos } from "@ledgerhq/live-dmk-speculos";
 import { retry } from "@ledgerhq/live-common/promise";
 
@@ -46,37 +49,40 @@ export const registerTransports = () => {
     });
   }
 
-  // Add dev mode support of an http proxy
-  let DebugHttpProxy: ReturnType<typeof withStaticURLs>;
-  const httpdebug: TransportModule = {
-    id: "httpdebug",
-    open: id => (id.startsWith("httpdebug|") ? DebugHttpProxy.open(id.slice(10)) : null),
-    disconnect: id =>
-      id.startsWith("httpdebug|")
-        ? Promise.resolve() // nothing to do
-        : null,
-  };
-
-  if (__DEV__ && Config.DEVICE_PROXY_URL) {
-    DebugHttpProxy = withStaticURLs(Config.DEVICE_PROXY_URL.split("|"));
-    httpdebug.discovery = new Observable<DescriptorEvent<string>>(o =>
-      DebugHttpProxy.listen(o),
-    ).pipe(
-      map(({ type, descriptor }) => ({
-        type,
-        id: `httpdebug|${descriptor}`,
-        deviceModel: getDeviceModel(
-          (Config?.FALLBACK_DEVICE_MODEL_ID as DeviceModelId) || DeviceModelId.nanoX,
-        ),
-        wired: Config?.FALLBACK_DEVICE_WIRED === "YES",
-        name: descriptor,
-      })),
-    );
-  } else {
-    DebugHttpProxy = withStaticURLs([]);
+  // Dev-only HTTP proxy transport. Gated on __DEV__ so production builds don't expose
+  // an `open` path that would accept arbitrary URLs. The module is registered for the
+  // whole __DEV__ build so the runtime "Settings > Debug > Connectivity > HTTP transport"
+  // flow can supply a URL at runtime; build-time URL polling is opt-in via DEVICE_PROXY_URL.
+  if (__DEV__) {
+    const httpdebug: TransportModule = {
+      id: "httpdebug",
+      open: id =>
+        id.startsWith("httpdebug|")
+          ? DeviceManagementKitHTTPProxyTransport.open(id.slice("httpdebug|".length))
+          : null,
+      disconnect: id =>
+        id.startsWith("httpdebug|")
+          ? Promise.resolve() // nothing to do
+          : null,
+    };
+    if (Config.DEVICE_PROXY_URL) {
+      const DebugHttpProxy = withStaticURLs(Config.DEVICE_PROXY_URL.split("|"));
+      httpdebug.discovery = new Observable<DescriptorEvent<string>>(o =>
+        DebugHttpProxy.listen(o),
+      ).pipe(
+        map(({ type, descriptor }) => ({
+          type,
+          id: `httpdebug|${descriptor}`,
+          deviceModel: getDeviceModel(
+            (Config?.FALLBACK_DEVICE_MODEL_ID as DeviceModelId) || DeviceModelId.nanoX,
+          ),
+          wired: Config?.FALLBACK_DEVICE_WIRED === "YES",
+          name: descriptor,
+        })),
+      );
+    }
+    registerTransportModule(httpdebug);
   }
-
-  registerTransportModule(httpdebug);
 
   // BLE is always the fallback choice because we always keep raw id in it
   registerTransportModule({

--- a/libs/live-dmk-mobile/jest.config.js
+++ b/libs/live-dmk-mobile/jest.config.js
@@ -13,5 +13,9 @@ module.exports = {
   testPathIgnorePatterns: ["lib/", "lib-es/"],
   setupFilesAfterEnv: ["<rootDir>/tests.setup.ts"],
   coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
-  reporters: ["default", ...(process.env.CI ? ["github-actions"] : [])],
+  reporters: [
+    "default",
+    ...(process.env.CI ? ["github-actions"] : []),
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
 };

--- a/libs/live-dmk-mobile/package.json
+++ b/libs/live-dmk-mobile/package.json
@@ -28,7 +28,8 @@
     "unimported": "pnpm knip --directory ../.. -W libs/live-dmk-mobile",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "coverage": "jest --coverage"
   },
   "dependencies": {
     "@ledgerhq/device-management-kit": "catalog:",

--- a/libs/live-dmk-mobile/package.json
+++ b/libs/live-dmk-mobile/package.json
@@ -39,7 +39,8 @@
     "@ledgerhq/live-dmk-shared": "workspace:^",
     "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
-    "@ledgerhq/types-devices": "workspace:^"
+    "@ledgerhq/types-devices": "workspace:^",
+    "purify-ts": "^2.1.0"
   },
   "devDependencies": {
     "@ledgerhq/device-transport-kit-react-native-hid": "catalog:",

--- a/libs/live-dmk-mobile/src/hooks/useDeviceManagementKit.tsx
+++ b/libs/live-dmk-mobile/src/hooks/useDeviceManagementKit.tsx
@@ -9,6 +9,7 @@ import { LedgerLiveLogger, UserHashService } from "@ledgerhq/live-dmk-shared";
 import { RNHidTransportFactory } from "@ledgerhq/device-transport-kit-react-native-hid";
 import { getEnv } from "@ledgerhq/live-env";
 import { LocalTracer } from "@ledgerhq/logs";
+import { httpProxyTransportFactory, httpProxyUrlSubject } from "../transport/HttpProxyDmkTransport";
 
 const tracer = new LocalTracer("live-dmk-tracer", { function: "useDeviceManagementKit" });
 
@@ -24,6 +25,7 @@ export const getDeviceManagementKit = (): DeviceManagementKit => {
     instance = new DeviceManagementKitBuilder()
       .addTransport(RNBleTransportFactory)
       .addTransport(RNHidTransportFactory)
+      .addTransport(httpProxyTransportFactory(httpProxyUrlSubject))
       .addLogger(new LedgerLiveLogger(LogLevel.Debug))
       .addConfig({ firmwareDistributionSalt })
       .build();

--- a/libs/live-dmk-mobile/src/index.ts
+++ b/libs/live-dmk-mobile/src/index.ts
@@ -2,6 +2,7 @@ import { useDeviceSessionState } from "@ledgerhq/live-dmk-shared";
 
 export { DeviceManagementKitBLETransport } from "./transport/DeviceManagementKitBLETransport";
 export { DeviceManagementKitHIDTransport } from "./transport/DeviceManagementKitHIDTransport";
+export { DeviceManagementKitHTTPProxyTransport } from "./transport/DeviceManagementKitHTTPProxyTransport";
 export * from "./errors";
 export * from "./hooks";
 export * from "./utils/matchDevicesByNameOrId";

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitHTTPProxyTransport.test.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitHTTPProxyTransport.test.ts
@@ -1,0 +1,433 @@
+import { BehaviorSubject, Observable, Subject } from "rxjs";
+import {
+  DeviceManagementKit,
+  DeviceModelId as DMKDeviceModelId,
+  DeviceSessionState,
+  DeviceSessionStateType,
+  DeviceStatus,
+  DiscoveredDevice,
+  SendApduEmptyResponseError,
+  DeviceDisconnectedBeforeSendingApdu,
+  DeviceDisconnectedWhileSendingError,
+} from "@ledgerhq/device-management-kit";
+import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DeviceManagementKitHTTPProxyTransport } from "./DeviceManagementKitHTTPProxyTransport";
+import { HTTP_PROXY_TRANSPORT_IDENTIFIER, httpProxyUrlSubject } from "./HttpProxyDmkTransport";
+import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";
+
+jest.mock("../hooks/useDeviceManagementKit", () => ({
+  getDeviceManagementKit: jest.fn(),
+}));
+
+const aMockedDeviceSessionState: DeviceSessionState = {
+  deviceStatus: DeviceStatus.CONNECTED,
+  sessionStateType: DeviceSessionStateType.Connected,
+  deviceModelId: DMKDeviceModelId.FLEX,
+};
+
+const mockDiscoveredDevice: DiscoveredDevice = {
+  id: "http-proxy-device",
+  name: "HTTP Proxy",
+  deviceModel: {
+    model: DMKDeviceModelId.NANO_X,
+    name: "Nano X",
+    id: DMKDeviceModelId.NANO_X,
+  },
+  transport: HTTP_PROXY_TRANSPORT_IDENTIFIER,
+};
+
+function createMockDMK(): DeviceManagementKit {
+  return {
+    getDeviceSessionState: jest.fn(),
+    listenToAvailableDevices: jest.fn(),
+    connect: jest.fn(),
+    sendApdu: jest.fn(),
+    disconnect: jest.fn(),
+  } as unknown as DeviceManagementKit;
+}
+
+type StaticFields = {
+  activeUrl: string | null;
+  activeSessionId: string | null;
+  inFlight: { url: string; promise: Promise<string> } | null;
+};
+
+const statics = DeviceManagementKitHTTPProxyTransport as unknown as StaticFields;
+
+function resetModuleState() {
+  statics.activeUrl = null;
+  statics.activeSessionId = null;
+  statics.inFlight = null;
+  httpProxyUrlSubject.next(null);
+}
+
+describe("DeviceManagementKitHTTPProxyTransport", () => {
+  let mockDmk: DeviceManagementKit;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    resetModuleState();
+    mockDmk = createMockDMK();
+    jest.mocked(getDeviceManagementKit).mockReturnValue(mockDmk);
+  });
+
+  describe("normalizeUrl", () => {
+    it("should convert ws:// to http://", () => {
+      expect(DeviceManagementKitHTTPProxyTransport.normalizeUrl("ws://localhost:8435")).toBe(
+        "http://localhost:8435",
+      );
+    });
+
+    it("should convert wss:// to https://", () => {
+      expect(DeviceManagementKitHTTPProxyTransport.normalizeUrl("wss://example.com")).toBe(
+        "https://example.com",
+      );
+    });
+
+    it("should leave http:// URLs unchanged", () => {
+      expect(DeviceManagementKitHTTPProxyTransport.normalizeUrl("http://localhost:8435")).toBe(
+        "http://localhost:8435",
+      );
+    });
+
+    it("should leave https:// URLs unchanged", () => {
+      expect(DeviceManagementKitHTTPProxyTransport.normalizeUrl("https://example.com")).toBe(
+        "https://example.com",
+      );
+    });
+  });
+
+  describe("open", () => {
+    beforeEach(() => {
+      jest.mocked(mockDmk.getDeviceSessionState).mockReturnValue(new Observable());
+      jest.mocked(mockDmk.listenToAvailableDevices).mockReturnValue(
+        new Observable(subscriber => {
+          subscriber.next([mockDiscoveredDevice]);
+        }),
+      );
+      jest.mocked(mockDmk.connect).mockResolvedValue("sessionId");
+    });
+
+    it("should reuse the singleton DMK and return a transport with dmk and sessionId", async () => {
+      const transport = await DeviceManagementKitHTTPProxyTransport.open("http://localhost:8435");
+
+      expect(transport).toBeInstanceOf(DeviceManagementKitHTTPProxyTransport);
+      expect(transport.dmk).toBe(mockDmk);
+      expect(transport.sessionId).toBe("sessionId");
+      expect(getDeviceManagementKit).toHaveBeenCalled();
+    });
+
+    it("should emit the normalized URL on the shared subject", async () => {
+      await DeviceManagementKitHTTPProxyTransport.open("ws://localhost:8435");
+
+      expect(httpProxyUrlSubject.getValue()).toBe("http://localhost:8435");
+    });
+
+    it("should call connect with the discovered device and isRefresherDisabled", async () => {
+      await DeviceManagementKitHTTPProxyTransport.open("http://localhost:8435");
+
+      expect(mockDmk.connect).toHaveBeenCalledWith({
+        device: mockDiscoveredDevice,
+        sessionRefresherOptions: { isRefresherDisabled: true },
+      });
+    });
+
+    it("should filter discovery to the HTTP proxy transport identifier", async () => {
+      await DeviceManagementKitHTTPProxyTransport.open("http://localhost:8435");
+
+      expect(mockDmk.listenToAvailableDevices).toHaveBeenCalledWith({
+        transport: HTTP_PROXY_TRANSPORT_IDENTIFIER,
+      });
+    });
+
+    it("should reuse the existing session for the same URL", async () => {
+      await DeviceManagementKitHTTPProxyTransport.open("http://localhost:8435");
+      await DeviceManagementKitHTTPProxyTransport.open("http://localhost:8435");
+
+      expect(mockDmk.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it("should create a new session when the previous one was cleared by disconnect", async () => {
+      const firstTransport =
+        await DeviceManagementKitHTTPProxyTransport.open("http://localhost:8435");
+      // Simulate what listenToDisconnect does when NOT_CONNECTED fires
+      statics.activeSessionId = null;
+      statics.activeUrl = null;
+
+      jest.mocked(mockDmk.connect).mockResolvedValue("sessionId2");
+
+      const secondTransport =
+        await DeviceManagementKitHTTPProxyTransport.open("http://localhost:8435");
+
+      expect(secondTransport.sessionId).toBe("sessionId2");
+      expect(mockDmk.connect).toHaveBeenCalledTimes(2);
+      expect(firstTransport.sessionId).toBe("sessionId");
+    });
+
+    it("should create a new session when the URL changes", async () => {
+      await DeviceManagementKitHTTPProxyTransport.open("http://localhost:8435");
+      jest.mocked(mockDmk.connect).mockResolvedValue("sessionId2");
+
+      const second = await DeviceManagementKitHTTPProxyTransport.open("http://other:9999");
+
+      expect(second.sessionId).toBe("sessionId2");
+      expect(mockDmk.connect).toHaveBeenCalledTimes(2);
+    });
+
+    it("should give each URL its own session when concurrent opens with different URLs are in flight", async () => {
+      let resolveA: (id: string) => void = () => {};
+      let resolveB: (id: string) => void = () => {};
+      jest
+        .mocked(mockDmk.connect)
+        .mockReturnValueOnce(new Promise<string>(r => (resolveA = r)))
+        .mockReturnValueOnce(new Promise<string>(r => (resolveB = r)));
+
+      const openA = DeviceManagementKitHTTPProxyTransport.open("http://a:1");
+      const openB = DeviceManagementKitHTTPProxyTransport.open("http://b:2");
+
+      // Resolve A first; B's connect must only start after A settles.
+      resolveA("sessionA");
+      await new Promise(r => setTimeout(r, 0));
+      resolveB("sessionB");
+
+      const [a, b] = await Promise.all([openA, openB]);
+
+      expect(a.sessionId).toBe("sessionA");
+      expect(b.sessionId).toBe("sessionB");
+      expect(mockDmk.connect).toHaveBeenCalledTimes(2);
+    });
+
+    it("should dedupe concurrent opens for the same URL", async () => {
+      let resolve: (id: string) => void = () => {};
+      jest.mocked(mockDmk.connect).mockReturnValueOnce(new Promise<string>(r => (resolve = r)));
+
+      const open1 = DeviceManagementKitHTTPProxyTransport.open("http://localhost:8435");
+      const open2 = DeviceManagementKitHTTPProxyTransport.open("http://localhost:8435");
+
+      resolve("sessionId");
+      const [t1, t2] = await Promise.all([open1, open2]);
+
+      expect(t1.sessionId).toBe("sessionId");
+      expect(t2.sessionId).toBe("sessionId");
+      expect(mockDmk.connect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("close", () => {
+    it("should resolve without error", async () => {
+      jest.mocked(mockDmk.getDeviceSessionState).mockReturnValue(new Observable());
+      const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+
+      await expect(transport.close()).resolves.toBeUndefined();
+    });
+
+    it("should unsubscribe from the device session state observable", async () => {
+      const deviceSessionStateSubject = new Subject<DeviceSessionState>();
+      jest
+        .mocked(mockDmk.getDeviceSessionState)
+        .mockReturnValue(deviceSessionStateSubject.asObservable());
+      const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+      const emitSpy = jest.spyOn(transport, "emit");
+
+      await transport.close();
+      deviceSessionStateSubject.next({
+        ...aMockedDeviceSessionState,
+        deviceStatus: DeviceStatus.NOT_CONNECTED,
+      });
+
+      expect(emitSpy).not.toHaveBeenCalledWith("disconnect");
+    });
+  });
+
+  describe("exchange", () => {
+    it("should call dmk.sendApdu and return the combined data+statusCode buffer", async () => {
+      jest.mocked(mockDmk.getDeviceSessionState).mockReturnValue(new Observable());
+      jest.mocked(mockDmk.sendApdu).mockResolvedValue({
+        data: Uint8Array.from([0x42, 0x21, 0x34]),
+        statusCode: Uint8Array.from([0x90, 0x00]),
+      });
+      const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+      const abortTimeoutMs = 42;
+
+      const response = await transport.exchange(Buffer.from([0xb0, 0x01, 0x00, 0x00, 0x00]), {
+        abortTimeoutMs,
+      });
+
+      expect(mockDmk.sendApdu).toHaveBeenCalledWith({
+        sessionId: "session",
+        apdu: Uint8Array.from([0xb0, 0x01, 0x00, 0x00, 0x00]),
+        abortTimeout: abortTimeoutMs,
+      });
+      expect(response).toEqual(Buffer.from([0x42, 0x21, 0x34, 0x90, 0x00]));
+    });
+
+    it("should re-throw unknown errors", async () => {
+      jest.mocked(mockDmk.getDeviceSessionState).mockReturnValue(new Observable());
+      jest.mocked(mockDmk.sendApdu).mockRejectedValue(new Error("unknown error"));
+      const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+
+      await expect(transport.exchange(Buffer.from([0x00]))).rejects.toThrow("unknown error");
+    });
+
+    [
+      new SendApduEmptyResponseError(),
+      new DeviceDisconnectedWhileSendingError(),
+      new DeviceDisconnectedBeforeSendingApdu(),
+    ].forEach(error => {
+      it(`should remap ${error.constructor.name} to DisconnectedDevice`, async () => {
+        jest.mocked(mockDmk.getDeviceSessionState).mockReturnValue(new Observable());
+        jest.mocked(mockDmk.sendApdu).mockRejectedValue(error);
+        const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+
+        let caughtError: unknown;
+        await transport.exchange(Buffer.from([0x00])).catch(e => {
+          caughtError = e;
+        });
+
+        expect(caughtError).toEqual(new DisconnectedDevice());
+      });
+    });
+  });
+
+  describe("listenToDisconnect", () => {
+    it("should be called on new transport", () => {
+      jest.mocked(mockDmk.getDeviceSessionState).mockReturnValue(new Observable());
+      jest.spyOn(DeviceManagementKitHTTPProxyTransport.prototype, "listenToDisconnect");
+
+      const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+
+      expect(transport.listenToDisconnect).toHaveBeenCalled();
+    });
+
+    it("should clear the cached session and emit disconnect on NOT_CONNECTED", () => {
+      const deviceSessionStateSubject = new Subject<DeviceSessionState>();
+      jest
+        .mocked(mockDmk.getDeviceSessionState)
+        .mockReturnValue(deviceSessionStateSubject.asObservable());
+      statics.activeUrl = "http://localhost:8435";
+      statics.activeSessionId = "session";
+      const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+      jest.spyOn(transport, "emit");
+
+      deviceSessionStateSubject.next({
+        ...aMockedDeviceSessionState,
+        deviceStatus: DeviceStatus.NOT_CONNECTED,
+      });
+
+      expect(statics.activeSessionId).toBeNull();
+      expect(statics.activeUrl).toBeNull();
+      expect(transport.emit).toHaveBeenCalledWith("disconnect");
+    });
+
+    it("should not clear the active cache when a stale instance fires NOT_CONNECTED for a different session", () => {
+      const deviceSessionStateSubject = new Subject<DeviceSessionState>();
+      jest
+        .mocked(mockDmk.getDeviceSessionState)
+        .mockReturnValue(deviceSessionStateSubject.asObservable());
+      // Active session belongs to a different (newer) instance.
+      statics.activeUrl = "http://localhost:9999";
+      statics.activeSessionId = "current-session";
+      // Stale transport built earlier for an older session.
+      const staleTransport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "stale-session");
+      jest.spyOn(staleTransport, "emit");
+
+      deviceSessionStateSubject.next({
+        ...aMockedDeviceSessionState,
+        deviceStatus: DeviceStatus.NOT_CONNECTED,
+      });
+
+      expect(statics.activeSessionId).toBe("current-session");
+      expect(statics.activeUrl).toBe("http://localhost:9999");
+      // Stale instance still emits its own disconnect for any local listeners.
+      expect(staleTransport.emit).toHaveBeenCalledWith("disconnect");
+    });
+
+    it("should not emit disconnect for non-NOT_CONNECTED states", () => {
+      const deviceSessionStateSubject = new Subject<DeviceSessionState>();
+      jest
+        .mocked(mockDmk.getDeviceSessionState)
+        .mockReturnValue(deviceSessionStateSubject.asObservable());
+      const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+      jest.spyOn(transport, "emit");
+
+      deviceSessionStateSubject.next({
+        ...aMockedDeviceSessionState,
+        deviceStatus: DeviceStatus.BUSY,
+      });
+
+      expect(transport.emit).not.toHaveBeenCalled();
+    });
+
+    it("should emit disconnect when the state observable completes", () => {
+      const deviceSessionStateSubject = new Subject<DeviceSessionState>();
+      jest
+        .mocked(mockDmk.getDeviceSessionState)
+        .mockReturnValue(deviceSessionStateSubject.asObservable());
+      const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+      jest.spyOn(transport, "emit");
+
+      deviceSessionStateSubject.complete();
+
+      expect(transport.emit).toHaveBeenCalledWith("disconnect");
+    });
+
+    it("should emit disconnect when the state observable errors", () => {
+      const deviceSessionStateSubject = new Subject<DeviceSessionState>();
+      jest
+        .mocked(mockDmk.getDeviceSessionState)
+        .mockReturnValue(deviceSessionStateSubject.asObservable());
+      const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+      jest.spyOn(transport, "emit");
+
+      deviceSessionStateSubject.error(new Error("state error"));
+
+      expect(transport.emit).toHaveBeenCalledWith("disconnect");
+    });
+
+    it("should not throw when the observable emits NOT_CONNECTED synchronously on subscribe", () => {
+      const deviceSessionStateSubject = new BehaviorSubject<DeviceSessionState>({
+        ...aMockedDeviceSessionState,
+        deviceStatus: DeviceStatus.NOT_CONNECTED,
+      });
+      jest
+        .mocked(mockDmk.getDeviceSessionState)
+        .mockReturnValue(deviceSessionStateSubject.asObservable());
+
+      expect(() => new DeviceManagementKitHTTPProxyTransport(mockDmk, "session")).not.toThrow();
+    });
+
+    it("should unsubscribe even when NOT_CONNECTED is emitted synchronously on subscribe", () => {
+      const deviceSessionStateSubject = new BehaviorSubject<DeviceSessionState>({
+        ...aMockedDeviceSessionState,
+        deviceStatus: DeviceStatus.NOT_CONNECTED,
+      });
+      jest
+        .mocked(mockDmk.getDeviceSessionState)
+        .mockReturnValue(deviceSessionStateSubject.asObservable());
+
+      const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+
+      expect(transport["disconnectSubscription"]?.closed).toBe(true);
+    });
+
+    it("should emit disconnect only once even if NOT_CONNECTED fires multiple times", () => {
+      const deviceSessionStateSubject = new Subject<DeviceSessionState>();
+      jest
+        .mocked(mockDmk.getDeviceSessionState)
+        .mockReturnValue(deviceSessionStateSubject.asObservable());
+      const transport = new DeviceManagementKitHTTPProxyTransport(mockDmk, "session");
+      const emitSpy = jest.spyOn(transport, "emit");
+
+      deviceSessionStateSubject.next({
+        ...aMockedDeviceSessionState,
+        deviceStatus: DeviceStatus.NOT_CONNECTED,
+      });
+      deviceSessionStateSubject.next({
+        ...aMockedDeviceSessionState,
+        deviceStatus: DeviceStatus.NOT_CONNECTED,
+      });
+
+      expect(emitSpy.mock.calls.filter(c => c[0] === "disconnect")).toHaveLength(1);
+    });
+  });
+});

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitHTTPProxyTransport.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitHTTPProxyTransport.ts
@@ -1,0 +1,144 @@
+import {
+  DeviceManagementKit,
+  DeviceStatus,
+  SendApduEmptyResponseError,
+  DeviceDisconnectedWhileSendingError,
+  DeviceDisconnectedBeforeSendingApdu,
+  type DiscoveredDevice,
+} from "@ledgerhq/device-management-kit";
+import { DisconnectedDevice } from "@ledgerhq/errors";
+import Transport from "@ledgerhq/hw-transport";
+import { firstValueFrom, type Subscription } from "rxjs";
+import { filter, timeout } from "rxjs/operators";
+import { HTTP_PROXY_TRANSPORT_IDENTIFIER, httpProxyUrlSubject } from "./HttpProxyDmkTransport";
+import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";
+
+export class DeviceManagementKitHTTPProxyTransport extends Transport {
+  readonly dmk: DeviceManagementKit;
+  sessionId: string;
+  private readonly disconnectSubscription?: Subscription;
+
+  private static activeUrl: string | null = null;
+  private static activeSessionId: string | null = null;
+  private static inFlight: { url: string; promise: Promise<string> } | null = null;
+
+  constructor(dmk: DeviceManagementKit, sessionId: string) {
+    super();
+    this.dmk = dmk;
+    this.sessionId = sessionId;
+    this.disconnectSubscription = this.listenToDisconnect();
+  }
+
+  static normalizeUrl(raw: string): string {
+    return raw.replace(/^ws(s?):\/\//, "http$1://");
+  }
+
+  private static async ensureSession(dmk: DeviceManagementKit, url: string): Promise<string> {
+    if (this.activeSessionId && this.activeUrl === url) return this.activeSessionId;
+    if (this.inFlight?.url === url) return this.inFlight.promise;
+    if (this.inFlight) {
+      // A connect for a different URL is in flight — wait for it to settle so the
+      // shared URL subject and DMK transport state don't get clobbered mid-connect.
+      await this.inFlight.promise.catch(() => {});
+      if (this.activeSessionId && this.activeUrl === url) return this.activeSessionId;
+    }
+
+    const promise = (async () => {
+      httpProxyUrlSubject.next(url);
+      const devices = await firstValueFrom<DiscoveredDevice[]>(
+        dmk.listenToAvailableDevices({ transport: HTTP_PROXY_TRANSPORT_IDENTIFIER }).pipe(
+          filter(list => list.length > 0),
+          timeout(10_000),
+        ),
+      );
+      const sessionId = await dmk.connect({
+        device: devices[0],
+        sessionRefresherOptions: { isRefresherDisabled: true },
+      });
+      this.activeSessionId = sessionId;
+      this.activeUrl = url;
+      return sessionId;
+    })();
+
+    this.inFlight = { url, promise };
+
+    try {
+      return await promise;
+    } finally {
+      if (this.inFlight?.promise === promise) {
+        this.inFlight = null;
+      }
+    }
+  }
+
+  static async open(rawUrl: string): Promise<DeviceManagementKitHTTPProxyTransport> {
+    const url = this.normalizeUrl(rawUrl);
+    const dmk = getDeviceManagementKit();
+    const sessionId = await this.ensureSession(dmk, url);
+    return new DeviceManagementKitHTTPProxyTransport(dmk, sessionId);
+  }
+
+  async exchange(
+    apdu: Buffer,
+    { abortTimeoutMs }: { abortTimeoutMs?: number } = {},
+  ): Promise<Buffer> {
+    return this.dmk
+      .sendApdu({
+        sessionId: this.sessionId,
+        apdu: new Uint8Array(apdu),
+        abortTimeout: abortTimeoutMs,
+      })
+      .then(({ data, statusCode }) => Buffer.from([...data, ...statusCode]))
+      .catch(error => {
+        if (
+          error instanceof SendApduEmptyResponseError ||
+          error instanceof DeviceDisconnectedWhileSendingError ||
+          error instanceof DeviceDisconnectedBeforeSendingApdu
+        ) {
+          throw new DisconnectedDevice();
+        }
+        throw error;
+      });
+  }
+
+  close(): Promise<void> {
+    this.disconnectSubscription?.unsubscribe();
+    return Promise.resolve();
+  }
+
+  listenToDisconnect() {
+    let isDisconnected = false;
+    // If the observable emits NOT_CONNECTED synchronously during subscribe(), `subscription`
+    // is still undefined when handleDisconnect runs — set this flag and tear it down right
+    // after subscribe() returns so we don't leak a live subscription.
+    let pendingUnsubscribe = false;
+    let subscription: Subscription | undefined;
+    const handleDisconnect = () => {
+      if (isDisconnected) return;
+      isDisconnected = true;
+      // Only clear the shared cache if it still refers to this transport's session.
+      // A late event from a stale instance (e.g. after the user switched URLs) must not
+      // wipe the entry of the currently-active session and force a needless reconnect.
+      if (DeviceManagementKitHTTPProxyTransport.activeSessionId === this.sessionId) {
+        DeviceManagementKitHTTPProxyTransport.activeSessionId = null;
+        DeviceManagementKitHTTPProxyTransport.activeUrl = null;
+      }
+      this.emit("disconnect");
+      if (subscription) subscription.unsubscribe();
+      else pendingUnsubscribe = true;
+    };
+    subscription = this.dmk.getDeviceSessionState({ sessionId: this.sessionId }).subscribe({
+      next: (state: { deviceStatus: DeviceStatus }) => {
+        if (state.deviceStatus === DeviceStatus.NOT_CONNECTED) handleDisconnect();
+      },
+      error: handleDisconnect,
+      complete: handleDisconnect,
+    });
+    if (pendingUnsubscribe) subscription.unsubscribe();
+    return subscription;
+  }
+
+  static readonly isSupported = async () => true;
+  static readonly list = async () => [];
+  static readonly listen = (_observer: unknown) => ({ unsubscribe: () => {} });
+}

--- a/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.test.ts
+++ b/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.test.ts
@@ -1,0 +1,325 @@
+import { BehaviorSubject } from "rxjs";
+import { ApduResponse, DeviceModelId, type TransportArgs } from "@ledgerhq/device-management-kit";
+import { HTTP_PROXY_TRANSPORT_IDENTIFIER, HttpProxyDmkTransport } from "./HttpProxyDmkTransport";
+
+const SYNTHETIC_DEVICE_ID = "http-proxy-device";
+
+const mockDeviceModel = {
+  model: DeviceModelId.NANO_X,
+  name: "Nano X",
+  id: DeviceModelId.NANO_X,
+};
+
+function createMockArgs(): TransportArgs {
+  return {
+    deviceModelDataSource: {
+      getDeviceModel: jest.fn().mockReturnValue(mockDeviceModel),
+    },
+  } as unknown as TransportArgs;
+}
+
+describe("HttpProxyDmkTransport", () => {
+  const url = "http://localhost:8435";
+  let originalFetch: typeof global.fetch;
+  let urlSubject: BehaviorSubject<string | null>;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    jest.restoreAllMocks();
+    global.fetch = jest.fn();
+    urlSubject = new BehaviorSubject<string | null>(url);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("getIdentifier", () => {
+    it("should return the HTTP proxy transport identifier", () => {
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      expect(transport.getIdentifier()).toBe(HTTP_PROXY_TRANSPORT_IDENTIFIER);
+    });
+  });
+
+  describe("isSupported", () => {
+    it("should always return true", () => {
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      expect(transport.isSupported()).toBe(true);
+    });
+  });
+
+  describe("listenToAvailableDevices", () => {
+    it("should emit the synthetic device when a URL is set", () => {
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      const emitted: unknown[][] = [];
+
+      transport.listenToAvailableDevices().subscribe({ next: list => emitted.push(list) });
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toHaveLength(1);
+      expect((emitted[0][0] as { id: string }).id).toBe(SYNTHETIC_DEVICE_ID);
+    });
+
+    it("should emit an empty list when the URL is null", () => {
+      urlSubject.next(null);
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      const emitted: unknown[][] = [];
+
+      transport.listenToAvailableDevices().subscribe({ next: list => emitted.push(list) });
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toHaveLength(0);
+    });
+
+    it("should re-emit when the URL subject changes", () => {
+      urlSubject.next(null);
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      const emitted: unknown[][] = [];
+
+      transport.listenToAvailableDevices().subscribe({ next: list => emitted.push(list) });
+      urlSubject.next("http://other:9999");
+
+      expect(emitted).toHaveLength(2);
+      expect(emitted[1]).toHaveLength(1);
+      expect((emitted[1][0] as { name: string }).name).toContain("http://other:9999");
+    });
+  });
+
+  describe("startDiscovering", () => {
+    it("should emit the synthetic device when a URL is set", () => {
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      const discovered: unknown[] = [];
+
+      transport.startDiscovering().subscribe({ next: d => discovered.push(d) });
+
+      expect(discovered).toHaveLength(1);
+      expect((discovered[0] as { id: string }).id).toBe(SYNTHETIC_DEVICE_ID);
+      expect((discovered[0] as { transport: string }).transport).toBe(
+        HTTP_PROXY_TRANSPORT_IDENTIFIER,
+      );
+    });
+
+    it("should emit nothing when the URL is null", () => {
+      urlSubject.next(null);
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      const discovered: unknown[] = [];
+
+      transport.startDiscovering().subscribe({ next: d => discovered.push(d) });
+
+      expect(discovered).toHaveLength(0);
+    });
+  });
+
+  describe("stopDiscovering", () => {
+    it("should not throw", () => {
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      expect(() => transport.stopDiscovering()).not.toThrow();
+    });
+  });
+
+  describe("disconnect", () => {
+    it("should return Right(undefined)", async () => {
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      const result = await transport.disconnect();
+      expect(result.isRight()).toBe(true);
+      expect(result.unsafeCoerce()).toBeUndefined();
+    });
+  });
+
+  describe("connect", () => {
+    it("should return Right with a TransportConnectedDevice", async () => {
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      const result = await transport.connect({
+        deviceId: SYNTHETIC_DEVICE_ID,
+        onDisconnect: jest.fn(),
+      });
+      expect(result.isRight()).toBe(true);
+    });
+
+    it("should return Left when the URL subject is null at connect time", async () => {
+      urlSubject.next(null);
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      const result = await transport.connect({
+        deviceId: SYNTHETIC_DEVICE_ID,
+        onDisconnect: jest.fn(),
+      });
+      expect(result.isLeft()).toBe(true);
+    });
+
+    describe("sendApdu", () => {
+      async function getSendApdu(subject = urlSubject) {
+        const transport = new HttpProxyDmkTransport(createMockArgs(), subject);
+        const result = await transport.connect({
+          deviceId: SYNTHETIC_DEVICE_ID,
+          onDisconnect: jest.fn(),
+        });
+        return result.unsafeCoerce().sendApdu;
+      }
+
+      it("should POST the APDU as hex to the current URL", async () => {
+        const sendApdu = await getSendApdu();
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: "9000" }),
+        });
+
+        await sendApdu(Uint8Array.from([0xb0, 0x01, 0x00, 0x00, 0x00]));
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          url,
+          expect.objectContaining({
+            method: "POST",
+            body: JSON.stringify({ apduHex: "b001000000" }),
+          }),
+        );
+      });
+
+      it("should POST to the URL captured at connect time even if the subject changes after", async () => {
+        const sendApdu = await getSendApdu();
+        (global.fetch as jest.Mock).mockResolvedValue({
+          ok: true,
+          json: async () => ({ data: "9000" }),
+        });
+
+        urlSubject.next("http://new-host:1234");
+        await sendApdu(Uint8Array.from([0x00]));
+
+        expect(global.fetch).toHaveBeenCalledWith(url, expect.anything());
+      });
+
+      it("should return Right(ApduResponse) with data and statusCode split correctly", async () => {
+        const sendApdu = await getSendApdu();
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: "deadbeef9000" }),
+        });
+
+        const result = await sendApdu(Uint8Array.from([0xb0, 0x01, 0x00, 0x00, 0x00]));
+
+        expect(result.isRight()).toBe(true);
+        const response = result.unsafeCoerce() as ApduResponse;
+        expect(Array.from(response.data)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+        expect(Array.from(response.statusCode)).toEqual([0x90, 0x00]);
+      });
+
+      it("should return Left when HTTP response is not ok", async () => {
+        const sendApdu = await getSendApdu();
+        (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 500 });
+
+        const result = await sendApdu(Uint8Array.from([0x00]));
+
+        expect(result.isLeft()).toBe(true);
+      });
+
+      it("should return Left when body contains an error field", async () => {
+        const sendApdu = await getSendApdu();
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ error: "device busy" }),
+        });
+
+        const result = await sendApdu(Uint8Array.from([0x00]));
+
+        expect(result.isLeft()).toBe(true);
+      });
+
+      it("should return Left when body.data is missing", async () => {
+        const sendApdu = await getSendApdu();
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({}),
+        });
+
+        const result = await sendApdu(Uint8Array.from([0x00]));
+
+        expect(result.isLeft()).toBe(true);
+      });
+
+      it("should return Left when body.data is not valid hex", async () => {
+        const sendApdu = await getSendApdu();
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: "not-hex" }),
+        });
+
+        const result = await sendApdu(Uint8Array.from([0x00]));
+
+        expect(result.isLeft()).toBe(true);
+      });
+
+      it("should return Left when the response is shorter than a status code", async () => {
+        const sendApdu = await getSendApdu();
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ data: "90" }),
+        });
+
+        const result = await sendApdu(Uint8Array.from([0x00]));
+
+        expect(result.isLeft()).toBe(true);
+      });
+
+      it("should return Left and NOT call onDisconnect when fetch throws", async () => {
+        const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+        const onDisconnect = jest.fn();
+        const connectResult = await transport.connect({
+          deviceId: SYNTHETIC_DEVICE_ID,
+          onDisconnect,
+        });
+        const sendApdu = connectResult.unsafeCoerce().sendApdu;
+
+        (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("Network error"));
+
+        const result = await sendApdu(Uint8Array.from([0x00]));
+
+        expect(result.isLeft()).toBe(true);
+        expect(onDisconnect).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("syntheticDevice", () => {
+    it("should pass the custom deviceModelId to deviceModelDataSource.getDeviceModel", () => {
+      const args = createMockArgs();
+      const transport = new HttpProxyDmkTransport(args, urlSubject, DeviceModelId.FLEX);
+
+      transport.listenToAvailableDevices().subscribe({ next: () => {} });
+
+      expect(args.deviceModelDataSource.getDeviceModel).toHaveBeenCalledWith({
+        id: DeviceModelId.FLEX,
+      });
+    });
+
+    it("should default to NANO_X when no deviceModelId is provided", () => {
+      const args = createMockArgs();
+      const transport = new HttpProxyDmkTransport(args, urlSubject);
+
+      transport.listenToAvailableDevices().subscribe({ next: () => {} });
+
+      expect(args.deviceModelDataSource.getDeviceModel).toHaveBeenCalledWith({
+        id: DeviceModelId.NANO_X,
+      });
+    });
+
+    it("should include the URL in the device name", () => {
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      const emitted: unknown[][] = [];
+
+      transport.listenToAvailableDevices().subscribe({ next: list => emitted.push(list) });
+
+      expect((emitted[0][0] as { name: string }).name).toContain(url);
+    });
+
+    it("should use a stable id across URL changes", () => {
+      const transport = new HttpProxyDmkTransport(createMockArgs(), urlSubject);
+      const ids: string[] = [];
+
+      transport.listenToAvailableDevices().subscribe({
+        next: list => list.forEach(d => ids.push((d as { id: string }).id)),
+      });
+      urlSubject.next("http://other:9999");
+
+      expect(ids).toEqual([SYNTHETIC_DEVICE_ID, SYNTHETIC_DEVICE_ID]);
+    });
+  });
+});

--- a/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.ts
+++ b/libs/live-dmk-mobile/src/transport/HttpProxyDmkTransport.ts
@@ -1,0 +1,150 @@
+import { BehaviorSubject, EMPTY, Observable, of } from "rxjs";
+import { map } from "rxjs/operators";
+import { Either, Left, Right } from "purify-ts";
+import {
+  ApduResponse,
+  DeviceModelId,
+  TransportConnectedDevice,
+  UnknownDeviceError,
+  bufferToHexaString,
+  hexaStringToBuffer,
+  type ConnectError,
+  type DmkError,
+  type Transport as DmkTransport,
+  type TransportArgs,
+  type TransportDiscoveredDevice,
+  type TransportFactory,
+} from "@ledgerhq/device-management-kit";
+
+export const HTTP_PROXY_TRANSPORT_IDENTIFIER = "HTTP_PROXY_TRANSPORT";
+const SYNTHETIC_DEVICE_ID = "http-proxy-device";
+
+export const httpProxyUrlSubject = new BehaviorSubject<string | null>(null);
+
+// Stringify an unknown error payload without falling back to "[object Object]".
+const stringifyError = (err: unknown): string => {
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  return JSON.stringify(err);
+};
+
+export class HttpProxyDmkTransport implements DmkTransport {
+  private readonly urlSubject: BehaviorSubject<string | null>;
+  private readonly deviceModelId: DeviceModelId;
+  private readonly args: TransportArgs;
+
+  constructor(
+    args: TransportArgs,
+    urlSubject: BehaviorSubject<string | null>,
+    deviceModelId: DeviceModelId = DeviceModelId.NANO_X,
+  ) {
+    this.args = args;
+    this.urlSubject = urlSubject;
+    this.deviceModelId = deviceModelId;
+  }
+
+  getIdentifier(): string {
+    return HTTP_PROXY_TRANSPORT_IDENTIFIER;
+  }
+
+  isSupported(): boolean {
+    return true;
+  }
+
+  listenToAvailableDevices(): Observable<TransportDiscoveredDevice[]> {
+    return this.urlSubject.pipe(map(url => (url ? [this.syntheticDevice(url)] : [])));
+  }
+
+  startDiscovering(): Observable<TransportDiscoveredDevice> {
+    const url = this.urlSubject.getValue();
+    return url ? of(this.syntheticDevice(url)) : EMPTY;
+  }
+
+  stopDiscovering(): void {
+    // Nothing to clean up.
+  }
+
+  async connect({
+    deviceId,
+  }: {
+    deviceId: string;
+    onDisconnect: (deviceId: string) => void;
+  }): Promise<Either<ConnectError, TransportConnectedDevice>> {
+    // Capture the URL at connect time so the session is bound to one endpoint
+    // for its lifetime — subject changes after this point only affect new sessions.
+    const url = this.urlSubject.getValue();
+    if (!url) {
+      return Left(new UnknownDeviceError("HTTP proxy URL not set"));
+    }
+
+    const sendApdu = async (apdu: Uint8Array): Promise<Either<DmkError, ApduResponse>> => {
+      try {
+        const apduHex = bufferToHexaString(apdu, false);
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({ apduHex }),
+        });
+        if (!resp.ok) {
+          return Left(new UnknownDeviceError(`HTTP ${resp.status}`));
+        }
+        const body = (await resp.json()) as { data?: string; error?: unknown };
+        if (body.error) {
+          return Left(new UnknownDeviceError(stringifyError(body.error)));
+        }
+        if (!body.data) {
+          return Left(new UnknownDeviceError("empty response from proxy"));
+        }
+        const bytes = hexaStringToBuffer(body.data);
+        if (!bytes) {
+          return Left(new UnknownDeviceError(`invalid hex in proxy response: ${body.data}`));
+        }
+        if (bytes.length < 2) {
+          return Left(new UnknownDeviceError(`malformed proxy response: ${body.data}`));
+        }
+        return Right(
+          new ApduResponse({
+            data: bytes.slice(0, -2),
+            statusCode: bytes.slice(-2),
+          }),
+        );
+      } catch (err) {
+        // Do NOT invoke DMK's onDisconnect — it signals physical disconnect and wipes
+        // the session from the registry. A failed HTTP request should be retryable.
+        const message = err instanceof Error ? err.message : String(err);
+        return Left(new UnknownDeviceError(message));
+      }
+    };
+
+    const connectedDevice = new TransportConnectedDevice({
+      id: deviceId,
+      deviceModel: this.args.deviceModelDataSource.getDeviceModel({ id: this.deviceModelId }),
+      type: "USB",
+      transport: HTTP_PROXY_TRANSPORT_IDENTIFIER,
+      sendApdu,
+    });
+
+    return Right(connectedDevice);
+  }
+
+  async disconnect(): Promise<Either<DmkError, void>> {
+    return Right(undefined);
+  }
+
+  private syntheticDevice(url: string): TransportDiscoveredDevice {
+    return {
+      id: SYNTHETIC_DEVICE_ID,
+      deviceModel: this.args.deviceModelDataSource.getDeviceModel({ id: this.deviceModelId }),
+      transport: HTTP_PROXY_TRANSPORT_IDENTIFIER,
+      name: `HTTP Proxy (${url})`,
+    };
+  }
+}
+
+export const httpProxyTransportFactory =
+  (urlSubject: BehaviorSubject<string | null>, deviceModelId?: DeviceModelId): TransportFactory =>
+  (args: TransportArgs) =>
+    new HttpProxyDmkTransport(args, urlSubject, deviceModelId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10701,6 +10701,9 @@ importers:
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../ledgerjs/packages/types-devices
+      purify-ts:
+        specifier: ^2.1.0
+        version: 2.1.0
     devDependencies:
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:**  
    - Mobile dev mode `httpdebug` transport (iOS simulator + `ledger-live proxy` CLI workflow)
    - `@ledgerhq/live-dmk-mobile`: new `DeviceManagementKitHTTPProxyTransport` export
    - `ledger-live proxy` CLI: HTTP exchange log line now prints the APDU hex

### 📝 Description

DMK-only coin families were broken on mobile in dev mode when forwarding APDUs through the `ledger-live proxy` CLI — the connection was rejected because the existing `httpdebug` transport was built on `withStaticURLs` from `@ledgerhq/hw-transport-http`, a legacy `Transport` with no `dmk`/`sessionId` properties, so `isDmkTransport()` returned false.

This PR wraps the proxy CLI's HTTP protocol into a proper DMK transport. The shape mirrors the speculos integration:

```
DeviceManagementKitHTTPProxyTransport ← outer hw-transport wrapper (exposes dmk + sessionId)
          │ shares the singleton DMK + caches the session for the active URL
          ▼
HttpProxyDmkTransport                 ← DMK Transport plugin
          │ implements DMK's Transport interface
          ▼
fetch() → ledger-live proxy           ← POST / with { apduHex }
```

Key behaviors:
  - URL normalization (`ws://` → `http://`, `wss://` → `https://`) since the proxy CLI emits `ws://` URLs by default while sharing the HTTP endpoint on the same port.
  - Session reuse: the most recently established `(url, sessionId)` pair is cached and returned by subsequent `open()` calls for the same URL. Concurrent `open()` calls are de-duplicated via a URL-keyed in-flight promise so the shared `httpProxyUrlSubject` and DMK transport state aren't clobbered mid-connect. Switching to a different URL reconnects (only one URL can be active at a time because the underlying `BehaviorSubject` holds a single value).
  - `sendApdu` returns `Left(UnknownDeviceError)` on fetch failure but **does not** call `onDisconnect` — that callback signals physical disconnection (USB unplugged, BLE dropped) and would wipe the DMK session registry. A failed HTTP request is not a physical disconnect.
  - Session refresher disabled (`isRefresherDisabled: true`) — the proxy is a dev-only tool with no need for periodic keepalives.
  - Disconnect detection via `getDeviceSessionState`: on `NOT_CONNECTED`, the cached `sessionId` is cleared so the next `open()` call establishes a fresh session.

The legacy `withStaticURLs` is retained inside the `__DEV__ && Config.DEVICE_PROXY_URL` block — it still drives URL-polling discovery; only the `open` path was swapped.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

