### PR TITLE
[LWDM] feat(live-common): add loadSigner to CoinModuleLoader registry

### DIFF
--- a/.changeset/silver-coins-register.md
+++ b/.changeset/silver-coins-register.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add loadSigner to CoinModuleLoader and expose loadSignerForFamily from registry; register Alpaca signers in loaders for evm, solana, stellar, tezos, and xrp; refactor getSigner to delegate to the registry instead of a hardcoded switch

--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -47,6 +47,8 @@ const walletCliLoaders: CoinModuleLoader[] = [
     loadPlatformAdapter: () =>
       require("@ledgerhq/live-common/families/evm/platformAdapter").default,
     loadValidateAddress: () => require("@ledgerhq/coin-evm/logic/validateAddress").validateAddress,
+    loadSigner: () =>
+      require("@ledgerhq/live-common/bridge/generic-alpaca/families/evm/signer").default,
   },
   {
     family: "solana",
@@ -55,6 +57,8 @@ const walletCliLoaders: CoinModuleLoader[] = [
     loadDeviceTxConfig: () => require("@ledgerhq/coin-solana/deviceTransactionConfig").default,
     loadWalletApiAdapter: () =>
       require("@ledgerhq/live-common/families/solana/walletApiAdapter").default,
+    loadSigner: () =>
+      require("@ledgerhq/live-common/bridge/generic-alpaca/families/solana/signer").default,
   },
 ];
 

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/signer.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/signer.ts
@@ -1,27 +1,14 @@
 import type { AlpacaSigner } from "./types";
+import { loadSignerForFamily } from "../../coin-modules/registry";
 
-/**
- * Lazy-load Alpaca signer modules so wallet-cli (EVM-only flows) does not bundle XRP/Stellar/Tezos HW stacks.
- */
-// TODO: we could also use dynamic import here but we need to update everything to async/await where getSigner is used
+const networkToFamily = (network: string) => {
+  if (network === "ripple") return "xrp";
+  return network;
+};
+
 export function getSigner(network: string): AlpacaSigner {
-  switch (network) {
-    case "ripple":
-    case "xrp": {
-      return require("./families/xrp/signer").default;
-    }
-    case "stellar": {
-      return require("./families/stellar/signer").default;
-    }
-    case "tezos": {
-      return require("./families/tezos/signer").default;
-    }
-    case "evm": {
-      return require("./families/evm/signer").default;
-    }
-    case "solana": {
-      return require("./families/solana/signer").default;
-    }
-  }
-  throw new Error(`signer for ${network} not implemented`);
+  const family = networkToFamily(network);
+  const signer = loadSignerForFamily(family);
+  if (!signer) throw new Error(`No signer registered for network ${network}`);
+  return signer;
 }

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -92,6 +92,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadPlatformAdapter: () => require("../families/evm/platformAdapter").default,
     loadMockBridge: () => require("../families/evm/bridge/mock").default,
     loadValidateAddress: () => require("@ledgerhq/coin-evm/logic/validateAddress").validateAddress,
+    loadSigner: () => require("../bridge/generic-alpaca/families/evm/signer").default,
     loadIsEditableOperation: () => require("../families/evm/operations").isEditableOperation,
     loadIsStuckOperation: () => require("../families/evm/operations").isStuckOperation,
     loadGetStuckAccountAndOperation: () => require("../families/evm/operations").getStuckAccountAndOperation,
@@ -167,6 +168,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadMockBridge: () => require("../families/solana/bridge/mock").default,
     loadValidateAddress: () =>
       require("@ledgerhq/coin-solana/logic/validateAddress").validateAddress,
+    loadSigner: () => require("../bridge/generic-alpaca/families/solana/signer").default,
   },
   {
     family: "stacks",
@@ -182,6 +184,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadMockBridge: () => require("../families/stellar/bridge/mock").default,
     loadValidateAddress: () =>
       require("@ledgerhq/coin-stellar/logic/validateAddress").validateAddress,
+    loadSigner: () => require("../bridge/generic-alpaca/families/stellar/signer").default,
   },
   {
     family: "sui",
@@ -198,6 +201,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadGetVotesCount: () => require("../families/tezos/getVotesCount").getVotesCount,
     loadValidateAddress: () =>
       require("@ledgerhq/coin-tezos/logic/validateAddress").validateAddress,
+    loadSigner: () => require("../bridge/generic-alpaca/families/tezos/signer").default,
   },
   {
     family: "ton",
@@ -233,5 +237,6 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadMockBridge: () => require("../families/xrp/bridge/mock").default,
     loadValidateAddress: () =>
       require("@ledgerhq/coin-xrp/logic/validateAddress").validateAddress,
+    loadSigner: () => require("../bridge/generic-alpaca/families/xrp/signer").default,
   },
 ];

--- a/libs/ledger-live-common/src/coin-modules/registry.test.ts
+++ b/libs/ledger-live-common/src/coin-modules/registry.test.ts
@@ -17,6 +17,7 @@ import {
   loadIsEditableOperationForFamily,
   loadIsStuckOperationForFamily,
   loadGetStuckAccountAndOperationForFamily,
+  loadSignerForFamily,
 } from "./registry";
 import type { CoinModuleLoader, FamilySetup, TransactionModule } from "./types";
 
@@ -63,6 +64,7 @@ const allLoaders: LoaderEntry[] = [
   { loaderKey: "loadIsEditableOperation", fn: loadIsEditableOperationForFamily },
   { loaderKey: "loadIsStuckOperation", fn: loadIsStuckOperationForFamily },
   { loaderKey: "loadGetStuckAccountAndOperation", fn: loadGetStuckAccountAndOperationForFamily },
+  { loaderKey: "loadSigner", fn: loadSignerForFamily },
 ];
 
 describe.each(allLoaders)("$fn.name", ({ loaderKey, fn, required }) => {

--- a/libs/ledger-live-common/src/coin-modules/registry.ts
+++ b/libs/ledger-live-common/src/coin-modules/registry.ts
@@ -1,6 +1,7 @@
 import { CurrencyNotSupported } from "@ledgerhq/errors";
 import type {
   AccountModule,
+  AlpacaSigner,
   CoinModuleLoader,
   DeviceTransactionConfigFn,
   FamilySetup,
@@ -100,6 +101,9 @@ export const loadClearAccountForFamily = (
 
 export const loadValidateAddressForFamily = (family: string): ValidateAddressFn | undefined =>
   loaders.get(family)?.loadValidateAddress?.();
+
+export const loadSignerForFamily = (family: string): AlpacaSigner | undefined =>
+  loaders.get(family)?.loadSigner?.();
 
 export const loadIsEditableOperationForFamily = (
   family: string,

--- a/libs/ledger-live-common/src/coin-modules/types.ts
+++ b/libs/ledger-live-common/src/coin-modules/types.ts
@@ -15,6 +15,8 @@ import type { Transaction as WalletAPITransaction } from "@ledgerhq/wallet-api-c
 import type { Resolver } from "../hw/getAddress/types";
 import type { SignMessage } from "../hw/signMessage/types";
 import type { GetWalletAPITransactionSignFlowInfos } from "../wallet-api/types";
+import type { AlpacaSigner } from "../bridge/generic-alpaca/types";
+export type { AlpacaSigner };
 
 export type MessageSignerModule = {
   signMessage: SignMessage;
@@ -117,4 +119,5 @@ export type CoinModuleLoader = {
   loadGetVotesCount?: () => (account: Account) => number;
   loadClearAccount?: () => (account: Account) => void;
   loadValidateAddress?: () => ValidateAddressFn;
+  loadSigner?: () => AlpacaSigner;
 };


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [ ] **Impact of the changes:**
  - `libs/ledger-live-common/src/coin-modules/` and `bridge/generic-alpaca/signer.ts` only
  - No runtime behaviour change — `getSigner` resolves identically, just via the registry

### 📝 Description

Subset of #16795: extracts only the `loadSigner` / registry wiring, leaving the `require()→static import` rework for a separate PR.

**What changed:**
- `CoinModuleLoader` gains `loadSigner?: () => AlpacaSigner`
- `loadSignerForFamily` exported from `coin-modules/registry`
- `loaders.ts`: `loadSigner` entries added for `evm`, `solana`, `stellar`, `tezos`, `xrp`
- `generic-alpaca/signer.ts`: `getSigner` now delegates to the registry instead of a hardcoded switch/require block
- `wallet-cli`: `loadSigner` entries for `evm` and `solana`

**Consumer side (after merge):**
```ts
// instead of maintaining the switch in signer.ts, new families just add:
loadSigner: () => require("../bridge/generic-alpaca/families/myfamily/signer").default,
// in their loaders.ts entry
```

### ❓ Context

- **JIRA or GitHub link**: subset of #16795
- **ADR link (if any)**: N/A