### PR TITLE
[LWM] feat(mobile): update tracking events in My Wallet

### DIFF
--- a/.changeset/violet-pugs-fold.md
+++ b/.changeset/violet-pugs-fold.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update tracking

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
@@ -75,7 +75,7 @@ export function useTopBarViewModel(
   }, [navigation, page, readOnlyModeEnabled, navigateToRebornFlow]);
 
   const onMyWalletPress = useCallback(() => {
-    track("menuentry_clicked", { button: "MyWallet", page });
+    track("button_clicked", { button: "My Wallet", page });
     navigation.navigate(NavigatorName.MyWallet, {
       screen: ScreenName.MyWallet,
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ScrollView } from "react-native";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { TrackScreen } from "~/analytics";
 import { ProfileSection } from "./views/ProfileSection";
 import { QuickActionsRow } from "./views/QuickActionsRow";
 import { DeviceSection } from "./views/DeviceSection";
@@ -8,6 +9,7 @@ import { DeviceSection } from "./views/DeviceSection";
 export function MyWalletScreen() {
   return (
     <Box style={{ flex: 1 }}>
+      <TrackScreen category="My Wallet" />
       <ScrollView>
         <Box lx={{ paddingHorizontal: "s16", gap: "s24", paddingBottom: "s24" }}>
           <ProfileSection />

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/__tests__/useMyWalletHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/__tests__/useMyWalletHeaderViewModel.test.ts
@@ -37,7 +37,7 @@ describe("useMyWalletHeaderViewModel", () => {
     expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.NotificationCenter, {
       screen: ScreenName.NotificationCenter,
     });
-    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+    expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Notifications",
       page: ScreenName.MyWallet,
     });
@@ -47,7 +47,7 @@ describe("useMyWalletHeaderViewModel", () => {
     const { result } = renderHook(() => useMyWalletHeaderViewModel());
     act(() => result.current.onSettingsPress());
     expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.Settings);
-    expect(track).toHaveBeenCalledWith("menuentry_clicked", {
+    expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Settings",
       page: ScreenName.MyWallet,
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/useMyWalletHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/useMyWalletHeaderViewModel.ts
@@ -20,14 +20,14 @@ export function useMyWalletHeaderViewModel() {
   }, [navigation]);
 
   const onNotificationsPress = useCallback(() => {
-    track("menuentry_clicked", { button: "Notifications", page: ScreenName.MyWallet });
+    track("button_clicked", { button: "Notifications", page: ScreenName.MyWallet });
     navigation.navigate(NavigatorName.NotificationCenter, {
       screen: ScreenName.NotificationCenter,
     });
   }, [navigation]);
 
   const onSettingsPress = useCallback(() => {
-    track("menuentry_clicked", { button: "Settings", page: ScreenName.MyWallet });
+    track("button_clicked", { button: "Settings", page: ScreenName.MyWallet });
     navigation.navigate(NavigatorName.Settings);
   }, [navigation]);
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Analytics-only changes (event renaming and screen tracking) — no behavioral logic to unit-test._
- [x] **Impact of the changes:**
  - Verify `button_clicked` events fire correctly for My Wallet, Notifications, and Settings buttons
  - Verify `TrackScreen` fires on My Wallet screen load with category "My Wallet"
  - Verify event payloads contain correct `button` and `page` values

### 📝 Description

**Problem**: The My Wallet screen was using inconsistent tracking event names (`menuentry_clicked`) and lacked screen-level tracking.

**Solution**: 
- Renamed all `menuentry_clicked` events to `button_clicked` for consistency with the rest of the app
- Updated button names to use human-readable format (e.g. `"MyWallet"` → `"My Wallet"`)
- Added `<TrackScreen category="My Wallet" />` to track screen views

### ❓ Context

- **JIRA or GitHub link**: [LIVE-26562](https://ledgerhq.atlassian.net/browse/LIVE-26562)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-26562]: https://ledgerhq.atlassian.net/browse/LIVE-26562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ