### PR TITLE
[LWD] fix(desktop): wait for currency preload before account scan

### DIFF
--- a/.changeset/fair-berries-sneeze.md
+++ b/.changeset/fair-berries-sneeze.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+wait for preload to complete when scanning accounts

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/__tests__/addAccountFlow.test.tsx
@@ -33,7 +33,7 @@ jest.mock("~/renderer/hooks/useConnectAppAction", () => ({
   }),
 }));
 
-let triggerNext: (accounts: Account[]) => void = () => null;
+let triggerNext: (account: Account) => void = () => null;
 let triggerComplete: () => void = () => null;
 
 const mockAccountBridge = {
@@ -42,31 +42,34 @@ const mockAccountBridge = {
   toOperationExtraRaw: (extra: unknown) => extra,
 };
 
-jest.mock("@ledgerhq/live-common/bridge/index", () => ({
-  __esModule: true,
-  getCurrencyBridge: () => ({
-    scanAccounts: () => ({
-      pipe: () => ({
-        subscribe: ({
-          next,
-          complete,
-        }: {
-          next: (accounts: Account[]) => void;
-          complete: () => void;
-        }) => {
-          triggerNext = accounts => next(accounts);
-          triggerComplete = () => complete();
-        },
-      }),
-    }),
-    preload: () => true,
-    hydrate: () => true,
-  }),
-  getAccountBridge: () => mockAccountBridge,
+jest.mock("~/renderer/bridge/cache", () => ({
+  prepareCurrency: jest.fn().mockResolvedValue(null),
 }));
 
+jest.mock("@ledgerhq/live-common/bridge/index", () => {
+  const { Observable } = require("rxjs");
+  return {
+    __esModule: true,
+    getCurrencyBridge: () => ({
+      scanAccounts: () =>
+        new Observable((subscriber: any) => {
+          triggerNext = (account: Account) => subscriber.next({ account });
+          triggerComplete = () => subscriber.complete();
+          return () => {};
+        }),
+      preload: () => Promise.resolve(true),
+      hydrate: () => true,
+    }),
+    getAccountBridge: () => mockAccountBridge,
+  };
+});
+
 const mockScanAccountsSubscription = async (accounts: Account[]) => {
-  await Promise.all(accounts.map((_, i) => act(() => triggerNext(accounts.slice(0, i + 1)))));
+  // flush the prepareCurrency promise so concat subscribes to scanAccounts and triggerNext is set
+  await act(async () => {});
+  for (const account of accounts) {
+    await act(() => triggerNext(account));
+  }
   await act(() => triggerComplete());
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/useScanAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/ScanAccounts/useScanAccounts.ts
@@ -5,7 +5,8 @@ import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account } from "@ledgerhq/types-live";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { Subscription } from "rxjs";
+import { concat, from, Subscription } from "rxjs";
+import { prepareCurrency } from "~/renderer/bridge/cache";
 import { openModal } from "~/renderer/actions/modals";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import * as RX from "rxjs/operators";
@@ -86,8 +87,10 @@ export function useScanAccounts({
   }, []);
 
   useEffect(() => {
-    scanSubscriptionRef.current = getCurrencyBridge(currency)
-      .scanAccounts({
+    const bridge = getCurrencyBridge(currency);
+    scanSubscriptionRef.current = concat(
+      from(prepareCurrency(currency)).pipe(RX.ignoreElements()),
+      bridge.scanAccounts({
         currency,
         deviceId,
         syncConfig: {
@@ -96,7 +99,8 @@ export function useScanAccounts({
           },
           blacklistedTokenIds: blacklistedTokenIds || [],
         },
-      })
+      }),
+    )
       .pipe(RX.scan((acc: Account[], { account }) => [...acc, account], []))
       .subscribe({
         next: accounts => {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__tests__/addAccountFlow.test.tsx
@@ -76,24 +76,26 @@ jest.mock("~/renderer/reducers/devices", () => {
 jest.mock("@ledgerhq/live-common/bridge/index", () => ({
   __esModule: true,
   getCurrencyBridge: () => ({
-    scanAccounts: () => ({
-      pipe: () => ({
-        subscribe: ({
-          next,
-          complete,
-        }: {
-          next: (accounts: Account[]) => void;
-          complete: () => void;
-        }) => {
-          triggerNext = accounts => next(accounts);
-          triggerComplete = () => complete();
-        },
+    scanAccounts: () =>
+      new Observable<{ account: Account }>(subscriber => {
+        triggerNext = accounts => {
+          const account = accounts[accounts.length - 1];
+          if (account) {
+            subscriber.next({ account });
+          }
+        };
+        triggerComplete = () => subscriber.complete();
       }),
-    }),
     preload: () => true,
     hydrate: () => true,
   }),
   getAccountBridge: () => mockAccountBridge,
+}));
+
+jest.mock("~/renderer/bridge/cache", () => ({
+  __esModule: true,
+  ...jest.requireActual("~/renderer/bridge/cache"),
+  prepareCurrency: jest.fn(() => Promise.resolve()),
 }));
 
 jest.mock("~/renderer/animations", () => ({


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Add account drawer scan startup sequencing
      - Regression coverage for preload + scan observable interaction

### 📝 Description

**Root cause:** `useScanAccounts.ts` called `bridge.scanAccounts()` directly without first awaiting the preload. The `ConnectYourDevice` screen fires `prepareCurrency` as a warm-up but doesn't block on it, so a race condition existed between preload completion and scan start. This caused visual glitches (blinking/flashing) on Tron and Solana, and is a correctness risk for any coin that strictly requires preload to complete before sync.

**Fix:** Wrapped the scan observable in a `concat` that sequences preload → scan:

```typescript
concat(
  from(prepareCurrency(currency)).pipe(RX.ignoreElements()),
  bridge.scanAccounts({ ... }),
)
```

`ignoreElements()` discards the resolved value but preserves the completion signal — so `concat` waits for the preload promise to fully resolve (including `bridge.hydrate()`) before subscribing to `scanAccounts`. This is identical to the pattern used in the legacy `StepImport.tsx` that worked correctly before the MVVM rewrite.

The `prepareCurrency` warm-up call in `ConnectYourDevice` is kept as-is — it's a useful performance optimization that pre-fetches while the user is still on the device connection screen. The correctness guarantee now lives in `useScanAccounts`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29110](https://ledgerhq.atlassian.net/browse/LIVE-29110)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29110]: https://ledgerhq.atlassian.net/browse/LIVE-29110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ