### PR TITLE
[LWDM] test(coin-modules): ensure we throw when broadcast fails (part 4)

### DIFF
--- a/.changeset/lucky-plums-punch.md
+++ b/.changeset/lucky-plums-punch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": patch
+---
+
+Harden Sui broadcast on invalid payload and missing RPC digest; add broadcast integ test

--- a/libs/coin-modules/coin-casper/src/bridge/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/broadcast.integ.test.ts
@@ -1,0 +1,55 @@
+import BigNumber from "bignumber.js";
+import {
+  CasperNetwork,
+  KeyAlgorithm,
+  PrivateKey,
+  PublicKey,
+  Transaction as CasperDeployTransaction,
+} from "casper-js-sdk";
+import { getCasperNodeRpcClient } from "../api";
+import { setCoinConfig } from "../config";
+import { CASPER_DEFAULT_TTL, CASPER_FEES_MOTES, CASPER_NETWORK } from "../consts";
+import { broadcast } from "./broadcast";
+
+describe("Broadcast", () => {
+  beforeAll(() => {
+    setCoinConfig(() => ({
+      status: { type: "active" },
+      infra: {
+        API_CASPER_NODE_ENDPOINT: "https://casper.coin.ledger.com/node/",
+        API_CASPER_INDEXER: "https://casper.coin.ledger.com/indexer/",
+      },
+    }));
+  });
+
+  it("throws on insufficient funds", async () => {
+    const privateKey = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+    const senderHex = privateKey.publicKey.toHex();
+
+    const casperNetwork = await CasperNetwork.create(getCasperNodeRpcClient());
+    const feeMotes = new BigNumber(CASPER_FEES_MOTES);
+    const deploy: CasperDeployTransaction = casperNetwork.createTransferTransaction(
+      PublicKey.fromHex(senderHex),
+      PublicKey.fromHex(senderHex),
+      CASPER_NETWORK,
+      "1",
+      feeMotes.toNumber(),
+      CASPER_DEFAULT_TTL,
+      0,
+    );
+
+    const signatureHex = Buffer.from(
+      privateKey.signAndAddAlgorithmBytes(new Uint8Array(deploy.toBytes())),
+    ).toString("hex");
+
+    await expect(
+      broadcast({
+        account: { freshAddress: senderHex },
+        signedOperation: {
+          signature: signatureHex,
+          rawData: { tx: JSON.stringify(deploy.toJSON()) },
+        },
+      } as any),
+    ).rejects.toThrow(/Code: -32016, err: Invalid transaction/);
+  });
+});

--- a/libs/coin-modules/coin-stacks/src/bridge/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-stacks/src/bridge/broadcast.integ.test.ts
@@ -1,0 +1,56 @@
+import { BigNumber } from "bignumber.js";
+import { StacksMainnet } from "@stacks/network";
+import {
+  AnchorMode,
+  makeRandomPrivKey,
+  makeSTXTokenTransfer,
+  privateKeyToString,
+  pubKeyfromPrivKey,
+  publicKeyToString,
+} from "@stacks/transactions";
+import { broadcast } from "./broadcast";
+
+const RECIPIENT_ADDRESS = "SP26AZ1JSFZQ82VH5W2NJSB2QW15EW5YKT6WMD69J";
+
+describe("Broadcast", () => {
+  it("throws on insufficient funds", async () => {
+    const senderKey = privateKeyToString(makeRandomPrivKey());
+    const feeMicroStx = new BigNumber(5000);
+    const amountMicroStx = new BigNumber(1);
+
+    const signedTx = await makeSTXTokenTransfer({
+      senderKey,
+      amount: amountMicroStx.toFixed(),
+      recipient: RECIPIENT_ADDRESS,
+      anchorMode: AnchorMode.Any,
+      network: new StacksMainnet({ url: "https://stacks.coin.ledger.com" }),
+      fee: feeMicroStx.toFixed(),
+      nonce: "0",
+    });
+
+    const sc = signedTx.auth.spendingCondition;
+    if (!("signature" in sc)) {
+      throw new Error("expected single-sig spending condition");
+    }
+
+    await expect(
+      broadcast({
+        signedOperation: {
+          operation: {
+            transactionSequenceNumber: new BigNumber(0),
+            extra: {},
+            value: amountMicroStx.plus(feeMicroStx),
+            fee: feeMicroStx,
+            recipients: [RECIPIENT_ADDRESS],
+          },
+          signature: sc.signature.data,
+          rawData: {
+            anchorMode: AnchorMode.Any,
+            network: "mainnet",
+            xpub: publicKeyToString(pubKeyfromPrivKey(senderKey)),
+          },
+        },
+      } as any),
+    ).rejects.toThrow("transaction rejected");
+  });
+});

--- a/libs/coin-modules/coin-sui/src/bridge/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/broadcast.integ.test.ts
@@ -1,0 +1,54 @@
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { JsonRpcHTTPTransport, SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+import { Transaction } from "@mysten/sui/transactions";
+import coinConfig from "../config";
+import { fetchForeignOwnedSuiGasPayment } from "../test/testUtils";
+import { broadcast } from "./broadcast";
+
+describe("Broadcast", () => {
+  beforeAll(() => {
+    coinConfig.setCoinConfig(() => ({
+      status: { type: "active" },
+      node: { url: "https://sui.coin.ledger.com" },
+    }));
+  });
+
+  it("throws when sender does not match gas object owner", async () => {
+    const client = new SuiJsonRpcClient({
+      transport: new JsonRpcHTTPTransport({ url: coinConfig.getCoinConfig().node.url }),
+      network: "mainnet",
+    });
+    const keypair = Ed25519Keypair.generate();
+    const sender = keypair.toSuiAddress();
+
+    const gasPayment = await fetchForeignOwnedSuiGasPayment(client);
+
+    const tx = new Transaction();
+    tx.setSender(sender);
+    tx.setGasPrice(191);
+    tx.setGasBudget("2358000");
+    tx.setGasPayment(gasPayment);
+    const [coin] = tx.splitCoins(tx.gas, [1000n]);
+    tx.transferObjects([coin], sender);
+
+    const unsigned = await tx.build({ client });
+    const { signature } = await keypair.signTransaction(unsigned);
+    const unsignedB64 = Buffer.from(unsigned).toString("base64");
+
+    await expect(
+      broadcast({
+        account: {
+          currency: { id: "sui" },
+        },
+        signedOperation: {
+          operation: {
+            id: "integ-out",
+            type: "OUT",
+          },
+          signature,
+          rawData: { unsigned: unsignedB64, serializedSignature: signature },
+        },
+      } as any),
+    ).rejects.toThrow(/Transaction was not signed by the correct sender/);
+  });
+});

--- a/libs/coin-modules/coin-sui/src/bridge/broadcast.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/broadcast.test.ts
@@ -1,7 +1,7 @@
 import { createFixtureOperation } from "../types/bridge.fixture";
 import { broadcast } from "./broadcast";
 
-const executeTransactionBlock = jest.fn();
+const executeTransactionBlock = jest.fn().mockResolvedValue({ digest: "test-digest-hash" });
 
 jest.mock("../network", () => {
   return {
@@ -11,6 +11,11 @@ jest.mock("../network", () => {
 });
 
 describe("broadcast", () => {
+  beforeEach(() => {
+    executeTransactionBlock.mockClear();
+    executeTransactionBlock.mockResolvedValue({ digest: "test-digest-hash" });
+  });
+
   it("calls explorer for broadcast operation", async () => {
     // WHEN
     await broadcast({

--- a/libs/coin-modules/coin-sui/src/logic/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-sui/src/logic/broadcast.integ.test.ts
@@ -1,0 +1,49 @@
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { JsonRpcHTTPTransport, SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
+import { Transaction } from "@mysten/sui/transactions";
+import coinConfig from "../config";
+import { fetchForeignOwnedSuiGasPayment } from "../test/testUtils";
+import { broadcast } from "./broadcast";
+
+const executeOptions = {
+  showInput: true,
+  showBalanceChanges: true,
+  showEffects: true,
+  showEvents: true,
+} as const;
+
+describe("Broadcast", () => {
+  beforeAll(() => {
+    coinConfig.setCoinConfig(() => ({
+      status: { type: "active" },
+      node: { url: "https://sui.coin.ledger.com" },
+    }));
+  });
+
+  it("throws when sender does not match gas object owner", async () => {
+    const client = new SuiJsonRpcClient({
+      transport: new JsonRpcHTTPTransport({ url: coinConfig.getCoinConfig().node.url }),
+      network: "mainnet",
+    });
+    const keypair = Ed25519Keypair.generate();
+    const sender = keypair.toSuiAddress();
+
+    const gasPayment = await fetchForeignOwnedSuiGasPayment(client);
+
+    const tx = new Transaction();
+    tx.setSender(sender);
+    tx.setGasPrice(191);
+    tx.setGasBudget("2358000");
+    tx.setGasPayment(gasPayment);
+    const [coin] = tx.splitCoins(tx.gas, [1000n]);
+    tx.transferObjects([coin], sender);
+
+    const unsigned = await tx.build({ client });
+    const { signature } = await keypair.signTransaction(unsigned);
+    const unsignedB64 = Buffer.from(unsigned).toString("base64");
+
+    await expect(
+      broadcast({ transactionBlock: unsignedB64, signature, options: executeOptions }, "sui"),
+    ).rejects.toThrow(/Transaction was not signed by the correct sender/);
+  });
+});

--- a/libs/coin-modules/coin-sui/src/logic/broadcast.test.ts
+++ b/libs/coin-modules/coin-sui/src/logic/broadcast.test.ts
@@ -38,24 +38,50 @@ describe("broadcast", () => {
     it("should not call executeTransactionBlock if format is not hex", async () => {
       const mockTransaction = "000g1234567890abcdef";
 
-      const result = await broadcast(mockTransaction);
-
-      expect(result).toBe("");
+      await expect(broadcast(mockTransaction)).rejects.toThrow(
+        "sui: invalid serialized transaction payload for broadcast",
+      );
       expect(suiAPI.executeTransactionBlock).toHaveBeenCalledTimes(0);
     });
 
     it("should not call executeTransactionBlock if format is incorrect", async () => {
       const mockTransaction = "000a1";
 
-      const result = await broadcast(mockTransaction);
-
-      expect(result).toBe("");
+      await expect(broadcast(mockTransaction)).rejects.toThrow(
+        "sui: invalid serialized transaction payload for broadcast",
+      );
       expect(suiAPI.executeTransactionBlock).toHaveBeenCalledTimes(0);
     });
   });
 
   describe("with ExecuteTransactionBlockParams input", () => {
-    it("should directly use provided params", async () => {
+    it("should forward params with showEffects forced so execution status is always available", async () => {
+      const mockParams = {
+        transactionBlock: "test-block",
+        signature: "test-signature",
+        options: {
+          showInput: true,
+          showEffects: false,
+        },
+      };
+
+      const result = await broadcast(mockParams);
+
+      expect(result).toBe("test-digest");
+      expect(suiAPI.executeTransactionBlock).toHaveBeenCalledWith(
+        {
+          transactionBlock: "test-block",
+          signature: "test-signature",
+          options: {
+            showInput: true,
+            showEffects: true,
+          },
+        },
+        undefined,
+      );
+    });
+
+    it("should throw when executeTransactionBlock returns no digest", async () => {
       const mockParams = {
         transactionBlock: "test-block",
         signature: "test-signature",
@@ -64,10 +90,38 @@ describe("broadcast", () => {
         },
       };
 
-      const result = await broadcast(mockParams);
+      jest.mocked(suiAPI.executeTransactionBlock).mockResolvedValueOnce(
+        // @ts-expect-error digest omitted on purpose (LIVE-27548 empty-response guard)
+        {},
+      );
 
-      expect(result).toBe("test-digest");
-      expect(suiAPI.executeTransactionBlock).toHaveBeenCalledWith(mockParams, undefined);
+      await expect(broadcast(mockParams)).rejects.toThrow(
+        "sui: broadcast returned no transaction digest",
+      );
+    });
+
+    it("should throw when RPC returns digest but execution status is failure", async () => {
+      const mockParams = {
+        transactionBlock: "test-block",
+        signature: "test-signature",
+        options: {
+          showEffects: true,
+        },
+      };
+
+      jest.mocked(suiAPI.executeTransactionBlock).mockResolvedValueOnce({
+        digest: "4fwBGMM9Nfc8rbiGfcn7469cvrqetYgik6pLiVCYg4Ud",
+        effects: {
+          status: {
+            status: "failure",
+            error: "InsufficientCoinBalance in command 0",
+          },
+        },
+      } as Awaited<ReturnType<typeof suiAPI.executeTransactionBlock>>);
+
+      await expect(broadcast(mockParams)).rejects.toThrow(
+        "sui: broadcast execution failed: InsufficientCoinBalance in command 0",
+      );
     });
   });
 });

--- a/libs/coin-modules/coin-sui/src/logic/broadcast.ts
+++ b/libs/coin-modules/coin-sui/src/logic/broadcast.ts
@@ -14,7 +14,9 @@ export async function broadcast(
   let params: ExecuteTransactionBlockParams;
   if (typeof transaction === "string") {
     const { rawTx, signature, success } = extractTxAndSignature(transaction);
-    if (!success) return "";
+    if (!success) {
+      throw new Error("sui: invalid serialized transaction payload for broadcast");
+    }
 
     params = {
       transactionBlock: rawTx,
@@ -24,10 +26,27 @@ export async function broadcast(
       },
     };
   } else {
-    params = transaction;
+    params = {
+      ...transaction,
+      options: {
+        ...(transaction.options ?? {}),
+        showEffects: true,
+      },
+    };
   }
   const result = await suiAPI.executeTransactionBlock(params, currencyId);
-  return result?.digest ?? "";
+  if (!result?.digest) {
+    throw new Error("sui: broadcast returned no transaction digest");
+  }
+  const status = result.effects?.status;
+  if (status?.status === "failure") {
+    const detail =
+      "error" in status && typeof status.error === "string" && status.error.length > 0
+        ? status.error
+        : "transaction execution failed";
+    throw new Error(`sui: broadcast execution failed: ${detail}`);
+  }
+  return result.digest;
 }
 
 function extractTxAndSignature(transaction: string): {

--- a/libs/coin-modules/coin-sui/src/test/testUtils.ts
+++ b/libs/coin-modules/coin-sui/src/test/testUtils.ts
@@ -39,3 +39,28 @@ export async function extractCoinTypeFromUnsignedTx(
 
   return coinTypes;
 }
+
+/**
+ * Fetches a live SUI coin owned by dead address to use as gas payment in
+ * integration tests that assert "sender does not own gas" failures.
+ */
+export async function fetchForeignOwnedSuiGasPayment(client: SuiJsonRpcClient) {
+  const { data } = await client.getCoins({
+    owner: "0x000000000000000000000000000000000000000000000000000000000000dead",
+    coinType: "0x2::sui::SUI",
+    limit: 1,
+  });
+  const coin = data[0];
+  if (!coin) {
+    throw new Error(
+      "sui integ: no SUI coin returned for burn address; cannot build foreign-owned gas fixture",
+    );
+  }
+  return [
+    {
+      objectId: coin.coinObjectId,
+      version: coin.version,
+      digest: coin.digest,
+    },
+  ];
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:**
- Mostly tests only.
- Sui: logic/broadcast now throws on invalid serialized payload and when the RPC returns no digest (no silent empty string).

### 📝 Description

Ensure we correctly reject when broadcast fails. This PR covers:

Casper (bridge)
Stacks (bridge)
Sui (bridge + alpaca; logic broadcast hardening)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: 
- https://ledgerhq.atlassian.net/browse/LIVE-29364
- https://ledgerhq.atlassian.net/browse/LIVE-29379
- https://ledgerhq.atlassian.net/browse/LIVE-29381

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
