### PR TITLE
fix(wallet-cli): lazy-load solana setup to eliminate ~700ms per-test startup cost

### DIFF
--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -52,7 +52,16 @@ const walletCliLoaders: CoinModuleLoader[] = [
   },
   {
     family: "solana",
-    loadSetup: () => require("@ledgerhq/live-common/families/solana/setup"),
+    loadSetup: () => {
+      const setup = require("@ledgerhq/live-common/families/solana/setup");
+      // Set on the CJS instance here (lazily) rather than eagerly at startup.
+      // The ESM import resolves to a different module instance than this require();
+      // calling it inside loadSetup ensures the flag is set on the exact instance
+      // that registerCoinModules will use, without paying the ~700ms require cost
+      // on every subprocess that never runs a Solana command.
+      setup.setSolanaLdmkEnabled(true);
+      return setup;
+    },
     loadTransaction: () => require("@ledgerhq/coin-solana/transaction").default,
     loadDeviceTxConfig: () => require("@ledgerhq/coin-solana/deviceTransactionConfig").default,
     loadWalletApiAdapter: () =>
@@ -76,9 +85,6 @@ require("@ledgerhq/live-config/LiveConfig").LiveConfig.setConfig(walletCliConfig
 // TODO: wallet-cli should own its Redux store setup (createRtkCryptoAssetsStore + RTK middleware)
 // instead of relying on setupCalClientStore from @ledgerhq/cryptoassets/cal-client (test-helpers).
 setupCalClientStore();
-// Also require() — the ESM import would set the flag on a different module instance
-// than the CJS setup.ts loaded by the lazy loaders above.
-require("@ledgerhq/live-common/families/solana/setup").setSolanaLdmkEnabled(true);
 registerWalletCliDmkTransport();
 
 setEnv("LEDGER_CLIENT_VERSION", "wallet-cli/0.1.0");


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli

### 📝 Description

The `require("@ledgerhq/live-common/families/solana/setup")` call at the bottom of `live-common-setup.ts` was executed eagerly on every subprocess invocation, paying a ~700ms CJS module load cost even for tests that never run a Solana command (session view/reset, balances, operations, etc.).

Move `setSolanaLdmkEnabled(true)` inside the Solana `loadSetup` arrow function so the Solana setup module is only loaded when a Solana command actually executes. Behavior for Solana commands is unchanged — the flag is still set on the same CJS instance before `registerCoinModules` uses it, just deferred from startup to first Solana command execution.

Result: per-test time for CLI e2e tests drops from ~1200ms to ~700ms (~40% faster). All 195 tests pass.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
