### PR TITLE
[LWM] feat(mobile): add asset detail screen layout with section placeholders

### DIFF
--- a/.changeset/rotten-planes-act.md
+++ b/.changeset/rotten-planes-act.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+add placeholders in asset detail view

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { render, screen } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import AssetDetailNavigator from "../Navigator";
+import { ASSET_DETAIL_TEST_IDS } from "../testIds";
+
+const Stack = createNativeStackNavigator();
+
+function AssetDetailTestNavigator() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name={NavigatorName.AssetDetail}
+        component={AssetDetailNavigator}
+        initialParams={{
+          screen: ScreenName.AssetDetail,
+          params: { currencyId: "bitcoin" },
+        }}
+        options={{ headerShown: false }}
+      />
+    </Stack.Navigator>
+  );
+}
+
+describe("AssetDetail screen layout", () => {
+  it("renders all section placeholders", () => {
+    render(<AssetDetailTestNavigator />);
+
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.balanceGraph)).toBeVisible();
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.balanceDetails)).toBeVisible();
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.addresses)).toBeVisible();
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.marketStats)).toBeVisible();
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.transactions)).toBeVisible();
+    expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.ctas)).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/AssetDetailView.tsx
@@ -1,19 +1,71 @@
 import React from "react";
-import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { RefreshControl, ScrollView } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { TrackScreen } from "~/analytics";
-import SafeAreaView from "~/components/SafeAreaView";
+import { ASSET_DETAIL_TEST_IDS } from "../../testIds";
+import { SectionPlaceholder } from "./components/SectionPlaceholder";
+import { Footer } from "./components/Footer";
+import { CTAS_HEIGHT, SECTION_HEIGHT, PLACEHOLDER_COLORS } from "./utils/constants";
 
-type Props = {
+type Props = Readonly<{
   currency: CryptoCurrency | undefined;
   source?: string;
-};
+  isRefreshing: boolean;
+  onRefresh: () => void;
+}>;
 
-export function AssetDetailView({ currency, source }: Props) {
+export function AssetDetailView({ currency, source, isRefreshing, onRefresh }: Props) {
+  const { bottom } = useSafeAreaInsets();
+
   return (
-    <SafeAreaView edges={["left", "right", "bottom"]} isFlex>
+    <Box testID={ASSET_DETAIL_TEST_IDS.screen} lx={screenStyle}>
       <TrackScreen category="Asset" currency={currency?.name} source={source} />
-      <Box lx={{ flex: 1 }} />
-    </SafeAreaView>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: CTAS_HEIGHT + bottom }}
+        refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}
+      >
+        <Box lx={contentStyle}>
+          <SectionPlaceholder
+            testID={ASSET_DETAIL_TEST_IDS.balanceGraph}
+            backgroundColor={PLACEHOLDER_COLORS.balanceGraph}
+            height={SECTION_HEIGHT}
+          />
+          <SectionPlaceholder
+            testID={ASSET_DETAIL_TEST_IDS.balanceDetails}
+            backgroundColor={PLACEHOLDER_COLORS.balanceDetails}
+            height={SECTION_HEIGHT}
+          />
+          <SectionPlaceholder
+            testID={ASSET_DETAIL_TEST_IDS.addresses}
+            backgroundColor={PLACEHOLDER_COLORS.addresses}
+            height={SECTION_HEIGHT}
+          />
+          <SectionPlaceholder
+            testID={ASSET_DETAIL_TEST_IDS.marketStats}
+            backgroundColor={PLACEHOLDER_COLORS.marketStats}
+            height={SECTION_HEIGHT}
+          />
+          <SectionPlaceholder
+            testID={ASSET_DETAIL_TEST_IDS.transactions}
+            backgroundColor={PLACEHOLDER_COLORS.transactions}
+            height={SECTION_HEIGHT}
+          />
+        </Box>
+      </ScrollView>
+      <Footer />
+    </Box>
   );
 }
+
+const screenStyle: LumenViewStyle = {
+  flex: 1,
+};
+
+const contentStyle: LumenViewStyle = {
+  padding: "s16",
+  gap: "s24",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Footer.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
+import { ASSET_DETAIL_TEST_IDS } from "../../../testIds";
+import { PLACEHOLDER_COLORS } from "../utils/constants";
+import { SectionPlaceholder } from "./SectionPlaceholder";
+
+export function Footer() {
+  const { bottom } = useSafeAreaInsets();
+
+  return (
+    <Box
+      testID={ASSET_DETAIL_TEST_IDS.ctas}
+      lx={containerStyle}
+      style={{ paddingBottom: bottom + 16 }}
+    >
+      <SectionPlaceholder
+        testID={`${ASSET_DETAIL_TEST_IDS.ctas}-content`}
+        backgroundColor={PLACEHOLDER_COLORS.ctas}
+        height={48}
+      />
+    </Box>
+  );
+}
+
+const containerStyle: LumenViewStyle = {
+  position: "absolute",
+  bottom: "s0",
+  left: "s0",
+  right: "s0",
+  paddingHorizontal: "s16",
+  paddingTop: "s16",
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/SectionPlaceholder.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/SectionPlaceholder.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+
+type Props = Readonly<{
+  testID: string;
+  backgroundColor: string;
+  height: number;
+}>;
+
+export function SectionPlaceholder({ testID, backgroundColor, height }: Props) {
+  return <View testID={testID} style={[styles.placeholder, { backgroundColor, height }]} />;
+}
+
+const styles = StyleSheet.create({
+  placeholder: {
+    borderRadius: 12,
+  },
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { useRoute } from "@react-navigation/native";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
@@ -13,8 +13,15 @@ export function useAssetDetailViewModel() {
 
   const currency = useMemo(() => findCryptoCurrencyById(currencyId), [currencyId]);
 
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const onRefresh = useCallback(() => {
+    setIsRefreshing(false);
+  }, []);
+
   return {
     currency,
     source,
+    isRefreshing,
+    onRefresh,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/utils/constants.ts
@@ -1,0 +1,11 @@
+export const CTAS_HEIGHT = 80;
+export const SECTION_HEIGHT = 120;
+
+export const PLACEHOLDER_COLORS = {
+  balanceGraph: "#E8D5F5",
+  balanceDetails: "#D5E8F5",
+  addresses: "#D5F5E8",
+  marketStats: "#F5E8D5",
+  transactions: "#F5D5E8",
+  ctas: "#D5D5F5",
+} as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/testIds.ts
@@ -1,0 +1,9 @@
+export const ASSET_DETAIL_TEST_IDS = {
+  screen: "asset-detail-screen",
+  balanceGraph: "asset-detail-balance-graph",
+  balanceDetails: "asset-detail-balance-details",
+  addresses: "asset-detail-addresses",
+  marketStats: "asset-detail-market-stats",
+  transactions: "asset-detail-transactions",
+  ctas: "asset-detail-ctas",
+} as const;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Asset detail screen layout and scroll behavior
  - Section placeholders visibility and ordering
  - Fixed bottom CTAs section with safe area handling

### 📝 Description

**Problem**: The Asset Detail screen (Wallet 4.0) needs a scrollable layout with placeholder sections to serve as the foundation for future feature implementation.

**Solution**: Implemented the global layout for the Asset Detail screen with:
- A `ScrollView` containing 5 placeholder sections (`BalanceGraph`, `BalanceDetails`, `Addresses`, `MarketStats`, `Transactions`) with colored backgrounds
- A fixed-bottom `Ctas` section using `position: absolute` with safe area insets
- A no-op `RefreshControl` for pull-to-refresh (to be wired later)
- Global `s16` padding and `s24` gap between sections using Lumen design tokens
- Stable `testID` on each section for E2E testing
- Integration test verifying all sections render correctly

No business logic — placeholders only, as specified in the ticket.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29723](https://ledgerhq.atlassian.net/browse/LIVE-29723)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29723]: https://ledgerhq.atlassian.net/browse/LIVE-29723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ