### PR TITLE
[LWM] refactor(mobile): bump crypto-icons to v2.0.1

### DIFF
--- a/.changeset/clever-icons-bump.md
+++ b/.changeset/clever-icons-bump.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/native-ui": patch
+---
+
+bump @ledgerhq/crypto-icons to v2.0.1 and migrate breaking changes

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -99,7 +99,7 @@
     "@ledgerhq/coin-module-framework": "catalog:",
     "@ledgerhq/coin-multiversx": "workspace:^",
     "@ledgerhq/coin-stacks": "workspace:^",
-    "@ledgerhq/crypto-icons": "catalog:",
+    "@ledgerhq/crypto-icons": "2.0.1",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/device-intent": "workspace:^",
     "@ledgerhq/context-module": "catalog:",

--- a/apps/ledger-live-mobile/src/components/CircleCurrencyIcon.tsx
+++ b/apps/ledger-live-mobile/src/components/CircleCurrencyIcon.tsx
@@ -16,7 +16,7 @@ type Props = {
 };
 
 function CircleCurrencyIcon({ size, currency, color, sizeRatio = 0.5, testID }: Props) {
-  const { colors, dark } = useTheme();
+  const { colors } = useTheme();
   const isToken = currency.type === "TokenCurrency";
   const backgroundColorContrast = ensureContrast(
     color || rgba(getCurrencyColor(currency), isToken ? 1 : 1),
@@ -31,7 +31,6 @@ function CircleCurrencyIcon({ size, currency, color, sizeRatio = 0.5, testID }: 
   const ledgerId = currency.id;
   const tickerProp = currency.ticker;
   const network = currency.type === "TokenCurrency" ? currency.parentCurrency.id : undefined;
-  const iconTheme = dark ? "dark" : "light";
   const iconSize = Math.round(size * sizeRatio);
   const validIconSize = getValidCryptoIconSizeNative(iconSize);
 
@@ -51,8 +50,6 @@ function CircleCurrencyIcon({ size, currency, color, sizeRatio = 0.5, testID }: 
         ledgerId={ledgerId}
         ticker={tickerProp}
         size={validIconSize}
-        theme={iconTheme}
-        backgroundColor={colors.background}
         {...(network && { network })}
       />
     </View>

--- a/apps/ledger-live-mobile/src/components/CurrencyIcon.tsx
+++ b/apps/ledger-live-mobile/src/components/CurrencyIcon.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from "react";
 import { Currency } from "@ledgerhq/types-cryptoassets";
 import { Flex } from "@ledgerhq/native-ui";
-import styled, { useTheme } from "styled-components/native";
+import styled from "styled-components/native";
 import { CryptoIcon } from "@ledgerhq/native-ui/pre-ldls";
 import { getValidCryptoIconSizeNative } from "@ledgerhq/live-common/helpers/cryptoIconSize";
 
@@ -20,7 +20,6 @@ type Props = {
 };
 
 const CurrencyIcon = ({ size, currency, disabled, hideNetwork, squared }: Props) => {
-  const { colors } = useTheme();
   const validIconSize = getValidCryptoIconSizeNative(size);
 
   if (currency.type === "FiatCurrency") {
@@ -29,7 +28,6 @@ const CurrencyIcon = ({ size, currency, disabled, hideNetwork, squared }: Props)
 
   const ledgerId = currency.id;
   const ticker = currency.ticker;
-  const overridesRadius = squared ? Math.round(validIconSize * 0.25) : undefined;
 
   const cryptoIconElement =
     !hideNetwork && currency.type === "TokenCurrency" ? (
@@ -37,17 +35,15 @@ const CurrencyIcon = ({ size, currency, disabled, hideNetwork, squared }: Props)
         ledgerId={ledgerId}
         ticker={ticker}
         size={validIconSize}
-        backgroundColor={colors.background.main}
         network={currency.parentCurrency.id}
-        overridesRadius={overridesRadius}
+        shape={squared ? "square" : undefined}
       />
     ) : (
       <CryptoIcon
         ledgerId={ledgerId}
         ticker={ticker}
         size={validIconSize}
-        backgroundColor={colors.background.main}
-        overridesRadius={overridesRadius}
+        shape={squared ? "square" : undefined}
       />
     );
 

--- a/apps/ledger-live-mobile/src/families/concordium/__tests__/Confirmation.test.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/__tests__/Confirmation.test.tsx
@@ -37,6 +37,7 @@ const mockAccount = {
   currency: {
     type: "CryptoCurrency" as const,
     id: "concordium",
+    ticker: "CCD",
     name: "Concordium",
     family: "concordium",
   },

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AccountSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AccountSelection/index.tsx
@@ -48,13 +48,7 @@ const AccountSelectionContent = ({
 
   const renderItem = useCallback(
     ({ item }: { item: RawDetailedAccount }) => {
-      return (
-        <AccountItem
-          account={item}
-          onClick={() => handleAccountSelected(item)}
-          cryptoIconBackgroundColor="transparent"
-        />
-      );
+      return <AccountItem account={item} onClick={() => handleAccountSelected(item)} />;
     },
     [handleAccountSelected],
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Web3Hub/screens/Web3HubApp/components/Web3Player/SelectAccountButton.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Web3Hub/screens/Web3HubApp/components/Web3Player/SelectAccountButton.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
 import { SetCurrentAccountHistDb } from "@ledgerhq/live-common/wallet-api/react";
 import { CryptoIcon } from "@ledgerhq/native-ui/pre-ldls";
-import { useTheme } from "@react-navigation/native";
 import Button from "~/components/Button";
 import { useSelectAccount } from "~/components/Web3AppWebview/helpers";
 
@@ -19,29 +18,26 @@ export default function SelectAccountButton({
     manifest,
     setCurrentAccountHistDb,
   });
-  const { dark } = useTheme();
-
   const currency =
     currentAccount?.type === "TokenAccount" ? currentAccount.token : currentAccount?.currency;
   const ledgerId = currency?.id;
   const tickerProp = currency?.ticker;
   const network = currency?.type === "TokenCurrency" ? currency.parentCurrency.id : undefined;
-  const iconTheme = dark ? "dark" : "light";
+
+  const canRenderIcon = !!currentAccount && !!ledgerId && !!tickerProp;
 
   return (
     <Button
       Icon={
-        !currentAccount ? undefined : (
+        canRenderIcon ? (
           <CryptoIcon
             ledgerId={ledgerId}
             ticker={tickerProp}
             size={32}
-            theme={iconTheme}
-            backgroundColor="dark"
-            overridesRadius={12}
+            shape="square"
             {...(network && { network })}
           />
-        )
+        ) : undefined
       }
       onPress={handleAddAccountPress}
       accessibilityLabel="Select Account"

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/AppsList/AppIcon.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/AppsList/AppIcon.tsx
@@ -26,7 +26,7 @@ function AppIcon({ size = 38, app, icon: defaultIcon = "" }: Readonly<Props>) {
     const ticker = currency.ticker;
     const validSize = getValidCryptoIconSizeNative(size);
 
-    return <CryptoIcon ledgerId={ledgerId} ticker={ticker} size={validSize} overridesRadius={12} />;
+    return <CryptoIcon ledgerId={ledgerId} ticker={ticker} size={validSize} shape="square" />;
   }
 
   // Fallback to manager icon for non-crypto apps

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/__tests__/GenerateMockAccounts.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/__tests__/GenerateMockAccounts.test.tsx
@@ -32,7 +32,7 @@ jest.mock("react-native-safe-area-context", () => ({
 }));
 
 jest.mock("@ledgerhq/live-common/currencies/index", () => ({
-  listSupportedCurrencies: () => [{ id: "ethereum", name: "Ethereum" }],
+  listSupportedCurrencies: () => [{ id: "ethereum", ticker: "ETH", name: "Ethereum" }],
 }));
 
 describe("GenerateMockAccountsButton", () => {

--- a/libs/ui/packages/native/.storybook-web/lumenUiRnativeStub.js
+++ b/libs/ui/packages/native/.storybook-web/lumenUiRnativeStub.js
@@ -1,0 +1,43 @@
+'use strict';
+// Stub for @ledgerhq/lumen-ui-rnative in the web Storybook context.
+// The full package pulls in @gorhom/bottom-sheet, @sbaiahmed1/react-native-blur,
+// expo-haptics, etc. — none of which are web-compatible.
+// Only the symbols consumed by @ledgerhq/crypto-icons/native need to render.
+const React = require('react');
+
+const noop = () => null;
+const passthrough = ({ children } = {}) => children ?? null;
+
+const Box = ({ children, style }) => React.createElement('div', { style }, children);
+const Text = ({ children, style }) => React.createElement('span', { style }, children);
+const Skeleton = ({ style }) => React.createElement('div', { style: { backgroundColor: '#e0e0e0', ...style } });
+const MediaImage = ({ src, size, shape, alt, testID }) =>
+  src
+    ? React.createElement('img', {
+        src,
+        alt,
+        'data-testid': testID,
+        style: { width: size, height: size, borderRadius: shape === 'circle' ? '50%' : 4, display: 'block' },
+      })
+    : null;
+const DotSymbol = ({ children }) =>
+  React.createElement('div', { style: { position: 'relative', display: 'inline-flex' } }, children);
+
+const mediaImageDotSizeMap = { 12: 4, 16: 4, 20: 4, 24: 4, 32: 6, 40: 8, 48: 8, 56: 8, 64: 8 };
+const mediaImageDotIconSizeMap = mediaImageDotSizeMap;
+
+module.exports = {
+  Box,
+  Text,
+  Skeleton,
+  MediaImage,
+  DotSymbol,
+  mediaImageDotSizeMap,
+  mediaImageDotIconSizeMap,
+  ThemeProvider: passthrough,
+  DotIcon: passthrough,
+  BottomSheetModalProvider: passthrough,
+  BottomSheetVirtualizedList: noop,
+  BottomSheetHeader: noop,
+  Banner: noop,
+};

--- a/libs/ui/packages/native/package.json
+++ b/libs/ui/packages/native/package.json
@@ -77,7 +77,7 @@
     "storybook-generate": "sb-rn-get-stories"
   },
   "dependencies": {
-    "@ledgerhq/crypto-icons": "catalog:",
+    "@ledgerhq/crypto-icons": "2.0.1",
     "@ledgerhq/icons-ui": "workspace:^",
     "@ledgerhq/ui-shared": "workspace:^",
     "color": "^4.0.0",
@@ -85,6 +85,8 @@
     "stylis": "catalog:"
   },
   "peerDependencies": {
+    "@ledgerhq/lumen-design-core": ">=0.1.11",
+    "@ledgerhq/lumen-ui-rnative": ">=0.1.25",
     "react": ">=17",
     "react-native": ">=0.64.0",
     "react-native-reanimated": ">=4.1",
@@ -109,6 +111,8 @@
     "@emotion/native": "^11.0.0",
     "@expo/cli": "0.24.14",
     "@expo/metro-config": "^0.19.11",
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
     "@rsbuild/core": "catalog:",
     "@rsbuild/plugin-react": "catalog:",
     "@react-native-async-storage/async-storage": "2.1.2",

--- a/libs/ui/packages/native/rsbuild.config.js
+++ b/libs/ui/packages/native/rsbuild.config.js
@@ -12,6 +12,7 @@ module.exports = defineConfig({
   resolve: {
     alias: {
       "expo-font": path.resolve(__dirname, ".storybook-web/expoFontStub.js"),
+      "@ledgerhq/lumen-ui-rnative": path.resolve(__dirname, ".storybook-web/lumenUiRnativeStub.js"),
       "@storybook/jest": path.resolve(__dirname, ".storybook-web/jestStub.js"),
       "@storybook/addon-actions": path.resolve(__dirname, ".storybook-web/addonActionsStub.js"),
       "expo-asset": require.resolve("expo-asset"),

--- a/libs/ui/packages/native/src/pre-ldls/components/AccountItem/AccountItem.tsx
+++ b/libs/ui/packages/native/src/pre-ldls/components/AccountItem/AccountItem.tsx
@@ -46,7 +46,6 @@ export type AccountItemProps = {
   rightElement?: RightElement;
   showIcon?: boolean;
   backgroundColor?: string;
-  cryptoIconBackgroundColor: string;
 };
 
 const ICON_BUTTONS_SIZE = 32;
@@ -151,7 +150,6 @@ export const AccountItem = ({
   rightElement,
   showIcon = true,
   backgroundColor,
-  cryptoIconBackgroundColor,
 }: AccountItemProps) => {
   const theme = useTheme();
   const colorType = theme.colors.type === "dark" ? "dark" : "light";
@@ -220,7 +218,6 @@ export const AccountItem = ({
             ticker={ticker}
             parentId={parentId}
             showIcon={showIcon}
-            backgroundColor={cryptoIconBackgroundColor}
           />
         </AccountInfoContainer>
 

--- a/libs/ui/packages/native/src/pre-ldls/components/Address/Address.tsx
+++ b/libs/ui/packages/native/src/pre-ldls/components/Address/Address.tsx
@@ -16,14 +16,12 @@ export const Address = ({
   cryptoId,
   ticker,
   parentId,
-  backgroundColor,
 }: {
   address: string;
   showIcon: boolean;
   cryptoId?: string;
   ticker?: string;
   parentId?: string;
-  backgroundColor: string;
 }) => {
   const { theme } = useTheme();
   const colorType = theme;
@@ -38,15 +36,8 @@ export const Address = ({
       >
         {address}
       </Text>
-      {showIcon && (
-        <CryptoIcon
-          ledgerId={cryptoId}
-          network={parentId}
-          ticker={ticker}
-          size={20}
-          theme={theme}
-          backgroundColor={backgroundColor}
-        />
+      {showIcon && cryptoId && ticker && (
+        <CryptoIcon ledgerId={cryptoId} network={parentId} ticker={ticker} size={20} />
       )}
     </Wrapper>
   );

--- a/libs/ui/packages/native/src/pre-ldls/components/CryptoIcon/CryptoIcon.stories.tsx
+++ b/libs/ui/packages/native/src/pre-ldls/components/CryptoIcon/CryptoIcon.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof CryptoIcon> = {
     ledgerId: "bitcoin",
     ticker: "BTC",
     size: 56,
-    backgroundColor: "red",
     network: "",
   },
   argTypes: {

--- a/libs/ui/packages/native/src/pre-ldls/components/NetworkItem/NetworkItem.tsx
+++ b/libs/ui/packages/native/src/pre-ldls/components/NetworkItem/NetworkItem.tsx
@@ -70,7 +70,7 @@ export const NetworkItem = ({
       })}
       testID={`network-item-${name}`}
     >
-      <CryptoIcon size={48} overridesRadius={12} ledgerId={id} ticker={ticker} />
+      <CryptoIcon size={48} shape="square" ledgerId={id} ticker={ticker} />
       <InfoWrapper tokens={tokens}>
         <Text
           variant="largeLineHeight"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1572,8 +1572,8 @@ importers:
         specifier: 1.16.0
         version: 1.16.0(@ledgerhq/device-management-kit@1.2.0(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
-        specifier: 'catalog:'
-        version: 1.4.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(styled-components@6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react@19.0.0))
+        specifier: 2.0.1
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.25(09ada5ee5ea348474dad2c68ccdb1c21))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
@@ -11474,8 +11474,8 @@ importers:
   libs/ui/packages/native:
     dependencies:
       '@ledgerhq/crypto-icons':
-        specifier: 'catalog:'
-        version: 1.4.0(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(styled-components@6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        specifier: 2.0.1
+        version: 2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.25(1dd0e7412354a1878032940528d87280))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: link:../icons
@@ -11537,6 +11537,12 @@ importers:
       '@expo/metro-config':
         specifier: ^0.19.11
         version: 0.19.12
+      '@ledgerhq/lumen-design-core':
+        specifier: 'catalog:'
+        version: 0.1.11
+      '@ledgerhq/lumen-ui-rnative':
+        specifier: 'catalog:'
+        version: 0.1.25(1dd0e7412354a1878032940528d87280)
       '@react-native-async-storage/async-storage':
         specifier: 2.1.2
         version: 2.1.2(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))
@@ -16812,6 +16818,27 @@ packages:
       react-native:
         optional: true
       styled-components:
+        optional: true
+
+  '@ledgerhq/crypto-icons@2.0.1':
+    resolution: {integrity: sha512-nGw1ENrkpLDiKUMjxzHeO3w5FZLD9dJLu+Gvbl7EfrLg7wQU0cOCokbvxEUXeWI8B3iAbUyBWW51JeqnbYO8JA==}
+    peerDependencies:
+      '@ledgerhq/lumen-design-core': '>=0.1.11'
+      '@ledgerhq/lumen-ui-react': '>=0.1.24'
+      '@ledgerhq/lumen-ui-rnative': '>=0.1.25'
+      react: 19.0.0
+      react-dom: 19.0.0
+      react-native: '>=0.70'
+    peerDependenciesMeta:
+      '@ledgerhq/lumen-design-core':
+        optional: true
+      '@ledgerhq/lumen-ui-react':
+        optional: true
+      '@ledgerhq/lumen-ui-rnative':
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
         optional: true
 
   '@ledgerhq/cryptoassets-evm-signatures@13.5.2':
@@ -45102,15 +45129,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/crypto-icons@1.4.0(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)(styled-components@6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
-    dependencies:
-      '@ledgerhq/ui-shared': 0.2.2
-      react: 19.0.0
-    optionalDependencies:
-      react-dom: 19.0.0(react@19.0.0)
-      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
-      styled-components: 6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-
   '@ledgerhq/crypto-icons@1.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@19.0.0(react@19.0.0))(react-is@17.0.2)(react@19.0.0))':
     dependencies:
       '@ledgerhq/ui-shared': 0.2.2
@@ -45127,13 +45145,22 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       styled-components: 6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
-  '@ledgerhq/crypto-icons@1.4.0(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)(styled-components@6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react@19.0.0))':
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.25(09ada5ee5ea348474dad2c68ccdb1c21))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@ledgerhq/ui-shared': 0.2.2
       react: 19.0.0
     optionalDependencies:
+      '@ledgerhq/lumen-design-core': 0.1.11
+      '@ledgerhq/lumen-ui-rnative': 0.1.25(09ada5ee5ea348474dad2c68ccdb1c21)
       react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0)
-      styled-components: 6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react@19.0.0)
+
+  '@ledgerhq/crypto-icons@2.0.1(@ledgerhq/lumen-design-core@0.1.11)(@ledgerhq/lumen-ui-rnative@0.1.25(1dd0e7412354a1878032940528d87280))(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@ledgerhq/lumen-design-core': 0.1.11
+      '@ledgerhq/lumen-ui-rnative': 0.1.25(1dd0e7412354a1878032940528d87280)
+      react-dom: 19.0.0(react@19.0.0)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
 
   '@ledgerhq/cryptoassets-evm-signatures@13.5.2':
     dependencies:
@@ -45463,6 +45490,22 @@ snapshots:
       react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.25(1dd0e7412354a1878032940528d87280)':
+    dependencies:
+      '@ledgerhq/lumen-design-core': 0.1.11
+      '@ledgerhq/lumen-utils-shared': 0.1.3(react@19.0.0)
+      '@types/react': 19.0.14
+      expo: 53.0.25(@babel/core@7.28.5)(expo-modules-core@2.5.0)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      i18next: 23.10.1
+      react: 19.0.0
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
+      react-native-reanimated: 4.1.6(@babel/core@7.28.5)(react-native-worklets@0.7.2(@babel/core@7.28.5)(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      react-native-safe-area-context: 5.6.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
+      react-native-svg: 15.15.1(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - react-dom
 
@@ -67305,6 +67348,16 @@ snapshots:
   react-freeze@1.0.4(react@19.0.0):
     dependencies:
       react: 19.0.0
+
+  react-i18next@14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      html-parse-stringify: 3.0.1
+      i18next: 23.10.1
+      react: 19.0.0
+    optionalDependencies:
+      react-dom: 19.0.0(react@19.0.0)
+      react-native: 0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.0.0)
 
   react-i18next@14.1.3(i18next@23.10.1)(react-dom@19.0.0(react@19.0.0))(react-native@0.79.7(patch_hash=4744872a4d5177ec833786050853390422679378b06f4cf3a90ad6e27b560053)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Visual migration — no logic change, not covered by unit tests._
- [x] **Impact of the changes:**
  - Crypto icon rendering in Market list and Market Detail screens
  - App icons in MyLedger device apps list
  - Network items in the native UI lib
  - Currency icons (squared variant) across accounts
  - `AccountItem` / `Address` components in the native UI lib

### 📝 Description

`@ledgerhq/crypto-icons` v2.0.1 replaces `styled-components` with Lumen components and introduces a revised prop API.

This PR bumps the dependency in `live-mobile` and `@ledgerhq/native-ui` (from `catalog:1.4.0`) and migrates all v1 breaking changes in the React Native code:

- `overridesRadius` → `shape="square"` (custom px radius removed, standard token used)
- `backgroundColor` prop removed (now handled by Lumen `ThemeProvider`)
- `theme` prop removed (same reason)
- `ticker` and `ledgerId` are now required — added guards where they were optional
- Cleaned up `cryptoIconBackgroundColor` prop from `AccountItem` / `Address` (no longer forwarded to the icon)

Dark theme:

https://github.com/user-attachments/assets/084ea610-1d8a-4acb-a334-151372e381f6

Light theme:

https://github.com/user-attachments/assets/9bbd3f73-7e70-4c36-85eb-f893874644ca





### ❓ Context

- **JIRA or GitHub link**: [LIVE-29864](https://ledgerhq.atlassian.net/browse/LIVE-29864)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29864]: https://ledgerhq.atlassian.net/browse/LIVE-29864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ