### PR TITLE
[LWDM] Tezos operation pagination so native and FA2 ops sharing the same tx hash stay on one page

### DIFF
--- a/.changeset/calm-tezos-pages.md
+++ b/.changeset/calm-tezos-pages.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+fix Tezos operation pagination so native and FA2 ops sharing the same tx hash stay on one page

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.integ.test.ts
@@ -148,24 +148,16 @@ describe("listOperations — mainnet FA2 / convertTokenOperation", () => {
     expect(Array.isArray(conversionDetails.parentRecipients)).toBe(true);
   });
 
-  it("returns a pagination cursor with native and token last ids", async () => {
+  it("returns a pagination cursor with lastLevel boundary", async () => {
     const [, nextToken] = await listOperations(ADDRESS, { ...baseOpts, limit: 20 });
     expect(nextToken.length).toBeGreaterThan(0);
 
     const parsed: unknown = JSON.parse(nextToken);
     expect(parsed).toEqual(
       expect.objectContaining({
-        nativeLastId: expect.anything(),
-        tokenLastId: expect.anything(),
+        lastLevel: expect.any(Number),
       }),
     );
-    const { nativeLastId, tokenLastId } = parsed as {
-      nativeLastId?: unknown;
-      tokenLastId?: unknown;
-    };
-    expect(nativeLastId === undefined || typeof nativeLastId === "number").toBe(true);
-    expect(tokenLastId === undefined || typeof tokenLastId === "number").toBe(true);
-    expect(nativeLastId !== undefined || tokenLastId !== undefined).toBe(true);
   });
 
   it("pagination returns disjoint operation ids across pages", async () => {
@@ -180,7 +172,7 @@ describe("listOperations — mainnet FA2 / convertTokenOperation", () => {
     expect(overlap).toHaveLength(0);
   });
 
-  it("second page uses tokenLastId from cursor for token transfer pagination", async () => {
+  it("second page accepts cursor with lastLevel for both streams", async () => {
     const limit = 30;
     const [, cursor] = await listOperations(ADDRESS, { ...baseOpts, limit });
     expect(cursor.length).toBeGreaterThan(0);
@@ -188,13 +180,26 @@ describe("listOperations — mainnet FA2 / convertTokenOperation", () => {
     const parsed: unknown = JSON.parse(cursor);
     expect(parsed).toEqual(
       expect.objectContaining({
-        tokenLastId: expect.any(Number),
+        lastLevel: expect.any(Number),
       }),
     );
 
     await expect(
       listOperations(ADDRESS, { ...baseOpts, limit, token: cursor }),
     ).resolves.toBeDefined();
+  });
+
+  it("does not split the same tx.hash across consecutive pages (limit 25)", async () => {
+    const limit = 25;
+    const [page1, cursor] = await listOperations(ADDRESS, { ...baseOpts, limit });
+    if (cursor.length === 0) {
+      return;
+    }
+    const [page2] = await listOperations(ADDRESS, { ...baseOpts, limit, token: cursor });
+    const hashesPage1 = new Set(page1.map(op => op.tx.hash));
+    const hashesPage2 = new Set(page2.map(op => op.tx.hash));
+    const overlap = [...hashesPage1].filter(h => hashesPage2.has(h));
+    expect(overlap).toHaveLength(0);
   });
 
   it("does not duplicate operation ids within the first page", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.integ.test.ts
@@ -149,7 +149,7 @@ describe("listOperations — mainnet FA2 / convertTokenOperation", () => {
   });
 
   it("returns a pagination cursor with lastLevel boundary", async () => {
-    const [, nextToken] = await listOperations(ADDRESS, { ...baseOpts, limit: 20 });
+    const [, nextToken] = await listOperations(ADDRESS, { ...baseOpts, limit: 3 });
     expect(nextToken.length).toBeGreaterThan(0);
 
     const parsed: unknown = JSON.parse(nextToken);
@@ -161,7 +161,7 @@ describe("listOperations — mainnet FA2 / convertTokenOperation", () => {
   });
 
   it("pagination returns disjoint operation ids across pages", async () => {
-    const limit = 10;
+    const limit = 3;
     const [page1, cursor] = await listOperations(ADDRESS, { ...baseOpts, limit });
     expect(cursor.length).toBeGreaterThan(0);
 
@@ -173,7 +173,7 @@ describe("listOperations — mainnet FA2 / convertTokenOperation", () => {
   });
 
   it("second page accepts cursor with lastLevel for both streams", async () => {
-    const limit = 30;
+    const limit = 3;
     const [, cursor] = await listOperations(ADDRESS, { ...baseOpts, limit });
     expect(cursor.length).toBeGreaterThan(0);
 
@@ -189,8 +189,8 @@ describe("listOperations — mainnet FA2 / convertTokenOperation", () => {
     ).resolves.toBeDefined();
   });
 
-  it("does not split the same tx.hash across consecutive pages (limit 25)", async () => {
-    const limit = 25;
+  it("does not split the same tx.hash across consecutive pages (limit 3)", async () => {
+    const limit = 3;
     const [page1, cursor] = await listOperations(ADDRESS, { ...baseOpts, limit });
     if (cursor.length === 0) {
       return;

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
@@ -239,7 +239,12 @@ describe("listOperations", () => {
       });
       // Then
       expect(results.length).toEqual(1);
-      expect(token).toEqual(JSON.stringify({ lastLevel: operation.level }));
+      expect(JSON.parse(token)).toEqual(
+        expect.objectContaining({
+          lastLevel: operation.level,
+          nativeLastId: operation.id,
+        }),
+      );
     },
   );
 
@@ -405,9 +410,13 @@ describe("listOperations", () => {
     });
     const tokenOp = results.find(o => o.asset.type === "fa2");
 
-    expect(JSON.parse(next)).toEqual({
-      lastLevel: 100,
-    });
+    expect(JSON.parse(next)).toEqual(
+      expect.objectContaining({
+        lastLevel: 100,
+        nativeLastId: transfer.id,
+        tokenLastId: 9001,
+      }),
+    );
 
     expect(tokenOp).toMatchObject({
       type: "IN",
@@ -688,6 +697,100 @@ describe("listOperations", () => {
     });
     expect(results).toHaveLength(1);
     expect(results[0]?.tx.block.height).toBe(2000);
+  });
+
+  it("emits nativeLastId on full single-level native page and forwards lastId on next request", async () => {
+    const op1 = { ...transfer, id: 900_001, level: 5000, status: "applied" as const };
+    const op2 = { ...transfer, id: 900_002, level: 5000, status: "applied" as const };
+    mockGetAccountOperations.mockResolvedValueOnce([op1, op2]).mockResolvedValueOnce([]);
+    mockGetAccountTokenTransfers.mockResolvedValue([]);
+
+    const [, token] = await listOperations(someSenderAddress, {
+      sort: "Descending",
+      minHeight: 0,
+      limit: 2,
+    });
+
+    expect(JSON.parse(token)).toEqual(
+      expect.objectContaining({
+        lastLevel: 5000,
+        nativeLastId: 900_002,
+      }),
+    );
+
+    await listOperations(someSenderAddress, {
+      sort: "Descending",
+      minHeight: 0,
+      limit: 2,
+      token,
+    });
+
+    expect(mockGetAccountOperations).toHaveBeenLastCalledWith(
+      someSenderAddress,
+      expect.objectContaining({
+        "level.lt": 5001,
+        lastId: 900_002,
+        sort: "Descending",
+        "level.ge": 0,
+        limit: 2,
+      }),
+    );
+  });
+
+  it("emits tokenLastId on full single-level token page and forwards id.lt on next request", async () => {
+    const fa2a: APITokenTransfer & { hash: string } = {
+      id: 9105,
+      level: 6000,
+      timestamp: "2023-06-01T17:00:00Z",
+      token: {
+        id: 6,
+        contract: { address: "KT1IntraTok" },
+        tokenId: "0",
+        standard: "fa2",
+      },
+      from: { address: someSenderAddress },
+      to: { address: someDestinationAddress },
+      amount: "1",
+      hash: "ooTokA",
+    };
+    const fa2b: APITokenTransfer & { hash: string } = {
+      ...fa2a,
+      id: 9106,
+      hash: "ooTokB",
+    };
+    mockGetAccountOperations.mockResolvedValue([]);
+    mockGetAccountTokenTransfers.mockResolvedValueOnce([fa2b, fa2a]).mockResolvedValueOnce([]);
+
+    const [, cursor] = await listOperations(someDestinationAddress, {
+      sort: "Descending",
+      minHeight: 0,
+      limit: 2,
+    });
+
+    expect(JSON.parse(cursor)).toEqual(
+      expect.objectContaining({
+        lastLevel: 6000,
+        tokenLastId: 9105,
+      }),
+    );
+
+    await listOperations(someDestinationAddress, {
+      sort: "Descending",
+      minHeight: 0,
+      limit: 2,
+      token: cursor,
+    });
+
+    expect(mockGetAccountTokenTransfers).toHaveBeenLastCalledWith(
+      someDestinationAddress,
+      expect.objectContaining({
+        "level.lt": 6001,
+        "id.lt": 9105,
+        sort: "Descending",
+        "level.ge": 0,
+        limit: 2,
+      }),
+    );
   });
 
   it("aligns native and token streams to the same boundary level (descending)", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
@@ -18,7 +18,11 @@ jest.mock("../network", () => ({
   },
 }));
 
-const options: { sort: "Ascending" | "Descending"; minHeight: number } = {
+const options: {
+  sort: "Ascending" | "Descending";
+  minHeight: number;
+  limit?: number;
+} = {
   sort: "Ascending",
   minHeight: 0,
 };
@@ -34,42 +38,67 @@ describe("listOperations", () => {
     mockGetAccountTokenTransfers.mockResolvedValue([]);
   });
 
-  it("forwards tokenLastId from pagination cursor as lastId to getAccountTokenTransfers", async () => {
+  it("forwards level.lt from cursor on both streams when sort is Descending", async () => {
     await listOperations("tz1PaginationAddr", {
       ...options,
-      token: JSON.stringify({ nativeLastId: 111, tokenLastId: 222 }),
+      sort: "Descending",
+      token: JSON.stringify({ lastLevel: 5_000_000 }),
     });
 
     expect(mockGetAccountOperations).toHaveBeenCalledWith(
       "tz1PaginationAddr",
       expect.objectContaining({
-        lastId: 111,
-        sort: options.sort,
+        "level.lt": 5_000_000,
+        sort: "Descending",
         "level.ge": options.minHeight,
       }),
     );
     expect(mockGetAccountTokenTransfers).toHaveBeenCalledWith(
       "tz1PaginationAddr",
       expect.objectContaining({
-        lastId: 222,
-        sort: options.sort,
+        "level.lt": 5_000_000,
+        sort: "Descending",
         "level.ge": options.minHeight,
       }),
     );
   });
 
-  it("parses legacy numeric pagination cursor as native lastId only", async () => {
-    await listOperations("tz1Legacy", {
+  it("forwards level.ge continuation when sort is Ascending and cursor has lastLevel", async () => {
+    await listOperations("tz1AscPage2", {
       ...options,
-      token: JSON.stringify(99_999),
+      sort: "Ascending",
+      minHeight: 0,
+      token: JSON.stringify({ lastLevel: 100 }),
     });
 
     expect(mockGetAccountOperations).toHaveBeenCalledWith(
-      "tz1Legacy",
-      expect.objectContaining({ lastId: 99_999 }),
+      "tz1AscPage2",
+      expect.objectContaining({
+        "level.ge": 101,
+        sort: "Ascending",
+      }),
     );
-    const [, legacyTokenOpts] = mockGetAccountTokenTransfers.mock.calls[0];
-    expect(legacyTokenOpts).not.toHaveProperty("lastId");
+    expect(mockGetAccountTokenTransfers).toHaveBeenCalledWith(
+      "tz1AscPage2",
+      expect.objectContaining({
+        "level.ge": 101,
+        sort: "Ascending",
+      }),
+    );
+  });
+
+  it("ignores legacy id-based pagination cursor (fresh level window)", async () => {
+    await listOperations("tz1Legacy", {
+      ...options,
+      token: JSON.stringify({ nativeLastId: 111, tokenLastId: 222 }),
+    });
+
+    const [, nativeOpts] = mockGetAccountOperations.mock.calls[0];
+    const [, tokenOpts] = mockGetAccountTokenTransfers.mock.calls[0];
+    expect(nativeOpts).not.toHaveProperty("level.lt");
+    expect(nativeOpts).not.toHaveProperty("lastId");
+    expect(tokenOpts).not.toHaveProperty("level.lt");
+    expect(tokenOpts).not.toHaveProperty("lastId");
   });
 
   it("ignores invalid pagination cursor JSON", async () => {
@@ -80,8 +109,8 @@ describe("listOperations", () => {
 
     const [, nativeOpts] = mockGetAccountOperations.mock.calls[0];
     const [, tokenOpts] = mockGetAccountTokenTransfers.mock.calls[0];
-    expect(nativeOpts).not.toHaveProperty("lastId");
-    expect(tokenOpts).not.toHaveProperty("lastId");
+    expect(nativeOpts).not.toHaveProperty("level.lt");
+    expect(tokenOpts).not.toHaveProperty("level.lt");
   });
 
   it("should return no operations", async () => {
@@ -198,15 +227,19 @@ describe("listOperations", () => {
     ["transfer", transfer],
     ["reveal", reveal],
   ])(
-    "should return %s operation with pagination equal to operation id",
+    "should return %s operation with pagination cursor lastLevel when page is full",
     async (_label, operation) => {
       // Given
       mockGetAccountOperations.mockResolvedValue([operation]);
       // When
-      const [results, token] = await listOperations("any address", options);
+      const [results, token] = await listOperations("any address", {
+        ...options,
+        limit: 1,
+        sort: "Descending",
+      });
       // Then
       expect(results.length).toEqual(1);
-      expect(token).toEqual(JSON.stringify({ nativeLastId: operation.id }));
+      expect(token).toEqual(JSON.stringify({ lastLevel: operation.level }));
     },
   );
 
@@ -244,7 +277,7 @@ describe("listOperations", () => {
     // Then
     expect(results.length).toEqual(1);
     expect(results[0].recipients).toEqual([]);
-    expect(token).toEqual(JSON.stringify({ nativeLastId: operation.id }));
+    expect(token).toEqual("");
   });
 
   it.each([
@@ -270,7 +303,7 @@ describe("listOperations", () => {
     // Then
     expect(results.length).toEqual(1);
     expect(results[0].senders).toEqual([]);
-    expect(token).toEqual(JSON.stringify({ nativeLastId: operation.id }));
+    expect(token).toEqual("");
   });
 
   it("should order the results in descending order even if the sort option is set to ascending", async () => {
@@ -362,15 +395,18 @@ describe("listOperations", () => {
       transactionId: transfer.id,
       hash: someHash,
     };
-    const appliedTransfer = { ...transfer, status: "applied" as const };
+    const appliedTransfer = { ...transfer, status: "applied" as const, level: 100 };
     mockGetAccountOperations.mockResolvedValue([appliedTransfer]);
     mockGetAccountTokenTransfers.mockResolvedValue([fa2]);
-    const [results, next] = await listOperations(someDestinationAddress, options);
+    const [results, next] = await listOperations(someDestinationAddress, {
+      ...options,
+      limit: 1,
+      sort: "Descending",
+    });
     const tokenOp = results.find(o => o.asset.type === "fa2");
 
     expect(JSON.parse(next)).toEqual({
-      nativeLastId: appliedTransfer.id,
-      tokenLastId: fa2.id,
+      lastLevel: 100,
     });
 
     expect(tokenOp).toMatchObject({
@@ -628,5 +664,78 @@ describe("listOperations", () => {
     const noBlock = results.find(o => o.asset.type === "fa2");
     expect(noBlock).toBeDefined();
     expect(noBlock!.tx.block.hash).toBe("");
+  });
+
+  it("trims partial bottom block on full page (descending) so levels are not split across pages", async () => {
+    const opHigh: APITransactionType = {
+      ...transfer,
+      id: 80010,
+      level: 2000,
+      status: "applied" as const,
+    };
+    const opLow: APITransactionType = {
+      ...transfer,
+      id: 80011,
+      level: 1999,
+      status: "applied" as const,
+    };
+    mockGetAccountOperations.mockResolvedValue([opHigh, opLow]);
+    mockGetAccountTokenTransfers.mockResolvedValue([]);
+    const [results] = await listOperations(someSenderAddress, {
+      sort: "Descending",
+      minHeight: 0,
+      limit: 2,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.tx.block.height).toBe(2000);
+  });
+
+  it("aligns native and token streams to the same boundary level (descending)", async () => {
+    const parentTx: APITransactionType = {
+      ...transfer,
+      id: 80020,
+      level: 1000,
+      status: "applied" as const,
+    };
+    const opOlder: APITransactionType = {
+      ...transfer,
+      id: 80021,
+      level: 500,
+      status: "applied" as const,
+    };
+    const fa2At1000: APITokenTransfer & { hash: string } = {
+      id: 80030,
+      level: 1000,
+      timestamp: "2023-06-01T12:00:00Z",
+      token: {
+        id: 1,
+        contract: { address: "KT1TokenContract" },
+        tokenId: "0",
+        standard: "fa2",
+        metadata: { decimals: "6" },
+      },
+      from: { address: someSenderAddress },
+      to: { address: someDestinationAddress },
+      amount: "1",
+      transactionId: parentTx.id,
+      hash: someHash,
+    };
+    const fa2Old: APITokenTransfer & { hash: string } = {
+      ...fa2At1000,
+      id: 80031,
+      level: 400,
+      hash: "ooOldTok",
+    };
+    mockGetAccountOperations.mockResolvedValue([parentTx, opOlder]);
+    mockGetAccountTokenTransfers.mockResolvedValue([fa2At1000, fa2Old]);
+    const [results] = await listOperations(someDestinationAddress, {
+      sort: "Descending",
+      minHeight: 0,
+      limit: 2,
+    });
+    expect(results.some(o => o.tx.hash === "ooOldTok")).toBe(false);
+    expect(results.filter(o => o.asset.type === "native")).toHaveLength(1);
+    expect(results.filter(o => o.asset.type === "fa2")).toHaveLength(1);
+    expect(results.find(o => o.asset.type === "fa2")?.tx.hash).toBe(someHash);
   });
 });

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
@@ -1,6 +1,7 @@
 import { Operation } from "@ledgerhq/coin-module-framework/api/types";
 import { log } from "@ledgerhq/logs";
 import { tzkt } from "../network";
+import type { APIOperation } from "../network/types";
 import {
   type APIDelegationType,
   type APIRevealType,
@@ -12,23 +13,80 @@ import {
   isAPITransactionType,
 } from "../network/types";
 
-/** Cursor: native + token transfer last ids. Legacy: JSON number = native only. */
-function parseCursor(token?: string): { nativeLastId?: number; tokenLastId?: number } {
-  if (!token) return {};
+/** Single block-level boundary cursor shared by native + token streams (legacy cursors ignored). */
+type ListOperationsCursor = { lastLevel: number };
+
+function parseCursor(token?: string): ListOperationsCursor | undefined {
+  if (!token) return undefined;
   try {
     const parsed: unknown = JSON.parse(token);
-    if (typeof parsed === "number") return { nativeLastId: parsed };
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      const output = parsed as { nativeLastId?: unknown; tokenLastId?: unknown };
-      const nativeLastId =
-        typeof output.nativeLastId === "number" ? output.nativeLastId : undefined;
-      const tokenLastId = typeof output.tokenLastId === "number" ? output.tokenLastId : undefined;
-      return { nativeLastId, tokenLastId };
+      const o = parsed as { lastLevel?: unknown };
+      if (typeof o.lastLevel === "number" && Number.isFinite(o.lastLevel)) {
+        return { lastLevel: o.lastLevel };
+      }
     }
   } catch {
     // ignore invalid cursor
   }
-  return {};
+  return undefined;
+}
+
+function minLevel<T extends { level: number }>(items: T[]): number | undefined {
+  if (items.length === 0) return undefined;
+  return Math.min(...items.map(i => i.level));
+}
+
+function maxLevel<T extends { level: number }>(items: T[]): number | undefined {
+  if (items.length === 0) return undefined;
+  return Math.max(...items.map(i => i.level));
+}
+
+/** When the API returned a full page, the trailing block level may be incomplete — drop it. */
+function trimPartialLastLevel<T extends { level: number }>(items: T[], full: boolean): T[] {
+  if (!full || items.length === 0) return items;
+  const lastLevel = items[items.length - 1].level;
+  const filtered = items.filter(op => op.level !== lastLevel);
+  if (filtered.length === 0) {
+    log("coin:tezos", "listOperations: full page single level — keeping all rows", {
+      lastLevel,
+      count: items.length,
+    });
+    return items;
+  }
+  return filtered;
+}
+
+function computeBoundary(
+  nativeTrim: { level: number }[],
+  tokenTrim: { level: number }[],
+  sort: "Ascending" | "Descending",
+): number | undefined {
+  if (sort === "Descending") {
+    const mn = minLevel(nativeTrim);
+    const mt = minLevel(tokenTrim);
+    if (mn === undefined && mt === undefined) return undefined;
+    if (mn === undefined) return mt!;
+    if (mt === undefined) return mn;
+    return Math.max(mn, mt);
+  }
+  const xn = maxLevel(nativeTrim);
+  const xt = maxLevel(tokenTrim);
+  if (xn === undefined && xt === undefined) return undefined;
+  if (xn === undefined) return xt!;
+  if (xt === undefined) return xn;
+  return Math.min(xn, xt);
+}
+
+function alignToBoundary<T extends { level: number }>(
+  items: T[],
+  boundary: number,
+  sort: "Ascending" | "Descending",
+): T[] {
+  if (sort === "Descending") {
+    return items.filter(op => op.level >= boundary);
+  }
+  return items.filter(op => op.level <= boundary);
 }
 
 /**
@@ -52,50 +110,72 @@ export async function listOperations(
     minHeight,
   }: { limit?: number; token?: string; sort: "Ascending" | "Descending"; minHeight: number },
 ): Promise<[Operation[], string]> {
-  const { nativeLastId, tokenLastId } = parseCursor(token);
+  const cursor = parseCursor(token);
+
+  const levelWindow =
+    sort === "Descending"
+      ? ({
+          "level.ge": minHeight,
+          ...(cursor ? { "level.lt": cursor.lastLevel } : {}),
+        } as const)
+      : ({
+          "level.ge": cursor ? Math.max(minHeight, cursor.lastLevel + 1) : minHeight,
+        } as const);
 
   const nativeOptions: AccountsGetOperationsOptions = {
     limit,
     sort,
-    "level.ge": minHeight,
-    ...(nativeLastId ? { lastId: nativeLastId } : {}),
+    ...levelWindow,
   };
 
   const tokenOptions = {
     limit,
     sort,
-    "level.ge": minHeight,
-    ...(tokenLastId ? { lastId: tokenLastId } : {}),
+    ...levelWindow,
   };
 
-  const [nativeOps, tokenTransfers] = await Promise.all([
+  const [nativeOpsRaw, tokenTransfersRaw] = await Promise.all([
     tzkt.getAccountOperations(address, nativeOptions),
     tzkt.getAccountTokenTransfers(address, tokenOptions),
   ]);
 
-  // Apply limit after fetching since tzkt API might not respect the limit parameter
-  const limitedNativeOps = limit ? nativeOps.slice(0, limit) : nativeOps;
-  const limitedTokenTransfers = limit ? tokenTransfers.slice(0, limit) : tokenTransfers;
+  const nativeSliced = limit !== undefined ? nativeOpsRaw.slice(0, limit) : nativeOpsRaw;
+  const tokenSliced = limit !== undefined ? tokenTransfersRaw.slice(0, limit) : tokenTransfersRaw;
+
+  const nativeFull = limit !== undefined && nativeOpsRaw.length >= limit;
+  const tokenFull = limit !== undefined && tokenTransfersRaw.length >= limit;
+
+  const nativeTrim = trimPartialLastLevel(nativeSliced, nativeFull);
+  const tokenTrim = trimPartialLastLevel(tokenSliced, tokenFull);
+
+  const boundary = computeBoundary(nativeTrim, tokenTrim, sort);
+
+  const nativeAligned =
+    boundary !== undefined ? alignToBoundary(nativeTrim, boundary, sort) : nativeTrim;
+  const tokenAligned =
+    boundary !== undefined ? alignToBoundary(tokenTrim, boundary, sort) : tokenTrim;
 
   const parentMap = new Map<number, APITransactionType>();
-  for (const op of nativeOps) {
+  for (const op of nativeAligned) {
     if (isAPITransactionType(op) && op.id !== null) {
       parentMap.set(op.id, op);
     }
   }
 
-  const lastNativeOp = limitedNativeOps.at(-1);
-  const lastTokenOp = limitedTokenTransfers.at(-1);
-  const nextToken =
-    lastNativeOp || lastTokenOp
-      ? JSON.stringify({
-          nativeLastId: lastNativeOp?.id,
-          tokenLastId: lastTokenOp?.id,
-        })
-      : "";
+  const shouldEmitNext =
+    boundary !== undefined &&
+    (nativeFull || tokenFull) &&
+    (nativeAligned.length > 0 || tokenAligned.length > 0);
 
-  const filteredNativeOps = limitedNativeOps
-    .filter(op => isAPITransactionType(op) || isAPIDelegationType(op) || isAPIRevealType(op))
+  const nextToken = shouldEmitNext
+    ? JSON.stringify({ lastLevel: boundary } satisfies ListOperationsCursor)
+    : "";
+
+  const filteredNativeOps = nativeAligned
+    .filter(
+      (op: APIOperation) =>
+        isAPITransactionType(op) || isAPIDelegationType(op) || isAPIRevealType(op),
+    )
     .filter(op => {
       const hasFailed = op.status !== "applied";
       if (hasFailed && isAPITransactionType(op)) {
@@ -109,11 +189,11 @@ export async function listOperations(
     .map(op => convertOperation(address, op))
     .flat();
 
-  const tokenConverted = limitedTokenTransfers.map(transfer =>
+  const tokenConverted = tokenAligned.map(transfer =>
     convertTokenOperation(
       address,
       transfer,
-      transfer.transactionId ? parentMap.get(transfer.transactionId)! : undefined,
+      transfer.transactionId ? parentMap.get(transfer.transactionId) : undefined,
     ),
   );
 

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
@@ -11,19 +11,35 @@ import {
   isAPIDelegationType,
   isAPIRevealType,
   isAPITransactionType,
+  type TokenTransfersGetOptions,
 } from "../network/types";
 
-/** Single block-level boundary cursor shared by native + token streams (legacy cursors ignored). */
-type ListOperationsCursor = { lastLevel: number };
+/** Block-level boundary + optional per-stream id cursors for intra-level continuation. */
+type ListOperationsCursor = {
+  lastLevel: number;
+  nativeLastId?: number;
+  tokenLastId?: number;
+};
 
 function parseCursor(token?: string): ListOperationsCursor | undefined {
   if (!token) return undefined;
   try {
     const parsed: unknown = JSON.parse(token);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      const o = parsed as { lastLevel?: unknown };
+      const o = parsed as {
+        lastLevel?: unknown;
+        nativeLastId?: unknown;
+        tokenLastId?: unknown;
+      };
       if (typeof o.lastLevel === "number" && Number.isFinite(o.lastLevel)) {
-        return { lastLevel: o.lastLevel };
+        const cursor: ListOperationsCursor = { lastLevel: o.lastLevel };
+        if (typeof o.nativeLastId === "number" && Number.isFinite(o.nativeLastId)) {
+          cursor.nativeLastId = o.nativeLastId;
+        }
+        if (typeof o.tokenLastId === "number" && Number.isFinite(o.tokenLastId)) {
+          cursor.tokenLastId = o.tokenLastId;
+        }
+        return cursor;
       }
     }
   } catch {
@@ -43,18 +59,103 @@ function maxLevel<T extends { level: number }>(items: T[]): number | undefined {
 }
 
 /** When the API returned a full page, the trailing block level may be incomplete — drop it. */
-function trimPartialLastLevel<T extends { level: number }>(items: T[], full: boolean): T[] {
-  if (!full || items.length === 0) return items;
-  const lastLevel = items[items.length - 1].level;
+function trimPartialLastLevel<T extends { level: number; id: number }>(
+  items: T[],
+  full: boolean,
+): { trimmed: T[]; intraLevelLastId?: number } {
+  if (!full || items.length === 0) return { trimmed: items };
+  const last = items.at(-1);
+  if (!last) return { trimmed: items };
+  const lastLevel = last.level;
   const filtered = items.filter(op => op.level !== lastLevel);
   if (filtered.length === 0) {
     log("coin:tezos", "listOperations: full page single level — keeping all rows", {
       lastLevel,
       count: items.length,
     });
-    return items;
+    return { trimmed: items, intraLevelLastId: last.id };
   }
-  return filtered;
+  return { trimmed: filtered };
+}
+
+function buildNativeOptions(
+  sort: "Ascending" | "Descending",
+  cursor: ListOperationsCursor | undefined,
+  minHeight: number,
+): AccountsGetOperationsOptions {
+  if (!cursor) {
+    return { sort, "level.ge": minHeight };
+  }
+
+  const { lastLevel, nativeLastId } = cursor;
+
+  if (sort === "Descending") {
+    if (nativeLastId !== undefined) {
+      return {
+        sort,
+        "level.ge": minHeight,
+        "level.lt": lastLevel + 1,
+        lastId: nativeLastId,
+      };
+    }
+    return {
+      sort,
+      "level.ge": minHeight,
+      "level.lt": lastLevel,
+    };
+  }
+
+  if (nativeLastId !== undefined) {
+    return {
+      sort,
+      "level.ge": Math.max(minHeight, lastLevel),
+      lastId: nativeLastId,
+    };
+  }
+  return {
+    sort,
+    "level.ge": Math.max(minHeight, lastLevel + 1),
+  };
+}
+
+function buildTokenOptions(
+  sort: "Ascending" | "Descending",
+  cursor: ListOperationsCursor | undefined,
+  minHeight: number,
+): TokenTransfersGetOptions {
+  if (!cursor) {
+    return { sort, "level.ge": minHeight };
+  }
+
+  const { lastLevel, tokenLastId } = cursor;
+
+  if (sort === "Descending") {
+    if (tokenLastId !== undefined) {
+      return {
+        sort,
+        "level.ge": minHeight,
+        "level.lt": lastLevel + 1,
+        "id.lt": tokenLastId,
+      };
+    }
+    return {
+      sort,
+      "level.ge": minHeight,
+      "level.lt": lastLevel,
+    };
+  }
+
+  if (tokenLastId !== undefined) {
+    return {
+      sort,
+      "level.ge": Math.max(minHeight, lastLevel),
+      "id.gt": tokenLastId,
+    };
+  }
+  return {
+    sort,
+    "level.ge": Math.max(minHeight, lastLevel + 1),
+  };
 }
 
 function computeBoundary(
@@ -89,6 +190,81 @@ function alignToBoundary<T extends { level: number }>(
   return items.filter(op => op.level <= boundary);
 }
 
+function clampPage<T>(raw: T[], limit?: number): { sliced: T[]; full: boolean } {
+  if (limit === undefined) {
+    return { sliced: raw, full: false };
+  }
+  return {
+    sliced: raw.slice(0, limit),
+    full: raw.length >= limit,
+  };
+}
+
+function buildParentMap(ops: APIOperation[]): Map<number, APITransactionType> {
+  const parentMap = new Map<number, APITransactionType>();
+  for (const op of ops) {
+    if (isAPITransactionType(op) && op.id !== null) {
+      parentMap.set(op.id, op);
+    }
+  }
+  return parentMap;
+}
+
+function keepNativeOp(
+  op: APIOperation,
+  address: string,
+): op is APITransactionType | APIDelegationType | APIRevealType {
+  if (!(isAPITransactionType(op) || isAPIDelegationType(op) || isAPIRevealType(op))) {
+    return false;
+  }
+  if (op.status !== "applied" && isAPITransactionType(op)) {
+    const isIn = op.target?.address === address;
+    if (isIn) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function convertNativeOps(ops: APIOperation[], address: string): Operation[] {
+  return ops
+    .filter((op): op is APITransactionType | APIDelegationType | APIRevealType =>
+      keepNativeOp(op, address),
+    )
+    .map(op => convertOperation(address, op))
+    .flat();
+}
+
+function convertTokenOps(
+  transfers: (APITokenTransfer & { hash: string; block?: string })[],
+  parentMap: Map<number, APITransactionType>,
+  address: string,
+): Operation[] {
+  return transfers.map(transfer =>
+    convertTokenOperation(
+      address,
+      transfer,
+      transfer.transactionId ? parentMap.get(transfer.transactionId) : undefined,
+    ),
+  );
+}
+
+function computeNextToken(
+  boundary: number | undefined,
+  nativeFull: boolean,
+  tokenFull: boolean,
+  hasResults: boolean,
+  nativeIntraLastId?: number,
+  tokenIntraLastId?: number,
+): string {
+  const shouldEmitNext = boundary !== undefined && (nativeFull || tokenFull) && hasResults;
+  if (!shouldEmitNext) return "";
+  const payload: ListOperationsCursor = { lastLevel: boundary };
+  if (nativeIntraLastId !== undefined) payload.nativeLastId = nativeIntraLastId;
+  if (tokenIntraLastId !== undefined) payload.tokenLastId = tokenIntraLastId;
+  return JSON.stringify(payload);
+}
+
 /**
  * Returns list of "Transfer", "Delegate" and "Undelegate" Operations associated to an account.
  * @param address Account address
@@ -112,26 +288,14 @@ export async function listOperations(
 ): Promise<[Operation[], string]> {
   const cursor = parseCursor(token);
 
-  const levelWindow =
-    sort === "Descending"
-      ? ({
-          "level.ge": minHeight,
-          ...(cursor ? { "level.lt": cursor.lastLevel } : {}),
-        } as const)
-      : ({
-          "level.ge": cursor ? Math.max(minHeight, cursor.lastLevel + 1) : minHeight,
-        } as const);
-
   const nativeOptions: AccountsGetOperationsOptions = {
     limit,
-    sort,
-    ...levelWindow,
+    ...buildNativeOptions(sort, cursor, minHeight),
   };
 
-  const tokenOptions = {
+  const tokenOptions: TokenTransfersGetOptions = {
     limit,
-    sort,
-    ...levelWindow,
+    ...buildTokenOptions(sort, cursor, minHeight),
   };
 
   const [nativeOpsRaw, tokenTransfersRaw] = await Promise.all([
@@ -139,63 +303,36 @@ export async function listOperations(
     tzkt.getAccountTokenTransfers(address, tokenOptions),
   ]);
 
-  const nativeSliced = limit !== undefined ? nativeOpsRaw.slice(0, limit) : nativeOpsRaw;
-  const tokenSliced = limit !== undefined ? tokenTransfersRaw.slice(0, limit) : tokenTransfersRaw;
+  const nativePage = clampPage(nativeOpsRaw, limit);
+  const tokenPage = clampPage(tokenTransfersRaw, limit);
 
-  const nativeFull = limit !== undefined && nativeOpsRaw.length >= limit;
-  const tokenFull = limit !== undefined && tokenTransfersRaw.length >= limit;
+  const nativeTrimmed = trimPartialLastLevel(nativePage.sliced, nativePage.full);
+  const tokenTrimmed = trimPartialLastLevel(tokenPage.sliced, tokenPage.full);
 
-  const nativeTrim = trimPartialLastLevel(nativeSliced, nativeFull);
-  const tokenTrim = trimPartialLastLevel(tokenSliced, tokenFull);
-
-  const boundary = computeBoundary(nativeTrim, tokenTrim, sort);
+  const boundary = computeBoundary(nativeTrimmed.trimmed, tokenTrimmed.trimmed, sort);
 
   const nativeAligned =
-    boundary !== undefined ? alignToBoundary(nativeTrim, boundary, sort) : nativeTrim;
+    boundary === undefined
+      ? nativeTrimmed.trimmed
+      : alignToBoundary(nativeTrimmed.trimmed, boundary, sort);
   const tokenAligned =
-    boundary !== undefined ? alignToBoundary(tokenTrim, boundary, sort) : tokenTrim;
+    boundary === undefined
+      ? tokenTrimmed.trimmed
+      : alignToBoundary(tokenTrimmed.trimmed, boundary, sort);
 
-  const parentMap = new Map<number, APITransactionType>();
-  for (const op of nativeAligned) {
-    if (isAPITransactionType(op) && op.id !== null) {
-      parentMap.set(op.id, op);
-    }
-  }
+  const parentMap = buildParentMap(nativeAligned);
 
-  const shouldEmitNext =
-    boundary !== undefined &&
-    (nativeFull || tokenFull) &&
-    (nativeAligned.length > 0 || tokenAligned.length > 0);
-
-  const nextToken = shouldEmitNext
-    ? JSON.stringify({ lastLevel: boundary } satisfies ListOperationsCursor)
-    : "";
-
-  const filteredNativeOps = nativeAligned
-    .filter(
-      (op: APIOperation) =>
-        isAPITransactionType(op) || isAPIDelegationType(op) || isAPIRevealType(op),
-    )
-    .filter(op => {
-      const hasFailed = op.status !== "applied";
-      if (hasFailed && isAPITransactionType(op)) {
-        const isIn = op.target?.address === address;
-        if (isIn) {
-          return false;
-        }
-      }
-      return true;
-    })
-    .map(op => convertOperation(address, op))
-    .flat();
-
-  const tokenConverted = tokenAligned.map(transfer =>
-    convertTokenOperation(
-      address,
-      transfer,
-      transfer.transactionId ? parentMap.get(transfer.transactionId) : undefined,
-    ),
+  const nextToken = computeNextToken(
+    boundary,
+    nativePage.full,
+    tokenPage.full,
+    nativeAligned.length > 0 || tokenAligned.length > 0,
+    nativeTrimmed.intraLevelLastId,
+    tokenTrimmed.intraLevelLastId,
   );
+
+  const filteredNativeOps = convertNativeOps(nativeAligned, address);
+  const tokenConverted = convertTokenOps(tokenAligned, parentMap, address);
 
   const sortedOperations = [...filteredNativeOps, ...tokenConverted].sort(
     (a, b) => b.tx.date.getTime() - a.tx.date.getTime(),

--- a/libs/coin-modules/coin-tezos/src/network/types.ts
+++ b/libs/coin-modules/coin-tezos/src/network/types.ts
@@ -94,6 +94,10 @@ export type AccountsGetOperationsOptions = {
   sort?: "Descending" | "Ascending";
   // the minimum height of the block the operation is in
   "level.ge": number;
+  /** Exclusive upper bound on block level (pagination window). */
+  "level.lt"?: number;
+  /** Exclusive lower bound on block level (pagination window). */
+  "level.gt"?: number;
 };
 
 export type APIOperation =
@@ -171,6 +175,8 @@ export type TokenTransfersGetOptions = {
   limit?: number;
   sort?: "Descending" | "Ascending";
   "level.ge"?: number;
+  "level.lt"?: number;
+  "level.gt"?: number;
 };
 
 /**

--- a/libs/coin-modules/coin-tezos/src/network/types.ts
+++ b/libs/coin-modules/coin-tezos/src/network/types.ts
@@ -171,12 +171,15 @@ export type APIBlock = {
 };
 
 export type TokenTransfersGetOptions = {
-  lastId?: number;
   limit?: number;
   sort?: "Descending" | "Ascending";
   "level.ge"?: number;
   "level.lt"?: number;
   "level.gt"?: number;
+  /** Exclusive upper bound on transfer id (TzKT `id.lt`). Used for intra-level pagination when sort is Descending. */
+  "id.lt"?: number;
+  /** Exclusive lower bound on transfer id (TzKT `id.gt`). Used for intra-level pagination when sort is Ascending. */
+  "id.gt"?: number;
 };
 
 /**

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
@@ -350,12 +350,18 @@ describe("tzkt network API", () => {
 
   describe("api.getAccountTokenTransfers", () => {
     it("returns empty hash when no numeric transaction ids are present", async () => {
-      const spyToken = spyOnApi("getTokenTransfers").mockResolvedValue([
-        makeTokenWithTxId(1, undefined),
-        makeTokenWithTxId(2, undefined),
-      ]);
       const spyTx = spyOnApi("getOperationsTransactions");
       const spyOrig = spyOnApi("getOperationsOrigination");
+
+      mockedNetwork.mockImplementation(async (config: { url: string }) => {
+        if (config.url.includes("/v1/tokens/transfers")) {
+          return networkResponse([
+            makeTokenWithTxId(1, undefined),
+            makeTokenWithTxId(2, undefined),
+          ]) as ReturnType<typeof network>;
+        }
+        throw new Error(`unexpected url: ${config.url}`);
+      });
 
       const result = await api.getAccountTokenTransfers("tz1x", {
         "level.ge": 10,
@@ -364,67 +370,85 @@ describe("tzkt network API", () => {
       expect(spyTx).not.toHaveBeenCalled();
       expect(spyOrig).not.toHaveBeenCalled();
       expect(result).toEqual([]);
-      expect(spyToken).toHaveBeenCalledWith(
-        10,
-        undefined,
-        expect.objectContaining({
-          "anyof.from.to": "tz1x",
-          "token.tokenId": "0",
-          "token.standard": "fa2",
-        }),
-      );
+      const firstCall = mockedNetwork.mock.calls[0]?.[0] as {
+        url: string;
+        params?: Record<string, unknown>;
+      };
+      expect(firstCall.params).toMatchObject({
+        "level.ge": 10,
+        "sort.asc": "id",
+        "anyof.from.to": "tz1x",
+        "token.tokenId": "0",
+        "token.standard": "fa2",
+      });
     });
 
     it("joins operation hashes and uses empty string when no match", async () => {
-      spyOnApi("getTokenTransfers").mockResolvedValue([
-        makeTokenWithTxId(1, 100),
-        makeTokenWithTxId(2, 200),
-      ]);
-      spyOnApi("getOperationsTransactions").mockResolvedValue([
-        { id: 100, hash: "h100", block: "BLK100" } as APITransactionType & {
-          hash: string;
-          block: string;
-        },
-      ]);
+      const spyTx = spyOnApi("getOperationsTransactions");
       const spyOrig = spyOnApi("getOperationsOrigination");
+      mockedNetwork.mockImplementation(async (config: { url: string }) => {
+        if (config.url.includes("/v1/tokens/transfers")) {
+          return networkResponse([
+            makeTokenWithTxId(1, 100),
+            makeTokenWithTxId(2, 200),
+          ]) as ReturnType<typeof network>;
+        }
+        if (config.url.includes("/v1/operations/transactions")) {
+          return networkResponse([
+            { id: 100, hash: "h100", block: "BLK100" } as APITransactionType & {
+              hash: string;
+              block: string;
+            },
+          ]) as ReturnType<typeof network>;
+        }
+        throw new Error(`unexpected url: ${config.url}`);
+      });
 
       const result = await api.getAccountTokenTransfers("tz1y", {
         "level.ge": 0,
-        lastId: 7,
       });
 
       expect(result).toEqual([
         expect.objectContaining({ id: 1, hash: "h100", block: "BLK100" }),
         expect.objectContaining({ id: 2, hash: "", block: "" }),
       ]);
-      expect(api.getOperationsTransactions).toHaveBeenCalledWith(0, undefined, {
+      expect(spyTx).toHaveBeenCalledWith(0, undefined, {
         "id.in": "100,200",
       });
       expect(spyOrig).not.toHaveBeenCalled();
     });
 
     it("attaches parent hash and block from originations when only originationIds are present", async () => {
-      jest
-        .spyOn(api, "getTokenTransfers")
-        .mockResolvedValue([makeTokenWithOrigId(1, 100), makeTokenWithOrigId(2, 200)]);
-      const spyTx = jest.spyOn(api, "getOperationsTransactions");
-      jest.spyOn(api, "getOperationsOrigination").mockResolvedValue([
-        { id: 100, hash: "h100", block: "BLK100" } as APITransactionType & {
-          hash: string;
-          block: string;
-        },
-        { id: 200, hash: "h200", block: "BLK200" } as APITransactionType & {
-          hash: string;
-          block: string;
-        },
-      ]);
+      const spyTx = spyOnApi("getOperationsTransactions");
+      const spyOrig = spyOnApi("getOperationsOrigination");
+      mockedNetwork.mockImplementation(async (config: { url: string }) => {
+        if (config.url.includes("/v1/tokens/transfers")) {
+          return networkResponse([
+            makeTokenWithOrigId(1, 100),
+            makeTokenWithOrigId(2, 200),
+          ]) as ReturnType<typeof network>;
+        }
+        if (config.url.includes("/v1/operations/originations")) {
+          return networkResponse([
+            { id: 100, hash: "h100", block: "BLK100" } as APITransactionType & {
+              hash: string;
+              block: string;
+            },
+            { id: 200, hash: "h200", block: "BLK200" } as APITransactionType & {
+              hash: string;
+              block: string;
+            },
+          ]) as ReturnType<typeof network>;
+        }
+        throw new Error(`unexpected url: ${config.url}`);
+      });
 
       const result = await api.getAccountTokenTransfers("tz1o", {
         "level.ge": 0,
       });
 
       expect(spyTx).not.toHaveBeenCalled();
-      expect(api.getOperationsOrigination).toHaveBeenCalledWith(0, undefined, {
+      expect(spyOrig).toHaveBeenCalledWith(0, undefined, {
         "id.in": "100,200",
       });
       expect(result).toEqual([
@@ -434,30 +458,42 @@ describe("tzkt network API", () => {
     });
 
     it("joins both transactions and originations when both ids are present", async () => {
-      jest
-        .spyOn(api, "getTokenTransfers")
-        .mockResolvedValue([makeTokenWithTxId(1, 100), makeTokenWithOrigId(2, 500)]);
-      jest.spyOn(api, "getOperationsTransactions").mockResolvedValue([
-        { id: 100, hash: "hTx", block: "BLK_TX" } as APITransactionType & {
-          hash: string;
-          block: string;
-        },
-      ]);
-      jest.spyOn(api, "getOperationsOrigination").mockResolvedValue([
-        { id: 500, hash: "hOrig", block: "BLK_ORIG" } as APITransactionType & {
-          hash: string;
-          block: string;
-        },
-      ]);
+      const spyTx = spyOnApi("getOperationsTransactions");
+      const spyOrig = spyOnApi("getOperationsOrigination");
+      mockedNetwork.mockImplementation(async (config: { url: string }) => {
+        if (config.url.includes("/v1/tokens/transfers")) {
+          return networkResponse([
+            makeTokenWithTxId(1, 100),
+            makeTokenWithOrigId(2, 500),
+          ]) as ReturnType<typeof network>;
+        }
+        if (config.url.includes("/v1/operations/transactions")) {
+          return networkResponse([
+            { id: 100, hash: "hTx", block: "BLK_TX" } as APITransactionType & {
+              hash: string;
+              block: string;
+            },
+          ]) as ReturnType<typeof network>;
+        }
+        if (config.url.includes("/v1/operations/originations")) {
+          return networkResponse([
+            { id: 500, hash: "hOrig", block: "BLK_ORIG" } as APITransactionType & {
+              hash: string;
+              block: string;
+            },
+          ]) as ReturnType<typeof network>;
+        }
+        throw new Error(`unexpected url: ${config.url}`);
+      });
 
       const result = await api.getAccountTokenTransfers("tz1mix", {
         "level.ge": 0,
       });
 
-      expect(api.getOperationsTransactions).toHaveBeenCalledWith(0, undefined, {
+      expect(spyTx).toHaveBeenCalledWith(0, undefined, {
         "id.in": "100",
       });
-      expect(api.getOperationsOrigination).toHaveBeenCalledWith(0, undefined, {
+      expect(spyOrig).toHaveBeenCalledWith(0, undefined, {
         "id.in": "500",
       });
       expect(result).toEqual([
@@ -467,27 +503,32 @@ describe("tzkt network API", () => {
     });
 
     it("keeps partial hash/block from the parent transaction without dropping transfers", async () => {
-      jest
-        .spyOn(api, "getTokenTransfers")
-        .mockResolvedValue([
-          makeTokenWithTxId(1, 100),
-          makeTokenWithTxId(2, 200),
-          makeTokenWithTxId(3, 300),
-        ]);
-      jest.spyOn(api, "getOperationsTransactions").mockResolvedValue([
-        { id: 100, hash: "h100", block: "" } as APITransactionType & {
-          hash: string;
-          block: string;
-        },
-        { id: 200, hash: "", block: "BLK200" } as APITransactionType & {
-          hash: string;
-          block: string;
-        },
-        { id: 300, hash: "h300", block: "BLK300" } as APITransactionType & {
-          hash: string;
-          block: string;
-        },
-      ]);
+      mockedNetwork.mockImplementation(async (config: { url: string }) => {
+        if (config.url.includes("/v1/tokens/transfers")) {
+          return networkResponse([
+            makeTokenWithTxId(1, 100),
+            makeTokenWithTxId(2, 200),
+            makeTokenWithTxId(3, 300),
+          ]) as ReturnType<typeof network>;
+        }
+        if (config.url.includes("/v1/operations/transactions")) {
+          return networkResponse([
+            { id: 100, hash: "h100", block: "" } as APITransactionType & {
+              hash: string;
+              block: string;
+            },
+            { id: 200, hash: "", block: "BLK200" } as APITransactionType & {
+              hash: string;
+              block: string;
+            },
+            { id: 300, hash: "h300", block: "BLK300" } as APITransactionType & {
+              hash: string;
+              block: string;
+            },
+          ]) as ReturnType<typeof network>;
+        }
+        throw new Error(`unexpected url: ${config.url}`);
+      });
       const spyOrig = jest.spyOn(api, "getOperationsOrigination");
 
       const result = await api.getAccountTokenTransfers("tz1z", {
@@ -503,28 +544,33 @@ describe("tzkt network API", () => {
     });
 
     it("keeps partial hash/block from the parent origination without dropping transfers", async () => {
-      jest
-        .spyOn(api, "getTokenTransfers")
-        .mockResolvedValue([
-          makeTokenWithOrigId(1, 100),
-          makeTokenWithOrigId(2, 200),
-          makeTokenWithOrigId(3, 300),
-        ]);
+      mockedNetwork.mockImplementation(async (config: { url: string }) => {
+        if (config.url.includes("/v1/tokens/transfers")) {
+          return networkResponse([
+            makeTokenWithOrigId(1, 100),
+            makeTokenWithOrigId(2, 200),
+            makeTokenWithOrigId(3, 300),
+          ]) as ReturnType<typeof network>;
+        }
+        if (config.url.includes("/v1/operations/originations")) {
+          return networkResponse([
+            { id: 100, hash: "h100", block: "" } as APITransactionType & {
+              hash: string;
+              block: string;
+            },
+            { id: 200, hash: "", block: "BLK200" } as APITransactionType & {
+              hash: string;
+              block: string;
+            },
+            { id: 300, hash: "h300", block: "BLK300" } as APITransactionType & {
+              hash: string;
+              block: string;
+            },
+          ]) as ReturnType<typeof network>;
+        }
+        throw new Error(`unexpected url: ${config.url}`);
+      });
       const spyTx = jest.spyOn(api, "getOperationsTransactions");
-      jest.spyOn(api, "getOperationsOrigination").mockResolvedValue([
-        { id: 100, hash: "h100", block: "" } as APITransactionType & {
-          hash: string;
-          block: string;
-        },
-        { id: 200, hash: "", block: "BLK200" } as APITransactionType & {
-          hash: string;
-          block: string;
-        },
-        { id: 300, hash: "h300", block: "BLK300" } as APITransactionType & {
-          hash: string;
-          block: string;
-        },
-      ]);
 
       const result = await api.getAccountTokenTransfers("tz1origZ", {
         "level.ge": 0,
@@ -536,6 +582,43 @@ describe("tzkt network API", () => {
         expect.objectContaining({ id: 3, hash: "h300", block: "BLK300" }),
       ]);
       expect(spyTx).not.toHaveBeenCalled();
+    });
+
+    it("uses sort.desc=id when sort is Descending and forwards level.lt / level.gt", async () => {
+      mockedNetwork.mockReturnValue(networkResponse([]) as ReturnType<typeof network>);
+
+      await api.getAccountTokenTransfers("tz1sort", {
+        sort: "Descending",
+        "level.ge": 1,
+        "level.lt": 9_000_000,
+        limit: 50,
+      });
+
+      const params = (mockedNetwork.mock.calls[0][0] as { params: Record<string, unknown> }).params;
+      expect(params).toMatchObject({
+        "sort.desc": "id",
+        "level.ge": 1,
+        "level.lt": 9_000_000,
+        limit: 50,
+      });
+      expect(params).not.toHaveProperty("sort.asc");
+    });
+
+    it("forwards level.gt for ascending continuation windows", async () => {
+      mockedNetwork.mockReturnValue(networkResponse([]) as ReturnType<typeof network>);
+
+      await api.getAccountTokenTransfers("tz1asc", {
+        sort: "Ascending",
+        "level.ge": 100,
+        "level.gt": 500,
+      });
+
+      const params = (mockedNetwork.mock.calls[0][0] as { params: Record<string, unknown> }).params;
+      expect(params).toMatchObject({
+        "sort.asc": "id",
+        "level.ge": 100,
+        "level.gt": 500,
+      });
     });
   });
 

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.test.ts
@@ -309,11 +309,12 @@ describe("tzkt network API", () => {
   // -------------------------------------------------------------------------
 
   describe("api.getTokenTransfers", () => {
-    it("fetches without cursor and strips undefined extra args", async () => {
+    it("passes through params and strips undefined extra args", async () => {
       const transfers: APITokenTransfer[] = [makeTokenItem(1)];
       mockedNetwork.mockReturnValue(networkResponse(transfers) as ReturnType<typeof network>);
 
-      const result = await api.getTokenTransfers(200, undefined, {
+      const result = await api.getTokenTransfers({
+        "level.gte": 200,
         unused: undefined,
         select: "id",
       });
@@ -322,8 +323,6 @@ describe("tzkt network API", () => {
       const params = (mockedNetwork.mock.calls[0][0] as { params: Record<string, unknown> }).params;
       expect(params).toMatchObject({
         "level.gte": 200,
-        limit: 1000,
-        "sort.asc": "id",
         select: "id",
       });
       expect(params).not.toHaveProperty("unused");
@@ -332,15 +331,6 @@ describe("tzkt network API", () => {
           url: expect.stringContaining("/v1/tokens/transfers"),
         }),
       );
-    });
-
-    it("includes offset.cr when cursor is set", async () => {
-      mockedNetwork.mockReturnValue(networkResponse([]) as ReturnType<typeof network>);
-
-      await api.getTokenTransfers(1, 55);
-
-      const params = (mockedNetwork.mock.calls[0][0] as { params: Record<string, unknown> }).params;
-      expect(params["offset.cr"]).toBe(55);
     });
   });
 

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.ts
@@ -171,19 +171,11 @@ const api = {
    * https://api.tzkt.io/#operation/Tokens_GetTokenTransfers
    */
   async getTokenTransfers(
-    level: number,
-    cursor?: number,
     apiQueryParams: Record<string, unknown> = {},
   ): Promise<APITokenTransfer[]> {
-    // Same rationale as getBlockTransactionsPage: explicit ascending sort keeps the
-    // offset.cr cursor advancing forward regardless of the API's default ordering.;
-    const params: Record<string, unknown> = {
-      "level.gte": level,
-      limit: BLOCK_PAGE_SIZE,
-      "sort.asc": "id",
+    const params = {
       ...clearUndefined(apiQueryParams),
     };
-    if (cursor !== undefined) params["offset.cr"] = cursor;
     const { data } = await network<APITokenTransfer[]>({
       url: `${getExplorerUrl()}/v1/tokens/transfers`,
       params,
@@ -224,8 +216,8 @@ const api = {
   /**
    * Fetches FA2 token transfers (tokenId = 0 only) for a given account.
    * This is limited to `token.standard=fa2` and `token.tokenId=0` on the TzKT API.
-   * Respects `query.sort` (unlike the lower-level `getTokenTransfers` helper which is
-   * fixed to ascending id for offset-based block pagination).
+   * Translates `query.sort` to TzKT's `sort.asc=id` / `sort.desc=id`.
+   * The lower-level `getTokenTransfers` helper is a generic pass-through and does not pin the sort.
    * https://api.tzkt.io/#operation/Tokens_GetTokenTransfers
    */
   async getAccountTokenTransfers(
@@ -242,15 +234,11 @@ const api = {
       "level.ge": query["level.ge"],
       "level.lt": query["level.lt"],
       "level.gt": query["level.gt"],
+      "id.lt": query["id.lt"],
+      "id.gt": query["id.gt"],
     };
-    Object.entries(params).forEach(
-      ([key, value]) => value === undefined && delete params[key as keyof typeof params],
-    );
 
-    const { data } = await network<APITokenTransfer[]>({
-      url: `${getExplorerUrl()}/v1/tokens/transfers`,
-      params,
-    });
+    const data = await api.getTokenTransfers(clearUndefined(params));
 
     const transactionIds = data
       .map(t => t.transactionId)
@@ -266,14 +254,14 @@ const api = {
 
     const transactions = transactionIds.length
       ? await api.getOperationsTransactions(query["level.ge"] || 0, undefined, {
-          "id.in": transactionIds.join(","),
-        })
+        "id.in": transactionIds.join(","),
+      })
       : [];
 
     const originations = originationIds.length
       ? await api.getOperationsOrigination(query["level.ge"] || 0, undefined, {
-          "id.in": originationIds.join(","),
-        })
+        "id.in": originationIds.join(","),
+      })
       : [];
 
     // Build id -> operation maps once so per-transfer lookups are O(1) instead of O(n).

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.ts
@@ -224,19 +224,33 @@ const api = {
   /**
    * Fetches FA2 token transfers (tokenId = 0 only) for a given account.
    * This is limited to `token.standard=fa2` and `token.tokenId=0` on the TzKT API.
+   * Respects `query.sort` (unlike the lower-level `getTokenTransfers` helper which is
+   * fixed to ascending id for offset-based block pagination).
    * https://api.tzkt.io/#operation/Tokens_GetTokenTransfers
    */
   async getAccountTokenTransfers(
     address: string,
     query: TokenTransfersGetOptions,
   ): Promise<(APITokenTransfer & { hash: string; block: string })[]> {
+    const sortKey = query.sort === "Descending" ? "sort.desc" : "sort.asc";
     const params: Record<string, unknown> = {
       "anyof.from.to": address,
       "token.tokenId": "0",
       "token.standard": "fa2",
+      [sortKey]: "id",
+      limit: query.limit,
+      "level.ge": query["level.ge"],
+      "level.lt": query["level.lt"],
+      "level.gt": query["level.gt"],
     };
+    Object.entries(params).forEach(
+      ([key, value]) => value === undefined && delete params[key as keyof typeof params],
+    );
 
-    const data = await api.getTokenTransfers(query["level.ge"] as number, query["lastId"], params);
+    const { data } = await network<APITokenTransfer[]>({
+      url: `${getExplorerUrl()}/v1/tokens/transfers`,
+      params,
+    });
 
     const transactionIds = data
       .map(t => t.transactionId)


### PR DESCRIPTION
fix Tezos operation pagination so native and FA2 ops sharing the same tx hash stay on one page

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Native operations and FA2 transfers are fetched from TzKT with two independent cursors (nativeLastId / tokenLastId). Applying limit to each stream separately could put the same transaction (tx.hash) on two different pages (e.g. native on page N, token on page N+1).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-29666


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
