### PR TITLE
[LWM] feat(mobile): replace MyWallet DeviceSection with SelectDevice2 from MyLedger

### DIFF
--- a/.changeset/friendly-ghosts-run.md
+++ b/.changeset/friendly-ghosts-run.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update my wallet page with the previous my ledger devices content

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -773,7 +773,7 @@ export function RequiredFirmwareUpdate({
   const { t } = useTranslation();
   const track = useTrack();
   const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(lastSeenDeviceSelector);
-  const { shouldDisplayWallet40MainNav } = useWalletFeaturesConfig("mobile");
+  const { shouldDisplayWallet40MainNav, shouldDisplayMyWallet } = useWalletFeaturesConfig("mobile");
 
   const usbFwUpdateActivated = !!lastSeenDevice;
   const deviceName = getDeviceModel(device.modelId).productName;
@@ -786,34 +786,61 @@ export function RequiredFirmwareUpdate({
       button: "OpenMyLedger",
       page: "Update_OS_To_Continue",
     });
-    const myLedgerState = {
-      routes: [
-        {
-          name: ScreenName.MyLedgerChooseDevice,
-          params: { device, firmwareUpdate: isDeviceConnectedViaUSB },
-        },
-      ],
-    };
-    if (shouldDisplayWallet40MainNav) {
-      navigation.reset({
-        index: 1,
+
+    if (shouldDisplayMyWallet) {
+      const myWalletState = {
         routes: [
-          { name: NavigatorName.Main },
-          { name: NavigatorName.MyLedger, state: myLedgerState },
+          {
+            name: ScreenName.MyWallet,
+            params: { device, firmwareUpdate: isDeviceConnectedViaUSB },
+          },
         ],
-      });
-    } else {
+      };
       navigation.reset({
         index: 0,
         routes: [
           {
-            name: NavigatorName.Main,
+            name: NavigatorName.Base,
             state: {
-              routes: [{ name: NavigatorName.MyLedger, state: myLedgerState }],
+              index: 1,
+              routes: [
+                { name: NavigatorName.Main },
+                { name: NavigatorName.MyWallet, state: myWalletState },
+              ],
             },
           },
         ],
       });
+    } else {
+      const myLedgerState = {
+        routes: [
+          {
+            name: ScreenName.MyLedgerChooseDevice,
+            params: { device, firmwareUpdate: isDeviceConnectedViaUSB },
+          },
+        ],
+      };
+      if (shouldDisplayWallet40MainNav) {
+        navigation.reset({
+          index: 1,
+          routes: [
+            { name: NavigatorName.Main },
+            { name: NavigatorName.MyLedger, state: myLedgerState },
+          ],
+        });
+      } else {
+        navigation.reset({
+          index: 0,
+          routes: [
+            {
+              name: NavigatorName.Main,
+              state: {
+                routes: [{ name: NavigatorName.MyLedger, state: myLedgerState }],
+              },
+            },
+          ],
+        });
+      }
     }
   };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/index.tsx
@@ -2,21 +2,33 @@ import React from "react";
 import { ScrollView } from "react-native";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { TrackScreen } from "~/analytics";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
 import { ProfileSection } from "./views/ProfileSection";
 import { QuickActionsRow } from "./views/QuickActionsRow";
 import { DeviceSection } from "./views/DeviceSection";
+import { MyLedgerSection } from "./views/MyLedgerSection";
 
 export function MyWalletScreen() {
+  const { shouldDisplayMyWallet } = useWalletFeaturesConfig("mobile");
+
   return (
     <Box style={{ flex: 1 }}>
       <TrackScreen category="My Wallet" />
-      <ScrollView>
-        <Box lx={{ paddingHorizontal: "s16", gap: "s24", paddingBottom: "s24" }}>
-          <ProfileSection />
-          <QuickActionsRow />
-          <DeviceSection />
+      <Box lx={{ paddingHorizontal: "s16", gap: "s24", paddingTop: "s24" }}>
+        <ProfileSection />
+        <QuickActionsRow />
+      </Box>
+      {shouldDisplayMyWallet ? (
+        <Box lx={{ paddingTop: "s24" }} style={{ flex: 1 }}>
+          <MyLedgerSection />
         </Box>
-      </ScrollView>
+      ) : (
+        <ScrollView>
+          <Box lx={{ paddingHorizontal: "s16", gap: "s24", paddingBottom: "s24" }}>
+            <DeviceSection />
+          </Box>
+        </ScrollView>
+      )}
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/types.ts
@@ -2,6 +2,13 @@ import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { ScreenName } from "~/const";
 
 export type MyWalletNavigatorStackParamList = {
-  [ScreenName.MyWallet]: { device?: Device } | undefined;
+  [ScreenName.MyWallet]:
+    | {
+        device?: Device;
+        firmwareUpdate?: boolean;
+        searchQuery?: string;
+        installApp?: string;
+      }
+    | undefined;
   [ScreenName.MyWalletHelp]: undefined;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/types.ts
@@ -1,6 +1,7 @@
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { ScreenName } from "~/const";
 
 export type MyWalletNavigatorStackParamList = {
-  [ScreenName.MyWallet]: undefined;
+  [ScreenName.MyWallet]: { device?: Device } | undefined;
   [ScreenName.MyWalletHelp]: undefined;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
@@ -13,6 +13,7 @@ import SelectDevice2, { SetHeaderOptionsRequest } from "~/components/SelectDevic
 import { track } from "~/analytics";
 import DeviceActionModal from "~/components/DeviceActionModal";
 import { useManagerDeviceAction } from "~/hooks/deviceActions";
+import { useAutoRedirectToPostOnboarding } from "~/hooks/useAutoRedirectToPostOnboarding";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { urls } from "~/utils/urls";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
@@ -26,6 +27,8 @@ function MyLedgerSectionContent() {
   const [device, setDevice] = useState<Device>();
   const { params } =
     useRoute<RouteProp<MyWalletNavigatorStackParamList, typeof ScreenName.MyWallet>>();
+
+  useAutoRedirectToPostOnboarding();
 
   // Auto-select a device passed via navigation params (e.g. redirect from "not enough space" error during a transactional flow).
   useEffect(() => {
@@ -58,7 +61,11 @@ function MyLedgerSectionContent() {
     if (result && "result" in result) {
       navigation.navigate(NavigatorName.MyLedger, {
         screen: ScreenName.MyLedgerDevice,
-        params: { ...result },
+        params: {
+          ...result,
+          firmwareUpdate: params?.firmwareUpdate,
+          searchQuery: params?.searchQuery || params?.installApp,
+        },
       });
     }
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Linking } from "react-native";
-import { useIsFocused, useNavigation } from "@react-navigation/native";
+import { useIsFocused, useNavigation, useRoute } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { RouteProp } from "@react-navigation/native";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { BluetoothRequired } from "@ledgerhq/errors";
 import { Result } from "@ledgerhq/live-common/hw/actions/manager";
@@ -16,12 +17,20 @@ import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { urls } from "~/utils/urls";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import type { LumenNativeStackNavigationOptions } from "LLM/components/Navigation";
+import type { MyWalletNavigatorStackParamList } from "../types";
 import { ExploreDevicesItem } from "./DeviceSection/components/ExploreDevicesItem";
 import { MyWalletHeaderTrailing } from "./Header";
 
 function MyLedgerSectionContent() {
   const action = useManagerDeviceAction();
   const [device, setDevice] = useState<Device>();
+  const { params } =
+    useRoute<RouteProp<MyWalletNavigatorStackParamList, typeof ScreenName.MyWallet>>();
+
+  // Auto-select a device passed via navigation params (e.g. redirect from "not enough space" error during a transactional flow).
+  useEffect(() => {
+    setDevice(params?.device);
+  }, [params?.device]);
   // TODO(wallet40-myWallet): enable ExploreDevicesItem when ready
   const { shouldDisplayMyWallet } = useWalletFeaturesConfig("mobile");
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
@@ -1,0 +1,122 @@
+import React, { useCallback, useState } from "react";
+import { Linking } from "react-native";
+import { useIsFocused, useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { BluetoothRequired } from "@ledgerhq/errors";
+import { Result } from "@ledgerhq/live-common/hw/actions/manager";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { useWalletFeaturesConfig } from "@ledgerhq/live-common/featureFlags/index";
+import { NavigatorName, ScreenName } from "~/const";
+import SelectDevice2, { SetHeaderOptionsRequest } from "~/components/SelectDevice2";
+import { track } from "~/analytics";
+import DeviceActionModal from "~/components/DeviceActionModal";
+import { useManagerDeviceAction } from "~/hooks/deviceActions";
+import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
+import { urls } from "~/utils/urls";
+import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
+import type { LumenNativeStackNavigationOptions } from "LLM/components/Navigation";
+import { ExploreDevicesItem } from "./DeviceSection/components/ExploreDevicesItem";
+import { MyWalletHeaderTrailing } from "./Header";
+
+function MyLedgerSectionContent() {
+  const action = useManagerDeviceAction();
+  const [device, setDevice] = useState<Device>();
+  // TODO(wallet40-myWallet): enable ExploreDevicesItem when ready
+  const { shouldDisplayMyWallet } = useWalletFeaturesConfig("mobile");
+
+  const navigation =
+    useNavigation<NativeStackNavigationProp<{ [key: string]: object | undefined }>>();
+
+  const exploreDevicesUrl = useLocalizedUrl(urls.exploreLedgerDevices);
+
+  const onExploreDevices = useCallback(() => {
+    track("button_clicked", { button: "ExploreDevices", page: ScreenName.MyWallet });
+    Linking.openURL(exploreDevicesUrl);
+  }, [exploreDevicesUrl]);
+
+  const onSelectDevice = (selected?: Device) => {
+    if (selected)
+      track("ManagerDeviceEntered", {
+        modelId: selected.modelId,
+      });
+    setDevice(selected);
+  };
+
+  const onSelect = (result: Result) => {
+    setDevice(undefined);
+
+    if (result && "result" in result) {
+      navigation.navigate(NavigatorName.MyLedger, {
+        screen: ScreenName.MyLedgerDevice,
+        params: { ...result },
+      });
+    }
+  };
+
+  const onModalHide = () => {
+    setDevice(undefined);
+  };
+
+  const onError = (error: Error) => {
+    if (error instanceof BluetoothRequired) {
+      setDevice(undefined);
+    }
+  };
+
+  const requestToSetHeaderOptions = useCallback(
+    (request: SetHeaderOptionsRequest) => {
+      const opts: Partial<LumenNativeStackNavigationOptions> =
+        request.type === "set"
+          ? {
+              lumenNavBar: {
+                renderLeading: request.options.headerLeft,
+                renderTrailing: request.options.headerRight,
+                renderCenter: () => null,
+              },
+            }
+          : {
+              lumenNavBar: {
+                renderLeading: undefined,
+                renderCenter: () => null,
+                renderTrailing: () => <MyWalletHeaderTrailing />,
+              },
+            };
+      navigation.setOptions(opts);
+    },
+    [navigation],
+  );
+
+  return (
+    <>
+      <Box style={{ flex: 1 }}>
+        <SelectDevice2
+          onSelect={onSelectDevice}
+          stopBleScanning={!!device}
+          requestToSetHeaderOptions={requestToSetHeaderOptions}
+          withMyLedgerTracking
+          hasPostOnboardingEntryPointCard
+        >
+          {/* TODO(wallet40-myWallet): enable ExploreDevicesItem when ready */}
+          {!shouldDisplayMyWallet && <ExploreDevicesItem onPress={onExploreDevices} />}
+        </SelectDevice2>
+      </Box>
+      <DeviceActionModal
+        onClose={() => onSelectDevice()}
+        device={device}
+        onResult={onSelect}
+        onModalHide={onModalHide}
+        action={action}
+        request={null}
+        onError={onError}
+        location={HOOKS_TRACKING_LOCATIONS.myLedgerDashboard}
+      />
+    </>
+  );
+}
+
+export function MyLedgerSection() {
+  const isFocused = useIsFocused();
+  if (!isFocused) return null;
+  return <MyLedgerSectionContent />;
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - MyWallet screen device section rendering
  - Device selection and BLE pairing flow within MyWallet
  - Navigation to MyLedgerDevice (manager) after device selection
  - ExploreDevicesItem display below device list
  - Header management during BLE pairing flow
  - Firmware update redirect now targets MyWallet when the feature flag is active
  - Parity with MyLedgerChooseDevice: auto-select device, searchQuery/installApp forwarding, post-onboarding redirect

### 📝 Description

The current MyWallet screen has a custom "My Devices" section (DeviceSection) that will be replaced by a different team in the future. To prepare for this, we need to integrate the existing MyLedger device management screen (SelectDevice2) into MyWallet as-is.

This PR replaces the DeviceSection with a new `MyLedgerSection` component that embeds `SelectDevice2` exactly as it works in the MyLedgerChooseDevice screen — same device list, same BLE scanning, same pairing flow, same DeviceActionModal, same navigation to the device manager. The old DeviceSection is preserved in an `else` branch behind the `shouldDisplayMyWallet` feature flag. `ExploreDevicesItem` is kept below the device list via SelectDevice2's `children` prop.

**Changes:**

#### MyWalletScreen (`index.tsx`)
- Removed outer ScrollView, ProfileSection and QuickActionsRow are now fixed header
- Conditional rendering: `MyLedgerSection` when `shouldDisplayMyWallet`, else `DeviceSection`

#### MyLedgerSection (`views/MyLedgerSection.tsx`)
- Thin wrapper around `SelectDevice2` + `DeviceActionModal`, ported from MyLedgerChooseDevice with context adaptations (no SafeAreaView, no title, lumenNavBar header management)
- **Device auto-selection via nav params**: `useEffect` reads `params?.device` to auto-select a device passed from transactional flows (e.g. "not enough space" redirect)
- **Firmware update forwarding**: `firmwareUpdate` param forwarded to `MyLedgerDevice` so the FW update drawer opens automatically when redirected from `RequiredFirmwareUpdate`
- **searchQuery/installApp forwarding**: `onSelect` forwards `searchQuery: params?.searchQuery || params?.installApp` to `MyLedgerDevice`, matching the original behavior
- **Post-onboarding redirect**: `useAutoRedirectToPostOnboarding()` hook ported from `MyLedgerChooseDevice` for Recover deeplink / post-onboarding flow parity

#### Navigation types (`types.ts`)
- `MyWalletNavigatorStackParamList` extended with `device?`, `firmwareUpdate?`, `searchQuery?`, `installApp?` params

#### RequiredFirmwareUpdate redirect (`rendering.tsx`)
- Added `shouldDisplayMyWallet` branch: when the flag is active, the "Go to My Ledger" button resets navigation to `MyWallet` (with device + firmwareUpdate params) instead of `MyLedgerChooseDevice`
- Uses `NavigatorName.Base` wrapper to target the root navigator from within the DeviceAction modal context

#### Not ported (intentional)
- `ContentCardsLocation` replaced by `ExploreDevicesItem` (design choice)
- `TrackScreen category="Manager"` — MyWallet has its own screen tracking
- SafeArea/TabBar wrappers — handled by MyWallet's parent layout

<img width="350" height="750" alt="Simulator Screenshot - Test Ios - 2026-04-28 at 11 01 09" src="https://github.com/user-attachments/assets/23fd2ab6-db3e-4cd4-8ab3-c446de4f8218" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29918](https://ledgerhq.atlassian.net/browse/LIVE-29918)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29918]: https://ledgerhq.atlassian.net/browse/LIVE-29918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ