### PR TITLE
test(desktop): link e2e failures to bug tickets

### DIFF
--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -45,6 +45,7 @@ const e2eDelegationAccounts = [
   {
     delegate: new Delegate(Account.OSMO_1, "0.0001", "Ledger by Figment"),
     xrayTicket: "B2CQA-3022",
+    bugTicket: "NAPPS-1357",
   },
 ];
 
@@ -83,6 +84,7 @@ const validators = [
   {
     delegate: new Delegate(Account.OSMO_2, "1", "Ledger by Figment"),
     xrayTicket: "B2CQA-2768",
+    bugTicket: "NAPPS-1357",
   },
 ];
 
@@ -130,6 +132,9 @@ for (const account of e2eDelegationAccounts) {
       },
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+        if (account.bugTicket) {
+          await addBugLink([account.bugTicket]);
+        }
 
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(account.delegate.account.accountName);
@@ -393,6 +398,9 @@ for (const validator of validators) {
       },
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+        if (validator.bugTicket) {
+          await addBugLink([validator.bugTicket]);
+        }
 
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
         await app.accounts.navigateToAccountByName(validator.delegate.account.accountName);

--- a/e2e/desktop/tests/specs/earn.v2.spec.ts
+++ b/e2e/desktop/tests/specs/earn.v2.spec.ts
@@ -3,7 +3,7 @@ import { test } from "tests/fixtures/common";
 import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
 import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { EARN_V2_DESKTOP_FLAGS, useLocalEarnManifest } from "tests/utils/featureFlagUtils";
-import { addTmsLink } from "tests/utils/allureUtils";
+import { addBugLink, addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import earnLocalManifestJson from "tests/utils/earnLocalManifest.json";
@@ -307,6 +307,7 @@ test.describe("Earn [v2]", () => {
       },
       async ({ app, page }) => {
         await navigateToEarn(app);
+        await addBugLink(["LIVE-29872"]);
         await app.earnV2Dashboard.verifyHotStartPage();
         await app.earnV2Dashboard.verifyPositionRowPresent(account.currency.ticker);
         await app.earnV2Dashboard.clickPositionRow(account.currency.ticker);

--- a/e2e/desktop/tests/specs/newSendFlow.tx.spec.ts
+++ b/e2e/desktop/tests/specs/newSendFlow.tx.spec.ts
@@ -3,7 +3,7 @@ import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { Fee } from "@ledgerhq/live-common/e2e/enum/Fee";
 import { Transaction } from "@ledgerhq/live-common/e2e/models/Transaction";
-import { addTmsLink } from "tests/utils/allureUtils";
+import { addBugLink, addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
 import { liveDataWithRecipientAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
@@ -72,6 +72,7 @@ const transactionsNewSendFlow = [
   {
     transaction: new Transaction(Account.XLM_1, Account.XLM_2, "0.0001", undefined, "noTag"),
     xrayTicket: "B2CQA-2813",
+    bugTicket: "LIVE-29554",
   },
   {
     transaction: new Transaction(Account.XRP_1, Account.XRP_2, "0.0001", undefined, "noTag"),
@@ -138,6 +139,9 @@ test.describe("New Send Flow", () => {
           const requiresMemoStep = family ? MEMO_STEP_FAMILIES.has(family) : false;
 
           await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+          if (entry.bugTicket) {
+            await addBugLink([entry.bugTicket]);
+          }
 
           await app.mainNavigation.openTargetFromMainNavigation("accounts");
           await app.accounts.navigateToAccountByName(tx.accountToDebit.accountName);

--- a/e2e/desktop/tests/specs/provider.swap.spec.ts
+++ b/e2e/desktop/tests/specs/provider.swap.spec.ts
@@ -4,7 +4,7 @@ import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
 import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-common/e2e/speculos";
 import { Swap } from "@ledgerhq/live-common/e2e/models/Swap";
-import { addTmsLink } from "tests/utils/allureUtils";
+import { addBugLink, addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { setupEnv, performSwapUntilQuoteSelectionStep } from "tests/utils/swapUtils";
@@ -18,16 +18,18 @@ const providerFlowTests = [
     toAccount: TokenAccount.ETH_USDC_1,
     provider: Provider.ONE_INCH,
     xrayTicket: "B2CQA-3120",
+    bugTickets: ["LIVE-29454", "LIVE-29858"],
   },
   {
     fromAccount: TokenAccount.ETH_USDT_1,
     toAccount: Account.ETH_1,
     provider: Provider.OKX,
     xrayTicket: "B2CQA-4728",
+    bugTickets: ["LIVE-29858"],
   },
 ];
 
-for (const { fromAccount, toAccount, provider, xrayTicket } of providerFlowTests) {
+for (const { fromAccount, toAccount, provider, xrayTicket, bugTickets } of providerFlowTests) {
   test.describe(`Swap - ${provider.uiName} flow`, () => {
     setupEnv(true);
 
@@ -73,6 +75,7 @@ for (const { fromAccount, toAccount, provider, xrayTicket } of providerFlowTests
       },
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+        await addBugLink(bugTickets);
 
         const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
         await app.swap.ensureTokenApproval(fromAccount, provider, minAmount);

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -193,6 +193,7 @@ const transactionE2E = [
     transaction: new Transaction(Account.XLM_1, Account.XLM_2, "0.0001", undefined, "noTag"),
     xrayTicket: "B2CQA-2813",
     bugTicket: "LIVE-24214",
+    bugTickets: ["LIVE-29554"],
   },
   {
     transaction: new Transaction(Account.ATOM_1, Account.ATOM_2, "0.00001", undefined, "noTag"),
@@ -294,8 +295,12 @@ test.describe("Send flows", () => {
         },
         async ({ app }) => {
           await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-          if (transaction.bugTicket) {
-            await addBugLink([transaction.bugTicket]);
+          const bugTickets = [
+            ...(transaction.bugTicket ? [transaction.bugTicket] : []),
+            ...(transaction.bugTickets ?? []),
+          ];
+          if (bugTickets.length) {
+            await addBugLink(bugTickets);
           }
 
           await app.mainNavigation.openTargetFromMainNavigation("accounts");

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -163,7 +163,7 @@ const transactionE2E = [
   {
     transaction: new Transaction(Account.POL_1, Account.POL_2, "0.001", Fee.SLOW),
     xrayTicket: "B2CQA-2807",
-    bugTicket: "LIVE-28070",
+    bugTickets: ["LIVE-28070"],
   },
   {
     transaction: new Transaction(Account.DOGE_1, Account.DOGE_2, "0.01", Fee.SLOW),
@@ -192,8 +192,7 @@ const transactionE2E = [
   {
     transaction: new Transaction(Account.XLM_1, Account.XLM_2, "0.0001", undefined, "noTag"),
     xrayTicket: "B2CQA-2813",
-    bugTicket: "LIVE-24214",
-    bugTickets: ["LIVE-29554"],
+    bugTickets: ["LIVE-24214", "LIVE-29554"],
   },
   {
     transaction: new Transaction(Account.ATOM_1, Account.ATOM_2, "0.00001", undefined, "noTag"),
@@ -235,7 +234,7 @@ const transactionE2E = [
   {
     transaction: new Transaction(Account.BASE_1, Account.BASE_2, "0.000001"),
     xrayTicket: "B2CQA-4225",
-    bugTicket: "LIVE-28070",
+    bugTickets: ["LIVE-28070"],
   },
   {
     transaction: new Transaction(Account.VET_1, Account.VET_2, "0.1"),
@@ -295,12 +294,8 @@ test.describe("Send flows", () => {
         },
         async ({ app }) => {
           await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-          const bugTickets = [
-            ...(transaction.bugTicket ? [transaction.bugTicket] : []),
-            ...(transaction.bugTickets ?? []),
-          ];
-          if (bugTickets.length) {
-            await addBugLink(bugTickets);
+          if (transaction.bugTickets) {
+            await addBugLink(transaction.bugTickets);
           }
 
           await app.mainNavigation.openTargetFromMainNavigation("accounts");


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not required for E2E-only test metadata changes._
- [ ] **Covered by automatic tests.** _Metadata-only update; validated with `pnpm desktop typecheck`._
- [x] **Impact of the changes:**
  - Desktop E2E Allure reports for known nightly failures
  - Bug links for Stellar send, Osmosis delegation, Swap provider flows, and Earn v2 ETH position failures
  - Jira traceability from failed Allure test cases

### 📝 Description

Some Desktop E2E nightly failures were missing Allure bug links, making it harder to trace known failures back to Jira from the report.

This PR adds bug links through the existing `addBugLink` helper for the affected data-driven tests: Stellar send flows, Osmosis delegation flows, 1inch/OKX swap provider flows, and the Earn v2 ETH position row flow.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29554](https://ledgerhq.atlassian.net/browse/LIVE-29554), [NAPPS-1357](https://ledgerhq.atlassian.net/browse/NAPPS-1357), [LIVE-29858](https://ledgerhq.atlassian.net/browse/LIVE-29858), [LIVE-29454](https://ledgerhq.atlassian.net/browse/LIVE-29454), [LIVE-29872](https://ledgerhq.atlassian.net/browse/LIVE-29872)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29554]: https://ledgerhq.atlassian.net/browse/LIVE-29554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NAPPS-1357]: https://ledgerhq.atlassian.net/browse/NAPPS-1357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-29858]: https://ledgerhq.atlassian.net/browse/LIVE-29858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ