### PR TITLE
[LWD] fix(desktop): allow device not setup error on genuine check

### DIFF
--- a/.changeset/tricky-pots-listen.md
+++ b/.changeset/tricky-pots-listen.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: allow device not setup error on genuine check page

--- a/apps/ledger-live-desktop/src/renderer/hooks/useConnectAppAction.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useConnectAppAction.ts
@@ -24,6 +24,7 @@ import { getEnv } from "@ledgerhq/live-env";
 import { mockedEventEmitter } from "~/renderer/components/debug/DebugMock";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Action } from "@ledgerhq/live-common/hw/actions/types";
+import { isDeviceNotOnboardedError } from "@ledgerhq/live-common/device-action/utils";
 
 /**
  * This hook creates an action for connecting to an app on a Ledger device.
@@ -109,6 +110,8 @@ export function useGenuineCheckAction(): Action<ManagerRequest, ManagerState, Ma
       connectManager({ isLdmkConnectAppEnabled })(input).pipe(
         catchError(error => {
           if (isCounterfeitError(error)) return throwError(() => error);
+          if (isDeviceNotOnboardedError(error)) return throwError(() => error);
+
           return throwError(() => new GenuineCheckFailed("", undefined, { cause: error }));
         }),
       );


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Allow `DeviceNotOnboarded` errors to display on the Genuine Check page.

### 📝 Description

Before we were displaying the generic `GenuineCheckFailed` error, but we have now added `DeviceNotOnboarded` to the whitelisted errors on this page.

| Before        | After         |
| ------------- | ------------- |
|       <img width="1624" height="1006" alt="Screenshot 2026-04-27 at 15 59 50" src="https://github.com/user-attachments/assets/ee127623-d1d7-4bde-a48e-d104a6a86063" />        |       <img width="1624" height="1006" alt="Screenshot 2026-04-27 at 15 59 05" src="https://github.com/user-attachments/assets/71c53142-6e91-4dad-8381-fd205ff2450c" />        |

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
- **ADR link (if any)**: <!-- Attach the relevant architectural decision record if applicable. -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
