### PR TITLE
[LWDM] feat(wallet-cli): secrets command group — hardware-backed file encryption

### DIFF
--- a/.agents/skills/ledger-wallet-cli/SKILL.md
+++ b/.agents/skills/ledger-wallet-cli/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: ledger-wallet-cli
-description: Official Ledger wallet-cli — USB-based CLI for Ledger hardware wallet flows (account discover, receive, balances, operations, send) built on the Device Management Kit (DMK)
+description: Official Ledger wallet-cli — USB-based CLI for Ledger hardware wallet flows (account discover, receive, balances, operations, send, secrets encryption) built on the Device Management Kit (DMK)
 ---
 
 # wallet-cli
 
 USB-based CLI for Ledger wallet flows. Networks: **bitcoin**, **ethereum**, **base**, **solana** (mainnet + testnets). Base uses the Ethereum app.
+
+Also supports hardware-backed **file encryption** via `secrets` commands.
 
 Run from repo root: `pnpm --silent wallet-cli start <command> [flags]`
 
@@ -19,17 +21,23 @@ Run from repo root: `pnpm --silent wallet-cli start <command> [flags]`
 
 ## Commands
 
-| Command            | Device | Sandbox      |
-| ------------------ | ------ | ------------ |
-| `session view`     | No     | No           |
-| `session reset`    | No     | No           |
-| `account discover` | Yes    | **Required** |
-| `receive`          | Yes    | **Required** |
-| `send`             | Yes*   | **Required** |
-| `balances`         | No     | No           |
-| `operations`       | No     | No           |
+| Command              | Device | Sandbox      |
+| -------------------- | ------ | ------------ |
+| `session view`       | No     | No           |
+| `session reset`      | No     | No           |
+| `account discover`   | Yes    | **Required** |
+| `receive`            | Yes    | **Required** |
+| `send`               | Yes*   | **Required** |
+| `balances`           | No     | No           |
+| `operations`         | No     | No           |
+| `secrets init`       | Yes†   | **Required** |
+| `secrets encrypt`    | No     | No           |
+| `secrets decrypt`    | No     | No           |
+| `secrets keys`       | No     | No           |
+| `secrets destroy`    | No     | No           |
 
 *`send --dry-run` needs no device and no sandbox bypass.
+†`secrets init` needs the device (Ledger Sync app) only on first run to register this machine as a trustchain member.
 
 ---
 
@@ -89,6 +97,32 @@ Ticker is **mandatory** in `--amount`. No `--token` flag — ticker drives asset
 **Bitcoin flags:** `--fee-per-byte <sats>`, `--rbf`
 
 **Solana flags:** `--mode send|stake.createAccount|stake.delegate|stake.undelegate|stake.withdraw`, `--validator <addr>`, `--stake-account <addr>`, `--memo <text>`
+
+### secrets
+
+Powered by LKRP (Ledger Key Ring Protocol): register this machine once with your Ledger device (`init`), then encrypt and decrypt files without the device. Only a machine credential is stored locally (in the OS keychain); the shared root key is end-to-end encrypted — Ledger's servers relay it between members but only registered members can read it.
+
+The `--key <domain>` argument is a namespace (e.g. `prod`, `staging`): each domain produces an independent AES-256-GCM key derived from that shared root, so secrets across domains cannot cross-decrypt. Multiple machines can be registered as members, meaning any of them can decrypt what another encrypted. `destroy` removes this machine's access.
+
+**Flag conventions:** `--out` = output file path; `--output` = format (`human`|`json`).
+
+```bash
+# one-time setup (device + Ledger Sync app required) — needs dangerouslyDisableSandbox
+pnpm --silent wallet-cli start secrets init [--name "my-machine"]
+
+# encrypt/decrypt (no device needed after init)
+pnpm --silent wallet-cli start secrets encrypt --key prod -i secret.txt --out secret.enc
+pnpm --silent wallet-cli start secrets decrypt --key prod -i secret.enc --out secret.txt
+
+# pipe
+echo "hello" | pnpm --silent wallet-cli start secrets encrypt --key foo | pnpm --silent wallet-cli start secrets decrypt --key foo
+
+# list tracked domain keys with first-used date
+pnpm --silent wallet-cli start secrets keys
+
+# revoke this machine's credentials (interactive confirmation)
+pnpm --silent wallet-cli start secrets destroy
+```
 
 ---
 

--- a/.agents/skills/ledger-wallet-cli/SKILL.md
+++ b/.agents/skills/ledger-wallet-cli/SKILL.md
@@ -106,6 +106,25 @@ The `--key <domain>` argument is a namespace (e.g. `prod`, `staging`): each doma
 
 **Flag conventions:** `--out` = output file path; `--output` = format (`human`|`json`).
 
+#### Password — agentic injection
+
+`secrets init` (default) wraps the private key with a password. All subsequent secrets commands need it. Without a TTY, set `WALLET_PASS` — pull it from the OS keychain at invocation time:
+
+```bash
+# macOS
+WALLET_PASS=$(security find-generic-password -a default -s ledger-cli -w) pnpm --silent wallet-cli start secrets encrypt ...
+
+# Linux
+WALLET_PASS=$(secret-tool lookup service ledger-cli account default) pnpm --silent wallet-cli start secrets encrypt ...
+
+# Windows (PowerShell)
+$env:WALLET_PASS=(Get-StoredCredential -Target ledger-cli).GetNetworkCredential().Password
+pnpm --silent wallet-cli start secrets encrypt ...
+```
+
+No TTY + no `WALLET_PASS` → CLI exits with an error showing the exact commands above.
+No password at all → use `secrets init --unsecure-no-password`.
+
 ```bash
 # one-time setup (device + Ledger Sync app required) — needs dangerouslyDisableSandbox
 pnpm --silent wallet-cli start secrets init [--name "my-machine"]
@@ -114,13 +133,11 @@ pnpm --silent wallet-cli start secrets init [--name "my-machine"]
 pnpm --silent wallet-cli start secrets encrypt --key prod -i secret.txt --out secret.enc
 pnpm --silent wallet-cli start secrets decrypt --key prod -i secret.enc --out secret.txt
 
-# pipe
-echo "hello" | pnpm --silent wallet-cli start secrets encrypt --key foo | pnpm --silent wallet-cli start secrets decrypt --key foo
+# pipe: password from WALLET_PASS, stdin free for data
+echo "hello" | pnpm --silent wallet-cli start secrets encrypt --key foo --out foo.enc
 
-# list tracked domain keys with first-used date
+# list domain keys / destroy credentials
 pnpm --silent wallet-cli start secrets keys
-
-# revoke this machine's credentials (interactive confirmation)
 pnpm --silent wallet-cli start secrets destroy
 ```
 

--- a/.changeset/wallet-cli-secrets.md
+++ b/.changeset/wallet-cli-secrets.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/wallet-cli": minor
+---
+
+Add `secrets` command group for hardware-backed encryption: `init`, `encrypt`, `decrypt`, `keys`, `destroy`.
+Secrets are encrypted with AES-256-GCM keys derived from a trustchain managed by the Ledger Key Ring Protocol.

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@bunli/core": "0.9.1",
     "@bunli/utils": "0.6.0",
+    "@napi-rs/keyring": "1.3.0",
     "@ledgerhq/coin-bitcoin": "workspace:^",
     "@ledgerhq/coin-evm": "workspace:^",
     "@ledgerhq/coin-module-framework": "catalog:",
@@ -33,6 +34,8 @@
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-exchange": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
+    "@ledgerhq/hw-ledger-key-ring-protocol": "workspace:^",
+    "@ledgerhq/ledger-key-ring-protocol": "workspace:^",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-common": "workspace:^",
     "@ledgerhq/live-config": "workspace:^",

--- a/apps/wallet-cli/src/cli.ts
+++ b/apps/wallet-cli/src/cli.ts
@@ -18,6 +18,7 @@ import OperationsCommand from "./commands/operations";
 import ReceiveCommand from "./commands/receive";
 import SendCommand from "./commands/send";
 import SwapGroup from "./commands/swap/index";
+import SecretsGroup from "./commands/secrets/index";
 
 emitTestingBuildBannerIfNeeded();
 
@@ -37,6 +38,7 @@ export async function runMain(argv: string[] = process.argv.slice(2)): Promise<n
   cli.command(ReceiveCommand);
   cli.command(SendCommand);
   cli.command(SwapGroup);
+  cli.command(SecretsGroup);
   const code = await cli.run(argv, { noExit: true });
   return code ?? 0;
 }

--- a/apps/wallet-cli/src/commands/inputs.ts
+++ b/apps/wallet-cli/src/commands/inputs.ts
@@ -1,11 +1,17 @@
 import { option } from "@bunli/core";
 import { z } from "zod";
+import { resolve } from "node:path";
 import { DEFAULT_DEVICE_TIMEOUT_MS } from "../device/connect-ledger-app";
 import { OutputFormatSchema, parseAccountDescriptor } from "../wallet/models";
 import type { AccountDescriptor } from "../wallet/models";
 import { parseV1 } from "../shared/accountDescriptor";
 import type { AccountDescriptorV1 } from "../shared/accountDescriptor";
 import { Session } from "../session/session-store";
+
+/** Resolve a user-supplied path against the directory where pnpm/npm was invoked (INIT_CWD), not the package dir. */
+export function resolveUserPath(p: string): string {
+  return resolve(process.env.INIT_CWD ?? process.cwd(), p);
+}
 
 /**
  * Shared --output option used by all commands. If omitted, the CLI keeps

--- a/apps/wallet-cli/src/commands/secrets/decrypt.ts
+++ b/apps/wallet-cli/src/commands/secrets/decrypt.ts
@@ -1,0 +1,61 @@
+import { defineCommand, option } from "@bunli/core";
+import { z } from "zod";
+import { chmod } from "node:fs/promises";
+import { loadDomainKey } from "../../secrets/load-secrets";
+import { decryptData } from "../../secrets/crypto";
+import { outputOption, resolveOutputFormat, resolveUserPath } from "../inputs";
+import { createCommandOutput } from "../../output";
+
+export default defineCommand({
+  name: "decrypt",
+  description: "Decrypt data with a domain-scoped AES-256-GCM key",
+  options: {
+    key: option(z.string().min(1).max(253).regex(/^\S+$/, "domain key must not contain whitespace"), {
+      description: "Domain name used to derive the scoped decryption key (e.g. openClaw-prod)",
+      short: "k",
+    }),
+    input: option(z.string().optional(), {
+      description: "Input file (default: stdin)",
+      short: "i",
+    }),
+    out: option(z.string().optional(), {
+      description: "Output file (default: stdout)",
+      short: "o",
+    }),
+    output: outputOption,
+  },
+  handler: async ({ flags }) => {
+    const format = resolveOutputFormat(flags.output);
+    const out = createCommandOutput(format, { command: "secrets decrypt", network: "all" });
+    await out.run(async () => {
+      if (format === "json" && !flags.out) {
+        throw new Error("--output json requires --out <file>: binary plaintext cannot be written as JSON to stdout.");
+      }
+      if (!flags.input && process.stdin.isTTY) {
+        throw new Error("No input: provide --input FILE or pipe data to stdin.");
+      }
+
+      const fetchSpin = out.spin("Fetching encryption key from trustchain…");
+      const { domainKey } = await loadDomainKey(flags.key);
+      fetchSpin?.success("Encryption key retrieved");
+
+      const ciphertext = new Uint8Array(
+        flags.input
+          ? await Bun.file(resolveUserPath(flags.input)).arrayBuffer()
+          : await Bun.stdin.arrayBuffer(),
+      );
+      const decSpin = out.spin(`Decrypting with domain "${flags.key}"…`);
+      const plaintext = await decryptData(domainKey, ciphertext);
+      decSpin?.success("Decrypted");
+
+      if (flags.out) {
+        const dest = resolveUserPath(flags.out);
+        await Bun.write(dest, plaintext);
+        await chmod(dest, 0o600).catch(() => {});
+        out.secretsDecrypt({ dest });
+      } else {
+        process.stdout.write(Buffer.from(plaintext));
+      }
+    });
+  },
+});

--- a/apps/wallet-cli/src/commands/secrets/decrypt.ts
+++ b/apps/wallet-cli/src/commands/secrets/decrypt.ts
@@ -1,7 +1,7 @@
 import { defineCommand, option } from "@bunli/core";
 import { z } from "zod";
 import { chmod } from "node:fs/promises";
-import { loadDomainKey } from "../../secrets/load-secrets";
+import { loadDomainKeyInteractive } from "../../secrets/load-secrets";
 import { decryptData } from "../../secrets/crypto";
 import { outputOption, resolveOutputFormat, resolveUserPath } from "../inputs";
 import { createCommandOutput } from "../../output";
@@ -36,7 +36,7 @@ export default defineCommand({
       }
 
       const fetchSpin = out.spin("Fetching encryption key from trustchain…");
-      const { domainKey } = await loadDomainKey(flags.key);
+      const { domainKey } = await loadDomainKeyInteractive(flags.key);
       fetchSpin?.success("Encryption key retrieved");
 
       const ciphertext = new Uint8Array(

--- a/apps/wallet-cli/src/commands/secrets/destroy.ts
+++ b/apps/wallet-cli/src/commands/secrets/destroy.ts
@@ -3,6 +3,8 @@ import { createInterface } from "node:readline";
 import { Session, trustchainFromMeta } from "../../session/session-store";
 import { loadMemberCredentials, deletePrivateKey } from "../../secrets/keychain";
 import { createLkrpSdk } from "../../secrets/lkrp-sdk";
+import { deriveWrappingKey } from "../../secrets/crypto";
+import { promptHidden } from "../../secrets/prompt";
 import { outputOption, resolveOutputFormat } from "../inputs";
 import { createCommandOutput } from "../../output";
 
@@ -37,7 +39,17 @@ export default defineCommand({
         return;
       }
 
-      const memberCredentials = await loadMemberCredentials();
+      let wrappingKey: CryptoKey | undefined;
+      if (session.passwordSalt) {
+        try {
+          const password = await promptHidden("Password (Enter to skip remote destroy): ");
+          if (password) wrappingKey = await deriveWrappingKey(password, session.passwordSalt);
+        } catch {
+          // Ctrl-C or no-TTY/no-WALLET_PASS — proceed with local wipe only
+        }
+      }
+
+      const memberCredentials = await loadMemberCredentials(wrappingKey).catch(() => null);
       const sdk = createLkrpSdk();
       const destroySpin = out.spin("Destroying trustchain…");
       let remoteDestroySucceeded = false;

--- a/apps/wallet-cli/src/commands/secrets/destroy.ts
+++ b/apps/wallet-cli/src/commands/secrets/destroy.ts
@@ -1,0 +1,63 @@
+import { defineCommand } from "@bunli/core";
+import { createInterface } from "node:readline";
+import { Session, trustchainFromMeta } from "../../session/session-store";
+import { loadMemberCredentials, deletePrivateKey } from "../../secrets/keychain";
+import { createLkrpSdk } from "../../secrets/lkrp-sdk";
+import { outputOption, resolveOutputFormat } from "../inputs";
+import { createCommandOutput } from "../../output";
+
+async function readConfirmation(): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise(resolve => {
+    rl.question('Type "destroy" to confirm: ', answer => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+export default defineCommand({
+  name: "destroy",
+  description: "Destroy the local trustchain membership and wipe credentials",
+  options: {
+    output: outputOption,
+  },
+  handler: async ({ flags }) => {
+    const out = createCommandOutput(resolveOutputFormat(flags.output), { command: "secrets destroy", network: "all" });
+    await out.run(async () => {
+      const session = await Session.read();
+      const trustchainMeta = session.trustchain;
+      if (!trustchainMeta) {
+        throw new Error("Nothing to destroy — encryption CLI is not initialized.");
+      }
+
+      const answer = await readConfirmation();
+      if (answer !== "destroy") {
+        out.secretsDestroyCancelled();
+        return;
+      }
+
+      const memberCredentials = await loadMemberCredentials();
+      const sdk = createLkrpSdk();
+      const destroySpin = out.spin("Destroying trustchain…");
+      let remoteDestroySucceeded = false;
+      if (memberCredentials) {
+        try {
+          const latest = await sdk.restoreTrustchain(trustchainFromMeta(trustchainMeta), memberCredentials);
+          await sdk.destroyTrustchain(latest, memberCredentials);
+          remoteDestroySucceeded = true;
+          destroySpin?.success("Trustchain destroyed");
+        } catch {
+          destroySpin?.error("Trustchain destroy failed (continuing with local wipe)");
+        }
+      } else {
+        destroySpin?.error("No credentials found in keychain (continuing with local wipe)");
+      }
+
+      await deletePrivateKey();
+      session.wipeSecrets();
+      await session.write();
+      out.secretsDestroy(remoteDestroySucceeded);
+    });
+  },
+});

--- a/apps/wallet-cli/src/commands/secrets/encrypt.ts
+++ b/apps/wallet-cli/src/commands/secrets/encrypt.ts
@@ -1,0 +1,62 @@
+import { defineCommand, option } from "@bunli/core";
+import { z } from "zod";
+import { loadDomainKey } from "../../secrets/load-secrets";
+import { encryptData } from "../../secrets/crypto";
+import { outputOption, resolveOutputFormat, resolveUserPath } from "../inputs";
+import { createCommandOutput } from "../../output";
+
+export default defineCommand({
+  name: "encrypt",
+  description: "Encrypt data with a domain-scoped AES-256-GCM key",
+  options: {
+    key: option(z.string().min(1).max(253).regex(/^\S+$/, "domain key must not contain whitespace"), {
+      description: "Domain name used to derive a scoped encryption key (e.g. openClaw-prod)",
+      short: "k",
+    }),
+    input: option(z.string().optional(), {
+      description: "Input file (default: stdin)",
+      short: "i",
+    }),
+    out: option(z.string().optional(), {
+      description: "Output file (default: stdout)",
+      short: "o",
+    }),
+    output: outputOption,
+  },
+  handler: async ({ flags }) => {
+    const format = resolveOutputFormat(flags.output);
+    const out = createCommandOutput(format, { command: "secrets encrypt", network: "all" });
+    await out.run(async () => {
+      if (format === "json" && !flags.out) {
+        throw new Error("--output json requires --out <file>: binary ciphertext cannot be written as JSON to stdout.");
+      }
+      if (!flags.input && process.stdin.isTTY) {
+        throw new Error("No input: provide --input FILE or pipe data to stdin.");
+      }
+
+      const fetchSpin = out.spin("Fetching encryption key from trustchain…");
+      const { session, domainKey } = await loadDomainKey(flags.key);
+      fetchSpin?.success("Encryption key retrieved");
+
+      const plaintext = new Uint8Array(
+        flags.input
+          ? await Bun.file(resolveUserPath(flags.input)).arrayBuffer()
+          : await Bun.stdin.arrayBuffer(),
+      );
+      const encSpin = out.spin(`Encrypting with domain "${flags.key}"…`);
+      const ciphertext = await encryptData(domainKey, plaintext);
+      encSpin?.success(`Encrypted (${ciphertext.byteLength} bytes, AES-256-GCM)`);
+
+      if (flags.out) {
+        const dest = resolveUserPath(flags.out);
+        await Bun.write(dest, ciphertext);
+        out.secretsEncrypt({ dest, bytes: ciphertext.byteLength });
+      } else {
+        process.stdout.write(Buffer.from(ciphertext));
+      }
+
+      session.trackDomain(flags.key);
+      await session.write();
+    });
+  },
+});

--- a/apps/wallet-cli/src/commands/secrets/encrypt.ts
+++ b/apps/wallet-cli/src/commands/secrets/encrypt.ts
@@ -1,6 +1,6 @@
 import { defineCommand, option } from "@bunli/core";
 import { z } from "zod";
-import { loadDomainKey } from "../../secrets/load-secrets";
+import { loadDomainKeyInteractive } from "../../secrets/load-secrets";
 import { encryptData } from "../../secrets/crypto";
 import { outputOption, resolveOutputFormat, resolveUserPath } from "../inputs";
 import { createCommandOutput } from "../../output";
@@ -35,7 +35,7 @@ export default defineCommand({
       }
 
       const fetchSpin = out.spin("Fetching encryption key from trustchain…");
-      const { session, domainKey } = await loadDomainKey(flags.key);
+      const { session, domainKey } = await loadDomainKeyInteractive(flags.key);
       fetchSpin?.success("Encryption key retrieved");
 
       const plaintext = new Uint8Array(

--- a/apps/wallet-cli/src/commands/secrets/index.ts
+++ b/apps/wallet-cli/src/commands/secrets/index.ts
@@ -1,0 +1,12 @@
+import { defineGroup } from "@bunli/core";
+import InitCommand from "./init";
+import EncryptCommand from "./encrypt";
+import DecryptCommand from "./decrypt";
+import KeysCommand from "./keys";
+import DestroyCommand from "./destroy";
+
+export default defineGroup({
+  name: "secrets",
+  description: "Hardware-backed file encryption using the trustchain",
+  commands: [InitCommand, EncryptCommand, DecryptCommand, KeysCommand, DestroyCommand],
+});

--- a/apps/wallet-cli/src/commands/secrets/init.ts
+++ b/apps/wallet-cli/src/commands/secrets/init.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import { Session } from "../../session/session-store";
 import { createLkrpSdk } from "../../secrets/lkrp-sdk";
 import { savePrivateKey } from "../../secrets/keychain";
+import { generatePasswordSalt, deriveWrappingKey } from "../../secrets/crypto";
+import { promptHidden } from "../../secrets/prompt";
 import { WALLET_CLI_DMK_DEVICE_ID } from "../../device/register-dmk-transport";
 import { withLkrpDeviceSession } from "../../session/bridge-device-session";
 import { MEMBER_NAME_MAX_LENGTH } from "../../secrets/constants";
@@ -23,6 +25,10 @@ export default defineCommand({
       description: `Member name (default: hostname + platform, max ${MEMBER_NAME_MAX_LENGTH} chars)`,
       short: "n",
     }),
+    "unsecure-no-password": option(z.boolean().default(false), {
+      description: "Skip password protection (stores private key unencrypted in the OS keychain)",
+      argumentKind: "flag",
+    }),
     output: outputOption,
   },
   handler: async ({ flags }) => {
@@ -33,6 +39,18 @@ export default defineCommand({
         throw new Error(
           "Encryption CLI already initialized. Run `wallet-cli secrets destroy` to reset.",
         );
+      }
+
+      let wrappingKey: CryptoKey | undefined;
+      let passwordSalt: string | undefined;
+
+      if (!flags["unsecure-no-password"]) {
+        const password = await promptHidden("Password: ");
+        if (!password) throw new Error("Password must not be empty.");
+        const confirm = await promptHidden("Confirm password: ");
+        if (password !== confirm) throw new Error("Passwords do not match.");
+        passwordSalt = generatePasswordSalt();
+        wrappingKey = await deriveWrappingKey(password, passwordSalt);
       }
 
       const memberName = flags.name ?? defaultMemberName();
@@ -50,11 +68,12 @@ export default defineCommand({
       );
       deviceSpin?.success("Trustchain created");
 
-      await savePrivateKey(memberCredentials.privatekey, memberCredentials.pubkey);
+      await savePrivateKey(memberCredentials.privatekey, memberCredentials.pubkey, wrappingKey);
       session.setTrustchain({
         rootId: trustchain.rootId,
         applicationPath: trustchain.applicationPath,
       });
+      if (passwordSalt) session.setPasswordSalt(passwordSalt);
       await session.write();
 
       out.secretsInit({ memberName, rootId: trustchain.rootId });

--- a/apps/wallet-cli/src/commands/secrets/init.ts
+++ b/apps/wallet-cli/src/commands/secrets/init.ts
@@ -1,0 +1,63 @@
+import { defineCommand, option } from "@bunli/core";
+import { z } from "zod";
+import os from "node:os";
+import { Session } from "../../session/session-store";
+import { createLkrpSdk } from "../../secrets/lkrp-sdk";
+import { savePrivateKey } from "../../secrets/keychain";
+import { WALLET_CLI_DMK_DEVICE_ID } from "../../device/register-dmk-transport";
+import { withLkrpDeviceSession } from "../../session/bridge-device-session";
+import { MEMBER_NAME_MAX_LENGTH } from "../../secrets/constants";
+import { outputOption, resolveOutputFormat } from "../inputs";
+import { createCommandOutput } from "../../output";
+
+function defaultMemberName(): string {
+  const raw = `${os.hostname()} (${os.platform()})`;
+  return raw.slice(0, MEMBER_NAME_MAX_LENGTH);
+}
+
+export default defineCommand({
+  name: "init",
+  description: "Register this machine as a trustchain member (device required)",
+  options: {
+    name: option(z.string().min(1).max(MEMBER_NAME_MAX_LENGTH).optional(), {
+      description: `Member name (default: hostname + platform, max ${MEMBER_NAME_MAX_LENGTH} chars)`,
+      short: "n",
+    }),
+    output: outputOption,
+  },
+  handler: async ({ flags }) => {
+    const out = createCommandOutput(resolveOutputFormat(flags.output), { command: "secrets init", network: "all" });
+    await out.run(async () => {
+      const session = await Session.read();
+      if (session.trustchain) {
+        throw new Error(
+          "Encryption CLI already initialized. Run `wallet-cli secrets destroy` to reset.",
+        );
+      }
+
+      const memberName = flags.name ?? defaultMemberName();
+      const sdk = createLkrpSdk(memberName);
+
+      const memberCredentials = await out.withActivity(
+        "Generating member credentials…",
+        "Member credentials created",
+        () => sdk.initMemberCredentials(),
+      );
+
+      const deviceSpin = out.spin("Connect device, open Ledger Sync app — creating trustchain…");
+      const { trustchain } = await withLkrpDeviceSession(() =>
+        sdk.getOrCreateTrustchain(WALLET_CLI_DMK_DEVICE_ID, memberCredentials),
+      );
+      deviceSpin?.success("Trustchain created");
+
+      await savePrivateKey(memberCredentials.privatekey, memberCredentials.pubkey);
+      session.setTrustchain({
+        rootId: trustchain.rootId,
+        applicationPath: trustchain.applicationPath,
+      });
+      await session.write();
+
+      out.secretsInit({ memberName, rootId: trustchain.rootId });
+    });
+  },
+});

--- a/apps/wallet-cli/src/commands/secrets/keys.ts
+++ b/apps/wallet-cli/src/commands/secrets/keys.ts
@@ -1,0 +1,22 @@
+import { defineCommand } from "@bunli/core";
+import { Session } from "../../session/session-store";
+import { outputOption, resolveOutputFormat } from "../inputs";
+import { createCommandOutput } from "../../output";
+
+export default defineCommand({
+  name: "keys",
+  description: "List tracked domain keys from the local secrets store",
+  options: {
+    output: outputOption,
+  },
+  handler: async ({ flags }) => {
+    const out = createCommandOutput(resolveOutputFormat(flags.output), { command: "secrets keys", network: "all" });
+    await out.run(async () => {
+      const session = await Session.read();
+      if (!session.trustchain) {
+        throw new Error("Encryption CLI not initialized. Run `wallet-cli secrets init` first.");
+      }
+      out.secretsKeys(session.domains);
+    });
+  },
+});

--- a/apps/wallet-cli/src/output-json.test.ts
+++ b/apps/wallet-cli/src/output-json.test.ts
@@ -154,6 +154,110 @@ describe("JsonCommandOutput", () => {
     expect(lines[0].quotes[0]).toMatchObject({ quoteId: "quote-1", provider: "paraswap" });
   });
 
+  it("secretsInit emits member and rootId in envelope", () => {
+    try {
+      const out = createCommandOutput("json", { command: "secrets init", network: "all" });
+      out.secretsInit({ memberName: "my-machine (darwin)", rootId: "root-abc" });
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({
+      status: "success",
+      command: "secrets init",
+      network: "all",
+      member: "my-machine (darwin)",
+      rootId: "root-abc",
+    });
+  });
+
+  it("secretsKeys emits keys array in envelope", () => {
+    try {
+      const out = createCommandOutput("json", { command: "secrets keys", network: "all" });
+      out.secretsKeys([
+        { domain: "prod", firstUsed: "2026-04-27T00:00:00.000Z" },
+        { domain: "staging", firstUsed: "2026-04-28T00:00:00.000Z" },
+      ]);
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({
+      status: "success",
+      command: "secrets keys",
+      keys: [
+        { domain: "prod", firstUsed: "2026-04-27T00:00:00.000Z" },
+        { domain: "staging", firstUsed: "2026-04-28T00:00:00.000Z" },
+      ],
+    });
+  });
+
+  it("secretsKeys emits empty keys array when no domains tracked", () => {
+    try {
+      const out = createCommandOutput("json", { command: "secrets keys", network: "all" });
+      out.secretsKeys([]);
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", keys: [] });
+  });
+
+  it("secretsDestroy emits destroyed=true when remote succeeded", () => {
+    try {
+      const out = createCommandOutput("json", { command: "secrets destroy", network: "all" });
+      out.secretsDestroy(true);
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", destroyed: true, local_wiped: true });
+  });
+
+  it("secretsDestroy emits destroyed=false when only local wipe", () => {
+    try {
+      const out = createCommandOutput("json", { command: "secrets destroy", network: "all" });
+      out.secretsDestroy(false);
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", destroyed: false, local_wiped: true });
+  });
+
+  it("secretsDestroyCancelled emits cancelled:true envelope", () => {
+    try {
+      const out = createCommandOutput("json", { command: "secrets destroy", network: "all" });
+      out.secretsDestroyCancelled();
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", cancelled: true });
+  });
+
+  it("secretsEncrypt emits output path and byte count", () => {
+    try {
+      const out = createCommandOutput("json", { command: "secrets encrypt", network: "all" });
+      out.secretsEncrypt({ dest: "/tmp/out.enc", bytes: 64 });
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", output: "/tmp/out.enc", bytes: 64 });
+  });
+
+  it("secretsDecrypt emits output path", () => {
+    try {
+      const out = createCommandOutput("json", { command: "secrets decrypt", network: "all" });
+      out.secretsDecrypt({ dest: "/tmp/out.txt" });
+    } finally {
+      restore();
+    }
+    const [line] = writes.join("").trim().split("\n").map(l => JSON.parse(l));
+    expect(line).toMatchObject({ status: "success", output: "/tmp/out.txt" });
+  });
+
   it("emits swap quote unavailability as an NDJSON error envelope", () => {
     try {
       const out = createCommandOutput("json", {

--- a/apps/wallet-cli/src/output.test.ts
+++ b/apps/wallet-cli/src/output.test.ts
@@ -1,5 +1,6 @@
 import "./live-common-setup";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { installOutputCapture } from "./shared/ui";
 
 type MockSpinner = {
   text: string;
@@ -97,5 +98,68 @@ describe("HumanCommandOutput", () => {
 
     expect(spin.text).toBe("[⧖] Review on device. Approve or reject.");
     expect(createdSpinners).toHaveLength(1);
+  });
+
+  describe("secrets human output", () => {
+    let writes: string[] = [];
+    let stderrWrites: string[] = [];
+    let restore: () => void;
+
+    beforeEach(() => {
+      writes = [];
+      stderrWrites = [];
+      restore = installOutputCapture({
+        stdout: chunk => writes.push(chunk),
+        stderr: chunk => stderrWrites.push(chunk),
+      });
+    });
+
+    afterEach(() => restore());
+
+    const ctx = { command: "secrets", network: "all" };
+
+    it("secretsKeys renders a table with domain and date columns", () => {
+      createCommandOutput("human", ctx).secretsKeys([
+        { domain: "prod", firstUsed: "2026-04-27T12:00:00.000Z" },
+        { domain: "staging", firstUsed: "2026-04-28T12:00:00.000Z" },
+      ]);
+      const out = writes.join("");
+      expect(out).toContain("prod");
+      expect(out).toContain("staging");
+      expect(out).toContain("2026-04-27");
+      expect(out).toContain("2026-04-28");
+    });
+
+    it("secretsKeys renders dim message when empty", () => {
+      createCommandOutput("human", ctx).secretsKeys([]);
+      expect(writes.join("")).toContain("No domain keys");
+    });
+
+    it("secretsDestroy shows destroyed message when remote succeeded", () => {
+      createCommandOutput("human", ctx).secretsDestroy(true);
+      expect(writes.join("")).toContain("trustchain destroyed");
+    });
+
+    it("secretsDestroy shows local-wipe message when remote failed", () => {
+      createCommandOutput("human", ctx).secretsDestroy(false);
+      expect(writes.join("")).toContain("local credentials wiped");
+    });
+
+    it("secretsDestroyCancelled writes Cancelled to stderr", () => {
+      createCommandOutput("human", ctx).secretsDestroyCancelled();
+      expect(stderrWrites.join("")).toContain("Cancelled");
+    });
+
+    it("secretsEncrypt shows written path and byte count", () => {
+      createCommandOutput("human", ctx).secretsEncrypt({ dest: "/tmp/out.enc", bytes: 128 });
+      const out = writes.join("");
+      expect(out).toContain("/tmp/out.enc");
+      expect(out).toContain("128");
+    });
+
+    it("secretsDecrypt shows written path", () => {
+      createCommandOutput("human", ctx).secretsDecrypt({ dest: "/tmp/out.txt" });
+      expect(writes.join("")).toContain("/tmp/out.txt");
+    });
   });
 });

--- a/apps/wallet-cli/src/output.ts
+++ b/apps/wallet-cli/src/output.ts
@@ -109,6 +109,7 @@ export interface CommandOutput {
    * WalletCliDeviceError handling in run()/fail().
    */
   deviceState(state: DeviceState): void;
+
   /** Print one progress line for swap execute long-running steps. */
   swapExecuteProgress(line: string): void;
   /** Print payload-only swap execute result. */
@@ -130,6 +131,19 @@ export interface CommandOutput {
     magnitudeAwareRate?: string;
     dryRun?: boolean;
   }): void;
+
+  /** Output secrets init result (human: member + rootId lines; json: envelope). */
+  secretsInit(result: { memberName: string; rootId: string }): void;
+  /** Output domain keys table (human: table or empty message; json: envelope with keys array). */
+  secretsKeys(domains: ReadonlyArray<{ domain: string; firstUsed: string }>): void;
+  /** Output secrets destroy result (human: colored message; json: envelope). */
+  secretsDestroy(remoteSucceeded: boolean): void;
+  /** User cancelled destroy confirmation (human: stderr line; json: envelope with cancelled:true). */
+  secretsDestroyCancelled(): void;
+  /** Output encrypt-to-file result (human: ✔ line; json: envelope with output path + bytes). */
+  secretsEncrypt(result: { dest: string; bytes: number }): void;
+  /** Output decrypt-to-file result (human: ✔ line; json: envelope with output path). */
+  secretsDecrypt(result: { dest: string }): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -351,7 +365,6 @@ class HumanCommandOutput implements CommandOutput {
 
   deviceState(state: DeviceState): void {
     if (isTerminalDeviceState(state)) {
-      // Terminal states are surfaced via thrown WalletCliDeviceError; avoid double-render.
       return;
     }
     const { glyph, message } = renderDeviceState(state);
@@ -413,6 +426,46 @@ class HumanCommandOutput implements CommandOutput {
     if (args.dryRun) {
       writeStdout(`${colors.bold("Dry run:")} yes (not signed or broadcasted)\n`);
     }
+  }
+
+  secretsInit({ memberName, rootId }: { memberName: string; rootId: string }): void {
+    writeStdout("");
+    writeStdout(`${colors.bold("Member:")}  ${memberName}`);
+    writeStdout(`${colors.bold("Root ID:")} ${rootId}`);
+    writeStdout(colors.dim("Encrypt/decrypt with: wallet-cli secrets encrypt --key <domain>"));
+  }
+
+  secretsKeys(domains: ReadonlyArray<{ domain: string; firstUsed: string }>): void {
+    if (domains.length === 0) {
+      writeStdout(colors.dim("No domain keys tracked yet. Use `secrets encrypt --key <domain>` to create one."));
+      return;
+    }
+    const w = Math.max(6, ...domains.map(d => d.domain.length));
+    writeStdout(`${colors.bold("Domain".padEnd(w))}  ${colors.bold("First Used")}`);
+    writeStdout("─".repeat(w + 2 + 10));
+    for (const { domain, firstUsed } of domains) {
+      writeStdout(`${domain.padEnd(w)}  ${firstUsed.slice(0, 10)}`);
+    }
+  }
+
+  secretsDestroy(remoteSucceeded: boolean): void {
+    writeStdout(
+      remoteSucceeded
+        ? `${colors.green("✔")} Encryption CLI trustchain destroyed.`
+        : `${colors.green("✔")} Encryption CLI local credentials wiped.`,
+    );
+  }
+
+  secretsDestroyCancelled(): void {
+    writeStderr("Cancelled.\n");
+  }
+
+  secretsEncrypt({ dest, bytes }: { dest: string; bytes: number }): void {
+    writeStdout(`${colors.green("✔")} Written to ${dest} (${bytes} bytes, AES-256-GCM)`);
+  }
+
+  secretsDecrypt({ dest }: { dest: string }): void {
+    writeStdout(`${colors.green("✔")} Written to ${dest}`);
   }
 }
 
@@ -637,6 +690,30 @@ class JsonCommandOutput implements CommandOutput {
         ...(args.dryRun ? { dry_run: true } : {}),
       }),
     );
+  }
+
+  secretsInit({ memberName, rootId }: { memberName: string; rootId: string }): void {
+    this._writeNdjson(this._envelope({ member: memberName, rootId }));
+  }
+
+  secretsKeys(domains: ReadonlyArray<{ domain: string; firstUsed: string }>): void {
+    this._writeNdjson(this._envelope({ keys: domains.map(d => ({ domain: d.domain, firstUsed: d.firstUsed })) }));
+  }
+
+  secretsDestroy(remoteSucceeded: boolean): void {
+    this._writeNdjson(this._envelope({ destroyed: remoteSucceeded, local_wiped: true }));
+  }
+
+  secretsDestroyCancelled(): void {
+    this._writeNdjson(this._envelope({ cancelled: true }));
+  }
+
+  secretsEncrypt({ dest, bytes }: { dest: string; bytes: number }): void {
+    this._writeNdjson(this._envelope({ output: dest, bytes }));
+  }
+
+  secretsDecrypt({ dest }: { dest: string }): void {
+    this._writeNdjson(this._envelope({ output: dest }));
   }
 }
 

--- a/apps/wallet-cli/src/secrets/constants.ts
+++ b/apps/wallet-cli/src/secrets/constants.ts
@@ -1,0 +1,3 @@
+export const ENCRYPTION_CLI_APPLICATION_ID = 17;
+
+export const MEMBER_NAME_MAX_LENGTH = 64;

--- a/apps/wallet-cli/src/secrets/crypto.test.ts
+++ b/apps/wallet-cli/src/secrets/crypto.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "bun:test";
+import { hexToBytes, pubkeyFromPrivatekey, deriveDomainKey, encryptData, decryptData } from "./crypto";
+
+const KEY_HEX = "cafe".repeat(16);
+
+describe("hexToBytes", () => {
+  it("converts valid hex", () => expect(hexToBytes("ff00ab")).toEqual(new Uint8Array([0xff, 0x00, 0xab])));
+  it("handles empty string", () => expect(hexToBytes("")).toEqual(new Uint8Array(0)));
+  it("throws on odd-length hex", () => expect(() => hexToBytes("abc")).toThrow());
+  it("throws on non-hex characters", () => expect(() => hexToBytes("zz")).toThrow());
+});
+
+describe("pubkeyFromPrivatekey", () => {
+  const PRIVATE = "0101010101010101010101010101010101010101010101010101010101010101";
+  it("returns a 66-char compressed pubkey hex", () =>
+    expect(pubkeyFromPrivatekey(PRIVATE)).toMatch(/^[0-9a-f]{66}$/));
+  it("is deterministic", () => expect(pubkeyFromPrivatekey(PRIVATE)).toBe(pubkeyFromPrivatekey(PRIVATE)));
+  it("throws on invalid hex", () => expect(() => pubkeyFromPrivatekey("not-hex")).toThrow());
+});
+
+describe("encryptData / decryptData", () => {
+  it("round-trip restores plaintext", async () => {
+    const key = await deriveDomainKey(KEY_HEX, "domain");
+    const pt = new TextEncoder().encode("hello world");
+    const ct = await encryptData(key, pt);
+    expect(ct.length).toBe(12 + pt.length + 16); // IV + plaintext + GCM tag
+    expect(new TextDecoder().decode(await decryptData(key, ct))).toBe("hello world");
+  });
+
+  it("different domains produce different keys", async () => {
+    const k1 = await deriveDomainKey(KEY_HEX, "domain-a");
+    const k2 = await deriveDomainKey(KEY_HEX, "domain-b");
+    const ct = await encryptData(k1, new TextEncoder().encode("secret"));
+    await expect(decryptData(k2, ct)).rejects.toThrow("Decryption failed");
+  });
+
+  it("decryptData throws on truncated ciphertext", async () =>
+    expect(decryptData(await deriveDomainKey(KEY_HEX, "x"), new Uint8Array(5))).rejects.toThrow(
+      "too short",
+    ));
+});

--- a/apps/wallet-cli/src/secrets/crypto.ts
+++ b/apps/wallet-cli/src/secrets/crypto.ts
@@ -1,0 +1,66 @@
+import { crypto as lkrpCrypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
+
+export function pubkeyFromPrivatekey(privateHex: string): string {
+  return lkrpCrypto.to_hex(lkrpCrypto.keypairFromSecretKey(hexToBytes(privateHex)).publicKey);
+}
+
+export function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
+  if (hex.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(hex)) {
+    throw new Error(`Invalid hex string (length=${hex.length}): expected even-length hex digits.`);
+  }
+  const result = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < result.length; i++) {
+    result[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return result;
+}
+
+const DOMAIN_SALT = new TextEncoder().encode("wallet-cli-domain-v1");
+
+export async function deriveDomainKey(
+  walletSyncEncryptionKey: string,
+  domain: string,
+): Promise<CryptoKey> {
+  const ikm = hexToBytes(walletSyncEncryptionKey);
+  const hkdfKey = await globalThis.crypto.subtle.importKey("raw", ikm, "HKDF", false, [
+    "deriveBits",
+  ]);
+  const bits = await globalThis.crypto.subtle.deriveBits(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: DOMAIN_SALT,
+      info: new TextEncoder().encode(domain),
+    },
+    hkdfKey,
+    256,
+  );
+  return globalThis.crypto.subtle.importKey("raw", bits, { name: "AES-GCM" }, false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+/** Wire format: [iv (12 bytes)][ciphertext] */
+export async function encryptData(key: CryptoKey, plaintext: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
+  const iv = globalThis.crypto.getRandomValues(new Uint8Array(12));
+  const ct = await globalThis.crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, plaintext);
+  const result = new Uint8Array(12 + ct.byteLength);
+  result.set(iv, 0);
+  result.set(new Uint8Array(ct), 12);
+  return result;
+}
+
+export async function decryptData(key: CryptoKey, ciphertext: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> {
+  if (ciphertext.length < 12) {
+    throw new Error("Invalid ciphertext: too short to contain IV.");
+  }
+  const iv = ciphertext.slice(0, 12);
+  const ct = ciphertext.slice(12);
+  try {
+    const pt = await globalThis.crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ct);
+    return new Uint8Array(pt);
+  } catch {
+    throw new Error("Decryption failed: wrong key or corrupted data.");
+  }
+}

--- a/apps/wallet-cli/src/secrets/crypto.ts
+++ b/apps/wallet-cli/src/secrets/crypto.ts
@@ -1,5 +1,36 @@
 import { crypto as lkrpCrypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 
+const PBKDF2_ITERATIONS = 100_000;
+const PBKDF2_SALT_BYTES = 16;
+
+export function generatePasswordSalt(): string {
+  return Buffer.from(globalThis.crypto.getRandomValues(new Uint8Array(PBKDF2_SALT_BYTES))).toString(
+    "hex",
+  );
+}
+
+export async function deriveWrappingKey(password: string, saltHex: string): Promise<CryptoKey> {
+  const keyMaterial = await globalThis.crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(password),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return globalThis.crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: hexToBytes(saltHex),
+      iterations: PBKDF2_ITERATIONS,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
 export function pubkeyFromPrivatekey(privateHex: string): string {
   return lkrpCrypto.to_hex(lkrpCrypto.keypairFromSecretKey(hexToBytes(privateHex)).publicKey);
 }

--- a/apps/wallet-cli/src/secrets/keychain.ts
+++ b/apps/wallet-cli/src/secrets/keychain.ts
@@ -1,0 +1,53 @@
+import { Entry } from "@napi-rs/keyring";
+import { APP_NAME } from "../session/session-store";
+import { pubkeyFromPrivatekey } from "./crypto";
+import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
+
+const SERVICE = APP_NAME;
+
+/**
+ * When XDG_STATE_HOME is set (standard on Linux, also used by tests to point at a temp dir),
+ * derive a unique account name per state directory so parallel workers don't clobber each other's keychain entries.
+ */
+function keychainAccount(): string {
+  const xdg = process.env.XDG_STATE_HOME;
+  if (xdg) {
+    const suffix = xdg.replaceAll(/[^a-z0-9]/gi, "").slice(-12);
+    return `member-private-key-${suffix}`;
+  }
+  return "member-private-key";
+}
+
+function getEntry() {
+  return new Entry(SERVICE, keychainAccount());
+}
+
+/**
+ * Save credentials to the OS keychain.
+ * pubkey is stored on a second line when supplied, to avoid re-deriving it later
+ * (the mock LKRP SDK uses non-hex private keys that cannot be used for secp256k1 derivation).
+ */
+export async function savePrivateKey(hex: string, pubkey?: string): Promise<void> {
+  const entry = await getEntry();
+  entry.setPassword(pubkey ? `${hex}\n${pubkey}` : hex);
+}
+
+export async function loadMemberCredentials(): Promise<MemberCredentials | null> {
+  try {
+    const stored = (await getEntry()).getPassword();
+    if (!stored) return null;
+    const lines = stored.trim().split("\n");
+    const privatekey = lines[0];
+    if (!privatekey) return null;
+    const pubkey = lines[1] || pubkeyFromPrivatekey(privatekey);
+    return { privatekey, pubkey };
+  } catch {
+    return null;
+  }
+}
+
+export async function deletePrivateKey(): Promise<void> {
+  try {
+    (await getEntry()).deletePassword();
+  } catch {}
+}

--- a/apps/wallet-cli/src/secrets/keychain.ts
+++ b/apps/wallet-cli/src/secrets/keychain.ts
@@ -1,9 +1,10 @@
 import { Entry } from "@napi-rs/keyring";
 import { APP_NAME } from "../session/session-store";
-import { pubkeyFromPrivatekey } from "./crypto";
+import { pubkeyFromPrivatekey, encryptData, decryptData, hexToBytes } from "./crypto";
 import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
 
 const SERVICE = APP_NAME;
+const ENC_PREFIX = "ENC:";
 
 /**
  * When XDG_STATE_HOME is set (standard on Linux, also used by tests to point at a temp dir),
@@ -24,26 +25,57 @@ function getEntry() {
 
 /**
  * Save credentials to the OS keychain.
+ * If wrappingKey is provided the private key hex is AES-256-GCM encrypted and prefixed with
+ * "ENC:" so the entry is self-describing regardless of session state.
  * pubkey is stored on a second line when supplied, to avoid re-deriving it later
  * (the mock LKRP SDK uses non-hex private keys that cannot be used for secp256k1 derivation).
  */
-export async function savePrivateKey(hex: string, pubkey?: string): Promise<void> {
+export async function savePrivateKey(
+  hex: string,
+  pubkey?: string,
+  wrappingKey?: CryptoKey,
+): Promise<void> {
+  let firstLine: string;
+  if (wrappingKey) {
+    const ct = await encryptData(wrappingKey, new TextEncoder().encode(hex));
+    firstLine = `${ENC_PREFIX}${Buffer.from(ct).toString("hex")}`;
+  } else {
+    firstLine = hex;
+  }
   const entry = await getEntry();
-  entry.setPassword(pubkey ? `${hex}\n${pubkey}` : hex);
+  entry.setPassword(pubkey ? `${firstLine}\n${pubkey}` : firstLine);
 }
 
-export async function loadMemberCredentials(): Promise<MemberCredentials | null> {
+export async function loadMemberCredentials(
+  wrappingKey?: CryptoKey,
+): Promise<MemberCredentials | null> {
+  let stored: string | null;
   try {
-    const stored = (await getEntry()).getPassword();
-    if (!stored) return null;
-    const lines = stored.trim().split("\n");
-    const privatekey = lines[0];
-    if (!privatekey) return null;
-    const pubkey = lines[1] || pubkeyFromPrivatekey(privatekey);
-    return { privatekey, pubkey };
+    stored = (await getEntry()).getPassword();
   } catch {
     return null;
   }
+  if (!stored) return null;
+
+  const lines = stored.trim().split("\n");
+  const firstLine = lines[0];
+  if (!firstLine) return null;
+
+  let privatekey: string;
+  if (firstLine.startsWith(ENC_PREFIX)) {
+    if (!wrappingKey) throw new Error("Private key is password-protected but no password provided.");
+    const ct = hexToBytes(firstLine.slice(ENC_PREFIX.length));
+    try {
+      privatekey = new TextDecoder().decode(await decryptData(wrappingKey, ct));
+    } catch {
+      throw new Error("Wrong password: failed to decrypt private key.");
+    }
+  } else {
+    privatekey = firstLine;
+  }
+
+  const pubkey = lines[1] || pubkeyFromPrivatekey(privatekey);
+  return { privatekey, pubkey };
 }
 
 export async function deletePrivateKey(): Promise<void> {

--- a/apps/wallet-cli/src/secrets/lkrp-sdk.ts
+++ b/apps/wallet-cli/src/secrets/lkrp-sdk.ts
@@ -1,0 +1,16 @@
+import { getSdk } from "@ledgerhq/ledger-key-ring-protocol/index";
+import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
+import { getEnv } from "@ledgerhq/live-env";
+import { ENCRYPTION_CLI_APPLICATION_ID } from "./constants";
+
+export function createLkrpSdk(memberName = "wallet-cli") {
+  return getSdk(
+    !!process.env.MOCK,
+    {
+      applicationId: ENCRYPTION_CLI_APPLICATION_ID,
+      name: memberName,
+      apiBaseUrl: getEnv("TRUSTCHAIN_API_PROD"),
+    },
+    withDevice,
+  );
+}

--- a/apps/wallet-cli/src/secrets/load-secrets.ts
+++ b/apps/wallet-cli/src/secrets/load-secrets.ts
@@ -1,0 +1,36 @@
+import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
+import { Session, type TrustchainMeta, trustchainFromMeta } from "../session/session-store";
+import { loadMemberCredentials } from "./keychain";
+import { createLkrpSdk } from "./lkrp-sdk";
+import { deriveDomainKey } from "./crypto";
+
+export type LoadedSecrets = {
+  session: Session;
+  trustchainMeta: TrustchainMeta;
+  memberCredentials: MemberCredentials;
+};
+
+export async function loadSecrets(): Promise<LoadedSecrets> {
+  const [session, memberCredentials] = await Promise.all([Session.read(), loadMemberCredentials()]);
+  const trustchainMeta = session.trustchain;
+  if (!trustchainMeta) {
+    throw new Error("Encryption CLI not initialized. Run `wallet-cli secrets init` first.");
+  }
+  if (!memberCredentials) {
+    throw new Error(
+      "Private key not found in keychain. Run `wallet-cli secrets destroy` then `init` to reset.",
+    );
+  }
+  return { session, trustchainMeta, memberCredentials };
+}
+
+export async function loadDomainKey(domain: string): Promise<{ session: Session; domainKey: CryptoKey }> {
+  const { session, trustchainMeta, memberCredentials } = await loadSecrets();
+  const sdk = createLkrpSdk();
+  const restored = await sdk.restoreTrustchain(trustchainFromMeta(trustchainMeta), memberCredentials);
+  if (restored.applicationPath !== trustchainMeta.applicationPath) {
+    session.setTrustchain({ rootId: trustchainMeta.rootId, applicationPath: restored.applicationPath });
+    await session.write();
+  }
+  return { session, domainKey: await deriveDomainKey(restored.walletSyncEncryptionKey, domain) };
+}

--- a/apps/wallet-cli/src/secrets/load-secrets.ts
+++ b/apps/wallet-cli/src/secrets/load-secrets.ts
@@ -2,7 +2,8 @@ import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types
 import { Session, type TrustchainMeta, trustchainFromMeta } from "../session/session-store";
 import { loadMemberCredentials } from "./keychain";
 import { createLkrpSdk } from "./lkrp-sdk";
-import { deriveDomainKey } from "./crypto";
+import { deriveDomainKey, deriveWrappingKey } from "./crypto";
+import { promptHidden } from "./prompt";
 
 export type LoadedSecrets = {
   session: Session;
@@ -10,8 +11,11 @@ export type LoadedSecrets = {
   memberCredentials: MemberCredentials;
 };
 
-export async function loadSecrets(): Promise<LoadedSecrets> {
-  const [session, memberCredentials] = await Promise.all([Session.read(), loadMemberCredentials()]);
+export async function loadSecrets(wrappingKey?: CryptoKey): Promise<LoadedSecrets> {
+  const [session, memberCredentials] = await Promise.all([
+    Session.read(),
+    loadMemberCredentials(wrappingKey),
+  ]);
   const trustchainMeta = session.trustchain;
   if (!trustchainMeta) {
     throw new Error("Encryption CLI not initialized. Run `wallet-cli secrets init` first.");
@@ -24,8 +28,15 @@ export async function loadSecrets(): Promise<LoadedSecrets> {
   return { session, trustchainMeta, memberCredentials };
 }
 
-export async function loadDomainKey(domain: string): Promise<{ session: Session; domainKey: CryptoKey }> {
-  const { session, trustchainMeta, memberCredentials } = await loadSecrets();
+async function resolveWrappingKey(session: Session): Promise<CryptoKey | undefined> {
+  if (!session.passwordSalt) return undefined;
+  const password = await promptHidden("Password: ");
+  if (!password) throw new Error("Password must not be empty.");
+  return deriveWrappingKey(password, session.passwordSalt);
+}
+
+export async function loadDomainKey(domain: string, wrappingKey?: CryptoKey): Promise<{ session: Session; domainKey: CryptoKey }> {
+  const { session, trustchainMeta, memberCredentials } = await loadSecrets(wrappingKey);
   const sdk = createLkrpSdk();
   const restored = await sdk.restoreTrustchain(trustchainFromMeta(trustchainMeta), memberCredentials);
   if (restored.applicationPath !== trustchainMeta.applicationPath) {
@@ -33,4 +44,10 @@ export async function loadDomainKey(domain: string): Promise<{ session: Session;
     await session.write();
   }
   return { session, domainKey: await deriveDomainKey(restored.walletSyncEncryptionKey, domain) };
+}
+
+export async function loadDomainKeyInteractive(domain: string): Promise<{ session: Session; domainKey: CryptoKey }> {
+  const session = await Session.read();
+  const wrappingKey = await resolveWrappingKey(session);
+  return loadDomainKey(domain, wrappingKey);
 }

--- a/apps/wallet-cli/src/secrets/prompt.ts
+++ b/apps/wallet-cli/src/secrets/prompt.ts
@@ -1,0 +1,45 @@
+export async function promptHidden(label: string): Promise<string> {
+  const envPass = process.env.WALLET_PASS;
+  if (envPass !== undefined) return envPass;
+
+  if (process.stdin.isTTY) {
+    process.stderr.write(label);
+    return new Promise((resolve, reject) => {
+      let value = "";
+      process.stdin.setRawMode(true);
+      process.stdin.resume();
+      process.stdin.setEncoding("utf8");
+
+      const onData = (ch: string) => {
+        if (ch === "\r" || ch === "\n") {
+          teardown();
+          resolve(value);
+        } else if (ch === "") {
+          teardown();
+          reject(new Error("Cancelled"));
+        } else if (ch === "" || ch === "\b") {
+          value = value.slice(0, -1);
+        } else {
+          value += ch;
+        }
+      };
+
+      const teardown = () => {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        process.stdin.off("data", onData);
+        process.stderr.write("\n");
+      };
+
+      process.stdin.on("data", onData);
+    });
+  }
+
+  throw new Error(
+    "Password required but no TTY available and WALLET_PASS is not set.\n" +
+      "Inject it from your OS keychain before running the command:\n" +
+      "  macOS : WALLET_PASS=$(security find-generic-password -a default -s ledger-cli -w) wallet-cli ...\n" +
+      "  Linux : WALLET_PASS=$(secret-tool lookup service ledger-cli account default) wallet-cli ...\n" +
+      "  Win   : $env:WALLET_PASS=(Get-StoredCredential -Target ledger-cli).GetNetworkCredential().Password",
+  );
+}

--- a/apps/wallet-cli/src/session/bridge-device-session.ts
+++ b/apps/wallet-cli/src/session/bridge-device-session.ts
@@ -1,4 +1,5 @@
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { TRUSTCHAIN_APP_NAME } from "@ledgerhq/hw-ledger-key-ring-protocol/ApduDevice";
 import { connectLedgerApp } from "../device/connect-ledger-app";
 import type { DeviceState } from "../device/device-state";
 import { WalletCliDeviceError } from "../device/wallet-cli-device-error";
@@ -37,6 +38,25 @@ export async function withCurrencyDeviceSession<T>(
     throw WalletCliDeviceError.fromUnknown(e, { expectedApp: managerAppName });
   }
   walletCliDebug("Device session ready.");
+  try {
+    return await fn();
+  } finally {
+    walletCliDebug("Resetting device session…");
+    await resetWalletCliDmkSession();
+  }
+}
+
+/** Open the Ledger Sync app and run a function that sends LKRP APDUs. No currency required. */
+export async function withLkrpDeviceSession<T>(fn: () => Promise<T>): Promise<T> {
+  walletCliDebug("Ensuring DMK transport for LKRP…");
+  try {
+    const transport = await ensureWalletCliDmkTransport();
+    walletCliDebug("Connecting Ledger Sync app…");
+    await connectLedgerApp(transport.dmk, transport.sessionId, TRUSTCHAIN_APP_NAME);
+  } catch (e) {
+    throw WalletCliDeviceError.fromUnknown(e, { expectedApp: TRUSTCHAIN_APP_NAME });
+  }
+  walletCliDebug("Ledger Sync app open.");
   try {
     return await fn();
   } finally {

--- a/apps/wallet-cli/src/session/session-store.ts
+++ b/apps/wallet-cli/src/session/session-store.ts
@@ -29,6 +29,7 @@ const SessionDataSchema = z.object({
   accounts: z.array(SessionEntrySchema).default([]),
   trustchain: TrustchainMetaSchema.optional(),
   domains: z.array(DomainEntrySchema).default([]),
+  passwordSalt: z.string().optional(),
 });
 
 export type SessionEntry = z.infer<typeof SessionEntrySchema>;
@@ -105,15 +106,16 @@ export class Session {
     private entries: SessionEntry[],
     private _trustchain: TrustchainMeta | undefined,
     private _domains: DomainEntry[],
+    private _passwordSalt: string | undefined,
   ) {}
 
   static async read(): Promise<Session> {
     const data = await readData();
-    return new Session(data.accounts, data.trustchain, data.domains);
+    return new Session(data.accounts, data.trustchain, data.domains, data.passwordSalt);
   }
 
   static from(entries: SessionEntry[]): Session {
-    return new Session([...entries], undefined, []);
+    return new Session([...entries], undefined, [], undefined);
   }
 
   get accounts(): ReadonlyArray<SessionEntry> {
@@ -122,6 +124,15 @@ export class Session {
 
   get trustchain(): TrustchainMeta | undefined {
     return this._trustchain;
+  }
+
+  get passwordSalt(): string | undefined {
+    return this._passwordSalt;
+  }
+
+  setPasswordSalt(salt: string): void {
+    this._passwordSalt = salt;
+    this._dirty = true;
   }
 
   setTrustchain(t: TrustchainMeta): void {
@@ -140,10 +151,11 @@ export class Session {
     }
   }
 
-  /** Clears trustchain and domain tracking, but keeps discovered accounts. */
+  /** Clears trustchain, domain tracking, and password salt, but keeps discovered accounts. */
   wipeSecrets(): void {
     this._trustchain = undefined;
     this._domains = [];
+    this._passwordSalt = undefined;
     this._dirty = true;
   }
 
@@ -178,6 +190,7 @@ export class Session {
     const data: Record<string, unknown> = { accounts: this.entries };
     if (this._trustchain) data.trustchain = this._trustchain;
     if (this._domains.length > 0) data.domains = this._domains;
+    if (this._passwordSalt) data.passwordSalt = this._passwordSalt;
     await Bun.write(getSessionPath(), YAML.stringify(data));
     this._dirty = false;
   }

--- a/apps/wallet-cli/src/session/session-store.ts
+++ b/apps/wallet-cli/src/session/session-store.ts
@@ -3,6 +3,7 @@ import { stateDir } from "@bunli/utils";
 import { join } from "node:path";
 import { mkdirSync } from "node:fs";
 import { z } from "zod";
+import type { Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import type { AccountDescriptorV1 } from "../shared/accountDescriptor";
 import { serializeV1 } from "../shared/accountDescriptor";
 
@@ -14,19 +15,38 @@ const SessionEntrySchema = z.object({
   descriptor: z.string(),
 });
 
+const TrustchainMetaSchema = z.object({
+  rootId: z.string(),
+  applicationPath: z.string(),
+});
+
+const DomainEntrySchema = z.object({
+  domain: z.string(),
+  firstUsed: z.string(),
+});
+
 const SessionDataSchema = z.object({
   accounts: z.array(SessionEntrySchema).default([]),
+  trustchain: TrustchainMetaSchema.optional(),
+  domains: z.array(DomainEntrySchema).default([]),
 });
 
 export type SessionEntry = z.infer<typeof SessionEntrySchema>;
+export type TrustchainMeta = z.infer<typeof TrustchainMetaSchema>;
+export type DomainEntry = z.infer<typeof DomainEntrySchema>;
 
 export function getSessionPath(): string {
   return join(stateDir(APP_NAME), SESSION_FILE);
 }
 
-function parseSessionData(raw: string): SessionEntry[] {
+/** Construct a Trustchain from metadata; walletSyncEncryptionKey is left empty (sufficient for auth-only LKRP calls). */
+export function trustchainFromMeta(meta: TrustchainMeta): Trustchain {
+  return { ...meta, walletSyncEncryptionKey: "" };
+}
+
+function parseSessionData(raw: string): z.infer<typeof SessionDataSchema> {
   try {
-    return SessionDataSchema.parse(YAML.parse(raw) ?? {}).accounts;
+    return SessionDataSchema.parse(YAML.parse(raw) ?? {});
   } catch {
     throw new Error(
       `Invalid session file at ${getSessionPath()}. Run \`wallet-cli session reset\` to clear it.`,
@@ -34,21 +54,16 @@ function parseSessionData(raw: string): SessionEntry[] {
   }
 }
 
-async function readEntries(): Promise<SessionEntry[]> {
+async function readData(): Promise<z.infer<typeof SessionDataSchema>> {
   let content: string;
   try {
     content = await Bun.file(getSessionPath()).text();
   } catch (err) {
-    if (err instanceof Error && "code" in err && err.code === "ENOENT") return [];
+    if (err instanceof Error && "code" in err && err.code === "ENOENT")
+      return SessionDataSchema.parse({});
     throw err;
   }
   return parseSessionData(content);
-}
-
-async function writeEntries(entries: SessionEntry[]): Promise<void> {
-  const dir = stateDir(APP_NAME);
-  mkdirSync(dir, { recursive: true });
-  await Bun.write(getSessionPath(), YAML.stringify({ accounts: entries }));
 }
 
 function derivationLabel(path: string): string {
@@ -84,28 +99,61 @@ export function generateLabel(
 }
 
 export class Session {
-  private constructor(private entries: SessionEntry[]) {}
+  private _dirty = false;
+
+  private constructor(
+    private entries: SessionEntry[],
+    private _trustchain: TrustchainMeta | undefined,
+    private _domains: DomainEntry[],
+  ) {}
 
   static async read(): Promise<Session> {
-    return new Session(await readEntries());
+    const data = await readData();
+    return new Session(data.accounts, data.trustchain, data.domains);
   }
 
   static from(entries: SessionEntry[]): Session {
-    return new Session([...entries]);
+    return new Session([...entries], undefined, []);
   }
 
   get accounts(): ReadonlyArray<SessionEntry> {
     return this.entries;
   }
 
-  /** Remove all entries. Returns count of entries that were present. */
+  get trustchain(): TrustchainMeta | undefined {
+    return this._trustchain;
+  }
+
+  setTrustchain(t: TrustchainMeta): void {
+    this._trustchain = t;
+    this._dirty = true;
+  }
+
+  get domains(): ReadonlyArray<DomainEntry> {
+    return this._domains;
+  }
+
+  trackDomain(domain: string): void {
+    if (!this._domains.some(d => d.domain === domain)) {
+      this._domains.push({ domain, firstUsed: new Date().toISOString() });
+      this._dirty = true;
+    }
+  }
+
+  /** Clears trustchain and domain tracking, but keeps discovered accounts. */
+  wipeSecrets(): void {
+    this._trustchain = undefined;
+    this._domains = [];
+    this._dirty = true;
+  }
+
   clear(): number {
     const count = this.entries.length;
     this.entries = [];
+    this._dirty = true;
     return count;
   }
 
-  /** Merge new descriptors in-place. Returns count of newly added entries. */
   addDescriptors(descriptors: AccountDescriptorV1[]): number {
     const knownDescriptors = new Set(this.entries.map(e => e.descriptor));
     const knownLabels = new Set(this.entries.map(e => e.label));
@@ -119,10 +167,18 @@ export class Session {
       this.entries.push({ label, descriptor: serialized });
       added++;
     }
+    if (added > 0) this._dirty = true;
     return added;
   }
 
   async write(): Promise<void> {
-    await writeEntries(this.entries);
+    if (!this._dirty) return;
+    const dir = stateDir(APP_NAME);
+    mkdirSync(dir, { recursive: true });
+    const data: Record<string, unknown> = { accounts: this.entries };
+    if (this._trustchain) data.trustchain = this._trustchain;
+    if (this._domains.length > 0) data.domains = this._domains;
+    await Bun.write(getSessionPath(), YAML.stringify(data));
+    this._dirty = false;
   }
 }

--- a/apps/wallet-cli/src/test/commands/secrets.test.ts
+++ b/apps/wallet-cli/src/test/commands/secrets.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeAll, afterAll, mock } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Readable } from "node:stream";
+import { runCli, type RunResult } from "../helpers/cli-runner";
+
+// Mock OS keychain so tests never touch macOS Keychain / libsecret.
+// Must be declared before any runCli() call that triggers a keychain import.
+const _store = new Map<string, string>();
+mock.module("@napi-rs/keyring", () => ({
+  Entry: class {
+    #k: string;
+    constructor(svc: string, acc: string) {
+      this.#k = `${svc}:${acc}`;
+    }
+    setPassword(v: string) {
+      _store.set(this.#k, v);
+    }
+    getPassword() {
+      return _store.get(this.#k) ?? null;
+    }
+    deletePassword() {
+      _store.delete(this.#k);
+    }
+  },
+}));
+
+const MOCK_ENV = { MOCK: "1" };
+const MOCK_ENV_DMK = { ...MOCK_ENV, WALLET_CLI_MOCK_DMK: "1" };
+
+function makeTmpDir(): { env: Record<string, string>; dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "wallet-cli-secrets-test-"));
+  return {
+    dir,
+    env: { XDG_STATE_HOME: dir, ...MOCK_ENV },
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("secrets — not initialized", () => {
+  const { env, cleanup } = makeTmpDir();
+  afterAll(cleanup);
+
+  it("keys exits 1", async () => {
+    expect((await runCli(["secrets", "keys"], env)).exitCode).toBe(1);
+  });
+
+  it("encrypt exits 1", async () => {
+    expect((await runCli(["secrets", "encrypt", "--key", "x"], env)).exitCode).toBe(1);
+  });
+
+  it("decrypt exits 1", async () => {
+    expect((await runCli(["secrets", "decrypt", "--key", "x"], env)).exitCode).toBe(1);
+  });
+
+  it("destroy exits 1", async () => {
+    expect((await runCli(["secrets", "destroy"], env)).exitCode).toBe(1);
+  });
+});
+
+describe("secrets — happy path", () => {
+  let dir: string;
+  let env: Record<string, string>;
+  let initResult: RunResult;
+  let plainFile: string;
+  let encFile: string;
+  let decFile: string;
+
+  beforeAll(async () => {
+    ({ dir, env } = makeTmpDir());
+    plainFile = join(dir, "plain.txt");
+    encFile = join(dir, "test.enc");
+    decFile = join(dir, "test.dec");
+    await Bun.write(plainFile, "hello secrets");
+
+    initResult = await runCli(["secrets", "init", "--name", "test-member"], {
+      ...env,
+      ...MOCK_ENV_DMK,
+    });
+    expect(initResult.exitCode, `init failed: ${initResult.stderr}`).toBe(0);
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("init outputs member name and root id", () => {
+    expect(initResult.stdout).toContain("test-member");
+    expect(initResult.stdout).toContain("mock-root-id");
+  });
+
+  it("init fails when already initialized", async () => {
+    const r = await runCli(["secrets", "init"], { ...env, ...MOCK_ENV_DMK });
+    expect(r.exitCode).toBe(1);
+  });
+
+  it("keys shows no domains after init", async () => {
+    const r = await runCli(["secrets", "keys"], env);
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect(r.stdout).toMatch(/no domain keys/i);
+  });
+
+  it("keys --output json returns empty keys array", async () => {
+    const r = await runCli(["secrets", "keys", "--output", "json"], env);
+    expect(r.exitCode, r.stderr).toBe(0);
+    const data = JSON.parse(r.stdout);
+    expect(data.command).toBe("secrets keys");
+    expect(data.keys).toHaveLength(0);
+  });
+
+  it("encrypt writes ciphertext to file", async () => {
+    const r = await runCli(
+      ["secrets", "encrypt", "--key", "prod", "--input", plainFile, "--out", encFile],
+      env,
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    const ct = await Bun.file(encFile).arrayBuffer();
+    expect(ct.byteLength).toBeGreaterThan("hello secrets".length);
+  });
+
+  it("keys shows domain after encrypt", async () => {
+    const r = await runCli(["secrets", "keys"], env);
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect(r.stdout).toContain("prod");
+  });
+
+  it("encrypt --output json reports dest and bytes", async () => {
+    const r = await runCli(
+      ["secrets", "encrypt", "--key", "prod", "--input", plainFile, "--out", encFile, "--output", "json"],
+      env,
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    const data = JSON.parse(r.stdout);
+    expect(data.output).toBe(encFile);
+    expect(data.bytes).toBeGreaterThan(0);
+  });
+
+  it("decrypt round-trips plaintext from file", async () => {
+    const r = await runCli(
+      ["secrets", "decrypt", "--key", "prod", "--input", encFile, "--out", decFile],
+      env,
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect(await Bun.file(decFile).text()).toBe("hello secrets");
+  });
+
+  it("decrypt --output json reports dest", async () => {
+    const r = await runCli(
+      ["secrets", "decrypt", "--key", "prod", "--input", encFile, "--out", decFile, "--output", "json"],
+      env,
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    const data = JSON.parse(r.stdout);
+    expect(data.output).toBe(decFile);
+  });
+
+  it("decrypt with wrong domain key fails", async () => {
+    const r = await runCli(
+      ["secrets", "decrypt", "--key", "wrong", "--input", encFile, "--out", decFile],
+      env,
+    );
+    expect(r.exitCode).toBe(1);
+  });
+
+  it("destroy wipes credentials after confirmation", async () => {
+    const origDesc = Object.getOwnPropertyDescriptor(process, "stdin");
+    const fakeStdin = new Readable({ read() {} });
+    fakeStdin.push("destroy\n");
+    fakeStdin.push(null);
+    Object.defineProperty(process, "stdin", { get: () => fakeStdin, configurable: true });
+    let r: RunResult;
+    try {
+      r = await runCli(["secrets", "destroy"], env);
+    } finally {
+      if (origDesc) Object.defineProperty(process, "stdin", origDesc);
+    }
+    expect(r!.exitCode, r!.stderr).toBe(0);
+  });
+
+  it("keys exits 1 after destroy", async () => {
+    const r = await runCli(["secrets", "keys"], env);
+    expect(r.exitCode).toBe(1);
+  });
+});

--- a/apps/wallet-cli/src/test/commands/secrets.test.ts
+++ b/apps/wallet-cli/src/test/commands/secrets.test.ts
@@ -5,6 +5,21 @@ import { tmpdir } from "node:os";
 import { Readable } from "node:stream";
 import { runCli, type RunResult } from "../helpers/cli-runner";
 
+function runCliWithStdin(
+  args: string[],
+  env: Record<string, string>,
+  stdinLines: string[],
+): Promise<RunResult> {
+  const origDesc = Object.getOwnPropertyDescriptor(process, "stdin");
+  const fakeStdin = new Readable({ read() {} });
+  for (const line of stdinLines) fakeStdin.push(`${line}\n`);
+  fakeStdin.push(null);
+  Object.defineProperty(process, "stdin", { get: () => fakeStdin, configurable: true });
+  return runCli(args, env).finally(() => {
+    if (origDesc) Object.defineProperty(process, "stdin", origDesc);
+  });
+}
+
 // Mock OS keychain so tests never touch macOS Keychain / libsecret.
 // Must be declared before any runCli() call that triggers a keychain import.
 const _store = new Map<string, string>();
@@ -74,10 +89,10 @@ describe("secrets — happy path", () => {
     decFile = join(dir, "test.dec");
     await Bun.write(plainFile, "hello secrets");
 
-    initResult = await runCli(["secrets", "init", "--name", "test-member"], {
-      ...env,
-      ...MOCK_ENV_DMK,
-    });
+    initResult = await runCli(
+      ["secrets", "init", "--name", "test-member", "--unsecure-no-password"],
+      { ...env, ...MOCK_ENV_DMK },
+    );
     expect(initResult.exitCode, `init failed: ${initResult.stderr}`).toBe(0);
   });
 
@@ -162,18 +177,78 @@ describe("secrets — happy path", () => {
   });
 
   it("destroy wipes credentials after confirmation", async () => {
-    const origDesc = Object.getOwnPropertyDescriptor(process, "stdin");
-    const fakeStdin = new Readable({ read() {} });
-    fakeStdin.push("destroy\n");
-    fakeStdin.push(null);
-    Object.defineProperty(process, "stdin", { get: () => fakeStdin, configurable: true });
-    let r: RunResult;
-    try {
-      r = await runCli(["secrets", "destroy"], env);
-    } finally {
-      if (origDesc) Object.defineProperty(process, "stdin", origDesc);
-    }
-    expect(r!.exitCode, r!.stderr).toBe(0);
+    const r = await runCliWithStdin(["secrets", "destroy"], env, ["destroy"]);
+    expect(r.exitCode, r.stderr).toBe(0);
+  });
+
+  it("keys exits 1 after destroy", async () => {
+    const r = await runCli(["secrets", "keys"], env);
+    expect(r.exitCode).toBe(1);
+  });
+});
+
+describe("secrets — with password", () => {
+  let dir: string;
+  let env: Record<string, string>;
+  let plainFile: string;
+  let encFile: string;
+
+  beforeAll(async () => {
+    ({ dir, env } = makeTmpDir());
+    plainFile = join(dir, "plain.txt");
+    encFile = join(dir, "test.enc");
+    await Bun.write(plainFile, "hello password");
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("init stores password-wrapped key", async () => {
+    const r = await runCli(
+      ["secrets", "init", "--name", "pw-member"],
+      { ...env, ...MOCK_ENV_DMK, WALLET_PASS: "testpw" },
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect(r.stdout).toContain("pw-member");
+  });
+
+  it("init rejects empty password", async () => {
+    const { dir: d2, env: e2 } = makeTmpDir();
+    const r = await runCli(
+      ["secrets", "init", "--name", "pw-member", "--output", "json"],
+      { ...e2, ...MOCK_ENV_DMK, WALLET_PASS: "" },
+    );
+    rmSync(d2, { recursive: true, force: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/must not be empty/i);
+  });
+
+  it("keychain stores encrypted private key", () => {
+    const allValues = [..._store.values()];
+    expect(allValues.some(v => v.startsWith("ENC:"))).toBe(true);
+  });
+
+  it("encrypt with correct password reaches trustchain (credentials decrypted)", async () => {
+    const r = await runCli(
+      ["secrets", "encrypt", "--key", "prod", "--input", plainFile, "--out", encFile, "--output", "json"],
+      { ...env, WALLET_PASS: "testpw" },
+    );
+    expect(r.exitCode, r.stderr).toBe(0);
+    expect(r.stdout).not.toMatch(/[Ww]rong password/);
+    expect(r.stdout).not.toMatch(/[Pp]rivate key not found/);
+  });
+
+  it("encrypt with wrong password fails at decryption", async () => {
+    const r = await runCli(
+      ["secrets", "encrypt", "--key", "prod", "--input", plainFile, "--out", encFile, "--output", "json"],
+      { ...env, WALLET_PASS: "wrongpw" },
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/[Ww]rong password/);
+  });
+
+  it("destroy with correct password fully destroys trustchain", async () => {
+    const r = await runCliWithStdin(["secrets", "destroy"], { ...env, WALLET_PASS: "testpw" }, ["destroy"]);
+    expect(r.exitCode, r.stderr).toBe(0);
   });
 
   it("keys exits 1 after destroy", async () => {

--- a/libs/ledger-key-ring-protocol/src/mockSdk.ts
+++ b/libs/ledger-key-ring-protocol/src/mockSdk.ts
@@ -101,7 +101,7 @@ export class MockSDK implements TrustchainSDK {
 
     const trustchain: Trustchain = trustchains.get("mock-root-id") || {
       rootId: "mock-root-id",
-      walletSyncEncryptionKey: "mock-wallet-sync-encryption-key",
+      walletSyncEncryptionKey: "cafe".repeat(16),
       applicationPath: "m/0'/16'/0'",
     };
     trustchains.set(trustchain.rootId, trustchain);
@@ -200,7 +200,7 @@ export class MockSDK implements TrustchainSDK {
     const index = 1 + parseInt(trustchain.applicationPath.split("/")[3].split("'")[0]);
     const newTrustchain = {
       rootId: trustchain.rootId,
-      walletSyncEncryptionKey: "mock-wallet-sync-encryption-key-" + index,
+      walletSyncEncryptionKey: index.toString(16).padStart(64, "0"),
       applicationPath: "m/0'/16'/" + index + "'",
     };
     trustchains.set(newTrustchain.rootId, newTrustchain);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2328,9 +2328,15 @@ importers:
       '@ledgerhq/hw-app-exchange':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/hw-app-exchange
+      '@ledgerhq/hw-ledger-key-ring-protocol':
+        specifier: workspace:^
+        version: link:../../libs/hw-ledger-key-ring-protocol
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../../libs/ledgerjs/packages/hw-transport
+      '@ledgerhq/ledger-key-ring-protocol':
+        specifier: workspace:^
+        version: link:../../libs/ledger-key-ring-protocol
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../libs/ledger-wallet-framework
@@ -2361,6 +2367,9 @@ importers:
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/types-live
+      '@napi-rs/keyring':
+        specifier: 1.3.0
+        version: 1.3.0
       '@shared/schema-primitives':
         specifier: workspace:^
         version: link:../../shared/schema-primitives
@@ -17407,6 +17416,87 @@ packages:
 
   '@mysten/utils@0.3.1':
     resolution: {integrity: sha512-36KhxG284uhDdSnlkyNaS6fzKTX9FpP2WQWOwUKIRsqQFFIm2ooCf2TP1IuqrtMpkairwpiWkAS0eg7cpemVzg==}
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    resolution: {integrity: sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    resolution: {integrity: sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    resolution: {integrity: sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    resolution: {integrity: sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.3.0':
+    resolution: {integrity: sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -46600,6 +46690,57 @@ snapshots:
   '@mysten/utils@0.3.1':
     dependencies:
       '@scure/base': 2.0.0
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring@1.3.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.3.0
+      '@napi-rs/keyring-darwin-x64': 1.3.0
+      '@napi-rs/keyring-freebsd-x64': 1.3.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.3.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.3.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-musl': 1.3.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.3.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.3.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.3.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** — unit tests for crypto (encrypt/decrypt round-trip, wrong key, corrupted data) + integration tests for all secrets commands including password protection
- [ ] **Impact of the changes:**
  - New `wallet-cli secrets` command group — no impact on existing commands
  - Adds three new workspace dependencies: `@ledgerhq/hw-ledger-key-ring-protocol`, `@ledgerhq/ledger-key-ring-protocol`, `@napi-rs/keyring`
  - Extends `session.yaml` with optional `trustchain`, `domains`, and `passwordSalt` sections
  - Modifies `bridge-device-session.ts` to add `withLkrpDeviceSession` helper

### 📝 Description

Implements the Encryption CLI (`secrets` command group) for `wallet-cli`. One-time device setup registers this machine as a trustchain member via LKRP. All subsequent encrypt/decrypt operations fetch `walletSyncEncryptionKey` from the trustchain (network, no device) and derive per-domain AES-256-GCM keys in-memory via HKDF-SHA256.

**What is stored locally:**
- **OS keychain** (via `@napi-rs/keyring`, service `ledger-wallet-cli`): the LKRP member private key, AES-256-GCM-wrapped with a user password (PBKDF2-SHA256, 100k iterations). The `ENC:` prefix on the stored value makes it self-describing.
- **`~/.local/state/ledger-wallet-cli/session.yaml`** (existing file, extended): trustchain metadata (`rootId`, `applicationPath`), domain key tracking (`domain`, `firstUsed`), and the PBKDF2 salt (`passwordSalt`, hex). No cryptographic material.

**What is never stored:**
- `walletSyncEncryptionKey` — fetched from the LKRP network per operation, used only in-memory (HKDF → AES-256-GCM key, discarded after use).
- The user password — used only to derive the wrapping key, never persisted.

**Commands:**
- `secrets init [--name <str>] [--unsecure-no-password]` — register this machine (device + Ledger Sync app required). Prompts for password + confirm by default; `--unsecure-no-password` skips wrapping.
- `secrets encrypt --key <domain> [-i file] [--out file]` — encrypt stdin/file to stdout/file
- `secrets decrypt --key <domain> [-i file] [--out file]` — decrypt stdin/file to stdout/file
- `secrets keys` — list tracked domain keys with first-used date
- `secrets destroy` — interactive confirmation + server destroy + local wipe; password optional (skipping it = local-only wipe)

**Password injection without a TTY (agentic / CI):**

Set `WALLET_PASS` before the command, pulling from the OS keychain so the secret never sits in a file or shell history:

```sh
# macOS
WALLET_PASS=$(security find-generic-password -a default -s ledger-cli -w) \
  wallet-cli secrets encrypt --key prod -i secret.txt --out secret.enc

# Linux
WALLET_PASS=$(secret-tool lookup service ledger-cli account default) \
  wallet-cli secrets encrypt --key prod -i secret.txt --out secret.enc
```

Without a TTY and without `WALLET_PASS`, the CLI exits with an actionable error listing the exact commands above.

**Consumer usage:**
```sh
# one-time setup (device required) — prompts for password × 2
wallet-cli secrets init

# encrypt a file, decrypt back
wallet-cli secrets encrypt --key prod -i secret.txt --out secret.enc
wallet-cli secrets decrypt --key prod -i secret.enc --out secret.txt

# pipe: password from WALLET_PASS or TTY — stdin is free for data
echo "foo" | wallet-cli secrets encrypt --key foo.xyz --out foo.enc
wallet-cli secrets decrypt --key foo.xyz -i foo.enc

# list tracked domain keys
wallet-cli secrets keys
```

**Key hierarchy:**
```
memberCredentials.privatekey (OS keychain — AES-256-GCM wrapped with user password)
    └─ authenticate to LKRP → walletSyncEncryptionKey (in-memory only, per operation)
           └─ HKDF-SHA256(info=domain) → AES-256-GCM key (in-memory, discarded after use)
```

Wire format: `[IV 12 bytes][AES-256-GCM ciphertext]`

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29920](https://ledgerhq.atlassian.net/browse/LIVE-29920)
- **ADR link (if any)**: N/A

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29920]: https://ledgerhq.atlassian.net/browse/LIVE-29920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ