### PR TITLE
feat(mobile): trigger receive prompt on confirmation exit

### DIFF
--- a/.changeset/fresh-ducks-receive.md
+++ b/.changeset/fresh-ducks-receive.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix receive notification prompt timing

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
@@ -24,7 +24,7 @@ import { urls } from "~/utils/urls";
 import ReceiveProvider from "~/screens/ReceiveFunds/01b-ReceiveProvider.";
 import { setIsOnboardingFlowReceiveSuccess } from "~/actions/settings";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
-import { useNotifications } from "LLM/features/NotificationsPrompt";
+import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
 
 export default function ReceiveFundsNavigator() {
   const { colors } = useTheme();
@@ -34,7 +34,7 @@ export default function ReceiveFundsNavigator() {
   const isOnboardingFlow = useSelector(isOnboardingFlowSelector);
   const dispatchRedux = useDispatch();
   const localizedWithdrawCryptoUrl = useLocalizedUrl(urls.withdrawCrypto);
-  const { tryTriggerPushNotificationDrawerAfterAction } = useNotifications();
+  const { notifyFlowCompleted } = useNotificationsContext();
 
   const onClose = useCallback(() => {
     track("button_clicked", {
@@ -71,16 +71,14 @@ export default function ReceiveFundsNavigator() {
     });
 
     dispatchRedux(setIsOnboardingFlowReceiveSuccess(true));
-    tryTriggerPushNotificationDrawerAfterAction("receive");
-  }, [dispatchRedux, tryTriggerPushNotificationDrawerAfterAction]);
+  }, [dispatchRedux]);
 
   const onVerificationConfirmationClose = useCallback(() => {
     track("button_clicked", {
       button: "HeaderRight Close",
       page: "ReceiveVerificationConfirmation",
     });
-    tryTriggerPushNotificationDrawerAfterAction("receive");
-  }, [tryTriggerPushNotificationDrawerAfterAction]);
+  }, []);
 
   return (
     <Stack.Navigator
@@ -150,6 +148,11 @@ export default function ReceiveFundsNavigator() {
               />
             </Flex>
           ),
+        })}
+        listeners={() => ({
+          beforeRemove: () => {
+            notifyFlowCompleted("receive");
+          },
         })}
       />
     </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/shared.tsx
@@ -20,6 +20,7 @@ import { BigNumber } from "bignumber.js";
 import { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
 import { ModularDrawer, useModularDrawerController } from "..";
 import ReceiveFundsNavigator from "~/components/RootNavigator/ReceiveFundsNavigator";
+import { NotificationsPromptProvider } from "LLM/features/NotificationsPrompt";
 
 export const WITH_ACCOUNT_SELECTION = "Open Drawer (with account selection)";
 export const WITHOUT_ACCOUNT_SELECTION = "Open Drawer (without account selection)";
@@ -133,7 +134,9 @@ const ModularDrawerWithDeviceSelectionStore = (props: MockModularDrawerComponent
   const store = useMemo(() => createStore({ overrideInitialState: withReadOnlyDisabled }), []);
   return (
     <Provider store={store}>
-      <StackNavigatorContent {...props} />
+      <NotificationsPromptProvider>
+        <StackNavigatorContent {...props} />
+      </NotificationsPromptProvider>
     </Provider>
   );
 };
@@ -145,5 +148,9 @@ export const ModularDrawerSharedNavigator = (props: MockModularDrawerComponentPr
     return <ModularDrawerWithDeviceSelectionStore {...props} />;
   }
 
-  return <StackNavigatorContent {...props} />;
+  return (
+    <NotificationsPromptProvider>
+      <StackNavigatorContent {...props} />
+    </NotificationsPromptProvider>
+  );
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptReceiveFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/NotificationsPromptReceiveFlow.test.tsx
@@ -1,0 +1,196 @@
+import React from "react";
+import { View } from "react-native";
+import { ABTestingVariants } from "@ledgerhq/types-live";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { render, screen, waitFor, withFlagOverrides, act } from "@tests/test-renderer";
+import storage from "LLM/storage";
+import ReceiveFundsNavigator from "~/components/RootNavigator/ReceiveFundsNavigator";
+import { NavigatorName, ScreenName } from "~/const";
+import { BTC_ACCOUNT } from "@ledgerhq/live-common/modularDrawer/__mocks__/accounts.mock";
+import GlobalDrawers from "~/GlobalDrawers";
+import { track } from "~/analytics";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
+
+type AuthorizationStatusType = (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus];
+
+const mockRequestPermission = jest.fn<Promise<AuthorizationStatusType>, []>(() =>
+  Promise.resolve(AuthorizationStatus.NOT_DETERMINED),
+);
+const mockHasPermission = jest.fn<Promise<AuthorizationStatusType>, []>(() =>
+  Promise.resolve(AuthorizationStatus.NOT_DETERMINED),
+);
+
+jest.mock("@react-native-firebase/messaging", () => {
+  const AuthorizationStatus = {
+    NOT_DETERMINED: -1,
+    DENIED: 0,
+    AUTHORIZED: 1,
+    PROVISIONAL: 2,
+    EPHEMERAL: 3,
+  } as const;
+
+  return {
+    AuthorizationStatus,
+    getMessaging: jest.fn(() => ({
+      requestPermission: mockRequestPermission,
+      hasPermission: mockHasPermission,
+    })),
+  };
+});
+
+const featureFlagsForReceivePrompt = {
+  brazePushNotifications: {
+    enabled: true,
+    params: {
+      action_events: {
+        complete_onboarding: {
+          enabled: true,
+          timer: 0,
+        },
+        add_favorite_coin: {
+          enabled: true,
+          timer: 0,
+        },
+        send: {
+          enabled: true,
+          timer: 0,
+        },
+        receive: {
+          enabled: true,
+          timer: 0,
+        },
+        buy: {
+          enabled: true,
+          timer: 0,
+        },
+        swap: {
+          enabled: true,
+          timer: 0,
+        },
+        stake: {
+          enabled: true,
+          timer: 0,
+        },
+      },
+      reprompt_schedule: [{ months: 0, days: 7, hours: 0, minutes: 0, seconds: 0 }],
+      inactivity_enabled: false,
+      inactivity_reprompt: { months: 6, days: 0, hours: 0, minutes: 0, seconds: 0 },
+    },
+  },
+  lwmNewWordingOptInNotificationsDrawer: {
+    enabled: true,
+    params: {
+      variant: ABTestingVariants.variantB,
+    },
+  },
+};
+
+describe("NotificationsPrompt receive flow", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(async () => {
+    jest.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    mockRequestPermission.mockResolvedValue(AuthorizationStatus.NOT_DETERMINED);
+    mockHasPermission.mockResolvedValue(AuthorizationStatus.NOT_DETERMINED);
+    await storage.deleteAll();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const Stack = createNativeStackNavigator();
+
+  const HOME_SCREEN = "Home";
+
+  function HomeScreen() {
+    return <View />;
+  }
+
+  const receiveFlowNavigationState = {
+    index: 1,
+    routes: [
+      {
+        name: HOME_SCREEN,
+      },
+      {
+        name: NavigatorName.ReceiveFunds,
+        state: {
+          index: 0,
+          routes: [
+            {
+              name: ScreenName.ReceiveConnectDevice,
+              params: {
+                accountId: BTC_ACCOUNT.id,
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  function ReceiveFlowTestApp() {
+    return (
+      <GlobalDrawers>
+        <Stack.Navigator screenOptions={{ headerShown: false }}>
+          <Stack.Screen name={HOME_SCREEN} component={HomeScreen} />
+          <Stack.Screen name={NavigatorName.ReceiveFunds} component={ReceiveFundsNavigator} />
+        </Stack.Navigator>
+      </GlobalDrawers>
+    );
+  }
+
+  it("should prompt the notifications drawer when leaving the receive flow", async () => {
+    const { user } = render(<ReceiveFlowTestApp />, {
+      navigationInitialState: receiveFlowNavigationState,
+      overrideInitialState: withFlagOverrides(featureFlagsForReceivePrompt, state => ({
+        ...state,
+        accounts: {
+          ...state.accounts,
+          active: [BTC_ACCOUNT],
+        },
+        notifications: {
+          ...state.notifications,
+          permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+        },
+        settings: {
+          ...state.settings,
+          readOnlyModeEnabled: true,
+          notifications: {
+            ...state.settings.notifications,
+            areNotificationsAllowed: true,
+          },
+        },
+      })),
+    });
+
+    await user.press(await screen.findByText(/^continue$/i));
+    await waitFor(() => expect(screen.getByTestId("button-receive-confirmation")).toBeVisible());
+
+    const backButtons = screen.getAllByTestId("navigation-header-back-button");
+    await user.press(backButtons[backButtons.length - 1]);
+    await act(async () => {
+      await jest.runOnlyPendingTimersAsync();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/allow notifications/i)).toBeVisible();
+    });
+    expect(track).toHaveBeenCalledWith("attempt_to_trigger_push_notification_drawer_after_action", {
+      action: "receive",
+      shouldPrompt: true,
+      variant: ABTestingVariants.variantB,
+      repromptDelay: null,
+      dismissedCount: 0,
+      skipReason: undefined,
+    });
+    expect(screen.getByText(/maybe later/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile receive confirmation exit behavior
  - Notifications prompt eligibility after leaving receive confirmation

### 📝 Description

Users should first have time to see the receive confirmation screen, then the notifications opt-in drawer should become eligible only when they leave that confirmation UI. Triggering the prompt from the leaf screen timing made this behavior depend on the screen lifecycle instead of the flow exit.

This PR wires the receive confirmation screen to the notifications prompt provider through a `beforeRemove` listener in `ReceiveFundsNavigator`. The receive success path now calls `notifyFlowCompleted("receive")` when leaving the confirmation screen, preserving the existing receive completion behavior while moving prompt timing to flow exit.


https://github.com/user-attachments/assets/fd2a14e7-0de8-4b0d-a239-bf804501518f



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29483](https://ledgerhq.atlassian.net/browse/LIVE-29483)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29483]: https://ledgerhq.atlassian.net/browse/LIVE-29483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ